### PR TITLE
PAN-509: Inspector panel shows contextually relevant terminal based on pipeline phase

### DIFF
--- a/.planning/PLANNING_PROMPT.md
+++ b/.planning/PLANNING_PROMPT.md
@@ -1,0 +1,238 @@
+<!-- panopticon:orchestration-context-start -->
+<!-- This is Panopticon orchestration context injected automatically.
+     It contains planning session setup instructions, not agent reasoning.
+     Session summarizers should SKIP this block and focus on the agent's
+     actual work, decisions, and tradeoffs that follow. -->
+
+# Planning Session: PAN-509
+
+## CRITICAL: PLANNING ONLY - NO IMPLEMENTATION
+
+**YOU ARE IN PLANNING MODE. DO NOT:**
+- Write or modify any code files (except STATE.md)
+- Run implementation commands (npm install, docker compose, make, etc.)
+- Create actual features or functionality
+- Start implementing the solution
+
+**YOU SHOULD ONLY:**
+- Ask clarifying questions (use AskUserQuestion tool)
+- Explore the codebase to understand context (read files, grep)
+- Generate planning artifacts:
+  - STATE.md (decisions, approach, architecture)
+  - vBRIEF plan at `.planning/plan.vbrief.json` (see format below)
+  - Implementation plan at `docs/prds/active/{issue-id-lowercase}/STATE.md` (copy of STATE.md, required for dashboard). The directory name MUST be lowercase (e.g. `pan-596`, not `PAN-596`) — uppercase strands the PRD where the lifecycle code can't find it.
+- Present options and tradeoffs for the user to decide
+
+**Finalizing the session:** When your vBRIEF is written and you're ready to hand off, run:
+
+```
+pan plan-finalize
+```
+
+This converts your `plan.vbrief.json` into beads tasks and writes the `.planning/.planning-complete` marker that lets the dashboard show the **Done** button. Do NOT run `bd create` yourself — `pan plan-finalize` does it deterministically from the vBRIEF.
+
+After `pan plan-finalize` succeeds, STOP. Tell the user: "Planning finalized — click Done in the dashboard to hand off to the implementation agent." Do not kill the tmux session yourself; the Stop button handles that if needed.
+
+## Panopticon Agent Taxonomy
+
+Panopticon orchestrates several distinct agent types. **You are the planning agent.** The other agents in the pipeline have different roles, different working directories, and read different `CLAUDE.md` files. Confusing them is a common error — read this section carefully before exploring the codebase.
+
+### Agents in the Panopticon pipeline
+
+| Agent | Role | Working dir | CLAUDE.md auto-loaded |
+|-------|------|-------------|-----------------------|
+| **planning** (you) | Discovery, vBRIEF, STATE.md. No code. | workspace worktree | workspace |
+| **work** | Implementation from your vBRIEF + beads tasks | workspace worktree | workspace |
+| **inspect** | Per-bead spec verification mid-implementation | project root | project root |
+| **review** | Strict code review against acceptance criteria | project root | project root |
+| **test** | Test execution and failure analysis | project root | project root |
+| **uat** | Browser-based requirement verification (Playwright) | project root | project root |
+| **merge** | PR merge, conflict resolution, post-merge cleanup | project root | project root |
+
+**Critical asymmetry:** the workspace `CLAUDE.md` you see is NOT the one specialists see. Specialists run in the project root and auto-load the repo-tracked devroot `CLAUDE.md`. Instructions you put in `STATE.md` reach the work agent (same workspace) but not specialists. If you need a specialist to know something, put it in your vBRIEF as an acceptance criterion — that propagates through the pipeline via the role-prompt templates in `src/lib/cloister/prompts/`.
+
+### Claude Code subagents (NOT Panopticon specialists)
+
+You may spawn ephemeral **Claude Code subagents** via the `Agent` tool for parallel exploration. These are NOT the same as Panopticon specialists:
+
+- `codebase-explorer`, `general-purpose` — fast read-only code search
+- `Plan` — architectural planning helper
+- `code-review-correctness` / `-security` / `-performance` — independent reviewers
+
+**These subagents live and die inside your session.** They have no role in the Panopticon pipeline and no relationship to `review-agent`/`test-agent`/`merge-agent`. If you encounter references in the codebase to "Explorer agent", "explore subagent", `subagent:*` work types, or files in `.claude/agents/` — those are Claude Code subagents, not Panopticon specialists. Do not conflate them.
+
+### What happens after you finalize
+
+After `pan plan-finalize` and the user clicks **Done**, the pipeline runs without you: work agent → inspect → review → test → uat → merge. You are responsible for the plan, not the implementation. Make your vBRIEF and acceptance criteria sharp enough that the work agent can succeed without coming back to you for clarification, and so specialists downstream have unambiguous targets to verify against.
+
+---
+
+## Auto Mode (Headless / Non-Interactive)
+
+**CRITICAL: You are running in auto mode. Do NOT use the AskUserQuestion tool under any circumstances.**
+
+- Make reasonable assumptions based on the issue description and codebase — do not pause for clarification
+- Proceed directly from discovery → vBRIEF → `pan plan-finalize` without waiting for human input
+- If something is genuinely ambiguous, pick the most conservative/safe interpretation and document your assumption in the vBRIEF description
+- When your plan is written, immediately run `pan plan-finalize` and then exit
+
+
+## Issue Details
+- **ID:** PAN-509
+- **Title:** Inspector panel should show contextually relevant terminal based on pipeline phase
+- **URL:** https://github.com/eltmon/panopticon-cli/issues/509
+
+## Description
+## Problem
+
+The Inspector panel currently always shows the work agent's terminal regardless of what phase the pipeline is in. When the review agent is actively reviewing, or verification is running, or tests are executing, the Inspector shows the work agent — which may be idle or stopped. The user has to know to look elsewhere for what's actually happening.
+
+## Desired Behavior
+
+The Inspector should automatically surface the **most relevant terminal/output** for the current pipeline phase:
+
+| Phase | What to show |
+|-------|-------------|
+| Planning | Planning agent terminal (`planning-<id>`) |
+| Agent working | Work agent terminal (`agent-<id>`) — current behavior |
+| Verification running | Verification output (quality gates: typecheck, lint, test) |
+| Review in progress (`reviewStatus: reviewing`) | Review agent terminal/logs |
+| Review failed — feedback loop | Work agent terminal again (agent is fixing) |
+| Tests running (`testStatus: testing`) | Test agent terminal/logs |
+| Merge in progress (`mergeStatus: merging`) | Merge agent terminal/logs |
+| Merge ready / done | Summary / status card |
+
+## Implementation Notes
+
+- The Inspector panel is `InspectorPanel` in `src/dashboard/frontend/src/components/`
+- Pipeline phase can be derived from `reviewStatus`, `testStatus`, `mergeStatus` on the issue's `ReviewStatusSnapshot`
+- Specialist terminals follow the `specialist-<name>` tmux session naming convention (e.g. `specialist-review-agent`)
+- A phase indicator at the top of the Inspector could show the current stage and let users manually switch if needed
+- Verification output may need a dedicated log stream (currently goes to agent feedback in tmux, may need its own channel)
+
+## Acceptance Criteria
+
+- [ ] Inspector automatically switches to the active specialist terminal when a specialist is running
+- [ ] Inspector shows verification output when quality gates are executing post-completion
+- [ ] Inspector returns to work agent terminal when feedback loop is active
+- [ ] A phase breadcrumb or tab strip makes the current stage legible at a glance
+- [ ] Manual override: user can pin any terminal regardless of auto-switch
+
+---
+
+## Your Mission
+
+You are a planning agent conducting a **discovery session** for this issue.
+
+### Phase 1: Understand Context
+1. **If a spec file was provided above**, read it thoroughly — it's your primary input
+2. Read the codebase to understand relevant files and patterns
+3. Identify what subsystems/files this issue affects
+4. Note any existing patterns we should follow
+
+### Phase 2: Discovery Conversation
+Use AskUserQuestion tool to ask contextual questions:
+- What's the scope? What's explicitly OUT of scope?
+- Any technical constraints or preferences?
+- What does "done" look like?
+- Are there edge cases we need to handle?
+
+### Difficulty Estimation
+
+For each sub-task, estimate difficulty using this rubric:
+
+| Level | When to Use | Model |
+|-------|-------------|-------|
+| `trivial` | Typo, comment, formatting only | haiku |
+| `simple` | Bug fix, single file, obvious change | haiku |
+| `medium` | New feature, 3-5 files, standard patterns | sonnet |
+| `complex` | Refactor, migration, 6+ files, some risk | sonnet |
+| `expert` | Architecture, security, performance, high risk | opus |
+
+### Phase 3: Generate Artifacts (NO CODE!)
+When discovery is complete:
+1. Create STATE.md with decisions made
+2. Copy STATE.md to implementation plan at `docs/prds/active/{issue-id-lowercase}/STATE.md` (required for dashboard). Use the LOWERCASE issue id for the directory name.
+3. Create a vBRIEF plan file at `.planning/plan.vbrief.json` — **MUST follow the exact format below**
+4. Run `pan plan-finalize` from the workspace root. This creates beads tasks from your vBRIEF and writes the `.planning/.planning-complete` marker.
+5. Summarize the plan and STOP
+
+**DO NOT run `bd create` commands directly.** `pan plan-finalize` is the only sanctioned way to materialize beads from a vBRIEF plan — it's deterministic and idempotent.
+
+### vBRIEF Plan Format (REQUIRED)
+
+The plan file MUST conform to vBRIEF v0.5 spec (https://github.com/deftai/vBRIEF).
+It MUST have exactly two top-level keys: `vBRIEFInfo` and `plan`.
+
+```json
+{
+  "vBRIEFInfo": {
+    "version": "0.5",
+    "created": "<ISO 8601 timestamp>",
+    "author": "panopticon-cli/0.0.0",
+    "description": "Plan for PAN-509: <issue title>"
+  },
+  "plan": {
+    "id": "pan-509",
+    "title": "<issue title>",
+    "status": "approved",
+    "uid": "<generate a UUID v4>",
+    "author": "agent:claude-opus-4-6",
+    "sequence": 1,
+    "created": "<ISO 8601 timestamp — same as vBRIEFInfo.created>",
+    "updated": "<ISO 8601 timestamp — same as created>",
+    "references": [
+      { "uri": "https://github.com/eltmon/panopticon-cli/issues/509", "label": "PAN-509", "type": "issue" }
+    ],
+    "tags": ["<relevant tags>"],
+    "narratives": {
+      "Problem": "<what problem this solves>",
+      "Proposal": "<the approach chosen>"
+    },
+    "items": [
+      {
+        "id": "<short-kebab-id>",
+        "title": "<task title>",
+        "status": "pending",
+        "priority": "medium",
+        "created": "<ISO 8601 timestamp>",
+        "metadata": {
+          "difficulty": "trivial|simple|medium|complex|expert",
+          "issueLabel": "pan-509"
+        },
+        "narrative": { "Action": "<what needs to be done>" },
+        "subItems": [
+          {
+            "id": "<parent-id>.ac1",
+            "title": "<specific testable acceptance criterion>",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          }
+        ]
+      }
+    ],
+    "edges": [
+      { "from": "<source-item-id>", "to": "<target-item-id>", "type": "blocks" }
+    ]
+  }
+}
+```
+
+**CRITICAL vBRIEF rules:**
+- The file MUST have `vBRIEFInfo` and `plan` as the ONLY top-level keys
+- `plan.id` MUST be the issue ID in lowercase (e.g., "pan-509")
+- `plan.uid` MUST be a freshly generated UUID v4
+- Do NOT use `issue`, `issueId`, or `issue_id` — use `plan.id`
+- `items[].status` MUST be one of: draft, proposed, approved, pending, running, completed, blocked, cancelled
+- Acceptance criteria MUST be `subItems` with `metadata.kind: "acceptance_criterion"`
+- `metadata.difficulty` and `metadata.issueLabel` are Panopticon extensions to the vBRIEF spec
+- Edge types: `blocks` (hard dependency), `informs` (soft), `invalidates`, `suggests`
+
+**IMPORTANT:** Create the plan file BEFORE creating beads tasks.
+**NOTE:** `*-spec.md` files are human-written specs — do NOT overwrite them. Your output is `*-plan.md`.
+
+**Remember:** Be a thinking partner, not an interviewer. Ask questions that help clarify.
+
+Start by exploring the codebase to understand the context, then begin the discovery conversation.
+
+<!-- panopticon:orchestration-context-end -->

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -33,3 +33,4 @@ None
 - **[2026-04-12T22:30Z] Resolved merge conflicts with main; ran `bun install` to pick up vitest 2.1.9 upgrade (PAN-645); all 202 test files pass (2730 tests)**
 - **[2026-04-12T23:00Z] Addressed code review BLOCK: fixed double-commit race (committingRef), stabilized callbacks (draftTitleRef), added 25 new tests across ConversationList.test.tsx and ConversationPanel.test.tsx, fixed pre-existing shadow-state.test.ts flakiness; all 204 test files pass (2756 tests); pushed commit c76dd114**
 - **[2026-04-13T12:02Z] review-agent → CHANGES-REQUESTED** — `.planning/feedback/013-review-agent-changes-requested.md`
+- **[2026-04-13T12:15Z] review-agent → CHANGES-REQUESTED** — `.planning/feedback/014-review-agent-changes-requested.md`

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,35 @@
+# PAN-596: Allow editing a conversation title
+
+## Status: Implementation Complete
+
+## Current Phase
+All beads closed. Fixing pre-existing test failures flagged by verification gate.
+
+## Completed Work
+- [x] feature-pan-489-rel: Added exported `updateConversationTitle(name, title)` API helper to ConversationList.tsx (commit: 6b1e048f)
+- [x] feature-pan-489-8er: Inline rename UI in ConversationList sidebar — pencil button, edit mode input, Enter/Esc/blur handlers, CSS styles; also fixed pre-existing TS error in deacon.ts (commit: 1322f09f)
+- [x] feature-pan-489-c72: Inline rename UI in ConversationPanel header — pencil button, edit state, mutation, Enter/Esc/blur, CSS styles (commit: a479538b)
+- [x] feature-pan-489-8o6: Verified backend title_source='manual' blocks AI override via code inspection (commit: b6794e87)
+- Fixed pre-existing test failure in teardown-workspace.test.ts (missing PRD path mock exports)
+- Fixed pre-existing test failures: ComposerPromptEditor scrollIntoView in jsdom, ActionsSection Cancel→Cancel Issue text, ArrowDown/ArrowUp wrap tests that assumed 4-item list
+
+## Remaining Work
+None
+
+## Key Decisions
+- API helper lives in ConversationList.tsx and is exported; ConversationPanel imports it
+- Each component manages its own `useMutation` instance (follows existing pattern)
+- Optimistic update not needed — invalidation is sufficient (list refetches at 10s, invalidation is immediate)
+- Edit state: editingTitle/draftTitle per component; useRef for autofocus
+- Empty/whitespace → revert without calling API (matches backend guard)
+- Pencil icon button opacity-0 until hover on both sidebar row and panel title
+
+## Specialist Feedback
+- None yet
+- **[2026-04-12T17:58Z] verification-gate → FAILED** — `.planning/feedback/001-verification-gate-failed.md`
+- **[2026-04-12T17:59Z] verification-gate → FAILED** — `.planning/feedback/002-verification-gate-failed.md`
+- **[2026-04-12T18:15Z] Fixed all 12 pre-existing test failures; all 381+2431 tests now pass**
+- **[2026-04-12T22:22Z] verification-gate → FAILED** — `.planning/feedback/003-verification-gate-failed.md`
+- **[2026-04-12T22:30Z] Resolved merge conflicts with main; ran `bun install` to pick up vitest 2.1.9 upgrade (PAN-645); all 202 test files pass (2730 tests)**
+- **[2026-04-12T23:00Z] Addressed code review BLOCK: fixed double-commit race (committingRef), stabilized callbacks (draftTitleRef), added 25 new tests across ConversationList.test.tsx and ConversationPanel.test.tsx, fixed pre-existing shadow-state.test.ts flakiness; all 204 test files pass (2756 tests); pushed commit c76dd114**
+- **[2026-04-13T12:02Z] review-agent → CHANGES-REQUESTED** — `.planning/feedback/013-review-agent-changes-requested.md`

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -34,3 +34,4 @@ None
 - **[2026-04-12T23:00Z] Addressed code review BLOCK: fixed double-commit race (committingRef), stabilized callbacks (draftTitleRef), added 25 new tests across ConversationList.test.tsx and ConversationPanel.test.tsx, fixed pre-existing shadow-state.test.ts flakiness; all 204 test files pass (2756 tests); pushed commit c76dd114**
 - **[2026-04-13T12:02Z] review-agent → CHANGES-REQUESTED** — `.planning/feedback/013-review-agent-changes-requested.md`
 - **[2026-04-13T12:15Z] review-agent → CHANGES-REQUESTED** — `.planning/feedback/014-review-agent-changes-requested.md`
+- **[2026-04-13T12:21Z] review-agent → CHANGES-REQUESTED** — `.planning/feedback/015-review-agent-changes-requested.md`

--- a/.planning/feedback/002-review-agent-changes-requested.md
+++ b/.planning/feedback/002-review-agent-changes-requested.md
@@ -1,0 +1,21 @@
+---
+specialist: review-agent
+issueId: PAN-509
+outcome: changes-requested
+timestamp: 2026-04-12T23:42:29Z
+---
+
+CODE REVIEW BLOCKED for PAN-509:
+
+1) MergedSummaryCard.tsx:15 formatCost bug — returns "$0.50¢" (mixes $ and ¢ symbols). 2) DetailPanelLayout.tsx:248 prUrl hardcoded to null — prUrl exists on contract type but is not plumbed through. 3) InspectorPanel.tsx duplicates phase-derivation logic (derivePhaseLabel + PHASE_BADGE_COLORS) that already lives in usePipelinePhase.ts/TerminalTabs.tsx — two parallel implementations can drift; should use usePipelinePhase hook.
+
+## REQUIRED: Fix ALL issues above BEFORE resubmitting
+
+1. Read each blocking issue carefully
+2. Fix the code for EVERY issue listed
+3. Run tests to verify your fixes
+4. Commit and push ALL changes
+5. ONLY THEN resubmit:
+curl -X POST http://localhost:3011/api/workspaces/PAN-509/request-review -H "Content-Type: application/json" -d '{}'
+
+Do NOT run the curl command until steps 1-4 are complete. Do NOT stop until review passes.

--- a/.planning/feedback/004-review-agent-changes-requested.md
+++ b/.planning/feedback/004-review-agent-changes-requested.md
@@ -1,0 +1,21 @@
+---
+specialist: review-agent
+issueId: PAN-509
+outcome: changes-requested
+timestamp: 2026-04-12T23:49:21Z
+---
+
+CODE REVIEW BLOCKED for PAN-509:
+
+Missing tests for new components (MergedSummaryCard, TerminalSessionWrapper). Dead state variant in TerminalSessionWrapper. Duplicate savePinState call in TerminalTabs.
+
+## REQUIRED: Fix ALL issues above BEFORE resubmitting
+
+1. Read each blocking issue carefully
+2. Fix the code for EVERY issue listed
+3. Run tests to verify your fixes
+4. Commit and push ALL changes
+5. ONLY THEN resubmit:
+curl -X POST http://localhost:3011/api/workspaces/PAN-509/request-review -H "Content-Type: application/json" -d '{}'
+
+Do NOT run the curl command until steps 1-4 are complete. Do NOT stop until review passes.

--- a/.planning/feedback/005-review-agent-changes-requested.md
+++ b/.planning/feedback/005-review-agent-changes-requested.md
@@ -1,0 +1,21 @@
+---
+specialist: review-agent
+issueId: PAN-509
+outcome: changes-requested
+timestamp: 2026-04-12T23:51:58Z
+---
+
+CODE REVIEW BLOCKED for PAN-509:
+
+Dead returned values from usePipelinePhase hook: planningSessionName and deadSessions are returned but never consumed by any caller. Comment at usePipelinePhase.ts:76-77 says the planning tab should be added conditionally by the hook caller, but no caller does so — Planning phase never gets a terminal tab. Either remove the unused return fields or wire up the planning tab in DetailPanelLayout.
+
+## REQUIRED: Fix ALL issues above BEFORE resubmitting
+
+1. Read each blocking issue carefully
+2. Fix the code for EVERY issue listed
+3. Run tests to verify your fixes
+4. Commit and push ALL changes
+5. ONLY THEN resubmit:
+curl -X POST http://localhost:3011/api/workspaces/PAN-509/request-review -H "Content-Type: application/json" -d '{}'
+
+Do NOT run the curl command until steps 1-4 are complete. Do NOT stop until review passes.

--- a/.planning/feedback/006-verification-gate-failed.md
+++ b/.planning/feedback/006-verification-gate-failed.md
@@ -1,0 +1,26 @@
+---
+specialist: verification-gate
+issueId: PAN-509
+outcome: failed
+timestamp: 2026-04-12T23:58:59Z
+---
+
+VERIFICATION FAILED for PAN-509 (attempt 3/10):
+
+Failed check: frontend-typecheck
+
+Verification FAILED at frontend-typecheck (4883ms):
+
+src/components/inspector/TerminalTabs.tsx(95,3): error TS6133: 'issueId' is declared but its value is never read.
+
+
+## REQUIRED: Fix the failing check BEFORE resubmitting
+
+1. Read the error output above carefully
+2. Fix the code causing the failure
+3. Run the failing check locally to verify it passes
+4. Commit and push ALL changes
+5. ONLY THEN resubmit:
+curl -X POST http://localhost:3011/api/workspaces/PAN-509/request-review -H "Content-Type: application/json" -d '{}'
+
+Do NOT run the curl command until steps 1-4 are complete. Do NOT stop until review passes.

