### PR TITLE
fix: resolve Traefik Docker network label mismatch (PAN-45)

### DIFF
--- a/templates/traefik/docker-compose.yml
+++ b/templates/traefik/docker-compose.yml
@@ -37,4 +37,4 @@ services:
 networks:
   panopticon:
     name: panopticon
-    driver: bridge
+    external: true  # Network created by 'pan install'


### PR DESCRIPTION
## Summary
- Fixes `pan up` failing with "network panopticon was found but has incorrect label" error
- Root cause: `pan install` creates network via `docker network create`, but docker-compose expects to manage it
- Solution: Mark network as `external: true` in Traefik docker-compose.yml

## Changes
- **templates/traefik/docker-compose.yml**: Changed network from `driver: bridge` to `external: true`
- **src/cli/commands/install.ts**: Added migration to patch existing docker-compose.yml files
- **src/cli/index.ts**: Added auto-fix before starting Traefik in `pan up`
- **tests/e2e-traefik.sh**: Added regression test (Test 4)

## Test plan
- [x] Fresh install: `pan install && pan up` starts Traefik without errors
- [x] Existing install: `pan up` auto-fixes and starts Traefik
- [x] Build passes: `npm run build` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)