### PR TITLE
fix(pipeline): cross-process notification for CLI-triggered status changes (PAN-891)

### DIFF
--- a/src/dashboard/server/main.ts
+++ b/src/dashboard/server/main.ts
@@ -16,6 +16,7 @@ import { initTrackerConfigCache } from './services/tracker-config.js';
 import { processPendingLifecycle } from './pending-lifecycle.js';
 import { processPendingFeedbackDeliveries } from './pending-feedback.js';
 import { setPipelineHandler } from '../../lib/pipeline-notifier.js';
+import { ensureInternalToken } from '../../lib/internal-token.js';
 import { clearStuckMergeStatuses, fixStuckReadyForMerge, fixStuckCommentedReviews, getReviewStatus } from '../../lib/review-status.js';
 import { enrichReviewStatus } from '../../lib/review-status-enrichment.js';
 import { clearStuckForks } from '../../lib/database/conversations-db.js';
@@ -35,6 +36,11 @@ declare const Bun: unknown;
 
 // Ensure PANOPTICON_HOME exists before any service that needs it (e.g. CacheService opening cache.db)
 await mkdir(getPanopticonHome(), { recursive: true });
+
+// Ensure the internal token exists before any in-process CLI sender resolves it (PAN-891).
+// Generates and persists a random token at <PANOPTICON_HOME>/internal-token (mode 0600)
+// on first start; reused on subsequent starts. Used by /api/internal/pipeline/notify.
+ensureInternalToken();
 
 // Prepare the managed tmux context exactly once, before any code path can spawn
 // tmux. After this call `buildTmuxArgs`, `buildTmuxCommandString`, and