--- a/.planning/feedback/007-review-agent-changes-requested.md
+++ b/.planning/feedback/007-review-agent-changes-requested.md
@@ -1,0 +1,21 @@
+---
+specialist: review-agent
+issueId: PAN-509
+outcome: changes-requested
+timestamp: 2026-04-13T00:01:21Z
+---
+
+CODE REVIEW BLOCKED for PAN-509:
+
+Dead type union member verifying (TerminalTabs.tsx:7) and dead PHASE_LABELS/PHASE_CHIP_COLORS entries (TerminalTabs.tsx:47,58) — derivePipelinePhase never returns verifying; mergeStatus=verifying maps to merging phase instead. Also: usePipelinePhase returns activeSession (usePipelinePhase.ts:16,120) but DetailPanelLayout.tsx:82 ignores it and re-derives activePhaseSession at line 108 from availableTerminals.find(...). Use the hook return value or drop it from the API.
+
+## REQUIRED: Fix ALL issues above BEFORE resubmitting
+
+1. Read each blocking issue carefully
+2. Fix the code for EVERY issue listed
+3. Run tests to verify your fixes
+4. Commit and push ALL changes
+5. ONLY THEN resubmit:
+curl -X POST http://localhost:3011/api/workspaces/PAN-509/request-review -H "Content-Type: application/json" -d '{}'
+
+Do NOT run the curl command until steps 1-4 are complete. Do NOT stop until review passes.

--- a/.planning/feedback/008-review-agent-changes-requested.md
+++ b/.planning/feedback/008-review-agent-changes-requested.md
@@ -1,0 +1,32 @@
+---
+specialist: review-agent
+issueId: PAN-509
+outcome: changes-requested
+timestamp: 2026-04-13T00:05:02Z
+---
+
+CODE REVIEW BLOCKED for PAN-509:
+
+BLOCKING ISSUES:
+
+1. [usePipelinePhase.ts:62] review-feedback phase only triggers when reviewStatus === "failed", but the backend writes reviewStatus = "blocked" on review rejection (see src/dashboard/server/routes/specialists.ts:302 and :1221 — both set "blocked", never "failed"). As a result the new "Review Feedback" phase badge and auto-switch will never fire in real usage. Extend the check to `rs === "blocked" || rs === "failed"` and add a test case for rs === "blocked".
+
+2. [usePipelinePhase.ts:27-71] The PipelinePhase type and PHASE_LABELS include "verifying", and the function docstring lists it in the precedence chain, but derivePipelinePhase never assigns phase = "verifying". Either wire it up (e.g. when agent signals done but verification gate is running) or remove "verifying" from PipelinePhase, PHASE_LABELS, PHASE_CHIP_COLORS, and the precedence comment. Dead phase values are misleading.
+
+3. [DetailPanelLayout.tsx:60-68 vs InspectorPanel.tsx:175-183] Both components now declare their own useQuery for ["review-status", issueId] with DIFFERENT refetchInterval values (15000 vs 30000). They share the cache key so it works, but the effective refetch cadence is implicit and confusing. Hoist the query to a single owner (DetailPanelLayout) and pass reviewStatus down as a prop, or lift it into a shared custom hook. Same applies to the ability for these to drift.
+
+REQUIRED FIXES:
+- Handle rs === "blocked" in derivePipelinePhase + test
+- Resolve the "verifying" phase: implement it or delete it from the types/labels/colors/docs
+- Consolidate the duplicated review-status useQuery to a single source of truth
+
+## REQUIRED: Fix ALL issues above BEFORE resubmitting
+
+1. Read each blocking issue carefully
+2. Fix the code for EVERY issue listed
+3. Run tests to verify your fixes
+4. Commit and push ALL changes
+5. ONLY THEN resubmit:
+curl -X POST http://localhost:3011/api/workspaces/PAN-509/request-review -H "Content-Type: application/json" -d '{}'
+
+Do NOT run the curl command until steps 1-4 are complete. Do NOT stop until review passes.

--- a/.planning/feedback/009-review-agent-changes-requested.md
+++ b/.planning/feedback/009-review-agent-changes-requested.md
@@ -1,0 +1,21 @@
+---
+specialist: review-agent
+issueId: PAN-509
+outcome: changes-requested
+timestamp: 2026-04-13T00:07:50Z
+---
+
+CODE REVIEW BLOCKED for PAN-509:
+
+Dead code in TerminalTabs.tsx: (1) issueId prop declared required but never destructured/used inside the component; (2) loadPersistedPin is a redundant wrapper around loadPinState — one of them must go; (3) auto-follow useEffect (lines 100-106) is dead because parent already derives selectedSession = pinned ? pinnedSession : activeSession, so activeTab.sessionName !== selectedSession is always false when not pinned.
+
+## REQUIRED: Fix ALL issues above BEFORE resubmitting
+
+1. Read each blocking issue carefully
+2. Fix the code for EVERY issue listed
+3. Run tests to verify your fixes
+4. Commit and push ALL changes
+5. ONLY THEN resubmit:
+curl -X POST http://localhost:3011/api/workspaces/PAN-509/request-review -H "Content-Type: application/json" -d '{}'
+
+Do NOT run the curl command until steps 1-4 are complete. Do NOT stop until review passes.

--- a/.planning/feedback/010-verification-gate-failed.md
+++ b/.planning/feedback/010-verification-gate-failed.md
@@ -1,0 +1,28 @@
+---
+specialist: verification-gate
+issueId: PAN-509
+outcome: failed
+timestamp: 2026-04-13T01:58:06Z
+---
+
+VERIFICATION FAILED for PAN-509 (attempt 1/10):
+
+Failed check: sync-target-branch
+
+Sync with main FAILED — merge conflicts detected:
+  - .planning/plan.vbrief.json
+  - src/dashboard/frontend/src/components/TerminalPanel.tsx
+  - tests/lib/shadow-state.test.ts
+
+## REQUIRED: Resolve merge conflicts with main BEFORE resubmitting
+
+The target branch advanced since you started working. Your branch has merge conflicts that must be resolved.
+
+1. Run: git fetch origin main && git merge origin/main
+2. Resolve all conflicts in the listed files
+3. Run the project's build and tests to verify nothing broke
+4. Commit and push ALL changes
+5. ONLY THEN resubmit:
+curl -X POST http://localhost:3011/api/workspaces/PAN-509/request-review -H "Content-Type: application/json" -d '{}'
+
+Do NOT resubmit until all conflicts are resolved and tests pass.

--- a/.planning/feedback/011-verification-gate-failed.md
+++ b/.planning/feedback/011-verification-gate-failed.md
@@ -1,0 +1,26 @@
+---
+specialist: verification-gate
+issueId: PAN-509
+outcome: failed
+timestamp: 2026-04-13T02:01:53Z
+---
+
+VERIFICATION FAILED for PAN-509 (attempt 2/10):
+
+Failed check: frontend-typecheck
+
+Verification FAILED at frontend-typecheck (5668ms):
+
+src/components/TerminalPanel.tsx(5,1): error TS6133: 'XTerminal' is declared but its value is never read.
+
+
+## REQUIRED: Fix the failing check BEFORE resubmitting
+
+1. Read the error output above carefully
+2. Fix the code causing the failure
+3. Run the failing check locally to verify it passes
+4. Commit and push ALL changes
+5. ONLY THEN resubmit:
+curl -X POST http://localhost:3011/api/workspaces/PAN-509/request-review -H "Content-Type: application/json" -d '{}'
+
+Do NOT run the curl command until steps 1-4 are complete. Do NOT stop until review passes.

--- a/.planning/feedback/012-merge-agent-pr-cleared.md
+++ b/.planning/feedback/012-merge-agent-pr-cleared.md
@@ -1,0 +1,22 @@
+---
+specialist: merge-agent
+issueId: PAN-509
+outcome: pr-cleared
+timestamp: 2026-04-13T06:55:00Z
+---
+
+## Stale PR Cleared — Fresh Review Required
+
+PR #527 was closed without being merged via Panopticon. Panopticon has cleared the stale PR reference.
+
+### Action Required
+
+You need to create a fresh PR and re-run the review pipeline. Run:
+
+```
+pan work done PAN-509
+```
+
+This will create a new PR against the current main branch and trigger the review → test → merge pipeline.
+
+If you have unfinished work, complete it first, commit, push, then run `pan work done`.

--- a/.planning/feedback/013-review-agent-changes-requested.md
+++ b/.planning/feedback/013-review-agent-changes-requested.md
@@ -1,0 +1,20 @@
+---
+specialist: review-agent
+issueId: PAN-509
+outcome: changes-requested
+timestamp: 2026-04-13T12:02:53Z
+---
+
+CODE REVIEW BLOCKED for PAN-509:
+
+Two integration bugs in DetailPanelLayout/TerminalPanel — the multi-tab terminal feature does not actually work end-to-end for the two highest-value cases (viewing specialist sessions after work agent dies, and viewing the last specialist log from the merged summary).
+
+## REQUIRED: Fix ALL issues above, then invoke the /rebase-and-submit skill
+
+1. Read each blocking issue carefully
+2. Fix the code for EVERY issue listed
+3. Run tests locally to verify your fixes
+4. Commit every change
+5. Invoke the /rebase-and-submit skill for PAN-509 — this is an atomic task that runs pan work done (which handles rebase + push + re-submit internally)
+
+Do NOT stop between steps. Do NOT run git push manually — the skill handles it. Do NOT stop until pan work done has completed successfully.

--- a/.planning/feedback/014-review-agent-changes-requested.md
+++ b/.planning/feedback/014-review-agent-changes-requested.md
@@ -1,0 +1,20 @@
+---
+specialist: review-agent
+issueId: PAN-509
+outcome: changes-requested
+timestamp: 2026-04-13T12:15:56Z
+---
+
+CODE REVIEW BLOCKED for PAN-509:
+
+Pin state leaks across issues
+
+## REQUIRED: Fix ALL issues above, then invoke the /rebase-and-submit skill
+
+1. Read each blocking issue carefully
+2. Fix the code for EVERY issue listed
+3. Run tests locally to verify your fixes
+4. Commit every change
+5. Invoke the /rebase-and-submit skill for PAN-509 — this is an atomic task that runs pan work done (which handles rebase + push + re-submit internally)
+
+Do NOT stop between steps. Do NOT run git push manually — the skill handles it. Do NOT stop until pan work done has completed successfully.

--- a/.planning/feedback/015-review-agent-changes-requested.md
+++ b/.planning/feedback/015-review-agent-changes-requested.md
@@ -1,0 +1,20 @@
+---
+specialist: review-agent
+issueId: PAN-509
+outcome: changes-requested
+timestamp: 2026-04-13T12:21:22Z
+---
+
+CODE REVIEW BLOCKED for PAN-509:
+
+Pin-button toggle in DetailPanelLayout loses the displayed session and is not persisted — see feedback for details
+
+## REQUIRED: Fix ALL issues above, then invoke the /rebase-and-submit skill
+
+1. Read each blocking issue carefully
+2. Fix the code for EVERY issue listed
+3. Run tests locally to verify your fixes
+4. Commit every change
+5. Invoke the /rebase-and-submit skill for PAN-509 — this is an atomic task that runs pan work done (which handles rebase + push + re-submit internally)
+
+Do NOT stop between steps. Do NOT run git push manually — the skill handles it. Do NOT stop until pan work done has completed successfully.

