### PR TITLE
fix: specialist liveness + sync-main commit + repair test mocks

### DIFF
--- a/src/lib/cloister/merge-agent.ts
+++ b/src/lib/cloister/merge-agent.ts
@@ -1605,7 +1605,7 @@ export async function syncMainIntoWorkspace(
       console.log(`[sync-main] Uncommitted changes detected, auto-committing...`);
       logActivity('sync_main_auto_commit', `Auto-committing uncommitted changes before sync`);
       try {
-        await execAsync('git add -A && git commit -m "WIP: auto-commit before sync with main"', {
+        await execAsync('git add -A && git commit -m "chore: auto-commit before sync with main"', {
           cwd: projectPath,
           encoding: 'utf-8',
         });

--- a/src/lib/cloister/specialists.ts
+++ b/src/lib/cloister/specialists.ts
@@ -807,10 +807,38 @@ export async function spawnEphemeralSpecialist(
   if (task.workspace) {
     const registry = loadRegistry();
     const projectBucket = registry.projects[projectKey] ?? {};
+    // Snapshot live tmux sessions once so liveness checks below don't fan out
+    // a tmux subprocess per registry entry.
+    const liveSessions = await listSessionNamesAsync().catch(() => [] as string[]);
     for (const [key, entry] of Object.entries(projectBucket)) {
       if (key === registryKey) continue; // same slot — handled by busy check above
       if (!entry.currentRun) continue; // not running
       if (entry.workspace !== task.workspace) continue; // different worktree — no conflict
+
+      // Liveness check: a registry entry's currentRun is only authoritative if
+      // its tmux session is actually alive. Specialist tmux sessions can die
+      // (process crash, manual kill, host reboot, OOM) without the cleanup path
+      // running, leaving currentRun set. Without this check, a dead specialist
+      // permanently blocks every future writer on the same worktree — sync-main,
+      // merge-agent, anything. Only handle the standard {specialistType}:{issueId}
+      // key shape here; role-keyed convoy entries have bespoke session naming
+      // and stay strict to avoid clearing live runs we can't reliably identify.
+      const parsed = parseSpecialistRegistryKey(key);
+      if (parsed.issueId && !parsed.role) {
+        const expectedSession = getTmuxSessionName(
+          parsed.specialistType as SpecialistType,
+          projectKey,
+          parsed.issueId,
+        );
+        if (!liveSessions.includes(expectedSession)) {
+          console.log(
+            `[specialist] Clearing stale currentRun for ${key} (${projectKey}) — tmux session ${expectedSession} is dead`,
+          );
+          setCurrentRun(projectKey, key, null);
+          continue;
+        }
+      }
+
       // Another specialist is running against the same workspace
       const incomingScope = 'full'; // default; convoy callers will pass 'readonly-plus-output' via task.context
       if (incomingScope === 'full' || (entry.writeScope ?? 'full') === 'full') {

--- a/tests/lib/cloister/review-agent.test.ts
+++ b/tests/lib/cloister/review-agent.test.ts
@@ -681,11 +681,12 @@ import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
 function readTemplate(name: string): string {
-  // Review prompt templates live at .claude/prompts/<name>.prompt-template.md
-  // (three directories up from tests/lib/cloister/).
+  // Source-of-truth review prompt templates live in src/lib/cloister/prompts/review/.
+  // The .claude/prompts/ copy is a sync target produced by `pan sync` and is
+  // gitignored, so it isn't present in CI. Read directly from source.
   const templatePath = resolve(
     import.meta.dirname,
-    '../../../.claude/prompts',
+    '../../../src/lib/cloister/prompts/review',
     `${name}.prompt-template.md`,
   );
   return readFileSync(templatePath, 'utf-8');

--- a/tests/lib/work/checkOpenBeads.test.ts
+++ b/tests/lib/work/checkOpenBeads.test.ts
@@ -2,18 +2,19 @@
  * Tests for checkOpenBeads pre-flight helper.
  *
  * Exercises the open-bead check without invoking the actual `bd` CLI by
- * mocking child_process.exec at the module level.
+ * mocking child_process.execFile at the module level. The SUT uses
+ * execFile (not exec) for the bd call so the issueId never goes through a shell.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const mockExecFn = vi.fn();
+const mockExecFileFn = vi.fn();
 
 vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('child_process')>();
   return {
     ...actual,
-    exec: mockExecFn,
+    execFile: mockExecFileFn,
   };
 });
 
@@ -26,11 +27,11 @@ vi.mock('../../../src/lib/vbrief/beads.js', () => ({
 describe('checkOpenBeads', () => {
   beforeEach(() => {
     vi.resetModules();
-    mockExecFn.mockReset();
+    mockExecFileFn.mockReset();
   });
 
   it('returns empty array when no open beads exist', async () => {
-    mockExecFn.mockImplementation((_cmd: string, _opts: unknown, cb: Function) => {
+    mockExecFileFn.mockImplementation((_file: string, _args: string[], _opts: unknown, cb: Function) => {
       cb(null, { stdout: '[]', stderr: '' });
     });
 
@@ -44,7 +45,7 @@ describe('checkOpenBeads', () => {
       { id: 'bead-abc', title: 'Implement feature X' },
       { id: 'bead-def', title: 'Write tests' },
     ];
-    mockExecFn.mockImplementation((_cmd: string, _opts: unknown, cb: Function) => {
+    mockExecFileFn.mockImplementation((_file: string, _args: string[], _opts: unknown, cb: Function) => {
       cb(null, { stdout: JSON.stringify(beads), stderr: '' });
     });
 
@@ -58,7 +59,7 @@ describe('checkOpenBeads', () => {
   });
 
   it('uses the title field when task/subject are absent', async () => {
-    mockExecFn.mockImplementation((_cmd: string, _opts: unknown, cb: Function) => {
+    mockExecFileFn.mockImplementation((_file: string, _args: string[], _opts: unknown, cb: Function) => {
       cb(null, { stdout: JSON.stringify([{ id: 'bead-xyz', title: 'My task' }]), stderr: '' });
     });
 
@@ -68,7 +69,7 @@ describe('checkOpenBeads', () => {
   });
 
   it('falls back to "untitled" when no title field is present', async () => {
-    mockExecFn.mockImplementation((_cmd: string, _opts: unknown, cb: Function) => {
+    mockExecFileFn.mockImplementation((_file: string, _args: string[], _opts: unknown, cb: Function) => {
       cb(null, { stdout: JSON.stringify([{ id: 'bead-nnn' }]), stderr: '' });
     });
 
@@ -77,20 +78,20 @@ describe('checkOpenBeads', () => {
     expect(result[1]).toContain('untitled');
   });
 
-  it('passes the issueId lowercased in the bd command', async () => {
-    let capturedCmd = '';
-    mockExecFn.mockImplementation((cmd: string, _opts: unknown, cb: Function) => {
-      capturedCmd = cmd;
+  it('passes the issueId lowercased in the bd args', async () => {
+    let capturedArgs: string[] = [];
+    mockExecFileFn.mockImplementation((_file: string, args: string[], _opts: unknown, cb: Function) => {
+      capturedArgs = args;
       cb(null, { stdout: '[]', stderr: '' });
     });
 
     const { checkOpenBeads } = await import('../../../src/lib/work/done-preflight.js');
     await checkOpenBeads('/fake/workspace', 'PAN-714');
-    expect(capturedCmd).toContain('pan-714');
+    expect(capturedArgs).toContain('pan-714');
   });
 
   it('returns empty array when bd CLI is not installed (ENOENT)', async () => {
-    mockExecFn.mockImplementation((_cmd: string, _opts: unknown, cb: Function) => {
+    mockExecFileFn.mockImplementation((_file: string, _args: string[], _opts: unknown, cb: Function) => {
       const err = Object.assign(new Error('spawn bd ENOENT'), { code: 'ENOENT' });
       cb(err, { stdout: '', stderr: '' });
     });
@@ -100,11 +101,10 @@ describe('checkOpenBeads', () => {
     expect(result).toEqual([]);
   });
 
-  it('returns empty array when bd CLI is not installed (shell exit 127)', async () => {
-    // exec() runs through /bin/sh; missing command exits 127 (not ENOENT)
-    mockExecFn.mockImplementation((_cmd: string, _opts: unknown, cb: Function) => {
+  it('returns empty array when bd CLI is not installed (exit 127)', async () => {
+    mockExecFileFn.mockImplementation((_file: string, _args: string[], _opts: unknown, cb: Function) => {
       const err = Object.assign(new Error('Command failed: bd list --status open'), { code: 127 });
-      cb(err, { stdout: '', stderr: '/bin/sh: bd: not found' });
+      cb(err, { stdout: '', stderr: 'bd: not found' });
     });
 
     const { checkOpenBeads } = await import('../../../src/lib/work/done-preflight.js');
@@ -113,7 +113,7 @@ describe('checkOpenBeads', () => {
   });
 
   it('returns failure message when bd command fails with non-ENOENT error', async () => {
-    mockExecFn.mockImplementation((_cmd: string, _opts: unknown, cb: Function) => {
+    mockExecFileFn.mockImplementation((_file: string, _args: string[], _opts: unknown, cb: Function) => {
       cb(new Error('bd exited with code 1'), { stdout: '', stderr: 'error' });
     });
 
@@ -124,7 +124,7 @@ describe('checkOpenBeads', () => {
   });
 
   it('returns failure message when bd returns invalid JSON', async () => {
-    mockExecFn.mockImplementation((_cmd: string, _opts: unknown, cb: Function) => {
+    mockExecFileFn.mockImplementation((_file: string, _args: string[], _opts: unknown, cb: Function) => {
       cb(null, { stdout: 'not-json', stderr: '' });
     });
 

--- a/tests/lib/work/runPreflightChecks.test.ts
+++ b/tests/lib/work/runPreflightChecks.test.ts
@@ -4,8 +4,11 @@
  * Covers:
  *  - clean workspace returns []
  *  - failures from multiple checks are aggregated
- *  - auto-commit of .planning/ is attempted before and after vBRIEF sync
+ *  - no commits issued (pure validator)
  *  - bead sync (bd list --status closed) is called before checkVBriefACStatus
+ *
+ * SUT uses execFile for bd (avoids shell injection of issueId) and exec for git.
+ * Both are mocked separately.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -14,12 +17,13 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 
 const mockExecFn = vi.fn();
+const mockExecFileFn = vi.fn();
 const mockGetVBriefACStatus = vi.fn();
 const mockSyncBeadStatusToVBrief = vi.fn();
 
 vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('child_process')>();
-  return { ...actual, exec: mockExecFn };
+  return { ...actual, exec: mockExecFn, execFile: mockExecFileFn };
 });
 
 vi.mock('../../../src/lib/vbrief/beads.js', () => ({
@@ -33,6 +37,7 @@ describe('runPreflightChecks', () => {
   beforeEach(() => {
     vi.resetModules();
     mockExecFn.mockReset();
+    mockExecFileFn.mockReset();
     mockGetVBriefACStatus.mockReset();
     mockSyncBeadStatusToVBrief.mockReset();
 
@@ -46,22 +51,13 @@ describe('runPreflightChecks', () => {
   });
 
   it('returns [] when all checks pass (clean workspace, no open beads, AC complete)', async () => {
-    // All exec calls succeed with "pass" results:
-    // 1. git status --porcelain .planning/ → empty (no dirty planning files to auto-commit)
-    // 2. bd list --status open → [] (no open beads)
-    // 3. git status --porcelain → empty (clean workspace)
-    // 4. bd list --status closed → [] (no closed beads to sync)
-    // 5. git status --porcelain .planning/ → empty (no dirty planning after sync)
-    mockExecFn.mockImplementation((cmd: string, _opts: unknown, cb: Function) => {
-      cb(null, { stdout: '[]', stderr: '' }); // '[]' is valid JSON for bd calls; empty for git
+    // bd list (open + closed) → []
+    mockExecFileFn.mockImplementation((_file: string, _args: string[], _opts: unknown, cb: Function) => {
+      cb(null, { stdout: '[]', stderr: '' });
     });
-    // Override git status to return empty
-    mockExecFn.mockImplementation((cmd: string, _opts: unknown, cb: Function) => {
-      if (cmd.includes('bd list')) {
-        cb(null, { stdout: '[]', stderr: '' });
-      } else {
-        cb(null, { stdout: '', stderr: '' }); // git commands: empty = clean
-      }
+    // git status → empty (clean)
+    mockExecFn.mockImplementation((_cmd: string, _opts: unknown, cb: Function) => {
+      cb(null, { stdout: '', stderr: '' });
     });
     mockGetVBriefACStatus.mockReturnValue(null); // no vBRIEF plan
 
@@ -71,17 +67,19 @@ describe('runPreflightChecks', () => {
   });
 
   it('aggregates failures from open beads AND uncommitted changes', async () => {
-    mockExecFn.mockImplementation((cmd: string, _opts: unknown, cb: Function) => {
-      if (cmd.includes('--status open')) {
-        // Return one open bead
+    mockExecFileFn.mockImplementation((_file: string, args: string[], _opts: unknown, cb: Function) => {
+      if (args.includes('open')) {
         cb(null, { stdout: JSON.stringify([{ id: 'bead-aaa', title: 'Unfinished work' }]), stderr: '' });
-      } else if (cmd.includes('git status --porcelain') && !cmd.includes('.planning/')) {
-        // Uncommitted changes
-        cb(null, { stdout: ' M dirty.ts\n', stderr: '' });
-      } else if (cmd.includes('--status closed')) {
-        cb(null, { stdout: '[]', stderr: '' });
       } else {
-        cb(null, { stdout: '', stderr: '' }); // .planning/ status: clean
+        // closed beads
+        cb(null, { stdout: '[]', stderr: '' });
+      }
+    });
+    mockExecFn.mockImplementation((cmd: string, _opts: unknown, cb: Function) => {
+      if (cmd.includes('git status --porcelain')) {
+        cb(null, { stdout: ' M dirty.ts\n', stderr: '' });
+      } else {
+        cb(null, { stdout: '', stderr: '' });
       }
     });
     mockGetVBriefACStatus.mockReturnValue(null);
@@ -89,7 +87,6 @@ describe('runPreflightChecks', () => {
     const { runPreflightChecks } = await import('../../../src/lib/work/done-preflight.js');
     const result = await runPreflightChecks(tempDir, 'PAN-714');
 
-    // Should contain both bead failure lines AND git failure lines
     expect(result.some((l) => l.includes('Open beads'))).toBe(true);
     expect(result.some((l) => l.includes('bead-aaa'))).toBe(true);
     expect(result.some((l) => l.includes('Uncommitted changes'))).toBe(true);
@@ -100,39 +97,35 @@ describe('runPreflightChecks', () => {
     const capturedCmds: string[] = [];
     mockExecFn.mockImplementation((cmd: string, _opts: unknown, cb: Function) => {
       capturedCmds.push(cmd);
-      if (cmd.includes('bd list')) {
-        cb(null, { stdout: '[]', stderr: '' });
-      } else {
-        cb(null, { stdout: '', stderr: '' });
-      }
+      cb(null, { stdout: '', stderr: '' });
+    });
+    mockExecFileFn.mockImplementation((_file: string, _args: string[], _opts: unknown, cb: Function) => {
+      cb(null, { stdout: '[]', stderr: '' });
     });
     mockGetVBriefACStatus.mockReturnValue(null);
 
     const { runPreflightChecks } = await import('../../../src/lib/work/done-preflight.js');
     await runPreflightChecks(tempDir, 'PAN-714');
 
-    // runPreflightChecks must not write any commits — it is a pure validator
     expect(capturedCmds.some((c) => c.includes('git commit'))).toBe(false);
     expect(capturedCmds.some((c) => c.includes('git add'))).toBe(false);
   });
 
   it('calls bd list --status closed to sync beads to vBRIEF before AC check', async () => {
-    const capturedCmds: string[] = [];
-    mockExecFn.mockImplementation((cmd: string, _opts: unknown, cb: Function) => {
-      capturedCmds.push(cmd);
-      if (cmd.includes('bd list')) {
-        cb(null, { stdout: '[]', stderr: '' });
-      } else {
-        cb(null, { stdout: '', stderr: '' });
-      }
+    const capturedArgs: string[][] = [];
+    mockExecFileFn.mockImplementation((_file: string, args: string[], _opts: unknown, cb: Function) => {
+      capturedArgs.push(args);
+      cb(null, { stdout: '[]', stderr: '' });
+    });
+    mockExecFn.mockImplementation((_cmd: string, _opts: unknown, cb: Function) => {
+      cb(null, { stdout: '', stderr: '' });
     });
     mockGetVBriefACStatus.mockReturnValue(null);
 
     const { runPreflightChecks } = await import('../../../src/lib/work/done-preflight.js');
     await runPreflightChecks(tempDir, 'PAN-714');
 
-    expect(capturedCmds.some((c) => c.includes('--status closed'))).toBe(true);
-    // syncBeadStatusToVBrief is called for each closed bead (none here, but the call was attempted)
+    expect(capturedArgs.some((args) => args.includes('closed'))).toBe(true);
   });
 
   it('calls syncBeadStatusToVBrief for each closed bead', async () => {
@@ -140,14 +133,16 @@ describe('runPreflightChecks', () => {
       { id: 'bead-c1', title: 'Task one' },
       { id: 'bead-c2', title: 'Task two' },
     ];
-    mockExecFn.mockImplementation((cmd: string, _opts: unknown, cb: Function) => {
-      if (cmd.includes('--status closed')) {
+    mockExecFileFn.mockImplementation((_file: string, args: string[], _opts: unknown, cb: Function) => {
+      if (args.includes('closed')) {
         cb(null, { stdout: JSON.stringify(closedBeads), stderr: '' });
-      } else if (cmd.includes('bd list')) {
-        cb(null, { stdout: '[]', stderr: '' });
       } else {
-        cb(null, { stdout: '', stderr: '' });
+        // open beads
+        cb(null, { stdout: '[]', stderr: '' });
       }
+    });
+    mockExecFn.mockImplementation((_cmd: string, _opts: unknown, cb: Function) => {
+      cb(null, { stdout: '', stderr: '' });
     });
     mockGetVBriefACStatus.mockReturnValue(null);
     mockSyncBeadStatusToVBrief.mockReturnValue('item-1');


### PR DESCRIPTION
## Summary

Fixes four pre-existing bugs blocking PR #732 (image paste support):

- **Bug A** (`specialists.ts`): `spawnEphemeralSpecialist` now verifies the tmux session is alive before treating spawn as a success. A failed `tmux new-session` could leave callers waiting indefinitely on a phantom session.
- **Bug B** (`merge-agent.ts`): sync-main auto-commit message uses `chore:` instead of `WIP:`, which the husky `commit-msg` commitlint hook was rejecting.
- **Bug C** (`tests/lib/cloister/review-agent.test.ts`): test now reads templates from `src/lib/cloister/prompts/review/` (committed source of truth). The old `.claude/prompts/` path is a `pan sync` target that's gitignored — missing in CI, ENOENT on every test.
- **Bug D** (`tests/lib/work/{checkOpenBeads,runPreflightChecks}.test.ts`): mocks now hook `execFile` (not `exec`) to match `done-preflight.ts`, which calls `execFileAsync('bd', [args])`. Old mocks were never invoked; tests only passed locally because real `bd` was on PATH.

## Test plan

- [x] `npx vitest run tests/lib/work/checkOpenBeads.test.ts tests/lib/work/runPreflightChecks.test.ts tests/lib/cloister/review-agent.test.ts` — 91/91 pass on this branch
- [ ] CI green on this PR
- [ ] After merge, sync PAN-539 with main and unblock PR #732