### PR TITLE
fix(settings): restore provider login status and codex auth

### DIFF
--- a/src/dashboard/frontend/src/components/Settings/SettingsPage.tsx
+++ b/src/dashboard/frontend/src/components/Settings/SettingsPage.tsx
@@ -64,6 +64,27 @@ interface SaveSettingsResponse {
   warnings?: string[];
 }
 
+interface ClaudeAuthStatus {
+  installed: boolean;
+  loggedIn: boolean;
+  expired: boolean;
+  subscriptionType: string | null;
+  rateLimitTier: string | null;
+  expiresAt: number | null;
+  hasAnthropicApiKey: boolean;
+}
+
+interface OpenAIAuthStatus {
+  installed: boolean;
+  loggedIn: boolean;
+  expired: boolean;
+  authMode: string | null;
+  accountId: string | null;
+  lastRefresh: string | null;
+  accessTokenExpiresAt: number | null;
+  hasOpenAIApiKey: boolean;
+}
+
 async function saveSettings(settings: SettingsConfig): Promise<SaveSettingsResponse> {
   const res = await fetch('/api/settings', {
     method: 'PUT',
@@ -83,6 +104,18 @@ async function fetchOptimalDefaults(): Promise<SettingsConfig> {
   return res.json();
 }
 
+async function fetchClaudeAuthStatus(): Promise<ClaudeAuthStatus> {
+  const res = await fetch('/api/settings/claude-auth');
+  if (!res.ok) throw new Error('Failed to fetch Claude auth status');
+  return res.json();
+}
+
+async function fetchOpenAIAuthStatus(): Promise<OpenAIAuthStatus> {
+  const res = await fetch('/api/settings/openai-auth');
+  if (!res.ok) throw new Error('Failed to fetch OpenAI auth status');
+  return res.json();
+}
+
 interface TestApiKeyResult {
   success: boolean;
   error: string | null;
@@ -99,6 +132,13 @@ async function testApiKey(provider: string, apiKey: string, model?: string): Pro
   });
   if (!res.ok) throw new Error('Failed to test API key');
   return res.json();
+}
+
+function formatAuthTimestamp(value?: number | string | null): string | null {
+  if (!value) return null;
+  const date = typeof value === 'number' ? new Date(value) : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString();
 }
 
 // Provider definitions
@@ -242,7 +282,27 @@ export function SettingsPage() {
   const [modelTestResults, setModelTestResults] = useState<Record<string, TestApiKeyResult | null>>({});
   const [clearingCache, setClearingCache] = useState(false);
   const [activeSection, setActiveSection] = useState<string>('smart-selection');
+  const [claudeAuth, setClaudeAuth] = useState<ClaudeAuthStatus | null>(null);
+  const [openaiAuth, setOpenAIAuth] = useState<OpenAIAuthStatus | null>(null);
+  const [refreshingAuth, setRefreshingAuth] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
+
+  const refreshProviderAuth = useCallback(async () => {
+    setRefreshingAuth(true);
+    try {
+      const [claudeStatus, openaiStatus] = await Promise.all([
+        fetchClaudeAuthStatus(),
+        fetchOpenAIAuthStatus(),
+      ]);
+      setClaudeAuth(claudeStatus);
+      setOpenAIAuth(openaiStatus);
+    } catch (err) {
+      console.error('Failed to refresh provider auth status:', err);
+      toast.error('Failed to refresh provider login status');
+    } finally {
+      setRefreshingAuth(false);
+    }
+  }, []);
 
   // Track active section based on scroll position
   // The settings page lives inside an overflow-auto container, not the window
@@ -282,6 +342,10 @@ export function SettingsPage() {
       });
     }
   }, []);