--- a/src/dashboard/server/routes/workspaces.ts
+++ b/src/dashboard/server/routes/workspaces.ts
@@ -4734,6 +4734,24 @@ const postInternalPipelineNotifyRoute = HttpRouter.add(
   'POST',
   '/api/internal/pipeline/notify',
   httpHandler(Effect.gen(function* () {
+    // Shared-secret check (PAN-891 review feedback). The dashboard binds 0.0.0.0
+    // by default, so this stateful endpoint must be unreachable without the
+    // server-issued token. Same token is read by CLI senders via getInternalToken().
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const { INTERNAL_TOKEN_HEADER, getInternalToken } = yield* Effect.promise(() =>
+      import('../../../lib/internal-token.js'),
+    );
+    const expected = getInternalToken();
+    if (!expected) {
+      return jsonResponse({ ok: false, error: 'internal token not configured' }, 503);
+    }
+    const headers = request.headers as Record<string, string | string[] | undefined>;
+    const raw = headers[INTERNAL_TOKEN_HEADER];
+    const provided = Array.isArray(raw) ? raw[0] : raw;
+    if (!provided || provided !== expected) {
+      return jsonResponse({ ok: false, error: 'forbidden' }, 403);
+    }
+
     const body = yield* readJsonBody;
     const { type, issueId } = body as { type?: string; issueId?: string };
 

--- a/src/dashboard/server/routes/workspaces.ts
+++ b/src/dashboard/server/routes/workspaces.ts
@@ -4715,6 +4715,47 @@ const getMergeQueueRoute = HttpRouter.add(
   })),
 );
 
+// ─── Route: POST /api/internal/pipeline/notify ────────────────────────────────
+//
+// Cross-process bridge for `notifyPipeline()` (PAN-891).
+//
+// `notifyPipeline` is an in-process handler registry; only the dashboard server
+// registers a handler. CLI processes (e.g. `pan review run`) write to the
+// shared SQLite review-status table but their `notifyPipeline()` calls are
+// no-ops in their own process. This endpoint lets them poke the dashboard so
+// it re-emits the `review.status_changed` domain event with the latest DB
+// snapshot (which the in-process handler enriches from live tmux sessions).
+//
+// Body: `{ type: 'status_changed', issueId: string }`. The body intentionally
+// does NOT carry a status payload — the server re-reads from SQLite to avoid
+// stale snapshots and races between writers.
+
+const postInternalPipelineNotifyRoute = HttpRouter.add(
+  'POST',
+  '/api/internal/pipeline/notify',
+  httpHandler(Effect.gen(function* () {
+    const body = yield* readJsonBody;
+    const { type, issueId } = body as { type?: string; issueId?: string };
+
+    if (type !== 'status_changed' || !issueId) {
+      return jsonResponse({ ok: false, error: 'expected { type: "status_changed", issueId }' }, 400);
+    }
+
+    const status = getReviewStatus(issueId);
+    if (!status) {
+      return jsonResponse({ ok: false, error: `no review status found for ${issueId}` }, 404);
+    }
+
+    // Re-enter the in-process pipeline handler — this triggers the same
+    // enrichment + event-store append path as direct in-process calls.
+    const { notifyPipeline } = yield* Effect.promise(() =>
+      import('../../../lib/pipeline-notifier.js'),
+    );
+    notifyPipeline({ type: 'status_changed', issueId, status });
+    return jsonResponse({ ok: true });
+  })),
+);
+
 export const workspacesRouteLayer = Layer.mergeAll(
   getWorkspaceRoute,
   postWorkspacesRoute,
@@ -4740,6 +4781,7 @@ export const workspacesRouteLayer = Layer.mergeAll(
   getWorkspaceTldrRoute,
   postWorkspaceRefreshTokenRoute,
   getMergeQueueRoute,
+  postInternalPipelineNotifyRoute,
 );
 
 export default workspacesRouteLayer;

--- a/src/lib/internal-token.ts
+++ b/src/lib/internal-token.ts
@@ -1,0 +1,103 @@
+/**
+ * Internal token — shared secret for server-internal endpoints (PAN-891).
+ *
+ * Used by routes such as `POST /api/internal/pipeline/notify` that perform
+ * stateful side effects but are not part of the public API surface. Without
+ * this, any process that can reach the dashboard port could inject domain
+ * events into the live event stream.
+ *
+ * Resolution order:
+ *   1. `PANOPTICON_INTERNAL_TOKEN` env var (preferred for tests / explicit setup)
+ *   2. `<PANOPTICON_HOME>/internal-token` (auto-generated on first server start)
+ *
+ * The dashboard server calls `ensureInternalToken()` once at startup, which
+ * generates a random token and persists it with mode 0600 if neither source is
+ * present. CLI processes (running as the same user) read it via
+ * `getInternalToken()` and attach it as the `X-Panopticon-Internal-Token`
+ * header. If the CLI cannot resolve a token (e.g. dashboard never started),
+ * `notifyPipeline()` skips the cross-process forward — the SQLite write is
+ * already durable, so no domain event is ever lost.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
+import { join } from 'node:path';
+
+import { getPanopticonHome } from './paths.js';
+
+export const INTERNAL_TOKEN_HEADER = 'x-panopticon-internal-token';
+const TOKEN_FILE_NAME = 'internal-token';
+
+let cachedToken: string | null | undefined;
+
+function tokenFilePath(): string {
+  return join(getPanopticonHome(), TOKEN_FILE_NAME);
+}
+
+/**
+ * Resolve the internal token from env or file. Returns null if neither source
+ * is present. Callers (CLI senders) should treat null as "no dashboard available
+ * to authenticate against" and skip the cross-process forward.
+ */
+export function getInternalToken(): string | null {
+  if (cachedToken !== undefined) return cachedToken;
+
+  const fromEnv = process.env.PANOPTICON_INTERNAL_TOKEN;
+  if (fromEnv && fromEnv.length > 0) {
+    cachedToken = fromEnv;
+    return cachedToken;
+  }
+
+  const path = tokenFilePath();
+  if (existsSync(path)) {
+    try {
+      const value = readFileSync(path, 'utf8').trim();
+      if (value.length > 0) {
+        cachedToken = value;
+        return cachedToken;
+      }
+    } catch {
+      // fall through
+    }
+  }
+
+  cachedToken = null;
+  return cachedToken;
+}
+
+/**
+ * Ensure the internal token exists. Generates and persists a random 32-byte
+ * hex token (mode 0600) if neither env nor file is present. Idempotent: safe
+ * to call on every server startup.
+ *
+ * Called from the dashboard server's main.ts so that CLI senders started
+ * afterwards can read the same value via {@link getInternalToken}.
+ */
+export function ensureInternalToken(): string {
+  const existing = getInternalToken();
+  if (existing) return existing;
+
+  const home = getPanopticonHome();
+  if (!existsSync(home)) {
+    mkdirSync(home, { recursive: true, mode: 0o700 });
+  }
+
+  const token = randomBytes(32).toString('hex');
+  const path = tokenFilePath();
+  writeFileSync(path, token + '\n', { mode: 0o600 });
+  // writeFileSync's mode arg is ignored if the file already exists; force it.
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    // best effort
+  }
+
+  cachedToken = token;
+  return token;
+}
+
+/**
+ * Test-only: clear the cached token so the next read re-resolves from env/file.
+ */
+export function _resetInternalTokenCacheForTests(): void {
+  cachedToken = undefined;
+}

--- a/src/lib/pipeline-notifier.ts
+++ b/src/lib/pipeline-notifier.ts
@@ -3,8 +3,15 @@
  *
  * Lightweight singleton that decouples state mutations (review-status, specialist queue)
  * from the dashboard's Socket.io server. Library code calls notifyPipeline() which is
- * fire-and-forget — if no handler is registered (CLI context), events are silently dropped.
- * File-based persistence remains the source of truth.
+ * fire-and-forget — when an in-process handler is registered (the dashboard server),
+ * the handler is invoked synchronously. Otherwise the call is forwarded to the
+ * dashboard via a best-effort HTTP POST so CLI-process state changes (e.g.
+ * `pan review run`) still propagate to the live WebSocket event stream (PAN-891).
+ *
+ * File-based persistence (SQLite) remains the source of truth — the HTTP forward
+ * is purely to wake the dashboard so it re-emits the domain event. If the
+ * dashboard is offline the call silently fails; the next dashboard read will
+ * pick up the latest DB state via `enrichReviewStatusFromSessions()`.
  */
 
 import type { ReviewStatus } from './review-status.js';
@@ -27,5 +34,32 @@ export function notifyPipeline(event: PipelineEvent): void {
     } catch (e) {
       console.error('[pipeline] handler error:', e);
     }
+    return;
   }
