### PR TITLE
feat(PAN-139): Add formatDuration and timeAgo utility functions

### DIFF
--- a/src/lib/format-duration.ts
+++ b/src/lib/format-duration.ts
@@ -1,0 +1,38 @@
+/**
+ * Format a duration in milliseconds to a human-readable string.
+ * 
+ * Examples:
+ *   formatDuration(500) => "< 1s"
+ *   formatDuration(5000) => "5s"
+ *   formatDuration(65000) => "1m 5s"
+ *   formatDuration(3665000) => "1h 1m 5s"
+ */
+export function formatDuration(ms: number): string {
+  if (ms < 0) return "0s";
+  if (ms < 1000) return "< 1s";
+
+  const seconds = Math.floor(ms / 1000) % 60;
+  const minutes = Math.floor(ms / 60000) % 60;
+  const hours = Math.floor(ms / 3600000);
+
+  const parts: string[] = [];
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0) parts.push(`${minutes}m`);
+  if (seconds > 0 || parts.length === 0) parts.push(`${seconds}s`);
+
+  return parts.join(" ");
+}
+
+/**
+ * Format a timestamp to relative time (e.g., "5 minutes ago").
+ */
+export function timeAgo(timestamp: string | Date): string {
+  const now = Date.now();
+  const then = new Date(timestamp).getTime();
+  const diff = now - then;
+
+  if (diff < 60000) return "just now";
+  if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
+  if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`;
+  return `${Math.floor(diff / 86400000)}d ago`;
+}

--- a/tests/lib/format-duration.test.ts
+++ b/tests/lib/format-duration.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { formatDuration, timeAgo } from "../../src/lib/format-duration.js";
+
+describe("formatDuration", () => {
+  it("should return '< 1s' for sub-second durations", () => {
+    expect(formatDuration(0)).toBe("< 1s");
+    expect(formatDuration(500)).toBe("< 1s");
+    expect(formatDuration(999)).toBe("< 1s");
+  });
+
+  it("should return '0s' for negative values", () => {
+    expect(formatDuration(-100)).toBe("0s");
+    expect(formatDuration(-1)).toBe("0s");
+  });
+
+  it("should format seconds correctly", () => {
+    expect(formatDuration(1000)).toBe("1s");
+    expect(formatDuration(5000)).toBe("5s");
+    expect(formatDuration(59000)).toBe("59s");
+  });
+
+  it("should format minutes and seconds", () => {
+    expect(formatDuration(60000)).toBe("1m");
+    expect(formatDuration(65000)).toBe("1m 5s");
+    expect(formatDuration(120000)).toBe("2m");
+    expect(formatDuration(3599000)).toBe("59m 59s");
+  });
+
+  it("should format hours, minutes, and seconds", () => {
+    expect(formatDuration(3600000)).toBe("1h");
+    expect(formatDuration(3665000)).toBe("1h 1m 5s");
+    expect(formatDuration(7200000)).toBe("2h");
+    expect(formatDuration(86400000)).toBe("24h");
+  });
+});
+
+describe("timeAgo", () => {
+  it("should return 'just now' for recent timestamps", () => {
+    const now = new Date();
+    expect(timeAgo(now)).toBe("just now");
+  });
+
+  it("should return minutes ago", () => {
+    const fiveMinAgo = new Date(Date.now() - 5 * 60000);
+    expect(timeAgo(fiveMinAgo)).toBe("5m ago");
+  });
+
+  it("should return hours ago", () => {
+    const twoHoursAgo = new Date(Date.now() - 2 * 3600000);
+    expect(timeAgo(twoHoursAgo)).toBe("2h ago");
+  });
+
+  it("should return days ago", () => {
+    const threeDaysAgo = new Date(Date.now() - 3 * 86400000);
+    expect(timeAgo(threeDaysAgo)).toBe("3d ago");
+  });
+
+  it("should accept string timestamps", () => {
+    const recent = new Date(Date.now() - 30000).toISOString();
+    expect(timeAgo(recent)).toBe("just now");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `formatDuration(ms)` for human-readable duration formatting
- Add `timeAgo(timestamp)` for relative time strings
- Comprehensive test coverage (10 tests)

## Test plan
- [x] All 10 tests pass locally on remote VM
- [ ] Review-agent approves
- [ ] Test-agent passes with baseline comparison
- [ ] Merge via dashboard

Closes #139