### PR TITLE
fix: throw when selected model provider key is missing

### DIFF
--- a/src/lib/model-fallback.ts
+++ b/src/lib/model-fallback.ts
@@ -2,8 +2,8 @@
  * Model Fallback Strategy
  *
  * When a non-Anthropic model is selected but its API key is missing,
- * automatically fallback to an equivalent Anthropic model. This ensures
- * Panopticon always works even without configuring external providers.
+ * fail fast with a clear error instead of silently falling back.
+ * This avoids unexpected Anthropic usage/cost when another provider is selected.
  */
 
 import { ModelId, AnthropicModel, OpenAIModel, GoogleModel } from './settings.js';
@@ -144,14 +144,15 @@ export function isProviderEnabled(
 }
 
 /**
- * Apply fallback strategy for a model
+ * Validate that the requested model can be used with currently enabled providers.
  *
- * If the model's provider is disabled (no API key), return an Anthropic equivalent.
- * Otherwise, return the original model.
+ * If the model's provider is disabled (no API key), throw a clear error instead of
+ * silently switching to another provider.
  *
  * @param modelId Requested model
  * @param enabledProviders Set of enabled provider names
- * @returns Original model if provider enabled, otherwise Anthropic fallback
+ * @returns Original model when provider is enabled
+ * @throws Error when provider API key is missing
  */
 export function applyFallback(
   modelId: ModelId,
@@ -164,10 +165,10 @@ export function applyFallback(
     return modelId;
   }
 
-  // Provider disabled — fall back to the equivalent Anthropic model
-  const fallback = getFallbackModel(modelId);
-  console.warn(`Model ${modelId} requires ${provider} API key which is not configured, falling back to ${fallback}`);
-  return fallback;
+  throw new Error(
+    `Model ${modelId} requires ${provider} API key which is not configured. ` +
+    `Configure ${provider} in Settings or choose an Anthropic model.`
+  );
 }
 
 /**

--- a/tests/lib/model-fallback.test.ts
+++ b/tests/lib/model-fallback.test.ts
@@ -116,46 +116,24 @@ describe('model-fallback', () => {
       expect(applyFallback('claude-opus-4-6', enabled)).toBe('claude-opus-4-6');
     });
 
-    it('should fallback GPT-5.2 Codex to Sonnet', () => {
+    it('should throw when OpenAI provider is disabled', () => {
       const enabled = new Set<ModelProvider>(['anthropic']);
-      expect(applyFallback('gpt-5.2-codex', enabled)).toBe('claude-sonnet-4-6');
-    });
-
-    it('should fallback O3 Deep Research to Sonnet', () => {
-      const enabled = new Set<ModelProvider>(['anthropic']);
-      expect(applyFallback('o3-deep-research', enabled)).toBe('claude-sonnet-4-6');
-    });
-
-    it('should fallback GPT-4o to Sonnet', () => {
-      const enabled = new Set<ModelProvider>(['anthropic']);
-      expect(applyFallback('gpt-4o', enabled)).toBe('claude-sonnet-4-6');
-    });
-
-    it('should fallback GPT-4o-mini to Haiku', () => {
-      const enabled = new Set<ModelProvider>(['anthropic']);
-      expect(applyFallback('gpt-4o-mini', enabled)).toBe('claude-haiku-4-5');
-    });
-
-    it('should fallback Gemini Pro to Sonnet', () => {
-      const enabled = new Set<ModelProvider>(['anthropic']);
-      expect(applyFallback('gemini-3-pro-preview', enabled)).toBe('claude-sonnet-4-6');
-    });
-
-    it('should fallback Gemini Flash to Haiku', () => {
-      const enabled = new Set<ModelProvider>(['anthropic']);
-      expect(applyFallback('gemini-3-flash-preview', enabled)).toBe('claude-haiku-4-5');
-    });
-
-    it('should log warning when applying fallback', () => {
-      const enabled = new Set<ModelProvider>(['anthropic']);
-      applyFallback('gpt-5.2-codex', enabled);
-
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Model gpt-5.2-codex requires openai API key')
+      expect(() => applyFallback('gpt-5.2-codex', enabled)).toThrow(
+        'Model gpt-5.2-codex requires openai API key which is not configured'
       );
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('falling back to claude-sonnet-4-6')
+    });
+
+    it('should throw when Google provider is disabled', () => {
+      const enabled = new Set<ModelProvider>(['anthropic']);
+      expect(() => applyFallback('gemini-3-pro-preview', enabled)).toThrow(
+        'Model gemini-3-pro-preview requires google API key which is not configured'
       );
+    });
+
+    it('should not log warning when provider is disabled (throws instead)', () => {
+      const enabled = new Set<ModelProvider>(['anthropic']);
+      expect(() => applyFallback('gpt-5.2-codex', enabled)).toThrow();
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
     it('should not log warning when provider is enabled', () => {
@@ -326,34 +304,22 @@ describe('model-fallback', () => {
   });
 
   describe('fallback strategy validation', () => {
-    it('should map premium models to Sonnet', () => {
+    it('should throw for premium models when provider key is missing', () => {
       const enabled = new Set<ModelProvider>(['anthropic']);
-      expect(applyFallback('gpt-5.2-codex', enabled)).toBe('claude-sonnet-4-6');
-      expect(applyFallback('o3-deep-research', enabled)).toBe('claude-sonnet-4-6');
-      expect(applyFallback('gemini-3-pro-preview', enabled)).toBe('claude-sonnet-4-6');
+      expect(() => applyFallback('gpt-5.2-codex', enabled)).toThrow();
+      expect(() => applyFallback('o3-deep-research', enabled)).toThrow();
+      expect(() => applyFallback('gemini-3-pro-preview', enabled)).toThrow();
     });
 
-    it('should map economy models to Haiku', () => {
+    it('should throw for economy models when provider key is missing', () => {
       const enabled = new Set<ModelProvider>(['anthropic']);
-      expect(applyFallback('gpt-4o-mini', enabled)).toBe('claude-haiku-4-5');
-      expect(applyFallback('gemini-3-flash-preview', enabled)).toBe('claude-haiku-4-5');
+      expect(() => applyFallback('gpt-4o-mini', enabled)).toThrow();
+      expect(() => applyFallback('gemini-3-flash-preview', enabled)).toThrow();
     });
 
-    it('should never fallback to Opus by default', () => {
+    it('should keep Anthropic models usable without external keys', () => {
       const enabled = new Set<ModelProvider>(['anthropic']);
-      const allModels: ModelId[] = [
-        'gpt-5.2-codex',
-        'o3-deep-research',
-        'gpt-4o',
-        'gpt-4o-mini',
-        'gemini-3-pro-preview',
-        'gemini-3-flash-preview',
-      ];
-
-      allModels.forEach((model) => {
-        const fallback = applyFallback(model, enabled);
-        expect(fallback).not.toBe('claude-opus-4-6');
-      });
+      expect(applyFallback('claude-opus-4-6', enabled)).toBe('claude-opus-4-6');
     });
   });
 });


### PR DESCRIPTION
## Summary
Restore fail-fast behavior for missing provider keys so Panopticon does not silently switch to Anthropic when a non-Anthropic model is selected.

## Changes
- `applyFallback()` now throws a clear error when the selected provider is disabled/missing API key
- updated `model-fallback` tests to assert throw behavior instead of fallback behavior
- removed warning-based silent fallback assertions

## Why
Silent fallback can cause unexpected provider usage and cost. This change makes configuration problems explicit and aligns model selection with user intent.

## Testing
- Updated `tests/lib/model-fallback.test.ts` expectations for missing-provider scenarios
- Test runner not executed locally in this environment (`vitest` not installed)

Fixes #640

Greetings, saschabuehrle