+
+  // No in-process handler — we are not the dashboard server (typically a CLI
+  // process such as `pan review run`). Forward to the dashboard so the live
+  // event stream stays in sync. Best-effort: fail silently if the dashboard
+  // is offline. The DB write that triggered this notification is durable.
+  // Tests can opt out with `PANOPTICON_PIPELINE_NOTIFY=off`.
+  if (event.type !== 'status_changed') return;
+  if (process.env.PANOPTICON_PIPELINE_NOTIFY === 'off') return;
+  // Skip in test environments — Vitest/Jest set NODE_ENV=test and there's no
+  // dashboard at localhost:3011 to receive the POST.
+  if (process.env.NODE_ENV === 'test') return;
+
+  const baseUrl = process.env.DASHBOARD_URL || 'http://localhost:3011';
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 1000);
+  void fetch(`${baseUrl}/api/internal/pipeline/notify`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ type: 'status_changed', issueId: event.issueId }),
+    signal: ctrl.signal,
+  })
+    .catch(() => {
+      // Dashboard down or unreachable — DB write already persisted, frontend
+      // will pick up latest state on next reconnect/snapshot.
+    })
+    .finally(() => clearTimeout(timer));
 }

--- a/src/lib/pipeline-notifier.ts
+++ b/src/lib/pipeline-notifier.ts
@@ -15,6 +15,7 @@
  */
 
 import type { ReviewStatus } from './review-status.js';
+import { getInternalToken, INTERNAL_TOKEN_HEADER } from './internal-token.js';
 
 export type PipelineEvent =
   | { type: 'status_changed'; issueId: string; status: ReviewStatus }
@@ -48,12 +49,20 @@ export function notifyPipeline(event: PipelineEvent): void {
   // dashboard at localhost:3011 to receive the POST.
   if (process.env.NODE_ENV === 'test') return;
 
+  // Resolve shared secret (PAN-891). If the dashboard hasn't started in this
+  // home (no token file, no env), skip the forward — DB write is durable.
+  const token = getInternalToken();
+  if (!token) return;
+
   const baseUrl = process.env.DASHBOARD_URL || 'http://localhost:3011';
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), 1000);
   void fetch(`${baseUrl}/api/internal/pipeline/notify`, {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: {
+      'content-type': 'application/json',
+      [INTERNAL_TOKEN_HEADER]: token,
+    },
     body: JSON.stringify({ type: 'status_changed', issueId: event.issueId }),
     signal: ctrl.signal,
   })


### PR DESCRIPTION
## Summary

Closes #891. CLI-triggered review status changes now reach the dashboard's live event stream.

`notifyPipeline()` is an in-process handler registry — only the dashboard server registers a handler. When `pan review run` writes review status from a CLI process, the in-process notification is a no-op for the dashboard and the live WebSocket stream never learns about the change. Visible symptom: dashboard terminal panel stuck on a stale `review-coordinator-*` session name from a previous round.

## Fix

When no in-process handler is registered, `notifyPipeline()` falls back to a best-effort HTTP POST to `/api/internal/pipeline/notify` on the dashboard. The receiving route reads the latest status from SQLite (avoiding stale-snapshot races between writers) and re-enters `notifyPipeline()` — which now finds the in-process handler and emits the `review.status_changed` domain event normally.

- `NODE_ENV=test` skips the HTTP fallback (no dashboard at localhost:3011 in tests).
- Opt-out via `PANOPTICON_PIPELINE_NOTIFY=off`.
- Dashboard offline → silent failure. DB write is durable; frontend picks up the latest state on next snapshot/reconnect via `enrichReviewStatusFromSessions()`.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Existing review-status tests pass (58 tests across 3 files)
- [ ] Manual: trigger `pan review run` from CLI, confirm dashboard terminal panel switches to the new coordinator session within ~1s of the CLI starting

## Why this is in v0.8.0

The bug surfaces during the v0.8.0 review cycle itself (the CLI-triggered reviews that finish the release fail to update the dashboard's terminal tab). Better to fix it as part of the release than ship around it.