### PR TITLE
Fix issue-scoped specialist session recovery

### DIFF
--- a/docs/prds/planned/PAN-754-specialist-identity-and-model-resolution.md
+++ b/docs/prds/planned/PAN-754-specialist-identity-and-model-resolution.md
@@ -42,6 +42,19 @@ Fix the four defects at their root without a broader rearchitecture:
 
 Strict rule: every bug above is fixed in one issue, not split across follow-ups (per `CLAUDE.md`: "Deliver Complete Features").
 
+## Agent Activity Visibility
+
+The Agents page currently shows a specialist row with project, type, and run status but not *what the agent is actively working on*. PAN-754 adds:
+
+- **`currentActivity: string | null`** — set at dispatch time (e.g., `"Reviewing PAN-754 — correctness"`, `"Testing PAN-754"`). Static at spawn time; represents intent, not live progress.
+- **`model: string | null`** — which model was resolved for this run (e.g., `"gpt-5.4"`).
+- **`issueId: string`** — displayed prominently on each row.
+- **"resolved via" tooltip** on the model name showing the resolution trace (e.g., `work-type-router → models.overrides`).
+
+**Live progress:** click any row → terminal panel opens the live tmux output for that session. No additional backend work needed; this already exists in the dashboard.
+
+The `currentActivity` field is descriptive enough for at-a-glance understanding without requiring a streaming capture of tmux output. Periodic tmux pane capture is explicitly out of scope for this PRD.
+
 ## Non-Goals (explicit)
 
 Documented here so they are not drifted into during implementation. See `docs/research/specialist-redesign.md` for the broader design exploration — these are future work, not this PRD:

--- a/docs/prds/planned/PAN-754-specialist-identity-and-model-resolution.md
+++ b/docs/prds/planned/PAN-754-specialist-identity-and-model-resolution.md
@@ -1,0 +1,326 @@
+# PAN-754: Fix Specialist Identity and Model Resolution
+
+## Problem
+
+Post PAN-722 (queue removal), four defects remain in specialist lifecycle. They share a single root: **the tmux session name is the identity key for agent lifecycle**, and everything downstream (registry shape, dashboard enumeration, busy-check, stuck detection) inherits the granularity of that key.
+
+### 1. Per-project singleton baked in at three places
+
+- `src/lib/cloister/specialists.ts:636` — `getTmuxSessionName(specialistType, projectKey)` returns `specialist-${projectKey}-${name}`. No issueId, no role-suffix for convoy. Two concurrent issues on the same project collide on one tmux session name.
+- `src/lib/cloister/specialists.ts:1476-1513` — registry is `projects[projectKey][specialistType]`. Two-level. One entry per `(project, type)`.
+- `src/lib/cloister/specialists.ts:1605-1648` — `getAllProjectSpecialistStatuses()` walks that two-level shape. Agents page renders one row per `(project, type)`.
+
+At dispatch (`spawnEphemeralSpecialist` line 693), the busy check (lines 720-733) returns `specialist_busy` if the named session is active; deacon retries on patrol. Throughput is capped at 1/project for review and test specialists regardless of issue count. PAN-722's PRD claimed parallel dispatch; the implementation did not deliver it.
+
+### 2. Inverted model priority — hidden Sonnet default
+
+`src/lib/cloister/config.ts:246` hardcodes `specialist_models.review_agent: 'sonnet'`. That default sits at a priority level that shadows `models.overrides.specialist-review-agent` in user-facing Settings. User sets `gpt-5.4`; Sonnet runs. No trace is surfaced to log or UI — operator cannot see which layer of config won, or why.
+
+### 3. PAN-540 convoy reviewers invisible
+
+On `feature/pan-540`, `src/lib/cloister/review-agent.ts:438-485` (`runParallelReview`) spawns 4 sibling tmux sessions named `review-<issueId>-<timestamp>-<role>` via `createSessionAsync` + `sendKeysAsync claude --model X`. These sessions are:
+
+- Not Claude Code subagents (they are sibling tmux processes)
+- Not entered in the specialist registry
+- Not shown on the Agents page
+- Not seen by the busy check or deacon's stuck-detection
+
+They execute outside the supervision boundary entirely.
+
+### 4. Duplicate-tab risk on shared worktree
+
+Today's only coordination primitive is the tmux session name keyed on `(project, type)`. There is no structural defense against two agents writing to the same worktree — the PAN-540 convoy in particular has 4 sibling agents reading the same worktree files. This is safe **by construction** (they write disjoint output files) but not safe **by policy** — nothing enforces the disjoint-output invariant.
+
+## Goal
+
+Fix the four defects at their root without a broader rearchitecture:
+
+1. Move specialist identity from `(project, type)` to `(project, issueId, role)`. 3-level registry, 3-level Agents page enumeration.
+2. Delete the hardcoded Sonnet default. Make `models.overrides.*` authoritative. Add a resolution trace visible in logs and one dashboard panel.
+3. Bring PAN-540's convoy reviewers into the same 3-level registry as first-class entries — not floating tmux sessions outside supervision.
+4. Enforce a "one writer per worktree" convention at dispatch with an explicit convoy allowance (reviewers share read-set; writes go to role-keyed output paths).
+
+Strict rule: every bug above is fixed in one issue, not split across follow-ups (per `CLAUDE.md`: "Deliver Complete Features").
+
+## Non-Goals (explicit)
+
+Documented here so they are not drifted into during implementation. See `docs/research/specialist-redesign.md` for the broader design exploration — these are future work, not this PRD:
+
+- Adopting vBRIEF v0.6 Plan/PlanItem/Edge as the SQLite substrate for specialist state
+- Migrating execution to xumux channels as agent-identity substrate
+- Generalized file-overlap audit scheduler using declared `ports`
+- Bounded specialist state machines (review / test)
+- Cross-plan DAG UI view
+- Dashboard rewrite (Agents / Specialists / Queues page consolidation)
+- Claude Code subagent (Task tool) runtime for reviewers — remains a follow-on
+- Changes to the merge-agent lifecycle (merge queue stays)
+- Changes to planning-agent or work-agent lifecycle
+
+## Current Architecture (summary of what changes)
+
+### Identity key
+
+```ts
+// src/lib/cloister/specialists.ts:636
+function getTmuxSessionName(specialistType: string, projectKey: string): string {
+  return `specialist-${projectKey}-${specialistType}`;
+}
+```
+
+### Registry shape
+
+```
+~/.panopticon/specialists/registry.json
+{
+  "projects": {
+    "<projectKey>": {
+      "<specialistType>": { status, pid, tmuxSession, dispatchedAt, ... }
+    }
+  }
+}
+```
+
+### Dispatch (`spawnEphemeralSpecialist`)
+
+```
+1. Compute session name from (type, projectKey)
+2. If registry[projectKey][type].status === 'running' → return 'specialist_busy'
+3. Else create tmux session, register, send prompt via sendKeysAsync
+```
+
+### Model resolution (current order, inverted)
+
+```
+1. cloister.specialist_models[<role>_agent]  ← 'sonnet' default HERE wins
+2. models.overrides['specialist-<role>-agent']  ← user Settings value
+3. fallback
+```
+
+### PAN-540 convoy (feature branch, not merged)
+
+```
+runParallelReview(issueId, prompt, agents[]) {
+  for agent in agents {
+    session = `review-${issueId}-${timestamp}-${agent.role}`
+    createSessionAsync(session)
+    sendKeysAsync(session, `claude --model ${agent.model} "${prompt}"`)
+  }
+  // Sessions are not registered. Completion detected by polling session existence.
+}
+```
+
+## New Architecture
+
+### 1. Identity key and registry shape
+
+**Session name becomes:**
+
+```ts
+function getTmuxSessionName(
+  specialistType: string,
+  projectKey: string,
+  issueId: string,
+  role?: string,  // convoy sub-role: 'security' | 'correctness' | 'performance' | 'requirements' | 'synthesis'
+): string {
+  const suffix = role ? `-${role}` : '';
+  return `specialist-${projectKey}-${issueId}-${specialistType}${suffix}`;
+}
+```
+
+**Registry shape becomes 3-level:**
+
+```
+~/.panopticon/specialists/registry.json
+{
+  "projects": {
+    "<projectKey>": {
+      "<issueId>": {
+        "<specialistType>[:<role>]": {
+          status, pid, tmuxSession, dispatchedAt, model, runtime, ...
+          resolutionTrace?: ResolutionTrace   // see §2
+        }
+      }
+    }
+  }
+}
+```
+
+The leaf key is `<specialistType>` for singletons (test, inspect, uat, review-synthesis) and `<specialistType>:<role>` for convoy sub-agents (`review:security`, `review:correctness`, `review:performance`, `review:requirements`).
+
+**`getAllProjectSpecialistStatuses()` and the `/api/specialists` route** iterate all three levels and return a flat list of specialist entries. The dashboard Agents page renders one row per leaf entry.
+
+**Busy check is narrowed:** the check at `spawnEphemeralSpecialist` (lines 720-733) asks "is there a running entry for `(projectKey, issueId, specialistType[:role])`?" not "is there a running entry for `(projectKey, specialistType)`?" This permits parallel dispatch across different issues on the same project, which is the entire point of PAN-722.
+
+### 2. Model resolution — authoritative chain + resolution trace
+
+**Delete the hardcoded default** in `src/lib/cloister/config.ts:246`. The `specialist_models` object remains for user-configured per-role defaults but ships empty; no fallback string is baked into code.
+
+**Resolution order becomes a single explicit chain, first hit wins, no hidden defaults:**
+
+```ts
+function resolveSpecialistModel(context: {
+  specialistType: string;    // 'review' | 'test' | 'inspect' | 'uat' | 'merge'
+  role?: string;             // convoy role, if any
+  issueId: string;
+  projectKey: string;
+  cliOverride?: string;      // --model flag
+}): ResolvedModel {
+  const trace: ResolutionTrace = { steps: [] };
+
+  // 1. Explicit CLI flag
+  if (context.cliOverride) { trace.steps.push({source: 'cli', model: context.cliOverride}); return {model: context.cliOverride, trace}; }
+
+  // 2. Convoy role override (if applicable)
+  if (context.role && config.convoy[`${context.specialistType}-${context.role}`]) { ... }
+
+  // 3. Project-level specialist model override
+  if (config.projects[projectKey]?.specialist_models?.[`${specialistType}_agent`]) { ... }
+
+  // 4. Global user-level override (models.overrides.specialist-<type>-agent)
+  if (config.models.overrides[`specialist-${specialistType}-agent`]) { ... }
+
+  // 5. Work-type router
+  if (config.models.workTypeRouter[context.specialistType]) { ... }
+
+  // 6. Global explicit fallback (if set; no baked-in string)
+  if (config.models.fallback) { ... }
+
+  // 7. Unresolved — error loudly with trace
+  trace.steps.push({source: 'unresolved', reason: 'no layer matched'});
+  throw new ModelUnresolvedError(trace);
+}
+```
+
+**`ResolutionTrace`** is a first-class type stored on the specialist registry entry at dispatch time. It records which layers were consulted, which matched, and the final model. This is the surface operators see when a specialist ran on an unexpected model.
+
+**Dashboard exposure:** the existing specialist row on the Agents page gains a "resolved via" tooltip / expandable section showing `trace.steps`. No new page; one UI addition per row.
+
+**Runtime resolution (subagent vs tmux) is out of scope for this PRD.** Today all specialists run as tmux sessions. Stays that way until follow-on.
+
+### 3. PAN-540 convoy reviewers in the registry
+
+The `feature/pan-540` `runParallelReview` implementation is rebased on the new 3-level registry. Each convoy sub-agent is registered at:
+
+```
+projects[projectKey][issueId][`review:${role}`]
+```
+
+Session name pattern becomes:
+
+```
+specialist-<projectKey>-<issueId>-review-<role>
+```
+
+matching the §1 scheme. This removes the `-<timestamp>-` segment currently used in `feature/pan-540` for per-run uniqueness; uniqueness now comes from `issueId`. If a review cycle is re-run on the same issue, the old entry is transitioned through its completion lifecycle before the new dispatch (same pattern as singleton specialists).
+
+**Busy check for convoy dispatch:** check each role slot independently (`review:security`, `review:correctness`, ...). If any are busy for this `(project, issue)`, return `specialist_busy` with the specific roles named — do NOT silently skip or overwrite.
+
+**Synthesis sub-agent** registers as `review:synthesis` and depends on completion of the 4 reviewer roles before dispatch (enforced in `runParallelReview` orchestration, not in the registry).
+
+**Agents page rendering:** the 5 convoy entries for an issue appear as 5 sibling rows under that issue, grouped visually (a minimal grouping by `(projectKey, issueId, specialistType)` prefix).
+
+### 4. Single-writer-per-worktree enforcement
+
+At dispatch time in `spawnEphemeralSpecialist`, before creating the tmux session, we enforce:
+
+- **Single-writer invariant:** if another specialist entry in the registry is currently `status === 'running'` against the same workspace path AND that entry's `writeScope !== 'readonly'`, refuse the dispatch with a typed error (`worktree_write_conflict`). This replaces ad-hoc contention handling with one explicit check.
+- **Convoy exception:** reviewers declare `writeScope: 'readonly-plus-output'` with an `outputPath` of `reviews/<role>.md`. Scheduler permits parallel dispatch as long as `outputPath` values are distinct. Paths are validated before dispatch.
+
+This is NOT a generalized file-overlap auditor — no declared `ports`, no transitive audit. It is a two-case policy:
+
+- `writeScope: 'full'` — full write access to worktree. Only one at a time.
+- `writeScope: 'readonly-plus-output'` — reads shared worktree, writes only to a single declared `outputPath`. Multiple allowed if `outputPath`s are disjoint.
+
+`writeScope` is declared on the specialist type registration (not per-dispatch):
+
+- `work` → `full`
+- `test` → `full`
+- `inspect` → `full`
+- `uat` → `full`
+- `review` (non-convoy) → `full`
+- `review:<role>` (convoy) → `readonly-plus-output` with `outputPath: 'reviews/<role>.md'`
+- `review:synthesis` → `readonly-plus-output` with `outputPath: 'reviews/synthesis.md'`
+- `merge` → `full` (and human-gated, unchanged)
+
+## Implementation
+
+### Files to modify
+
+**`src/lib/cloister/specialists.ts`:**
+- `getTmuxSessionName()` — new signature `(type, projectKey, issueId, role?)`
+- Registry shape refactor to 3-level — internal storage + file layout
+  - `ensureProjectSpecialistDir()` becomes `ensureIssueSpecialistDir()`
+  - All registry reads/writes updated to 3-level path
+- `spawnEphemeralSpecialist(projectKey, issueId, specialistType, task, opts?)` — new required `issueId` parameter; optional `role` for convoy sub-agents; optional `writeScope`/`outputPath` override
+- Busy check narrowed to `(projectKey, issueId, specialistType[:role])`
+- Write-scope check added before tmux creation
+- `getAllProjectSpecialistStatuses()` — walks 3-level; returns flat list with `{projectKey, issueId, specialistType, role?, ...}`
+
+**`src/lib/cloister/config.ts`:**
+- Delete `specialist_models.review_agent: 'sonnet'` default at line 246
+- Delete any sibling hardcoded model defaults in the same block
+- Ensure `specialist_models` ships empty
+- Add `resolveSpecialistModel()` function + `ModelUnresolvedError` + `ResolutionTrace` type
+
+**`src/lib/cloister/review-agent.ts`** (rebased from `feature/pan-540`):
+- `runParallelReview` uses new `spawnEphemeralSpecialist` signature with `issueId` + `role`
+- Each of 4 reviewer roles + synthesis registered with `writeScope: 'readonly-plus-output'` and distinct `outputPath`
+- Remove the ad-hoc `createSessionAsync` + `sendKeysAsync` path — dispatch goes through `spawnEphemeralSpecialist`
+- Remove the `-<timestamp>-` segment from session names
+
+**`src/lib/cloister/deacon.ts`:**
+- Stuck-detection walks 3-level registry
+- `checkStuckSpecialists()` and related — update projections
+
+**Dashboard server:**
+- `src/dashboard/server/routes/specialists.ts` `GET /api/specialists` — returns flat list of 3-level entries. Response shape change.
+- Any service reading 2-level registry directly — updated. All async, per CLAUDE.md dashboard rules.
+
+**Dashboard frontend:**
+- `src/dashboard/frontend/src/components/AgentList.tsx` lines 252-296 — render flat list; group convoy roles under a single issue header
+- Add "resolved via" expandable section per row showing `ResolutionTrace`
+- Settings page: where specialist-model dropdowns are rendered, add an inline resolution preview ("your setting → resolved to: X via `models.overrides.specialist-review-agent`")
+
+**Tests:**
+- Update `tests/lib/cloister/specialists-*.test.ts` to cover:
+  - Two concurrent issues on same project → both dispatch successfully
+  - Convoy of 4 reviewers + synthesis on same issue → all 5 entries in registry
+  - Busy check within same `(project, issue, type:role)` → returns `specialist_busy`
+  - Busy check across different `(project, issue)` with same type → dispatches
+  - `writeScope: 'full'` + another `full` on same worktree → `worktree_write_conflict`
+  - Two `readonly-plus-output` with disjoint `outputPath` on same worktree → both dispatch
+  - Two `readonly-plus-output` with **same** `outputPath` → `worktree_write_conflict`
+  - Model resolution order — each layer wins at the right precedence
+  - Model resolution unresolved → `ModelUnresolvedError` with full trace
+- Update integration tests covering the review flow to exercise both singleton-review path and convoy path
+
+### Migration
+
+**Registry migration on first run after upgrade:** existing `projects[projectKey][specialistType]` entries are read and migrated into `projects[projectKey][<unknown>][specialistType]` under the sentinel issueId `<unknown>`. A subsequent deacon patrol garbage-collects `<unknown>` entries that don't correspond to a live tmux session. This avoids losing track of in-flight work across the upgrade.
+
+**Config migration:** `specialist_models.review_agent: 'sonnet'` (if present in user config) is left untouched. Only the hardcoded code-level default is removed. Users who explicitly set Sonnet in their YAML keep it; users who inherited the hidden default get nothing (and resolution falls through to `models.overrides`).
+
+## Acceptance Criteria
+
+1. Dispatching a review for issue A on project P while a review for issue B on project P is running → both dispatch and run concurrently, both appear on the Agents page.
+2. Setting `models.overrides.specialist-review-agent: gpt-5.4` with no `specialist_models.review_agent` configured → the review specialist runs on `gpt-5.4`. The Agents-page row shows a resolution trace terminating at `models.overrides`.
+3. PAN-540 parallel review dispatched for an issue → all 4 reviewer sub-agents AND the synthesis sub-agent appear on the Agents page, grouped under the issue, each with its own row, status, and resolution trace.
+4. Attempting to dispatch a `work` specialist against a worktree currently in use by another `full`-scope specialist → returns `worktree_write_conflict` with the conflicting specialist named. No tmux session is created.
+5. The deacon's stuck-detection identifies and recovers hung convoy sub-agents the same way it handles singleton specialists. Registry cleanup operates on 3-level paths.
+6. Registry migration on upgrade: pre-existing 2-level entries are migrated to sentinel-issueId entries; a deacon patrol within one minute reconciles against tmux and removes stale `<unknown>` entries that have no live session.
+7. Unit + integration tests above all pass. `npm run typecheck`, `npm run lint`, `npm test` all pass.
+
+## Risks
+
+- **Registry file layout change.** Existing users have an on-disk 2-level `registry.json`. The migration path above handles it, but a bad migration leaves in-flight specialists orphaned. Mitigation: migrate under a backup (`registry.json.pre-pan-754.bak`) and deacon-reconcile before accepting new dispatches.
+- **Dashboard response shape change.** `GET /api/specialists` response changes. Frontend and server ship in lockstep from one build; no external API consumers to worry about.
+- **PAN-540 feature branch conflicts.** This PRD effectively consumes and rebases `feature/pan-540`. The branch should be landed as part of PAN-754, not separately.
+- **Agents page visual density.** A 4-issue project with convoy reviews produces 20+ rows (4 issues × 5 convoy sub-agents). Grouping by `(projectKey, issueId)` is required for readability; not optional.
+- **Model resolution trace bloat in registry.** Trace is small (≤ 8 steps × short strings). Acceptable. Truncate or drop on registry file write if it exceeds 2 KB per entry.
+
+## References
+
+- Research: `docs/research/specialist-redesign.md` (broader rearchitecture options; non-goals for this PRD)
+- PAN-722: `docs/prds/planned/PAN-722-remove-specialist-queues.md` (predecessor — queue removal)
+- PAN-540: `feature/pan-540` branch — `src/lib/cloister/review-agent.ts` convoy implementation (to be rebased onto this)
+- CLAUDE.md rules: No bandaids, Never do agent work, Deliver complete features, Humans-only merge (unchanged)