--- a/docs/prds/active/pan-509/STATE.md
+++ b/docs/prds/active/pan-509/STATE.md
@@ -1,0 +1,84 @@
+# PAN-509 — Inspector: Phase-Aware Terminal
+
+## Problem
+
+`InspectorPanel` always streams the work-agent tmux session (`agent.id`) regardless of which pipeline phase is actually running. When review/test/merge specialists are executing, the Inspector shows an idle or stopped work agent. Users must know to leave the Inspector and hunt the specialist terminals elsewhere.
+
+## Goal
+
+The Inspector automatically surfaces the most relevant terminal for the current pipeline phase, with a visible phase indicator and a manual pin/override so users can stick on a specific terminal when they want to.
+
+## Current architecture (observed)
+
+- `InspectorPanel.tsx:117` receives `agent`, `issue`, `issueId` and an `onOpenTerminal` callback.
+- `DetailPanelLayout.tsx:48` owns the two-pane layout (`inspector+terminal`) and constructs `<TerminalPanel key={agent.id} agent={agent} … />` — the terminal session name is hardwired to `agent.id`.
+- `TerminalPanel.tsx` renders `<XTerminal sessionName={agent.id} />` (raw websocket at `/ws/terminal?session=<name>`).
+- `XTerminal` is already session-agnostic — it accepts any `sessionName` prop and streams it (confirmed by `ConversationPanel.tsx:162` and `PlanDialog.tsx:861`).
+- Review status (`reviewStatus`/`testStatus`/`mergeStatus`) is already fetched in `InspectorPanel.tsx:159` via `/api/workspaces/:issueId/review-status` and consumed by `ActionsSection.tsx`.
+- Specialist tmux sessions follow `specialist-<projectKey>-<name>` for project-scoped specialists and `specialist-<name>` for global ones (`src/lib/cloister/specialists.ts:561`).
+- Planning tmux session name is `planning-<issueId>` (per issue description).
+- `/api/specialists` returns the list of specialists with their `tmuxSession` field (see `SpecialistAgentCard.tsx`).
+
+**Good news:** no server work is needed. The `/ws/terminal` endpoint already streams any tmux session by name, and the data we need (phase, specialist session names) is already exposed by existing endpoints. This is a **frontend-only** change.
+
+## Decision summary
+
+1. **Derive phase on the client** from the already-fetched `reviewStatus` + agent status + planning state. Single hook `usePipelinePhase(issueId, agent, reviewStatus, planning)` returns `{ phase, activeSession, availableTerminals }`.
+2. **Render a tab strip** at the top of the right-hand terminal pane (not the Inspector body) listing the relevant terminals for this issue: Planning, Work, Review, Test, Merge. The currently-active tab is auto-selected; completed phases stay clickable (history); future phases are disabled-but-visible.
+3. **Manual pin** — clicking a tab while auto-follow is on pins that session and freezes auto-switching until the user clicks the "Auto" chip to release it. Pin state persists per-issue in `localStorage` (key: `pan-terminal-pin-<issueId>`).
+4. **Session name resolution** happens client-side using the issue's `project.id` to construct `specialist-<projectKey>-<role>`. The frontend already knows the project from `issue.project.id`.
+5. **Verification output** — the issue mentions quality gates (verification gate, PAN-174) may need a dedicated log stream. Current behavior: verification feedback is delivered directly into the work agent's tmux via `sendKeysAsync` (`ws-terminal.ts` + `tmux.ts`), so the work-agent tab already displays it. **For this feature we do NOT add a new log stream** — we simply keep the Work tab active during the `verifying` substate and tag the phase chip as "Verifying" so the user knows to watch there. A dedicated verification log stream is out of scope and tracked separately if needed.
+6. **Merge ready / done** — show a lightweight summary card in the terminal pane instead of a live stream when `mergeStatus === 'merged'`. Falls back to the last-active specialist terminal if the tmux session still exists.
+
+## Phase → session mapping
+
+| Phase detected | Condition | Active tmux session |
+|---|---|---|
+| `planning` | planning agent running (optional; only if we can detect it) | `planning-<issueId>` |
+| `working` | `agent.status === 'running'` and no specialist active | `<agent.id>` (work agent) |
+| `verifying` | post-completion verification gate running | `<agent.id>` (feedback goes here) |
+| `reviewing` | `reviewStatus.reviewStatus === 'reviewing'` | `specialist-<projectKey>-review-agent` |
+| `review-feedback` | review failed, `agent.status === 'running'` | `<agent.id>` |
+| `testing` | `reviewStatus.testStatus === 'testing'` | `specialist-<projectKey>-test-agent` |
+| `merging` | `reviewStatus.mergeStatus` ∈ {`queued`,`merging`,`verifying`} | `specialist-<projectKey>-merge-agent` |
+| `merged` | `reviewStatus.mergeStatus === 'merged'` | summary card (no stream) |
+
+Precedence (first match wins, top-to-bottom): `merging` → `testing` → `reviewing` → `verifying` → `working` → `planning` → `merged`.
+
+## Files to change
+
+- `src/dashboard/frontend/src/components/inspector/usePipelinePhase.ts` — **new**. Derives phase + active session from inputs. Pure function (unit-testable).
+- `src/dashboard/frontend/src/components/inspector/TerminalTabs.tsx` — **new**. Tab strip + auto/pin toggle + phase chip. Persists pin state to `localStorage`.
+- `src/dashboard/frontend/src/components/inspector/MergedSummaryCard.tsx` — **new**. Small card shown when phase is `merged`.
+- `src/dashboard/frontend/src/components/TerminalPanel.tsx` — accept optional `sessionName` + `title` props (default to `agent.id` for back-compat); replace hardcoded `<XTerminal sessionName={agent.id} />`.
+- `src/dashboard/frontend/src/components/DetailPanelLayout.tsx` — compute phase + active session via `usePipelinePhase`, render `<TerminalTabs>` above `<TerminalPanel sessionName={activeSession} …>`, gate the "merged" state on `MergedSummaryCard`.
+- `src/dashboard/frontend/src/components/InspectorPanel.tsx` — expose a small phase badge in the header (reuse the existing `reviewStatus` query, don't add a second fetch). Minimal change: one badge component.
+- `src/dashboard/frontend/src/components/inspector/usePipelinePhase.test.ts` — **new**. Unit tests covering the precedence table above.
+- `src/dashboard/frontend/src/components/inspector/TerminalTabs.test.tsx` — **new**. Render tests for auto-follow, pinning, and persistence.
+
+No backend changes. No new API routes. No new event types.
+
+## Out of scope (explicit)
+
+- Dedicated verification-output log stream (work agent tmux already receives verification feedback).
+- Planning-phase auto-switching when the planning tab is active — planning uses its own dialog/flow (`PlanDialog.tsx`) and is launched separately; the Inspector isn't the right surface for the active planning terminal and `planning-<id>` may not exist at Inspector-view time. We still *expose* the Planning tab if a `planning-<id>` session exists (cheap check), but the phase arrow never points at it automatically.
+- Server-side phase computation or a new `/api/issues/:id/phase` endpoint. All derivation is client-side from data we already fetch.
+- Historical specialist terminal replay after a specialist session is destroyed. If the tmux session is gone, the tab is disabled with a tooltip "session ended".
+- Uat-agent phase. UAT is not in the issue's phase table and its integration is still evolving; we'll add it opportunistically if the session name pattern holds, but it is not a deliverable.
+
+## Risk / watch-outs
+
+- **Project key resolution**: `specialist-<projectKey>-<role>` requires the canonical project key. Use `issue.project.id` (already on the issue object) but sanity-check against what `specialists.ts:561` actually uses (`projectKey` variable). If mismatch, fall back to fetching `/api/specialists` filtered by project and reading `tmuxSession` directly.
+- **Stale sessions**: if the review-agent tmux session has been killed after completion, `/ws/terminal?session=...` will fail to connect. `XTerminal` already has reconnect logic — we must ensure it doesn't spin forever. Add a "session ended" empty state after N failed reconnects (~3s × 2 tries) and fall back to a one-shot GET of the last buffered output via `/api/agents/:id/activity` or `/api/specialists/:name/logs` if available.
+- **Auto-switch churn**: if the phase flips rapidly (e.g., review → work → review during a feedback loop), tab auto-switching could disorient. Mitigation: debounce auto-switching by 1s; the user's pin always wins instantly.
+- **Terminal pane not visible**: today `panelMode` can be `inspector-only` (user collapsed terminal). Auto-switching a hidden terminal is a no-op — when the user re-opens the terminal, it should open to the current phase, not the last-pinned session from a previous visit. Clear pin on terminal close? No — pin is a deliberate user choice and should survive. Instead: on re-open with `panelMode === 'inspector+terminal'`, honor the pin; the phase chip at the top shows what's active vs what's pinned.
+
+## Difficulty
+
+Medium. ~7 files, 1 pure hook, 2 new components, one layout rewire. No state-machine or backend changes. Standard React patterns.
+
+## Testing strategy
+
+- Unit: `usePipelinePhase` precedence table (vitest).
+- Unit: `TerminalTabs` auto-follow + pin + localStorage persistence (vitest + @testing-library/react).
+- Manual (work agent must verify): open the Inspector for an issue that's mid-review; confirm the terminal pane switches to the review-agent tmux; pin the work-agent tab; force a phase change; confirm it stays pinned; click "Auto"; confirm it follows again.

--- a/docs/prds/active/pan-509/plan.vbrief.json
+++ b/docs/prds/active/pan-509/plan.vbrief.json
@@ -1,0 +1,247 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.5",
+    "created": "2026-04-12T22:40:35Z",
+    "author": "panopticon-cli/0.0.0",
+    "description": "Plan for PAN-509: Inspector panel should show contextually relevant terminal based on pipeline phase"
+  },
+  "plan": {
+    "id": "pan-509",
+    "title": "Inspector panel should show contextually relevant terminal based on pipeline phase",
+    "status": "approved",
+    "uid": "0d71c277-a011-423d-a773-0f82a026a90d",
+    "author": "agent:claude-opus-4-6",
+    "sequence": 1,
+    "created": "2026-04-12T22:40:35Z",
+    "updated": "2026-04-12T22:40:35Z",
+    "references": [
+      { "uri": "https://github.com/eltmon/panopticon-cli/issues/509", "label": "PAN-509", "type": "issue" }
+    ],
+    "tags": ["frontend", "inspector", "terminal", "pipeline"],
+    "narratives": {
+      "Problem": "The Inspector panel's terminal pane is hardwired to the work-agent tmux session (agent.id). When review/test/merge specialists are running, or post-completion verification is executing, the Inspector still shows an idle or stopped work agent — users have to leave the Inspector to find the currently-active terminal.",
+      "Proposal": "Add a client-side pipeline-phase derivation (usePipelinePhase hook) driven by the already-fetched reviewStatus/testStatus/mergeStatus plus agent state. Render a tab strip above the terminal pane with Planning / Work / Review / Test / Merge tabs; the tab strip auto-follows the current phase and supports a per-issue manual pin persisted to localStorage. Session names are resolved client-side using the existing specialist-<projectKey>-<role> naming convention; the existing /ws/terminal endpoint already streams any tmux session by name, so no backend changes are needed. Merged issues get a summary card instead of a live stream. Verification output reuses the work-agent terminal (verification feedback is already routed into the work-agent tmux via sendKeysAsync) — a dedicated verification log stream is explicitly out of scope."
+    },
+    "items": [
+      {
+        "id": "phase-hook",
+        "title": "Create usePipelinePhase hook with precedence-based phase derivation",
+        "status": "pending",
+        "priority": "high",
+        "created": "2026-04-12T22:40:35Z",
+        "metadata": {
+          "difficulty": "simple",
+          "issueLabel": "pan-509"
+        },
+        "narrative": {
+          "Action": "Add src/dashboard/frontend/src/components/inspector/usePipelinePhase.ts. Pure function signature: usePipelinePhase({ issueId, agent, reviewStatus, projectKey }) returns { phase, activeSession, availableTerminals }. Phase precedence (first match wins): merging → testing → reviewing → verifying → working → planning → merged. Map each phase to a tmux session name: work → agent.id; review/test/merge → specialist-<projectKey>-<role>-agent; planning → planning-<issueId>; merged → null (summary card). availableTerminals is the full list of tabs to render (regardless of which is active) with a disabled flag for phases whose session doesn't exist yet. Export a plain TypeScript function alongside the hook for unit testing without React."
+        },
+        "subItems": [
+          {
+            "id": "phase-hook.ac1",
+            "title": "usePipelinePhase returns phase='reviewing' and activeSession='specialist-<projectKey>-review-agent' when reviewStatus.reviewStatus === 'reviewing'",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "phase-hook.ac2",
+            "title": "usePipelinePhase returns phase='merging' and activeSession='specialist-<projectKey>-merge-agent' when reviewStatus.mergeStatus is one of {'queued','merging','verifying'}",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "phase-hook.ac3",
+            "title": "usePipelinePhase returns phase='working' and activeSession=agent.id when agent.status === 'running' and no specialist phase is active (including review-feedback loops where reviewStatus.reviewStatus === 'failed' and agent is running again)",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "phase-hook.ac4",
+            "title": "usePipelinePhase returns phase='merged' and activeSession=null when reviewStatus.mergeStatus === 'merged'",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "phase-hook.ac5",
+            "title": "Vitest unit test file usePipelinePhase.test.ts covers every row of the precedence table in STATE.md (Files to change § Phase → session mapping) with at least one positive and one negative case per phase; tests pass under npm test",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          }
+        ]
+      },
+      {
+        "id": "terminal-panel-session-prop",
+        "title": "Parameterize TerminalPanel / DetailPanelLayout on sessionName instead of hardcoding agent.id",
+        "status": "pending",
+        "priority": "high",
+        "created": "2026-04-12T22:40:35Z",
+        "metadata": {
+          "difficulty": "simple",
+          "issueLabel": "pan-509"
+        },
+        "narrative": {
+          "Action": "Update src/dashboard/frontend/src/components/TerminalPanel.tsx to accept an optional sessionName?: string and title?: string prop, falling back to agent.id and the current title when unset (back-compat for any other callers). Pass the value through to <XTerminal sessionName={...}/>. Update DetailPanelLayout.tsx to compute activeSession via usePipelinePhase and pass it to <TerminalPanel sessionName={activeSession} …/>. Keep the key tied to the session so the XTerminal remounts cleanly on switch."
+        },
+        "subItems": [
+          {
+            "id": "terminal-panel-session-prop.ac1",
+            "title": "TerminalPanel accepts optional sessionName prop; when omitted, still renders with agent.id (existing callers are unaffected)",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "terminal-panel-session-prop.ac2",
+            "title": "DetailPanelLayout uses usePipelinePhase to derive activeSession and passes it to TerminalPanel; the XTerminal websocket connects to /ws/terminal?session=<activeSession> (verifiable via network inspector or a jsdom WebSocket mock in the existing XTerminal.test.tsx harness)",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "terminal-panel-session-prop.ac3",
+            "title": "Switching phase (e.g., work → review) causes the XTerminal component to remount with the new sessionName (React key includes sessionName); no stale data from the previous session leaks into the new terminal",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          }
+        ]
+      },
+      {
+        "id": "terminal-tabs",
+        "title": "Render TerminalTabs strip with auto-follow + manual pin",
+        "status": "pending",
+        "priority": "high",
+        "created": "2026-04-12T22:40:35Z",
+        "metadata": {
+          "difficulty": "medium",
+          "issueLabel": "pan-509"
+        },
+        "narrative": {
+          "Action": "Add src/dashboard/frontend/src/components/inspector/TerminalTabs.tsx. Renders a horizontal tab strip above TerminalPanel showing the five phase tabs (Planning, Work, Review, Test, Merge). The tab matching the current phase gets a pulsing dot indicator. Clicking any tab pins it (overrides auto-follow); pinned state is persisted to localStorage as pan-terminal-pin-<issueId> with value { sessionName, phase }. An 'Auto' chip next to the tabs shows pin status and releases the pin when clicked. Debounce auto-switching by 1s to avoid churn during rapid phase flips. Disabled tabs (session doesn't exist) are visible but not clickable, with tooltip 'session not running'. Mount this in DetailPanelLayout directly above <TerminalPanel>."
+        },
+        "subItems": [
+          {
+            "id": "terminal-tabs.ac1",
+            "title": "Tab strip auto-switches to the active phase tab when the derived phase changes (e.g., work → reviewing), after a 1s debounce",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "terminal-tabs.ac2",
+            "title": "Clicking a tab pins that terminal; subsequent phase changes do NOT switch the active session until the 'Auto' chip is clicked to release the pin",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "terminal-tabs.ac3",
+            "title": "Pin state survives page reload (persisted to localStorage under key pan-terminal-pin-<issueId>)",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "terminal-tabs.ac4",
+            "title": "Disabled tabs (for phases whose tmux session does not exist) are rendered but not clickable, with a tooltip explaining why; enabling happens automatically when the session comes up without a page reload",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "terminal-tabs.ac5",
+            "title": "Render tests (TerminalTabs.test.tsx) cover: auto-follow, pinning via click, unpinning via 'Auto' chip, localStorage persistence (mocked), and disabled tab behavior; all pass under npm test",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          }
+        ]
+      },
+      {
+        "id": "phase-badge-inspector",
+        "title": "Add phase badge to Inspector header",
+        "status": "pending",
+        "priority": "medium",
+        "created": "2026-04-12T22:40:35Z",
+        "metadata": {
+          "difficulty": "simple",
+          "issueLabel": "pan-509"
+        },
+        "narrative": {
+          "Action": "In src/dashboard/frontend/src/components/InspectorPanel.tsx, add a small badge next to the issueId in the header showing the current phase label (Planning / Working / Verifying / Reviewing / Testing / Merging / Merged). Reuse the existing reviewStatus query already on the component — do NOT add a second network fetch. Drive the label from the same usePipelinePhase hook so the Inspector header and the tab strip stay in sync."
+        },
+        "subItems": [
+          {
+            "id": "phase-badge-inspector.ac1",
+            "title": "Inspector header shows a phase badge whose label matches the currently active tab in TerminalTabs at all times (shared source of truth: usePipelinePhase)",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "phase-badge-inspector.ac2",
+            "title": "The phase badge does NOT add a new network request — it reuses the already-fetched reviewStatus query (confirmed by no new useQuery in the component diff)",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          }
+        ]
+      },
+      {
+        "id": "merged-summary-card",
+        "title": "Show summary card instead of live terminal for merged issues",
+        "status": "pending",
+        "priority": "medium",
+        "created": "2026-04-12T22:40:35Z",
+        "metadata": {
+          "difficulty": "simple",
+          "issueLabel": "pan-509"
+        },
+        "narrative": {
+          "Action": "Add src/dashboard/frontend/src/components/inspector/MergedSummaryCard.tsx. When usePipelinePhase returns phase='merged', DetailPanelLayout renders this card in place of the XTerminal. Card content: merge timestamp (from reviewStatus.updatedAt), link to the PR, total cost (already available via the costData query in InspectorPanel), and a 'View last specialist log' affordance that switches to the most recent specialist tab if its session still exists."
+        },
+        "subItems": [
+          {
+            "id": "merged-summary-card.ac1",
+            "title": "When reviewStatus.mergeStatus === 'merged', the terminal pane renders MergedSummaryCard instead of XTerminal (verifiable by rendering the issue in the test harness with a mocked 'merged' reviewStatus)",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "merged-summary-card.ac2",
+            "title": "Summary card displays merge timestamp, PR link (if available), and total cost; the 'View last specialist log' button switches to the most recent specialist tab when clicked and its session still exists",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          }
+        ]
+      },
+      {
+        "id": "stale-session-fallback",
+        "title": "Handle stale / ended specialist sessions gracefully",
+        "status": "pending",
+        "priority": "medium",
+        "created": "2026-04-12T22:40:35Z",
+        "metadata": {
+          "difficulty": "medium",
+          "issueLabel": "pan-509"
+        },
+        "narrative": {
+          "Action": "When the tab strip's active session websocket fails to connect after 2 reconnect attempts (~3s), show an inline 'Session ended' empty state in the terminal pane with a button to 'Show last output' that fetches the most recent buffered output from the existing agent activity endpoint (or falls back to nothing if unavailable). Do NOT modify XTerminal's reconnect loop itself — wrap it in a small status-aware container component. The tab stays visible but gets a 'dimmed' style to indicate the session is gone."
+        },
+        "subItems": [
+          {
+            "id": "stale-session-fallback.ac1",
+            "title": "When the active tmux session does not exist (websocket connect fails twice), the terminal pane shows a 'Session ended' empty state instead of an infinite reconnection spinner",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "stale-session-fallback.ac2",
+            "title": "Auto-switching skips over phases whose session is dead — e.g., if review passed and the review-agent tmux was killed, phase=reviewing will NOT be auto-selected",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          }
+        ]
+      }
+    ],
+    "edges": [
+      { "from": "phase-hook", "to": "terminal-panel-session-prop", "type": "blocks" },
+      { "from": "phase-hook", "to": "terminal-tabs", "type": "blocks" },
+      { "from": "phase-hook", "to": "phase-badge-inspector", "type": "blocks" },
+      { "from": "phase-hook", "to": "merged-summary-card", "type": "blocks" },
+      { "from": "terminal-panel-session-prop", "to": "terminal-tabs", "type": "blocks" },
+      { "from": "terminal-tabs", "to": "stale-session-fallback", "type": "informs" },
+      { "from": "terminal-panel-session-prop", "to": "merged-summary-card", "type": "blocks" }
+    ]
+  }
+}

--- a/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
+++ b/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
@@ -119,10 +119,17 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
         // Un-pinning: clear pin from localStorage
         savePinState(issueId, null);
         setPinnedSession(null);
+      } else if (activeSession) {
+        // Engaging pin: capture the currently-displayed session and persist it
+        setPinnedSession(activeSession);
+        savePinState(issueId, activeSession);
+      } else {
+        // No active session to pin — no-op, stay in auto-follow mode
+        return prev;
       }
       return next;
     });
-  }, [issueId]);
+  }, [issueId, activeSession]);
 
 
   // Reset panel state when issue changes

--- a/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
+++ b/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
@@ -5,7 +5,7 @@ import { Panel, Group, Separator } from 'react-resizable-panels';
 import { useQuery } from '@tanstack/react-query';
 import { InspectorPanel } from './InspectorPanel';
 import { TerminalPanel } from './TerminalPanel';
-import { TerminalTabs, savePinState, loadPersistedPin } from './inspector/TerminalTabs';
+import { TerminalTabs, savePinState, loadPinState } from './inspector/TerminalTabs';
 import { MergedSummaryCard } from './inspector/MergedSummaryCard';
 import { usePipelinePhase } from './inspector/usePipelinePhase';
 import { Agent, Issue } from '../types';
@@ -100,9 +100,9 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
 
   // Pinned session state: null = auto-follow, string = pinned to that session
   const [pinnedSession, setPinnedSession] = useState<string | null>(() =>
-    loadPersistedPin(issueId),
+    loadPinState(issueId),
   );
-  const [pinned, setPinned] = useState(() => loadPersistedPin(issueId) !== null);
+  const [pinned, setPinned] = useState(() => loadPinState(issueId) !== null);
 
   // The currently displayed session: pinned overrides auto
   const selectedSession = pinned ? pinnedSession : activeSession;
@@ -246,7 +246,6 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
             <div className="flex flex-col" style={{ width: '100%', height: '100%', overflow: 'hidden' }}>
               {availableTerminals.length > 0 && (
                 <TerminalTabs
-                  issueId={issueId}
                   tabs={availableTerminals}
                   selectedSession={selectedSession}
                   activePhase={phase}

--- a/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
+++ b/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
@@ -237,7 +237,7 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
                   selectedSession={selectedSession}
                   activePhase={phase}
                   pinned={pinned}
-                  onSelectSession={handleTabSelect}
+                  onSelectSession={handleSelectSession}
                   onTogglePin={handleTogglePin}
                 />
               )}

--- a/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
+++ b/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
@@ -130,6 +130,13 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
     setPanelState(loadPanelState(issueId));
   }, [issueId]);
 
+  // Reset pin state when issue changes
+  useEffect(() => {
+    const saved = loadPinState(issueId);
+    setPinnedSession(saved);
+    setPinned(saved !== null);
+  }, [issueId]);
+
   const openTerminal = useCallback(() => {
     setPanelState(prev => {
       const newState: PanelState = { ...prev, panelMode: 'inspector+terminal' };

--- a/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
+++ b/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
@@ -124,11 +124,6 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
     });
   }, [issueId]);
 
-  // When a new tab is clicked in TerminalTabs, engage pin
-  const handleTabSelect = useCallback((sessionName: string | null) => {
-    handleSelectSession(sessionName);
-    if (!pinned) setPinned(true);
-  }, [handleSelectSession, pinned]);
 
   // Reset panel state when issue changes
   useEffect(() => {
@@ -255,7 +250,8 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
                 />
               )}
               <div className="flex-1 min-h-0">