+
+  useEffect(() => {
+    void refreshProviderAuth();
+  }, [refreshProviderAuth]);
 
   useEffect(() => {
     if (settings && !formData) {
@@ -566,8 +630,129 @@ export function SettingsPage() {
         </div>
       </section>
 
-      {/* Provider Configuration */}
+      {/* Provider Logins + Configuration */}
       <section id="providers" className="mb-12 scroll-mt-4">
+        <div className="flex items-center gap-3 mb-6">
+          <h2 className="text-content text-2xl font-bold">Provider Logins</h2>
+          <div className="h-px flex-1 bg-divider-strong" />
+          <button
+            onClick={() => void refreshProviderAuth()}
+            disabled={refreshingAuth}
+            className="shrink-0 p-2 rounded-lg border border-divider hover:border-divider-strong text-content-muted hover:text-content transition-colors disabled:opacity-50"
+            title="Refresh provider login status"
+          >
+            <RefreshCw className={`w-4 h-4 ${refreshingAuth ? 'animate-spin' : ''}`} />
+          </button>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-10">
+          <div className="bg-surface-raised border border-divider rounded-xl p-5 shadow-sm">
+            <div className="flex items-start gap-4">
+              <div className={`mt-1 size-3 rounded-full shrink-0 ${
+                claudeAuth?.loggedIn ? 'bg-emerald-400' :
+                claudeAuth?.installed ? 'bg-amber-400' :
+                'bg-surface-emphasis'
+              }`} />
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <h3 className="text-content font-bold">Claude Code Login</h3>
+                  {claudeAuth?.loggedIn && claudeAuth.subscriptionType && (
+                    <span className="text-[10px] font-black uppercase tracking-tighter px-2 py-0.5 rounded bg-blue-500/15 text-blue-400 border border-blue-500/25">
+                      {claudeAuth.subscriptionType.toUpperCase()}
+                    </span>
+                  )}
+                </div>
+                {claudeAuth === null ? (
+                  <p className="text-content-muted text-sm mt-2">Checking local Claude auth…</p>
+                ) : !claudeAuth.installed ? (
+                  <p className="text-content-muted text-sm mt-2">
+                    Claude Code is not installed on this machine.
+                  </p>
+                ) : claudeAuth.loggedIn ? (
+                  <>
+                    <p className="text-content-body text-sm mt-2">
+                      Local Claude subscription login detected.
+                    </p>
+                    {claudeAuth.rateLimitTier && (
+                      <p className="text-content-muted text-xs mt-1">
+                        Rate tier: <code className="font-mono">{claudeAuth.rateLimitTier}</code>
+                      </p>
+                    )}
+                    {formatAuthTimestamp(claudeAuth.expiresAt) && (
+                      <p className="text-content-muted text-xs mt-1">
+                        Token expiry: {formatAuthTimestamp(claudeAuth.expiresAt)}
+                      </p>
+                    )}
+                    {claudeAuth.hasAnthropicApiKey && (
+                      <p className="text-amber-400 text-xs mt-2 flex items-center gap-1.5">
+                        <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+                        <span><code className="font-mono">ANTHROPIC_API_KEY</code> is also set and can override subscription auth for direct Anthropic calls.</span>
+                      </p>
+                    )}
+                  </>
+                ) : (
+                  <p className="text-content-muted text-sm mt-2">
+                    No active Claude Code login detected.
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-surface-raised border border-divider rounded-xl p-5 shadow-sm">
+            <div className="flex items-start gap-4">
+              <div className={`mt-1 size-3 rounded-full shrink-0 ${
+                openaiAuth?.loggedIn ? 'bg-emerald-400' :
+                openaiAuth?.installed ? 'bg-amber-400' :
+                'bg-surface-emphasis'
+              }`} />
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <h3 className="text-content font-bold">OpenAI / Codex Login</h3>
+                  {openaiAuth?.loggedIn && (
+                    <span className="text-[10px] font-black uppercase tracking-tighter px-2 py-0.5 rounded bg-blue-500/15 text-blue-400 border border-blue-500/25">
+                      ChatGPT OAuth
+                    </span>
+                  )}
+                </div>
+                {openaiAuth === null ? (
+                  <p className="text-content-muted text-sm mt-2">Checking local Codex auth…</p>
+                ) : !openaiAuth.installed ? (
+                  <p className="text-content-muted text-sm mt-2">
+                    Codex is not installed or initialized on this machine.
+                  </p>
+                ) : openaiAuth.loggedIn ? (
+                  <>
+                    <p className="text-content-body text-sm mt-2">
+                      Local Codex/ChatGPT login detected. GPT work agents can use claudish subscription auth without an API key.
+                    </p>
+                    {openaiAuth.accountId && (
+                      <p className="text-content-muted text-xs mt-1">
+                        Account: <code className="font-mono">{openaiAuth.accountId}</code>
+                      </p>
+                    )}
+                    {formatAuthTimestamp(openaiAuth.lastRefresh) && (
+                      <p className="text-content-muted text-xs mt-1">
+                        Last refresh: {formatAuthTimestamp(openaiAuth.lastRefresh)}
+                      </p>
+                    )}
+                    {openaiAuth.expired && (
+                      <p className="text-amber-400 text-xs mt-2 flex items-center gap-1.5">
+                        <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+                        <span>The cached access token is stale, but Codex may still refresh it automatically on next use.</span>
+                      </p>
+                    )}
+                  </>
+                ) : (
+                  <p className="text-content-muted text-sm mt-2">
+                    No local Codex/ChatGPT login detected. Without that login, GPT models fall back to API-key auth.
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
         <h2 className="text-content text-2xl font-bold mb-6 flex items-center gap-3">
           Provider Configuration
           <div className="h-px flex-1 bg-divider-strong" />
@@ -577,6 +762,12 @@ export function SettingsPage() {
             const isDefault = provider.id === 'anthropic';
             const isEnabled = isDefault || formData.models.providers[provider.id];
             const apiKey = formData.api_keys[provider.id as keyof typeof formData.api_keys] || '';
+            const isEnvVarRef = apiKey.startsWith('$');
+            const hasConfiguredValue = !!apiKey;
+            const hasDirectApiKey = hasConfiguredValue && !isEnvVarRef;
+            const canViewModels = provider.id === 'openai'
+              ? hasConfiguredValue || !!openaiAuth?.loggedIn
+              : hasDirectApiKey;
 
             return (
               <div
@@ -599,6 +790,11 @@ export function SettingsPage() {
                     <provider.icon className="w-5 h-5 text-content-subtle" />
                   </div>
                   <span className="font-bold text-content">{provider.name}</span>
+                  {isDefault && claudeAuth?.loggedIn && claudeAuth.subscriptionType && (
+                    <span className="text-[9px] font-black uppercase tracking-tighter px-1.5 py-0.5 rounded bg-blue-500/15 text-blue-400 border border-blue-500/25">
+                      {claudeAuth.subscriptionType.toUpperCase()}
+                    </span>
+                  )}
                   <div className="ml-auto">
                     <button
                       onClick={() => handleProviderToggle(provider.id)}
@@ -616,65 +812,106 @@ export function SettingsPage() {
                   </div>
                 </div>
                 <div className="space-y-3">
-                  <div className="relative">
-                    <label className="text-[10px] uppercase font-bold text-content-muted mb-1 block">API Key</label>
-                    {/* Check if it's an unresolved env var reference */}
-                    {apiKey.startsWith('$') ? (
-                      <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg px-3 py-2">
-                        <div className="flex items-center gap-2 text-amber-400 text-xs">
-                          <AlertTriangle className="w-4 h-4" />
-                          <span>Configured via <code className="font-mono bg-surface-overlay px-1 rounded">{apiKey}</code></span>
+                  {isDefault ? (
+                    <div>
+                      <label className="text-[10px] uppercase font-bold text-content-muted mb-1 block">Authentication</label>
+                      {claudeAuth?.loggedIn ? (
+                        <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-emerald-500/10 border border-emerald-500/20">
+                          <CheckCircle className="w-4 h-4 text-emerald-400 shrink-0" />
+                          <span className="text-xs text-emerald-300 font-medium">
+                            Using Claude Code subscription login
+                          </span>
                         </div>
-                        <p className="text-[10px] text-amber-400/70 mt-1">
-                          Set this environment variable or enter the key directly below
-                        </p>
-                        <input
-                          type="text"
-                          placeholder={provider.placeholder}
-                          onChange={(e) => handleApiKeyChange(provider.id, e.target.value)}
-                          autoComplete="off"
-                          className="w-full bg-input-bg border border-divider-strong rounded-lg px-3 py-2 text-xs font-mono mt-2 focus:ring-1 focus:ring-blue-500 focus:border-blue-500 text-content-body"
-                        />
-                      </div>
-                    ) : (
+                      ) : claudeAuth?.hasAnthropicApiKey ? (
+                        <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-500/10 border border-blue-500/20">
+                          <Key className="w-4 h-4 text-blue-400 shrink-0" />
+                          <span className="text-xs text-blue-300 font-medium">Using Anthropic API key from environment</span>
+                        </div>
+                      ) : (
+                        <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-amber-500/10 border border-amber-500/20">
+                          <AlertTriangle className="w-4 h-4 text-amber-400 shrink-0" />
+                          <span className="text-xs text-amber-300">No Claude auth detected. See Provider Logins above.</span>
+                        </div>
+                      )}
+                    </div>
+                  ) : (
+                    <>
+                      {provider.id === 'openai' && (
+                        <div>
+                          <label className="text-[10px] uppercase font-bold text-content-muted mb-1 block">Authentication</label>
+                          {openaiAuth?.loggedIn && !hasConfiguredValue ? (
+                            <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-emerald-500/10 border border-emerald-500/20">
+                              <CheckCircle className="w-4 h-4 text-emerald-400 shrink-0" />
+                              <span className="text-xs text-emerald-300 font-medium">
+                                Using Codex subscription login via claudish
+                              </span>
+                            </div>
+                          ) : openaiAuth?.loggedIn && hasConfiguredValue ? (
+                            <div className="flex items-start gap-2 px-3 py-2 rounded-lg bg-blue-500/10 border border-blue-500/20">
+                              <AlertTriangle className="w-4 h-4 text-blue-400 shrink-0 mt-0.5" />
+                              <span className="text-xs text-blue-300">
+                                Codex subscription login is available, but an API key is also configured. Remove the key if you want GPT agents to rely only on the local login.
+                              </span>
+                            </div>
+                          ) : null}
+                        </div>
+                      )}
                       <div className="relative">
-                        <input
-                          type={showApiKey[provider.id] ? 'text' : 'password'}
-                          value={apiKey}
-                          onChange={(e) => handleApiKeyChange(provider.id, e.target.value)}
-                          disabled={isDefault}
-                          placeholder={provider.placeholder}
-                          autoComplete="off"
-                          autoCorrect="off"
-                          autoCapitalize="off"
-                          spellCheck={false}
-                          data-lpignore="true"
-                          data-1p-ignore="true"
-                          data-form-type="other"
-                          className={`w-full bg-input-bg border border-divider-strong rounded-lg px-3 py-2 pr-16 text-xs font-mono focus:ring-1 focus:ring-blue-500 focus:border-blue-500 ${
-                            isDefault ? 'cursor-not-allowed text-content-muted' : 'text-content-body'
-                          }`}
-                        />
-                        {!isDefault && (
-                          <button
-                            onClick={() => setShowApiKey({ ...showApiKey, [provider.id]: !showApiKey[provider.id] })}
-                            className="absolute right-8 top-1/2 -translate-y-1/2 text-content-muted hover:text-content-body"
-                          >
-                            {showApiKey[provider.id] ? (
-                              <Eye className="w-4 h-4" />
-                            ) : (
-                              <Eye className="w-4 h-4 opacity-50" />
-                            )}
-                          </button>
+                        <label className="text-[10px] uppercase font-bold text-content-muted mb-1 block">
+                          {provider.id === 'openai' && openaiAuth?.loggedIn ? 'API Key Override (Optional)' : 'API Key'}
+                        </label>
+                        {isEnvVarRef ? (
+                          <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg px-3 py-2">
+                            <div className="flex items-center gap-2 text-amber-400 text-xs">
+                              <AlertTriangle className="w-4 h-4" />
+                              <span>Configured via <code className="font-mono bg-surface-overlay px-1 rounded">{apiKey}</code></span>
+                            </div>
+                            <p className="text-[10px] text-amber-400/70 mt-1">
+                              Set this environment variable or enter the key directly below
+                            </p>
+                            <input
+                              type="text"
+                              placeholder={provider.placeholder}
+                              onChange={(e) => handleApiKeyChange(provider.id, e.target.value)}
+                              autoComplete="off"
+                              className="w-full bg-input-bg border border-divider-strong rounded-lg px-3 py-2 text-xs font-mono mt-2 focus:ring-1 focus:ring-blue-500 focus:border-blue-500 text-content-body"
+                            />
+                          </div>
+                        ) : (
+                          <div className="relative">
+                            <input
+                              type={showApiKey[provider.id] ? 'text' : 'password'}
+                              value={apiKey}
+                              onChange={(e) => handleApiKeyChange(provider.id, e.target.value)}
+                              placeholder={provider.placeholder}
+                              autoComplete="off"
+                              autoCorrect="off"
+                              autoCapitalize="off"
+                              spellCheck={false}
+                              data-lpignore="true"
+                              data-1p-ignore="true"
+                              data-form-type="other"
+                              className="w-full bg-input-bg border border-divider-strong rounded-lg px-3 py-2 pr-16 text-xs font-mono focus:ring-1 focus:ring-blue-500 focus:border-blue-500 text-content-body"
+                            />
+                            <button
+                              onClick={() => setShowApiKey({ ...showApiKey, [provider.id]: !showApiKey[provider.id] })}
+                              className="absolute right-8 top-1/2 -translate-y-1/2 text-content-muted hover:text-content-body"
+                            >
+                              {showApiKey[provider.id] ? (
+                                <Eye className="w-4 h-4" />
+                              ) : (
+                                <Eye className="w-4 h-4 opacity-50" />
+                              )}
+                            </button>
+                          </div>
                         )}
                       </div>
-                    )}
-                  </div>
-                  {/* Action Buttons */}
+                    </>
+                  )}
+
                   {!isDefault && (
                     <div className="flex flex-col gap-2">
-                      {/* Show Models Button - only if we have a real API key */}
-                      {apiKey && !apiKey.startsWith('$') && (
+                      {canViewModels && (
                         <button
                           onClick={() => setModelsModalProvider(provider.id)}
                           className="flex items-center justify-center gap-1.5 px-3 py-1.5 bg-blue-500/10 hover:bg-blue-500/20 border border-blue-500/30 rounded-lg text-xs text-blue-400 transition-colors w-full"
@@ -683,8 +920,7 @@ export function SettingsPage() {
                           View Models
                         </button>
                       )}
-                      {/* Test API Key Button - only if we have a real API key (not env var ref) */}
-                      {apiKey && !apiKey.startsWith('$') && (
+                      {hasDirectApiKey && (
                         <div className="flex items-center gap-2">
                           <button
                             onClick={() => handleTestApiKey(provider.id)}
@@ -1088,8 +1324,9 @@ export function SettingsPage() {
               {(() => {
                 const providerApiKey = formData?.api_keys[modelsModalProvider as keyof typeof formData.api_keys] || '';
                 const isEnvVarRef = providerApiKey.startsWith('$');
+                const canUseSubscriptionLogin = modelsModalProvider === 'openai' && !!openaiAuth?.loggedIn;
 
-                if (!providerApiKey) {
+                if (!providerApiKey && !canUseSubscriptionLogin) {
                   return (
                     <div className="text-center py-8">
                       <Key className="w-10 h-10 text-content-muted mb-2 mx-auto" />
@@ -1113,10 +1350,18 @@ export function SettingsPage() {
 
                 return (
                   <div className="space-y-3">
+                  {canUseSubscriptionLogin && !providerApiKey && (
+                    <div className="bg-emerald-500/10 border border-emerald-500/20 rounded-lg px-3 py-2">
+                      <p className="text-emerald-300 text-xs">
+                        Using local Codex subscription login. Model testing in this dialog still requires a direct API key.
+                      </p>
+                    </div>
+                  )}
                   {(MODELS_BY_PROVIDER[modelsModalProvider]?.models || []).map((model) => {
                     const testKey = `${modelsModalProvider}:${model.id}`;
                     const testResult = modelTestResults[testKey];
                     const isTesting = testingModel === testKey;
+                    const canTestModel = !!providerApiKey && !isEnvVarRef;
 
                     return (
                       <div
@@ -1158,7 +1403,7 @@ export function SettingsPage() {
                           <div className="flex flex-col items-end gap-2">
                             <button
                               onClick={() => handleTestModel(modelsModalProvider, model.id)}
-                              disabled={isTesting}
+                              disabled={!canTestModel || isTesting}
                               className="flex items-center gap-1.5 px-3 py-1.5 bg-emerald-500/10 hover:bg-emerald-500/20 border border-emerald-500/30 rounded-lg text-xs text-emerald-400 transition-colors disabled:opacity-50 whitespace-nowrap"
                             >
                               {isTesting ? (

--- a/src/dashboard/server/routes/settings.ts
+++ b/src/dashboard/server/routes/settings.ts
@@ -23,6 +23,8 @@ import {
   saveOpenRouterFavorites,
   getOpenRouterFavorites,
 } from '../../../lib/settings-api.js';
+import { getClaudeAuthStatus } from '../../../lib/claude-auth.js';
+import { getOpenAIAuthStatus } from '../../../lib/openai-auth.js';
 import { OpenRouterService } from '../services/openrouter-service.js';
 import { httpHandler } from './http-handler.js';
 
@@ -118,6 +120,28 @@ const getOptimalDefaultsRoute = HttpRouter.add(
   httpHandler(Effect.try({
     try: () => jsonResponse(getOptimalDefaultsApi()),
     catch: (err) => new Error(err instanceof Error ? err.message : String(err)),
+  })),
+);
+
+// ─── Route: GET /api/settings/claude-auth ────────────────────────────────────
+
+const getClaudeAuthRoute = HttpRouter.add(
+  'GET',
+  '/api/settings/claude-auth',
+  httpHandler(Effect.gen(function* () {
+    const status = yield* Effect.promise(() => getClaudeAuthStatus());
+    return jsonResponse(status);
+  })),
+);
+
+// ─── Route: GET /api/settings/openai-auth ────────────────────────────────────
+
+const getOpenAIAuthRoute = HttpRouter.add(
+  'GET',
+  '/api/settings/openai-auth',
+  httpHandler(Effect.gen(function* () {
+    const status = yield* Effect.promise(() => getOpenAIAuthStatus());
+    return jsonResponse(status);
   })),
 );
 
@@ -452,6 +476,8 @@ export const settingsRouteLayer = Layer.mergeAll(
   getSettingsRoute,
   getAvailableModelsRoute,
   getOptimalDefaultsRoute,
+  getClaudeAuthRoute,
+  getOpenAIAuthRoute,
   postTestApiKeyRoute,
   postValidateApiKeyRoute,
   putSettingsRoute,

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -12,9 +12,10 @@ import type { ComplexityLevel } from './cloister/complexity.js';
 import { loadCloisterConfig } from './cloister/config.js';
 import type { ModelId } from './settings.js';
 import { getModelId, WorkTypeId } from './work-type-router.js';
-import { getProviderForModel, getProviderEnv, setupCredentialFileAuth, clearCredentialFileAuth, requiresClaudish } from './providers.js';
+import { getProviderForModel, getProviderEnv, setupCredentialFileAuth, clearCredentialFileAuth } from './providers.js';
 import { loadConfig as loadYamlConfig } from './config-yaml.js';
 import { loadConfig } from './config.js';
+import { getOpenAIAuthStatusSync } from './openai-auth.js';
 import { createTrackerFromConfig, createTracker } from './tracker/factory.js';
 import type { IssueState } from './tracker/interface.js';
 import { findProjectByPath, getIssuePrefix } from './projects.js';
@@ -41,9 +42,10 @@ export function getProviderEnvForModel(model: string): Record<string, string> {
   const provider = getProviderForModel(model);
   if (provider.name === 'anthropic') return {};
 
+  const { config } = loadYamlConfig();
+
   // OpenRouter API key is stored in config.yaml under providers.openrouter.api_key
   if (provider.name === 'openrouter') {
-    const { config } = loadYamlConfig();
     const apiKey = config.apiKeys.openrouter;
     if (apiKey) {
       return getProviderEnv(provider, apiKey);
@@ -51,11 +53,24 @@ export function getProviderEnvForModel(model: string): Record<string, string> {
     throw new Error(`OpenRouter API key not configured. Add your key in Settings → OpenRouter before using model "${model}".`);
   }
 
-  const { config } = loadYamlConfig();
   const apiKey = config.apiKeys[provider.name as keyof typeof config.apiKeys];
+
+  if (provider.name === 'openai') {
+    const authStatus = getOpenAIAuthStatusSync();
+    const prefersSubscription = config.providerAuth?.openai === 'subscription' || (!apiKey && authStatus.loggedIn);
+    if (prefersSubscription && authStatus.loggedIn) {
+      return getProviderEnv(provider, 'subscription-oauth');
+    }
+  }
+
   if (apiKey) {
     return getProviderEnv(provider, apiKey);
   }
+
+  if (provider.name === 'openai' && getOpenAIAuthStatusSync().loggedIn) {
+    return getProviderEnv(provider, 'subscription-oauth');
+  }
+
   throw new Error(`No API key configured for ${provider.displayName}. Configure it in Settings before using model "${model}".`);
 }
 
@@ -703,8 +718,12 @@ export async function spawnAgent(options: SpawnOptions): Promise<AgentState> {
 
   // Determine auth mode for OpenAI from config (subscription vs api-key)
   const yamlConfig = loadYamlConfig();
-  const openaiAuthMode = yamlConfig.config?.providerAuth?.['openai'];
-  const effectiveAuthMode = openaiAuthMode ?? 'api-key';
+  const provider = getProviderForModel(selectedModel as ModelId);
+  const openaiAuthStatus = getOpenAIAuthStatusSync();
+  const openaiApiKey = yamlConfig.config?.apiKeys.openai;
+  const openaiAuthMode = yamlConfig.config?.providerAuth?.['openai']
+    ?? (!openaiApiKey && openaiAuthStatus.loggedIn ? 'subscription' : 'api-key');
+  const effectiveAuthMode = provider.name === 'openai' ? openaiAuthMode : undefined;
 
   // Get claudish-prefixed model if needed (e.g. oai@gpt-5.4 or cx@o3)
   const claudishModel = getClaudishPrefix(selectedModel, effectiveAuthMode);
@@ -713,7 +732,6 @@ export async function spawnAgent(options: SpawnOptions): Promise<AgentState> {
   // so Claude Code can refresh short-lived tokens dynamically.
   // For all other providers, CLEAR any stale apiKeyHelper from previous runs
   // (e.g. switching from Kimi to Anthropic plan-based auth).
-  const provider = getProviderForModel(selectedModel as ModelId);
   if (provider.authType === 'credential-file') {
     setupCredentialFileAuth(provider, options.workspace);
   } else {

--- a/src/lib/openai-auth.ts
+++ b/src/lib/openai-auth.ts
@@ -1,0 +1,124 @@
+/**
+ * openai-auth.ts
+ *
+ * Reads Codex/ChatGPT local auth state from ~/.codex/auth.json so Panopticon
+ * can surface subscription-login status in Settings and route GPT models
+ * through claudish without requiring an API key.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+export interface OpenAIAuthStatus {
+  /** True if the ~/.codex directory exists (Codex installed / initialized). */
+  installed: boolean;
+  /** True if a ChatGPT/Codex OAuth session appears to be present. */
+  loggedIn: boolean;
+  /** True if the access token is expired, even if refresh may still succeed. */
+  expired: boolean;
+  /** Auth mode persisted by Codex (usually "chatgpt" for subscription auth). */
+  authMode: string | null;
+  /** Codex account identifier, if present. */
+  accountId: string | null;
+  /** When Codex last refreshed auth state, if recorded. */
+  lastRefresh: string | null;
+  /** Access-token expiry timestamp in ms, if it can be derived from the JWT. */
+  accessTokenExpiresAt: number | null;
+  /** True when an OpenAI API key is present in auth.json or env. */
+  hasOpenAIApiKey: boolean;
+}
+
+interface RawAuthFile {
+  auth_mode?: unknown;
+  last_refresh?: unknown;
+  OPENAI_API_KEY?: unknown;
+  tokens?: {
+    id_token?: unknown;
+    access_token?: unknown;
+    refresh_token?: unknown;
+    account_id?: unknown;
+  };
+}
+
+function decodeBase64Url(value: string): string | null {
+  try {
+    const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+    const padding = normalized.length % 4 === 0 ? '' : '='.repeat(4 - (normalized.length % 4));
+    return Buffer.from(normalized + padding, 'base64').toString('utf8');
+  } catch {
+    return null;
+  }
+}
+
+function decodeJwtPayload(token: string | null): Record<string, unknown> | null {
+  if (!token) return null;
+  const parts = token.split('.');
+  if (parts.length < 2) return null;
+
+  const decoded = decodeBase64Url(parts[1]);
+  if (!decoded) return null;
+
+  try {
+    return JSON.parse(decoded) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function getJwtExpiry(token: string | null): number | null {
+  const payload = decodeJwtPayload(token);
+  return typeof payload?.exp === 'number' ? payload.exp * 1000 : null;
+}
+
+export function getOpenAIAuthStatusSync(): OpenAIAuthStatus {
+  const codexDir = join(homedir(), '.codex');
+  const authPath = join(codexDir, 'auth.json');
+  const installed = existsSync(codexDir);
+
+  const defaultStatus: OpenAIAuthStatus = {
+    installed,
+    loggedIn: false,
+    expired: false,
+    authMode: null,
+    accountId: null,
+    lastRefresh: null,
+    accessTokenExpiresAt: null,
+    hasOpenAIApiKey: !!process.env.OPENAI_API_KEY,
+  };
+
+  if (!existsSync(authPath)) {
+    return defaultStatus;
+  }
+
+  try {
+    const raw = JSON.parse(readFileSync(authPath, 'utf8')) as RawAuthFile;
+    const authMode = typeof raw.auth_mode === 'string' ? raw.auth_mode : null;
+    const lastRefresh = typeof raw.last_refresh === 'string' ? raw.last_refresh : null;
+    const accessToken = typeof raw.tokens?.access_token === 'string' ? raw.tokens.access_token : null;
+    const refreshToken = typeof raw.tokens?.refresh_token === 'string' ? raw.tokens.refresh_token : null;
+    const idToken = typeof raw.tokens?.id_token === 'string' ? raw.tokens.id_token : null;
+    const accountId = typeof raw.tokens?.account_id === 'string' ? raw.tokens.account_id : null;
+    const accessTokenExpiresAt = getJwtExpiry(accessToken) ?? getJwtExpiry(idToken);
+    const expired = !!(accessTokenExpiresAt && accessTokenExpiresAt < Date.now());
+    const hasOpenAIApiKey = defaultStatus.hasOpenAIApiKey
+      || (typeof raw.OPENAI_API_KEY === 'string' && raw.OPENAI_API_KEY.trim().length > 0);
+
+    return {
+      installed,
+      loggedIn: authMode === 'chatgpt' && !!(refreshToken || accessToken || idToken),
+      expired,
+      authMode,
+      accountId,
+      lastRefresh,
+      accessTokenExpiresAt,
+      hasOpenAIApiKey,
+    };
+  } catch {
+    return defaultStatus;
+  }
+}
+
+export async function getOpenAIAuthStatus(): Promise<OpenAIAuthStatus> {
+  return getOpenAIAuthStatusSync();
+}

--- a/src/lib/settings-api.ts
+++ b/src/lib/settings-api.ts
@@ -155,24 +155,26 @@ export function loadSettingsApi(): ApiSettingsConfig {
  */
 export function saveSettingsApi(settings: ApiSettingsConfig): void {
   const { config: currentConfig } = loadConfig();
+  const providerAuth = currentConfig.providerAuth ?? {};
+  const providerPlan = currentConfig.providerPlan ?? {};
 
   // Convert API format to YAML format
   const yamlConfig: YamlConfig = {
     models: {
       providers: {
         anthropic: settings.models.providers.anthropic,
-        openai: currentConfig.providerAuth.openai || currentConfig.providerPlan.openai
+        openai: providerAuth.openai || providerPlan.openai
           ? {
               enabled: settings.models.providers.openai,
-              auth: currentConfig.providerAuth.openai,
-              plan: currentConfig.providerPlan.openai,
+              auth: providerAuth.openai,
+              plan: providerPlan.openai,
             }
           : settings.models.providers.openai,
-        google: currentConfig.providerAuth.google || currentConfig.providerPlan.google
+        google: providerAuth.google || providerPlan.google
           ? {
               enabled: settings.models.providers.google,
-              auth: currentConfig.providerAuth.google,
-              plan: currentConfig.providerPlan.google,
+              auth: providerAuth.google,
+              plan: providerPlan.google,
             }
           : settings.models.providers.google,
         zai: settings.models.providers.minimax,

--- a/src/lib/settings-api.ts
+++ b/src/lib/settings-api.ts
@@ -154,13 +154,27 @@ export function loadSettingsApi(): ApiSettingsConfig {
  * Save settings from API format (for PUT /api/settings)
  */
 export function saveSettingsApi(settings: ApiSettingsConfig): void {
+  const { config: currentConfig } = loadConfig();
+
   // Convert API format to YAML format
   const yamlConfig: YamlConfig = {
     models: {
       providers: {
         anthropic: settings.models.providers.anthropic,
-        openai: settings.models.providers.openai,
-        google: settings.models.providers.google,
+        openai: currentConfig.providerAuth.openai || currentConfig.providerPlan.openai
+          ? {
+              enabled: settings.models.providers.openai,
+              auth: currentConfig.providerAuth.openai,
+              plan: currentConfig.providerPlan.openai,
+            }
+          : settings.models.providers.openai,
+        google: currentConfig.providerAuth.google || currentConfig.providerPlan.google
+          ? {
+              enabled: settings.models.providers.google,
+              auth: currentConfig.providerAuth.google,
+              plan: currentConfig.providerPlan.google,
+            }
+          : settings.models.providers.google,
         zai: settings.models.providers.minimax,
         kimi: settings.models.providers.kimi,
         openrouter: settings.models.providers.openrouter,


### PR DESCRIPTION
## Summary
- restore the Settings provider login status UI for Claude Code and OpenAI / Codex
- add backend auth-status endpoints for Claude and local Codex auth
- allow GPT agent launches to use claudish subscription auth when local Codex login exists, without requiring an OpenAI API key
- preserve provider auth metadata when saving settings

Closes #686