--- a/docs/research/specialist-redesign.md
+++ b/docs/research/specialist-redesign.md
@@ -1,0 +1,290 @@
+# Specialist Redesign — Research & Brainstorming
+
+**Status:** Research / pre-PRD. Produced 2026-04-18.
+**Context:** Investigation of per-project specialist singleton problems (post PAN-722) → rearchitecture discussion → deft.ai concept study (vBRIEF, directive/deft-swarm, deft-review-cycle) + xumux.
+
+This document captures (a) the problem inventory, (b) the DAG reframe, (c) the deft/xumux synthesis, (d) open questions feeding the PRD. It is not itself a PRD.
+
+---
+
+## 1. Problem inventory
+
+Three design disasters surfaced during the specialist/Agents-page investigation. They are not independent bugs — they share the same root: **identity-by-name instead of identity-by-data**.
+
+### 1.1 PAN-722 (queue removal) left a per-project singleton
+
+The queue abstraction was removed. The singleton was not.
+
+Singleton is baked in at three places:
+
+- `src/lib/cloister/specialists.ts:636` — `getTmuxSessionName(specialistType, projectKey)` returns `specialist-${projectKey}-${name}`. No issueId/runId. Two concurrent issues collide on the same tmux session name.
+- `src/lib/cloister/specialists.ts:1476-1513` — registry shape is `projects[projectKey][specialistType]`. 2-level. One entry per type per project.
+- `src/lib/cloister/specialists.ts:1605-1648` — `getAllProjectSpecialistStatuses()` walks that 2-level shape. Agents page renders one row per `(project, specialistType)`.
+
+At dispatch (`spawnEphemeralSpecialist` line 693), a busy check (lines 720-733) returns `specialist_busy` if the named session is active. The deacon patrol retries on its next pass. **This is not reuse. It is contention-serialization via retry.** Throughput is capped at 1 review-per-project regardless of issue count.
+
+The PAN-722 PRD itself says "we spawn N ephemeral specialists in parallel" (line 115). The code does not.
+
+### 1.2 Inverted model priority — Sonnet lurking under every config
+
+`src/lib/cloister/config.ts:246` hardcodes `specialist_models.review_agent: 'sonnet'`. That default sits at a priority level that shadows `models.overrides.specialist-review-agent` in `~/.panopticon.env`-derived config. User sets `gpt-5.4` in Settings; reviewer runs on `sonnet`. Silent.
+
+This is a **priority-inversion bug expressed in configuration layers** — the deeper, older config wins over the newer user-facing one. No resolution trace is surfaced to the UI.
+
+### 1.3 PAN-540 parallel review — invisible sibling tmux sessions
+
+`feature/pan-540` branch, `src/lib/cloister/review-agent.ts:438-485` (`runParallelReview`) spawns 4 sibling tmux sessions via `createSessionAsync` + `sendKeysAsync claude --model X`. Session names: `review-<issueId>-<timestamp>-<role>`.
+
+These are **not**:
+- Claude Code subagents (Task tool) — would be in-process, tool-use chain integrated
+- Registered in the specialist registry
+- Visible on the Agents page
+
+They are separate tmux sessions, outside the supervision boundary. The "busy check" doesn't see them. The Agents page doesn't see them. The deacon's stuck detection doesn't see them either unless it walks `tmux list-sessions`.
+
+### 1.4 Cross-cutting: duplicate-tab failure mode
+
+Per directive `#261`/`#263`: two agents on the same worktree corrupt each other's `tool_use` / `tool_result` message chains. Our current architecture has no structural defense against this — tmux session name is the only coordination primitive, and it's keyed on projectKey not worktree.
+
+---
+
+## 2. Root cause
+
+All four symptoms share a single cause: **the tmux session name is the identity key for agent lifecycle**. Everything downstream (registry shape, dashboard listing, busy check, stuck detection) inherits the granularity of that key.
+
+If the key is `specialist-<project>-<type>`, you get one specialist per project per type. If it's `<issueId>-<role>`, you get siblings that nobody tracks. The design cannot express "this agent is working on plan X item Y with write-set Z" because the key doesn't carry that data.
+
+**Fix direction:** identity-by-data. The agent's identity is the work it is doing — which is a vBRIEF PlanItem. The tmux session (or subagent, or remote runner) is an implementation of that work, not its identity.
+
+---
+
+## 3. The DAG reframe
+
+User's aha-intuition: "the DAG we create from the vBrief — what does it look like when all issues' DAGs are interconnected? One huge DAG where different features/issues meet."
+
+This isn't abstract. It is the correct data model.
+
+- **Plan** (vBRIEF) = one issue's decomposition.
+- **PlanItem** = one atom of work (implementation step, review cycle, test run, uat, deacon tick, merge checkpoint).
+- **Edge** (blocks / informs / invalidates / suggests / data / custom) = typed dependency.
+- **planRef with fragment `#item-id`** = the primitive for **cross-plan** edges. This is where features meet.
+
+The "one huge DAG" the user imagined is the UNION of all active Plans, joined on `planRef` edges. Intersection points are either:
+- PlanItems shared between Plans (via planRef)
+- PlanItems from different Plans that touch the same files (via `ports.out` intersection — see §4.2)
+
+Both are first-class and queryable.
+
+Collapse today's primitives:
+- **Run** → a subgraph: one Plan's items plus their dependency closure
+- **Agent** → a worker-assignment on a PlanItem (has runtime = subagent | tmux | remote; has role = work | review | test | uat | merge | deacon)
+- **Specialist** → stops being a persistent entity. It is a **role** that gets assigned to a PlanItem when the item's node type demands it.
+
+---
+
+## 4. Concept synthesis (deft + xumux)
+
+Five concepts, one design.
+
+### 4.1 vBRIEF Plan schema as the SQLite substrate
+
+**Steal:** use vBRIEF v0.6 verbatim as the database schema. Panopticon's rows serialize directly to valid vBRIEF.
+
+Keeps:
+- `id`, `uid`, `sequence`, `changeLog` — audit trail free
+- `fork` — parent-child (issue spawned from parent plan, split/merge)
+- `items[]` — work atoms
+- `edges[]` — typed dependencies
+- `status` enum: `draft | proposed | approved | pending | running | completed | blocked | failed | cancelled` — maps exactly to our lifecycle
+- `narratives` — human/agent rationale on each item, live context for the reviewer/merger
+- `planRef` with fragment — cross-issue intersections
+
+**Workflow Profile extension** (strictly additive):
+- `nodeType: Trigger | Processing | FlowControl | Output` — deacon ticks are Triggers; agent work is Processing; merge/push is Output
+- `ports: { in, out }` on each item — **file read/write sets, declared up front**
+- `data` edges between items — dataflow
+- `retryOnFail`, `maxRetries`, `workflow.settings` — execution policy on the item itself
+
+Everything we currently hang off ad-hoc DB columns (queue name, specialist name, status, attempts) collapses into vBRIEF.
+
+**Interop bonus:** Panopticon-as-deft-engine story becomes trivial. We don't translate to/from vBRIEF at the edge; we *are* vBRIEF at the core.
+
+### 4.2 File-overlap audit as scheduler primitive (replaces busy check)
+
+**Steal:** deft-swarm Phase 1 Step 2. Before parallel dispatch, verify zero write-set overlap. Transitive. Shared append-only files (CHANGELOG) policy-allowed.
+
+In the new scheduler:
+- Each PlanItem declares `ports.out` (writes) and `ports.in` (reads) — required, not optional
+- Scheduler walks items with no unmet `blocks` edges
+- Computes pairwise write-set intersection
+- Refuses to co-dispatch items with intersecting writes (transitively)
+- Append-only allow-list configurable per-project
+
+**This replaces the busy check entirely.** We never ask "is session X busy" — we ask "do the declared write-sets allow parallel execution." Deterministic, declarative, inspectable.
+
+Eliminates:
+- Duplicate-tab failure mode (two agents on same worktree ⇒ worktree path in both write-sets ⇒ scheduler serializes)
+- PAN-540 safety question (4 reviewers writing to 4 distinct report files ⇒ disjoint ⇒ provably safe to parallelize)
+- Contention-retry-via-deacon anti-pattern
+
+### 4.3 Capability-detection precedence (replaces hardcoded defaults)
+
+**Steal:** deft-swarm Phase 3 Step 1 + directive's explicit rule: "⊗ Present static launch options (A/B/C) instead of detecting capabilities at runtime."
+
+The Sonnet-lurking bug IS this anti-pattern in disguise. Settings page offers static model dropdowns per role; under them lives a hardcoded default that wins when the dropdown is unset.
+
+Fix: **one ordered capability chain**. Each step is a probe; first hit wins; no defaults at lower layers.
+
+```
+resolveAgent(context) =
+  1. context.runtimeOverride          (CLI --model, explicit)
+  2. context.planItem.workflow.model   (vBRIEF-level model override)
+  3. context.plan.workflow.model       (plan-level)
+  4. project.convoyConfig[role]        (convoy roles)
+  5. project.agentConfig[role]         (per-project role default)
+  6. global.workTypeRouter[workType]   (work-type routing)
+  7. global.fallback                   (explicit, loud, visible)
+  8. → emit "unresolved" error, surface to UI
+```
+
+**No hidden defaults.** If nothing resolves, we error out with a resolution trace. Settings page stops being a flat dropdown grid and becomes "show me the resolution for `role=review` on `project=X`" — the trace.
+
+Applies identically to **runtime** resolution (subagent vs tmux vs remote), not just model.
+
+### 4.4 Bounded review loop as reviewer state machine
+
+**Steal:** deft-review-cycle Phase 2 loop, verbatim.
+
+Current reviewer: spawned once, opaque internal logic, unclear exit condition.
+
+New reviewer: explicit state machine, **data-driven exit**.
+
+```
+IDLE
+ ↓ dispatch
+FETCH        ← gather all findings (dual source: gh + mcp with capability probe)
+ ↓
+ANALYZE      ← classify P0/P1/P2/P3; collect confidence scores
+ ↓
+BATCH_FIX    ← commit all trivial fixes; push one batch
+ ↓
+PUSH
+ ↓
+WAIT_RE_REVIEW (cadence: 20-30s → 60s → 90s adaptive)
+ ↓
+FETCH (again)
+ ↓
+(no P0/P1 && confidence > 3) → DONE
+(has P0/P1 && iterations < max) → ANALYZE
+(iterations >= max) → BLOCKED (human attention)
+```
+
+Exit is data-driven (query findings). Not agent-judgment-driven. Auditable.
+
+**Same pattern for test specialist:** RUN → ANALYZE → FIX → PUSH → RE-RUN → EXIT_ON_GREEN_OR_BLOCK. Merge stays human-only (hard rule).
+
+Deacon becomes the Trigger node: emits PlanItems like `review-cycle` or `stuck-recovery` based on patrol observations. Not a persistent agent — a scheduler that generates items.
+
+### 4.5 xumux as the execution substrate
+
+**Steal (new, not in user's ranked list):** xumux channels replace tmux-session-name as agent identity.
+
+Today: tmux session name is identity. Dashboard walks `tmux list-sessions`. Streaming via ttyd. Claude Code subagents and remote workers don't fit the model.
+
+xumux reframe: every agent, regardless of runtime, is a **named channel** with metadata on a multiplexed connection.
+
+- `OPEN_CHANNEL` carries `{ planId, planItemId, role, runtime }` as metadata
+- Control plane (channel 0) is reliable+ordered — lifecycle, findings, errors
+- Per-agent application channel carries streaming I/O — reliability tunable (unreliable for hot output, reliable for structured findings)
+- `PING/PONG` with RTT gives free heartbeat / stuck-detection
+- `CLOSE_CHANNEL` with code = `completed | failed | blocked | cancelled` — lifecycle termination typed
+
+Dashboard subscribes to the connection and enumerates channels. **Sibling tmux sessions cannot be invisible** because they don't exist as tmux sessions — they exist as channels on the same connection.
+
+Unifies runtime:
+- **Subagent** (Claude Code Task tool) → channel wrapped around in-process Task handle
+- **Local tmux** → channel wrapped around stdio of the tmux window
+- **Remote worker** → channel wrapped around ws connection to remote runner
+- Scheduler sees one abstraction: "assign PlanItem → runtime → OPEN_CHANNEL"
+
+xumux is v0.1.0-draft. We would be early adopter. Aligned with the Panopticon-as-deft-engine story (Jonathan's discussion).
+
+---
+
+## 5. The unified design in one sentence
+
+**Panopticon is a vBRIEF Plan executor over xumux channels, scheduled by file-overlap audit, with capability-detected workers and bounded-loop specialists.**
+
+Each layer kills a specific current-architecture problem:
+
+| Layer | Kills |
+|---|---|
+| vBRIEF schema | ad-hoc DB shape, tracker/agent impedance mismatch, cross-issue invisibility |
+| file-overlap audit | busy check, duplicate-tab failure, PAN-540 safety question, contention-via-retry |
+| capability chain | Sonnet-lurking default, static-dropdown anti-pattern, hidden resolution |
+| bounded specialist loops | opaque reviewer exit, stuck-reviewer mystery, unbounded merge-agent (enforces human-only) |
+| xumux channels | per-project singleton, invisible siblings, tmux-name-as-identity, heterogeneous runtime patchwork |
+
+---
+
+## 6. What goes away
+
+- `specialist_models` config section — absorbed into capability chain
+- Busy check + `dispatch_failed` + deacon-contention-retry — replaced by write-set audit
+- `getTmuxSessionName(type, projectKey)` — no session-name identity
+- `projects[key][type]` registry shape — replaced by Plan/PlanItem rows
+- `getAllProjectSpecialistStatuses` — replaced by xumux channel enumeration
+- Convoy as special case — becomes generic "N disjoint-write PlanItems scheduled in parallel"
+- Queue abstraction residue — all gone
+
+---
+
+## 7. Risks & open questions
+
+- **vBRIEF v0.6 is draft.** If deft churns the spec, we either pin or track. Tracking is consistent with the Jonathan/engine pitch. Pin with explicit extension field for Panopticon-specific data.
+- **xumux v0.1.0-draft** — same tradeoff, same recommendation (track, contribute upstream).
+- **Migration is pause-the-world.** User wants "stop everything else, do it all at once in place." With live workspaces and 60 skills depending on the current shape, we need a hard cutover plan: flag-day, ledger-replay into new schema, new runtime parallel until parity, switch.
+- **Subagent vs tmux tradeoffs** — which roles benefit from in-process subagent isolation (review, analysis) vs need their own process (long work, user-observable)? Capability chain must resolve runtime, not just model.
+- **Resolution trace UI** — when capability chain yields "unresolved" or surprising results, operator needs first-class visibility. Not a log line — a dashboard panel per dispatch attempt.
+- **planRef graph visualization** — how to render the cross-plan DAG at 10+ plans, 100+ items, without becoming noise. Force-directed layout? Layered by project? Collapse per-plan to super-node by default, expand on focus?
+- **Dashboard rewrite scope** — Agents page, Queues page, Specialists page all collapse into "Channels on connection" + "Plan DAG view." Queues page probably dies entirely.
+- **Append-only allow-list policy** — per-project config. Needs a sane default (CHANGELOG, docs/index), override surface.
+- **planItem.workflow.model precedence vs convoy role** — convoy should probably be expressed as planItems with role-tagged workflow.model, not a separate config block. Then precedence is trivial.
+
+---
+
+## 8. PRD deliverables (forward reference)
+
+The PRD that grows from this research should produce:
+
+1. SQLite schema aligned to vBRIEF Plan/PlanItem/Edge (verbatim column names, `extensions` column for Panopticon-specific data)
+2. Unified `resolveAgent(context)` API with explicit capability chain + resolution trace surfaced to dashboard
+3. File-overlap scheduler using `ports` declared in Workflow Profile
+4. xumux channel registry replacing tmux-session-name registry
+5. Review and test specialist state machines (explicit, bounded, data-driven exit)
+6. Dashboard rewrite: Agents page → channel enumeration; new Plan-DAG view
+7. Cutover plan: hard migration, no long coexistence period
+
+---
+
+## 9. Source material
+
+All referenced content extracted locally:
+
+- `/tmp/vbrief-0.6.md` — vBRIEF spec v0.6 (`~/Projects/vbrief` branch `origin/feat/builder-v0.6`)
+- `/tmp/vbrief-workflow.md` — vBRIEF Workflow Profile extension
+- `/tmp/deft-swarm-full.md` — `~/Projects/directive` `skills/deft-swarm/SKILL.md`
+- `/tmp/deft-review-cycle-full.md` — `~/Projects/directive` `skills/deft-review-cycle/SKILL.md`
+- `/tmp/xumux/README.md`, `PRD.md`, `SPECIFICATION.md` — `github.com/deftai/xumux`
+
+Upstream repos (deftai org): `vBRIEF`, `directive`, `xumux` (relevant); `dashdash`, `socketpipe`, `vroom` (scoped out for this research per user).
+
+---
+
+## 10. Not yet decided
+
+- Whether convoy reviewers remain a separate concept or fully dissolve into generic parallel PlanItems
+- Whether deacon remains a single patrol loop or dissolves into per-trigger-type Processing items
+- Whether `uat` becomes a PlanItem role or stays external
+- Which runtime (subagent vs tmux) is the default for each role
+- Whether we contribute xumux TypeScript reference impl upstream or ship our own internal one first

--- a/scripts/stop-hook
+++ b/scripts/stop-hook
@@ -33,7 +33,7 @@ TEMP_FILE="$RUNTIME_FILE.tmp"
 if [ -f "$RUNTIME_FILE" ]; then
   # Merge with existing runtime state (preserves contextPercent, sessionId, etc.)
   jq --arg ts "$(date -Iseconds)" \
-    '.state = "idle" | .lastActivity = $ts | del(.currentTool)' \
+    '.state = "idle" | .lastActivity = $ts | del(.currentTool) | del(.waitingReason) | del(.waitingStartedAt) | del(.waitingNotification)' \
     "$RUNTIME_FILE" > "$TEMP_FILE" 2>/dev/null && mv "$TEMP_FILE" "$RUNTIME_FILE" 2>/dev/null || true
 else
   # Create initial runtime state

--- a/src/cli/commands/unarchive-conversation.ts
+++ b/src/cli/commands/unarchive-conversation.ts
@@ -1,0 +1,54 @@
+import chalk from 'chalk';
+import {
+  getConversationByName,
+  listArchivedConversations,
+  unarchiveConversation,
+} from '../../lib/database/conversations-db.js';
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export async function unarchiveConversationCommand(query: string): Promise<void> {
+  const normalizedQuery = normalize(query);
+  if (!normalizedQuery) {
+    console.log(chalk.yellow('Provide a conversation name or title to unarchive.'));
+    process.exit(1);
+  }
+
+  const byName = getConversationByName(query);
+  if (byName?.archivedAt) {
+    unarchiveConversation(byName.name);
+    console.log(chalk.green(`Unarchived conversation ${byName.name}`));
+    console.log(chalk.gray(`  Title: ${byName.title || 'untitled'}`));
+    return;
+  }
+  if (byName && !byName.archivedAt) {
+    console.log(chalk.yellow(`Conversation ${byName.name} is already active`));
+    return;
+  }
+
+  const archived = listArchivedConversations();
+  const exactTitleMatches = archived.filter((conv) => normalize(conv.title || '') === normalizedQuery);
+  const partialTitleMatches = archived.filter((conv) => normalize(conv.title || '').includes(normalizedQuery));
+  const matches = exactTitleMatches.length > 0 ? exactTitleMatches : partialTitleMatches;
+
+  if (matches.length === 0) {
+    console.log(chalk.yellow(`No archived conversation matched: ${query}`));
+    process.exit(1);
+  }
+
+  if (matches.length > 1) {
+    console.log(chalk.yellow(`Multiple archived conversations matched: ${query}`));
+    for (const conv of matches.slice(0, 10)) {
+      console.log(chalk.gray(`  ${conv.name} — ${conv.title || 'untitled'}`));
+    }
+    console.log(chalk.dim('Use the exact conversation name to disambiguate.'));
+    process.exit(1);
+  }
+
+  const match = matches[0];
+  unarchiveConversation(match.name);
+  console.log(chalk.green(`Unarchived conversation ${match.name}`));
+  console.log(chalk.gray(`  Title: ${match.title || 'untitled'}`));
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -41,6 +41,7 @@ import { issueCommand as startCommand } from './commands/start.js';
 import { tellCommand } from './commands/tell.js';
 import { killCommand } from './commands/kill.js';
 import { forkCommand } from './commands/fork.js';
+import { unarchiveConversationCommand } from './commands/unarchive-conversation.js';
 import { resumeCommand } from './commands/resume.js';
 import { recoverCommand } from './commands/recover.js';
 import { syncMainCommand } from './commands/sync-main.js';
@@ -239,6 +240,11 @@ program
   .option('--model <model>', 'Model for the summary-forked session')
   .option('--cwd <path>', 'Working directory for the summary-forked session')
   .action(forkCommand);
+
+program
+  .command('unarchive-conversation <query>')
+  .description('Restore an archived conversation by exact name or matching title')
+  .action(unarchiveConversationCommand);
 
 program
   .command('resume <id>')

--- a/src/dashboard/frontend/src/components/AgentDetailView.tsx
+++ b/src/dashboard/frontend/src/components/AgentDetailView.tsx
@@ -87,23 +87,14 @@ function isSpecialistAgent(agentId: string): boolean {
 }
 
 /**
- * Parse a per-project ephemeral session name.
- * "specialist-pan-merge-agent" → { projectKey: "pan", specialistType: "merge-agent" }
+ * Parse an issue-scoped ephemeral session name.
+ * "specialist-pan-PAN-509-merge-agent" → { projectKey: "pan", issueId: "PAN-509", specialistType: "merge-agent" }
  * Returns null for global specialist sessions like "specialist-merge-agent".
  */
-function parseEphemeralSession(agentId: string): { projectKey: string; specialistType: string } | null {
-  const validTypes = ['merge-agent', 'review-agent', 'test-agent', 'inspect-agent', 'uat-agent'];
-  if (!agentId.startsWith('specialist-')) return null;
-  const withoutPrefix = agentId.slice('specialist-'.length);
-  for (const type of validTypes) {
-    if (withoutPrefix.endsWith(`-${type}`)) {
-      const projectKey = withoutPrefix.slice(0, withoutPrefix.length - type.length - 1);
-      if (projectKey && projectKey !== '') {
-        return { projectKey, specialistType: type };
-      }
-    }
-  }
-  return null;
+function parseEphemeralSession(agentId: string): { projectKey: string; issueId: string; specialistType: string } | null {
+  const match = agentId.match(/^specialist-(.+)-([A-Z]+-\d+)-(merge-agent|review-agent|test-agent|inspect-agent|uat-agent)$/);
+  if (!match) return null;
+  return { projectKey: match[1], issueId: match[2], specialistType: match[3] };
 }
 
 export function AgentDetailView({ agentId, onClose }: AgentDetailViewProps) {
@@ -159,6 +150,9 @@ export function AgentDetailView({ agentId, onClose }: AgentDetailViewProps) {
                 <div className="flex items-center gap-2 mt-1">
                   <span className="badge-bg-secondary text-signal-review px-1.5 py-0.5 rounded text-xs font-mono">
                     {ephemeralInfo.projectKey.toUpperCase()}
+                  </span>
+                  <span className="badge-bg-secondary text-primary px-1.5 py-0.5 rounded text-xs font-mono">
+                    {ephemeralInfo.issueId}
                   </span>
                   <span className="text-sm text-content-subtle">{ephemeralInfo.specialistType} (ephemeral)</span>
                 </div>

--- a/src/dashboard/frontend/src/components/AgentList.tsx
+++ b/src/dashboard/frontend/src/components/AgentList.tsx
@@ -322,11 +322,11 @@ export function AgentList({ selectedAgent, onSelectAgent }: AgentListProps) {
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
-                      fetch(`/api/specialists/${ps.projectKey}/${ps.specialistType}/kill`, { method: 'POST' })
+                      fetch(`/api/specialists/${ps.projectKey}/${ps.issueId}/${ps.specialistType}/kill`, { method: 'POST' })
                         .then(() => queryClient.invalidateQueries({ queryKey: ['project-specialists-running'] }));
                     }}
                     className="p-2 text-content-subtle hover:text-destructive hover:bg-surface-emphasis rounded"
-                    title={`Kill ${ps.specialistType} (${ps.projectKey})`}
+                    title={`Kill ${ps.specialistType} (${ps.projectKey}/${ps.issueId ?? 'unknown'})`}
                   >
                     <XCircle className="w-4 h-4" />
                   </button>

--- a/src/dashboard/frontend/src/components/AgentList.tsx
+++ b/src/dashboard/frontend/src/components/AgentList.tsx
@@ -37,11 +37,17 @@ interface AgentListProps {
 interface ProjectSpecialistStatus {
   projectKey: string;
   specialistType: 'merge-agent' | 'review-agent' | 'test-agent';
+  registryKey?: string;
+  issueId?: string;
+  role?: string;
   metadata: {
     runCount: number;
     lastRunAt: string | null;
     lastRunStatus: 'passed' | 'failed' | 'blocked' | null;
     currentRun: string | null;
+    currentActivity?: string | null;
+    model?: string | null;
+    writeScope?: 'full' | 'readonly-plus-output';
   };
   isRunning: boolean;
   tmuxSession: string;
@@ -267,26 +273,44 @@ export function AgentList({ selectedAgent, onSelectAgent }: AgentListProps) {
                   ps.tmuxSession === selectedAgent ? 'bg-surface-overlay' : 'hover:bg-surface-emphasis'
                 }`}
               >
-                <div className="flex items-center gap-3">
-                  <Brain className="w-5 h-5 text-success" />
-                  <div>
-                    <div className="font-medium text-content flex items-center gap-2">
+                <div className="flex items-center gap-3 min-w-0 flex-1">
+                  <Brain className="w-5 h-5 text-success flex-shrink-0" />
+                  <div className="min-w-0 flex-1">
+                    <div className="font-medium text-content flex items-center gap-2 flex-wrap">
                       <span className="badge-bg-secondary text-signal-review px-1.5 py-0.5 rounded text-xs font-mono">
                         {ps.projectKey.toUpperCase()}
                       </span>
+                      {ps.issueId && (
+                        <span className="text-xs font-mono text-content-muted">{ps.issueId}</span>
+                      )}
                       {ps.specialistType.replace('-', ' ').replace(/\b\w/g, c => c.toUpperCase())}
+                      {ps.role && (
+                        <span className="text-xs px-1.5 py-0.5 rounded bg-surface-emphasis text-content-muted font-mono">
+                          :{ps.role}
+                        </span>
+                      )}
                       {ps.isRunning ? (
-                        <span className="w-2 h-2 rounded-full bg-success animate-pulse" title="Running" />
+                        <span className="w-2 h-2 rounded-full bg-success animate-pulse flex-shrink-0" title="Running" />
                       ) : (
-                        <span className="w-2 h-2 rounded-full bg-content-muted" title="Completed" />
+                        <span className="w-2 h-2 rounded-full bg-content-muted flex-shrink-0" title="Completed" />
                       )}
                     </div>
-                    <div className="text-xs text-content-muted font-mono mt-0.5">
-                      {ps.metadata?.currentRun ? `Run: ${ps.metadata.currentRun.split('-').slice(-1)[0] || ps.metadata.currentRun}` : ps.tmuxSession}
+                    {ps.metadata?.currentActivity && ps.isRunning && (
+                      <div className="text-xs text-content-muted mt-0.5 truncate" title={ps.metadata.currentActivity}>
+                        {ps.metadata.currentActivity}
+                      </div>
+                    )}
+                    <div className="text-xs text-content-subtle font-mono mt-0.5 flex items-center gap-2">
+                      {ps.metadata?.model && (
+                        <span className="text-content-muted">{ps.metadata.model.split('/').pop()?.replace('claude-', '')}</span>
+                      )}
+                      {ps.metadata?.currentRun && (
+                        <span>{ps.metadata.currentRun.split('-').slice(-1)[0] || ps.metadata.currentRun}</span>
+                      )}
                     </div>
                   </div>
                 </div>
-                <div className="flex items-center gap-3">
+                <div className="flex items-center gap-3 flex-shrink-0">
                   <div className="text-right text-xs text-content-subtle">
                     <div className={ps.isRunning ? 'text-success' : 'text-content-muted'}>
                       {ps.isRunning ? '● Running' : '○ Completed'}

--- a/src/dashboard/frontend/src/components/AgentOutputPanel.tsx
+++ b/src/dashboard/frontend/src/components/AgentOutputPanel.tsx
@@ -21,11 +21,11 @@ interface AgentOutputPanelProps {
   agentId: string;
 }
 
-// Parse specialist tmux session name: specialist-{projectKey}-{type}
-function parseSpecialistSession(agentId: string): { projectKey: string; type: string } | null {
-  const match = agentId.match(/^specialist-(.+)-(review-agent|test-agent|merge-agent)$/);
+// Parse specialist tmux session name: specialist-{projectKey}-{issueId}-{type}
+function parseSpecialistSession(agentId: string): { projectKey: string; issueId: string; type: string } | null {
+  const match = agentId.match(/^specialist-(.+)-([A-Z]+-\d+)-(review-agent|test-agent|merge-agent)$/);
   if (!match) return null;
-  return { projectKey: match[1], type: match[2] };
+  return { projectKey: match[1], issueId: match[2], type: match[3] };
 }
 
 // Derive issueId for work and planning agents: agent-pan-505 → PAN-505, planning-pan-503 → PAN-503
@@ -56,7 +56,7 @@ export function AgentOutputPanel({ agentId }: AgentOutputPanelProps) {
     queryKey: ['specialist-panel-status', agentId],
     queryFn: async () => {
       if (!specialist) return null;
-      const res = await fetch(`/api/specialists/${specialist.projectKey}/${specialist.type}/status`);
+      const res = await fetch(`/api/specialists/${specialist.projectKey}/${specialist.issueId}/${specialist.type}/status`);
       if (!res.ok) return null;
       return res.json() as Promise<{ isRunning: boolean; sessionId?: string }>;
     },

--- a/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
+++ b/src/dashboard/frontend/src/components/DetailPanelLayout.tsx
@@ -78,7 +78,10 @@ export function DetailPanelLayout({ agent, issueId, issueUrl, issue, onClose, su
     staleTime: 60000,
   });
 
-  const projectKey = issue?.project?.id;
+  // Use repo name from sourceRepo (e.g. "eltmon/panopticon-cli" → "panopticon-cli")
+  // as the specialist session key. project.id includes "github-{owner}-" prefix which
+  // doesn't match the tmux session naming used by getTmuxSessionName.
+  const projectKey = issue?.sourceRepo ? issue.sourceRepo.split('/')[1] : undefined;
   const { phase, activeSession, availableTerminals, markSessionDead } = usePipelinePhase({
     issueId,
     agent,

--- a/src/dashboard/frontend/src/components/HealthDashboard.tsx
+++ b/src/dashboard/frontend/src/components/HealthDashboard.tsx
@@ -194,8 +194,8 @@ export function HealthDashboard() {
         {health.map((agent) => {
           const config = STATUS_CONFIG[agent.status];
           const Icon = config.icon;
-          // Parse per-project specialist session name: specialist-{projectKey}-{type}
-          const ephemeralMatch = agent.agentId.match(/^specialist-([a-z0-9]+)-(merge-agent|review-agent|test-agent)$/);
+          // Parse issue-scoped specialist session name: specialist-{projectKey}-{issueId}-{type}
+          const ephemeralMatch = agent.agentId.match(/^specialist-(.+)-([A-Z]+-\d+)-(merge-agent|review-agent|test-agent)$/);
           return (
             <div
               key={agent.agentId}
@@ -205,9 +205,14 @@ export function HealthDashboard() {
                 <div>
                   <div className="font-medium text-content flex items-center gap-2 flex-wrap">
                     {ephemeralMatch && (
-                      <span className="badge-bg-secondary text-signal-review px-1.5 py-0.5 rounded text-xs font-mono">
-                        {ephemeralMatch[1].toUpperCase()}
-                      </span>
+                      <>
+                        <span className="badge-bg-secondary text-signal-review px-1.5 py-0.5 rounded text-xs font-mono">
+                          {ephemeralMatch[1].toUpperCase()}
+                        </span>
+                        <span className="badge-bg-secondary text-primary px-1.5 py-0.5 rounded text-xs font-mono">
+                          {ephemeralMatch[2]}
+                        </span>
+                      </>
                     )}
                     {agent.agentId}
                   </div>

--- a/src/dashboard/frontend/src/components/__tests__/AgentOutputPanel.test.tsx
+++ b/src/dashboard/frontend/src/components/__tests__/AgentOutputPanel.test.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { deriveAgentIssueId } from '../AgentOutputPanel';
 
@@ -82,6 +82,7 @@ describe('deriveAgentIssueId', () => {
   // Non-matching ids
   it('returns null for specialist session names', () => {
     expect(deriveAgentIssueId('specialist-pan-review-agent')).toBeNull();
+    expect(deriveAgentIssueId('specialist-panopticon-PAN-509-review-agent')).toBeNull();
   });
 
   it('returns null for unrecognized id formats', () => {
@@ -96,6 +97,7 @@ describe('deriveAgentIssueId', () => {
 describe('AgentOutputPanel — planning agent rendering (AC4)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ isRunning: true }) })));
     // Default: store returns null (no agent in store, fall back to id-based derivation)
     (useDashboardStore as ReturnType<typeof vi.fn>).mockReturnValue(null);
   });
@@ -124,5 +126,16 @@ describe('AgentOutputPanel — planning agent rendering (AC4)', () => {
     expect(screen.queryByTestId('activity-view')).not.toBeInTheDocument();
     expect(screen.queryByTestId('xterm')).not.toBeInTheDocument();
     expect(screen.getByText(/No issue associated/)).toBeInTheDocument();
+  });
+
+  it('fetches specialist status with project and issue scoped route', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({ isRunning: true }) }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderPanel('specialist-panopticon-PAN-509-review-agent');
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/specialists/panopticon/PAN-509/review-agent/status');
+    });
   });
 });

--- a/src/dashboard/frontend/src/components/__tests__/DetailPanelLayout.test.tsx
+++ b/src/dashboard/frontend/src/components/__tests__/DetailPanelLayout.test.tsx
@@ -141,7 +141,7 @@ describe('DetailPanelLayout', () => {
 
   describe('Issue 1 — specialist tab streaming with dead work agent', () => {
     it('renders TerminalPanel keyed to the review specialist session when the review phase is active, even when the work agent is stopped', async () => {
-      const reviewSession = 'specialist-panopticon-review-agent';
+      const reviewSession = 'specialist-panopticon-PAN-509-review-agent';
       mockPipelineResult = {
         phase: 'reviewing',
         activeSession: reviewSession,
@@ -343,7 +343,7 @@ describe('DetailPanelLayout', () => {
           {
             id: 'merging',
             label: 'Merge',
-            sessionName: 'specialist-panopticon-merge-agent',
+            sessionName: 'specialist-panopticon-PAN-509-merge-agent',
             isActive: false,
             disabled: false,
           } satisfies TerminalTab,
@@ -360,7 +360,7 @@ describe('DetailPanelLayout', () => {
     });
 
     it('clicking "View last specialist log" replaces MergedSummaryCard with TerminalPanel for the merge session', async () => {
-      const mergeSession = 'specialist-panopticon-merge-agent';
+      const mergeSession = 'specialist-panopticon-PAN-509-merge-agent';
       mockPipelineResult = {
         phase: 'merged',
         activeSession: null,

--- a/src/dashboard/frontend/src/components/inspector/usePipelinePhase.test.ts
+++ b/src/dashboard/frontend/src/components/inspector/usePipelinePhase.test.ts
@@ -49,7 +49,7 @@ describe('derivePipelinePhase precedence table', () => {
       const input = makeInput({ reviewStatus: makeReviewStatus({ mergeStatus: 'queued' }) });
       const { phase, activeSession } = derivePipelinePhase(input);
       expect(phase).toBe('merging');
-      expect(activeSession).toBe('specialist-panopticon-merge-agent');
+      expect(activeSession).toBe('specialist-panopticon-pan-509-merge-agent');
     });
 
     it('returns merging when mergeStatus === merging', () => {
@@ -78,7 +78,7 @@ describe('derivePipelinePhase precedence table', () => {
         reviewStatus: makeReviewStatus({ mergeStatus: 'merging' }),
       });
       const { activeSession } = derivePipelinePhase(input);
-      expect(activeSession).toBe('specialist-my-project-merge-agent');
+      expect(activeSession).toBe('specialist-my-project-pan-509-merge-agent');
     });
 
     it('falls back to global session name when no project key', () => {
@@ -92,7 +92,7 @@ describe('derivePipelinePhase precedence table', () => {
 
     it('returns null activeSession when merging session is dead', () => {
       const input = makeInput({ reviewStatus: makeReviewStatus({ mergeStatus: 'merging' }) });
-      const dead = new Set(['specialist-panopticon-merge-agent']);
+      const dead = new Set(['specialist-panopticon-pan-509-merge-agent']);
       const { activeSession } = derivePipelinePhase(input, dead);
       expect(activeSession).toBeNull();
     });
@@ -128,7 +128,7 @@ describe('derivePipelinePhase precedence table', () => {
       const input = makeInput({ reviewStatus: makeReviewStatus({ testStatus: 'testing' }) });
       const { phase, activeSession } = derivePipelinePhase(input);
       expect(phase).toBe('testing');
-      expect(activeSession).toBe('specialist-panopticon-test-agent');
+      expect(activeSession).toBe('specialist-panopticon-pan-509-test-agent');
     });
 
     it('does NOT return testing when testStatus !== testing', () => {
@@ -147,7 +147,7 @@ describe('derivePipelinePhase precedence table', () => {
 
     it('returns null activeSession when test session is dead', () => {
       const input = makeInput({ reviewStatus: makeReviewStatus({ testStatus: 'testing' }) });
-      const dead = new Set(['specialist-panopticon-test-agent']);
+      const dead = new Set(['specialist-panopticon-pan-509-test-agent']);
       const { activeSession } = derivePipelinePhase(input, dead);
       expect(activeSession).toBeNull();
     });
@@ -158,7 +158,7 @@ describe('derivePipelinePhase precedence table', () => {
       const input = makeInput({ reviewStatus: makeReviewStatus({ reviewStatus: 'reviewing' }) });
       const { phase, activeSession } = derivePipelinePhase(input);
       expect(phase).toBe('reviewing');
-      expect(activeSession).toBe('specialist-panopticon-review-agent');
+      expect(activeSession).toBe('specialist-panopticon-pan-509-review-agent');
     });
 
     it('does NOT return reviewing when reviewStatus !== reviewing', () => {
@@ -178,7 +178,7 @@ describe('derivePipelinePhase precedence table', () => {
 
     it('returns null activeSession when review session is dead', () => {
       const input = makeInput({ reviewStatus: makeReviewStatus({ reviewStatus: 'reviewing' }) });
-      const dead = new Set(['specialist-panopticon-review-agent']);
+      const dead = new Set(['specialist-panopticon-pan-509-review-agent']);
       const { activeSession } = derivePipelinePhase(input, dead);
       expect(activeSession).toBeNull();
     });
@@ -354,7 +354,7 @@ describe('derivePipelinePhase availableTerminals', () => {
 
   it('marks dead sessions as disabled', () => {
     const input = makeInput({ reviewStatus: makeReviewStatus({ reviewStatus: 'passed' }) });
-    const dead = new Set(['specialist-panopticon-review-agent']);
+    const dead = new Set(['specialist-panopticon-pan-509-review-agent']);
     const { availableTerminals } = derivePipelinePhase(input, dead);
     const reviewTab = availableTerminals.find(t => t.id === 'reviewing');
     expect(reviewTab?.disabled).toBe(true);

--- a/src/dashboard/frontend/src/components/inspector/usePipelinePhase.ts
+++ b/src/dashboard/frontend/src/components/inspector/usePipelinePhase.ts
@@ -29,12 +29,12 @@ export function derivePipelinePhase(
   input: PipelinePhaseInput,
   deadSessions: ReadonlySet<string> = new Set(),
 ): PipelinePhaseResult {
-  const { agent, reviewStatus, projectKey } = input;
+  const { agent, reviewStatus, projectKey, issueId } = input;
 
   // Session name helpers
   const workSession = agent?.id ?? null;
   const specialistSession = (role: string): string =>
-    projectKey ? `specialist-${projectKey}-${role}` : `specialist-${role}`;
+    projectKey ? `specialist-${projectKey}-${issueId}-${role}` : `specialist-${role}`;
 
   const reviewSession = specialistSession('review-agent');
   const testSession = specialistSession('test-agent');

--- a/src/dashboard/server/routes/conversations.ts
+++ b/src/dashboard/server/routes/conversations.ts
@@ -36,6 +36,7 @@ import {
   updateConversationCost,
   updateConversationModel,
   archiveConversation,
+  unarchiveConversation,
   canReplaceTitle,
   listFavoritedIds,
   setFavorite,
@@ -811,6 +812,34 @@ const postConversationArchiveRoute = HttpRouter.add(
   }),
 );
 
+// ─── Route: POST /api/conversations/:name/unarchive ─────────────────────────
+
+const postConversationUnarchiveRoute = HttpRouter.add(
+  'POST',
+  '/api/conversations/:name/unarchive',
+  Effect.gen(function* () {
+    const params = yield* HttpRouter.params;
+    const name = params['name'] ?? '';
+    return yield* Effect.promise(async () => {
+      try {
+        const conv = getConversationByName(name);
+        if (!conv) {
+          return jsonResponse({ error: 'Conversation not found' }, { status: 404 });
+        }
+        if (!conv.archivedAt) {
+          return jsonResponse({ error: 'Conversation is not archived' }, { status: 400 });
+        }
+
+        unarchiveConversation(name);
+        return jsonResponse({ success: true });
+      } catch (error: unknown) {
+        const msg = error instanceof Error ? error.message : String(error);
+        return jsonResponse({ error: 'Failed to unarchive conversation: ' + msg }, { status: 500 });
+      }
+    });
+  }),
+);
+
 // ─── Route: POST /api/conversations/restart-all ─────────────────────────────
 //
 // Kill all active conversation tmux sessions and re-spawn them with
@@ -1029,6 +1058,7 @@ export const conversationsRouteLayer = Layer.mergeAll(
   postConversationSwitchModelRoute,
   postConversationRestartAllRoute,
   postConversationArchiveRoute,
+  postConversationUnarchiveRoute,
   getConversationMessagesRoute,
   postConversationMessageRoute,
   postConversationFavoriteRoute,

--- a/src/dashboard/server/routes/specialists.ts
+++ b/src/dashboard/server/routes/specialists.ts
@@ -563,7 +563,7 @@ const postSpecialistsDoneRoute = HttpRouter.add(
           const { messageAgent } = await import('../../../lib/agents.js');
 
           if (sessionExists(workAgentId)) {
-            const reviewMsg = `REVIEW FEEDBACK: The review specialist found issues that must be fixed:\n\n${notes}\n\nPlease address all issues, push your changes, then resubmit: curl -s -X POST http://localhost:3011/api/review/${normalizedIssueId}/request -H "Content-Type: application/json" -d "{}"`;
+            const reviewMsg = `REVIEW FEEDBACK: The review specialist found issues that must be fixed:\n\n${notes}\n\nPlease address all issues, push your changes, then re-request review with: pan review request ${normalizedIssueId} -m "Fixed review issues"`;
             await messageAgent(workAgentId, reviewMsg);
             console.log(`[specialists/done] Sent review feedback to ${workAgentId}`);
           }

--- a/src/dashboard/server/routes/specialists.ts
+++ b/src/dashboard/server/routes/specialists.ts
@@ -21,8 +21,8 @@ import { encodeClaudeProjectDir } from '../../../lib/paths.js';
  *   DELETE /api/specialists/:name/queue/:itemId
  *   PUT    /api/specialists/:name/queue/reorder
  *   POST   /api/specialists/:name/auto-complete
- *   GET    /api/specialists/:project/:type/status
- *   POST   /api/specialists/:project/:type/kill
+ *   GET    /api/specialists/:project/:issueId/:type/status
+ *   POST   /api/specialists/:project/:issueId/:type/kill
  *   GET    /api/specialists/:project/:type/queue
  *   POST   /api/specialists/:project/:type/spawn
  *   GET    /api/specialists/:project/:type/runs
@@ -1093,14 +1093,15 @@ const postSpecialistAutoCompleteRoute = HttpRouter.add(
   })),
 );
 
-// ─── Route: GET /api/specialists/:project/:type/status ────────────────────────
+// ─── Route: GET /api/specialists/:project/:issueId/:type/status ───────────────
 
 const getProjectSpecialistStatusRoute = HttpRouter.add(
   'GET',
-  '/api/specialists/:project/:type/status',
+  '/api/specialists/:project/:issueId/:type/status',
   httpHandler(Effect.gen(function* () {
     const params = yield* HttpRouter.params;
     const project = params['project'] as string;
+    const issueId = params['issueId'] as string;
     const type = params['type'] as string;
 
     if (!validateSpecialistType(type)) {
@@ -1110,20 +1111,41 @@ const getProjectSpecialistStatusRoute = HttpRouter.add(
       );
     }
 
-    const { getSpecialistStatus } = yield* Effect.promise(() => import('../../../lib/cloister/specialists.js'));
-    const status = yield* Effect.promise(() => getSpecialistStatus(type, project));
-    return jsonResponse(status);
+    const {
+      makeSpecialistRegistryKey,
+      getRunMetadata,
+      getTmuxSessionName,
+      isProjectSpecialistActivelyRunning,
+    } = yield* Effect.promise(() => import('../../../lib/cloister/specialists.js'));
+    const { getAgentRuntimeState } = yield* Effect.promise(() => import('../../../lib/agents.js'));
+
+    const registryKey = makeSpecialistRegistryKey(type, issueId);
+    const metadata = getRunMetadata(project, registryKey);
+    const tmuxSession = metadata.tmuxSession ?? getTmuxSessionName(type, project, issueId);
+    const runtimeState = getAgentRuntimeState(tmuxSession);
+    const isRunning = isProjectSpecialistActivelyRunning(runtimeState, metadata.currentRun !== null);
+
+    return jsonResponse({
+      name: type,
+      state: isRunning ? 'active' : 'sleeping',
+      isRunning,
+      tmuxSession,
+      currentIssue: issueId,
+      sessionId: metadata.sessionId,
+      contextTokens: undefined,
+    });
   })),
 );
 
-// ─── Route: POST /api/specialists/:project/:type/kill ────────────────────────
+// ─── Route: POST /api/specialists/:project/:issueId/:type/kill ───────────────
 
 const postProjectSpecialistKillRoute = HttpRouter.add(
   'POST',
-  '/api/specialists/:project/:type/kill',
+  '/api/specialists/:project/:issueId/:type/kill',
   httpHandler(Effect.gen(function* () {
     const params = yield* HttpRouter.params;
     const project = params['project'] as string;
+    const issueId = params['issueId'] as string;
     const type = params['type'] as string;
 
     if (!validateSpecialistType(type)) {
@@ -1133,17 +1155,12 @@ const postProjectSpecialistKillRoute = HttpRouter.add(
       );
     }
 
-    const { getTmuxSessionName, makeSpecialistRegistryKey, findActiveRegistryKey, getRunMetadata } =
+    const { getTmuxSessionName, makeSpecialistRegistryKey, getRunMetadata } =
       yield* Effect.promise(() => import('../../../lib/cloister/specialists.js'));
 
-    // Look up the active issueId from the registry to find the correct session name (PAN-754)
-    const activeKey = findActiveRegistryKey(project, type) ?? type;
-    const { issueId: activeIssueId } = activeKey.includes(':')
-      ? { issueId: activeKey.split(':')[1] }
-      : { issueId: undefined };
-
-    const tmuxSession = getRunMetadata(project, activeKey).tmuxSession
-      ?? getTmuxSessionName(type, project, activeIssueId);
+    const registryKey = makeSpecialistRegistryKey(type, issueId);
+    const tmuxSession = getRunMetadata(project, registryKey).tmuxSession
+      ?? getTmuxSessionName(type, project, issueId);
 
     yield* Effect.promise(() => killSessionAsync(tmuxSession).catch(() => {}));
     // Do NOT clearSessionId — the Claude session persists and should be resumed on next dispatch
@@ -1153,7 +1170,7 @@ const postProjectSpecialistKillRoute = HttpRouter.add(
     });
     return jsonResponse({
       success: true,
-      message: `Killed ${type} (${project})`,
+      message: `Killed ${type} (${project}/${issueId})`,
     });
   })),
 );

--- a/src/dashboard/server/routes/specialists.ts
+++ b/src/dashboard/server/routes/specialists.ts
@@ -1133,8 +1133,18 @@ const postProjectSpecialistKillRoute = HttpRouter.add(
       );
     }
 
-    const { getTmuxSessionName } = yield* Effect.promise(() => import('../../../lib/cloister/specialists.js'));
-    const tmuxSession = getTmuxSessionName(type, project);
+    const { getTmuxSessionName, makeSpecialistRegistryKey, findActiveRegistryKey, getRunMetadata } =
+      yield* Effect.promise(() => import('../../../lib/cloister/specialists.js'));
+
+    // Look up the active issueId from the registry to find the correct session name (PAN-754)
+    const activeKey = findActiveRegistryKey(project, type) ?? type;
+    const { issueId: activeIssueId } = activeKey.includes(':')
+      ? { issueId: activeKey.split(':')[1] }
+      : { issueId: undefined };
+
+    const tmuxSession = getRunMetadata(project, activeKey).tmuxSession
+      ?? getTmuxSessionName(type, project, activeIssueId);
+
     yield* Effect.promise(() => killSessionAsync(tmuxSession).catch(() => {}));
     // Do NOT clearSessionId — the Claude session persists and should be resumed on next dispatch
     saveAgentRuntimeState(tmuxSession, {
@@ -1537,7 +1547,7 @@ const postProjectSpecialistCompleteRoute = HttpRouter.add(
     const project = params['project'] as string;
     const type = params['type'] as string;
     const body = yield* readJsonBody;
-    const { status, notes } = body as { status?: string; notes?: string };
+    const { status, notes, issueId } = body as { status?: string; notes?: string; issueId?: string };
 
     if (!status || !['passed', 'failed', 'blocked'].includes(status)) {
       return jsonResponse(
@@ -1555,7 +1565,7 @@ const postProjectSpecialistCompleteRoute = HttpRouter.add(
 
     const { signalSpecialistCompletion } =
       yield* Effect.promise(() => import('../../../lib/cloister/specialists.js'));
-    signalSpecialistCompletion(project, type, { status, notes });
+    signalSpecialistCompletion(project, type, { status, notes }, issueId);
     return jsonResponse({
       success: true,
       message: 'Specialist completion signaled, grace period started',

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -1357,10 +1357,15 @@ export async function resumeAgent(agentId: string, message?: string): Promise<{ 
     // inside the shell tmux spawns. This mirrors the spawnAgent pattern at ~line 806.
     const model = agentState.model || 'claude-sonnet-4-6';
     const providerExports = getProviderExportsForModel(model);
+    // Non-Anthropic models route through a proxy (ANTHROPIC_BASE_URL). Without an explicit
+    // --model flag, Claude Code defaults to claude-sonnet-4-6 on resume, sending claude
+    // requests through the proxy → "unknown provider" 502. Always include --model when
+    // providerExports sets ANTHROPIC_BASE_URL so the resumed session uses the correct model.
+    const resumeModelFlag = providerExports.includes('ANTHROPIC_BASE_URL') ? ` --model ${model}` : '';
     const launcherScript = join(getAgentDir(normalizedId), 'launcher.sh');
     const launcherContent = `#!/bin/bash
 export CI=1
-${providerExports}exec claude --resume "${sessionId}" --dangerously-skip-permissions --permission-mode bypassPermissions
+${providerExports}exec claude --resume "${sessionId}"${resumeModelFlag} --dangerously-skip-permissions --permission-mode bypassPermissions
 `;
     writeFileSync(launcherScript, launcherContent, { mode: 0o755 });
     const claudeCmd = `bash ${launcherScript}`;

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -227,8 +227,10 @@ function clearReadySignal(agentId: string): void {
 }
 
 /**
- * Wait for SessionStart hook to signal ready (async - non-blocking)
- * Returns true if ready signal received, false if timeout
+ * Wait for agent to be ready (async - non-blocking).
+ * Primary: ready.json written by SessionStart hook.
+ * Fallback: tmux pane shows Claude's interactive prompt indicator.
+ * Returns true if ready signal received, false if timeout.
  */
 async function waitForReadySignal(agentId: string, timeoutSeconds = 30): Promise<boolean> {
   const readyPath = getReadySignalPath(agentId);
@@ -247,6 +249,16 @@ async function waitForReadySignal(agentId: string, timeoutSeconds = 30): Promise
         // File exists but invalid - keep waiting
       }
     }
+
+    // Fallback: check tmux pane for Claude's interactive prompt indicator.
+    // ready.json is currently not written by any hook (PAN-759), so this is the
+    // primary detection path for resumed/fresh-started agents.
+    try {
+      const pane = await capturePaneAsync(agentId, 200);
+      if (pane.includes('bypass permissions on') || pane.includes('⏵⏵')) {
+        return true;
+      }
+    } catch { /* non-fatal — session may not exist yet */ }
   }
 
   return false;

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -327,6 +327,7 @@ function markAgentRunning(state: AgentState): void {
 function markAgentStopped(state: AgentState): void {
   state.status = 'stopped';
   state.stoppedAt = new Date().toISOString();
+  (state as AgentState & { stoppedByUser?: boolean }).stoppedByUser = true;
 }
 
 // ============================================================================

--- a/src/lib/cloister/__tests__/startup-recovery.test.ts
+++ b/src/lib/cloister/__tests__/startup-recovery.test.ts
@@ -1,5 +1,26 @@
 import { describe, it, expect } from 'vitest';
-import { identifyOrphanedReviewingIssues } from '../service.js';
+import { identifyOrphanedReviewingIssues, parseSpecialistAgentSession } from '../service.js';
+
+describe('parseSpecialistAgentSession', () => {
+  it('parses issue-scoped specialist sessions', () => {
+    expect(parseSpecialistAgentSession('specialist-panopticon-cli-PAN-714-review-agent')).toEqual({
+      projectKey: 'panopticon-cli',
+      issueId: 'PAN-714',
+      specialistType: 'review-agent',
+    });
+  });
+
+  it('parses legacy project-scoped specialist sessions', () => {
+    expect(parseSpecialistAgentSession('specialist-panopticon-cli-review-agent')).toEqual({
+      projectKey: 'panopticon-cli',
+      specialistType: 'review-agent',
+    });
+  });
+
+  it('returns null for non-specialist sessions', () => {
+    expect(parseSpecialistAgentSession('agent-pan-714')).toBeNull();
+  });
+});
 
 describe('identifyOrphanedReviewingIssues', () => {
   it('returns empty array when no statuses exist', () => {

--- a/src/lib/cloister/config.ts
+++ b/src/lib/cloister/config.ts
@@ -94,9 +94,9 @@ export interface ModelSelectionConfig {
     expert: 'opus' | 'sonnet' | 'haiku';
   };
   specialist_models: {
-    merge_agent: 'opus' | 'sonnet' | 'haiku';
-    review_agent: 'opus' | 'sonnet' | 'haiku';
-    test_agent: 'opus' | 'sonnet' | 'haiku';
+    merge_agent?: 'opus' | 'sonnet' | 'haiku';
+    review_agent?: 'opus' | 'sonnet' | 'haiku';
+    test_agent?: 'opus' | 'sonnet' | 'haiku';
     inspect_agent?: 'opus' | 'sonnet' | 'haiku';
     uat_agent?: 'opus' | 'sonnet' | 'haiku';
   };
@@ -242,11 +242,8 @@ export const DEFAULT_CLOISTER_CONFIG: CloisterConfig = {
       expert: 'opus',
     },
     specialist_models: {
-      merge_agent: 'sonnet',
-      review_agent: 'sonnet',
-      test_agent: 'haiku',
-      inspect_agent: 'sonnet',
-      uat_agent: 'sonnet',
+      // PAN-754: no hardcoded defaults. User config.yaml overrides are authoritative.
+      // Resolution falls through to work-type-router, then to the global fallback model.
     },
   },
   handoffs: {

--- a/src/lib/cloister/deacon.ts
+++ b/src/lib/cloister/deacon.ts
@@ -857,7 +857,10 @@ const ACTIVE_STATUS_PATTERNS = [
 
 /**
  * Check if agent tmux output indicates active work (not idle)
- * Parses last 5 lines of tmux capture-pane output for status indicators
+ * Checks the last 8 non-blank lines of pane output for status indicators.
+ * Claude Code's live status bar (◆ Bash, ◆ Thinking, ⏵⏵) appears at the
+ * bottom of the pane — only those lines are relevant, not the full visible
+ * area which may contain completed tool calls like "● Bash(...)" from prior output.
  */
 export async function isAgentActiveInTmux(sessionName: string): Promise<boolean> {
   try {
@@ -865,12 +868,18 @@ export async function isAgentActiveInTmux(sessionName: string): Promise<boolean>
 
     if (!stdout.trim()) return false;
 
+    // Only scan the bottom of the pane where Claude Code's live status bar lives.
+    // Scanning the full visible area causes false positives: completed tool calls
+    // like "● Bash(npm run typecheck...)" are visible but the agent may be idle.
+    const lines = stdout.split('\n').filter(l => l.trim().length > 0);
+    const tail = lines.slice(-8).join('\n');
+
     for (const pattern of ACTIVE_STATUS_PATTERNS) {
-      if (pattern.test(stdout)) {
+      if (pattern.test(tail)) {
         // "Thinking" with a duration over the threshold is NOT active — it's stuck.
         // Don't let stuck agents masquerade as active.
-        if (/thinking/i.test(stdout)) {
-          const thinkingMs = parseThinkingDuration(stdout);
+        if (/thinking/i.test(tail)) {
+          const thinkingMs = parseThinkingDuration(tail);
           if (thinkingMs !== null && thinkingMs >= STUCK_THINKING_THRESHOLD_MS) {
             return false; // Stuck, not active
           }
@@ -1888,8 +1897,10 @@ export async function checkDeadEndAgents(): Promise<string[]> {
     const now = Date.now();
 
     for (const [key, status] of Object.entries(statuses)) {
-      // Only act on blocked reviews, failed tests, or CI-blocked merges
-      const isReviewBlocked = status.reviewStatus === 'blocked';
+      // Only act on blocked/failed reviews, failed tests, or CI-blocked merges.
+      // 'failed' covers verification gate errors (e.g. JSON parse error in plan.vbrief.json)
+      // that prevent the review specialist from running at all.
+      const isReviewBlocked = status.reviewStatus === 'blocked' || status.reviewStatus === 'failed';
       const isTestFailed = status.testStatus === 'failed';
       const isMergeCiFailed = status.mergeStatus === 'failed' &&
         typeof status.mergeNotes === 'string' &&
@@ -1935,7 +1946,7 @@ export async function checkDeadEndAgents(): Promise<string[]> {
       // Agent is idle with a blocked/failed status — this is a dead end
       let statusType: string;
       if (isReviewBlocked) {
-        statusType = 'review blocked';
+        statusType = status.reviewStatus === 'failed' ? 'review failed' : 'review blocked';
       } else if (isTestFailed) {
         statusType = 'tests failed';
       } else {
@@ -1962,9 +1973,12 @@ export async function checkDeadEndAgents(): Promise<string[]> {
 
       // Send the agent a nudge message with the correct resubmit command
       try {
+        const reviewFailedMsg = status.reviewStatus === 'failed'
+          ? `Review verification failed for ${issueId}. Check .planning/feedback/ for details. Common cause: merge conflict markers in .planning/plan.vbrief.json — fix by resolving conflicts in that file, then run: pan review request ${issueId} -m "Fixed verification error"`
+          : `The review agent found issues in your code. Read .planning/feedback/ for the latest blocked feedback, fix every issue listed, commit all changes, then run: pan review request ${issueId} -m "Fixed review issues". Do NOT stop until pan review request completes successfully.`;
         const nudgeMessage = isReviewBlocked
-          ? `The review agent found issues in your code. Read .planning/feedback/ for details, fix the issues, commit, then invoke the /rebase-and-submit skill for ${issueId}. The skill is an atomic task — do not stop until \`pan work request-review\` has completed successfully (this is the re-review path, not \`pan work done\`).`
-          : `Tests failed for your changes. Read .planning/feedback/ for details, fix the failures, commit, then invoke the /rebase-and-submit skill for ${issueId}. The skill is an atomic task — do not stop until \`pan work request-review\` has completed successfully (this is the re-review path, not \`pan work done\`).`;
+          ? reviewFailedMsg
+          : `Tests failed for your changes. Read .planning/feedback/ for details, fix the failures, commit, then run: pan review request ${issueId} -m "Fixed test failures". Do NOT stop until pan review request completes successfully.`;
 
         await sendKeysAsync(agentSessionName, nudgeMessage);
         actions.push(`Dead-end recovery: nudged ${agentSessionName} (${statusType}, idle for ${Math.round((now - new Date(status.updatedAt || '').getTime()) / 60000)}m)`);
@@ -2019,7 +2033,10 @@ export async function checkFirstCompletionAgents(): Promise<string[]> {
 
       // Check if agent is idle
       const runtimeState = getAgentRuntimeState(agent.id);
-      if (!runtimeState || runtimeState.state !== 'idle') continue;
+      if (!runtimeState) continue;
+      // Allow 'active' through — hook may not have fired to update state to 'idle'
+      // after the agent returned to the prompt. The pane check below is ground truth.
+      if (runtimeState.state === 'suspended' || runtimeState.state === 'completed') continue;
 
       // Check idle duration
       const lastActivity = new Date(runtimeState.lastActivity);
@@ -2605,6 +2622,13 @@ export async function runPatrol(): Promise<PatrolResult> {
   const failedMergeRetryActions = await checkFailedMergeRetry();
   actions.push(...failedMergeRetryActions);
   for (const a of failedMergeRetryActions) addLog('action', a, state.patrolCycle);
+
+  // Dead-end agent recovery: nudge agents stuck with reviewStatus=blocked/failed after
+  // fixing review issues but not re-requesting review. Has 10-min per-issue cooldown and
+  // 7-requeue circuit breaker to avoid runaway API credit consumption.
+  const deadEndActions = await checkDeadEndAgents();
+  actions.push(...deadEndActions);
+  for (const a of deadEndActions) addLog('action', a, state.patrolCycle);
 
   // Resolution patrol DISABLED — auto-completing and poking agents consumes
   // API credits and is unreliable. Human operator can take action via dashboard.

--- a/src/lib/cloister/deacon.ts
+++ b/src/lib/cloister/deacon.ts
@@ -839,9 +839,6 @@ const ACTIVE_STATUS_PATTERNS = [
   /computing/i,
   /fermenting/i,
   /thinking/i,
-  /forming/i,     // Claude Code "Forming…" computation status
-  /embellish/i,   // Claude Code "Embellishing…" computation status
-  /baking/i,      // Claude Code "Baking…" computation status
   /reading/i,
   /writing/i,
   /editing/i,
@@ -879,9 +876,9 @@ export async function isAgentActiveInTmux(sessionName: string): Promise<boolean>
 
     for (const pattern of ACTIVE_STATUS_PATTERNS) {
       if (pattern.test(tail)) {
-        // Extended computation (Thinking/Forming/Embellishing/Baking) over threshold = stuck.
+        // Extended computation (Thinking/Fermenting) over threshold = stuck.
         // Don't let stuck agents masquerade as active.
-        if (/thinking|forming|embellish|baking|fermenting/i.test(tail)) {
+        if (/thinking|fermenting/i.test(tail)) {
           const thinkingMs = parseThinkingDuration(tail);
           if (thinkingMs !== null && thinkingMs >= STUCK_THINKING_THRESHOLD_MS) {
             return false; // Stuck, not active
@@ -895,6 +892,33 @@ export async function isAgentActiveInTmux(sessionName: string): Promise<boolean>
   } catch {
     return false;
   }
+}
+
+/**
+ * Determine if an agent is idle based on its runtime.json hook state.
+ *
+ * The Stop hook (fired by Claude Code's Stop lifecycle event) writes state='idle'
+ * to runtime.json whenever Claude finishes a turn and returns to the prompt. This
+ * is the authoritative idle signal — no pane parsing needed.
+ *
+ * Stale-active fallback: if Stop hook never fired (state='active' persists), treat
+ * the agent as idle once the heartbeat is older than staleActiveThresholdMs. The
+ * heartbeat-hook fires on PostToolUse, so a stale heartbeat means no tool calls
+ * and therefore no active computation.
+ *
+ * Returns false if: no runtime state, suspended, completed, or recently active.
+ */
+function isAgentIdleForNudge(agentId: string, staleActiveThresholdMs = 5 * 60 * 1000): boolean {
+  const runtimeState = getAgentRuntimeState(agentId);
+  if (!runtimeState) {
+    console.log(`[deacon] ${agentId}: no runtime.json — skipping (hook not yet fired)`);
+    return false;
+  }
+  if (runtimeState.state === 'suspended' || runtimeState.state === 'stopped') return false;
+  if (runtimeState.state === 'idle') return true;
+  // Stale-active: heartbeat hasn't fired in staleActiveThresholdMs (state='active'/'uninitialized')
+  const ageMs = Date.now() - new Date(runtimeState.lastActivity).getTime();
+  return ageMs > staleActiveThresholdMs;
 }
 
 // ============================================================================
@@ -925,9 +949,9 @@ const stuckRecoveryState: Map<string, { lastAttempt: number; attempts: number }>
  * Returns duration in milliseconds, or null if not currently thinking.
  */
 function parseThinkingDuration(tmuxOutput: string): number | null {
-  // Match Claude Code computation status phrases followed by a duration.
-  // Handles: "Thinking… (22m 41s", "Forming… (5s", "Embellishing… (20m 1s", "Baking… (3m"
-  const match = tmuxOutput.match(/(?:[Tt]hinking|[Ff]orming|[Ee]mbellish\w*|[Bb]aking|[Ff]ermenting)[^\n]*?\((?:(\d+)m\s*)?(\d+)s/);
+  // Match Claude Code thinking/fermenting status phrases followed by a duration.
+  // Handles: "Thinking… (22m 41s", "Fermenting… (5m 10s"
+  const match = tmuxOutput.match(/(?:[Tt]hinking|[Ff]ermenting)[^\n]*?\((?:(\d+)m\s*)?(\d+)s/);
   if (!match) return null;
 
   const minutes = match[1] ? parseInt(match[1], 10) : 0;
@@ -1195,12 +1219,7 @@ export async function checkOrphanedReviewStatuses(): Promise<string[]> {
     for (const projSpec of projectStatuses) {
       if (!projSpec.isRunning) continue;
       const rState = getAgentRuntimeState(projSpec.tmuxSession);
-      // Include specialists with state=active OR state=waiting-on-human.
-      // The notification-hook previously set specialists to waiting-on-human on
-      // startup (PAN-760), causing false-positive orphan detection that reset
-      // review/test statuses before the specialist could complete its work.
-      // The hook is now fixed, but existing sessions may still have the stale state.
-      const isWorking = rState?.state === 'active' || rState?.state === 'waiting-on-human';
+      const isWorking = rState?.state === 'active';
       if (isWorking && rState.currentIssue) {
         if (projSpec.specialistType === 'review-agent') {
           activeReviewSessions.add(rState.currentIssue.toUpperCase());
@@ -1315,7 +1334,11 @@ export async function checkOrphanedReviewStatuses(): Promise<string[]> {
         const agentIdForCheck = `agent-${issueId.toLowerCase()}`;
         const completedProcessedFile = join(AGENTS_DIR, agentIdForCheck, 'completed.processed');
         if (existsSync(completedProcessedFile)) {
-          const agentState = getAgentState(agentIdForCheck);
+          const agentState = getAgentState(agentIdForCheck) as (ReturnType<typeof getAgentState> & { stoppedByUser?: boolean }) | null;
+          if (agentState?.status === 'stopped' && agentState.stoppedByUser) {
+            actions.push(`Skipped pending review for ${issueId}: work agent was explicitly stopped`);
+            continue;
+          }
           const { resolveProjectFromIssue } = await import('../projects.js');
           const resolved = resolveProjectFromIssue(issueId);
           const issueLower = issueId.toLowerCase();
@@ -1516,6 +1539,7 @@ export async function checkPostReviewCommits(): Promise<string[]> {
         // the work agent pushes a fix (e.g. to address a CI check failure).
         mergeRetryCount: 0,
       });
+      ciRetryMap.delete(issueId);
       actions.push(
         `Reset review for ${issueId}: new commits after review passed ` +
         `(${status.reviewedAtCommit.substring(0, 8)} → ${currentHead.substring(0, 8)})`,
@@ -1669,8 +1693,14 @@ const timeoutNudgeCooldowns = new Map<string, number>();
 const FAILED_MERGE_RETRY_COOLDOWN_MS = 30 * 60 * 1000; // 30 minutes
 // Minimum time (ms) between timeout nudges to the same work agent
 const TIMEOUT_NUDGE_COOLDOWN_MS = 30 * 60 * 1000; // 30 minutes
+// Shorter cooldown for CI-transient failures (pending checks that may resolve quickly)
+const CI_TRANSIENT_RETRY_COOLDOWN_MS = 2 * 60 * 1000; // 2 minutes
 // Max number of automatic retries before requiring manual intervention
 const FAILED_MERGE_MAX_RETRIES = 3;
+
+// In-memory CI failure retry tracking — separate from mergeRetryCount because
+// CI failures are transient and should not permanently block merge attempts.
+export const ciRetryMap = new Map<string, { count: number; lastAttempt: number }>();
 
 /**
  * Auto-retry issues whose mergeStatus='failed' due to transient post-rebase
@@ -1711,40 +1741,65 @@ export async function checkFailedMergeRetry(): Promise<string[]> {
       if (status.mergeStatus !== 'failed') continue;
       if (status.reviewStatus !== 'passed' || status.testStatus !== 'passed') continue;
 
-      // CI check failures are permanent until the work agent pushes a fix — retrying
-      // the merge won't help. Write feedback to the workspace so the agent knows what
-      // to fix, then saturate the circuit breaker so we don't re-enter this branch.
-      // checkPostReviewCommits() will reset the retry count once new commits are pushed.
       const isCiCheckFailure = typeof status.mergeNotes === 'string' &&
         status.mergeNotes.includes('failing required checks');
+      const issueId = status.issueId || key;
+
       if (isCiCheckFailure) {
-        const retryCountCi = status.mergeRetryCount || 0;
-        if (retryCountCi >= FAILED_MERGE_MAX_RETRIES) continue; // already processed
-        console.log(`[deacon] CI check failure for ${key} — routing to work agent, not retrying merge`);
-        setReviewStatus(key, {
-          mergeRetryCount: FAILED_MERGE_MAX_RETRIES, // saturate to suppress future re-entry
-          readyForMerge: false,
-        });
-        const issueIdForFb = status.issueId || key;
-        const ciNotes = status.mergeNotes!;
+        const ciEntry = ciRetryMap.get(issueId) ?? { count: 0, lastAttempt: 0 };
+        const timeSinceLastCi = now - ciEntry.lastAttempt;
+
+        if (ciEntry.count >= 5) {
+          if (ciEntry.count === 5) {
+            console.log(`[deacon] CI check failure for ${issueId} — retries exhausted, notifying work agent`);
+            const ciNotes = status.mergeNotes || 'CI checks are failing on the PR';
+            const { writeFeedbackFile } = await import('./feedback-writer.js');
+            await writeFeedbackFile({
+              issueId,
+              specialist: 'merge-agent',
+              outcome: 'ci-failure',
+              summary: 'CI checks still failing after 5 transient retries — merge blocked',
+              markdownBody: `## CI Check Failure — Merge Blocked\n\n${ciNotes}\n\n### Action Required\n\nFix the failing CI checks, commit, and push. Panopticon will detect the new commits and re-run the review pipeline automatically.\n\nAlternatively:\n\n\`\`\`\npan done ${issueId}\n\`\`\``,
+            }).catch((err: Error) => console.error(`[deacon] Failed to write CI failure feedback for ${issueId}:`, err.message));
+            const agentSession = `agent-${issueId.toLowerCase()}`;
+            if (sessionExists(agentSession)) {
+              await sendKeysAsync(agentSession,
+                `CI checks are failing on the PR after 5 retries. Read .planning/feedback/ for details, fix the failures, commit, then invoke the /rebase-and-submit skill for ${issueId}. The skill is an atomic task — do not stop until pan done has completed successfully.`
+              );
+            }
+            ciEntry.count++;
+            ciRetryMap.set(issueId, ciEntry);
+            actions.push(`CI retry exhausted for ${issueId} — wrote feedback, notified agent`);
+          } else {
+            console.log(`[deacon] CI check failure for ${issueId} — max retries (5) exhausted, awaiting agent fix`);
+          }
+          continue;
+        }
+        if (timeSinceLastCi < CI_TRANSIENT_RETRY_COOLDOWN_MS) {
+          continue;
+        }
+
+        ciEntry.count++;
+        ciEntry.lastAttempt = now;
+        ciRetryMap.set(issueId, ciEntry);
+
+        console.log(`[deacon] CI check failure for ${issueId} — notifying agent to re-submit (attempt ${ciEntry.count}/5)`);
+        const ciNotes = status.mergeNotes || 'CI checks are failing on the PR';
         const { writeFeedbackFile } = await import('./feedback-writer.js');
         await writeFeedbackFile({
-          issueId: issueIdForFb,
+          issueId,
           specialist: 'merge-agent',
           outcome: 'ci-failure',
-          summary: 'CI checks are failing — merge blocked until CI passes',
-          markdownBody: `## CI Check Failure — Merge Blocked\n\n${ciNotes}\n\n### Action Required\n\nFix the failing CI checks, commit, and push. Panopticon will detect the new commits and re-run the review pipeline automatically.\n\nAlternatively:\n\n\`\`\`\npan work done ${issueIdForFb}\n\`\`\``,
-        }).catch((err: Error) => console.error(`[deacon] Failed to write CI failure feedback for ${issueIdForFb}:`, err.message));
-        // Nudge the work agent session if it's running. Use the /rebase-and-submit
-        // skill as the atomic task contract so Claude doesn't stop partway through
-        // the submit flow (the failure mode that caused PAN-509 to sit idle).
-        const agentSession = `agent-${issueIdForFb.toLowerCase()}`;
-        if (sessionExists(agentSession)) {
-          await sendKeysAsync(agentSession,
-            `CI checks are failing on the PR. Read .planning/feedback/ for details, fix the failures, commit, then invoke the /rebase-and-submit skill for ${issueIdForFb}. The skill is an atomic task — do not stop until pan work done has completed successfully.`
+          summary: 'CI checks failed at merge — re-submit to re-enter merge queue',
+          markdownBody: `## CI Check Failure\n\n${ciNotes}\n\nCI checks failed at merge time. This may be transient (pending checks, GitHub status lag). Re-submit to re-enter the merge queue:\n\n\`\`\`\npan done ${issueId}\n\`\`\``,
+        }).catch((err: Error) => console.error(`[deacon] Failed to write CI failure feedback for ${issueId}:`, err.message));
+        const agentSessionCi = `agent-${issueId.toLowerCase()}`;
+        if (sessionExists(agentSessionCi)) {
+          await sendKeysAsync(agentSessionCi,
+            `CI checks failed on the PR for ${issueId}. This may be transient. Read .planning/feedback/ for details, then invoke the /rebase-and-submit skill for ${issueId}.`
           );
         }
-        actions.push(`CI check failure for ${issueIdForFb} — wrote feedback, saturated merge retry counter`);
+        actions.push(`CI failure notification for ${issueId} (attempt ${ciEntry.count}/5)`);
         continue;
       }
 
@@ -1798,7 +1853,6 @@ export async function checkFailedMergeRetry(): Promise<string[]> {
 
       failedMergeRetryCooldowns.set(key, now);
 
-      const issueId = status.issueId || key;
       const nextRetry = retryCount + 1;
       console.log(`[deacon] Auto-retrying failed merge for ${issueId} (attempt ${nextRetry}/${FAILED_MERGE_MAX_RETRIES})`);
 
@@ -1842,15 +1896,16 @@ async function clearStaleCiFeedback(issueId: string): Promise<void> {
 
   try {
     if (!existsSync(candidateFeedbackDir)) return;
-    const files = readdirSync(candidateFeedbackDir);
+    const files = await readdir(candidateFeedbackDir);
     for (const file of files) {
       if (file.includes('merge-agent') && file.includes('ci-failure') && file.endsWith('.md')) {
         await rm(join(candidateFeedbackDir, file));
         console.log(`[deacon] Cleared stale CI feedback: ${file} for ${issueId}`);
       }
     }
-  } catch (err: any) {
-    console.log(`[deacon] Could not clear stale CI feedback for ${issueId}: ${err.message}`);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.log(`[deacon] Could not clear stale CI feedback for ${issueId}: ${message}`);
   }
 }
 
@@ -1931,6 +1986,13 @@ export async function checkDeadEndAgents(): Promise<string[]> {
         continue;
       }
 
+      // CI-blocked merges have their own retry circuit breaker in checkFailedMergeRetry().
+      // Once that counter is saturated, only a new commit should reset the merge path.
+      if (isMergeCiFailed && (status.mergeRetryCount || 0) >= FAILED_MERGE_MAX_RETRIES) {
+        console.log(`[deacon] Dead-end detected for ${key} but merge retry ceiling is saturated (${status.mergeRetryCount}/${FAILED_MERGE_MAX_RETRIES})`);
+        continue;
+      }
+
       // Check if the work agent exists and is idle
       const issueId = status.issueId || key;
       const agentSessionName = `agent-${issueId.toLowerCase()}`;
@@ -1940,10 +2002,9 @@ export async function checkDeadEndAgents(): Promise<string[]> {
         continue;
       }
 
-      // Check if agent is actively working (don't interrupt active agents)
-      const isActive = await isAgentActiveInTmux(agentSessionName);
-      if (isActive) {
-        // Agent is still working on fixes — let it finish
+      // Check if agent is idle via Stop hook state (authoritative idle signal)
+      if (!isAgentIdleForNudge(agentSessionName)) {
+        // Agent is still working or has no hook state — let it finish
         continue;
       }
 
@@ -2035,33 +2096,15 @@ export async function checkFirstCompletionAgents(): Promise<string[]> {
       const completedFile = join(AGENTS_DIR, agent.id, 'completed');
       if (existsSync(completedFile)) continue;
 
-      // Check if agent is idle
-      const runtimeState = getAgentRuntimeState(agent.id);
-      if (!runtimeState) continue;
-      // Allow 'active' through — hook may not have fired to update state to 'idle'
-      // after the agent returned to the prompt. The pane check below is ground truth.
-      if (runtimeState.state === 'suspended' || runtimeState.state === 'completed') continue;
+      // Check idle duration and idle state via Stop hook
+      // isAgentIdleForNudge uses FIRST_COMPLETION_IDLE_MS as the stale-active threshold:
+      // if the agent's heartbeat is older than the idle minimum, it's safe to treat as idle.
+      if (!isAgentIdleForNudge(agent.id, FIRST_COMPLETION_IDLE_MS)) continue;
 
-      // Check idle duration
+      const runtimeState = getAgentRuntimeState(agent.id)!;
       const lastActivity = new Date(runtimeState.lastActivity);
       const idleMs = now - lastActivity.getTime();
       if (idleMs < FIRST_COMPLETION_IDLE_MS) continue;
-
-      // Verify agent is at an idle prompt (not computing/thinking)
-      // Don't use isAgentActiveInTmux here — it checks last 5 lines which may
-      // contain stale tool call names (e.g., "Bash(...)") from prior output.
-      // Instead, check the very last line for the Claude Code idle prompt marker.
-      try {
-        const lastLines = await capturePaneAsync(agent.id, 3);
-        // Check the last few non-empty lines for idle prompt indicators
-        const lines = lastLines.split('\n').filter(l => l.trim().length > 0);
-        const tail = lines.slice(-3).join('\n');
-        // Claude Code shows "❯" prompt and "bypass permissions" status bar when idle
-        const isAtPrompt = /❯/.test(tail) || /bypass permissions/.test(tail) || /Worked for/.test(tail);
-        if (!isAtPrompt) continue; // Agent is actively working
-      } catch {
-        continue;
-      }
 
       // Check cooldown
       const lastNudge = firstCompletionCooldowns.get(agent.id);

--- a/src/lib/cloister/deacon.ts
+++ b/src/lib/cloister/deacon.ts
@@ -961,6 +961,24 @@ export async function checkStuckWorkAgents(): Promise<string[]> {
 
     if (!tmuxOutput.trim()) continue;
 
+    // Detect agents stuck on Claude Code's "exclude from context" interactive dialog.
+    // This dialog fires when Claude Code wants to add a file to .claudeignore and waits
+    // for user input (Esc to cancel, Tab to amend). The notification-hook sets runtime
+    // state to 'waiting-on-human', but no automated recovery was wired up for this case.
+    const isExcludeDialog = tmuxOutput.includes('Do you want to make this edit to exclude')
+      || tmuxOutput.includes('Esc to cancel') && tmuxOutput.includes('Tab to amend');
+    if (isExcludeDialog) {
+      console.log(`[deacon] Work agent ${agent.id} stuck on exclude-from-context dialog — dismissing with Escape`);
+      try {
+        await execAsync(`${buildTmuxCommandString(['send-keys', '-t', agent.id, 'Escape'])} 2>/dev/null || true`);
+        saveAgentRuntimeState(agent.id, { state: 'active' });
+        actions.push(`Stuck recovery: dismissed exclude-from-context dialog for ${agent.id}`);
+      } catch (err) {
+        console.error(`[deacon] Failed to send Escape to ${agent.id}:`, err);
+      }
+      continue;
+    }
+
     // Parse thinking duration
     const thinkingMs = parseThinkingDuration(tmuxOutput);
     if (thinkingMs === null || thinkingMs < STUCK_THINKING_THRESHOLD_MS) {
@@ -1164,7 +1182,13 @@ export async function checkOrphanedReviewStatuses(): Promise<string[]> {
     for (const projSpec of projectStatuses) {
       if (!projSpec.isRunning) continue;
       const rState = getAgentRuntimeState(projSpec.tmuxSession);
-      if (rState?.state === 'active' && rState.currentIssue) {
+      // Include specialists with state=active OR state=waiting-on-human.
+      // The notification-hook previously set specialists to waiting-on-human on
+      // startup (PAN-760), causing false-positive orphan detection that reset
+      // review/test statuses before the specialist could complete its work.
+      // The hook is now fixed, but existing sessions may still have the stale state.
+      const isWorking = rState?.state === 'active' || rState?.state === 'waiting-on-human';
+      if (isWorking && rState.currentIssue) {
         if (projSpec.specialistType === 'review-agent') {
           activeReviewSessions.add(rState.currentIssue.toUpperCase());
         } else if (projSpec.specialistType === 'test-agent') {

--- a/src/lib/cloister/deacon.ts
+++ b/src/lib/cloister/deacon.ts
@@ -1948,6 +1948,7 @@ export async function checkDeadEndAgents(): Promise<string[]> {
       readyForMerge?: boolean;
       mergeStatus?: string;
       mergeNotes?: string;
+      mergeRetryCount?: number;
       updatedAt?: string;
       autoRequeueCount?: number;
       history?: Array<{ type: string; status: string; timestamp?: string }>;

--- a/src/lib/cloister/deacon.ts
+++ b/src/lib/cloister/deacon.ts
@@ -2630,6 +2630,13 @@ export async function runPatrol(): Promise<PatrolResult> {
   actions.push(...deadEndActions);
   for (const a of deadEndActions) addLog('action', a, state.patrolCycle);
 
+  // First-completion gap detection: nudge work agents that finished implementation
+  // but never called pan done. Only fires for agents idle >10min with commits and
+  // no completion marker or review status entry. Has 15-min cooldown per agent.
+  const firstCompletionActions = await checkFirstCompletionAgents();
+  actions.push(...firstCompletionActions);
+  for (const a of firstCompletionActions) addLog('action', a, state.patrolCycle);
+
   // Resolution patrol DISABLED — auto-completing and poking agents consumes
   // API credits and is unreliable. Human operator can take action via dashboard.
 

--- a/src/lib/cloister/deacon.ts
+++ b/src/lib/cloister/deacon.ts
@@ -839,6 +839,9 @@ const ACTIVE_STATUS_PATTERNS = [
   /computing/i,
   /fermenting/i,
   /thinking/i,
+  /forming/i,     // Claude Code "Forming…" computation status
+  /embellish/i,   // Claude Code "Embellishing…" computation status
+  /baking/i,      // Claude Code "Baking…" computation status
   /reading/i,
   /writing/i,
   /editing/i,
@@ -876,9 +879,9 @@ export async function isAgentActiveInTmux(sessionName: string): Promise<boolean>
 
     for (const pattern of ACTIVE_STATUS_PATTERNS) {
       if (pattern.test(tail)) {
-        // "Thinking" with a duration over the threshold is NOT active — it's stuck.
+        // Extended computation (Thinking/Forming/Embellishing/Baking) over threshold = stuck.
         // Don't let stuck agents masquerade as active.
-        if (/thinking/i.test(tail)) {
+        if (/thinking|forming|embellish|baking|fermenting/i.test(tail)) {
           const thinkingMs = parseThinkingDuration(tail);
           if (thinkingMs !== null && thinkingMs >= STUCK_THINKING_THRESHOLD_MS) {
             return false; // Stuck, not active
@@ -922,8 +925,9 @@ const stuckRecoveryState: Map<string, { lastAttempt: number; attempts: number }>
  * Returns duration in milliseconds, or null if not currently thinking.
  */
 function parseThinkingDuration(tmuxOutput: string): number | null {
-  // Match patterns like "Thinking… (22m 41s" or "Thinking… (5s"
-  const match = tmuxOutput.match(/[Tt]hinking[^\n]*?\((?:(\d+)m\s*)?(\d+)s/);
+  // Match Claude Code computation status phrases followed by a duration.
+  // Handles: "Thinking… (22m 41s", "Forming… (5s", "Embellishing… (20m 1s", "Baking… (3m"
+  const match = tmuxOutput.match(/(?:[Tt]hinking|[Ff]orming|[Ee]mbellish\w*|[Bb]aking|[Ff]ermenting)[^\n]*?\((?:(\d+)m\s*)?(\d+)s/);
   if (!match) return null;
 
   const minutes = match[1] ? parseInt(match[1], 10) : 0;

--- a/src/lib/cloister/service.ts
+++ b/src/lib/cloister/service.ts
@@ -62,6 +62,7 @@ import { existsSync, writeFileSync, unlinkSync, readFileSync, readdirSync, renam
 import { join } from 'path';
 import { AGENTS_DIR } from '../paths.js';
 import { loadReviewStatuses, setReviewStatus } from '../review-status.js';
+import { sessionExistsAsync } from '../tmux.js';
 
 // State file for cross-process communication
 const CLOISTER_STATE_FILE = join(PANOPTICON_HOME, 'cloister.state');
@@ -88,6 +89,31 @@ export function identifyOrphanedReviewingIssues(
     orphaned.push(issueId);
   }
   return orphaned;
+}
+
+export function parseSpecialistAgentSession(name: string): {
+  projectKey: string;
+  specialistType: 'review-agent' | 'test-agent' | 'merge-agent';
+  issueId?: string;
+} | null {
+  const issueScoped = name.match(/^specialist-(.+)-([A-Z]+-\d+)-(review-agent|test-agent|merge-agent)$/);
+  if (issueScoped) {
+    return {
+      projectKey: issueScoped[1],
+      issueId: issueScoped[2],
+      specialistType: issueScoped[3] as 'review-agent' | 'test-agent' | 'merge-agent',
+    };
+  }
+
+  const legacy = name.match(/^specialist-(.+)-(review-agent|test-agent|merge-agent)$/);
+  if (legacy) {
+    return {
+      projectKey: legacy[1],
+      specialistType: legacy[2] as 'review-agent' | 'test-agent' | 'merge-agent',
+    };
+  }
+
+  return null;
 }
 
 /**
@@ -270,14 +296,11 @@ export class CloisterService {
     try {
       if (existsSync(AGENTS_DIR)) {
         const { isRunning: isSpecialistRunning } = await import('./specialists.js');
-        const specialistPattern = /^specialist-(.+)-(review-agent|test-agent|merge-agent)$/;
         const entries = readdirSync(AGENTS_DIR, { withFileTypes: true });
         for (const entry of entries) {
           if (!entry.isDirectory()) continue;
-          const match = specialistPattern.exec(entry.name);
-          if (!match) continue;
-          const projectKey = match[1];
-          const specialistType = match[2] as 'review-agent' | 'test-agent' | 'merge-agent';
+          const parsed = parseSpecialistAgentSession(entry.name);
+          if (!parsed) continue;
           const runtimeState = getAgentRuntimeState(entry.name);
           if (!runtimeState?.currentIssue) continue;
 
@@ -285,8 +308,12 @@ export class CloisterService {
             saveAgentRuntimeState(entry.name, { currentIssue: undefined });
             console.log(`  ✓ Cleared stale currentIssue '${runtimeState.currentIssue}' from idle ${entry.name}`);
           } else if (runtimeState.state === 'active') {
-            // Check if the process is actually alive — if not, the state is stale from a crash
-            const stillRunning = await isSpecialistRunning(specialistType, projectKey);
+            // Check if the process is actually alive — if not, the state is stale from a crash.
+            // For issue-scoped specialists, check the exact tmux session instead of the legacy
+            // project/type singleton lookup, which cannot represent PAN-754 session identity.
+            const stillRunning = parsed.issueId
+              ? await sessionExistsAsync(entry.name)
+              : await isSpecialistRunning(parsed.specialistType, parsed.projectKey);
             if (!stillRunning) {
               saveAgentRuntimeState(entry.name, {
                 state: 'idle',

--- a/src/lib/cloister/specialists.ts
+++ b/src/lib/cloister/specialists.ts
@@ -212,6 +212,18 @@ export interface SpecialistStatus extends SpecialistMetadata {
 }
 
 /**
+ * One step in the model resolution trace (PAN-754)
+ */
+export interface ResolutionStep {
+  source: 'work-type-router' | 'cloister-config' | 'fallback';
+  workTypeId?: string;
+  configKey?: string;
+  resolvedAlias?: string;
+  resolvedModel: string;
+  matched: boolean;
+}
+
+/**
  * Per-project specialist metadata
  */
 export interface ProjectSpecialistMetadata {
@@ -220,6 +232,17 @@ export interface ProjectSpecialistMetadata {
   lastRunStatus: 'passed' | 'failed' | 'blocked' | null;
   currentRun: string | null; // Run ID if active
   sessionId?: string; // Legacy session ID for transition period
+  // Identity fields (PAN-754)
+  issueId?: string;
+  tmuxSession?: string; // Stored at spawn time so we can look it up without recomputing
+  role?: string; // For convoy members: 'correctness' | 'performance' | etc.
+  // Activity visibility (PAN-754)
+  currentActivity?: string | null;
+  model?: string | null;
+  resolutionTrace?: ResolutionStep[] | null;
+  // Write-scope (PAN-754)
+  writeScope?: 'full' | 'readonly-plus-output';
+  outputPath?: string | null;
 }
 
 export function isProjectSpecialistActivelyRunning(
@@ -633,12 +656,33 @@ export function getSpecialistState(name: SpecialistType): Exclude<SpecialistStat
  * @param projectKey - Optional project key for per-project specialists
  * @returns Expected tmux session name
  */
-export function getTmuxSessionName(name: SpecialistType, projectKey?: string): string {
+export function getTmuxSessionName(name: SpecialistType, projectKey?: string, issueId?: string): string {
+  if (projectKey && issueId) {
+    return `specialist-${projectKey}-${issueId}-${name}`;
+  }
   if (projectKey) {
     return `specialist-${projectKey}-${name}`;
   }
   // Legacy format for backward compatibility
   return `specialist-${name}`;
+}
+
+/**
+ * Construct the compound registry key for a per-issue specialist (PAN-754).
+ * Format: `${specialistType}:${issueId}` or `${specialistType}:${issueId}:${role}` for convoy.
+ */
+export function makeSpecialistRegistryKey(specialistType: string, issueId: string, role?: string): string {
+  return role ? `${specialistType}:${issueId}:${role}` : `${specialistType}:${issueId}`;
+}
+
+/**
+ * Parse a compound registry key back into its parts.
+ */
+export function parseSpecialistRegistryKey(key: string): { specialistType: string; issueId?: string; role?: string } {
+  const parts = key.split(':');
+  if (parts.length === 1) return { specialistType: parts[0] };
+  if (parts.length === 2) return { specialistType: parts[0], issueId: parts[1] };
+  return { specialistType: parts[0], issueId: parts[1], role: parts[2] };
 }
 
 /**
@@ -711,7 +755,8 @@ export async function spawnEphemeralSpecialist(
   // Ensure project specialist directory exists
   ensureProjectSpecialistDir(projectKey, specialistType);
 
-  const tmuxSession = getTmuxSessionName(specialistType, projectKey);
+  const registryKey = makeSpecialistRegistryKey(specialistType, task.issueId);
+  const tmuxSession = getTmuxSessionName(specialistType, projectKey, task.issueId);
 
   // Busy check FIRST — before any state mutation. A rejected dispatch must NOT
   // create a run log, advance currentRun, or write task files into the shared
@@ -767,9 +812,9 @@ export async function spawnEphemeralSpecialist(
     contextDigest || undefined
   );
 
-  // Update metadata
-  setCurrentRun(projectKey, specialistType, runId);
-  incrementProjectRunCount(projectKey, specialistType);
+  // Update metadata (3-level: projectKey + issueId + specialistType via compound key)
+  setCurrentRun(projectKey, registryKey, runId);
+  incrementProjectRunCount(projectKey, registryKey);
 
   // Build task prompt (use override if provided, otherwise build from template)
   const basePrompt = task.promptOverride ?? await buildTaskPrompt(projectKey, specialistType, task, contextDigest);
@@ -796,36 +841,58 @@ ${basePrompt}`;
 
   try {
     // Determine model for this specialist
-    // Priority: cloister config specialist_models > work-type-router > default fallback
+    // Priority: work-type-router (respects config.yaml overrides) > cloister config defaults > fallback
+    // PAN-754: work-type-router MUST be checked first so user's models.overrides.specialist-X config wins.
     const fallbackModel = 'claude-sonnet-4-6';
     let model: string | undefined;
+    const resolutionTrace: ResolutionStep[] = [];
 
     try {
-      const cloisterConfig = loadCloisterConfig();
-      const normalizedName = specialistType.replace(/-/g, '_');
-      const configuredModel = (cloisterConfig.model_selection?.specialist_models as any)?.[normalizedName] as string | undefined;
-      if (configuredModel) {
-        const modelMap: Record<string, string> = { opus: 'claude-opus-4-6', sonnet: 'claude-sonnet-4-6', haiku: 'claude-haiku-4-5' };
-        model = modelMap[configuredModel];
-        if (model) {
-          console.log(`[specialist] Using model "${model}" for ${specialistType} (from cloister config)`);
-        }
+      const workTypeId: WorkTypeId = `specialist-${specialistType}` as WorkTypeId;
+      const resolved = getModelId(workTypeId);
+      if (resolved) {
+        model = resolved;
+        resolutionTrace.push({ source: 'work-type-router', workTypeId, resolvedModel: resolved, matched: true });
+        console.log(`[specialist] Using model "${model}" for ${specialistType} (from work-type-router)`);
       }
     } catch {
-      // Config lookup failed, fall through to work-type-router
+      resolutionTrace.push({ source: 'work-type-router', workTypeId: `specialist-${specialistType}`, resolvedModel: '', matched: false });
     }
 
     if (!model) {
       try {
-        const workTypeId: WorkTypeId = `specialist-${specialistType}` as WorkTypeId;
-        model = getModelId(workTypeId);
-        console.log(`[specialist] Using model "${model}" for ${specialistType} (from work-type-router)`);
+        const cloisterConfig = loadCloisterConfig();
+        const normalizedName = specialistType.replace(/-/g, '_');
+        const configuredAlias = (cloisterConfig.model_selection?.specialist_models as any)?.[normalizedName] as string | undefined;
+        if (configuredAlias) {
+          const modelMap: Record<string, string> = { opus: 'claude-opus-4-7', sonnet: 'claude-sonnet-4-6', haiku: 'claude-haiku-4-5' };
+          const resolved = modelMap[configuredAlias];
+          if (resolved) {
+            model = resolved;
+            resolutionTrace.push({ source: 'cloister-config', configKey: normalizedName, resolvedAlias: configuredAlias, resolvedModel: resolved, matched: true });
+            console.log(`[specialist] Using model "${model}" for ${specialistType} (from cloister config default)`);
+          }
+        }
       } catch {
-        console.warn(`Warning: Could not resolve model for ${specialistType} via work-type-router, using default`);
+        // Config lookup failed
       }
     }
 
-    model = model || fallbackModel;
+    if (!model) {
+      model = fallbackModel;
+      resolutionTrace.push({ source: 'fallback', resolvedModel: fallbackModel, matched: true });
+      console.warn(`[specialist] Falling back to default model "${fallbackModel}" for ${specialistType}`);
+    }
+
+    // Store model + trace in registry metadata for Agent activity visibility
+    updateRunMetadata(projectKey, registryKey, {
+      model,
+      resolutionTrace,
+      issueId: task.issueId,
+      tmuxSession,
+      currentActivity: `Running ${specialistType} for ${task.issueId}`,
+      writeScope: 'full',
+    });
 
     // Get provider-specific env vars (BASE_URL, AUTH_TOKEN) for non-Anthropic models
     const providerEnv = getProviderEnvForModel(model);
@@ -954,7 +1021,7 @@ exec script -qfaec "bash '${innerScript}'" "${logFilePath}"
     console.error(`[specialist] Failed to spawn ${specialistType}:`, error);
 
     // Clean up metadata
-    setCurrentRun(projectKey, specialistType, null);
+    setCurrentRun(projectKey, registryKey, null);
 
     return {
       success: false,
@@ -1316,6 +1383,34 @@ export function getGracePeriodState(
 }
 
 /**
+ * Find the active registry key for (projectKey, specialistType).
+ * Searches compound keys; falls back to plain specialistType key.
+ * Returns undefined if nothing is currently active.
+ */
+export function findActiveRegistryKey(projectKey: string, specialistType: SpecialistType): string | undefined {
+  const registry = loadRegistry();
+  const bucket = registry.projects[projectKey] ?? {};
+
+  // Check compound keys first (new format: "type:issueId")
+  const prefix = `${specialistType}:`;
+  const activeCompound = Object.keys(bucket).find(k =>
+    k.startsWith(prefix) && bucket[k].currentRun !== null
+  );
+  if (activeCompound) return activeCompound;
+
+  // Check legacy plain key
+  if (bucket[specialistType]?.currentRun !== null) return specialistType;
+
+  // Return most recently touched key even if not active
+  const allMatching = Object.keys(bucket).filter(k =>
+    k === specialistType || k.startsWith(prefix)
+  ).sort((a, b) =>
+    (bucket[b].lastRunAt ?? '').localeCompare(bucket[a].lastRunAt ?? '')
+  );
+  return allMatching[0];
+}
+
+/**
  * Signal that a specialist has completed its task
  *
  * This should be called when the specialist finishes its work.
@@ -1324,6 +1419,7 @@ export function getGracePeriodState(
  * @param projectKey - Project identifier
  * @param specialistType - Specialist type
  * @param result - Task result
+ * @param issueId - Optional: issue being handled (used to compute compound registry key)
  */
 export function signalSpecialistCompletion(
   projectKey: string,
@@ -1331,12 +1427,19 @@ export function signalSpecialistCompletion(
   result: {
     status: 'passed' | 'failed' | 'blocked';
     notes?: string;
-  }
+  },
+  issueId?: string
 ): void {
-  const metadata = getProjectSpecialistMetadata(projectKey, specialistType);
+  const registryKey = issueId
+    ? makeSpecialistRegistryKey(specialistType, issueId)
+    : (findActiveRegistryKey(projectKey, specialistType) ?? specialistType);
+  const metadata = getRunMetadata(projectKey, registryKey);
+
+  // Derive tmuxSession: use stored field when available, recompute as fallback
+  const resolvedTmuxSession = metadata.tmuxSession ?? getTmuxSessionName(specialistType, projectKey, issueId);
 
   // Update status
-  updateRunStatus(projectKey, specialistType, result.status);
+  updateRunStatus(projectKey, registryKey, result.status);
 
   // Finalize log if there's a current run
   if (metadata.currentRun) {
@@ -1354,10 +1457,11 @@ export function signalSpecialistCompletion(
 
   // Completion means the run itself is over, even if the tmux session stays alive
   // during the grace period for inspection or manual termination.
-  setCurrentRun(projectKey, specialistType, null);
+  setCurrentRun(projectKey, registryKey, null);
+  updateRunMetadata(projectKey, registryKey, { currentActivity: null });
   import('../agents.js')
     .then(({ saveAgentRuntimeState }) => {
-      saveAgentRuntimeState(getTmuxSessionName(specialistType, projectKey), {
+      saveAgentRuntimeState(resolvedTmuxSession, {
         state: 'idle',
         lastActivity: new Date().toISOString(),
         currentIssue: undefined,
@@ -1383,10 +1487,16 @@ export function signalSpecialistCompletion(
  */
 export async function terminateSpecialist(
   projectKey: string,
-  specialistType: SpecialistType
+  specialistType: SpecialistType,
+  issueId?: string
 ): Promise<void> {
-  const tmuxSession = getTmuxSessionName(specialistType, projectKey);
-  const metadata = getProjectSpecialistMetadata(projectKey, specialistType);
+  const registryKey = issueId
+    ? makeSpecialistRegistryKey(specialistType, issueId)
+    : (findActiveRegistryKey(projectKey, specialistType) ?? specialistType);
+  const metadata = getRunMetadata(projectKey, registryKey);
+
+  // Derive tmuxSession: use stored field, or recompute
+  const tmuxSession = metadata.tmuxSession ?? getTmuxSessionName(specialistType, projectKey, issueId);
 
   try {
     // Kill tmux session
@@ -1410,8 +1520,10 @@ export async function terminateSpecialist(
     }
 
     // Clear current run
-    setCurrentRun(projectKey, specialistType, null);
+    setCurrentRun(projectKey, registryKey, null);
   }
+
+  updateRunMetadata(projectKey, registryKey, { currentActivity: null });
 
   // Clear grace period state
   const key = `${projectKey}-${specialistType}`;
@@ -1487,11 +1599,12 @@ export function ensureProjectSpecialistDir(projectKey: string, specialistType: S
 }
 
 /**
- * Get per-project specialist metadata
+ * Get metadata for a specific (projectKey, registryKey) pair.
+ * registryKey is either a plain specialistType (legacy) or a compound key from makeSpecialistRegistryKey().
  */
-export function getProjectSpecialistMetadata(
+export function getRunMetadata(
   projectKey: string,
-  specialistType: SpecialistType
+  registryKey: string,
 ): ProjectSpecialistMetadata {
   const registry = loadRegistry();
 
@@ -1499,9 +1612,8 @@ export function getProjectSpecialistMetadata(
     registry.projects[projectKey] = {};
   }
 
-  if (!registry.projects[projectKey][specialistType]) {
-    // Initialize with defaults
-    registry.projects[projectKey][specialistType] = {
+  if (!registry.projects[projectKey][registryKey]) {
+    registry.projects[projectKey][registryKey] = {
       runCount: 0,
       lastRunAt: null,
       lastRunStatus: null,
@@ -1510,15 +1622,15 @@ export function getProjectSpecialistMetadata(
     saveRegistry(registry);
   }
 
-  return registry.projects[projectKey][specialistType];
+  return registry.projects[projectKey][registryKey];
 }
 
 /**
- * Update per-project specialist metadata
+ * Update metadata for a specific (projectKey, registryKey) pair.
  */
-export function updateProjectSpecialistMetadata(
+export function updateRunMetadata(
   projectKey: string,
-  specialistType: SpecialistType,
+  registryKey: string,
   updates: Partial<ProjectSpecialistMetadata>
 ): void {
   const registry = loadRegistry();
@@ -1527,8 +1639,8 @@ export function updateProjectSpecialistMetadata(
     registry.projects[projectKey] = {};
   }
 
-  if (!registry.projects[projectKey][specialistType]) {
-    registry.projects[projectKey][specialistType] = {
+  if (!registry.projects[projectKey][registryKey]) {
+    registry.projects[projectKey][registryKey] = {
       runCount: 0,
       lastRunAt: null,
       lastRunStatus: null,
@@ -1536,8 +1648,8 @@ export function updateProjectSpecialistMetadata(
     };
   }
 
-  registry.projects[projectKey][specialistType] = {
-    ...registry.projects[projectKey][specialistType],
+  registry.projects[projectKey][registryKey] = {
+    ...registry.projects[projectKey][registryKey],
     ...updates,
   };
 
@@ -1545,36 +1657,111 @@ export function updateProjectSpecialistMetadata(
 }
 
 /**
- * Increment run count for a project's specialist
+ * Get per-project specialist metadata — backward-compat wrapper.
+ * Searches compound-key entries for this project+type; returns the active run, or most recent.
  */
-export function incrementProjectRunCount(projectKey: string, specialistType: SpecialistType): void {
-  const metadata = getProjectSpecialistMetadata(projectKey, specialistType);
-  updateProjectSpecialistMetadata(projectKey, specialistType, {
+export function getProjectSpecialistMetadata(
+  projectKey: string,
+  specialistType: SpecialistType
+): ProjectSpecialistMetadata {
+  const registry = loadRegistry();
+  const projectBucket = registry.projects[projectKey] ?? {};
+
+  // Check for exact legacy key first
+  if (projectBucket[specialistType]) {
+    return projectBucket[specialistType];
+  }
+
+  // Search compound keys for the most relevant entry
+  const prefix = `${specialistType}:`;
+  const candidates = Object.entries(projectBucket)
+    .filter(([k]) => k.startsWith(prefix))
+    .map(([, v]) => v);
+
+  // Prefer active run, then most recently started
+  const active = candidates.find(c => c.currentRun !== null);
+  if (active) return active;
+  const sorted = candidates.sort((a, b) =>
+    (b.lastRunAt ?? '').localeCompare(a.lastRunAt ?? '')
+  );
+  if (sorted.length > 0) return sorted[0];
+
+  // No entry found — return blank default (don't save it)
+  return { runCount: 0, lastRunAt: null, lastRunStatus: null, currentRun: null };
+}
+
+/**
+ * Update per-project specialist metadata — backward-compat wrapper.
+ * Updates the active compound-key entry, or the legacy plain-key entry.
+ */
+export function updateProjectSpecialistMetadata(
+  projectKey: string,
+  specialistType: SpecialistType,
+  updates: Partial<ProjectSpecialistMetadata>
+): void {
+  const registry = loadRegistry();
+  const projectBucket = registry.projects[projectKey] ?? {};
+
+  // Try legacy key first
+  if (projectBucket[specialistType]) {
+    updateRunMetadata(projectKey, specialistType, updates);
+    return;
+  }
+
+  // Find the active compound-key entry for this type
+  const prefix = `${specialistType}:`;
+  const activeKey = Object.keys(projectBucket).find(k =>
+    k.startsWith(prefix) && projectBucket[k].currentRun !== null
+  );
+  if (activeKey) {
+    updateRunMetadata(projectKey, activeKey, updates);
+    return;
+  }
+
+  // Fall back to most recent
+  const latestKey = Object.keys(projectBucket)
+    .filter(k => k.startsWith(prefix))
+    .sort((a, b) => (projectBucket[b].lastRunAt ?? '').localeCompare(projectBucket[a].lastRunAt ?? ''))
+    .shift();
+  if (latestKey) {
+    updateRunMetadata(projectKey, latestKey, updates);
+  }
+}
+
+/**
+ * Increment run count for a project's specialist.
+ * registryKey may be a plain specialistType (legacy) or a compound key.
+ */
+export function incrementProjectRunCount(projectKey: string, registryKey: string): void {
+  const metadata = getRunMetadata(projectKey, registryKey);
+  updateRunMetadata(projectKey, registryKey, {
     runCount: metadata.runCount + 1,
     lastRunAt: new Date().toISOString(),
   });
 }
 
 /**
- * Set current run for a project's specialist
+ * Set current run for a project's specialist.
+ * registryKey may be a plain specialistType (legacy) or a compound key.
  */
 export function setCurrentRun(
   projectKey: string,
-  specialistType: SpecialistType,
+  registryKey: string,
   runId: string | null
 ): void {
-  updateProjectSpecialistMetadata(projectKey, specialistType, { currentRun: runId });
+  updateRunMetadata(projectKey, registryKey, { currentRun: runId });
 }
 
 /**
- * Update run status for a project's specialist
+ * Update run status for a project's specialist.
+ * registryKey may be a plain specialistType (legacy) or a compound key.
  */
 export function updateRunStatus(
   projectKey: string,
-  specialistType: SpecialistType,
+  registryKey: string,
   status: 'passed' | 'failed' | 'blocked' | null
 ): void {
-  updateProjectSpecialistMetadata(projectKey, specialistType, { lastRunStatus: status });
+  updateRunMetadata(projectKey, registryKey, { lastRunStatus: status });
 }
 
 /**
@@ -1600,43 +1787,53 @@ export function listSpecialistsForProject(projectKey: string): SpecialistType[] 
 }
 
 /**
- * Get all per-project specialist statuses
+ * Get all per-project specialist statuses (PAN-754: compound-key aware).
+ * Walks registry including compound keys (type:issueId[:role]) and returns
+ * enriched entries with issueId, model, currentActivity for the Agents page.
  */
 export async function getAllProjectSpecialistStatuses(): Promise<Array<{
   projectKey: string;
   specialistType: SpecialistType;
+  registryKey: string;
+  issueId?: string;
+  role?: string;
   metadata: ProjectSpecialistMetadata;
   isRunning: boolean;
   tmuxSession: string;
 }>> {
   const registry = loadRegistry();
+  const { getAgentRuntimeState } = await import('../agents.js');
+
   const results: Array<{
     projectKey: string;
     specialistType: SpecialistType;
+    registryKey: string;
+    issueId?: string;
+    role?: string;
     metadata: ProjectSpecialistMetadata;
     isRunning: boolean;
     tmuxSession: string;
   }> = [];
 
   for (const [projectKey, specialists] of Object.entries(registry.projects)) {
-    for (const [specialistType, metadata] of Object.entries(specialists)) {
-      const tmuxSession = getTmuxSessionName(specialistType as SpecialistType, projectKey);
-      const { getAgentRuntimeState } = await import('../agents.js');
+    for (const [registryKey, metadata] of Object.entries(specialists)) {
+      const { specialistType, issueId, role } = parseSpecialistRegistryKey(registryKey);
+
+      // Determine tmux session: use stored field when available
+      const tmuxSession = metadata.tmuxSession
+        ?? getTmuxSessionName(specialistType as SpecialistType, projectKey, issueId);
+
       const runtimeState = getAgentRuntimeState(tmuxSession);
-      const running = isProjectSpecialistActivelyRunning(
-        runtimeState,
-        await isRunning(specialistType as SpecialistType, projectKey)
-      );
-      const effectiveMetadata = running
-        ? metadata
-        : {
-            ...metadata,
-            currentRun: null,
-          };
+      const sessionRunning = await isRunning(specialistType as SpecialistType, projectKey).catch(() => false);
+      const running = isProjectSpecialistActivelyRunning(runtimeState, sessionRunning);
+      const effectiveMetadata = running ? metadata : { ...metadata, currentRun: null };
 
       results.push({
         projectKey,
         specialistType: specialistType as SpecialistType,
+        registryKey,
+        issueId,
+        role,
         metadata: effectiveMetadata,
         isRunning: running,
         tmuxSession,

--- a/src/lib/cloister/specialists.ts
+++ b/src/lib/cloister/specialists.ts
@@ -243,6 +243,7 @@ export interface ProjectSpecialistMetadata {
   // Write-scope (PAN-754)
   writeScope?: 'full' | 'readonly-plus-output';
   outputPath?: string | null;
+  workspace?: string | null; // workspace path for write-scope conflict detection
 }
 
 export function isProjectSpecialistActivelyRunning(
@@ -334,7 +335,7 @@ export function initSpecialistsDirectory(): void {
   // Create default registry if it doesn't exist
   if (!existsSync(REGISTRY_FILE)) {
     const registry: SpecialistRegistry = {
-      version: '2.0', // Updated for per-project structure
+      version: '3.0', // Updated for compound-key (issueId-aware) structure (PAN-754)
       defaults: {
         contextRuns: 5,
         digestModel: null,
@@ -356,38 +357,46 @@ export function initSpecialistsDirectory(): void {
 }
 
 /**
- * Migrate old registry format to new per-project structure
+ * Migrate old registry format to new per-project structure (PAN-754: compound-key aware).
+ *
+ * v1.0 → v2.0: flat specialist list → projects[projectKey][specialistType]
+ * v2.0 → v3.0: projects[projectKey][specialistType] → projects[projectKey][compoundKey]
+ *   Legacy v2.0 plain-type keys are left as-is (still readable by compat wrappers).
+ *   getProjectSpecialistMetadata() and updateProjectSpecialistMetadata() handle both formats.
  */
 function migrateRegistryIfNeeded(): void {
   try {
     const content = readFileSync(REGISTRY_FILE, 'utf-8');
     const registry = JSON.parse(content) as SpecialistRegistry;
 
-    // Check if already migrated
-    if (registry.version === '2.0' || registry.projects) {
+    // v2.0 already migrated (or registry.projects exists for fresh installs)
+    if (registry.version === '2.0' && registry.projects) {
+      // No additional migration needed — legacy plain-type keys are handled by compat wrappers.
       return;
     }
 
-    // Migrate to new structure
-    console.log('[specialists] Migrating registry to per-project structure...');
+    if (!registry.projects) {
+      // v1.0 → v2.0: add projects map
+      console.log('[specialists] Migrating registry v1.0 → v2.0...');
 
-    const migratedRegistry: SpecialistRegistry = {
-      version: '2.0',
-      defaults: {
-        contextRuns: 5,
-        digestModel: null,
-        retention: {
-          maxDays: 30,
-          maxRuns: 50,
+      const migratedRegistry: SpecialistRegistry = {
+        version: '2.0',
+        defaults: {
+          contextRuns: 5,
+          digestModel: null,
+          retention: {
+            maxDays: 30,
+            maxRuns: 50,
+          },
         },
-      },
-      projects: {},
-      specialists: registry.specialists, // Keep for backward compat
-      lastUpdated: new Date().toISOString(),
-    };
+        projects: {},
+        specialists: registry.specialists,
+        lastUpdated: new Date().toISOString(),
+      };
 
-    saveRegistry(migratedRegistry);
-    console.log('[specialists] Registry migration complete');
+      saveRegistry(migratedRegistry);
+      console.log('[specialists] Registry migration v1.0 → v2.0 complete');
+    }
   } catch (error) {
     console.error('[specialists] Failed to migrate registry:', error);
   }
@@ -799,6 +808,29 @@ export async function spawnEphemeralSpecialist(
     // Non-fatal: session check failure shouldn't block spawn
   }
 
+  // Write-scope enforcement (PAN-754): enforce single-writer-per-worktree policy.
+  // 'full' scope specialists have exclusive write access; only one may run per workspace.
+  // 'readonly-plus-output' specialists (convoy reviewers) may run concurrently as long
+  // as their outputPath values are disjoint.
+  if (task.workspace) {
+    const registry = loadRegistry();
+    const projectBucket = registry.projects[projectKey] ?? {};
+    for (const [key, entry] of Object.entries(projectBucket)) {
+      if (key === registryKey) continue; // same slot — handled by busy check above
+      if (!entry.currentRun) continue; // not running
+      if (entry.workspace !== task.workspace) continue; // different worktree — no conflict
+      // Another specialist is running against the same workspace
+      const incomingScope = 'full'; // default; convoy callers will pass 'readonly-plus-output' via task.context
+      if (incomingScope === 'full' || (entry.writeScope ?? 'full') === 'full') {
+        return {
+          success: false,
+          message: `Write conflict: specialist ${key} (${projectKey}) is already running with full write scope on workspace ${task.workspace}`,
+          error: 'worktree_write_conflict',
+        };
+      }
+    }
+  }
+
   // Load context digest
   const { loadContextDigest } = await import('./specialist-context.js');
   const contextDigest = loadContextDigest(projectKey, specialistType);
@@ -884,12 +916,13 @@ ${basePrompt}`;
       console.warn(`[specialist] Falling back to default model "${fallbackModel}" for ${specialistType}`);
     }
 
-    // Store model + trace in registry metadata for Agent activity visibility
+    // Store model + trace + identity in registry metadata for Agent activity visibility
     updateRunMetadata(projectKey, registryKey, {
       model,
       resolutionTrace,
       issueId: task.issueId,
       tmuxSession,
+      workspace: task.workspace ?? null,
       currentActivity: `Running ${specialistType} for ${task.issueId}`,
       writeScope: 'full',
     });

--- a/src/lib/cloister/specialists.ts
+++ b/src/lib/cloister/specialists.ts
@@ -21,7 +21,8 @@ import { loadConfig as loadYamlConfig } from '../config-yaml.js';
 import { loadCloisterConfig } from './config.js';
 import { readCavemanVariant } from '../caveman/workspace.js';
 import { getModelId, WorkTypeId } from '../work-type-router.js';
-import { getProviderForModel, getProviderEnv, setupCredentialFileAuth, clearCredentialFileAuth } from '../providers.js';
+import { getProviderForModel, setupCredentialFileAuth, clearCredentialFileAuth } from '../providers.js';
+import { getProviderEnvForModel } from '../agents.js';
 import { sendKeysAsync, capturePaneAsync, waitForClaudePrompt, confirmDelivery, createSessionAsync, killSessionAsync, buildTmuxCommandString, listPaneValuesAsync, listSessionNamesAsync, sessionExistsAsync } from '../tmux.js';
 import { notifyPipeline } from '../pipeline-notifier.js';
 import { isTaskReady } from './task-readiness.js';
@@ -78,31 +79,6 @@ async function resolveWorkspaceGitInfo(workspace: string | undefined, taskBranch
 }
 
 /**
- * Get provider-specific env vars (BASE_URL, AUTH_TOKEN) for a model.
- * For non-Anthropic providers (Kimi, Z.AI, etc.), returns env vars needed
- * to redirect Claude Code API calls to the correct endpoint.
- */
-function getProviderEnvForModel(model: string): Record<string, string> {
-  const provider = getProviderForModel(model as ModelId);
-  if (provider.name === 'anthropic') return {};
-
-  // OpenRouter has its own key path
-  if (provider.name === 'openrouter') {
-    const { config } = loadYamlConfig();
-    const apiKey = config.apiKeys.openrouter;
-    if (apiKey) return getProviderEnv(provider, apiKey);
-    throw new Error(`OpenRouter API key not configured. Add your key in Settings before using model "${model}".`);
-  }
-
-  const { config } = loadYamlConfig();
-  const apiKey = config.apiKeys[provider.name as keyof typeof config.apiKeys];
-  if (apiKey) {
-    return getProviderEnv(provider, apiKey);
-  }
-  throw new Error(`No API key configured for ${provider.displayName}. Configure it in Settings before using model "${model}".`);
-}
-
-/**
  * Shell fragment that unsets every provider-routing env var a parent tmux server
  * may have leaked into its child sessions. The panopticon tmux server is long-lived
  * and inherits whatever env existed when it was spawned — so fresh Anthropic-model
@@ -120,6 +96,17 @@ const PROVIDER_ENV_UNSETS = [
 ];
 const PROVIDER_UNSET_LINES = PROVIDER_ENV_UNSETS.map(k => `unset ${k}`).join('\n');
 const PROVIDER_UNSET_CMD = `unset ${PROVIDER_ENV_UNSETS.join(' ')}`;
+
+/**
+ * Convert a providerEnv dict to bash export lines (re-export after PROVIDER_UNSET_LINES).
+ * Non-Anthropic models (e.g. gpt-5.4 via cliproxy) need ANTHROPIC_BASE_URL set in the
+ * script body — tmux -e flags are wiped by PROVIDER_UNSET_LINES before claude runs.
+ */
+function buildProviderExportLines(providerEnv: Record<string, string>): string {
+  const entries = Object.entries(providerEnv);
+  if (entries.length === 0) return '';
+  return entries.map(([k, v]) => `export ${k}="${v}"`).join('\n') + '\n';
+}
 
 /**
  * Build tmux -e flags for environment variables
@@ -993,11 +980,12 @@ ${basePrompt}`;
       loadYamlConfig().config.caveman
     );
 
+    const providerExportLines = buildProviderExportLines(providerEnv);
     writeFileSync(innerScript, `#!/bin/bash
 set -o pipefail
 cd "${cwd}"
 ${PROVIDER_UNSET_LINES}
-export CI=1
+${providerExportLines}export CI=1
 export PANOPTICON_AGENT_ID="${tmuxSession}"
 export PANOPTICON_ISSUE_ID="${task.issueId}"
 export PANOPTICON_SESSION_TYPE="${sessionTypeLabel}"
@@ -2195,10 +2183,11 @@ export async function initializeSpecialist(name: SpecialistType): Promise<{
 
     writeFileSync(promptFile, identityPrompt);
     const newSessionId = randomUUID();
+    const initProviderExportLines = buildProviderExportLines(providerEnv);
     writeFileSync(launcherScript, `#!/bin/bash
 cd "${cwd}"
 ${PROVIDER_UNSET_LINES}
-prompt=$(cat "${promptFile}")
+${initProviderExportLines}prompt=$(cat "${promptFile}")
 exec claude --dangerously-skip-permissions --permission-mode bypassPermissions --session-id "${newSessionId}" --model ${model} "$prompt"
 `, { mode: 0o755 });
     setSessionId(name, newSessionId);
@@ -2423,7 +2412,11 @@ export async function wakeSpecialist(
       // signatures, making resumed sessions permanently fail (PAN-612).
       const effectiveSessionId = sessionId || randomUUID();
       if (!sessionId) setSessionId(name, effectiveSessionId);
-      const claudeCmd = `${PROVIDER_UNSET_CMD}; exec claude --session-id "${effectiveSessionId}" ${modelFlag} ${permissionFlags}`;
+      const providerExportCmd = Object.entries(providerEnv)
+        .map(([k, v]) => `export ${k}="${v}"`)
+        .join('; ');
+      const providerSetupCmd = providerExportCmd ? `${providerExportCmd}; ` : '';
+      const claudeCmd = `${PROVIDER_UNSET_CMD}; ${providerSetupCmd}exec claude --session-id "${effectiveSessionId}" ${modelFlag} ${permissionFlags}`;
 
       // Kill stale session first to prevent "duplicate session" error (PAN-430)
       await killSessionAsync(tmuxSession).catch(() => { /* no stale session */ });

--- a/src/lib/cloister/verification-runner.ts
+++ b/src/lib/cloister/verification-runner.ts
@@ -18,6 +18,7 @@ import { writeFeedbackFile } from './feedback-writer.js';
 import { messageAgent } from '../agents.js';
 import { findProjectByPath } from '../projects.js';
 import { getVBriefACStatus } from '../vbrief/beads.js';
+import { VBriefMergeConflictError } from '../vbrief/io.js';
 import type { TemplatePlaceholders } from '../workspace-config.js';
 
 const execAsync = promisify(exec);
@@ -265,7 +266,46 @@ export async function runVerificationForIssue(
     }
 
     // vBRIEF AC gate: check all acceptance criteria are completed (runs after quality gates)
-    const acStatus = getVBriefACStatus(workspacePath);
+    // Wrap in try-catch to detect merge conflict markers in plan.vbrief.json and send
+    // actionable feedback rather than falling through to a generic infrastructure error.
+    let acStatus: ReturnType<typeof getVBriefACStatus>;
+    try {
+      acStatus = getVBriefACStatus(workspacePath);
+    } catch (vbriefErr: any) {
+      if (vbriefErr instanceof VBriefMergeConflictError) {
+        const newCycleCount = currentCycles + 1;
+        const failedCheck = 'vbrief-conflicts';
+        const summary = `plan.vbrief.json has unresolved git merge conflict markers. Resolve all conflict markers in .planning/plan.vbrief.json and commit before resubmitting.`;
+        setReviewStatus(issueId, {
+          reviewStatus: 'pending',
+          verificationStatus: 'failed',
+          verificationNotes: summary,
+          verificationCycleCount: newCycleCount,
+          verificationMaxCycles: VERIFICATION_MAX_CYCLES,
+        });
+        const feedbackBody = `VERIFICATION FAILED for ${issueId} (attempt ${newCycleCount}/${VERIFICATION_MAX_CYCLES}):\n\nFailed check: ${failedCheck}\n\n${summary}\n\n## REQUIRED: Fix merge conflicts in plan.vbrief.json BEFORE resubmitting\n\n1. Open .planning/plan.vbrief.json\n2. Find and resolve all <<<<<<< HEAD / ======= / >>>>>>> conflict markers\n3. Ensure the file is valid JSON (only keep ONE version of each conflicted block)\n4. Commit the fixed file\n5. ONLY THEN resubmit: pan review request ${issueId} -m "Resolved plan.vbrief.json merge conflict"\n\nDo NOT resubmit until plan.vbrief.json parses cleanly.`;
+        try {
+          const fileResult = await writeFeedbackFile({
+            issueId,
+            workspacePath,
+            specialist: 'verification-gate',
+            outcome: 'failed',
+            summary: `vBRIEF plan has merge conflicts (attempt ${newCycleCount}/${VERIFICATION_MAX_CYCLES})`,
+            markdownBody: feedbackBody,
+          });
+          if (fileResult.success) {
+            const agentId = `agent-${issueId.toLowerCase()}`;
+            const msg = `VERIFICATION FAILED for ${issueId}.\nFailed check: ${failedCheck} — plan.vbrief.json has merge conflict markers\nRead and address: ${fileResult.relativePath}`;
+            await messageAgent(agentId, msg);
+            console.log(`[${logPrefix}] vBRIEF conflict detected for ${issueId} — sent feedback to ${agentId}`);
+          }
+        } catch (feedbackErr: any) {
+          console.error(`[${logPrefix}] Failed to write vBRIEF conflict feedback for ${issueId}:`, feedbackErr);
+        }
+        return { outcome: 'failed', failedCheck, cycleCount: newCycleCount, maxCycles: VERIFICATION_MAX_CYCLES };
+      }
+      throw vbriefErr;
+    }
     if (acStatus && !acStatus.allCompleted) {
       const newCycleCount = currentCycles + 1;
       const failedCheck = 'vbrief-ac';

--- a/src/lib/database/conversations-db.ts
+++ b/src/lib/database/conversations-db.ts
@@ -117,6 +117,22 @@ export function getConversationById(id: number): Conversation | null {
   return row ? rowToConversation(row) : null;
 }
 
+export function listArchivedConversations(): Conversation[] {
+  const db = getDatabase();
+  const rows = db
+    .prepare(
+      `SELECT id, name, tmux_session, status, cwd, issue_id,
+              created_at, ended_at, last_attached_at, session_file, title,
+              title_source, title_seed, total_cost, archived_at, model, effort,
+              fork_status, fork_error
+       FROM conversations
+       WHERE archived_at IS NOT NULL
+       ORDER BY archived_at DESC, created_at DESC`,
+    )
+    .all() as Record<string, unknown>[];
+  return rows.map(rowToConversation);
+}
+
 // ─── Write operations ─────────────────────────────────────────────────────────
 
 export function createConversation(opts: {

--- a/src/lib/vbrief/io.ts
+++ b/src/lib/vbrief/io.ts
@@ -24,8 +24,21 @@ export function findPlan(workspacePath: string): string | null {
  * ({ issue, title, items, edges? }) produced by some planning prompts.
  * Throws if the file does not exist or is invalid JSON.
  */
+export class VBriefMergeConflictError extends Error {
+  constructor(planPath: string) {
+    super(
+      `plan.vbrief.json at ${planPath} contains unresolved git merge conflict markers. ` +
+      `Resolve all <<<<<<</=======/>>>>>>> markers in that file and commit the result before re-requesting review.`
+    );
+    this.name = 'VBriefMergeConflictError';
+  }
+}
+
 export function readPlan(planPath: string): VBriefDocument {
   const raw = readFileSync(planPath, 'utf-8');
+  if (raw.includes('<<<<<<<') && raw.includes('=======') && raw.includes('>>>>>>>')) {
+    throw new VBriefMergeConflictError(planPath);
+  }
   const parsed = JSON.parse(raw);
 
   // vBRIEF v0.5 requires exactly two top-level keys: vBRIEFInfo and plan

--- a/tests/e2e/work-flow.test.ts
+++ b/tests/e2e/work-flow.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, existsSync, rmSync, writeFileSync, readFileSync } from 'fs';
+import { mkdirSync, existsSync, rmSync, writeFileSync, readFileSync, mkdtempSync } from 'fs';
 import { join } from 'path';
-import { TEMP_DIR } from '../setup.js';
+import { tmpdir } from 'os';
 
 /**
  * E2E tests for the work command flow
@@ -36,20 +36,24 @@ vi.mock('@linear/sdk', () => ({
 }));
 
 describe('E2E: Work Flow', () => {
-  const workspaceRoot = join(TEMP_DIR, 'workspaces');
-  const testWorkspace = join(workspaceRoot, 'TEST-42');
+  let tempDir: string;
+  let workspaceRoot: string;
+  let testWorkspace: string;
 
   beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'panopticon-work-flow-'));
+    workspaceRoot = join(tempDir, 'workspaces');
+    testWorkspace = join(workspaceRoot, 'TEST-42');
     mkdirSync(workspaceRoot, { recursive: true });
   });
 
   afterEach(() => {
-    if (existsSync(TEMP_DIR)) {
+    if (existsSync(tempDir)) {
       try {
-        rmSync(TEMP_DIR, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+        rmSync(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
       } catch (error) {
         // Ignore cleanup errors in tests
-        console.warn('Failed to clean up TEMP_DIR:', error);
+        console.warn('Failed to clean up work flow temp dir:', error);
       }
     }
     vi.clearAllMocks();

--- a/tests/lib/cloister/deacon-ci-retry.test.ts
+++ b/tests/lib/cloister/deacon-ci-retry.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests for checkFailedMergeRetry — CI failure notification state machine.
+ * Tests for checkPostReviewCommits — ciRetryMap.delete on new-commit detection.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, mkdtempSync, unlinkSync, rmSync } from 'fs';
+import { join } from 'path';
+import { homedir, tmpdir } from 'os';
+import { execSync } from 'child_process';
+
+const mockSetReviewStatus = vi.fn();
+const mockLoadReviewStatuses = vi.fn();
+const mockSessionExists = vi.fn();
+const mockSendKeysAsync = vi.fn();
+const mockWriteFeedbackFile = vi.fn();
+const mockResolveProjectFromIssue = vi.fn();
+
+vi.mock('../../../src/lib/review-status.js', () => ({
+  setReviewStatus: (...args: unknown[]) => mockSetReviewStatus(...args),
+  loadReviewStatuses: (...args: unknown[]) => mockLoadReviewStatuses(...args),
+}));
+
+vi.mock('../../../src/lib/tmux.js', () => ({
+  sessionExists: (...args: unknown[]) => mockSessionExists(...args),
+  sendKeysAsync: (...args: unknown[]) => mockSendKeysAsync(...args),
+  sessionExistsAsync: vi.fn().mockResolvedValue(false),
+  buildTmuxCommandString: vi.fn(),
+  capturePaneAsync: vi.fn(),
+  createSessionAsync: vi.fn(),
+  killSession: vi.fn(),
+  killSessionAsync: vi.fn(),
+  listPaneValues: vi.fn(),
+  listPaneValuesAsync: vi.fn(),
+  listSessionNamesAsync: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../../src/lib/cloister/feedback-writer.js', () => ({
+  writeFeedbackFile: (...args: unknown[]) => mockWriteFeedbackFile(...args),
+}));
+
+vi.mock('../../../src/lib/cloister/specialists.js', () => ({
+  getEnabledSpecialists: vi.fn().mockReturnValue([]),
+  getTmuxSessionName: vi.fn(),
+  isRunning: vi.fn().mockResolvedValue(false),
+  initializeSpecialist: vi.fn(),
+  wakeSpecialist: vi.fn(),
+  clearSessionId: vi.fn(),
+  spawnEphemeralSpecialist: vi.fn(),
+  wakeSpecialistWithTask: vi.fn(),
+  getAllProjectSpecialistStatuses: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../../src/lib/agents.js', () => ({
+  getAgentRuntimeState: vi.fn().mockReturnValue(null),
+  saveAgentRuntimeState: vi.fn(),
+  saveSessionId: vi.fn(),
+  listRunningAgents: vi.fn().mockResolvedValue([]),
+  getAgentDir: vi.fn().mockReturnValue('/tmp'),
+  getAgentState: vi.fn().mockReturnValue(null),
+  saveAgentState: vi.fn(),
+}));
+
+vi.mock('../../../src/lib/projects.js', () => ({
+  resolveProjectFromIssue: (...args: unknown[]) => mockResolveProjectFromIssue(...args),
+  findProjectByPath: vi.fn().mockReturnValue(null),
+}));
+
+const REVIEW_STATUS_FILE = join(homedir(), '.panopticon', 'review-status.json');
+const ISSUE_ID = 'PAN-714-CI-TEST';
+const CI_FAILED_STATUS = {
+  issueId: ISSUE_ID,
+  reviewStatus: 'passed',
+  testStatus: 'passed',
+  mergeStatus: 'failed',
+  mergeNotes: 'Merge failed: failing required checks',
+  readyForMerge: false,
+  mergeRetryCount: 0,
+  updatedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+};
+
+function writeStatusFile(statuses: Record<string, unknown>): void {
+  mkdirSync(join(homedir(), '.panopticon'), { recursive: true });
+  writeFileSync(REVIEW_STATUS_FILE, JSON.stringify(statuses, null, 2), 'utf-8');
+}
+
+describe('checkFailedMergeRetry — CI transient retry state machine', () => {
+  let originalContent: string | null = null;
+  let checkFailedMergeRetry: () => Promise<string[]>;
+  let checkPostReviewCommits: () => Promise<string[]>;
+  let ciRetryMap: Map<string, { count: number; lastAttempt: number }>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockSetReviewStatus.mockReset();
+    mockLoadReviewStatuses.mockReset().mockReturnValue({});
+    mockSessionExists.mockReset().mockReturnValue(false);
+    mockSendKeysAsync.mockReset().mockResolvedValue(undefined);
+    mockWriteFeedbackFile.mockReset().mockResolvedValue(undefined);
+    mockResolveProjectFromIssue.mockReset().mockReturnValue(null);
+
+    if (existsSync(REVIEW_STATUS_FILE)) {
+      originalContent = readFileSync(REVIEW_STATUS_FILE, 'utf-8');
+    } else {
+      originalContent = null;
+    }
+
+    const mod = await import('../../../src/lib/cloister/deacon.js');
+    checkFailedMergeRetry = mod.checkFailedMergeRetry;
+    checkPostReviewCommits = mod.checkPostReviewCommits;
+    ciRetryMap = mod.ciRetryMap;
+    ciRetryMap.clear();
+  });
+
+  afterEach(() => {
+    if (originalContent !== null) {
+      writeFileSync(REVIEW_STATUS_FILE, originalContent, 'utf-8');
+    } else if (existsSync(REVIEW_STATUS_FILE)) {
+      unlinkSync(REVIEW_STATUS_FILE);
+    }
+  });
+
+  it('notifies agent to re-submit when cooldown has passed', async () => {
+    writeStatusFile({ [ISSUE_ID]: CI_FAILED_STATUS });
+
+    const actions = await checkFailedMergeRetry();
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatch(/CI failure notification/);
+    expect(actions[0]).toContain(ISSUE_ID);
+    expect(actions[0]).toMatch(/attempt 1\/5/);
+    expect(mockWriteFeedbackFile).toHaveBeenCalledOnce();
+    expect(mockSetReviewStatus).not.toHaveBeenCalled();
+    expect(ciRetryMap.get(ISSUE_ID)?.count).toBe(1);
+  });
+
+  it('respects 2-minute cooldown', async () => {
+    writeStatusFile({ [ISSUE_ID]: CI_FAILED_STATUS });
+    ciRetryMap.set(ISSUE_ID, { count: 1, lastAttempt: Date.now() - 60_000 });
+
+    const actions = await checkFailedMergeRetry();
+
+    expect(actions).toHaveLength(0);
+    expect(mockSetReviewStatus).not.toHaveBeenCalled();
+  });
+
+  it('writes feedback and notifies agent exactly once at exhaustion', async () => {
+    writeStatusFile({ [ISSUE_ID]: CI_FAILED_STATUS });
+    ciRetryMap.set(ISSUE_ID, { count: 5, lastAttempt: Date.now() - 5 * 60 * 1000 });
+    mockSessionExists.mockReturnValue(true);
+
+    const actions = await checkFailedMergeRetry();
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatch(/CI retry exhausted/);
+    expect(mockWriteFeedbackFile).toHaveBeenCalledOnce();
+    expect(mockSendKeysAsync).toHaveBeenCalledOnce();
+    expect(ciRetryMap.get(ISSUE_ID)?.count).toBe(6);
+    expect(mockSetReviewStatus).not.toHaveBeenCalled();
+  });
+
+  it('does nothing after exhaustion has already been reported', async () => {
+    writeStatusFile({ [ISSUE_ID]: CI_FAILED_STATUS });
+    ciRetryMap.set(ISSUE_ID, { count: 6, lastAttempt: Date.now() - 5 * 60 * 1000 });
+
+    const actions = await checkFailedMergeRetry();
+
+    expect(actions).toHaveLength(0);
+    expect(mockWriteFeedbackFile).not.toHaveBeenCalled();
+    expect(mockSendKeysAsync).not.toHaveBeenCalled();
+    expect(mockSetReviewStatus).not.toHaveBeenCalled();
+  });
+
+  it('clears ciRetryMap on new commits', async () => {
+    const projectPath = mkdtempSync(join(tmpdir(), 'pan-deacon-ci-retry-'));
+    const workspacePath = join(projectPath, 'workspaces', `feature-${ISSUE_ID.toLowerCase()}`);
+    mkdirSync(workspacePath, { recursive: true });
+    execSync('git init && git commit --allow-empty -m "fix: ci checks"', {
+      cwd: workspacePath,
+      stdio: 'pipe',
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: 'test',
+        GIT_AUTHOR_EMAIL: 'test@test.com',
+        GIT_COMMITTER_NAME: 'test',
+        GIT_COMMITTER_EMAIL: 'test@test.com',
+      },
+    });
+
+    try {
+      mockLoadReviewStatuses.mockReturnValue({
+        [ISSUE_ID]: {
+          reviewStatus: 'passed',
+          readyForMerge: true,
+          mergeStatus: undefined,
+          reviewedAtCommit: 'deadbeef00000000000000000000000000000000',
+        },
+      });
+      mockResolveProjectFromIssue.mockReturnValue({ projectPath });
+      ciRetryMap.set(ISSUE_ID, { count: 6, lastAttempt: Date.now() - 5 * 60 * 1000 });
+
+      const resetActions = await checkPostReviewCommits();
+
+      expect(resetActions).toHaveLength(1);
+      expect(ciRetryMap.has(ISSUE_ID)).toBe(false);
+      expect(mockSetReviewStatus).toHaveBeenCalledWith(
+        ISSUE_ID,
+        expect.objectContaining({ mergeRetryCount: 0 }),
+      );
+
+      writeStatusFile({ [ISSUE_ID]: CI_FAILED_STATUS });
+      const retryActions = await checkFailedMergeRetry();
+
+      expect(retryActions).toHaveLength(1);
+      expect(retryActions[0]).toMatch(/attempt 1\/5/);
+      expect(ciRetryMap.get(ISSUE_ID)?.count).toBe(1);
+    } finally {
+      rmSync(projectPath, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/lib/cloister/deacon-orphan-recovery.test.ts
+++ b/tests/lib/cloister/deacon-orphan-recovery.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync, rmSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 
@@ -42,15 +42,17 @@ vi.mock('../../../src/lib/tmux.js', () => ({
 
 const mockGetAgentRuntimeState = vi.fn();
 const mockGetAgentState = vi.fn();
+const mockGetAgentDir = vi.fn();
 
 vi.mock('../../../src/lib/agents.js', () => ({
   getAgentRuntimeState: (...args: unknown[]) => mockGetAgentRuntimeState(...args),
   saveAgentRuntimeState: vi.fn(),
   saveSessionId: vi.fn(),
   listRunningAgents: vi.fn().mockResolvedValue([]),
-  getAgentDir: vi.fn().mockReturnValue('/tmp'),
+  getAgentDir: (...args: unknown[]) => mockGetAgentDir(...args),
   getAgentState: (...args: unknown[]) => mockGetAgentState(...args),
   saveAgentState: vi.fn(),
+  getReviewStatus: vi.fn().mockReturnValue(null),
 }));
 
 const mockResolveProjectFromIssue = vi.fn();
@@ -61,7 +63,7 @@ vi.mock('../../../src/lib/projects.js', () => ({
 }));
 
 // Import after mocks are in place
-import { checkOrphanedReviewStatuses } from '../../../src/lib/cloister/deacon.js';
+import { checkDeadEndAgents, checkOrphanedReviewStatuses } from '../../../src/lib/cloister/deacon.js';
 
 // ---------------------------------------------------------------------------
 // Test data and helpers
@@ -92,6 +94,8 @@ describe('checkOrphanedReviewStatuses — PAN-369 orphan recovery', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
+    mockGetAgentDir.mockImplementation((agentId: string) => join(homedir(), '.panopticon', 'agents', agentId));
+
     // Back up any existing review-status.json so tests are non-destructive
     if (existsSync(REVIEW_STATUS_FILE)) {
       originalContent = readFileSync(REVIEW_STATUS_FILE, 'utf-8');
@@ -106,6 +110,8 @@ describe('checkOrphanedReviewStatuses — PAN-369 orphan recovery', () => {
   });
 
   afterEach(() => {
+    rmSync(join(homedir(), '.panopticon', 'agents', `agent-${ISSUE_ID.toLowerCase()}`), { recursive: true, force: true });
+
     // Restore original state to avoid polluting real Panopticon data
     if (originalContent !== null) {
       writeFileSync(REVIEW_STATUS_FILE, originalContent, 'utf-8');
@@ -274,5 +280,70 @@ describe('checkOrphanedReviewStatuses — PAN-369 orphan recovery', () => {
     expect(content[ISSUE_ID].reviewStatus).toBe('passed');
     expect(content[ISSUE_ID].testStatus).toBe('passed');
     expect(content[ISSUE_ID].readyForMerge).toBeTypeOf('boolean');
+  });
+
+  it('does not re-arm CI-blocked merge when merge retry ceiling is saturated', async () => {
+    const updatedAt = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+
+    writeStatusFile({
+      [ISSUE_ID]: {
+        issueId: ISSUE_ID,
+        reviewStatus: 'passed',
+        testStatus: 'passed',
+        mergeStatus: 'failed',
+        mergeNotes: 'Merge blocked: failing required checks on PR',
+        mergeRetryCount: 3,
+        readyForMerge: false,
+        updatedAt,
+        history: [],
+      },
+    });
+
+    mockSessionExists.mockImplementation((sessionName: string) => sessionName === `agent-${ISSUE_ID.toLowerCase()}`);
+    mockGetAgentRuntimeState.mockReturnValue({
+      status: 'waiting',
+      lastHeartbeat: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+    });
+
+    const actions = await checkDeadEndAgents();
+
+    expect(actions).toEqual([]);
+
+    const content = readStatusFile();
+    expect(content[ISSUE_ID].mergeStatus).toBe('failed');
+    expect(content[ISSUE_ID].readyForMerge).toBe(false);
+    expect(content[ISSUE_ID].mergeRetryCount).toBe(3);
+  });
+
+  it('does not re-dispatch pending review when the work agent was explicitly stopped', async () => {
+    const agentDir = join(homedir(), '.panopticon', 'agents', `agent-${ISSUE_ID.toLowerCase()}`);
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'completed.processed'), 'done\n', 'utf-8');
+
+    writeStatusFile({
+      [ISSUE_ID]: {
+        issueId: ISSUE_ID,
+        reviewStatus: 'pending',
+        testStatus: 'pending',
+        mergeStatus: 'pending',
+        readyForMerge: false,
+        prUrl: 'https://github.com/eltmon/panopticon-cli/pull/999',
+        history: [],
+      },
+    });
+
+    mockGetAgentState.mockReturnValue({
+      workspace: '/workspaces/feature-pan-369-test',
+      status: 'stopped',
+      stoppedByUser: true,
+    });
+
+    const actions = await checkOrphanedReviewStatuses();
+
+    expect(mockSpawnEphemeralSpecialist).not.toHaveBeenCalled();
+    expect(actions).toContain(`Skipped pending review for ${ISSUE_ID}: work agent was explicitly stopped`);
+
+    const content = readStatusFile();
+    expect(content[ISSUE_ID].reviewStatus).toBe('pending');
   });
 });


### PR DESCRIPTION
## Summary
- make specialist status and dashboard terminal routing issue-aware for PAN-754 session names
- stop deacon from re-dispatching review work after an agent was explicitly stopped by the user
- add conversation unarchive support plus regression coverage for specialist recovery and CI retry behavior

## Test plan
- [x] npm test -- src/lib/cloister/__tests__/startup-recovery.test.ts tests/lib/cloister/deacon-orphan-recovery.test.ts tests/lib/cloister/deacon-ci-retry.test.ts src/dashboard/frontend/src/components/__tests__/AgentOutputPanel.test.tsx src/dashboard/frontend/src/components/__tests__/DetailPanelLayout.test.tsx src/dashboard/frontend/src/components/inspector/usePipelinePhase.test.ts
- [x] npm run build
- [x] browser check on dashboard Health view under Node 22 build
- [x] browser/API check for /api/specialists/panopticon-cli/PAN-714/review-agent/status returning the issue-scoped tmux session

🤖 Generated with [Claude Code](https://claude.com/claude-code)