-                {phase === 'merged' ? (
+                {/* Show merged summary unless the user has pinned a specific session to view */}
+                {phase === 'merged' && !(pinned && pinnedSession) ? (
                   <MergedSummaryCard
                     mergedAt={reviewStatus?.updatedAt ?? new Date().toISOString()}
                     prUrl={workspaceData?.mrUrl ?? null}
@@ -264,7 +260,10 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
                       availableTerminals.some(t => t.id === 'merging' && !t.disabled)
                         ? () => {
                             const mergeTab = availableTerminals.find(t => t.id === 'merging');
-                            if (mergeTab?.sessionName) handleTabSelect(mergeTab.sessionName);
+                            if (mergeTab?.sessionName) {
+                              handleSelectSession(mergeTab.sessionName);
+                              setPinned(true);
+                            }
                           }
                         : null
                     }

--- a/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
+++ b/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
@@ -79,7 +79,7 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
   });
 
   const projectKey = issue?.project?.id;
-  const { phase, availableTerminals, markSessionDead } = usePipelinePhase({
+  const { phase, activeSession, availableTerminals, markSessionDead } = usePipelinePhase({
     issueId,
     agent,
     reviewStatus,
@@ -105,8 +105,7 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
   const [pinned, setPinned] = useState(() => loadPersistedPin(issueId) !== null);
 
   // The currently displayed session: pinned overrides auto
-  const activePhaseSession = availableTerminals.find(t => t.isActive && !t.disabled)?.sessionName ?? null;
-  const selectedSession = pinned ? pinnedSession : activePhaseSession;
+  const selectedSession = pinned ? pinnedSession : activeSession;
 
   const handleSelectSession = useCallback((sessionName: string | null) => {
     setPinnedSession(sessionName);

--- a/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
+++ b/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
@@ -78,6 +78,14 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
     staleTime: 60000,
   });
 
+  const projectKey = issue?.project?.id;
+  const { phase, availableTerminals, markSessionDead } = usePipelinePhase({
+    issueId,
+    agent,
+    reviewStatus,
+    projectKey,
+  });
+
   // Shares cache key with InspectorPanel's workspace query — no extra network request
   const { data: workspaceData } = useQuery<WorkspaceInfo>({
     queryKey: ['workspace', issueId],
@@ -88,14 +96,6 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
     },
     enabled: phase === 'merged',
     staleTime: 30000,
-  });
-
-  const projectKey = issue?.project?.id;
-  const { phase, availableTerminals, markSessionDead } = usePipelinePhase({
-    issueId,
-    agent,
-    reviewStatus,
-    projectKey,
   });
 
   // Pinned session state: null = auto-follow, string = pinned to that session

--- a/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
+++ b/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
@@ -9,7 +9,7 @@ import { TerminalTabs, savePinState, loadPersistedPin } from './inspector/Termin
 import { MergedSummaryCard } from './inspector/MergedSummaryCard';
 import { usePipelinePhase } from './inspector/usePipelinePhase';
 import { Agent, Issue } from '../types';
-import type { ReviewStatus } from './inspector/types';
+import type { ReviewStatus, WorkspaceInfo } from './inspector/types';
 
 type PanelMode = 'closed' | 'inspector-only' | 'inspector+terminal';
 
@@ -76,6 +76,18 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
     },
     enabled: reviewStatus?.mergeStatus === 'merged',
     staleTime: 60000,
+  });
+
+  // Shares cache key with InspectorPanel's workspace query — no extra network request
+  const { data: workspaceData } = useQuery<WorkspaceInfo>({
+    queryKey: ['workspace', issueId],
+    queryFn: async () => {
+      const res = await fetch(`/api/workspaces/${issueId}`);
+      if (!res.ok) throw new Error('Failed to fetch workspace info');
+      return res.json();
+    },
+    enabled: phase === 'merged',
+    staleTime: 30000,
   });
 
   const projectKey = issue?.project?.id;
@@ -213,6 +225,7 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
                 issueId={issueId}
                 issueUrl={issueUrl}
                 issue={issue}
+                phase={phase}
                 onClose={onClose}
                 onOpenTerminal={openTerminal}
               />
@@ -245,7 +258,7 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
                 {phase === 'merged' ? (
                   <MergedSummaryCard
                     mergedAt={reviewStatus?.updatedAt ?? new Date().toISOString()}
-                    prUrl={null}
+                    prUrl={workspaceData?.mrUrl ?? null}
                     totalCost={costData?.totalCost}
                     onViewLastLog={
                       availableTerminals.some(t => t.id === 'merging' && !t.disabled)
@@ -280,6 +293,7 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
             issueId={issueId}
             issueUrl={issueUrl}
             issue={issue}
+            phase={phase}
             onClose={onClose}
             onOpenTerminal={agent ? openTerminal : undefined}
           />

--- a/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
+++ b/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
@@ -56,8 +56,8 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
   const [panelState, setPanelState] = useState<PanelState>(() => loadPanelState(issueId));
   const [isResizing, setIsResizing] = useState(false);
 
-  // Fetch review status here so both InspectorPanel badge and TerminalTabs use the same data
-  const { data: reviewStatus } = useQuery<ReviewStatus>({
+  // Fetch review status here — single owner; passed as prop to InspectorPanel to avoid duplicate queries
+  const { data: reviewStatus, isLoading: reviewStatusLoading } = useQuery<ReviewStatus>({
     queryKey: ['review-status', issueId],
     queryFn: async () => {
       const res = await fetch(`/api/workspaces/${issueId}/review-status`);
@@ -225,6 +225,8 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
                 issueUrl={issueUrl}
                 issue={issue}
                 phase={phase}
+                reviewStatus={reviewStatus}
+                reviewStatusLoading={reviewStatusLoading}
                 onClose={onClose}
                 onOpenTerminal={openTerminal}
               />
@@ -293,6 +295,8 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
             issueUrl={issueUrl}
             issue={issue}
             phase={phase}
+            reviewStatus={reviewStatus}
+            reviewStatusLoading={reviewStatusLoading}
             onClose={onClose}
             onOpenTerminal={agent ? openTerminal : undefined}
           />

--- a/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
+++ b/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
@@ -2,9 +2,14 @@ import { useState, useEffect, useCallback } from 'react';
 // react-resizable-panels v4 exports: Group, Panel, Separator (NOT PanelGroup/PanelResizeHandle)
 // v4 props: orientation (NOT direction), onLayoutChanged (NOT onLayout)
 import { Panel, Group, Separator } from 'react-resizable-panels';
+import { useQuery } from '@tanstack/react-query';
 import { InspectorPanel } from './InspectorPanel';
 import { TerminalPanel } from './TerminalPanel';
+import { TerminalTabs, savePinState, loadPersistedPin } from './inspector/TerminalTabs';
+import { MergedSummaryCard } from './inspector/MergedSummaryCard';
+import { usePipelinePhase } from './inspector/usePipelinePhase';
 import { Agent, Issue } from '../types';
+import type { ReviewStatus } from './inspector/types';
 
 type PanelMode = 'closed' | 'inspector-only' | 'inspector+terminal';
 
@@ -50,6 +55,69 @@ export interface DetailPanelLayoutProps {
 export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, suppressTerminal }: DetailPanelLayoutProps) {
   const [panelState, setPanelState] = useState<PanelState>(() => loadPanelState(issueId));
   const [isResizing, setIsResizing] = useState(false);
+
+  // Fetch review status here so both InspectorPanel badge and TerminalTabs use the same data
+  const { data: reviewStatus } = useQuery<ReviewStatus>({
+    queryKey: ['review-status', issueId],
+    queryFn: async () => {
+      const res = await fetch(`/api/workspaces/${issueId}/review-status`);
+      if (!res.ok) throw new Error('Failed to fetch review status');
+      return res.json();
+    },
+    refetchInterval: 15000,
+  });
+
+  const { data: costData } = useQuery<{ totalCost?: number }>({
+    queryKey: ['issueCosts', issueId],
+    queryFn: async () => {
+      const res = await fetch(`/api/issues/${issueId}/costs`);
+      if (!res.ok) return {};
+      return res.json();
+    },
+    enabled: reviewStatus?.mergeStatus === 'merged',
+    staleTime: 60000,
+  });
+
+  const projectKey = issue?.project?.id;
+  const { phase, availableTerminals, markSessionDead } = usePipelinePhase({
+    issueId,
+    agent,
+    reviewStatus,
+    projectKey,
+  });
+
+  // Pinned session state: null = auto-follow, string = pinned to that session
+  const [pinnedSession, setPinnedSession] = useState<string | null>(() =>
+    loadPersistedPin(issueId),
+  );
+  const [pinned, setPinned] = useState(() => loadPersistedPin(issueId) !== null);
+
+  // The currently displayed session: pinned overrides auto
+  const activePhaseSession = availableTerminals.find(t => t.isActive && !t.disabled)?.sessionName ?? null;
+  const selectedSession = pinned ? pinnedSession : activePhaseSession;
+
+  const handleSelectSession = useCallback((sessionName: string | null) => {
+    setPinnedSession(sessionName);
+    savePinState(issueId, sessionName);
+  }, [issueId]);
+
+  const handleTogglePin = useCallback(() => {
+    setPinned(prev => {
+      const next = !prev;
+      if (!next) {
+        // Un-pinning: clear pin from localStorage
+        savePinState(issueId, null);
+        setPinnedSession(null);
+      }
+      return next;
+    });
+  }, [issueId]);
+
+  // When a new tab is clicked in TerminalTabs, engage pin
+  const handleTabSelect = useCallback((sessionName: string | null) => {
+    handleSelectSession(sessionName);
+    if (!pinned) setPinned(true);
+  }, [handleSelectSession, pinned]);
 
   // Reset panel state when issue changes
   useEffect(() => {
@@ -161,8 +229,46 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
           />
 
           <Panel id="terminal" minSize="30%">
-            <div style={{ width: '100%', height: '100%', overflow: 'hidden' }}>
-              <TerminalPanel key={agent.id} agent={agent} onClose={closeTerminal} />
+            <div className="flex flex-col" style={{ width: '100%', height: '100%', overflow: 'hidden' }}>
+              {availableTerminals.length > 0 && (
+                <TerminalTabs
+                  issueId={issueId}
+                  tabs={availableTerminals}
+                  selectedSession={selectedSession}
+                  activePhase={phase}
+                  pinned={pinned}
+                  onSelectSession={handleTabSelect}
+                  onTogglePin={handleTogglePin}
+                />
+              )}
+              <div className="flex-1 min-h-0">
+                {phase === 'merged' ? (
+                  <MergedSummaryCard
+                    mergedAt={reviewStatus?.updatedAt ?? new Date().toISOString()}
+                    prUrl={null}
+                    totalCost={costData?.totalCost}
+                    onViewLastLog={
+                      availableTerminals.some(t => t.id === 'merging' && !t.disabled)
+                        ? () => {
+                            const mergeTab = availableTerminals.find(t => t.id === 'merging');
+                            if (mergeTab?.sessionName) handleTabSelect(mergeTab.sessionName);
+                          }
+                        : null
+                    }
+                  />
+                ) : selectedSession ? (
+                  <TerminalPanel
+                    key={selectedSession}
+                    agent={agent}
+                    onClose={closeTerminal}
+                    sessionName={selectedSession}
+                    title={selectedSession}
+                    onSessionEnded={markSessionDead}
+                  />
+                ) : (
+                  <TerminalPanel key={agent.id} agent={agent} onClose={closeTerminal} />
+                )}
+              </div>
             </div>
           </Panel>
         </Group>

--- a/src/dashboard/frontend/src/components/InspectorPanel.tsx
+++ b/src/dashboard/frontend/src/components/InspectorPanel.tsx
@@ -113,11 +113,15 @@ export interface InspectorPanelProps {
   issue?: Issue;
   /** Current pipeline phase — passed from parent (DetailPanelLayout) via usePipelinePhase */
   phase?: PipelinePhase | string;
+  /** Review status — hoisted to DetailPanelLayout to avoid duplicate queries */
+  reviewStatus?: ReviewStatus;
+  /** Loading state for reviewStatus */
+  reviewStatusLoading?: boolean;
   onClose: () => void;
   onOpenTerminal?: () => void;
 }
 
-export function InspectorPanel({ agent, issueId, issueUrl, issue, phase, onClose, onOpenTerminal }: InspectorPanelProps) {
+export function InspectorPanel({ agent, issueId, issueUrl, issue, phase, reviewStatus: reviewStatusProp, reviewStatusLoading: reviewStatusLoadingProp, onClose, onOpenTerminal }: InspectorPanelProps) {
   const queryClient = useQueryClient();
   const confirm = useConfirm();
   const [copied, setCopied] = useState(false);
@@ -172,15 +176,10 @@ export function InspectorPanel({ agent, issueId, issueUrl, issue, phase, onClose
     refetchInterval: (workspaceCreating || containersStarting) ? 5000 : 30000,
   });
 
-  const { data: reviewStatus, isLoading: reviewStatusLoading } = useQuery<ReviewStatus>({
-    queryKey: ['review-status', issueId],
-    queryFn: async () => {
-      const res = await fetch(`/api/review/${issueId}/status`);
-      if (!res.ok) throw new Error('Failed to fetch review status');
-      return res.json();
-    },
-    refetchInterval: 30000,
-  });
+  // reviewStatus and reviewStatusLoading are hoisted to DetailPanelLayout to avoid
+  // duplicate queries — they share react-query cache key ['review-status', issueId]
+  const reviewStatus = reviewStatusProp;
+  const reviewStatusLoading = reviewStatusLoadingProp ?? false;
 
   const { data: prdContent } = useQuery({
     queryKey: ['prd', issueId],

--- a/src/dashboard/frontend/src/components/InspectorPanel.tsx
+++ b/src/dashboard/frontend/src/components/InspectorPanel.tsx
@@ -33,6 +33,7 @@ import { refreshDashboardState } from '../lib/refresh-dashboard-state';
 import { AgentInfoSection } from './inspector/AgentInfoSection';
 import { ContainerSection } from './inspector/ContainerSection';
 import { ActionsSection } from './inspector/ActionsSection';
+import { PHASE_CHIP_COLORS, PHASE_LABELS, type PipelinePhase } from './inspector/TerminalTabs';
 
 interface SessionCost {
   id: string;
@@ -110,39 +111,13 @@ export interface InspectorPanelProps {
   issueId: string;
   issueUrl?: string;
   issue?: Issue;
+  /** Current pipeline phase — passed from parent (DetailPanelLayout) via usePipelinePhase */
+  phase?: PipelinePhase | string;
   onClose: () => void;
   onOpenTerminal?: () => void;
 }
 
-/** Derive the current pipeline phase label from already-fetched data — no new network requests. */
-export function derivePhaseLabel(
-  agent: Agent | undefined,
-  reviewStatus: ReviewStatus | undefined,
-): string {
-  if (!reviewStatus && !agent) return '';
-  const ms = reviewStatus?.mergeStatus;
-  if (ms === 'queued' || ms === 'merging' || ms === 'verifying') return 'Merging';
-  if (ms === 'merged') return 'Merged';
-  if (reviewStatus?.testStatus === 'testing') return 'Testing';
-  if (reviewStatus?.reviewStatus === 'reviewing') return 'Reviewing';
-  if (
-    reviewStatus?.reviewStatus === 'failed' &&
-    (agent?.status === 'healthy' || agent?.status === 'starting')
-  ) return 'Review Feedback';
-  if (agent?.status === 'healthy' || agent?.status === 'starting') return 'Working';
-  return '';
-}
-
-const PHASE_BADGE_COLORS: Record<string, { bg: string; text: string }> = {
-  'Merging':         { bg: '#2d2014', text: '#fb923c' },
-  'Merged':          { bg: '#1a3a2d', text: '#34d399' },
-  'Testing':         { bg: '#1a2d3a', text: '#38bdf8' },
-  'Reviewing':       { bg: '#2d1a3a', text: '#c084fc' },
-  'Review Feedback': { bg: '#3a1a1a', text: '#f87171' },
-  'Working':         { bg: '#1a3a1a', text: '#4ade80' },
-};
-
-export function InspectorPanel({ agent, issueId, issueUrl, issue, onClose, onOpenTerminal }: InspectorPanelProps) {
+export function InspectorPanel({ agent, issueId, issueUrl, issue, phase, onClose, onOpenTerminal }: InspectorPanelProps) {
   const queryClient = useQueryClient();
   const confirm = useConfirm();
   const [copied, setCopied] = useState(false);
@@ -648,16 +623,14 @@ export function InspectorPanel({ agent, issueId, issueUrl, issue, onClose, onOpe
               <span className="w-1.5 h-1.5 rounded-full bg-content-muted shrink-0" />
             )}
             <span className="font-mono text-sm font-semibold text-content truncate">{issueId.toUpperCase()}</span>
-            {(() => {
-              const phaseLabel = derivePhaseLabel(agent, reviewStatus);
-              if (!phaseLabel) return null;
-              const colors = PHASE_BADGE_COLORS[phaseLabel] ?? { bg: '#1e2d47', text: '#92a4c9' };
+            {phase && PHASE_LABELS[phase] && (() => {
+              const colors = PHASE_CHIP_COLORS[phase] ?? { bg: '#1e2d47', text: '#92a4c9' };
               return (
                 <span
                   className="text-[10px] font-semibold px-1.5 py-0.5 rounded shrink-0"
                   style={{ backgroundColor: colors.bg, color: colors.text }}
                 >
-                  {phaseLabel}
+                  {PHASE_LABELS[phase]}
                 </span>
               );
             })()}

--- a/src/dashboard/frontend/src/components/InspectorPanel.tsx
+++ b/src/dashboard/frontend/src/components/InspectorPanel.tsx
@@ -114,6 +114,34 @@ export interface InspectorPanelProps {
   onOpenTerminal?: () => void;
 }
 
+/** Derive the current pipeline phase label from already-fetched data — no new network requests. */
+export function derivePhaseLabel(
+  agent: Agent | undefined,
+  reviewStatus: ReviewStatus | undefined,
+): string {
+  if (!reviewStatus && !agent) return '';
+  const ms = reviewStatus?.mergeStatus;
+  if (ms === 'queued' || ms === 'merging' || ms === 'verifying') return 'Merging';
+  if (ms === 'merged') return 'Merged';
+  if (reviewStatus?.testStatus === 'testing') return 'Testing';
+  if (reviewStatus?.reviewStatus === 'reviewing') return 'Reviewing';
+  if (
+    reviewStatus?.reviewStatus === 'failed' &&
+    (agent?.status === 'healthy' || agent?.status === 'starting')
+  ) return 'Review Feedback';
+  if (agent?.status === 'healthy' || agent?.status === 'starting') return 'Working';
+  return '';
+}
+
+const PHASE_BADGE_COLORS: Record<string, { bg: string; text: string }> = {
+  'Merging':         { bg: '#2d2014', text: '#fb923c' },
+  'Merged':          { bg: '#1a3a2d', text: '#34d399' },
+  'Testing':         { bg: '#1a2d3a', text: '#38bdf8' },
+  'Reviewing':       { bg: '#2d1a3a', text: '#c084fc' },
+  'Review Feedback': { bg: '#3a1a1a', text: '#f87171' },
+  'Working':         { bg: '#1a3a1a', text: '#4ade80' },
+};
+
 export function InspectorPanel({ agent, issueId, issueUrl, issue, onClose, onOpenTerminal }: InspectorPanelProps) {
   const queryClient = useQueryClient();
   const confirm = useConfirm();
@@ -620,6 +648,19 @@ export function InspectorPanel({ agent, issueId, issueUrl, issue, onClose, onOpe
               <span className="w-1.5 h-1.5 rounded-full bg-content-muted shrink-0" />
             )}
             <span className="font-mono text-sm font-semibold text-content truncate">{issueId.toUpperCase()}</span>
+            {(() => {
+              const phaseLabel = derivePhaseLabel(agent, reviewStatus);
+              if (!phaseLabel) return null;
+              const colors = PHASE_BADGE_COLORS[phaseLabel] ?? { bg: '#1e2d47', text: '#92a4c9' };
+              return (
+                <span
+                  className="text-[10px] font-semibold px-1.5 py-0.5 rounded shrink-0"
+                  style={{ backgroundColor: colors.bg, color: colors.text }}
+                >
+                  {phaseLabel}
+                </span>
+              );
+            })()}
           </div>
           <div className="flex items-center gap-1 shrink-0">
             {onOpenTerminal && agent && (

--- a/src/dashboard/frontend/src/components/TerminalPanel.tsx
+++ b/src/dashboard/frontend/src/components/TerminalPanel.tsx
@@ -11,6 +11,12 @@ import { deriveAgentIssueId } from './AgentOutputPanel';
 interface TerminalPanelProps {
   agent: Agent;
   onClose: () => void;
+  /** Override the tmux session to stream. Defaults to agent.id for back-compat. */
+  sessionName?: string;
+  /** Override the header title. Defaults to agent.id. */
+  title?: string;
+  /** Called when XTerminal exhausts reconnect attempts for this session. */
+  onSessionEnded?: (sessionName: string) => void;
 }
 
 function popoutTerminal(sessionName: string, title: string): void {
@@ -38,7 +44,9 @@ async function fetchConversation(agentId: string): Promise<ConversationResponse>
   return res.json();
 }
 
-export function TerminalPanel({ agent, onClose }: TerminalPanelProps) {
+export function TerminalPanel({ agent, onClose, sessionName: sessionNameProp, title: titleProp, onSessionEnded }: TerminalPanelProps) {
+  const activeSession = sessionNameProp ?? agent.id;
+  const displayTitle = titleProp ?? agent.id;
   const terminalRef = useRef<HTMLPreElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const [autoScroll, setAutoScroll] = useState(true);
@@ -147,7 +155,7 @@ export function TerminalPanel({ agent, onClose }: TerminalPanelProps) {
         style={{ borderColor, backgroundColor: '#161b26' }}
       >
         <span className="text-xs font-medium" style={{ color: textSecondary }}>
-          {isStopped ? (hasConversation ? 'Conversation' : 'Last output') : agent.id}
+          {isStopped ? (hasConversation ? 'Conversation' : 'Last output') : displayTitle}
         </span>
         <div className="flex items-center gap-1">
           {isStopped && (
@@ -162,7 +170,7 @@ export function TerminalPanel({ agent, onClose }: TerminalPanelProps) {
           )}
           {!isStopped && (
             <button
-              onClick={() => popoutTerminal(agent.id, `agent-${agent.issueId ?? agent.id} · ${agent.issueId ?? agent.id}`)}
+              onClick={() => popoutTerminal(activeSession, displayTitle)}
               className="p-1 rounded transition-colors hover:bg-white/10"
               style={{ color: textSecondary }}
               title="Pop out terminal"
@@ -204,7 +212,10 @@ export function TerminalPanel({ agent, onClose }: TerminalPanelProps) {
         )
       ) : (
         <div className="flex-1 min-h-0">
-          <XTerminal sessionName={agent.id} />
+          <XTerminal
+            sessionName={activeSession}
+            onDisconnect={onSessionEnded ? () => onSessionEnded(activeSession) : undefined}
+          />
         </div>
       )}
     </div>

--- a/src/dashboard/frontend/src/components/TerminalPanel.tsx
+++ b/src/dashboard/frontend/src/components/TerminalPanel.tsx
@@ -55,6 +55,12 @@ export function TerminalPanel({ agent, onClose, sessionName: sessionNameProp, ti
   const isPlanningAgent = agent.agentPhase === 'planning' || agent.id.startsWith('planning-');
   const planningIssueId = isPlanningAgent ? deriveAgentIssueId(agent.id, agent.issueId) : null;
 
+  // Only probe the work agent's session liveness when we're actually viewing it.
+  // Specialist sessions (sessionNameProp !== agent.id) stream their own tmux sessions
+  // independently — keying isStopped off agent.id when a specialist tab is selected would
+  // cause the work agent's fallback content to render in place of the specialist stream.
+  const isViewingWorkAgent = !sessionNameProp || sessionNameProp === agent.id;
+
   // Check if agent's tmux session is alive via a lightweight probe.
   // The store status can be stale after server restarts, so verify with the server.
   // Default to showing XTerminal (optimistic) — switch to raw log only if probe confirms dead.
@@ -67,10 +73,12 @@ export function TerminalPanel({ agent, onClose, sessionName: sessionNameProp, ti
       return data.alive === true;
     },
     refetchInterval: 10000,
+    enabled: isViewingWorkAgent,
   });
 
-  // Optimistic: show XTerminal until probe confirms dead (tmuxAlive === false, not undefined)
-  const isStopped = tmuxAlive === false;
+  // Optimistic: show XTerminal until probe confirms dead (tmuxAlive === false, not undefined).
+  // Never true for specialist tabs — they manage their own session lifecycle via onSessionEnded.
+  const isStopped = isViewingWorkAgent && tmuxAlive === false;
 
   // Only fetch for stopped agents — running agents use XTerminal WebSocket
   const { data: output, refetch: refetchOutput } = useQuery({

--- a/src/dashboard/frontend/src/components/TerminalPanel.tsx
+++ b/src/dashboard/frontend/src/components/TerminalPanel.tsx
@@ -2,11 +2,11 @@ import { useRef, useEffect, useCallback, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { X, RefreshCw, ExternalLink } from 'lucide-react';
 import { Agent } from '../types';
-import { XTerminal } from './XTerminal';
 import { MessagesTimeline } from './chat/MessagesTimeline';
 import type { ConversationResponse } from '@panopticon/contracts';
 import { ActivityView } from './MissionControl/ActivityView';
 import { deriveAgentIssueId } from './AgentOutputPanel';
+import { TerminalSessionWrapper } from './inspector/TerminalSessionWrapper';
 
 interface TerminalPanelProps {
   agent: Agent;
@@ -200,21 +200,21 @@ export function TerminalPanel({ agent, onClose, sessionName: sessionNameProp, ti
             />
           </div>
         ) : (
-        <pre
-          ref={terminalRef}
-          onScroll={handleScroll}
-          className="flex-1 min-h-0 overflow-auto p-3 font-mono text-xs leading-relaxed m-0 whitespace-pre text-content"
-          style={{ backgroundColor: bgTerminal }}
-        >
-          {output || 'No saved output available.'}
-          <div ref={bottomRef} />
-        </pre>
+          <pre
+            ref={terminalRef}
+            onScroll={handleScroll}
+            className="flex-1 min-h-0 overflow-auto p-3 font-mono text-xs leading-relaxed m-0 whitespace-pre text-content"
+            style={{ backgroundColor: bgTerminal }}
+          >
+            {output || 'No saved output available.'}
+            <div ref={bottomRef} />
+          </pre>
         )
       ) : (
         <div className="flex-1 min-h-0">
-          <XTerminal
+          <TerminalSessionWrapper
             sessionName={activeSession}
-            onDisconnect={onSessionEnded ? () => onSessionEnded(activeSession) : undefined}
+            onSessionEnded={onSessionEnded ? () => onSessionEnded(activeSession) : undefined}
           />
         </div>
       )}

--- a/src/dashboard/frontend/src/components/__tests__/DetailPanelLayout.test.tsx
+++ b/src/dashboard/frontend/src/components/__tests__/DetailPanelLayout.test.tsx
@@ -8,6 +8,9 @@ import type { PipelinePhaseResult } from '../inspector/usePipelinePhase';
 
 // ─── Module mocks ─────────────────────────────────────────────────────────────
 
+// Hoist savePinState mock so the vi.mock factory below can reference it
+const mockSavePinState = vi.hoisted(() => vi.fn());
+
 vi.mock('react-resizable-panels', () => ({
   Group: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="panel-group">{children}</div>
@@ -27,10 +30,15 @@ vi.mock('../TerminalPanel', () => ({
 }));
 
 vi.mock('../inspector/TerminalTabs', () => ({
-  TerminalTabs: () => <div data-testid="terminal-tabs" />,
+  // Expose onTogglePin as a button so integration tests can fire the real handler
+  TerminalTabs: ({ onTogglePin }: { onTogglePin?: () => void; [k: string]: unknown }) => (
+    <div data-testid="terminal-tabs">
+      <button data-testid="pin-button" onClick={onTogglePin}>Pin</button>
+    </div>
+  ),
   // Use the real localStorage key so tests can pre-populate state
   loadPinState: (issueId: string) => localStorage.getItem(`pan-terminal-pin-${issueId}`),
-  savePinState: vi.fn(),
+  savePinState: mockSavePinState,
 }));
 
 vi.mock('../inspector/MergedSummaryCard', () => ({
@@ -253,6 +261,76 @@ describe('DetailPanelLayout', () => {
         expect(screen.getByTestId('terminal-panel')).toHaveAttribute('data-session', activeSessionB);
       });
       expect(screen.getByTestId('terminal-panel')).not.toHaveAttribute('data-session', sessionA);
+    });
+  });
+
+  describe('Issue 4 — Pin button in auto-mode captures active session', () => {
+    it('retains the displayed session and persists pin when clicking Pin in auto-mode', async () => {
+      const activeSession = 'work-agent-session-123';
+
+      mockPipelineResult = {
+        phase: 'working' as PipelinePhase,
+        activeSession,
+        availableTerminals: [
+          {
+            id: 'working',
+            label: 'Work',
+            sessionName: activeSession,
+            isActive: true,
+            disabled: false,
+          } satisfies TerminalTab,
+        ],
+        markSessionDead: vi.fn(),
+      };
+
+      renderLayout(makeAgent({ status: 'running' }));
+
+      // Initially in auto-follow mode: terminal shows the activeSession
+      await waitFor(() => {
+        expect(screen.getByTestId('terminal-panel')).toHaveAttribute('data-session', activeSession);
+      });
+
+      // Click the Pin button — fires handleTogglePin in DetailPanelLayout
+      fireEvent.click(screen.getByTestId('pin-button'));
+
+      // (a) The displayed session must survive the pin toggle
+      await waitFor(() => {
+        expect(screen.getByTestId('terminal-panel')).toHaveAttribute('data-session', activeSession);
+      });
+
+      // (b) savePinState must have been called with the active session
+      expect(mockSavePinState).toHaveBeenCalledWith('PAN-509', activeSession);
+    });
+
+    it('is a no-op when there is no active session to pin', async () => {
+      mockPipelineResult = {
+        phase: 'working' as PipelinePhase,
+        activeSession: null,
+        availableTerminals: [
+          {
+            id: 'working',
+            label: 'Work',
+            sessionName: 'some-dead-session',
+            isActive: false,
+            disabled: true,
+          } satisfies TerminalTab,
+        ],
+        markSessionDead: vi.fn(),
+      };
+
+      renderLayout(makeAgent({ status: 'stopped' }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('terminal-tabs')).toBeInTheDocument();
+      });
+
+      mockSavePinState.mockClear();
+
+      // Click Pin button when there is no active session — must be a no-op
+      fireEvent.click(screen.getByTestId('pin-button'));
+
+      // savePinState must NOT have been called
+      expect(mockSavePinState).not.toHaveBeenCalled();
     });
   });
 

--- a/src/dashboard/frontend/src/components/__tests__/DetailPanelLayout.test.tsx
+++ b/src/dashboard/frontend/src/components/__tests__/DetailPanelLayout.test.tsx
@@ -1,0 +1,231 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { Agent } from '../../types';
+import type { PipelinePhase, TerminalTab } from '../inspector/TerminalTabs';
+import type { PipelinePhaseResult } from '../inspector/usePipelinePhase';
+
+// ─── Module mocks ─────────────────────────────────────────────────────────────
+
+vi.mock('react-resizable-panels', () => ({
+  Group: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="panel-group">{children}</div>
+  ),
+  Panel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Separator: () => <div />,
+}));
+
+vi.mock('../InspectorPanel', () => ({
+  InspectorPanel: () => <div data-testid="inspector-panel" />,
+}));
+
+vi.mock('../TerminalPanel', () => ({
+  TerminalPanel: ({ sessionName }: { sessionName?: string; agent?: unknown }) => (
+    <div data-testid="terminal-panel" data-session={sessionName ?? '__default__'} />
+  ),
+}));
+
+vi.mock('../inspector/TerminalTabs', () => ({
+  TerminalTabs: () => <div data-testid="terminal-tabs" />,
+  loadPinState: () => null,
+  savePinState: vi.fn(),
+}));
+
+vi.mock('../inspector/MergedSummaryCard', () => ({
+  MergedSummaryCard: ({
+    onViewLastLog,
+  }: {
+    mergedAt: string;
+    onViewLastLog?: (() => void) | null;
+  }) => (
+    <div data-testid="merged-summary-card">
+      {onViewLastLog != null && (
+        <button onClick={onViewLastLog}>View last specialist log</button>
+      )}
+    </div>
+  ),
+}));
+
+// Mutable pipeline result — each test sets it before rendering.
+let mockPipelineResult: PipelinePhaseResult & { markSessionDead: ReturnType<typeof vi.fn> } = {
+  phase: 'working' as PipelinePhase,
+  activeSession: 'agent-123',
+  availableTerminals: [],
+  markSessionDead: vi.fn(),
+};
+
+vi.mock('../inspector/usePipelinePhase', () => ({
+  usePipelinePhase: () => mockPipelineResult,
+}));
+
+// ─── Import under test ────────────────────────────────────────────────────────
+
+import { DetailPanelLayout } from '../DetailPanelLayout';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return { id: 'agent-123', issueId: 'PAN-509', status: 'stopped', ...overrides } as Agent;
+}
+
+function makeQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+type ReviewStatusOverrides = {
+  reviewStatus?: string;
+  mergeStatus?: string;
+  testStatus?: string;
+  updatedAt?: string;
+};
+
+function makeFetch(reviewStatusOverrides: ReviewStatusOverrides = {}): typeof global.fetch {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('/review-status')) {
+      return new Response(
+        JSON.stringify({
+          reviewStatus: 'pending',
+          mergeStatus: 'pending',
+          testStatus: 'pending',
+          updatedAt: '2026-04-13T00:00:00Z',
+          ...reviewStatusOverrides,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+  }) as typeof global.fetch;
+}
+
+function renderLayout(agent: Agent, fetchImpl: typeof global.fetch = makeFetch()) {
+  global.fetch = fetchImpl;
+  const client = makeQueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <DetailPanelLayout agent={agent} issueId="PAN-509" onClose={vi.fn()} />
+    </QueryClientProvider>,
+  );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('DetailPanelLayout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    // Default panel state so the terminal section is shown
+    localStorage.setItem(
+      'pan-panel-state-PAN-509',
+      JSON.stringify({ panelMode: 'inspector+terminal', inspectorDefaultSize: '35%' }),
+    );
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  describe('Issue 1 — specialist tab streaming with dead work agent', () => {
+    it('renders TerminalPanel keyed to the review specialist session when the review phase is active, even when the work agent is stopped', async () => {
+      const reviewSession = 'specialist-panopticon-review-agent';
+      mockPipelineResult = {
+        phase: 'reviewing',
+        activeSession: reviewSession,
+        availableTerminals: [
+          {
+            id: 'working',
+            label: 'Work',
+            sessionName: 'agent-123',
+            isActive: false,
+            disabled: true, // work agent is dead
+          } satisfies TerminalTab,
+          {
+            id: 'reviewing',
+            label: 'Review',
+            sessionName: reviewSession,
+            isActive: true,
+            disabled: false,
+          } satisfies TerminalTab,
+        ],
+        markSessionDead: vi.fn(),
+      };
+
+      renderLayout(
+        makeAgent({ status: 'stopped' }),
+        makeFetch({ reviewStatus: 'reviewing' }),
+      );
+
+      // TerminalPanel must render with the review specialist session, not the work agent session
+      await waitFor(() => {
+        const panel = screen.getByTestId('terminal-panel');
+        expect(panel).toHaveAttribute('data-session', reviewSession);
+      });
+
+      // Not the work agent session
+      expect(screen.getByTestId('terminal-panel')).not.toHaveAttribute('data-session', 'agent-123');
+    });
+  });
+
+  describe('Issue 2 — "View last specialist log" button in merged phase', () => {
+    it('shows MergedSummaryCard initially in merged phase', async () => {
+      mockPipelineResult = {
+        phase: 'merged',
+        activeSession: null,
+        availableTerminals: [
+          {
+            id: 'merging',
+            label: 'Merge',
+            sessionName: 'specialist-panopticon-merge-agent',
+            isActive: false,
+            disabled: false,
+          } satisfies TerminalTab,
+        ],
+        markSessionDead: vi.fn(),
+      };
+
+      renderLayout(makeAgent({ status: 'stopped' }), makeFetch({ mergeStatus: 'merged' }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('merged-summary-card')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('terminal-panel')).not.toBeInTheDocument();
+    });
+
+    it('clicking "View last specialist log" replaces MergedSummaryCard with TerminalPanel for the merge session', async () => {
+      const mergeSession = 'specialist-panopticon-merge-agent';
+      mockPipelineResult = {
+        phase: 'merged',
+        activeSession: null,
+        availableTerminals: [
+          {
+            id: 'merging',
+            label: 'Merge',
+            sessionName: mergeSession,
+            isActive: false,
+            disabled: false,
+          } satisfies TerminalTab,
+        ],
+        markSessionDead: vi.fn(),
+      };
+
+      renderLayout(makeAgent({ status: 'stopped' }), makeFetch({ mergeStatus: 'merged' }));
+
+      // Wait for initial render with MergedSummaryCard
+      await waitFor(() => {
+        expect(screen.getByTestId('merged-summary-card')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('terminal-panel')).not.toBeInTheDocument();
+
+      // Click the "View last specialist log" button
+      fireEvent.click(screen.getByText('View last specialist log'));
+
+      // MergedSummaryCard must be replaced by TerminalPanel showing the merge session
+      await waitFor(() => {
+        expect(screen.getByTestId('terminal-panel')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('terminal-panel')).toHaveAttribute('data-session', mergeSession);
+      expect(screen.queryByTestId('merged-summary-card')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/dashboard/frontend/src/components/__tests__/DetailPanelLayout.test.tsx
+++ b/src/dashboard/frontend/src/components/__tests__/DetailPanelLayout.test.tsx
@@ -28,7 +28,8 @@ vi.mock('../TerminalPanel', () => ({
 
 vi.mock('../inspector/TerminalTabs', () => ({
   TerminalTabs: () => <div data-testid="terminal-tabs" />,
-  loadPinState: () => null,
+  // Use the real localStorage key so tests can pre-populate state
+  loadPinState: (issueId: string) => localStorage.getItem(`pan-terminal-pin-${issueId}`),
   savePinState: vi.fn(),
 }));
 
@@ -99,12 +100,16 @@ function makeFetch(reviewStatusOverrides: ReviewStatusOverrides = {}): typeof gl
   }) as typeof global.fetch;
 }
 
-function renderLayout(agent: Agent, fetchImpl: typeof global.fetch = makeFetch()) {
+function renderLayout(
+  agent: Agent,
+  fetchImpl: typeof global.fetch = makeFetch(),
+  issueId = 'PAN-509',
+) {
   global.fetch = fetchImpl;
   const client = makeQueryClient();
   return render(
     <QueryClientProvider client={client}>
-      <DetailPanelLayout agent={agent} issueId="PAN-509" onClose={vi.fn()} />
+      <DetailPanelLayout agent={agent} issueId={issueId} onClose={vi.fn()} />
     </QueryClientProvider>,
   );
 }
@@ -164,6 +169,90 @@ describe('DetailPanelLayout', () => {
 
       // Not the work agent session
       expect(screen.getByTestId('terminal-panel')).not.toHaveAttribute('data-session', 'agent-123');
+    });
+  });
+
+  describe('Issue 3 — pin state resets when issueId changes', () => {
+    it('re-reads pin state from localStorage when issueId prop changes', async () => {
+      const sessionA = 'specialist-session-for-issue-a';
+      const sessionB = 'specialist-session-for-issue-b';
+
+      // Pre-populate pin state for both issues
+      localStorage.setItem('pan-terminal-pin-PAN-509', sessionA);
+      localStorage.setItem('pan-terminal-pin-PAN-510', sessionB);
+      // Panel state so the terminal section renders
+      localStorage.setItem(
+        'pan-panel-state-PAN-510',
+        JSON.stringify({ panelMode: 'inspector+terminal', inspectorDefaultSize: '35%' }),
+      );
+
+      mockPipelineResult = {
+        phase: 'working' as PipelinePhase,
+        activeSession: 'fallback-active-session',
+        availableTerminals: [],
+        markSessionDead: vi.fn(),
+      };
+
+      const { rerender } = renderLayout(makeAgent({ issueId: 'PAN-509' }));
+
+      // Issue A: TerminalPanel shows the pinned session for PAN-509
+      await waitFor(() => {
+        expect(screen.getByTestId('terminal-panel')).toHaveAttribute('data-session', sessionA);
+      });
+
+      // Switch to issue B by updating the issueId prop
+      const client = makeQueryClient();
+      rerender(
+        <QueryClientProvider client={client}>
+          <DetailPanelLayout agent={makeAgent({ issueId: 'PAN-510' })} issueId="PAN-510" onClose={vi.fn()} />
+        </QueryClientProvider>,
+      );
+
+      // Issue B: TerminalPanel must show the pinned session for PAN-510, not the stale PAN-509 session
+      await waitFor(() => {
+        expect(screen.getByTestId('terminal-panel')).toHaveAttribute('data-session', sessionB);
+      });
+      expect(screen.getByTestId('terminal-panel')).not.toHaveAttribute('data-session', sessionA);
+    });
+
+    it('clears pin state when switching to an issue with no saved pin', async () => {
+      const sessionA = 'specialist-session-for-issue-a';
+
+      localStorage.setItem('pan-terminal-pin-PAN-509', sessionA);
+      localStorage.setItem(
+        'pan-panel-state-PAN-510',
+        JSON.stringify({ panelMode: 'inspector+terminal', inspectorDefaultSize: '35%' }),
+      );
+      // PAN-510 has no saved pin
+
+      const activeSessionB = 'active-work-session-b';
+      mockPipelineResult = {
+        phase: 'working' as PipelinePhase,
+        activeSession: activeSessionB,
+        availableTerminals: [],
+        markSessionDead: vi.fn(),
+      };
+
+      const { rerender } = renderLayout(makeAgent({ issueId: 'PAN-509' }));
+
+      // Issue A: shows pinned session
+      await waitFor(() => {
+        expect(screen.getByTestId('terminal-panel')).toHaveAttribute('data-session', sessionA);
+      });
+
+      // Switch to issue B (no saved pin)
+      const client = makeQueryClient();
+      rerender(
+        <QueryClientProvider client={client}>
+          <DetailPanelLayout agent={makeAgent({ issueId: 'PAN-510' })} issueId="PAN-510" onClose={vi.fn()} />
+        </QueryClientProvider>,
+      );
+
+      // Must fall back to activeSession (not pinned), not the stale PAN-509 session
+      await waitFor(() => {
+        expect(screen.getByTestId('terminal-panel')).toHaveAttribute('data-session', activeSessionB);
+      });
+      expect(screen.getByTestId('terminal-panel')).not.toHaveAttribute('data-session', sessionA);
     });
   });
 

--- a/src/dashboard/frontend/src/components/__tests__/TerminalPanel.test.tsx
+++ b/src/dashboard/frontend/src/components/__tests__/TerminalPanel.test.tsx
@@ -174,3 +174,40 @@ describe('TerminalPanel — stopped agent content rendering', () => {
     });
   });
 });
+
+describe('TerminalPanel — specialist session (sessionName prop)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders XTerminal for a specialist session even when the work agent tmux session is dead', async () => {
+    // Work agent is dead (tmuxAlive: false) but we are viewing a specialist tab
+    const fetch = makeFetch({
+      tmuxAlive: false,
+      conversationMessages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+    });
+    global.fetch = fetch;
+    const client = makeQueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <TerminalPanel
+          agent={makeAgent({ status: 'stopped' })}
+          onClose={() => {}}
+          sessionName="specialist-panopticon-review-agent"
+          title="Review"
+        />
+      </QueryClientProvider>,
+    );
+
+    // isViewingWorkAgent=false → isStopped=false → XTerminal shown, not fallback
+    expect(screen.getByTestId('xterm')).toBeInTheDocument();
+    expect(screen.queryByTestId('messages-timeline')).not.toBeInTheDocument();
+    expect(screen.queryByText('No saved output available.')).not.toBeInTheDocument();
+
+    // The tmux-alive probe must NOT fire for the work agent while viewing a specialist session
+    expect(fetch).not.toHaveBeenCalledWith(
+      expect.stringContaining('/tmux-alive'),
+      expect.anything(),
+    );
+  });
+});

--- a/src/dashboard/frontend/src/components/inspector/MergedSummaryCard.test.tsx
+++ b/src/dashboard/frontend/src/components/inspector/MergedSummaryCard.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MergedSummaryCard } from './MergedSummaryCard';
+
+const MERGED_AT = '2026-04-10T14:30:00.000Z';
+
+describe('MergedSummaryCard', () => {
+  it('renders merged status and timestamp', () => {
+    render(<MergedSummaryCard mergedAt={MERGED_AT} />);
+    expect(screen.getByText('Merged')).toBeInTheDocument();
+    // Timestamp is locale-formatted — just verify some date text exists
+    expect(screen.getByText(/Apr/)).toBeInTheDocument();
+  });
+
+  it('renders cost pill when totalCost > 0', () => {
+    render(<MergedSummaryCard mergedAt={MERGED_AT} totalCost={1.5} />);
+    expect(screen.getByText('$1.50')).toBeInTheDocument();
+    expect(screen.getByText('Total cost')).toBeInTheDocument();
+  });
+
+  it('does not render cost pill when totalCost is 0', () => {
+    render(<MergedSummaryCard mergedAt={MERGED_AT} totalCost={0} />);
+    expect(screen.queryByText('Total cost')).not.toBeInTheDocument();
+  });
+
+  it('does not render cost pill when totalCost is null', () => {
+    render(<MergedSummaryCard mergedAt={MERGED_AT} totalCost={null} />);
+    expect(screen.queryByText('Total cost')).not.toBeInTheDocument();
+  });
+
+  it('renders PR link when prUrl is provided', () => {
+    render(<MergedSummaryCard mergedAt={MERGED_AT} prUrl="https://github.com/org/repo/pull/42" />);
+    const link = screen.getByText('View PR');
+    expect(link).toBeInTheDocument();
+    expect(link.closest('a')).toHaveAttribute('href', 'https://github.com/org/repo/pull/42');
+  });
+
+  it('does not render PR link when prUrl is null', () => {
+    render(<MergedSummaryCard mergedAt={MERGED_AT} prUrl={null} />);
+    expect(screen.queryByText('View PR')).not.toBeInTheDocument();
+  });
+
+  it('does not render PR link when prUrl is undefined', () => {
+    render(<MergedSummaryCard mergedAt={MERGED_AT} />);
+    expect(screen.queryByText('View PR')).not.toBeInTheDocument();
+  });
+
+  it('renders "View last specialist log" button when onViewLastLog is provided', () => {
+    const onViewLastLog = vi.fn();
+    render(<MergedSummaryCard mergedAt={MERGED_AT} onViewLastLog={onViewLastLog} />);
+    const button = screen.getByText('View last specialist log');
+    expect(button).toBeInTheDocument();
+    fireEvent.click(button.closest('button')!);
+    expect(onViewLastLog).toHaveBeenCalledOnce();
+  });
+
+  it('does not render "View last specialist log" button when onViewLastLog is null', () => {
+    render(<MergedSummaryCard mergedAt={MERGED_AT} onViewLastLog={null} />);
+    expect(screen.queryByText('View last specialist log')).not.toBeInTheDocument();
+  });
+
+  describe('formatCost', () => {
+    it('formats dollars for cost >= 0.01', () => {
+      render(<MergedSummaryCard mergedAt={MERGED_AT} totalCost={0.50} />);
+      expect(screen.getByText('$0.50')).toBeInTheDocument();
+    });
+
+    it('formats cents (no $ prefix) for cost < 0.01', () => {
+      render(<MergedSummaryCard mergedAt={MERGED_AT} totalCost={0.005} />);
+      // 0.005 * 100 = 0.50 → '0.50¢'
+      expect(screen.getByText('0.50¢')).toBeInTheDocument();
+    });
+
+    it('does not mix $ and ¢ symbols', () => {
+      render(<MergedSummaryCard mergedAt={MERGED_AT} totalCost={0.003} />);
+      const costText = screen.getByText(/¢/);
+      expect(costText.textContent).not.toMatch(/\$/);
+    });
+  });
+});

--- a/src/dashboard/frontend/src/components/inspector/MergedSummaryCard.tsx
+++ b/src/dashboard/frontend/src/components/inspector/MergedSummaryCard.tsx
@@ -1,0 +1,129 @@
+import { GitMerge, ExternalLink, ScrollText, DollarSign } from 'lucide-react';
+
+export interface MergedSummaryCardProps {
+  /** ISO timestamp when the merge completed (from reviewStatus.updatedAt) */
+  mergedAt: string;
+  /** PR / MR URL — workspace.mrUrl */
+  prUrl?: string | null;
+  /** Total cost in USD — from /api/issues/:id/costs */
+  totalCost?: number | null;
+  /** Callback to switch to the last specialist log tab. Only present if a session exists. */
+  onViewLastLog?: (() => void) | null;
+}
+
+function formatCost(cost: number): string {
+  if (cost < 0.01) return `$${(cost * 100).toFixed(2)}¢`;
+  return `$${cost.toFixed(2)}`;
+}
+
+function formatTimestamp(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+const bgCard = '#0d1117';
+const bgInner = '#161b26';
+const borderColor = '#232f48';
+const textPrimary = '#e2e8f0';
+const textSecondary = '#92a4c9';
+const accentGreen = '#34d399';
+
+export function MergedSummaryCard({ mergedAt, prUrl, totalCost, onViewLastLog }: MergedSummaryCardProps) {
+  return (
+    <div
+      className="flex flex-col items-center justify-center h-full gap-4 p-6"
+      style={{ backgroundColor: bgCard }}
+    >
+      {/* Merged badge */}
+      <div className="flex flex-col items-center gap-2">
+        <div
+          className="flex items-center justify-center w-12 h-12 rounded-full"
+          style={{ backgroundColor: '#1a3a2d', border: `1.5px solid ${accentGreen}` }}
+        >
+          <GitMerge className="w-6 h-6" style={{ color: accentGreen }} />
+        </div>
+        <span className="text-lg font-semibold" style={{ color: accentGreen }}>
+          Merged
+        </span>
+        <span className="text-xs" style={{ color: textSecondary }}>
+          {formatTimestamp(mergedAt)}
+        </span>
+      </div>
+
+      {/* Detail pills */}
+      <div
+        className="flex flex-col gap-2 w-full max-w-xs rounded-lg p-3"
+        style={{ backgroundColor: bgInner, border: `1px solid ${borderColor}` }}
+      >
+        {/* Cost row */}
+        {totalCost != null && totalCost > 0 && (
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-1.5">
+              <DollarSign className="w-3.5 h-3.5" style={{ color: textSecondary }} />
+              <span className="text-xs" style={{ color: textSecondary }}>
+                Total cost
+              </span>
+            </div>
+            <span className="text-xs font-medium" style={{ color: textPrimary }}>
+              {formatCost(totalCost)}
+            </span>
+          </div>
+        )}
+
+        {/* PR link */}
+        {prUrl && (
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-1.5">
+              <ExternalLink className="w-3.5 h-3.5" style={{ color: textSecondary }} />
+              <span className="text-xs" style={{ color: textSecondary }}>
+                Pull request
+              </span>
+            </div>
+            <a
+              href={prUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs font-medium hover:underline"
+              style={{ color: '#60a5fa' }}
+            >
+              View PR
+            </a>
+          </div>
+        )}
+      </div>
+
+      {/* View last log button */}
+      {onViewLastLog && (
+        <button
+          onClick={onViewLastLog}
+          className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded transition-colors"
+          style={{
+            color: textSecondary,
+            backgroundColor: bgInner,
+            border: `1px solid ${borderColor}`,
+          }}
+          onMouseEnter={e => {
+            (e.currentTarget as HTMLButtonElement).style.borderColor = '#3a4a6a';
+            (e.currentTarget as HTMLButtonElement).style.color = textPrimary;
+          }}
+          onMouseLeave={e => {
+            (e.currentTarget as HTMLButtonElement).style.borderColor = borderColor;
+            (e.currentTarget as HTMLButtonElement).style.color = textSecondary;
+          }}
+        >
+          <ScrollText className="w-3.5 h-3.5" />
+          View last specialist log
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/dashboard/frontend/src/components/inspector/MergedSummaryCard.tsx
+++ b/src/dashboard/frontend/src/components/inspector/MergedSummaryCard.tsx
@@ -12,7 +12,7 @@ export interface MergedSummaryCardProps {
 }
 
 function formatCost(cost: number): string {
-  if (cost < 0.01) return `$${(cost * 100).toFixed(2)}¢`;
+  if (cost < 0.01) return `${(cost * 100).toFixed(2)}¢`;
   return `$${cost.toFixed(2)}`;
 }
 

--- a/src/dashboard/frontend/src/components/inspector/TerminalSessionWrapper.test.tsx
+++ b/src/dashboard/frontend/src/components/inspector/TerminalSessionWrapper.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TerminalSessionWrapper } from './TerminalSessionWrapper';
+
+vi.mock('../XTerminal', () => ({
+  XTerminal: function MockXTerminal({
+    sessionName,
+    onDisconnect,
+  }: {
+    sessionName: string;
+    onDisconnect?: () => void;
+  }) {
+    return (
+      <div data-testid="xterm" data-session={sessionName}>
+        <button data-testid="trigger-disconnect" onClick={onDisconnect}>
+          disconnect
+        </button>
+      </div>
+    );
+  },
+}));
+
+vi.mock('lucide-react', () => ({
+  WifiOff: () => <span data-testid="wifi-off-icon" />,
+  RefreshCw: () => <span data-testid="refresh-icon" />,
+}));
+
+describe('TerminalSessionWrapper', () => {
+  it('initial state renders XTerminal with the correct session name', () => {
+    render(<TerminalSessionWrapper sessionName="my-session" />);
+    expect(screen.getByTestId('xterm')).toBeInTheDocument();
+    expect(screen.getByTestId('xterm')).toHaveAttribute('data-session', 'my-session');
+  });
+
+  it('transitions to ended state on disconnect', () => {
+    render(<TerminalSessionWrapper sessionName="my-session" />);
+    fireEvent.click(screen.getByTestId('trigger-disconnect'));
+    expect(screen.queryByTestId('xterm')).not.toBeInTheDocument();
+    expect(screen.getByText('Session ended')).toBeInTheDocument();
+  });
+
+  it('ended state shows the session name', () => {
+    render(<TerminalSessionWrapper sessionName="panopticon-work" />);
+    fireEvent.click(screen.getByTestId('trigger-disconnect'));
+    expect(screen.getByText(/panopticon-work/)).toBeInTheDocument();
+  });
+
+  it('ended state shows retry button', () => {
+    render(<TerminalSessionWrapper sessionName="my-session" />);
+    fireEvent.click(screen.getByTestId('trigger-disconnect'));
+    expect(screen.getByText('Retry connection')).toBeInTheDocument();
+  });
+
+  it('clicking Retry transitions back to connecting state', () => {
+    render(<TerminalSessionWrapper sessionName="my-session" />);
+    fireEvent.click(screen.getByTestId('trigger-disconnect'));
+    expect(screen.getByText('Session ended')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Retry connection'));
+    expect(screen.getByTestId('xterm')).toBeInTheDocument();
+    expect(screen.queryByText('Session ended')).not.toBeInTheDocument();
+  });
+
+  it('fires onSessionEnded callback on disconnect', () => {
+    const onSessionEnded = vi.fn();
+    render(<TerminalSessionWrapper sessionName="my-session" onSessionEnded={onSessionEnded} />);
+    fireEvent.click(screen.getByTestId('trigger-disconnect'));
+    expect(onSessionEnded).toHaveBeenCalledOnce();
+  });
+
+  it('does not fire onSessionEnded when not provided', () => {
+    // Should not throw when onSessionEnded is undefined
+    expect(() => {
+      render(<TerminalSessionWrapper sessionName="my-session" />);
+      fireEvent.click(screen.getByTestId('trigger-disconnect'));
+    }).not.toThrow();
+  });
+});

--- a/src/dashboard/frontend/src/components/inspector/TerminalSessionWrapper.tsx
+++ b/src/dashboard/frontend/src/components/inspector/TerminalSessionWrapper.tsx
@@ -1,0 +1,84 @@
+import { useState, useCallback } from 'react';
+import { WifiOff, RefreshCw } from 'lucide-react';
+import { XTerminal } from '../XTerminal';
+
+export type SessionState = 'connecting' | 'connected' | 'ended';
+
+interface TerminalSessionWrapperProps {
+  sessionName: string;
+  /** Fired when XTerminal exhausts its reconnect attempts */
+  onSessionEnded?: () => void;
+}
+
+const bgCard = '#0d1117';
+const bgInner = '#161b26';
+const borderColor = '#232f48';
+const textSecondary = '#92a4c9';
+const textMuted = '#4a5568';
+const accentOrange = '#fb923c';
+
+export function TerminalSessionWrapper({ sessionName, onSessionEnded }: TerminalSessionWrapperProps) {
+  const [state, setState] = useState<SessionState>('connecting');
+
+  const handleDisconnect = useCallback(() => {
+    setState('ended');
+    onSessionEnded?.();
+  }, [onSessionEnded]);
+
+  if (state === 'ended') {
+    return (
+      <div
+        className="flex flex-col items-center justify-center h-full gap-4 p-6"
+        style={{ backgroundColor: bgCard }}
+      >
+        <div
+          className="flex items-center justify-center w-10 h-10 rounded-full"
+          style={{ backgroundColor: '#2d1a00', border: `1.5px solid ${accentOrange}` }}
+        >
+          <WifiOff className="w-5 h-5" style={{ color: accentOrange }} />
+        </div>
+        <div className="flex flex-col items-center gap-1 text-center">
+          <span className="text-sm font-medium" style={{ color: textSecondary }}>
+            Session ended
+          </span>
+          <span className="text-xs max-w-[200px]" style={{ color: textMuted }}>
+            The tmux session{' '}
+            <code className="font-mono" style={{ color: textSecondary }}>
+              {sessionName}
+            </code>{' '}
+            is no longer available.
+          </span>
+        </div>
+        <button
+          onClick={() => setState('connecting')}
+          className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded transition-colors"
+          style={{
+            color: textSecondary,
+            backgroundColor: bgInner,
+            border: `1px solid ${borderColor}`,
+          }}
+          onMouseEnter={e => {
+            (e.currentTarget as HTMLButtonElement).style.borderColor = '#3a4a6a';
+            (e.currentTarget as HTMLButtonElement).style.color = '#e2e8f0';
+          }}
+          onMouseLeave={e => {
+            (e.currentTarget as HTMLButtonElement).style.borderColor = borderColor;
+            (e.currentTarget as HTMLButtonElement).style.color = textSecondary;
+          }}
+        >
+          <RefreshCw className="w-3.5 h-3.5" />
+          Retry connection
+        </button>
+      </div>
+    );
+  }
+
+  // 'connecting' or 'connected': render XTerminal normally
+  return (
+    <XTerminal
+      key={`${sessionName}-${state}`}
+      sessionName={sessionName}
+      onDisconnect={handleDisconnect}
+    />
+  );
+}

--- a/src/dashboard/frontend/src/components/inspector/TerminalSessionWrapper.tsx
+++ b/src/dashboard/frontend/src/components/inspector/TerminalSessionWrapper.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import { WifiOff, RefreshCw } from 'lucide-react';
 import { XTerminal } from '../XTerminal';
 
-export type SessionState = 'connecting' | 'connected' | 'ended';
+export type SessionState = 'connecting' | 'ended';
 
 interface TerminalSessionWrapperProps {
   sessionName: string;
@@ -73,7 +73,7 @@ export function TerminalSessionWrapper({ sessionName, onSessionEnded }: Terminal
     );
   }
 
-  // 'connecting' or 'connected': render XTerminal normally
+  // 'connecting': render XTerminal normally
   return (
     <XTerminal
       key={`${sessionName}-${state}`}

--- a/src/dashboard/frontend/src/components/inspector/TerminalTabs.test.tsx
+++ b/src/dashboard/frontend/src/components/inspector/TerminalTabs.test.tsx
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { TerminalTabs, savePinState, loadPersistedPin, type TerminalTab } from './TerminalTabs';
+
+function makeTab(overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id: 'working',
+    label: 'Work',
+    sessionName: 'agent-123',
+    isActive: true,
+    disabled: false,
+    ...overrides,
+  };
+}
+
+const defaultProps = {
+  issueId: 'pan-509',
+  tabs: [makeTab()],
+  selectedSession: 'agent-123',
+  activePhase: 'working' as const,
+  pinned: false,
+  onSelectSession: vi.fn(),
+  onTogglePin: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('TerminalTabs', () => {
+  describe('auto-follow behaviour', () => {
+    it('switches to active tab when not pinned and active tab changes', () => {
+      const onSelectSession = vi.fn();
+      const tabs = [
+        makeTab({ id: 'working', label: 'Work', sessionName: 'agent-123', isActive: false }),
+        makeTab({ id: 'reviewing', label: 'Review', sessionName: 'specialist-proj-review-agent', isActive: true }),
+      ];
+      render(
+        <TerminalTabs
+          {...defaultProps}
+          tabs={tabs}
+          selectedSession="agent-123"
+          activePhase="reviewing"
+          pinned={false}
+          onSelectSession={onSelectSession}
+        />,
+      );
+      // useEffect fires — should auto-switch to the active (reviewing) tab
+      expect(onSelectSession).toHaveBeenCalledWith('specialist-proj-review-agent');
+    });
+
+    it('does NOT auto-switch when pinned', () => {
+      const onSelectSession = vi.fn();
+      const tabs = [
+        makeTab({ id: 'working', label: 'Work', sessionName: 'agent-123', isActive: false }),
+        makeTab({ id: 'reviewing', label: 'Review', sessionName: 'specialist-proj-review-agent', isActive: true }),
+      ];
+      render(
+        <TerminalTabs
+          {...defaultProps}
+          tabs={tabs}
+          selectedSession="agent-123"
+          activePhase="reviewing"
+          pinned={true}
+          onSelectSession={onSelectSession}
+        />,
+      );
+      expect(onSelectSession).not.toHaveBeenCalled();
+    });
+
+    it('does NOT auto-switch when already on the active tab', () => {
+      const onSelectSession = vi.fn();
+      const tabs = [makeTab({ sessionName: 'agent-123', isActive: true })];
+      render(
+        <TerminalTabs
+          {...defaultProps}
+          tabs={tabs}
+          selectedSession="agent-123"
+          pinned={false}
+          onSelectSession={onSelectSession}
+        />,
+      );
+      expect(onSelectSession).not.toHaveBeenCalled();
+    });
+
+    it('does NOT auto-switch to disabled active tab', () => {
+      const onSelectSession = vi.fn();
+      const tabs = [
+        makeTab({ id: 'working', label: 'Work', sessionName: 'agent-123', isActive: false }),
+        makeTab({ id: 'reviewing', label: 'Review', sessionName: 'specialist-proj-review-agent', isActive: true, disabled: true }),
+      ];
+      render(
+        <TerminalTabs
+          {...defaultProps}
+          tabs={tabs}
+          selectedSession="agent-123"
+          activePhase="reviewing"
+          pinned={false}
+          onSelectSession={onSelectSession}
+        />,
+      );
+      expect(onSelectSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('tab click behaviour', () => {
+    it('calls onSelectSession when an enabled tab is clicked', () => {
+      const onSelectSession = vi.fn();
+      const tabs = [
+        makeTab({ id: 'working', label: 'Work', sessionName: 'agent-123', isActive: true }),
+        makeTab({ id: 'reviewing', label: 'Review', sessionName: 'specialist-review-agent', isActive: false }),
+      ];
+      render(
+        <TerminalTabs
+          {...defaultProps}
+          tabs={tabs}
+          selectedSession="agent-123"
+          pinned={false}
+          onSelectSession={onSelectSession}
+        />,
+      );
+      fireEvent.click(screen.getByText('Review'));
+      expect(onSelectSession).toHaveBeenCalledWith('specialist-review-agent');
+    });
+
+    it('clicking a non-active tab engages pin', () => {
+      const onTogglePin = vi.fn();
+      const tabs = [
+        makeTab({ id: 'working', label: 'Work', sessionName: 'agent-123', isActive: true }),
+        makeTab({ id: 'reviewing', label: 'Review', sessionName: 'specialist-review-agent', isActive: false }),
+      ];
+      render(
+        <TerminalTabs
+          {...defaultProps}
+          tabs={tabs}
+          selectedSession="agent-123"
+          pinned={false}
+          onTogglePin={onTogglePin}
+        />,
+      );
+      fireEvent.click(screen.getByText('Review'));
+      expect(onTogglePin).toHaveBeenCalled();
+    });
+
+    it('does NOT call onSelectSession for disabled tabs', () => {
+      const onSelectSession = vi.fn();
+      const tabs = [makeTab({ label: 'Test', disabled: true, isActive: false })];
+      render(
+        <TerminalTabs
+          {...defaultProps}
+          tabs={tabs}
+          selectedSession={null}
+          pinned={false}
+          onSelectSession={onSelectSession}
+        />,
+      );
+      fireEvent.click(screen.getByText('Test'));
+      expect(onSelectSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pin toggle button', () => {
+    it('shows Auto when not pinned', () => {
+      render(<TerminalTabs {...defaultProps} pinned={false} />);
+      expect(screen.getByText('Auto')).toBeTruthy();
+    });
+
+    it('shows Pinned when pinned', () => {
+      render(<TerminalTabs {...defaultProps} pinned={true} />);
+      expect(screen.getByText('Pinned')).toBeTruthy();
+    });
+
+    it('calls onTogglePin when clicked', () => {
+      const onTogglePin = vi.fn();
+      render(<TerminalTabs {...defaultProps} onTogglePin={onTogglePin} />);
+      // Find the pin toggle button (contains "Auto" text)
+      fireEvent.click(screen.getByText('Auto').closest('button')!);
+      expect(onTogglePin).toHaveBeenCalled();
+    });
+  });
+
+  describe('phase chip', () => {
+    it('renders the phase label for known phases', () => {
+      render(<TerminalTabs {...defaultProps} activePhase="reviewing" />);
+      expect(screen.getByText('Reviewing')).toBeTruthy();
+    });
+
+    it('renders the raw phase string for unknown phases', () => {
+      render(<TerminalTabs {...defaultProps} activePhase="custom-phase" />);
+      expect(screen.getByText('custom-phase')).toBeTruthy();
+    });
+  });
+
+  describe('localStorage pin persistence', () => {
+    it('savePinState stores session name in localStorage', () => {
+      savePinState('pan-509', 'specialist-review-agent');
+      expect(localStorage.getItem('pan-terminal-pin-pan-509')).toBe('specialist-review-agent');
+    });
+
+    it('savePinState removes item when null', () => {
+      localStorage.setItem('pan-terminal-pin-pan-509', 'old');
+      savePinState('pan-509', null);
+      expect(localStorage.getItem('pan-terminal-pin-pan-509')).toBeNull();
+    });
+
+    it('loadPersistedPin returns stored value', () => {
+      localStorage.setItem('pan-terminal-pin-pan-509', 'agent-xyz');
+      expect(loadPersistedPin('pan-509')).toBe('agent-xyz');
+    });
+
+    it('loadPersistedPin returns null when not set', () => {
+      expect(loadPersistedPin('pan-509')).toBeNull();
+    });
+
+    it('clicking a tab stores session in localStorage', () => {
+      const tabs = [
+        makeTab({ id: 'working', label: 'Work', sessionName: 'agent-123', isActive: true }),
+        makeTab({ id: 'reviewing', label: 'Review', sessionName: 'specialist-review-agent', isActive: false }),
+      ];
+      render(
+        <TerminalTabs
+          {...defaultProps}
+          issueId="pan-509"
+          tabs={tabs}
+          selectedSession="agent-123"
+          pinned={false}
+        />,
+      );
+      act(() => {
+        fireEvent.click(screen.getByText('Review'));
+      });
+      expect(localStorage.getItem('pan-terminal-pin-pan-509')).toBe('specialist-review-agent');
+    });
+  });
+});

--- a/src/dashboard/frontend/src/components/inspector/TerminalTabs.test.tsx
+++ b/src/dashboard/frontend/src/components/inspector/TerminalTabs.test.tsx
@@ -217,7 +217,8 @@ describe('TerminalTabs', () => {
       expect(loadPersistedPin('pan-509')).toBeNull();
     });
 
-    it('clicking a tab stores session in localStorage', () => {
+    it('clicking a tab calls onSelectSession with the session name (parent handles persistence)', () => {
+      const onSelectSession = vi.fn();
       const tabs = [
         makeTab({ id: 'working', label: 'Work', sessionName: 'agent-123', isActive: true }),
         makeTab({ id: 'reviewing', label: 'Review', sessionName: 'specialist-review-agent', isActive: false }),
@@ -229,12 +230,13 @@ describe('TerminalTabs', () => {
           tabs={tabs}
           selectedSession="agent-123"
           pinned={false}
+          onSelectSession={onSelectSession}
         />,
       );
       act(() => {
         fireEvent.click(screen.getByText('Review'));
       });
-      expect(localStorage.getItem('pan-terminal-pin-pan-509')).toBe('specialist-review-agent');
+      expect(onSelectSession).toHaveBeenCalledWith('specialist-review-agent');
     });
   });
 });

--- a/src/dashboard/frontend/src/components/inspector/TerminalTabs.test.tsx
+++ b/src/dashboard/frontend/src/components/inspector/TerminalTabs.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
-import { TerminalTabs, savePinState, loadPersistedPin, type TerminalTab } from './TerminalTabs';
+import { TerminalTabs, savePinState, loadPinState, type TerminalTab } from './TerminalTabs';
 
 function makeTab(overrides: Partial<TerminalTab> = {}): TerminalTab {
   return {
@@ -33,81 +33,6 @@ afterEach(() => {
 });
 
 describe('TerminalTabs', () => {
-  describe('auto-follow behaviour', () => {
-    it('switches to active tab when not pinned and active tab changes', () => {
-      const onSelectSession = vi.fn();
-      const tabs = [
-        makeTab({ id: 'working', label: 'Work', sessionName: 'agent-123', isActive: false }),
-        makeTab({ id: 'reviewing', label: 'Review', sessionName: 'specialist-proj-review-agent', isActive: true }),
-      ];
-      render(
-        <TerminalTabs
-          {...defaultProps}
-          tabs={tabs}
-          selectedSession="agent-123"
-          activePhase="reviewing"
-          pinned={false}
-          onSelectSession={onSelectSession}
-        />,
-      );
-      // useEffect fires — should auto-switch to the active (reviewing) tab
-      expect(onSelectSession).toHaveBeenCalledWith('specialist-proj-review-agent');
-    });
-
-    it('does NOT auto-switch when pinned', () => {
-      const onSelectSession = vi.fn();
-      const tabs = [
-        makeTab({ id: 'working', label: 'Work', sessionName: 'agent-123', isActive: false }),
-        makeTab({ id: 'reviewing', label: 'Review', sessionName: 'specialist-proj-review-agent', isActive: true }),
-      ];
-      render(
-        <TerminalTabs
-          {...defaultProps}
-          tabs={tabs}
-          selectedSession="agent-123"
-          activePhase="reviewing"
-          pinned={true}
-          onSelectSession={onSelectSession}
-        />,
-      );
-      expect(onSelectSession).not.toHaveBeenCalled();
-    });
-
-    it('does NOT auto-switch when already on the active tab', () => {
-      const onSelectSession = vi.fn();
-      const tabs = [makeTab({ sessionName: 'agent-123', isActive: true })];
-      render(
-        <TerminalTabs
-          {...defaultProps}
-          tabs={tabs}
-          selectedSession="agent-123"
-          pinned={false}
-          onSelectSession={onSelectSession}
-        />,
-      );
-      expect(onSelectSession).not.toHaveBeenCalled();
-    });
-
-    it('does NOT auto-switch to disabled active tab', () => {
-      const onSelectSession = vi.fn();
-      const tabs = [
-        makeTab({ id: 'working', label: 'Work', sessionName: 'agent-123', isActive: false }),
-        makeTab({ id: 'reviewing', label: 'Review', sessionName: 'specialist-proj-review-agent', isActive: true, disabled: true }),
-      ];
-      render(
-        <TerminalTabs
-          {...defaultProps}
-          tabs={tabs}
-          selectedSession="agent-123"
-          activePhase="reviewing"
-          pinned={false}
-          onSelectSession={onSelectSession}
-        />,
-      );
-      expect(onSelectSession).not.toHaveBeenCalled();
-    });
-  });
-
   describe('tab click behaviour', () => {
     it('calls onSelectSession when an enabled tab is clicked', () => {
       const onSelectSession = vi.fn();
@@ -208,13 +133,13 @@ describe('TerminalTabs', () => {
       expect(localStorage.getItem('pan-terminal-pin-pan-509')).toBeNull();
     });
 
-    it('loadPersistedPin returns stored value', () => {
+    it('loadPinState returns stored value', () => {
       localStorage.setItem('pan-terminal-pin-pan-509', 'agent-xyz');
-      expect(loadPersistedPin('pan-509')).toBe('agent-xyz');
+      expect(loadPinState('pan-509')).toBe('agent-xyz');
     });
 
-    it('loadPersistedPin returns null when not set', () => {
-      expect(loadPersistedPin('pan-509')).toBeNull();
+    it('loadPinState returns null when not set', () => {
+      expect(loadPinState('pan-509')).toBeNull();
     });
 
     it('clicking a tab calls onSelectSession with the session name (parent handles persistence)', () => {

--- a/src/dashboard/frontend/src/components/inspector/TerminalTabs.tsx
+++ b/src/dashboard/frontend/src/components/inspector/TerminalTabs.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { Pin, PinOff } from 'lucide-react';
 
 export type PipelinePhase =
@@ -24,7 +23,6 @@ export interface TerminalTab {
 }
 
 interface TerminalTabsProps {
-  issueId: string;
   tabs: TerminalTab[];
   /** The session name currently being displayed */
   selectedSession: string | null;
@@ -63,7 +61,7 @@ const textMuted = '#4a5568';
 const bgActive = '#1e2d47';
 const bgHover = '#1a2236';
 
-function loadPinState(issueId: string): string | null {
+export function loadPinState(issueId: string): string | null {
   try {
     return localStorage.getItem(`pan-terminal-pin-${issueId}`);
   } catch {
@@ -84,10 +82,6 @@ export function savePinState(issueId: string, sessionName: string | null): void 
   }
 }
 
-export function loadPersistedPin(issueId: string): string | null {
-  return loadPinState(issueId);
-}
-
 export function TerminalTabs({
   tabs,
   selectedSession,
@@ -96,15 +90,6 @@ export function TerminalTabs({
   onSelectSession,
   onTogglePin,
 }: TerminalTabsProps) {
-  // When auto-follow is on (not pinned), switch to the active tab automatically
-  useEffect(() => {
-    if (pinned) return;
-    const activeTab = tabs.find(t => t.isActive && !t.disabled);
-    if (activeTab && activeTab.sessionName !== selectedSession) {
-      onSelectSession(activeTab.sessionName);
-    }
-  }, [pinned, tabs, selectedSession, onSelectSession]);
-
   const phaseColors = PHASE_CHIP_COLORS[activePhase] ?? { bg: '#1e2d47', text: textSecondary };
   const phaseLabel = PHASE_LABELS[activePhase] ?? activePhase;
 

--- a/src/dashboard/frontend/src/components/inspector/TerminalTabs.tsx
+++ b/src/dashboard/frontend/src/components/inspector/TerminalTabs.tsx
@@ -1,0 +1,207 @@
+import { useEffect } from 'react';
+import { Pin, PinOff } from 'lucide-react';
+
+export type PipelinePhase =
+  | 'planning'
+  | 'working'
+  | 'verifying'
+  | 'reviewing'
+  | 'review-feedback'
+  | 'testing'
+  | 'merging'
+  | 'merged';
+
+export interface TerminalTab {
+  /** Phase or role identifier */
+  id: PipelinePhase | string;
+  /** Human-readable label */
+  label: string;
+  /** tmux session name — null means show summary card */
+  sessionName: string | null;
+  /** Whether this tab should be auto-selected for the current phase */
+  isActive: boolean;
+  /** Disabled when the session doesn't exist yet */
+  disabled: boolean;
+}
+
+interface TerminalTabsProps {
+  issueId: string;
+  tabs: TerminalTab[];
+  /** The session name currently being displayed */
+  selectedSession: string | null;
+  /** Current auto-derived phase label (shown in the phase chip) */
+  activePhase: PipelinePhase | string;
+  /** True when the user has manually pinned a session */
+  pinned: boolean;
+  onSelectSession: (sessionName: string | null) => void;
+  onTogglePin: () => void;
+}
+
+const PHASE_CHIP_COLORS: Record<string, { bg: string; text: string }> = {
+  planning:        { bg: '#1e3a5f', text: '#60a5fa' },
+  working:         { bg: '#1a3a1a', text: '#4ade80' },
+  verifying:       { bg: '#2d2a14', text: '#fbbf24' },
+  reviewing:       { bg: '#2d1a3a', text: '#c084fc' },
+  'review-feedback': { bg: '#3a1a1a', text: '#f87171' },
+  testing:         { bg: '#1a2d3a', text: '#38bdf8' },
+  merging:         { bg: '#2d2014', text: '#fb923c' },
+  merged:          { bg: '#1a3a2d', text: '#34d399' },
+};
+
+const PHASE_LABELS: Record<string, string> = {
+  planning:          'Planning',
+  working:           'Working',
+  verifying:         'Verifying',
+  reviewing:         'Reviewing',
+  'review-feedback': 'Review Feedback',
+  testing:           'Testing',
+  merging:           'Merging',
+  merged:            'Merged',
+};
+
+const borderColor = '#232f48';
+const bgHeader = '#161b26';
+const textSecondary = '#92a4c9';
+const textMuted = '#4a5568';
+const bgActive = '#1e2d47';
+const bgHover = '#1a2236';
+
+function loadPinState(issueId: string): string | null {
+  try {
+    return localStorage.getItem(`pan-terminal-pin-${issueId}`);
+  } catch {
+    return null;
+  }
+}
+
+export function savePinState(issueId: string, sessionName: string | null): void {
+  try {
+    const key = `pan-terminal-pin-${issueId}`;
+    if (sessionName === null) {
+      localStorage.removeItem(key);
+    } else {
+      localStorage.setItem(key, sessionName);
+    }
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export function loadPersistedPin(issueId: string): string | null {
+  return loadPinState(issueId);
+}
+
+export function TerminalTabs({
+  issueId,
+  tabs,
+  selectedSession,
+  activePhase,
+  pinned,
+  onSelectSession,
+  onTogglePin,
+}: TerminalTabsProps) {
+  // When auto-follow is on (not pinned), switch to the active tab automatically
+  useEffect(() => {
+    if (pinned) return;
+    const activeTab = tabs.find(t => t.isActive && !t.disabled);
+    if (activeTab && activeTab.sessionName !== selectedSession) {
+      onSelectSession(activeTab.sessionName);
+    }
+  }, [pinned, tabs, selectedSession, onSelectSession]);
+
+  const phaseColors = PHASE_CHIP_COLORS[activePhase] ?? { bg: '#1e2d47', text: textSecondary };
+  const phaseLabel = PHASE_LABELS[activePhase] ?? activePhase;
+
+  return (
+    <div
+      className="flex items-center gap-1 px-2 border-b shrink-0 select-none"
+      style={{ borderColor, backgroundColor: bgHeader, height: '32px' }}
+    >
+      {/* Phase chip */}
+      <span
+        className="text-xs font-semibold px-1.5 py-0.5 rounded mr-1"
+        style={{ backgroundColor: phaseColors.bg, color: phaseColors.text, fontSize: '10px' }}
+      >
+        {phaseLabel}
+      </span>
+
+      {/* Tab buttons */}
+      <div className="flex items-center gap-0.5 flex-1 min-w-0 overflow-x-auto">
+        {tabs.map(tab => {
+          const isSelected = tab.sessionName === selectedSession;
+          return (
+            <button
+              key={tab.id}
+              disabled={tab.disabled}
+              onClick={() => {
+                if (!tab.disabled) {
+                  onSelectSession(tab.sessionName);
+                  // If user clicks a different tab than auto, engage pin
+                  if (!tab.isActive && !pinned) {
+                    onTogglePin();
+                  }
+                  savePinState(issueId, tab.sessionName);
+                }
+              }}
+              title={tab.disabled ? 'Session not available' : tab.label}
+              className="text-xs px-2 py-0.5 rounded transition-colors whitespace-nowrap"
+              style={{
+                color: tab.disabled
+                  ? textMuted
+                  : isSelected
+                    ? '#e2e8f0'
+                    : textSecondary,
+                backgroundColor: isSelected ? bgActive : 'transparent',
+                cursor: tab.disabled ? 'default' : 'pointer',
+                fontWeight: tab.isActive ? 600 : 400,
+                fontSize: '11px',
+              }}
+              onMouseEnter={e => {
+                if (!tab.disabled && !isSelected) {
+                  (e.currentTarget as HTMLButtonElement).style.backgroundColor = bgHover;
+                }
+              }}
+              onMouseLeave={e => {
+                if (!isSelected) {
+                  (e.currentTarget as HTMLButtonElement).style.backgroundColor = 'transparent';
+                }
+              }}
+            >
+              {tab.label}
+              {tab.isActive && (
+                <span
+                  className="ml-1 inline-block w-1.5 h-1.5 rounded-full"
+                  style={{ backgroundColor: phaseColors.text, verticalAlign: 'middle' }}
+                />
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Auto / Pin toggle */}
+      <button
+        onClick={onTogglePin}
+        title={pinned ? 'Pinned — click to follow phase automatically' : 'Auto-following phase — click to pin current session'}
+        className="flex items-center gap-1 text-xs px-1.5 py-0.5 rounded transition-colors ml-1 shrink-0"
+        style={{
+          color: pinned ? '#fbbf24' : textMuted,
+          backgroundColor: 'transparent',
+        }}
+        onMouseEnter={e => {
+          (e.currentTarget as HTMLButtonElement).style.backgroundColor = bgHover;
+        }}
+        onMouseLeave={e => {
+          (e.currentTarget as HTMLButtonElement).style.backgroundColor = 'transparent';
+        }}
+      >
+        {pinned ? (
+          <Pin className="w-3 h-3" />
+        ) : (
+          <PinOff className="w-3 h-3" />
+        )}
+        <span style={{ fontSize: '10px' }}>{pinned ? 'Pinned' : 'Auto'}</span>
+      </button>
+    </div>
+  );
+}

--- a/src/dashboard/frontend/src/components/inspector/TerminalTabs.tsx
+++ b/src/dashboard/frontend/src/components/inspector/TerminalTabs.tsx
@@ -92,7 +92,6 @@ export function loadPersistedPin(issueId: string): string | null {
 }
 
 export function TerminalTabs({
-  issueId,
   tabs,
   selectedSession,
   activePhase,

--- a/src/dashboard/frontend/src/components/inspector/TerminalTabs.tsx
+++ b/src/dashboard/frontend/src/components/inspector/TerminalTabs.tsx
@@ -4,7 +4,6 @@ import { Pin, PinOff } from 'lucide-react';
 export type PipelinePhase =
   | 'planning'
   | 'working'
-  | 'verifying'
   | 'reviewing'
   | 'review-feedback'
   | 'testing'
@@ -38,20 +37,18 @@ interface TerminalTabsProps {
 }
 
 export const PHASE_CHIP_COLORS: Record<string, { bg: string; text: string }> = {
-  planning:        { bg: '#1e3a5f', text: '#60a5fa' },
-  working:         { bg: '#1a3a1a', text: '#4ade80' },
-  verifying:       { bg: '#2d2a14', text: '#fbbf24' },
-  reviewing:       { bg: '#2d1a3a', text: '#c084fc' },
+  planning:          { bg: '#1e3a5f', text: '#60a5fa' },
+  working:           { bg: '#1a3a1a', text: '#4ade80' },
+  reviewing:         { bg: '#2d1a3a', text: '#c084fc' },
   'review-feedback': { bg: '#3a1a1a', text: '#f87171' },
-  testing:         { bg: '#1a2d3a', text: '#38bdf8' },
-  merging:         { bg: '#2d2014', text: '#fb923c' },
-  merged:          { bg: '#1a3a2d', text: '#34d399' },
+  testing:           { bg: '#1a2d3a', text: '#38bdf8' },
+  merging:           { bg: '#2d2014', text: '#fb923c' },
+  merged:            { bg: '#1a3a2d', text: '#34d399' },
 };
 
 export const PHASE_LABELS: Record<string, string> = {
   planning:          'Planning',
   working:           'Working',
-  verifying:         'Verifying',
   reviewing:         'Reviewing',
   'review-feedback': 'Review Feedback',
   testing:           'Testing',

--- a/src/dashboard/frontend/src/components/inspector/TerminalTabs.tsx
+++ b/src/dashboard/frontend/src/components/inspector/TerminalTabs.tsx
@@ -140,7 +140,6 @@ export function TerminalTabs({
                   if (!tab.isActive && !pinned) {
                     onTogglePin();
                   }
-                  savePinState(issueId, tab.sessionName);
                 }
               }}
               title={tab.disabled ? 'Session not available' : tab.label}

--- a/src/dashboard/frontend/src/components/inspector/TerminalTabs.tsx
+++ b/src/dashboard/frontend/src/components/inspector/TerminalTabs.tsx
@@ -37,7 +37,7 @@ interface TerminalTabsProps {
   onTogglePin: () => void;
 }
 
-const PHASE_CHIP_COLORS: Record<string, { bg: string; text: string }> = {
+export const PHASE_CHIP_COLORS: Record<string, { bg: string; text: string }> = {
   planning:        { bg: '#1e3a5f', text: '#60a5fa' },
   working:         { bg: '#1a3a1a', text: '#4ade80' },
   verifying:       { bg: '#2d2a14', text: '#fbbf24' },
@@ -48,7 +48,7 @@ const PHASE_CHIP_COLORS: Record<string, { bg: string; text: string }> = {
   merged:          { bg: '#1a3a2d', text: '#34d399' },
 };
 
-const PHASE_LABELS: Record<string, string> = {
+export const PHASE_LABELS: Record<string, string> = {
   planning:          'Planning',
   working:           'Working',
   verifying:         'Verifying',

--- a/src/dashboard/frontend/src/components/inspector/usePipelinePhase.test.ts
+++ b/src/dashboard/frontend/src/components/inspector/usePipelinePhase.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect } from 'vitest';
+import { derivePipelinePhase, type PipelinePhaseInput } from './usePipelinePhase';
+import type { Agent } from '../../types';
+import type { ReviewStatus } from './types';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: 'agent-abc',
+    issueId: 'pan-509',
+    runtime: 'node',
+    model: 'claude-sonnet-4-6',
+    status: 'healthy',
+    startedAt: new Date().toISOString(),
+    consecutiveFailures: 0,
+    killCount: 0,
+    ...overrides,
+  };
+}
+
+function makeReviewStatus(overrides: Partial<ReviewStatus> = {}): ReviewStatus {
+  return {
+    issueId: 'pan-509',
+    reviewStatus: 'pending',
+    testStatus: 'pending',
+    mergeStatus: 'pending',
+    updatedAt: new Date().toISOString(),
+    readyForMerge: false,
+    ...overrides,
+  };
+}
+
+function makeInput(overrides: Partial<PipelinePhaseInput> = {}): PipelinePhaseInput {
+  return {
+    issueId: 'pan-509',
+    projectKey: 'panopticon',
+    ...overrides,
+  };
+}
+
+// ─── Phase precedence tests ────────────────────────────────────────────────────
+
+describe('derivePipelinePhase precedence table', () => {
+  // Precedence: merging → testing → reviewing → review-feedback → working → planning → merged
+
+  describe('merging phase', () => {
+    it('returns merging when mergeStatus === queued', () => {
+      const input = makeInput({ reviewStatus: makeReviewStatus({ mergeStatus: 'queued' }) });
+      const { phase, activeSession } = derivePipelinePhase(input);
+      expect(phase).toBe('merging');
+      expect(activeSession).toBe('specialist-panopticon-merge-agent');
+    });
+
+    it('returns merging when mergeStatus === merging', () => {
+      const input = makeInput({ reviewStatus: makeReviewStatus({ mergeStatus: 'merging' }) });
+      const { phase } = derivePipelinePhase(input);
+      expect(phase).toBe('merging');
+    });
+
+    it('returns merging when mergeStatus === verifying', () => {
+      const input = makeInput({ reviewStatus: makeReviewStatus({ mergeStatus: 'verifying' }) });
+      const { phase } = derivePipelinePhase(input);
+      expect(phase).toBe('merging');
+    });
+
+    it('merging takes precedence over testing', () => {
+      const input = makeInput({
+        reviewStatus: makeReviewStatus({ mergeStatus: 'merging', testStatus: 'testing' }),
+      });
+      const { phase } = derivePipelinePhase(input);
+      expect(phase).toBe('merging');
+    });
+
+    it('uses specialist session name with project key', () => {
+      const input = makeInput({
+        projectKey: 'my-project',
+        reviewStatus: makeReviewStatus({ mergeStatus: 'merging' }),
+      });
+      const { activeSession } = derivePipelinePhase(input);
+      expect(activeSession).toBe('specialist-my-project-merge-agent');
+    });
+
+    it('falls back to global session name when no project key', () => {
+      const input = makeInput({
+        projectKey: undefined,
+        reviewStatus: makeReviewStatus({ mergeStatus: 'merging' }),
+      });
+      const { activeSession } = derivePipelinePhase(input);
+      expect(activeSession).toBe('specialist-merge-agent');
+    });
+
+    it('returns null activeSession when merging session is dead', () => {
+      const input = makeInput({ reviewStatus: makeReviewStatus({ mergeStatus: 'merging' }) });
+      const dead = new Set(['specialist-panopticon-merge-agent']);
+      const { activeSession } = derivePipelinePhase(input, dead);
+      expect(activeSession).toBeNull();
+    });
+  });
+
+  describe('merged phase', () => {
+    it('returns merged when mergeStatus === merged', () => {
+      const input = makeInput({ reviewStatus: makeReviewStatus({ mergeStatus: 'merged' }) });
+      const { phase, activeSession } = derivePipelinePhase(input);
+      expect(phase).toBe('merged');
+      expect(activeSession).toBeNull();
+    });
+
+    it('merged takes precedence over testing', () => {
+      const input = makeInput({
+        reviewStatus: makeReviewStatus({ mergeStatus: 'merged', testStatus: 'testing' }),
+      });
+      const { phase } = derivePipelinePhase(input);
+      expect(phase).toBe('merged');
+    });
+
+    it('merged takes precedence over reviewing', () => {
+      const input = makeInput({
+        reviewStatus: makeReviewStatus({ mergeStatus: 'merged', reviewStatus: 'reviewing' }),
+      });
+      const { phase } = derivePipelinePhase(input);
+      expect(phase).toBe('merged');
+    });
+  });
+
+  describe('testing phase', () => {
+    it('returns testing when testStatus === testing', () => {
+      const input = makeInput({ reviewStatus: makeReviewStatus({ testStatus: 'testing' }) });
+      const { phase, activeSession } = derivePipelinePhase(input);
+      expect(phase).toBe('testing');
+      expect(activeSession).toBe('specialist-panopticon-test-agent');
+    });
+
+    it('does NOT return testing when testStatus !== testing', () => {
+      const input = makeInput({ reviewStatus: makeReviewStatus({ testStatus: 'passed' }) });
+      const { phase } = derivePipelinePhase(input);
+      expect(phase).not.toBe('testing');
+    });
+
+    it('testing takes precedence over reviewing', () => {
+      const input = makeInput({
+        reviewStatus: makeReviewStatus({ testStatus: 'testing', reviewStatus: 'reviewing' }),
+      });
+      const { phase } = derivePipelinePhase(input);
+      expect(phase).toBe('testing');
+    });
+
+    it('returns null activeSession when test session is dead', () => {
+      const input = makeInput({ reviewStatus: makeReviewStatus({ testStatus: 'testing' }) });
+      const dead = new Set(['specialist-panopticon-test-agent']);
+      const { activeSession } = derivePipelinePhase(input, dead);
+      expect(activeSession).toBeNull();
+    });
+  });
+
+  describe('reviewing phase', () => {
+    it('returns reviewing when reviewStatus === reviewing', () => {
+      const input = makeInput({ reviewStatus: makeReviewStatus({ reviewStatus: 'reviewing' }) });
+      const { phase, activeSession } = derivePipelinePhase(input);
+      expect(phase).toBe('reviewing');
+      expect(activeSession).toBe('specialist-panopticon-review-agent');
+    });
+
+    it('does NOT return reviewing when reviewStatus !== reviewing', () => {
+      const input = makeInput({ reviewStatus: makeReviewStatus({ reviewStatus: 'passed' }) });
+      const { phase } = derivePipelinePhase(input);
+      expect(phase).not.toBe('reviewing');
+    });
+
+    it('reviewing takes precedence over working', () => {
+      const input = makeInput({
+        agent: makeAgent({ status: 'healthy' }),
+        reviewStatus: makeReviewStatus({ reviewStatus: 'reviewing' }),
+      });
+      const { phase } = derivePipelinePhase(input);
+      expect(phase).toBe('reviewing');
+    });
+
+    it('returns null activeSession when review session is dead', () => {
+      const input = makeInput({ reviewStatus: makeReviewStatus({ reviewStatus: 'reviewing' }) });
+      const dead = new Set(['specialist-panopticon-review-agent']);
+      const { activeSession } = derivePipelinePhase(input, dead);
+      expect(activeSession).toBeNull();
+    });
+  });
+
+  describe('review-feedback phase', () => {
+    it('returns review-feedback when review failed and agent is running', () => {
+      const input = makeInput({
+        agent: makeAgent({ status: 'healthy' }),
+        reviewStatus: makeReviewStatus({ reviewStatus: 'failed' }),
+      });
+      const { phase, activeSession } = derivePipelinePhase(input);
+      expect(phase).toBe('review-feedback');
+      expect(activeSession).toBe('agent-abc');
+    });
+
+    it('returns review-feedback when review failed and agent is starting', () => {
+      const input = makeInput({
+        agent: makeAgent({ status: 'starting' }),
+        reviewStatus: makeReviewStatus({ reviewStatus: 'failed' }),
+      });
+      const { phase } = derivePipelinePhase(input);
+      expect(phase).toBe('review-feedback');
+    });
+
+    it('does NOT return review-feedback when review failed but agent is stopped', () => {
+      const input = makeInput({
+        agent: makeAgent({ status: 'stopped' }),
+        reviewStatus: makeReviewStatus({ reviewStatus: 'failed' }),
+      });
+      const { phase } = derivePipelinePhase(input);
+      expect(phase).not.toBe('review-feedback');
+    });
+
+    it('review-feedback takes precedence over plain working', () => {
+      const input = makeInput({
+        agent: makeAgent({ status: 'healthy' }),
+        reviewStatus: makeReviewStatus({ reviewStatus: 'failed' }),
+      });
+      const { phase } = derivePipelinePhase(input);
+      expect(phase).toBe('review-feedback');
+    });
+  });
+
+  describe('working phase', () => {
+    it('returns working when agent is healthy and no specialist active', () => {
+      const input = makeInput({ agent: makeAgent({ status: 'healthy' }) });
+      const { phase, activeSession } = derivePipelinePhase(input);
+      expect(phase).toBe('working');
+      expect(activeSession).toBe('agent-abc');
+    });
+
+    it('returns working when agent is starting and no specialist active', () => {
+      const input = makeInput({ agent: makeAgent({ status: 'starting' }) });
+      const { phase } = derivePipelinePhase(input);
+      expect(phase).toBe('working');
+    });
+
+    it('does NOT return working for stopped agent', () => {
+      const input = makeInput({ agent: makeAgent({ status: 'stopped' }) });
+      const { phase } = derivePipelinePhase(input);
+      expect(phase).not.toBe('working');
+    });
+
+    it('does NOT return working when reviewing is active', () => {
+      const input = makeInput({
+        agent: makeAgent({ status: 'healthy' }),
+        reviewStatus: makeReviewStatus({ reviewStatus: 'reviewing' }),
+      });
+      const { phase } = derivePipelinePhase(input);
+      expect(phase).not.toBe('working');
+    });
+  });
+
+  describe('planning / idle phase', () => {
+    it('returns planning when no agent and no specialist active', () => {
+      const input = makeInput();
+      const { phase, activeSession } = derivePipelinePhase(input);
+      expect(phase).toBe('planning');
+      expect(activeSession).toBeNull();
+    });
+
+    it('returns planning when agent is stopped', () => {
+      const input = makeInput({ agent: makeAgent({ status: 'stopped' }) });
+      const { phase } = derivePipelinePhase(input);
+      expect(phase).toBe('planning');
+    });
+  });
+});
+
+// ─── availableTerminals tests ──────────────────────────────────────────────────
+
+describe('derivePipelinePhase availableTerminals', () => {
+  it('includes Work tab when agent exists', () => {
+    const input = makeInput({ agent: makeAgent() });
+    const { availableTerminals } = derivePipelinePhase(input);
+    const workTab = availableTerminals.find(t => t.id === 'working');
+    expect(workTab).toBeTruthy();
+    expect(workTab?.sessionName).toBe('agent-abc');
+  });
+
+  it('does NOT include Work tab when no agent', () => {
+    const input = makeInput();
+    const { availableTerminals } = derivePipelinePhase(input);
+    expect(availableTerminals.find(t => t.id === 'working')).toBeUndefined();
+  });
+
+  it('includes Review tab when reviewStatus is not pending', () => {
+    const input = makeInput({ reviewStatus: makeReviewStatus({ reviewStatus: 'passed' }) });
+    const { availableTerminals } = derivePipelinePhase(input);
+    expect(availableTerminals.find(t => t.id === 'reviewing')).toBeTruthy();
+  });
+
+  it('does NOT include Review tab when reviewStatus === pending', () => {
+    const input = makeInput({ reviewStatus: makeReviewStatus({ reviewStatus: 'pending' }) });
+    const { availableTerminals } = derivePipelinePhase(input);
+    expect(availableTerminals.find(t => t.id === 'reviewing')).toBeUndefined();
+  });
+
+  it('includes Test tab when testStatus is not pending', () => {
+    const input = makeInput({ reviewStatus: makeReviewStatus({ testStatus: 'passed' }) });
+    const { availableTerminals } = derivePipelinePhase(input);
+    expect(availableTerminals.find(t => t.id === 'testing')).toBeTruthy();
+  });
+
+  it('includes Merge tab when mergeStatus is not pending', () => {
+    const input = makeInput({ reviewStatus: makeReviewStatus({ mergeStatus: 'merged' }) });
+    const { availableTerminals } = derivePipelinePhase(input);
+    expect(availableTerminals.find(t => t.id === 'merging')).toBeTruthy();
+  });
+
+  it('marks Review tab as active when phase is reviewing', () => {
+    const input = makeInput({ reviewStatus: makeReviewStatus({ reviewStatus: 'reviewing' }) });
+    const { availableTerminals } = derivePipelinePhase(input);
+    const reviewTab = availableTerminals.find(t => t.id === 'reviewing');
+    expect(reviewTab?.isActive).toBe(true);
+  });
+
+  it('marks Work tab as active when phase is working', () => {
+    const input = makeInput({ agent: makeAgent({ status: 'healthy' }) });
+    const { availableTerminals } = derivePipelinePhase(input);
+    const workTab = availableTerminals.find(t => t.id === 'working');
+    expect(workTab?.isActive).toBe(true);
+  });
+
+  it('marks dead sessions as disabled', () => {
+    const input = makeInput({ reviewStatus: makeReviewStatus({ reviewStatus: 'passed' }) });
+    const dead = new Set(['specialist-panopticon-review-agent']);
+    const { availableTerminals } = derivePipelinePhase(input, dead);
+    const reviewTab = availableTerminals.find(t => t.id === 'reviewing');
+    expect(reviewTab?.disabled).toBe(true);
+  });
+
+  it('does NOT include tabs whose sessions are undefined (no reviewStatus)', () => {
+    const input = makeInput({ agent: makeAgent() });
+    const { availableTerminals } = derivePipelinePhase(input);
+    // No specialist tabs when reviewStatus is absent
+    expect(availableTerminals.filter(t => t.id !== 'working')).toHaveLength(0);
+  });
+});

--- a/src/dashboard/frontend/src/components/inspector/usePipelinePhase.test.ts
+++ b/src/dashboard/frontend/src/components/inspector/usePipelinePhase.test.ts
@@ -221,6 +221,34 @@ describe('derivePipelinePhase precedence table', () => {
       const { phase } = derivePipelinePhase(input);
       expect(phase).toBe('review-feedback');
     });
+
+    it('returns review-feedback when review is blocked (backend writes blocked on rejection)', () => {
+      const input = makeInput({
+        agent: makeAgent({ status: 'healthy' }),
+        reviewStatus: makeReviewStatus({ reviewStatus: 'blocked' }),
+      });
+      const { phase, activeSession } = derivePipelinePhase(input);
+      expect(phase).toBe('review-feedback');
+      expect(activeSession).toBe('agent-abc');
+    });
+
+    it('returns review-feedback when review blocked and agent is starting', () => {
+      const input = makeInput({
+        agent: makeAgent({ status: 'starting' }),
+        reviewStatus: makeReviewStatus({ reviewStatus: 'blocked' }),
+      });
+      const { phase } = derivePipelinePhase(input);
+      expect(phase).toBe('review-feedback');
+    });
+
+    it('does NOT return review-feedback when review blocked but agent is stopped', () => {
+      const input = makeInput({
+        agent: makeAgent({ status: 'stopped' }),
+        reviewStatus: makeReviewStatus({ reviewStatus: 'blocked' }),
+      });
+      const { phase } = derivePipelinePhase(input);
+      expect(phase).not.toBe('review-feedback');
+    });
   });
 
   describe('working phase', () => {

--- a/src/dashboard/frontend/src/components/inspector/usePipelinePhase.ts
+++ b/src/dashboard/frontend/src/components/inspector/usePipelinePhase.ts
@@ -60,7 +60,7 @@ export function derivePipelinePhase(
   } else if (rs === 'reviewing') {
     phase = 'reviewing';
     activeSession = deadSessions.has(reviewSession) ? null : reviewSession;
-  } else if (rs === 'failed' && (agent?.status === 'healthy' || agent?.status === 'starting')) {
+  } else if ((rs === 'failed' || rs === 'blocked') && (agent?.status === 'healthy' || agent?.status === 'starting')) {
     phase = 'review-feedback';
     activeSession = workSession;
   } else if (agent?.status === 'healthy' || agent?.status === 'starting') {

--- a/src/dashboard/frontend/src/components/inspector/usePipelinePhase.ts
+++ b/src/dashboard/frontend/src/components/inspector/usePipelinePhase.ts
@@ -148,8 +148,9 @@ export function usePipelinePhase(input: PipelinePhaseInput): PipelinePhaseResult
 
   const immediateResult = useMemo(
     () => derivePipelinePhase(input, deadSessions),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [input.agent, input.reviewStatus, input.projectKey, input.issueId, deadSessions],
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- input.agent narrowed to id+status;
+    // the full object reference changes on every parent render, which would reset the 1s debounce timer
+    [input.agent?.id, input.agent?.status, input.reviewStatus, input.projectKey, input.issueId, deadSessions],
   );
 
   useEffect(() => {

--- a/src/dashboard/frontend/src/components/inspector/usePipelinePhase.ts
+++ b/src/dashboard/frontend/src/components/inspector/usePipelinePhase.ts
@@ -22,7 +22,8 @@ export interface PipelinePhaseResult {
  * Pure function — unit-testable without React.
  *
  * Precedence (first match wins):
- *   merging → testing → reviewing → verifying → working → planning → merged
+ *   merging (queued|merging|verifying mergeStatus) → merged → testing → reviewing
+ *   → review-feedback → working → planning
  */
 export function derivePipelinePhase(
   input: PipelinePhaseInput,

--- a/src/dashboard/frontend/src/components/inspector/usePipelinePhase.ts
+++ b/src/dashboard/frontend/src/components/inspector/usePipelinePhase.ts
@@ -73,9 +73,6 @@ export function derivePipelinePhase(
   // Build available tabs — only include tabs that are relevant to the current state
   const tabs: TerminalTab[] = [];
 
-  // Planning tab: shown if a planning session exists (can't check from pure fn, handled by hook)
-  // We include it in the list but callers add it conditionally
-
   // Work tab: always show if agent exists
   if (workSession) {
     tabs.push({
@@ -129,12 +126,8 @@ export function derivePipelinePhase(
  */
 export function usePipelinePhase(input: PipelinePhaseInput): PipelinePhaseResult & {
   markSessionDead: (sessionName: string) => void;
-  deadSessions: Set<string>;
-  planningSessionName: string;
 } {
-  const { issueId } = input;
   const [deadSessions, setDeadSessions] = useState<Set<string>>(() => new Set());
-  const planningSessionName = `planning-${issueId}`;
 
   const markSessionDead = useCallback((sessionName: string) => {
     setDeadSessions(prev => {
@@ -184,7 +177,5 @@ export function usePipelinePhase(input: PipelinePhaseInput): PipelinePhaseResult
   return {
     ...debouncedResult,
     markSessionDead,
-    deadSessions,
-    planningSessionName,
   };
 }

--- a/src/dashboard/frontend/src/components/inspector/usePipelinePhase.ts
+++ b/src/dashboard/frontend/src/components/inspector/usePipelinePhase.ts
@@ -1,0 +1,190 @@
+import { useMemo, useRef, useCallback, useEffect, useState } from 'react';
+import type { Agent } from '../../types';
+import type { ReviewStatus } from './types';
+import type { PipelinePhase, TerminalTab } from './TerminalTabs';
+
+export interface PipelinePhaseInput {
+  issueId: string;
+  agent?: Agent;
+  reviewStatus?: ReviewStatus;
+  /** The canonical project key used in specialist session names (e.g. "panopticon") */
+  projectKey?: string;
+}
+
+export interface PipelinePhaseResult {
+  phase: PipelinePhase;
+  activeSession: string | null;
+  availableTerminals: TerminalTab[];
+}
+
+/**
+ * Derive the current pipeline phase from inputs.
+ * Pure function — unit-testable without React.
+ *
+ * Precedence (first match wins):
+ *   merging → testing → reviewing → verifying → working → planning → merged
+ */
+export function derivePipelinePhase(
+  input: PipelinePhaseInput,
+  deadSessions: ReadonlySet<string> = new Set(),
+): PipelinePhaseResult {
+  const { agent, reviewStatus, projectKey } = input;
+
+  // Session name helpers
+  const workSession = agent?.id ?? null;
+  const specialistSession = (role: string): string =>
+    projectKey ? `specialist-${projectKey}-${role}` : `specialist-${role}`;
+
+  const reviewSession = specialistSession('review-agent');
+  const testSession = specialistSession('test-agent');
+  const mergeSession = specialistSession('merge-agent');
+
+  const ms = reviewStatus?.mergeStatus;
+  const rs = reviewStatus?.reviewStatus;
+  const ts = reviewStatus?.testStatus;
+
+  // Phase detection — precedence order
+  let phase: PipelinePhase;
+  let activeSession: string | null;
+
+  if (ms === 'queued' || ms === 'merging' || ms === 'verifying') {
+    phase = 'merging';
+    activeSession = deadSessions.has(mergeSession) ? null : mergeSession;
+  } else if (ms === 'merged') {
+    phase = 'merged';
+    activeSession = null;
+  } else if (ts === 'testing') {
+    phase = 'testing';
+    activeSession = deadSessions.has(testSession) ? null : testSession;
+  } else if (rs === 'reviewing') {
+    phase = 'reviewing';
+    activeSession = deadSessions.has(reviewSession) ? null : reviewSession;
+  } else if (rs === 'failed' && (agent?.status === 'healthy' || agent?.status === 'starting')) {
+    phase = 'review-feedback';
+    activeSession = workSession;
+  } else if (agent?.status === 'healthy' || agent?.status === 'starting') {
+    phase = 'working';
+    activeSession = workSession;
+  } else {
+    phase = 'planning';
+    activeSession = null; // planning session only shown if it exists
+  }
+
+  // Build available tabs — only include tabs that are relevant to the current state
+  const tabs: TerminalTab[] = [];
+
+  // Planning tab: shown if a planning session exists (can't check from pure fn, handled by hook)
+  // We include it in the list but callers add it conditionally
+
+  // Work tab: always show if agent exists
+  if (workSession) {
+    tabs.push({
+      id: 'working',
+      label: 'Work',
+      sessionName: workSession,
+      isActive: phase === 'working' || phase === 'review-feedback',
+      disabled: deadSessions.has(workSession),
+    });
+  }
+
+  // Review tab: show once review has started (not just pending)
+  if (rs && rs !== 'pending') {
+    tabs.push({
+      id: 'reviewing',
+      label: 'Review',
+      sessionName: reviewSession,
+      isActive: phase === 'reviewing',
+      disabled: deadSessions.has(reviewSession),
+    });
+  }
+
+  // Test tab: show once testing has started
+  if (ts && ts !== 'pending') {
+    tabs.push({
+      id: 'testing',
+      label: 'Test',
+      sessionName: testSession,
+      isActive: phase === 'testing',
+      disabled: deadSessions.has(testSession),
+    });
+  }
+
+  // Merge tab: show once merge has been queued or beyond
+  if (ms && ms !== 'pending') {
+    tabs.push({
+      id: 'merging',
+      label: 'Merge',
+      sessionName: mergeSession,
+      isActive: phase === 'merging',
+      disabled: ms === 'merged' || deadSessions.has(mergeSession),
+    });
+  }
+
+  return { phase, activeSession, availableTerminals: tabs };
+}
+
+/**
+ * React hook wrapping derivePipelinePhase. Tracks dead sessions via onSessionEnded callbacks.
+ * Auto-switches are debounced by 1 second to prevent churn.
+ */
+export function usePipelinePhase(input: PipelinePhaseInput): PipelinePhaseResult & {
+  markSessionDead: (sessionName: string) => void;
+  deadSessions: Set<string>;
+  planningSessionName: string;
+} {
+  const { issueId } = input;
+  const [deadSessions, setDeadSessions] = useState<Set<string>>(() => new Set());
+  const planningSessionName = `planning-${issueId}`;
+
+  const markSessionDead = useCallback((sessionName: string) => {
+    setDeadSessions(prev => {
+      if (prev.has(sessionName)) return prev;
+      const next = new Set(prev);
+      next.add(sessionName);
+      return next;
+    });
+  }, []);
+
+  // Debounce phase changes by 1s to prevent auto-switch churn
+  const resultRef = useRef<PipelinePhaseResult | null>(null);
+  const [debouncedResult, setDebouncedResult] = useState<PipelinePhaseResult>(() =>
+    derivePipelinePhase(input, deadSessions),
+  );
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const immediateResult = useMemo(
+    () => derivePipelinePhase(input, deadSessions),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [input.agent, input.reviewStatus, input.projectKey, input.issueId, deadSessions],
+  );
+
+  useEffect(() => {
+    const prev = resultRef.current;
+    resultRef.current = immediateResult;
+
+    // If phase changed, debounce the update to avoid rapid tab switching
+    if (prev?.phase !== immediateResult.phase) {
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = setTimeout(() => {
+        setDebouncedResult(immediateResult);
+      }, 1000);
+    } else {
+      // Non-phase changes (session added/removed) apply immediately
+      setDebouncedResult(immediateResult);
+    }
+  }, [immediateResult]);
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    };
+  }, []);
+
+  return {
+    ...debouncedResult,
+    markSessionDead,
+    deadSessions,
+    planningSessionName,
+  };
+}


### PR DESCRIPTION
## Summary
- Implements phase-aware terminal tab switching in the inspector panel
- Adds MergedSummaryCard shown when a workspace is merged (timestamp, cost, PR link)
- Adds pipeline phase badge to InspectorPanel header
- Introduces usePipelinePhase hook as single source of truth for phase derivation

## Changes
- `usePipelinePhase.ts` — new hook deriving phase from agent + reviewStatus; handles `blocked`/`failed` for review-feedback
- `TerminalTabs.tsx` — new tab strip with phase chip, pin/unpin, exported color/label maps
- `TerminalSessionWrapper.tsx` — wraps XTerminal with session-ended retry UI
- `MergedSummaryCard.tsx` — merged state card with cost pill and PR link
- `TerminalPanel.tsx` — parameterized with sessionName/title/onSessionEnded
- `DetailPanelLayout.tsx` — single owner of review-status query; wires all new components
- `InspectorPanel.tsx` — accepts phase/reviewStatus as props; removed duplicate phase derivation

## Test plan
- [ ] 206 test files passing, 2803 tests
- [ ] TypeScript strict clean
- [ ] ESLint clean
- [ ] MergedSummaryCard.test.tsx (12 tests)
- [ ] TerminalSessionWrapper.test.tsx (7 tests)
- [ ] usePipelinePhase.test.ts (41 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)