### PR TITLE
fix: detect Claude Code credentials from macOS Keychain

### DIFF
--- a/src/lib/claude-auth.ts
+++ b/src/lib/claude-auth.ts
@@ -1,11 +1,15 @@
 /**
  * claude-auth.ts
  *
- * Reads Claude Code's local credentials file to determine whether the user
- * is logged in with a subscription (MAX / Pro) or not.
+ * Reads Claude Code's credentials to determine whether the user is logged in
+ * with a subscription (MAX / Pro / Team) or not.
  *
- * The credentials live at ~/.claude/.credentials.json and contain:
- *   claudeAiOauth.subscriptionType  — "max" | "pro" | null
+ * Credentials are checked in order:
+ *   1. ~/.claude/.credentials.json  (Linux, older Claude Code versions)
+ *   2. macOS Keychain: "Claude Code-credentials" (macOS with newer Claude Code)
+ *
+ * The credential payload contains:
+ *   claudeAiOauth.subscriptionType  — "max" | "pro" | "team" | null
  *   claudeAiOauth.rateLimitTier     — e.g. "default_claude_max_20x"
  *   claudeAiOauth.accessToken       — OAuth bearer token
  *   claudeAiOauth.expiresAt         — Unix timestamp (ms)
@@ -13,8 +17,10 @@
 
 import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
+import { execFile } from 'child_process';
 import { homedir } from 'os';
 import { join } from 'path';
+import { platform } from 'process';
 
 export interface ClaudeAuthStatus {
   /** True if the ~/.claude directory exists (i.e. Claude Code has been installed). */
@@ -23,7 +29,7 @@ export interface ClaudeAuthStatus {
   loggedIn: boolean;
   /** True if the token exists but has already expired. */
   expired: boolean;
-  /** "max" | "pro" | null — from claudeAiOauth.subscriptionType */
+  /** "max" | "pro" | "team" | null — from claudeAiOauth.subscriptionType */
   subscriptionType: string | null;
   /** e.g. "default_claude_max_20x" */
   rateLimitTier: string | null;
@@ -32,6 +38,51 @@ export interface ClaudeAuthStatus {
   /** True when ANTHROPIC_API_KEY is set in the server process environment.
    *  When present, Claude Code prefers this over subscription auth. */
   hasAnthropicApiKey: boolean;
+}
+
+/**
+ * Read credentials JSON from macOS Keychain.
+ * Claude Code ≥2.x stores credentials under service "Claude Code-credentials".
+ */
+async function readKeychainCredentials(): Promise<string | null> {
+  if (platform !== 'darwin') return null;
+  return new Promise((resolve) => {
+    execFile(
+      'security',
+      ['find-generic-password', '-s', 'Claude Code-credentials', '-w'],
+      { timeout: 3000 },
+      (err, stdout) => {
+        if (err || !stdout.trim()) return resolve(null);
+        resolve(stdout.trim());
+      },
+    );
+  });
+}
+
+function parseOAuthPayload(raw: string): {
+  loggedIn: boolean;
+  expired: boolean;
+  subscriptionType: string | null;
+  rateLimitTier: string | null;
+  expiresAt: number | null;
+} {
+  const creds = JSON.parse(raw) as Record<string, unknown>;
+  const oauth = (creds.claudeAiOauth ?? {}) as Record<string, unknown>;
+
+  if (!oauth.accessToken) {
+    return { loggedIn: false, expired: false, subscriptionType: null, rateLimitTier: null, expiresAt: null };
+  }
+
+  const expiresAt = typeof oauth.expiresAt === 'number' ? oauth.expiresAt : null;
+  const expired = !!(expiresAt && expiresAt < Date.now());
+
+  return {
+    loggedIn: true,
+    expired,
+    subscriptionType: typeof oauth.subscriptionType === 'string' ? oauth.subscriptionType : null,
+    rateLimitTier: typeof oauth.rateLimitTier === 'string' ? oauth.rateLimitTier : null,
+    expiresAt,
+  };
 }
 
 export async function getClaudeAuthStatus(): Promise<ClaudeAuthStatus> {
@@ -47,26 +98,35 @@ export async function getClaudeAuthStatus(): Promise<ClaudeAuthStatus> {
   let rateLimitTier: string | null = null;
   let expiresAt: number | null = null;
 
+  // 1. Try flat credentials file (Linux, older Claude Code)
   if (existsSync(credPath)) {
     try {
       const raw = await readFile(credPath, 'utf-8');
-      const creds = JSON.parse(raw) as Record<string, unknown>;
-      const oauth = (creds.claudeAiOauth ?? {}) as Record<string, unknown>;
+      const result = parseOAuthPayload(raw);
+      loggedIn = result.loggedIn;
+      expired = result.expired;
+      subscriptionType = result.subscriptionType;
+      rateLimitTier = result.rateLimitTier;
+      expiresAt = result.expiresAt;
+    } catch {
+      // Credentials file unreadable or malformed — fall through to keychain.
+    }
+  }
 
-      if (oauth.accessToken) {
-        expiresAt = typeof oauth.expiresAt === 'number' ? oauth.expiresAt : null;
-        const now = Date.now();
-        expired = !!(expiresAt && expiresAt < now);
-        // Treat as logged in if an access token exists — Claude Code auto-refreshes
-        // expired tokens transparently. Only mark as not-logged-in if there's no
-        // token at all. The dashboard doesn't make API calls itself, so an expired
-        // token doesn't affect functionality.
-        loggedIn = true;
-        subscriptionType = typeof oauth.subscriptionType === 'string' ? oauth.subscriptionType : null;
-        rateLimitTier = typeof oauth.rateLimitTier === 'string' ? oauth.rateLimitTier : null;
+  // 2. Fall back to macOS Keychain (Claude Code ≥2.x on macOS)
+  if (!loggedIn) {
+    try {
+      const keychainRaw = await readKeychainCredentials();
+      if (keychainRaw) {
+        const result = parseOAuthPayload(keychainRaw);
+        loggedIn = result.loggedIn;
+        expired = result.expired;
+        subscriptionType = result.subscriptionType;
+        rateLimitTier = result.rateLimitTier;
+        expiresAt = result.expiresAt;
       }
     } catch {
-      // Credentials file unreadable or malformed — treat as not logged in.
+      // Keychain read failed — treat as not logged in.
     }
   }
 


### PR DESCRIPTION
## Summary
- Claude Code ≥2.x on macOS stores OAuth credentials in the system keychain (`"Claude Code-credentials"` service) instead of `~/.claude/.credentials.json`
- The dashboard only checked the flat file, so it always showed "not logged in" on macOS
- Added keychain fallback via `security find-generic-password` when the flat file doesn't exist

## Test plan
- [x] Verified on macOS with Claude Code 2.1.85 — auth endpoint returns `loggedIn: true`, `subscriptionType: "team"`
- [x] Dashboard header shows "TEAM" badge correctly
- [ ] Verify Linux still works (flat file path unchanged, keychain code is `darwin`-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)