### PR TITLE
PAN-963: Settings UI Redesign

### DIFF
--- a/.pan/continue.json
+++ b/.pan/continue.json
@@ -1,147 +1,35 @@
 {
   "version": "1",
-  "issueId": "PAN-982",
-  "created": "2026-05-07T01:59:13.002Z",
-  "updated": "2026-05-07T03:12:00.000Z",
-  "gitState": { "branch": "feature/pan-982", "sha": "585a53f9d", "dirty": false },
+  "issueId": "PAN-963",
+  "created": "2026-05-07T00:45:00Z",
+  "updated": "2026-05-07T01:00:00Z",
+  "gitState": { "branch": "feature/pan-963", "sha": "fe2b7ca", "dirty": true },
   "decisions": [
-    {
-      "id": "D1",
-      "summary": "Adopt --agent partially: use .claude/agents/pan-*.md for model, permissions, tools, and PreToolUse/PostToolUse/Stop hooks. Keep launcher.sh for env var injection (provider routing, Panopticon identity, terminal env, mkcert CA, TMUX unset, keep-alive, script wrapper, caveman). This is because --agent handles declarative config but has no mechanism for env var setup or shell-level pre/post behaviors.",
-      "rationale": "Claude Code's --agent frontmatter only supports Anthropic models in the model: field. Non-Anthropic models (Kimi, OpenAI CLIProxy, OpenRouter) still need ANTHROPIC_BASE_URL/AUTH_TOKEN env injection. Per-agent hooks only support PreToolUse/PostToolUse/Stop — 6 other hook events (SessionStart, UserPromptSubmit, PreCompact, PostCompact, Notification, PermissionRequest) must stay in global settings.json with env-var gating. The launcher script becomes thinner (env-only) but cannot be eliminated entirely.",
-      "recordedAt": "2026-05-07T02:30:00.000Z"
-    },
-    {
-      "id": "D2",
-      "summary": "Use pan- prefix for pipeline agent definitions (pan-work-agent.md, pan-review-agent.md, etc.) to distinguish from existing Claude Code subagent definitions (codebase-explorer.md, planning-agent.md, etc.). These are separate concerns: pipeline agents drive Panopticon lifecycle; subagent definitions drive the Agent tool.",
-      "rationale": "The existing .claude/agents/ files (codebase-explorer, planning-agent, triage-agent, health-monitor) are Claude Code subagent definitions used by the Agent tool for in-session delegation. Panopticon pipeline agents serve a completely different purpose — they're spawned by tmux, run autonomously, and are part of the work→review→test→merge pipeline. Using the pan- prefix makes them visually distinct in 'claude agents' listing and prevents naming collisions.",
-      "recordedAt": "2026-05-07T02:30:00.000Z"
-    },
-    {
-      "id": "D3",
-      "summary": "Use --model CLI override for non-Anthropic models alongside --agent (verified: --model overrides frontmatter model:). Don't use --agents JSON injection as the primary path — reserve it for edge cases.",
-      "rationale": "Empirically tested: --model flag overrides agent frontmatter model: field. This means we can define pan-work-agent.md with model: sonnet as default, but override to kimi-k2 or gpt-5.4 at spawn time via --model. The --agents JSON injection was also tested and works, but adds shell quoting complexity for nested JSON objects. Filesystem definitions + --model override is simpler and more maintainable.",
-      "recordedAt": "2026-05-07T02:30:00.000Z"
-    },
-    {
-      "id": "D4",
-      "summary": "Agent Teams feature is explicitly out of scope. Panopticon's tmux + beads + sendKeysAsync is strictly more capable and battle-tested.",
-      "rationale": "Agent Teams is experimental (disabled by default, requires CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1), has known limitations (no session resumption with teammates, one team per session, no nested teams, slow shutdown), and uses file-locked shared task lists that reinvent what beads + tmux message delivery already provide reliably. Panopticon's lifecycle management (tmux sessions, ready signal polling, state tracking, hook system) is not replaceable by Agent Teams.",
-      "recordedAt": "2026-05-07T02:30:00.000Z"
-    },
-    {
-      "id": "D5",
-      "summary": "Hook migration must be atomic — PreToolUse/PostToolUse/Stop hooks must be removed from global settings.json at the same time they're deployed in per-agent frontmatter, to avoid double-firing.",
-      "rationale": "If both global hooks and per-agent hooks define the same event (e.g., PostToolUse → heartbeat-hook), the hook will fire twice. This would double heartbeat events, double cost recordings, and cause confusing duplicate behavior. The pan sync command should handle this atomically: deploy agent definitions and prune migrated global hooks in the same operation.",
-      "recordedAt": "2026-05-07T02:30:00.000Z"
-    },
-    {
-      "id": "D6",
-      "summary": "Named sessions (--name) is a low-priority optional enhancement. Not load-bearing for the migration.",
-      "rationale": "Named sessions add ergonomic value (human-readable session names, easier manual debugging via 'claude --resume agent-pan-982') but don't change the fundamental architecture. Panopticon already tracks sessions via tmux session names (agent-pan-982) and agent state files. This can be added after the core migration without risk.",
-      "recordedAt": "2026-05-07T02:30:00.000Z"
-    }
+    { "id": "D1", "summary": "7-bead decomposition: primitives → shell → providers → model-routing → conversations+terminal → trackers+appearance+maintenance+desktop → polish. Each bead = one commit for inspector verification.", "recordedAt": "2026-05-07T00:45:00Z" },
+    { "id": "D2", "summary": "Don't touch modal/editor flows (ModelOverrideModal, OpenRouterModelBrowser, OpenRouterPage) — only rebuild the page shell around them per PRD §impl guidance.", "recordedAt": "2026-05-07T00:45:00Z" },
+    { "id": "D3", "summary": "Anchor-based section navigation (single page with active-state syncing) rather than route-based subpages. PRD §4 accepts either; anchors are simpler and avoid routing complexity.", "recordedAt": "2026-05-07T00:48:00Z" }
   ],
   "hazards": [
-    {
-      "id": "H1",
-      "summary": "Per-agent hooks fire only when --agent is used. If launcher fails to pass --agent flag, agents run without hooks entirely — no heartbeat, no cost recording, no stop-hook.",
-      "mitigation": "Add a smoke test in spawnAgent() that verifies the --agent flag is present in the generated launcher command. Also keep the session-start global hook as a safety net — it can detect when a Panopticon agent starts without --agent by checking for PANOPTICON_AGENT_ID env var presence and missing per-agent hook behavior."
-    },
-    {
-      "id": "H2",
-      "summary": "User's ad-hoc Claude sessions in a workspace directory will see pan-*.md in 'claude agents' listing and could accidentally use --agent pan-work-agent, getting Panopticon hooks.",
-      "mitigation": "The pan- prefix makes accidental use unlikely (users would have to explicitly type --agent pan-work-agent). Additionally, Panopticon hooks are idempotent — running heartbeat or cost recorder without PANOPTICON_AGENT_ID set results in a graceful no-op (hooks check for agent ID and exit 0 if missing)."
-    },
-    {
-      "id": "H3",
-      "summary": "--agent + --resume behavior may change in future Claude Code versions. Migration depends on resumed sessions adopting the new agent's config.",
-      "mitigation": "Pin minimum Claude Code version in pan doctor checks. Add a CI test that verifies --agent + --resume applies the new agent's model (the empirical test done during planning). If behavior changes, fall back to baking full config into the initial spawn and not relying on --agent on resume."
-    },
-    {
-      "id": "H4",
-      "summary": "Hook deduplication gap during migration — if pan sync deploys agent definitions before removing global hooks, there's a window where hooks fire twice.",
-      "mitigation": "Make the migration atomic in pan sync: read current global hooks, deploy agent definitions, remove migrated hooks from global settings, all in one operation. If any step fails, roll back all changes. Add a test that verifies no hook event type appears in both global settings and any pan-*.md agent definition."
-    },
-    {
-      "id": "H5",
-      "summary": "claudish wrapper path (non-direct providers) cannot use --agent because claudish is a separate binary, not Claude Code CLI.",
-      "mitigation": "The claudish path is explicitly excluded from --agent migration. getAgentRuntimeBaseCommand() already branches on provider.compatibility: direct providers get 'claude --agent', claudish providers keep the existing 'claudish -i --model' path. Document this limitation clearly."
-    },
-    {
-      "id": "H6",
-      "summary": "Agent definitions contain absolute paths to hook scripts (/home/eltmon/.panopticon/bin/). These break on different machines or if the Panopticon install location changes.",
-      "mitigation": "Use relative paths from the workspace root where possible. For hooks that must reference ~/.panopticon/bin/, use $HOME expansion or have pan sync template the paths at deployment time. Long-term: move hook scripts into the project repo so paths are repo-relative."
-    }
-  ],
-  "beadsMapping": {},
-  "agentModel": "agent:claude-opus-4-6",
-  "sessionHistory": [
-    {
-      "timestamp": "2026-05-07T01:59:13.002Z",
-      "reason": "planning",
-      "note": "Planning session started for PAN-982: Evaluate Claude Code --agent/subagent system for agent lifecycle",
-      "agentModel": "agent:claude-opus-4-6"
-    },
-    {
-      "timestamp": "2026-05-07T02:35:00.000Z",
-      "reason": "planning-complete",
-      "note": "Deep research completed. Empirically tested --agent + --resume (works, new agent config adopted), --agent + --model (override works), --agents JSON inline (works). Wrote comprehensive PRD at docs/prds/planned/PAN-982-claude-code-agent-integration.md. Created 15-bead vBRIEF plan covering 7 agent definitions, 4 launcher/spawn integration beads, hook migration, test updates, sync deployment, and optional named sessions. Key decision: partial adoption — use --agent for model/permissions/tools/hooks, keep launcher.sh for env vars and shell-level behaviors. Agent Teams explicitly deferred.",
-      "agentModel": "agent:claude-opus-4-6"
-    },
-    {
-      "timestamp": "2026-05-07T03:12:00.000Z",
-      "reason": "bead-close",
-      "note": "Closed bead workspace-o99 (update-launcher-tests). Added 6 new test cases asserting --agent flag pass-through in launcher scripts: work-agent (Anthropic, no --model/no permission flags), work-agent (non-Anthropic with --model override), planning-agent, resume-agent (--agent + --resume), specialist-dispatch (--agent pan-review-agent), and --agent + --name combined. All 24 tests pass (18 existing inline snapshots untouched + 6 new). Tests treat baseCommand as opaque, so they validate behavior independently of getAgentRuntimeBaseCommand() changes — they will continue to pass after the modify-base-command bead alters that helper.",
-      "agentModel": "agent:claude-opus-4-7"
-    },
-    {
-      "timestamp": "2026-05-07T03:14:00.000Z",
-      "reason": "bead-close",
-      "note": "Closed bead workspace-c6q (named-sessions). Added optional agentName parameter to getAgentRuntimeBaseCommand() that emits '--name <agentName>'. Wired all 4 spawn callsites (work agent at line ~1100, fallback restart at ~1450, recovery at ~1811, resume at ~1670) to pass the normalized agentId. claudish wrapper path skipped because --name is not passed through by claudish. The resume path uses extraArgs rather than getAgentRuntimeBaseCommand because it constructs baseCommand inline. Typecheck passes; all 24 launcher-generator tests still pass.",
-      "agentModel": "agent:claude-opus-4-7"
-    },
-    {
-      "timestamp": "2026-05-07T03:16:00.000Z",
-      "reason": "bead-close",
-      "note": "Closed bead workspace-eet (wire-spawn-agent). Added PanopticonAgentType union ('work'|'planning'|'review'|'test'|'inspect'|'uat'|'merge') and panopticonAgentName() helper. Extended getAgentRuntimeBaseCommand() signature with optional agentType parameter (currently underscore-prefixed and unused — bead workspace-7if turns this into actual --agent flag emission). Wired 3 callsites to pass agentType: spawnAgent work path passes 'work' or 'planning' based on options.phase; fallback restart at ~1450 passes 'work'; recovery at ~1811 passes 'work'. Resume path at ~1670 inline-emits 'claude --agent pan-work-agent' as baseCommand to satisfy AC2 (resume uses --agent pan-work-agent alongside --resume). claudish wrapper path inherits no agentType because non-direct providers cannot consume --agent. Typecheck + all 24 launcher tests pass.",
-      "agentModel": "agent:claude-opus-4-7"
-    },
-    {
-      "timestamp": "2026-05-07T03:18:00.000Z",
-      "reason": "bead-close",
-      "note": "Closed bead workspace-r2l (update-launcher-config). Modified buildNonConversationCommand() to skip permission flag emission when baseCommand already contains '--agent ' (per-agent frontmatter handles permissions via permissionMode). Specialists not yet migrated to --agent (specialist-init at specialists.ts:2310, specialist-dispatch branch) still emit permissionFlags. Removed permissionFlags array from agents.ts resume path because baseCommand now includes '--agent pan-work-agent'. Updated existing 'work agent resume' inline snapshot to reflect the new shape (claude --agent pan-work-agent --resume ... --model ...). 24/24 tests still pass; typecheck clean.",
-      "agentModel": "agent:claude-opus-4-7"
-    },
-    {
-      "timestamp": "2026-05-07T03:20:00.000Z",
-      "reason": "bead-close",
-      "note": "Closed bead workspace-7if (modify-base-command). getAgentRuntimeBaseCommand() now consumes the agentType parameter wired by bead workspace-eet. Anthropic direct path emits 'claude --agent pan-<type>-agent --name <id>' (no --model, no permission flags — frontmatter handles them). OpenAI CLIProxy path emits 'claude --agent pan-<type>-agent --model <resolvedId> --name <id>' (CLIProxy needs explicit --model since frontmatter model: only accepts Anthropic ids). Claudish wrapper path is unchanged because claudish does not recognize --agent. Behavior is gated on agentType: if a caller does not pass agentType (legacy callers), the function returns the pre-migration shape with permission flags inline. Typecheck + 24/24 launcher tests pass.",
-      "agentModel": "agent:claude-opus-4-7"
-    },
-    {
-      "timestamp": "2026-05-07T03:24:00.000Z",
-      "reason": "discovery",
-      "note": "Identified the source-of-truth location for Panopticon pipeline agent definitions: top-level `agents/` directory in the repo (resolved via SOURCE_AGENTS_DIR in src/lib/paths.ts:86). pan sync copies *.md files from `agents/` to `~/.panopticon/agent-definitions/` (cache) and then on to `<devroot>/.claude/agents/` via planSync/executeSync. The user rejected 5 prior Write attempts that targeted `.claude/agents/` — that is the SYNC TARGET, not the source. All pan-*-agent.md definitions must be created in `agents/` so they get picked up by the existing mirrorRepoToCache flow. This means bead workspace-d7n (sync deploy) is largely satisfied by the existing sync code; only verification or minor wiring remains. Created agents/pan-work-agent.md.",
-      "agentModel": "agent:claude-opus-4-7"
-    },
-    {
-      "timestamp": "2026-05-07T03:25:00.000Z",
-      "reason": "bead-close",
-      "note": "Closed bead workspace-59m (define-work-agent). Created agents/pan-work-agent.md with full YAML frontmatter: name, description, model: sonnet, permissionMode: bypassPermissions, effort: high, and per-agent hooks. Hooks mirror the global ~/.claude/settings.json structure: PreToolUse (.* → pre-tool-hook; Read → tldr-read-enforcer), PostToolUse (.* → heartbeat-hook + permission-event-hook; Bash → inspect-on-bead-close; Edit|Write → tldr-post-edit), Stop (.* → stop-hook + permission-event-hook). Hook command paths use $HOME/.panopticon/bin/ for portability across machines. Markdown body describes the per-bead workflow, completion path via pan done, and boundaries (no history rewriting, no JSONL deletion, no self-review).",
-      "agentModel": "agent:claude-opus-4-7"
-    },
-    {
-      "timestamp": "2026-05-07T03:30:00.000Z",
-      "reason": "bead-close",
-      "note": "Closed bead workspace-hik (wire-specialist-dispatch). Updated 4 launcher constructions to emit '--agent pan-<specialistType>': (1) dispatchSpecialist in specialists.ts:1090 — replaces baseCommand 'claude' + permissionFlags array with 'claude --agent pan-<specialistType>', dropping the redundant flags array; (2) initializeSpecialist in specialists.ts:2310 — same pattern for the canonical reviewer init path; (3) spawnSingleReviewer in review-agent.ts:540 — passes agentType='review' + sessionName to getAgentRuntimeBaseCommand() so it emits 'claude --agent pan-review-agent --name <session>'; (4) spawn-planning-session.ts:491 — passes agentType='planning' + sessionName for the planning launcher. Conversation route in dashboard/server/routes/conversations.ts:735 was deliberately left unchanged (legacy ad-hoc Claude sessions, AC2 says they may not use --agent). SpecialistType already ends in '-agent' so the mapping is 'pan-' + name. All 716 tests pass; typecheck clean.",
-      "agentModel": "agent:claude-opus-4-7"
-    }
+    { "id": "H1", "summary": "Must preserve formData/hasChanges/saveMutation state model verbatim — refactor layout around it, not the state logic.", "mitigation": "Keep all state hooks and handlers in the top-level SettingsPage component, pass as props to section components." }
   ],
   "resumePoint": {
-    "description": "Bead workspace-c6q closed (named sessions). Following bd ready strict order per user instruction. Remaining ready beads: workspace-hik (specialist dispatch --agent), workspace-l71 (migrate hooks to per-agent frontmatter), workspace-d7n (sync deploy agent definitions). Five additional ready beads will become available after closing one of those — the bead dep graph appears inverted but bd ready is the source of truth. Next: claim workspace-hik or workspace-l71. workspace-l71 requires creating .claude/agents/pan-*.md definitions (work, planning, review, test, inspect, uat, merge) — multiple prior Write attempts to .claude/agents/ were user-rejected, indicating user wants a different ordering or pattern for those files; check feedback before retrying.",
-    "beadId": "workspace-c6q",
-    "filesToRead": [".pan/spec.vbrief.json", "src/lib/agents.ts:102", "src/lib/cloister/specialists.ts:1090", "~/.claude/settings.json"]
+    "description": "Bead 2 (shell+nav) complete. Next: beads 3-6 (section redesigns). Bead 3 = providers summary-first. Bead 4 = model routing presets. Bead 5 = conversations+terminal. Bead 6 = tracker+appearance+maintenance+desktop.",
+    "beadId": "workspace-0hx1",
+    "filesToRead": ["src/dashboard/frontend/src/components/Settings/SettingsPage.tsx"]
   },
-  "feedback": []
+  "beadsMapping": {
+    "workspace-0oxv": "bead 1: settings primitives",
+    "workspace-jf4d": "bead 2: page shell and navigation",
+    "workspace-0hx1": "bead 3: providers redesign",
+    "workspace-tt6m": "bead 4: model routing redesign",
+    "workspace-ze9u": "bead 5: conversations and terminal",
+    "workspace-wymy": "bead 6: tracker keys, appearance, maintenance, desktop",
+    "workspace-fq8g": "bead 7: polish and accessibility"
+  },
+  "agentModel": "claude-opus-4-6",
+  "sessionHistory": [
+    { "timestamp": "2026-05-07T00:45:00Z", "reason": "start", "note": "Fresh session for PAN-963 Settings UI redesign. Merged with main, created 7 beads with dependency chain.", "agentModel": "claude-opus-4-6" },
+    { "timestamp": "2026-05-07T00:50:00Z", "reason": "progress", "note": "Completed bead 1: created primitives/SettingsLayout, SettingsSection, SettingsRow, SettingsSidebarNav, SettingsCardSection, SettingsRowStatus + barrel index + 22 passing tests.", "agentModel": "claude-opus-4-6" },
+    { "timestamp": "2026-05-07T00:57:00Z", "reason": "progress", "note": "Completed bead 2: restructured SettingsPage with SettingsLayout+SettingsHeader+SettingsSidebarNav. Removed dual headers, removed hero section, removed standalone Claude Code section. Reordered sections per PRD. Moved preset buttons into Model Routing section. All 51 tests pass.", "agentModel": "claude-opus-4-6" }
+  ]
 }

--- a/src/dashboard/frontend/src/components/Settings/SettingsPage.tsx
+++ b/src/dashboard/frontend/src/components/Settings/SettingsPage.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import {
   Loader2,
   X,
+  ChevronDown,
   Search,
   Code,
   Beaker,
@@ -33,9 +34,11 @@ import {
   Key,
   GitBranch,
   Flag,
-  Settings,
   RefreshCw,
   Trash2,
+  Palette,
+  Wrench,
+  Monitor,
 } from 'lucide-react';
 import { useAlert } from '../DialogProvider';
 import { SettingsConfig, Provider, WorkTypeId, ModelId } from './types';
@@ -48,13 +51,16 @@ import {
   ModelOverrideModal,
   getCapabilityMatchScore,
   getModelById,
-  WORK_TYPE_CAPABILITIES,
-  CAPABILITY_INFO,
-  Capability,
   MODELS_BY_PROVIDER,
   OpenRouterFavoriteModel,
 } from './AgentCards/ModelOverrideModal';
 import { getEffectiveModelId } from './modelDefaults';
+import {
+  SettingsLayout,
+  SettingsHeader,
+  SettingsSidebarNav,
+  type NavItem,
+} from './primitives';
 
 // OpenRouter types matching OpenRouterModelBrowser
 interface OpenRouterModelCatalog {
@@ -258,6 +264,17 @@ function getModelDisplay(modelId?: string): string {
   return modelId;
 }
 
+const SETTINGS_NAV_ITEMS: NavItem[] = [
+  { id: 'model-routing', label: 'Model Routing', icon: Route },
+  { id: 'providers', label: 'Providers', icon: Key },
+  { id: 'conversations', label: 'Conversations', icon: MessageCircle },
+  { id: 'terminal', label: 'Terminal', icon: Terminal },
+  { id: 'tracker-keys', label: 'Tracker Keys', icon: GitBranch },
+  { id: 'appearance', label: 'Appearance', icon: Palette },
+  { id: 'desktop', label: 'Desktop App', icon: Monitor },
+  { id: 'maintenance', label: 'Maintenance', icon: Wrench },
+];
+
 export function SettingsPage() {
   const queryClient = useQueryClient();
   const showAlert = useAlert();
@@ -288,15 +305,22 @@ export function SettingsPage() {
     expiresAt: number | null;
     hasAnthropicApiKey: boolean;
   } | null>(null);
-  const [refreshingAuth, setRefreshingAuth] = useState(false);
+  const [activeSection, setActiveSection] = useState('model-routing');
+  const [expandedProviders, setExpandedProviders] = useState<Record<string, boolean>>({});
+
+  const scrollToSection = useCallback((id: string) => {
+    setActiveSection(id);
+    const el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, []);
 
   const fetchClaudeAuth = async () => {
-    setRefreshingAuth(true);
     try {
       const res = await fetch('/api/settings/claude-auth');
       if (res.ok) setClaudeAuth(await res.json());
     } catch { /* ignore */ }
-    finally { setRefreshingAuth(false); }
   };
 
   useEffect(() => { void fetchClaudeAuth(); }, []);
@@ -574,402 +598,343 @@ export function SettingsPage() {
   };
 
   return (
-    <div>
-      {/* Sticky action bar */}
-      <div className="sticky top-0 z-30 bg-card/95 backdrop-blur-sm border-b border-border shadow-sm">
-        <div className="max-w-[1200px] mx-auto px-6 md:px-10 flex items-center justify-between py-3">
-          <div className="flex items-center gap-2">
-            <Settings className="w-5 h-5 text-primary" />
-            <h1 className="text-foreground text-lg font-black tracking-tight">Settings</h1>
-          </div>
-          <div className="flex items-center gap-3">
-            {saveMutation.isSuccess && (
-              <span className="flex items-center gap-1.5 text-success text-sm">
-                <CheckCircle className="w-4 h-4" />
-                Saved!
-              </span>
-            )}
-            {saveMutation.isError && (
-              <span className="flex items-center gap-1.5 text-destructive text-sm">
-                <AlertTriangle className="w-4 h-4" />
-                Save failed
-              </span>
-            )}
-            <button
-              onClick={handleRestoreOptimalDefaults}
-              className="px-3 py-1.5 text-warning hover:text-warning/80 font-semibold text-sm transition-colors flex items-center gap-1.5"
-              title="Set all model assignments to research-based optimal defaults (Anthropic + Kimi)"
-            >
-              <Zap className="w-4 h-4" />
-              Optimal Defaults
-            </button>
-            <button
-              onClick={handleRestoreMiniMaxDefaults}
-              className="px-3 py-1.5 text-amber-400 hover:text-amber-300 font-semibold text-sm transition-colors flex items-center gap-1.5"
-              title="Set all model assignments to MiniMax M2.7 (lowest cost)"
-            >
-              <Zap className="w-4 h-4" />
-              MiniMax Defaults
-            </button>
-            <button
-              onClick={handleReset}
-              disabled={!hasChanges}
-              className="px-3 py-1.5 text-muted-foreground hover:text-foreground font-semibold text-sm transition-colors disabled:opacity-40"
-            >
-              Undo
-            </button>
-            <button
-              onClick={handleSave}
-              disabled={!hasChanges || saveMutation.isPending}
-              className="px-5 py-1.5 bg-primary hover:bg-primary/90 text-primary-foreground font-black rounded-lg transition-all shadow-md shadow-primary/20 text-sm disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-            >
-              {saveMutation.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
-              Save Changes
-            </button>
-          </div>
-        </div>
-      </div>
-
-      <div className="max-w-[1200px] mx-auto px-6 md:px-10 py-8">
-      {/* Page Header */}
-      <div className="flex flex-col gap-1 mb-8">
-        <div className="flex items-center gap-2 mb-1">
-          <Settings className="w-8 h-8 text-primary" />
-          <h1 className="text-foreground text-4xl font-black tracking-tight">Settings</h1>
-        </div>
-        <p className="text-muted-foreground text-base">Configure AI model orchestration and agent permissions.</p>
-      </div>
-
+    <SettingsLayout
+      header={
+        <SettingsHeader
+          title="Settings"
+          hasChanges={hasChanges}
+          saving={saveMutation.isPending}
+          saveSuccess={saveMutation.isSuccess}
+          saveError={saveMutation.isError}
+          onSave={handleSave}
+          onReset={handleReset}
+        />
+      }
+      sidebar={
+        <SettingsSidebarNav
+          items={SETTINGS_NAV_ITEMS}
+          activeId={activeSection}
+          onSelect={scrollToSection}
+        />
+      }
+    >
       {/* Deprecation Warning Banner */}
       {formData.deprecation_warnings && formData.deprecation_warnings.length > 0 && (
-        <div className="badge-bg-warning border badge-border-warning rounded-xl px-4 py-3 mb-6">
+        <div className="bg-warning/10 border border-warning/25 rounded-lg px-4 py-3 mb-6">
           <div className="flex items-start gap-3">
-            <AlertTriangle className="w-6 h-6 text-warning shrink-0 mt-0.5" />
+            <AlertTriangle className="w-5 h-5 text-warning shrink-0 mt-0.5" />
             <div className="flex-1">
-              <p className="text-warning font-semibold mb-2">
-                Deprecated Model IDs Detected
+              <p className="text-warning text-sm font-medium mb-1">
+                Deprecated model IDs detected
               </p>
-              <div className="space-y-1">
+              <div className="space-y-0.5">
                 {formData.deprecation_warnings.map((warning, idx) => (
-                  <p key={idx} className="text-warning/90 text-sm">
-                    <span className="font-mono text-xs badge-bg-warning px-1.5 py-0.5 rounded">{warning.workType}</span>
+                  <p key={idx} className="text-muted-foreground text-xs">
+                    <code className="font-mono">{warning.workType}</code>
                     {': '}
-                    <span className="font-mono text-xs badge-bg-warning px-1.5 py-0.5 rounded line-through">
-                      {warning.from}
-                    </span>
+                    <code className="font-mono line-through">{warning.from}</code>
                     {' → '}
-                    <span className="font-mono text-xs badge-bg-warning px-1.5 py-0.5 rounded">
-                      {warning.to}
-                    </span>
+                    <code className="font-mono">{warning.to}</code>
                   </p>
                 ))}
               </div>
-              <p className="text-warning/80 text-xs mt-3">
-                Click <span className="font-semibold">Save</span> to automatically migrate to current model IDs. A backup will be created before migration.
+              <p className="text-muted-foreground text-xs mt-2">
+                Save to migrate automatically.
               </p>
             </div>
           </div>
         </div>
       )}
 
-
-      {/* Smart Model Selection Hero */}
-      <section className="mb-10">
-        <div className="bg-card border border-border rounded-xl overflow-hidden">
-          <div className="flex flex-col lg:flex-row">
-            {/* Visualization */}
-            <div className="lg:w-2/5 bg-card p-8 flex flex-col justify-center items-center border-b lg:border-b-0 lg:border-r border-border relative overflow-hidden">
-              <div className="absolute inset-0 opacity-10 pointer-events-none bg-[radial-gradient(circle_at_50%_50%,#3b82f6_0%,transparent_70%)]" />
-              <div className="relative z-10 flex flex-col items-center gap-6 w-full max-w-xs">
-                <div className="flex items-center justify-between w-full">
-                  <div className="size-12 rounded-lg bg-card border border-border flex items-center justify-center shadow-sm">
-                    <Terminal className="w-5 h-5 text-muted-foreground" />
-                  </div>
-                  <div className="flex-1 h-px bg-gradient-to-r from-divider-strong via-primary to-divider-strong mx-2" />
-                  <div className="size-12 rounded-lg bg-card border border-border flex items-center justify-center shadow-sm">
-                    <User className="w-5 h-5 text-primary" />
-                  </div>
-                  <div className="flex-1 h-px bg-gradient-to-r from-divider via-primary to-divider mx-2" />
-                  <div className="size-12 rounded-lg bg-primary flex items-center justify-center shadow-lg">
-                    <Zap className="w-5 h-5 text-foreground" />
-                  </div>
-                </div>
-                <div className="flex justify-between w-full px-2 text-[10px] uppercase tracking-widest font-bold text-muted-foreground">
-                  <span>Task</span>
-                  <span>Capability</span>
-                  <span>Model</span>
-                </div>
-              </div>
-            </div>
-            {/* Content */}
-            <div className="lg:w-3/5 p-8">
-              <div className="flex items-center gap-2 mb-4">
-                <span className="px-2 py-0.5 badge-bg-primary text-primary text-[10px] font-bold uppercase tracking-wider rounded border badge-border-primary">Active</span>
-                <h3 className="text-foreground text-xl font-bold">Smart Model Selection</h3>
-              </div>
-              <p className="text-muted-foreground mb-6 leading-relaxed">
-                Panopticon automatically routes tasks to the optimal model based on capabilities, token budget, and latency requirements.
-              </p>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="flex items-start gap-3">
-                  <CheckCircle className="w-4 h-4 text-primary mt-1" />
-                  <div>
-                    <p className="text-sm font-semibold text-foreground">Capability Matching</p>
-                    <p className="text-xs text-muted-foreground">Best model for each task type</p>
-                  </div>
-                </div>
-                <div className="flex items-start gap-3">
-                  <CheckCircle className="w-4 h-4 text-primary mt-1" />
-                  <div>
-                    <p className="text-sm font-semibold text-foreground">Cost Optimization</p>
-                    <p className="text-xs text-muted-foreground">Balance performance vs spend</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Claude Code Authentication */}
-      <section className="mb-12">
-        <h2 className="text-foreground text-2xl font-bold mb-6 flex items-center gap-3">
-          Claude Code
-          <div className="h-px flex-1 bg-divider-strong" />
+      {/* Model Routing */}
+      <section id="model-routing" className="py-6 scroll-mt-4">
+        <h2 className="text-foreground text-base font-semibold tracking-tight mb-4">
+          Model Routing
         </h2>
-        <div className="bg-card border border-border rounded-xl p-6 flex flex-col gap-4">
-          <div className="flex items-start justify-between gap-4">
-            <div className="flex items-start gap-4">
-              {/* Status dot */}
-              <div className={`mt-1 w-3 h-3 rounded-full shrink-0 ${
-                claudeAuth?.loggedIn ? 'bg-success' :
-                claudeAuth?.expired ? 'bg-warning' :
-                claudeAuth?.installed ? 'bg-destructive' :
-                'bg-muted-foreground'
-              }`} />
-              <div>
-                {claudeAuth === null ? (
-                  <p className="text-foreground text-sm">Checking authentication status…</p>
-                ) : !claudeAuth.installed ? (
-                  <>
-                    <p className="text-foreground font-semibold">Claude Code not detected</p>
-                    <p className="text-muted-foreground text-sm mt-1">
-                      Install Claude Code to use subscription-based authentication.
-                    </p>
-                  </>
-                ) : claudeAuth.loggedIn ? (
-                  <>
-                    <div className="flex items-center gap-2">
-                      <p className="text-foreground font-semibold">Logged in</p>
-                      {claudeAuth.subscriptionType && (
-                        <span className="text-[10px] font-black uppercase tracking-tighter px-2 py-0.5 rounded bg-primary/15 text-primary border border-primary/25">
-                          {claudeAuth.subscriptionType.toUpperCase()}
-                        </span>
-                      )}
-                    </div>
-                    {claudeAuth.rateLimitTier && (
-                      <p className="text-muted-foreground text-xs mt-1">
-                        Rate tier: <code className="font-mono text-muted-foreground">{claudeAuth.rateLimitTier}</code>
-                      </p>
-                    )}
-                    {claudeAuth.hasAnthropicApiKey && (
-                      <div className="flex items-center gap-1.5 mt-2">
-                        <AlertTriangle className="w-3.5 h-3.5 text-warning shrink-0" />
-                        <p className="text-warning text-xs">
-                          <code className="font-mono">ANTHROPIC_API_KEY</code> is set — this overrides subscription auth for direct API calls
-                        </p>
-                      </div>
-                    )}
-                  </>
-                ) : claudeAuth.expired ? (
-                  <>
-                    <p className="text-foreground font-semibold text-warning">Session expired</p>
-                    <p className="text-muted-foreground text-sm mt-1">
-                      Your Claude Code session has expired. Run <code className="font-mono bg-popover px-1 rounded">claude</code> in the terminal and use <code className="font-mono bg-popover px-1 rounded">/login</code> to re-authenticate.
-                    </p>
-                  </>
-                ) : (
-                  <>
-                    <p className="text-foreground font-semibold">Not logged in</p>
-                    <p className="text-muted-foreground text-sm mt-1">
-                      No active subscription session. To log in, type <code className="font-mono bg-popover px-1 rounded">! claude</code> in the command bar, then use <code className="font-mono bg-popover px-1 rounded">/login</code>.
-                    </p>
-                    {claudeAuth.hasAnthropicApiKey && (
-                      <p className="text-muted-foreground text-xs mt-2">
-                        Falling back to <code className="font-mono">ANTHROPIC_API_KEY</code> for Anthropic models.
-                      </p>
-                    )}
-                  </>
-                )}
-              </div>
-            </div>
+
+        {/* Preset summary */}
+        <div className="flex items-center justify-between px-4 py-3 bg-card border border-border rounded-lg mb-4">
+          <div>
+            <span className="text-xs text-muted-foreground">Active preset</span>
+            <p className="text-sm font-medium text-foreground">Custom configuration</p>
+          </div>
+          <div className="flex items-center gap-2">
             <button
-              onClick={() => void fetchClaudeAuth()}
-              disabled={refreshingAuth}
-              className="shrink-0 p-2 rounded-lg border border-border hover:border-border text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
-              title="Refresh auth status"
+              type="button"
+              onClick={handleRestoreOptimalDefaults}
+              className="px-2.5 py-1 text-xs font-medium text-muted-foreground hover:text-foreground border border-border rounded-md transition-colors"
             >
-              <RefreshCw className={`w-4 h-4 ${refreshingAuth ? 'animate-spin' : ''}`} />
+              Apply Optimal
+            </button>
+            <button
+              type="button"
+              onClick={handleRestoreMiniMaxDefaults}
+              className="px-2.5 py-1 text-xs font-medium text-muted-foreground hover:text-foreground border border-border rounded-md transition-colors"
+            >
+              Apply MiniMax
             </button>
           </div>
         </div>
+
+        {/* Override summary */}
+        {(() => {
+          const overrideCount = Object.keys(formData.models.overrides).length;
+          const deprecatedCount = formData.deprecation_warnings?.length || 0;
+          const allAgents = AGENT_CATEGORIES.flatMap(c => c.agents);
+          const poorFitCount = allAgents.filter(agent => {
+            const modelId = getEffectiveModelId(agent.id, formData.models.overrides);
+            const { score } = getCapabilityMatchScore(modelId, agent.id);
+            return score < 0.5 && agent.implemented;
+          }).length;
+
+          return (
+            <div className="flex items-center gap-4 px-4 py-2 mb-4 text-xs text-muted-foreground">
+              <span>{overrideCount} override{overrideCount !== 1 ? 's' : ''}</span>
+              {deprecatedCount > 0 && (
+                <span className="text-warning">{deprecatedCount} deprecated</span>
+              )}
+              {poorFitCount > 0 && (
+                <span className="text-destructive">{poorFitCount} poor fit</span>
+              )}
+            </div>
+          );
+        })()}
+
+        {/* Overrides by category */}
+        <div className="space-y-4">
+          {AGENT_CATEGORIES.map((category) => (
+            <div key={category.name}>
+              <div className="flex items-center gap-2 mb-2 px-1">
+                <category.icon className="w-3.5 h-3.5 text-muted-foreground" />
+                <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">{category.name}</span>
+              </div>
+
+              <div className="space-y-0.5">
+                {category.agents.map((agent) => {
+                  const currentModelId = getEffectiveModelId(agent.id, formData.models.overrides);
+                  const modelDisplay = getModelDisplay(currentModelId);
+                  const { score } = getCapabilityMatchScore(currentModelId, agent.id);
+                  const hasOverride = !!formData.models.overrides[agent.id];
+                  const isDeprecated = formData.deprecation_warnings?.some(
+                    (w) => w.workType === agent.id && w.from === currentModelId
+                  );
+
+                  return (
+                    <button
+                      key={agent.id}
+                      type="button"
+                      onClick={() => agent.implemented && setModalWorkType(agent.id)}
+                      disabled={!agent.implemented}
+                      className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-muted/50 transition-colors text-left disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:outline-none"
+                    >
+                      <agent.icon className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+                      <span className="text-xs font-medium text-foreground flex-1 min-w-0 truncate">
+                        {agent.name}
+                      </span>
+                      <span className="text-[10px] text-muted-foreground truncate max-w-[140px]">
+                        {modelDisplay}
+                      </span>
+                      {hasOverride && (
+                        <span className="text-[9px] font-medium px-1 py-0.5 rounded bg-primary/10 text-primary">
+                          override
+                        </span>
+                      )}
+                      {isDeprecated && (
+                        <span className="text-[9px] font-medium px-1 py-0.5 rounded bg-warning/10 text-warning">
+                          deprecated
+                        </span>
+                      )}
+                      <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${
+                        isDeprecated ? 'bg-warning' :
+                        score >= 1 ? 'bg-success' :
+                        score >= 0.5 ? 'bg-warning' :
+                        'bg-destructive'
+                      }`} />
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
       </section>
 
-      {/* Provider Configuration */}
-      <section className="mb-12">
-        <h2 className="text-foreground text-2xl font-bold mb-6 flex items-center gap-3">
-          Provider Configuration
-          <div className="h-px flex-1 bg-divider-strong" />
+      {/* Providers */}
+      <section id="providers" className="py-6 scroll-mt-4">
+        <h2 className="text-foreground text-base font-semibold tracking-tight mb-4">
+          Providers
         </h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        <div className="space-y-1">
           {PROVIDERS.map((provider) => {
             const isDefault = provider.id === 'anthropic';
             const isEnabled = formData.models.providers[provider.id];
             const apiKey = formData.api_keys[provider.id as keyof typeof formData.api_keys] || '';
+            const isExpanded = expandedProviders[provider.id] || false;
+
+            const getAuthSummary = () => {
+              if (isDefault) {
+                if (claudeAuth?.loggedIn) return { text: claudeAuth.subscriptionType ? `${claudeAuth.subscriptionType} plan` : 'Subscription', variant: 'success' as const };
+                if (claudeAuth?.hasAnthropicApiKey) return { text: 'API key', variant: 'neutral' as const };
+                return { text: 'Not authenticated', variant: 'warning' as const };
+              }
+              if (provider.id === 'openai') {
+                if (codexAuth?.status === 'valid') return { text: 'OAuth', variant: 'success' as const };
+                if (codexAuth?.status === 'expired' || codexAuth?.status === 'burned') return { text: codexAuth.status, variant: 'warning' as const };
+              }
+              if (apiKey && !apiKey.startsWith('$')) return { text: 'Key configured', variant: 'success' as const };
+              if (apiKey?.startsWith('$')) return { text: `via ${apiKey}`, variant: 'neutral' as const };
+              return { text: 'No key', variant: 'neutral' as const };
+            };
+
+            const authSummary = getAuthSummary();
 
             return (
-              <div
-                key={provider.id}
-                className={`bg-card border rounded-xl p-5 relative transition-colors shadow-sm ${
-                  isDefault
-                    ? 'border-primary/50 shadow-lg shadow-primary/5'
-                    : 'border-border hover:border-border'
-                }`}
-              >
-                {isDefault && (
-                  <div className="absolute -top-3 right-4">
-                    <span className="bg-primary text-primary-foreground text-[10px] font-black px-2 py-0.5 rounded uppercase tracking-tighter">
-                      Default
+              <div key={provider.id} className="border border-transparent rounded-lg hover:border-border transition-colors">
+                {/* Summary row */}
+                <div className="flex items-center gap-3 px-3 py-2.5">
+                  <provider.icon className="w-4 h-4 text-muted-foreground shrink-0" />
+                  <span className="text-sm font-medium text-foreground flex-1 min-w-0">{provider.name}</span>
+                  <div className="flex items-center gap-2">
+                    <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${
+                      authSummary.variant === 'success' ? 'text-success bg-success/10' :
+                      authSummary.variant === 'warning' ? 'text-warning bg-warning/10' :
+                      'text-muted-foreground bg-muted/50'
+                    }`}>
+                      {authSummary.text}
                     </span>
-                  </div>
-                )}
-                <div className="flex items-center gap-3 mb-5">
-                  <div className="size-10 rounded-lg bg-card border border-border flex items-center justify-center">
-                    <provider.icon className="w-5 h-5 text-muted-foreground" />
-                  </div>
-                  <span className="font-bold text-foreground">{provider.name}</span>
-                  {/* Subscription badge in the Anthropic card header */}
-                  {isDefault && claudeAuth?.loggedIn && claudeAuth.subscriptionType && (
-                    <span className="text-[9px] font-black uppercase tracking-tighter px-1.5 py-0.5 rounded bg-primary/15 text-primary border border-primary/25">
-                      {claudeAuth.subscriptionType.toUpperCase()}
-                    </span>
-                  )}
-                  <div className="ml-auto">
                     <button
+                      type="button"
                       onClick={() => handleProviderToggle(provider.id)}
-                      className={`w-10 h-5 rounded-full relative transition-colors ${
-                        isEnabled ? 'bg-primary' : 'bg-card'
-                      } cursor-pointer`}
+                      role="switch"
+                      aria-checked={isEnabled}
+                      aria-label={`${isEnabled ? 'Disable' : 'Enable'} ${provider.name}`}
+                      className={`w-8 h-4.5 rounded-full relative transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
+                        isEnabled ? 'bg-primary' : 'bg-muted'
+                      }`}
                     >
-                      <div
-                        className={`absolute top-0.5 size-4 bg-white rounded-full transition-all ${
-                          isEnabled ? 'right-0.5' : 'left-0.5'
-                        }`}
-                      />
+                      <span className={`absolute top-0.5 size-3.5 bg-white rounded-full transition-all ${
+                        isEnabled ? 'right-0.5' : 'left-0.5'
+                      }`} />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setExpandedProviders(prev => ({ ...prev, [provider.id]: !prev[provider.id] }))}
+                      className="p-1 text-muted-foreground hover:text-foreground transition-colors rounded"
+                      aria-expanded={isExpanded}
+                      aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${provider.name} details`}
+                    >
+                      <ChevronDown className={`w-3.5 h-3.5 transition-transform ${isExpanded ? '' : '-rotate-90'}`} />
                     </button>
                   </div>
                 </div>
-                <div className="space-y-3">
-                  <div className="relative">
-                    {/* Anthropic: show authentication method rather than raw API key field */}
+
+                {/* Expanded details */}
+                {isExpanded && (
+                  <div className="px-3 pb-3 pt-0 ml-7 space-y-3">
                     {isDefault ? (
-                      <div>
-                        <label className="text-[10px] uppercase font-bold text-muted-foreground mb-1 block">Authentication</label>
+                      <div className="space-y-2">
                         {claudeAuth?.loggedIn ? (
-                          <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-success/10 border border-success/20">
-                            <div className="w-2 h-2 rounded-full bg-success shrink-0" />
-                            <span className="text-xs text-success font-medium">
-                              Subscription{claudeAuth.subscriptionType ? ` — ${claudeAuth.subscriptionType.toUpperCase()} plan` : ''}
+                          <div className="flex items-center gap-2 text-xs">
+                            <div className="w-1.5 h-1.5 rounded-full bg-success" />
+                            <span className="text-muted-foreground">
+                              Subscription{claudeAuth.subscriptionType ? ` — ${claudeAuth.subscriptionType.toUpperCase()}` : ''}
+                              {claudeAuth.rateLimitTier ? ` · ${claudeAuth.rateLimitTier}` : ''}
                             </span>
                           </div>
                         ) : claudeAuth?.hasAnthropicApiKey ? (
-                          <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-primary/10 border border-primary/20">
-                            <Key className="w-3.5 h-3.5 text-primary shrink-0" />
-                            <span className="text-xs text-primary font-medium">API Key (via env)</span>
+                          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                            <Key className="w-3 h-3" />
+                            <span>Using ANTHROPIC_API_KEY from environment</span>
                           </div>
                         ) : (
-                          <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-warning/10 border border-warning/20">
-                            <AlertTriangle className="w-3.5 h-3.5 text-warning shrink-0" />
-                            <span className="text-xs text-warning">Not authenticated — see Claude Code section above</span>
-                          </div>
+                          <p className="text-xs text-warning">
+                            Not authenticated. Run <code className="font-mono bg-muted px-1 rounded">claude</code> and use <code className="font-mono bg-muted px-1 rounded">/login</code>.
+                          </p>
                         )}
                         {claudeAuth?.hasAnthropicApiKey && claudeAuth.loggedIn && (
-                          <p className="text-[10px] text-warning mt-1.5 flex items-center gap-1">
-                            <AlertTriangle className="w-3 h-3 shrink-0" />
-                            <code className="font-mono">ANTHROPIC_API_KEY</code> overrides subscription for direct API calls
+                          <p className="text-[10px] text-muted-foreground flex items-center gap-1">
+                            <AlertTriangle className="w-3 h-3 text-warning" />
+                            ANTHROPIC_API_KEY overrides subscription for direct API calls
                           </p>
                         )}
                       </div>
                     ) : provider.id === 'openai' ? (
-                      <div>
-                        <label className="text-[10px] uppercase font-bold text-muted-foreground mb-1 block">Authentication</label>
+                      <div className="space-y-2">
                         {codexAuth?.status === 'valid' ? (
-                          <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-success/10 border border-success/20">
-                            <div className="w-2 h-2 rounded-full bg-success shrink-0" />
-                            <span className="text-xs text-success font-medium">Subscription OAuth</span>
-                          </div>
-                        ) : codexAuth?.status === 'expired' || codexAuth?.status === 'burned' ? (
-                          <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-warning/10 border border-warning/20">
-                            <AlertTriangle className="w-3.5 h-3.5 text-warning shrink-0" />
-                            <span className="text-xs text-warning font-medium capitalize">{codexAuth.status}</span>
-                          </div>
-                        ) : (
-                          <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-primary/10 border border-primary/20">
-                            <Key className="w-3.5 h-3.5 text-primary shrink-0" />
-                            <span className="text-xs text-primary font-medium">API Key</span>
-                          </div>
-                        )}
-                        {codexAuth?.email && codexAuth.status !== 'missing' && (
-                          <p className="text-[10px] text-muted-foreground mt-1.5">
-                            <SensitiveText value={codexAuth.email} className="text-[10px] text-muted-foreground" />
-                            {codexAuth.expiresAt && (
-                              <span className="ml-1">
-                                · Expires {new Date(codexAuth.expiresAt).toLocaleString()}
-                              </span>
+                          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                            <div className="w-1.5 h-1.5 rounded-full bg-success" />
+                            <span>OAuth active</span>
+                            {codexAuth.email && (
+                              <SensitiveText value={codexAuth.email} className="text-[10px] text-muted-foreground" />
                             )}
-                          </p>
-                        )}
-                        {(codexAuth?.status === 'expired' || codexAuth?.status === 'burned') && (
-                          <button
-                            onClick={async () => {
-                              try {
-                                const res = await fetch('/api/settings/codex-reauth', { method: 'POST' });
-                                if (!res.ok) {
-                                  const body = await res.json().catch(() => ({}));
-                                  throw new Error(body.error || `Failed to spawn re-auth session (${res.status})`);
+                          </div>
+                        ) : (codexAuth?.status === 'expired' || codexAuth?.status === 'burned') ? (
+                          <div className="flex items-center gap-2">
+                            <span className="text-xs text-warning capitalize">{codexAuth.status}</span>
+                            <button
+                              onClick={async () => {
+                                try {
+                                  const res = await fetch('/api/settings/codex-reauth', { method: 'POST' });
+                                  if (!res.ok) {
+                                    const body = await res.json().catch(() => ({}));
+                                    throw new Error(body.error || `Failed (${res.status})`);
+                                  }
+                                  const { sessionName, token } = await res.json() as { sessionName: string; token: string };
+                                  window.location.href = `/terminal/${sessionName}?token=${encodeURIComponent(token)}`;
+                                } catch (err) {
+                                  toast.error(err instanceof Error ? err.message : 'Failed to start re-authentication');
                                 }
-                                const { sessionName, token } = await res.json() as { sessionName: string; token: string };
-                                window.location.href = `/terminal/${sessionName}?token=${encodeURIComponent(token)}`;
-                              } catch (err) {
-                                toast.error(err instanceof Error ? err.message : 'Failed to start re-authentication');
-                              }
-                            }}
-                            className="mt-2 flex items-center justify-center gap-1.5 px-3 py-1.5 badge-bg-warning hover:bg-warning/20 border badge-border-warning rounded-lg text-xs text-warning transition-colors w-full"
-                          >
-                            <RefreshCw className="w-3.5 h-3.5" />
-                            Re-authenticate
-                          </button>
-                        )}
+                              }}
+                              className="text-[10px] text-warning hover:text-warning/80 underline"
+                            >
+                              Re-authenticate
+                            </button>
+                          </div>
+                        ) : null}
+                        {/* API key input for OpenAI */}
+                        <div className="relative">
+                          <input
+                            type={showApiKey[provider.id] ? 'text' : 'password'}
+                            value={apiKey}
+                            onChange={(e) => handleApiKeyChange(provider.id, e.target.value)}
+                            placeholder={provider.placeholder}
+                            autoComplete="off"
+                            className="w-full bg-background border border-border rounded-md px-3 py-1.5 text-xs font-mono focus:ring-1 focus:ring-primary focus:border-primary text-foreground pr-14"
+                          />
+                          {apiKey && (
+                            <>
+                              <button
+                                onClick={() => setShowApiKey({ ...showApiKey, [provider.id]: !showApiKey[provider.id] })}
+                                className="absolute right-7 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                                title={showApiKey[provider.id] ? 'Hide' : 'Show'}
+                                aria-label={showApiKey[provider.id] ? 'Hide key' : 'Show key'}
+                              >
+                                <Eye className="w-3.5 h-3.5" />
+                              </button>
+                              <button
+                                onClick={() => handleApiKeyChange(provider.id, '')}
+                                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-destructive"
+                                title="Remove key"
+                                aria-label="Remove API key"
+                              >
+                                <Trash2 className="w-3 h-3" />
+                              </button>
+                            </>
+                          )}
+                        </div>
                       </div>
                     ) : (
-                      <>
-                        <label className="text-[10px] uppercase font-bold text-muted-foreground mb-1 block">API Key</label>
-                        {/* Check if it's an unresolved env var reference */}
+                      <div className="space-y-2">
                         {apiKey.startsWith('$') ? (
-                          <div className="badge-bg-warning border badge-border-warning rounded-lg px-3 py-2">
-                            <div className="flex items-center gap-2 text-warning text-xs">
-                              <AlertTriangle className="w-4 h-4" />
-                              <span>Configured via <code className="font-mono bg-popover px-1 rounded">{apiKey}</code></span>
-                            </div>
-                            <p className="text-[10px] text-warning/70 mt-1">
-                              Set this environment variable or enter the key directly below
-                            </p>
+                          <div className="text-xs">
+                            <span className="text-muted-foreground">Env: </span>
+                            <code className="font-mono text-muted-foreground">{apiKey}</code>
                             <input
                               type="text"
                               placeholder={provider.placeholder}
                               onChange={(e) => handleApiKeyChange(provider.id, e.target.value)}
                               autoComplete="off"
-                              className="w-full bg-background border border-border rounded-lg px-3 py-2 text-xs font-mono mt-2 focus:ring-1 focus:ring-primary focus:border-primary text-foreground"
+                              className="w-full bg-background border border-border rounded-md px-3 py-1.5 text-xs font-mono mt-1.5 focus:ring-1 focus:ring-primary focus:border-primary text-foreground"
                             />
                           </div>
                         ) : (
@@ -980,135 +945,137 @@ export function SettingsPage() {
                               onChange={(e) => handleApiKeyChange(provider.id, e.target.value)}
                               placeholder={provider.placeholder}
                               autoComplete="off"
-                              autoCorrect="off"
-                              autoCapitalize="off"
-                              spellCheck={false}
-                              data-lpignore="true"
-                              data-1p-ignore="true"
-                              data-form-type="other"
-                              className={`w-full bg-background border border-border rounded-lg px-3 py-2 text-xs font-mono focus:ring-1 focus:ring-primary focus:border-primary text-foreground ${apiKey ? 'pr-16' : 'pr-8'}`}
+                              className="w-full bg-background border border-border rounded-md px-3 py-1.5 text-xs font-mono focus:ring-1 focus:ring-primary focus:border-primary text-foreground pr-14"
                             />
                             {apiKey && (
-                              <button
-                                onClick={() => setShowApiKey({ ...showApiKey, [provider.id]: !showApiKey[provider.id] })}
-                                className="absolute right-8 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                                title={showApiKey[provider.id] ? 'Hide key' : 'Show key'}
-                              >
-                                {showApiKey[provider.id] ? (
-                                  <Eye className="w-4 h-4" />
-                                ) : (
-                                  <Eye className="w-4 h-4 opacity-50" />
-                                )}
-                              </button>
-                            )}
-                            {apiKey && (
-                              <button
-                                onClick={() => handleApiKeyChange(provider.id, '')}
-                                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-destructive transition-colors"
-                                title="Delete API key"
-                              >
-                                <Trash2 className="w-3.5 h-3.5" />
-                              </button>
+                              <>
+                                <button
+                                  onClick={() => setShowApiKey({ ...showApiKey, [provider.id]: !showApiKey[provider.id] })}
+                                  className="absolute right-7 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                                  title={showApiKey[provider.id] ? 'Hide' : 'Show'}
+                                  aria-label={showApiKey[provider.id] ? 'Hide key' : 'Show key'}
+                                >
+                                  <Eye className="w-3.5 h-3.5" />
+                                </button>
+                                <button
+                                  onClick={() => handleApiKeyChange(provider.id, '')}
+                                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-destructive"
+                                  title="Remove key"
+                                  aria-label="Remove API key"
+                                >
+                                  <Trash2 className="w-3 h-3" />
+                                </button>
+                              </>
                             )}
                           </div>
                         )}
-                      </>
+                      </div>
                     )}
-                  </div>
-                  {/* Action Buttons */}
-                  {!isDefault && (
-                    <div className="flex flex-col gap-2">
-                      {/* Show Models Button - only if we have a real API key */}
-                      {apiKey && !apiKey.startsWith('$') && (
+                    {/* Action buttons for non-default providers */}
+                    {!isDefault && apiKey && !apiKey.startsWith('$') && (
+                      <div className="flex items-center gap-2">
                         <button
                           onClick={() => setModelsModalProvider(provider.id)}
-                          className="flex items-center justify-center gap-1.5 px-3 py-1.5 badge-bg-primary hover:bg-primary/20 border badge-border-primary rounded-lg text-xs text-primary transition-colors w-full"
+                          className="text-xs text-primary hover:text-primary/80 font-medium"
                         >
-                          <BarChart3 className="w-3.5 h-3.5" />
-                          View Models
+                          View models
                         </button>
-                      )}
-                      {/* Test API Key Button - only if we have a real API key (not env var ref) */}
-                      {apiKey && !apiKey.startsWith('$') && (
-                        <div className="flex items-center gap-2">
-                          <button
-                            onClick={() => handleTestApiKey(provider.id)}
-                            disabled={testingProvider === provider.id}
-                            className="flex items-center gap-1.5 px-3 py-1.5 bg-card hover:bg-divider-strong border border-border rounded-lg text-xs text-foreground transition-colors disabled:opacity-50"
-                          >
-                            {testingProvider === provider.id ? (
-                              <Loader2 className="w-3 h-3 animate-spin" />
-                            ) : (
-                              <Beaker className="w-3.5 h-3.5" />
-                            )}
-                            Test 2+3
-                          </button>
-                          {testResults[provider.id] && (
-                            <div className={`flex items-center gap-1 text-xs ${testResults[provider.id]?.success ? 'text-success' : 'text-destructive'}`}>
-                              {testResults[provider.id]?.success ? (
-                                <CheckCircle className="w-3.5 h-3.5" />
-                              ) : (
-                                <AlertTriangle className="w-3.5 h-3.5" />
-                              )}
-                              {testResults[provider.id]?.success
-                                ? `${testResults[provider.id]?.latencyMs}ms`
-                                : testResults[provider.id]?.error}
-                            </div>
-                          )}
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </div>
+                        <span className="text-border">·</span>
+                        <button
+                          onClick={() => handleTestApiKey(provider.id)}
+                          disabled={testingProvider === provider.id}
+                          className="text-xs text-muted-foreground hover:text-foreground font-medium disabled:opacity-50 flex items-center gap-1"
+                        >
+                          {testingProvider === provider.id && <Loader2 className="w-3 h-3 animate-spin" />}
+                          Test
+                        </button>
+                        {testResults[provider.id] && (
+                          <span className={`text-[10px] ${testResults[provider.id]?.success ? 'text-success' : 'text-destructive'}`}>
+                            {testResults[provider.id]?.success
+                              ? `${testResults[provider.id]?.latencyMs}ms`
+                              : testResults[provider.id]?.error?.slice(0, 20)}
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
             );
           })}
+
+          {/* OpenRouter as part of providers */}
+          <div className="border border-transparent rounded-lg hover:border-border transition-colors">
+            <div className="flex items-center gap-3 px-3 py-2.5">
+              <Globe className="w-4 h-4 text-muted-foreground shrink-0" />
+              <span className="text-sm font-medium text-foreground flex-1">OpenRouter</span>
+              <div className="flex items-center gap-2">
+                <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${
+                  formData.api_keys.openrouter ? 'text-success bg-success/10' : 'text-muted-foreground bg-muted/50'
+                }`}>
+                  {formData.api_keys.openrouter ? 'Configured' : 'No key'}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => handleProviderToggle('openrouter')}
+                  role="switch"
+                  aria-checked={!!formData.models.providers.openrouter}
+                  aria-label={`${formData.models.providers.openrouter ? 'Disable' : 'Enable'} OpenRouter`}
+                  className={`w-8 h-4.5 rounded-full relative transition-colors ${
+                    formData.models.providers.openrouter ? 'bg-primary' : 'bg-muted'
+                  }`}
+                >
+                  <span className={`absolute top-0.5 size-3.5 bg-white rounded-full transition-all ${
+                    formData.models.providers.openrouter ? 'right-0.5' : 'left-0.5'
+                  }`} />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setExpandedProviders(prev => ({ ...prev, openrouter: !prev.openrouter }))}
+                  className="p-1 text-muted-foreground hover:text-foreground transition-colors rounded"
+                  aria-expanded={expandedProviders.openrouter || false}
+                  aria-label={`${expandedProviders.openrouter ? 'Collapse' : 'Expand'} OpenRouter details`}
+                >
+                  <ChevronDown className={`w-3.5 h-3.5 transition-transform ${expandedProviders.openrouter ? '' : '-rotate-90'}`} />
+                </button>
+              </div>
+            </div>
+            {expandedProviders.openrouter && (
+              <div className="px-3 pb-3 pt-0 ml-7">
+                <OpenRouterPage
+                  apiKey={formData.api_keys.openrouter}
+                  enabled={!!formData.models.providers.openrouter}
+                  onApiKeyChange={(key) => handleApiKeyChange('openrouter', key)}
+                  onToggleEnabled={() => handleProviderToggle('openrouter')}
+                  onApiKeySaved={(savedKey) => {
+                    setFormData(prev => prev ? {
+                      ...prev,
+                      api_keys: { ...prev.api_keys, openrouter: savedKey },
+                    } : prev);
+                  }}
+                />
+              </div>
+            )}
+          </div>
         </div>
       </section>
 
-      {/* OpenRouter */}
-      <section className="mb-12">
-        <h2 className="text-foreground text-2xl font-bold mb-6 flex items-center gap-3">
-          OpenRouter
-          <div className="h-px flex-1 bg-divider-strong" />
-        </h2>
-        <OpenRouterPage
-          apiKey={formData.api_keys.openrouter}
-          enabled={!!formData.models.providers.openrouter}
-          onApiKeyChange={(key) => handleApiKeyChange('openrouter', key)}
-          onToggleEnabled={() => handleProviderToggle('openrouter')}
-          onApiKeySaved={(savedKey) => {
-            // OpenRouterPage already persisted the key — just sync local form state
-            setFormData(prev => prev ? {
-              ...prev,
-              api_keys: { ...prev.api_keys, openrouter: savedKey },
-            } : prev);
-          }}
-        />
-      </section>
-
       {/* Conversations */}
-      <section id="conversations" className="mb-12 scroll-mt-4">
-        <h2 className="text-foreground text-2xl font-bold mb-6 flex items-center gap-3">
+      <section id="conversations" className="py-6 scroll-mt-4">
+        <h2 className="text-foreground text-base font-semibold tracking-tight mb-4">
           Conversations
-          <div className="h-px flex-1 bg-divider-strong" />
         </h2>
-        <p className="text-muted-foreground text-sm mb-6">
-          Control how Panopticon handles compaction for dashboard-owned resume flows and for typed <code>/compact</code> commands in the conversation composer.
-        </p>
-
-        <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
-          <div className="bg-card border border-border rounded-xl p-5 space-y-4">
-            <div>
-              <h3 className="font-bold text-foreground">Compaction &amp; summary model</h3>
-              <p className="text-sm text-muted-foreground mt-1">
-                Used for native conversation compaction and as the default summary model when forking conversations. Does not affect Claude Code&apos;s built-in <code>/compact</code>.
-              </p>
+        <div className="space-y-1">
+          {/* Compaction model */}
+          <div className="flex items-center justify-between gap-4 px-4 py-3 rounded-lg hover:bg-muted/30 transition-colors">
+            <div className="min-w-0">
+              <span className="text-sm font-medium text-foreground">Compaction model</span>
+              <p className="text-xs text-muted-foreground mt-0.5">Used for native compaction and fork summaries</p>
             </div>
             <select
               value={formData.conversations?.compaction_model || 'claude-haiku-4-5'}
               onChange={(e) => handleCompactionModelChange(e.target.value as ModelId)}
-              className="w-full bg-background border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+              className="bg-background border border-border rounded-md px-2 py-1.5 text-xs text-foreground focus:ring-1 focus:ring-primary max-w-[200px]"
             >
               {Object.entries(MODELS_BY_PROVIDER).flatMap(([, providerDef]) =>
                 providerDef.models.map((model) => (
@@ -1123,22 +1090,18 @@ export function SettingsPage() {
                 </option>
               ))}
             </select>
-            <p className="text-xs text-muted-foreground">
-              Default: Claude Haiku 4.5 for fast, low-cost compaction.
-            </p>
           </div>
 
-          <div className="bg-card border border-border rounded-xl p-5 space-y-4">
-            <div>
-              <h3 className="font-bold text-foreground">AI title generation model</h3>
-              <p className="text-sm text-muted-foreground mt-1">
-                Used to generate conversation titles from the first message. Falls back to message truncation if the model is unavailable.
-              </p>
+          {/* Title model */}
+          <div className="flex items-center justify-between gap-4 px-4 py-3 rounded-lg hover:bg-muted/30 transition-colors">
+            <div className="min-w-0">
+              <span className="text-sm font-medium text-foreground">Title generation model</span>
+              <p className="text-xs text-muted-foreground mt-0.5">Generates conversation titles from first message</p>
             </div>
             <select
               value={formData.conversations?.title_model || 'claude-haiku-4-5'}
               onChange={(e) => handleTitleModelChange(e.target.value as ModelId)}
-              className="w-full bg-background border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+              className="bg-background border border-border rounded-md px-2 py-1.5 text-xs text-foreground focus:ring-1 focus:ring-primary max-w-[200px]"
             >
               {Object.entries(MODELS_BY_PROVIDER).flatMap(([, providerDef]) =>
                 providerDef.models.map((model) => (
@@ -1153,238 +1116,131 @@ export function SettingsPage() {
                 </option>
               ))}
             </select>
-            <p className="text-xs text-muted-foreground">
-              Default: Claude Haiku 4.5 for fast, low-cost title generation.
-            </p>
           </div>
 
-          <div className="bg-card border border-border rounded-xl p-5 space-y-4">
-            <div>
-              <h3 className="font-bold text-foreground">Typed /compact handling</h3>
-              <p className="text-sm text-muted-foreground mt-1">
-                Choose whether a user-typed <code>/compact</code> is passed through to Claude Code or intercepted and handled by Panopticon-native compaction.
+          {/* /compact handling */}
+          <div className="flex items-center justify-between gap-4 px-4 py-3 rounded-lg hover:bg-muted/30 transition-colors">
+            <div className="min-w-0">
+              <span className="text-sm font-medium text-foreground">/compact handling</span>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {(formData.conversations?.manual_compact_mode || 'claude-code') === 'claude-code'
+                  ? 'Pass through to Claude Code'
+                  : 'Panopticon-native compaction'}
               </p>
             </div>
-            <div className="grid grid-cols-1 gap-3">
-              <button
-                type="button"
-                onClick={() => handleManualCompactModeChange('claude-code')}
-                className={`text-left rounded-xl border p-4 transition-colors ${
-                  (formData.conversations?.manual_compact_mode || 'claude-code') === 'claude-code'
-                    ? 'border-blue-500 bg-blue-500/10'
-                    : 'border-border bg-card hover:border-border'
-                }`}
-              >
-                <div className="flex items-center justify-between gap-4 mb-2">
-                  <div>
-                    <div className="font-bold text-foreground">Pass through to Claude Code</div>
-                    <div className="text-xs text-muted-foreground font-mono">Default</div>
-                  </div>
-                  {(formData.conversations?.manual_compact_mode || 'claude-code') === 'claude-code' && (
-                    <div className="text-blue-400 text-xs font-semibold">Selected</div>
-                  )}
-                </div>
-                <p className="text-sm text-muted-foreground">
-                  Preserve today&apos;s behavior: sending <code>/compact</code> directly to the Claude Code session.
-                </p>
-              </button>
-
-              <button
-                type="button"
-                onClick={() => handleManualCompactModeChange('panopticon-native')}
-                className={`text-left rounded-xl border p-4 transition-colors ${
-                  formData.conversations?.manual_compact_mode === 'panopticon-native'
-                    ? 'border-emerald-500 bg-emerald-500/10'
-                    : 'border-border bg-card hover:border-border'
-                }`}
-              >
-                <div className="flex items-center justify-between gap-4 mb-2">
-                  <div>
-                    <div className="font-bold text-foreground">Use Panopticon-native compaction</div>
-                    <div className="text-xs text-muted-foreground font-mono">Opt-in override</div>
-                  </div>
-                  {formData.conversations?.manual_compact_mode === 'panopticon-native' && (
-                    <div className="text-emerald-400 text-xs font-semibold">Selected</div>
-                  )}
-                </div>
-                <p className="text-sm text-muted-foreground">
-                  Intercept typed <code>/compact</code> in the dashboard and run Panopticon&apos;s native compaction instead of Claude Code&apos;s built-in command.
-                </p>
-              </button>
-            </div>
+            <select
+              value={formData.conversations?.manual_compact_mode || 'claude-code'}
+              onChange={(e) => handleManualCompactModeChange(e.target.value as 'claude-code' | 'panopticon-native')}
+              className="bg-background border border-border rounded-md px-2 py-1.5 text-xs text-foreground focus:ring-1 focus:ring-primary"
+            >
+              <option value="claude-code">Pass through</option>
+              <option value="panopticon-native">Native compaction</option>
+            </select>
           </div>
 
-          <div className="bg-card border border-border rounded-xl p-5 space-y-4">
-            <div>
-              <h3 className="font-bold text-foreground">Richer compaction / forking summaries</h3>
-              <p className="text-sm text-muted-foreground mt-1">
-                Use a more verbose 9-section summary format instead of the default 6-section format. Includes all user messages and fuller code snippets.
+          {/* Rich compaction */}
+          <div className="flex items-center justify-between gap-4 px-4 py-3 rounded-lg hover:bg-muted/30 transition-colors">
+            <div className="min-w-0">
+              <span className="text-sm font-medium text-foreground">Rich summaries</span>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                9-section verbose format (higher token usage)
               </p>
             </div>
-            <div className="flex items-center justify-between gap-4">
-              <div className="text-sm text-foreground">
-                <span className={formData.conversations?.rich_compaction ? 'text-foreground' : 'text-muted-foreground'}>
-                  {formData.conversations?.rich_compaction ? 'Enabled' : 'Disabled'}
-                </span>
-                <span className="text-xs text-muted-foreground ml-2">(default: on)</span>
-              </div>
-              <button
-                type="button"
-                onClick={() => handleRichCompactionChange(!formData.conversations?.rich_compaction)}
-                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${
-                  formData.conversations?.rich_compaction ? 'bg-blue-500' : 'bg-gray-400'
-                }`}
-              >
-                <span
-                  className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                    formData.conversations?.rich_compaction ? 'translate-x-6' : 'translate-x-1'
-                  }`}
-                />
-              </button>
-            </div>
-            <div className="rounded-lg bg-amber-500/10 border border-amber-500/20 p-3">
-              <p className="text-xs text-amber-400 flex items-start gap-2">
-                <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
-                <span>
-                  Higher token usage per summary. Less efficient incremental updates. May hit the context window sooner, requiring more frequent compaction.
-                </span>
-              </p>
-            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={!!formData.conversations?.rich_compaction}
+              aria-label="Toggle rich compaction summaries"
+              onClick={() => handleRichCompactionChange(!formData.conversations?.rich_compaction)}
+              className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
+                formData.conversations?.rich_compaction ? 'bg-primary' : 'bg-muted'
+              }`}
+            >
+              <span className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${
+                formData.conversations?.rich_compaction ? 'translate-x-[18px]' : 'translate-x-[3px]'
+              }`} />
+            </button>
           </div>
         </div>
       </section>
 
       {/* Terminal */}
-      <section id="tmux" className="mb-12 scroll-mt-4">
-        <h2 className="text-foreground text-2xl font-bold mb-6 flex items-center gap-3">
+      <section id="terminal" className="py-6 scroll-mt-4">
+        <h2 className="text-foreground text-base font-semibold tracking-tight mb-4">
           Terminal
-          <div className="h-px flex-1 bg-divider-strong" />
         </h2>
-        <p className="text-muted-foreground text-sm mb-6">
-          Control whether Panopticon launches tmux in its own managed server with a Panopticon-owned config, or intentionally inherits your user tmux config.
-        </p>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <button
-            type="button"
-            onClick={() => handleTmuxConfigModeChange('managed')}
-            className={`text-left rounded-xl border p-5 transition-colors ${
-              (formData.tmux?.config_mode || 'managed') === 'managed'
-                ? 'border-blue-500 bg-blue-500/10'
-                : 'border-border bg-card hover:border-border'
-            }`}
-          >
-            <div className="flex items-center justify-between gap-4 mb-2">
-              <div>
-                <div className="font-bold text-foreground">Managed tmux</div>
-                <div className="text-xs text-muted-foreground font-mono">Default</div>
-              </div>
-              {(formData.tmux?.config_mode || 'managed') === 'managed' && (
-                <div className="text-blue-400 text-xs font-semibold">Selected</div>
-              )}
+        <div className="space-y-1">
+          <div className="flex items-center justify-between gap-4 px-4 py-3 rounded-lg hover:bg-muted/30 transition-colors">
+            <div className="min-w-0">
+              <span className="text-sm font-medium text-foreground">tmux configuration</span>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {(formData.tmux?.config_mode || 'managed') === 'managed'
+                  ? 'Using Panopticon-managed tmux socket and config'
+                  : 'Inheriting your user tmux configuration'}
+              </p>
             </div>
-            <p className="text-sm text-muted-foreground">
-              Use Panopticon&apos;s own tmux socket and config file. This avoids depending on your dotfiles while preserving Panopticon&apos;s required mouse behavior.
-            </p>
-          </button>
-
-          <button
-            type="button"
-            onClick={() => handleTmuxConfigModeChange('inherit-user')}
-            className={`text-left rounded-xl border p-5 transition-colors ${
-              formData.tmux?.config_mode === 'inherit-user'
-                ? 'border-amber-500 bg-amber-500/10'
-                : 'border-border bg-card hover:border-border'
-            }`}
-          >
-            <div className="flex items-center justify-between gap-4 mb-2">
-              <div>
-                <div className="font-bold text-foreground">Inherit user tmux</div>
-                <div className="text-xs text-muted-foreground font-mono">Advanced opt-out</div>
-              </div>
-              {formData.tmux?.config_mode === 'inherit-user' && (
-                <div className="text-amber-400 text-xs font-semibold">Selected</div>
-              )}
-            </div>
-            <p className="text-sm text-muted-foreground">
-              Use your existing tmux server/config behavior instead of Panopticon-managed tmux. Choose this only if you specifically want Panopticon to follow your personal tmux setup.
-            </p>
-          </button>
+            <select
+              value={formData.tmux?.config_mode || 'managed'}
+              onChange={(e) => handleTmuxConfigModeChange(e.target.value as 'managed' | 'inherit-user')}
+              className="bg-background border border-border rounded-md px-2 py-1.5 text-xs text-foreground focus:ring-1 focus:ring-primary"
+            >
+              <option value="managed">Managed</option>
+              <option value="inherit-user">Inherit user</option>
+            </select>
+          </div>
         </div>
       </section>
 
-      {/* Tracker API Keys */}
-      <section className="mb-12">
-        <h2 className="text-foreground text-2xl font-bold mb-6 flex items-center gap-3">
-          Tracker API Keys
-          <div className="h-px flex-1 bg-divider-strong" />
+      {/* Tracker Keys */}
+      <section id="tracker-keys" className="py-6 scroll-mt-4">
+        <h2 className="text-foreground text-base font-semibold tracking-tight mb-4">
+          Tracker Keys
         </h2>
-        <p className="text-muted-foreground text-sm mb-6">
-          Configure API keys for your issue trackers. These override environment variables ({TRACKERS.map(t => t.envVar).join(', ')}).
+        <p className="text-xs text-muted-foreground mb-3">
+          Override environment variables ({TRACKERS.map(t => t.envVar).join(', ')}).
         </p>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        <div className="space-y-1">
           {TRACKERS.map((tracker) => {
             const trackerKey = formData.tracker_keys?.[tracker.id] || '';
 
             return (
-              <div
-                key={tracker.id}
-                className="bg-card border border-border rounded-xl p-5 relative transition-colors shadow-sm hover:border-border"
-              >
-                <div className="flex items-center gap-3 mb-5">
-                  <div className="size-10 rounded-lg bg-card border border-border flex items-center justify-center">
-                    <tracker.icon className="w-5 h-5 text-muted-foreground" />
+              <div key={tracker.id} className="flex items-center gap-3 px-4 py-3 rounded-lg hover:bg-muted/30 transition-colors">
+                <tracker.icon className="w-4 h-4 text-muted-foreground shrink-0" />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-foreground">{tracker.name}</span>
+                    <span className="text-[10px] text-muted-foreground font-mono">{tracker.envVar}</span>
                   </div>
-                  <div>
-                    <span className="font-bold text-foreground">{tracker.name}</span>
-                    <p className="text-[10px] text-muted-foreground font-mono">{tracker.envVar}</p>
-                  </div>
+                  {trackerKey.startsWith('$') && (
+                    <p className="text-[10px] text-warning mt-0.5">
+                      Configured via env: <code className="font-mono">{trackerKey}</code>
+                    </p>
+                  )}
                 </div>
-                <div className="space-y-3">
-                  <div className="relative">
-                    <label className="text-[10px] uppercase font-bold text-muted-foreground mb-1 block">API Key / Token</label>
-                    {trackerKey.startsWith('$') ? (
-                      <div className="badge-bg-warning border badge-border-warning rounded-lg px-3 py-2">
-                        <div className="flex items-center gap-2 text-warning text-xs">
-                          <AlertTriangle className="w-4 h-4" />
-                          <span>Configured via <code className="font-mono bg-popover px-1 rounded">{trackerKey}</code></span>
-                        </div>
-                        <input
-                          type="text"
-                          placeholder={tracker.placeholder}
-                          onChange={(e) => handleTrackerKeyChange(tracker.id, e.target.value)}
-                          autoComplete="off"
-                          className="w-full bg-background border border-border rounded-lg px-3 py-2 text-xs font-mono mt-2 focus:ring-1 focus:ring-primary focus:border-primary text-foreground"
-                        />
-                      </div>
-                    ) : (
-                      <div className="relative">
-                        <input
-                          type={showTrackerKey[tracker.id] ? 'text' : 'password'}
-                          value={trackerKey}
-                          onChange={(e) => handleTrackerKeyChange(tracker.id, e.target.value)}
-                          placeholder={tracker.placeholder}
-                          autoComplete="off"
-                          autoCorrect="off"
-                          autoCapitalize="off"
-                          spellCheck={false}
-                          data-lpignore="true"
-                          data-1p-ignore="true"
-                          data-form-type="other"
-                          className="w-full bg-background border border-border rounded-lg px-3 py-2 pr-10 text-xs font-mono focus:ring-1 focus:ring-primary focus:border-primary text-foreground"
-                        />
-                        <button
-                          onClick={() => setShowTrackerKey({ ...showTrackerKey, [tracker.id]: !showTrackerKey[tracker.id] })}
-                          className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                        >
-                          {showTrackerKey[tracker.id] ? (
-                            <Eye className="w-4 h-4" />
-                          ) : (
-                            <Eye className="w-4 h-4 opacity-50" />
-                          )}
-                        </button>
-                      </div>
-                    )}
-                  </div>
+                <div className="relative w-[200px] shrink-0">
+                  <input
+                    type={showTrackerKey[tracker.id] ? 'text' : 'password'}
+                    value={trackerKey.startsWith('$') ? '' : trackerKey}
+                    onChange={(e) => handleTrackerKeyChange(tracker.id, e.target.value)}
+                    placeholder={trackerKey.startsWith('$') ? 'Override env value...' : tracker.placeholder}
+                    autoComplete="off"
+                    autoCorrect="off"
+                    autoCapitalize="off"
+                    spellCheck={false}
+                    data-lpignore="true"
+                    data-1p-ignore="true"
+                    data-form-type="other"
+                    className="w-full bg-background border border-border rounded-md px-2.5 py-1.5 pr-8 text-xs font-mono focus:ring-1 focus:ring-primary focus:border-primary text-foreground"
+                  />
+                  {(trackerKey && !trackerKey.startsWith('$')) && (
+                    <button
+                      onClick={() => setShowTrackerKey({ ...showTrackerKey, [tracker.id]: !showTrackerKey[tracker.id] })}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                      aria-label={showTrackerKey[tracker.id] ? 'Hide key' : 'Show key'}
+                    >
+                      <Eye className="w-3.5 h-3.5" />
+                    </button>
+                  )}
                 </div>
               </div>
             );
@@ -1392,171 +1248,46 @@ export function SettingsPage() {
         </div>
       </section>
 
-      {/* Agent Configuration by Category */}
-      <section id="model-assignments" className="mb-12 scroll-mt-4">
-        <h2 className="text-foreground text-2xl font-bold mb-2 flex items-center gap-3">
-          Model Assignments
-          <div className="h-px flex-1 bg-divider-strong" />
-        </h2>
-        <p className="text-muted-foreground text-sm mb-5 leading-relaxed">
-          Assign models to specific <strong className="text-foreground">work types</strong> — the internal routing identifiers that Panopticon uses to resolve which model an agent or workflow step should use. Click any card to change its model.
-        </p>
-
-        <div className="space-y-8">
-          {AGENT_CATEGORIES.map((category) => (
-            <div key={category.name}>
-              <div className="flex items-center gap-2 mb-4">
-                <category.icon className="w-5 h-5 text-muted-foreground" />
-                <h3 className="text-foreground font-semibold text-sm uppercase tracking-wider">{category.name}</h3>
-                <div className="h-px flex-1 bg-divider" />
-              </div>
-
-              <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
-                {category.agents.map((agent) => {
-                  const currentModelId = getEffectiveModelId(agent.id, formData.models.overrides);
-                  const modelDisplay = getModelDisplay(currentModelId);
-                  const { score, matched, missing } = getCapabilityMatchScore(currentModelId, agent.id);
-                  const requiredCaps = WORK_TYPE_CAPABILITIES[agent.id] || [];
-
-                  // Check if this model is deprecated
-                  const isDeprecated = formData.deprecation_warnings?.some(
-                    (w) => w.workType === agent.id && w.from === currentModelId
-                  );
-
-                  // Determine fit quality (poor fit is implicit else case)
-                  const isGoodFit = score >= 1 && !isDeprecated;
-                  const isOkFit = score >= 0.5 && score < 1 && !isDeprecated;
-
-                  // Build hover text
-                  const hoverText = [
-                    `${agent.name}: ${agent.description}`,
-                    !agent.implemented ? '⚠️ NOT YET IMPLEMENTED' : '',
-                    `Model: ${modelDisplay}`,
-                    isDeprecated ? '⚠️ DEPRECATED: Click to update to current model' : '',
-                    `Needs: ${requiredCaps.map(c => CAPABILITY_INFO[c].name).join(', ')}`,
-                    matched.length > 0 ? `✓ Has: ${matched.map(c => CAPABILITY_INFO[c].name).join(', ')}` : '',
-                    missing.length > 0 ? `✗ Missing: ${missing.map(c => CAPABILITY_INFO[c].name).join(', ')}` : '',
-                  ].filter(Boolean).join('\n');
-
-                  return (
-                    <div
-                      key={agent.id}
-                      onClick={() => agent.implemented && setModalWorkType(agent.id)}
-                      title={hoverText}
-                      className={`p-3 border rounded-lg transition-all group relative ${
-                        !agent.implemented
-                          ? 'opacity-50 bg-card border-border cursor-not-allowed'
-                          : `cursor-pointer ${
-                            isDeprecated
-                              ? 'badge-bg-warning border-warning/50 hover:border-warning/70 hover:bg-warning/15'
-                              : isGoodFit
-                                ? 'badge-bg-success border-success/30 hover:border-success/50 hover:bg-success/10'
-                                : isOkFit
-                                  ? 'badge-bg-warning border-warning/30 hover:border-warning/50 hover:bg-warning/10'
-                                  : 'badge-bg-destructive border-destructive/30 hover:border-destructive/50 hover:bg-destructive/10'
-                            }`
-                      }`}
-                    >
-                      {isDeprecated && (
-                        <div className="absolute top-1 right-1">
-                          <span className="bg-warning text-foreground text-[8px] font-black px-1 py-0.5 rounded uppercase tracking-tighter">
-                            DEPRECATED
-                          </span>
-                        </div>
-                      )}
-                      {!agent.implemented && (
-                        <div className="absolute top-1 right-1">
-                          <span className="bg-muted-foreground text-foreground text-[8px] font-black px-1 py-0.5 rounded uppercase tracking-tighter">
-                            NOT YET IMPLEMENTED
-                          </span>
-                        </div>
-                      )}
-                      <div className="flex items-center justify-between mb-2">
-                        <agent.icon className={`w-4 h-4 ${
-                          isDeprecated ? 'text-warning' : isGoodFit ? 'text-success' : isOkFit ? 'text-warning' : 'text-destructive'
-                        }`} />
-                        {agent.implemented && (
-                          <span className={`text-[9px] font-bold ${
-                            isDeprecated ? 'text-warning' : isGoodFit ? 'text-success' : isOkFit ? 'text-warning' : 'text-destructive'
-                          }`}>
-                            {Math.round(score * 100)}%
-                          </span>
-                        )}
-                      </div>
-                      <p className="text-xs font-semibold text-foreground truncate">{agent.name}</p>
-                      {agent.implemented && <p className="text-[10px] text-muted-foreground truncate mb-2">{modelDisplay}</p>}
-
-                      {/* Capability indicators */}
-                      <div className="flex gap-1 flex-wrap">
-                        {requiredCaps.slice(0, 3).map((cap: Capability) => {
-                          const hasIt = matched.includes(cap);
-                          return (
-                            <span
-                              key={cap}
-                              title={`${CAPABILITY_INFO[cap].name}: ${hasIt ? 'Model has this' : 'Model missing this'}`}
-                              className={`text-[8px] px-1 py-0.5 rounded ${
-                                hasIt
-                                  ? 'badge-bg-success text-success-foreground'
-                                  : 'badge-bg-destructive text-destructive-foreground'
-                              }`}
-                            >
-                              {CAPABILITY_INFO[cap].name}
-                            </span>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          ))}
-        </div>
-      </section>
-
       {/* Appearance */}
-      <section className="mb-12">
-        <h2 className="text-foreground text-2xl font-bold mb-6 flex items-center gap-3">
-          <Eye className="w-6 h-6 text-primary" />
+      <section id="appearance" className="py-6 scroll-mt-4">
+        <h2 className="text-foreground text-base font-semibold tracking-tight mb-4">
           Appearance
         </h2>
-        <div className="bg-card border border-border rounded-xl overflow-hidden">
-          <div className="flex items-center justify-between px-5 py-4">
-            <div>
-              <h3 className="text-sm font-bold text-foreground flex items-center gap-2">
-                <GitMerge className="w-4 h-4 text-success" />
-                Ready to Merge shimmer
-              </h3>
-              <p className="text-xs text-muted-foreground mt-1">
-                Animate the "READY TO MERGE" badge with a subtle shimmer to draw attention to cards awaiting your merge approval.
+        <div className="space-y-1">
+          <div className="flex items-center justify-between gap-4 px-4 py-3 rounded-lg hover:bg-muted/30 transition-colors">
+            <div className="min-w-0">
+              <span className="text-sm font-medium text-foreground">Ready to Merge shimmer</span>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Animate the badge with a subtle shimmer for cards awaiting merge approval
               </p>
             </div>
             <button
+              type="button"
               role="switch"
               aria-checked={uiPrefs.readyToMergeShimmer}
+              aria-label="Toggle Ready to Merge shimmer"
               onClick={() => updateUIPrefs({ readyToMergeShimmer: !uiPrefs.readyToMergeShimmer })}
-              className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${uiPrefs.readyToMergeShimmer ? 'bg-primary' : 'bg-input'}`}
+              className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
+                uiPrefs.readyToMergeShimmer ? 'bg-primary' : 'bg-muted'
+              }`}
             >
-              <span
-                className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-150 ${uiPrefs.readyToMergeShimmer ? 'translate-x-5' : 'translate-x-0'}`}
-              />
+              <span className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${
+                uiPrefs.readyToMergeShimmer ? 'translate-x-[18px]' : 'translate-x-[3px]'
+              }`} />
             </button>
           </div>
         </div>
       </section>
 
       {/* Maintenance */}
-      <section className="space-y-3 pb-20">
-        <h2 className="text-xl font-black text-foreground">Maintenance</h2>
-        <div className="bg-card rounded-xl border border-border p-5">
-          <div className="flex items-center justify-between">
-            <div>
-              <h3 className="text-sm font-bold text-foreground flex items-center gap-2">
-                <Trash2 className="w-4 h-4 text-muted-foreground" />
-                Issue Cache
-              </h3>
-              <p className="text-xs text-muted-foreground mt-1">
-                Clear cached issue data and re-fetch from all trackers. Use this if issue identifiers or data appear stale.
+      <section id="maintenance" className="py-6 scroll-mt-4">
+        <h2 className="text-foreground text-base font-semibold tracking-tight mb-4">Maintenance</h2>
+        <div className="space-y-1">
+          <div className="flex items-center justify-between gap-4 px-4 py-3 rounded-lg hover:bg-muted/30 transition-colors">
+            <div className="min-w-0">
+              <span className="text-sm font-medium text-foreground">Issue cache</span>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Clear cached issue data and re-fetch from all trackers
               </p>
             </div>
             <button
@@ -1574,17 +1305,19 @@ export function SettingsPage() {
                 }
               }}
               disabled={clearingCache}
-              className="px-4 py-2 text-sm font-semibold rounded-lg border border-border hover:border-warning/50 hover:bg-warning/10 text-muted-foreground hover:text-warning transition-all flex items-center gap-2 disabled:opacity-50"
+              className="px-3 py-1.5 text-xs font-medium rounded-md border border-border hover:border-warning/50 hover:bg-warning/10 text-muted-foreground hover:text-warning transition-all flex items-center gap-1.5 disabled:opacity-50"
             >
-              {clearingCache ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
+              {clearingCache ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <RefreshCw className="w-3.5 h-3.5" />}
               {clearingCache ? 'Clearing...' : 'Clear & Refresh'}
             </button>
           </div>
         </div>
       </section>
 
-
-      </div>{/* end max-w content */}
+      {/* Desktop App settings — shown only inside Electron */}
+      <div id="desktop" className="py-6 scroll-mt-4">
+        <DesktopSettingsSection />
+      </div>
 
       {/* Model Override Modal */}
       {modalWorkType && (
@@ -1742,40 +1475,27 @@ export function SettingsPage() {
         </div>
       )}
 
-      {/* Desktop App settings — shown only inside Electron */}
-      <DesktopSettingsSection />
-
       {/* Experimental — research-preview features, must remain the LAST section on the page */}
       <section
+        id="experimental"
         data-testid="experimental-section"
         aria-label="Experimental"
-        className="space-y-3 pb-20 border-t-2 border-amber-500/40 pt-8 mt-4"
+        className="py-6 scroll-mt-4 border-t border-warning/30 mt-4"
       >
-        <h2 className="text-xl font-black text-amber-400 flex items-center gap-2">
-          <Beaker className="w-5 h-5" />
+        <h2 className="text-foreground text-base font-semibold tracking-tight mb-4 flex items-center gap-2">
+          <Beaker className="w-4 h-4 text-warning" />
           Experimental
         </h2>
-        <p className="text-sm text-muted-foreground">
-          Research-preview features that may break, change, or be removed without notice. Use at your own risk.
+        <p className="text-xs text-muted-foreground mb-3">
+          Research-preview features that may change or be removed without notice.
         </p>
-
-        <div className="bg-card border border-amber-500/30 rounded-xl p-5 space-y-4">
-          <div className="flex items-start justify-between gap-4">
-            <div className="flex-1">
-              <h3 className="font-bold text-foreground">
-                Use Claude Code Channels for prompt delivery (work agents only)
-              </h3>
-              <p className="text-sm text-muted-foreground mt-1">
-                Routes prompts via a stdio MCP bridge instead of tmux send-keys. Requires Claude Code with claude.ai or Console API auth. Does not apply to Codex, Cursor, Gemini, or Bedrock/Vertex/Foundry runtimes; those continue using tmux. Triggers a confirmation dialog at agent startup that Panopticon dismisses automatically.
+        <div className="space-y-1">
+          <div className="flex items-center justify-between gap-4 px-4 py-3 rounded-lg hover:bg-muted/30 transition-colors">
+            <div className="min-w-0">
+              <span className="text-sm font-medium text-foreground">Claude Code Channels</span>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Route prompts via stdio MCP bridge instead of tmux send-keys (work agents only)
               </p>
-              <a
-                href="https://code.claude.com/docs/en/channels"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs text-amber-400 hover:text-amber-300 underline mt-2 inline-block"
-              >
-                Channels documentation →
-              </a>
             </div>
             <button
               type="button"
@@ -1785,19 +1505,18 @@ export function SettingsPage() {
               data-testid="experimental-claude-code-channels-toggle"
               onClick={() => handleClaudeCodeChannelsToggle(!formData.experimental?.claudeCodeChannels)}
               disabled={saveMutation.isPending}
-              className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 disabled:opacity-50 ${
-                formData.experimental?.claudeCodeChannels ? 'bg-amber-500' : 'bg-gray-400'
+              className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:opacity-50 ${
+                formData.experimental?.claudeCodeChannels ? 'bg-primary' : 'bg-muted'
               }`}
             >
-              <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                  formData.experimental?.claudeCodeChannels ? 'translate-x-6' : 'translate-x-1'
-                }`}
-              />
+              <span className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${
+                formData.experimental?.claudeCodeChannels ? 'translate-x-[18px]' : 'translate-x-[3px]'
+              }`} />
             </button>
           </div>
         </div>
       </section>
-    </div>
+
+    </SettingsLayout>
   );
 }

--- a/src/dashboard/frontend/src/components/Settings/primitives/SettingsCardSection.tsx
+++ b/src/dashboard/frontend/src/components/Settings/primitives/SettingsCardSection.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+import { cn } from '../../../lib/utils';
+
+export interface SettingsCardSectionProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function SettingsCardSection({ children, className }: SettingsCardSectionProps) {
+  return (
+    <div className={cn('bg-card border border-border rounded-lg p-4', className)}>
+      {children}
+    </div>
+  );
+}

--- a/src/dashboard/frontend/src/components/Settings/primitives/SettingsLayout.tsx
+++ b/src/dashboard/frontend/src/components/Settings/primitives/SettingsLayout.tsx
@@ -1,0 +1,93 @@
+import type { ReactNode } from 'react';
+import { cn } from '../../../lib/utils';
+
+export interface SettingsLayoutProps {
+  sidebar: ReactNode;
+  children: ReactNode;
+  header: ReactNode;
+}
+
+export function SettingsLayout({ sidebar, children, header }: SettingsLayoutProps) {
+  return (
+    <div className="flex flex-col h-full">
+      {header}
+      <div className="flex-1 flex overflow-hidden">
+        <aside className="w-48 shrink-0 border-r border-border overflow-y-auto py-4 px-2 hidden md:block">
+          {sidebar}
+        </aside>
+        <main className="flex-1 overflow-y-auto">
+          <div className="max-w-[800px] mx-auto px-6 md:px-10 py-6">
+            {children}
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+export interface SettingsHeaderProps {
+  title: string;
+  hasChanges: boolean;
+  saving: boolean;
+  saveSuccess: boolean;
+  saveError: boolean;
+  onSave: () => void;
+  onReset: () => void;
+  actions?: ReactNode;
+}
+
+export function SettingsHeader({
+  title,
+  hasChanges,
+  saving,
+  saveSuccess,
+  saveError,
+  onSave,
+  onReset,
+  actions,
+}: SettingsHeaderProps) {
+  return (
+    <div className="sticky top-0 z-30 bg-card/95 backdrop-blur-sm border-b border-border">
+      <div className="flex items-center justify-between px-6 py-3">
+        <h1 className="text-foreground text-lg font-semibold tracking-tight">
+          {title}
+        </h1>
+        <div className="flex items-center gap-3">
+          {saveSuccess && (
+            <span className="text-success text-xs font-medium">Saved</span>
+          )}
+          {saveError && (
+            <span className="text-destructive text-xs font-medium">Save failed</span>
+          )}
+          {actions}
+          <button
+            type="button"
+            onClick={onReset}
+            disabled={!hasChanges}
+            className={cn(
+              'px-3 py-1.5 text-sm font-medium rounded-md transition-colors',
+              hasChanges
+                ? 'text-muted-foreground hover:text-foreground'
+                : 'text-muted-foreground/40 cursor-not-allowed'
+            )}
+          >
+            Reset
+          </button>
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={!hasChanges || saving}
+            className={cn(
+              'px-4 py-1.5 text-sm font-medium rounded-md transition-colors',
+              hasChanges && !saving
+                ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+                : 'bg-muted text-muted-foreground cursor-not-allowed'
+            )}
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/dashboard/frontend/src/components/Settings/primitives/SettingsRow.tsx
+++ b/src/dashboard/frontend/src/components/Settings/primitives/SettingsRow.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from 'react';
+import { cn } from '../../../lib/utils';
+
+export interface SettingsRowProps {
+  label: string;
+  description?: string;
+  children: ReactNode;
+  status?: ReactNode;
+  vertical?: boolean;
+  className?: string;
+}
+
+export function SettingsRow({
+  label,
+  description,
+  children,
+  status,
+  vertical = false,
+  className,
+}: SettingsRowProps) {
+  return (
+    <div
+      className={cn(
+        'flex gap-4 px-4 py-3 rounded-lg border border-transparent hover:border-border hover:bg-card/50 transition-colors',
+        vertical ? 'flex-col' : 'items-center justify-between',
+        className
+      )}
+    >
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-foreground text-sm font-medium">{label}</span>
+          {status}
+        </div>
+        {description && (
+          <p className="text-muted-foreground text-xs mt-0.5">{description}</p>
+        )}
+      </div>
+      <div className={cn('flex items-center gap-2 shrink-0', vertical && 'w-full')}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/dashboard/frontend/src/components/Settings/primitives/SettingsRowStatus.tsx
+++ b/src/dashboard/frontend/src/components/Settings/primitives/SettingsRowStatus.tsx
@@ -1,0 +1,28 @@
+import { cn } from '../../../lib/utils';
+
+export type StatusVariant = 'success' | 'warning' | 'error' | 'neutral';
+
+export interface SettingsRowStatusProps {
+  variant: StatusVariant;
+  label: string;
+}
+
+const variantStyles: Record<StatusVariant, string> = {
+  success: 'bg-success/15 text-success border-success/25',
+  warning: 'bg-warning/15 text-warning border-warning/25',
+  error: 'bg-destructive/15 text-destructive border-destructive/25',
+  neutral: 'bg-muted text-muted-foreground border-border',
+};
+
+export function SettingsRowStatus({ variant, label }: SettingsRowStatusProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border',
+        variantStyles[variant]
+      )}
+    >
+      {label}
+    </span>
+  );
+}

--- a/src/dashboard/frontend/src/components/Settings/primitives/SettingsSection.tsx
+++ b/src/dashboard/frontend/src/components/Settings/primitives/SettingsSection.tsx
@@ -1,0 +1,68 @@
+import { useState, type ReactNode } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { cn } from '../../../lib/utils';
+
+export interface SettingsSectionProps {
+  id: string;
+  title: string;
+  description?: string;
+  children: ReactNode;
+  collapsible?: boolean;
+  defaultOpen?: boolean;
+  actions?: ReactNode;
+}
+
+export function SettingsSection({
+  id,
+  title,
+  description,
+  children,
+  collapsible = false,
+  defaultOpen = true,
+  actions,
+}: SettingsSectionProps) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <section id={id} className="py-6 first:pt-0">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-3 min-w-0">
+          {collapsible ? (
+            <button
+              type="button"
+              onClick={() => setOpen(!open)}
+              className="flex items-center gap-2 text-left group"
+              aria-expanded={open}
+              aria-controls={`${id}-content`}
+            >
+              <h2 className="text-foreground text-base font-semibold tracking-tight">
+                {title}
+              </h2>
+              <ChevronDown
+                className={cn(
+                  'w-4 h-4 text-muted-foreground transition-transform',
+                  !open && '-rotate-90'
+                )}
+              />
+            </button>
+          ) : (
+            <h2 className="text-foreground text-base font-semibold tracking-tight">
+              {title}
+            </h2>
+          )}
+          {description && (
+            <span className="text-muted-foreground text-sm hidden sm:inline">
+              — {description}
+            </span>
+          )}
+        </div>
+        {actions && <div className="flex items-center gap-2 shrink-0">{actions}</div>}
+      </div>
+      {(!collapsible || open) && (
+        <div id={`${id}-content`} className="space-y-1">
+          {children}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/dashboard/frontend/src/components/Settings/primitives/SettingsSidebarNav.tsx
+++ b/src/dashboard/frontend/src/components/Settings/primitives/SettingsSidebarNav.tsx
@@ -1,0 +1,40 @@
+import { cn } from '../../../lib/utils';
+
+export interface NavItem {
+  id: string;
+  label: string;
+  icon?: React.ComponentType<{ className?: string }>;
+}
+
+export interface SettingsSidebarNavProps {
+  items: NavItem[];
+  activeId: string;
+  onSelect: (id: string) => void;
+}
+
+export function SettingsSidebarNav({ items, activeId, onSelect }: SettingsSidebarNavProps) {
+  return (
+    <nav aria-label="Settings sections" className="space-y-0.5">
+      {items.map((item) => {
+        const isActive = item.id === activeId;
+        return (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => onSelect(item.id)}
+            className={cn(
+              'w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1',
+              isActive
+                ? 'bg-primary/10 text-primary font-medium'
+                : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
+            )}
+            aria-current={isActive ? 'true' : undefined}
+          >
+            {item.icon && <item.icon className="w-4 h-4 shrink-0" />}
+            <span className="truncate">{item.label}</span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/dashboard/frontend/src/components/Settings/primitives/__tests__/primitives.test.tsx
+++ b/src/dashboard/frontend/src/components/Settings/primitives/__tests__/primitives.test.tsx
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SettingsSection } from '../SettingsSection';
+import { SettingsRow } from '../SettingsRow';
+import { SettingsSidebarNav } from '../SettingsSidebarNav';
+import { SettingsLayout, SettingsHeader } from '../SettingsLayout';
+import { SettingsRowStatus } from '../SettingsRowStatus';
+import { SettingsCardSection } from '../SettingsCardSection';
+
+describe('SettingsSection', () => {
+  it('renders title and children', () => {
+    render(
+      <SettingsSection id="test" title="General">
+        <div>Content</div>
+      </SettingsSection>
+    );
+    expect(screen.getByText('General')).toBeInTheDocument();
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+
+  it('renders description when provided', () => {
+    render(
+      <SettingsSection id="test" title="General" description="Configure basics">
+        <div>Content</div>
+      </SettingsSection>
+    );
+    expect(screen.getByText('— Configure basics')).toBeInTheDocument();
+  });
+
+  it('renders as collapsible with toggle', () => {
+    render(
+      <SettingsSection id="test" title="Advanced" collapsible defaultOpen>
+        <div>Hidden content</div>
+      </SettingsSection>
+    );
+    const toggle = screen.getByRole('button', { name: /Advanced/i });
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Hidden content')).toBeInTheDocument();
+  });
+
+  it('hides content when collapsed', () => {
+    render(
+      <SettingsSection id="test" title="Advanced" collapsible defaultOpen={false}>
+        <div>Hidden content</div>
+      </SettingsSection>
+    );
+    expect(screen.queryByText('Hidden content')).not.toBeInTheDocument();
+  });
+
+  it('toggles open/closed on click', () => {
+    render(
+      <SettingsSection id="test" title="Advanced" collapsible defaultOpen>
+        <div>Toggled content</div>
+      </SettingsSection>
+    );
+    const toggle = screen.getByRole('button', { name: /Advanced/i });
+    fireEvent.click(toggle);
+    expect(screen.queryByText('Toggled content')).not.toBeInTheDocument();
+    fireEvent.click(toggle);
+    expect(screen.getByText('Toggled content')).toBeInTheDocument();
+  });
+
+  it('renders actions slot', () => {
+    render(
+      <SettingsSection id="test" title="Section" actions={<button>Reset</button>}>
+        <div>Content</div>
+      </SettingsSection>
+    );
+    expect(screen.getByRole('button', { name: 'Reset' })).toBeInTheDocument();
+  });
+});
+
+describe('SettingsRow', () => {
+  it('renders label and children', () => {
+    render(
+      <SettingsRow label="Theme">
+        <select><option>Dark</option></select>
+      </SettingsRow>
+    );
+    expect(screen.getByText('Theme')).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('renders description', () => {
+    render(
+      <SettingsRow label="Auto-save" description="Save settings automatically">
+        <input type="checkbox" />
+      </SettingsRow>
+    );
+    expect(screen.getByText('Save settings automatically')).toBeInTheDocument();
+  });
+
+  it('renders status badge', () => {
+    render(
+      <SettingsRow label="Provider" status={<span>Active</span>}>
+        <button>Configure</button>
+      </SettingsRow>
+    );
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+});
+
+describe('SettingsSidebarNav', () => {
+  const items = [
+    { id: 'model-routing', label: 'Model Routing' },
+    { id: 'providers', label: 'Providers' },
+    { id: 'conversations', label: 'Conversations' },
+  ];
+
+  it('renders all nav items', () => {
+    render(
+      <SettingsSidebarNav items={items} activeId="providers" onSelect={() => {}} />
+    );
+    expect(screen.getByText('Model Routing')).toBeInTheDocument();
+    expect(screen.getByText('Providers')).toBeInTheDocument();
+    expect(screen.getByText('Conversations')).toBeInTheDocument();
+  });
+
+  it('marks active item with aria-current', () => {
+    render(
+      <SettingsSidebarNav items={items} activeId="providers" onSelect={() => {}} />
+    );
+    const active = screen.getByText('Providers').closest('button');
+    expect(active).toHaveAttribute('aria-current', 'true');
+    const inactive = screen.getByText('Model Routing').closest('button');
+    expect(inactive).not.toHaveAttribute('aria-current');
+  });
+
+  it('calls onSelect with section id on click', () => {
+    const onSelect = vi.fn();
+    render(
+      <SettingsSidebarNav items={items} activeId="providers" onSelect={onSelect} />
+    );
+    fireEvent.click(screen.getByText('Conversations'));
+    expect(onSelect).toHaveBeenCalledWith('conversations');
+  });
+
+  it('applies active styling to the selected item', () => {
+    render(
+      <SettingsSidebarNav items={items} activeId="model-routing" onSelect={() => {}} />
+    );
+    const activeBtn = screen.getByText('Model Routing').closest('button');
+    expect(activeBtn?.className).toContain('text-primary');
+  });
+});
+
+describe('SettingsLayout', () => {
+  it('renders header, sidebar, and content', () => {
+    render(
+      <SettingsLayout
+        header={<div>Header</div>}
+        sidebar={<div>Sidebar</div>}
+      >
+        <div>Main Content</div>
+      </SettingsLayout>
+    );
+    expect(screen.getByText('Header')).toBeInTheDocument();
+    expect(screen.getByText('Sidebar')).toBeInTheDocument();
+    expect(screen.getByText('Main Content')).toBeInTheDocument();
+  });
+});
+
+describe('SettingsHeader', () => {
+  it('renders title and save/reset buttons', () => {
+    render(
+      <SettingsHeader
+        title="Settings"
+        hasChanges={true}
+        saving={false}
+        saveSuccess={false}
+        saveError={false}
+        onSave={() => {}}
+        onReset={() => {}}
+      />
+    );
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.getByText('Save')).toBeInTheDocument();
+    expect(screen.getByText('Reset')).toBeInTheDocument();
+  });
+
+  it('disables save when no changes', () => {
+    render(
+      <SettingsHeader
+        title="Settings"
+        hasChanges={false}
+        saving={false}
+        saveSuccess={false}
+        saveError={false}
+        onSave={() => {}}
+        onReset={() => {}}
+      />
+    );
+    expect(screen.getByText('Save')).toBeDisabled();
+    expect(screen.getByText('Reset')).toBeDisabled();
+  });
+
+  it('shows saving state', () => {
+    render(
+      <SettingsHeader
+        title="Settings"
+        hasChanges={true}
+        saving={true}
+        saveSuccess={false}
+        saveError={false}
+        onSave={() => {}}
+        onReset={() => {}}
+      />
+    );
+    expect(screen.getByText('Saving…')).toBeInTheDocument();
+  });
+
+  it('shows success indicator', () => {
+    render(
+      <SettingsHeader
+        title="Settings"
+        hasChanges={false}
+        saving={false}
+        saveSuccess={true}
+        saveError={false}
+        onSave={() => {}}
+        onReset={() => {}}
+      />
+    );
+    expect(screen.getByText('Saved')).toBeInTheDocument();
+  });
+
+  it('shows error indicator', () => {
+    render(
+      <SettingsHeader
+        title="Settings"
+        hasChanges={false}
+        saving={false}
+        saveSuccess={false}
+        saveError={true}
+        onSave={() => {}}
+        onReset={() => {}}
+      />
+    );
+    expect(screen.getByText('Save failed')).toBeInTheDocument();
+  });
+});
+
+describe('SettingsRowStatus', () => {
+  it('renders with success variant', () => {
+    render(<SettingsRowStatus variant="success" label="Connected" />);
+    const el = screen.getByText('Connected');
+    expect(el.className).toContain('text-success');
+  });
+
+  it('renders with error variant', () => {
+    render(<SettingsRowStatus variant="error" label="Failed" />);
+    const el = screen.getByText('Failed');
+    expect(el.className).toContain('text-destructive');
+  });
+});
+
+describe('SettingsCardSection', () => {
+  it('renders children in a card container', () => {
+    render(
+      <SettingsCardSection>
+        <div>Card content</div>
+      </SettingsCardSection>
+    );
+    expect(screen.getByText('Card content')).toBeInTheDocument();
+    const container = screen.getByText('Card content').parentElement;
+    expect(container?.className).toContain('bg-card');
+    expect(container?.className).toContain('border');
+  });
+});

--- a/src/dashboard/frontend/src/components/Settings/primitives/index.ts
+++ b/src/dashboard/frontend/src/components/Settings/primitives/index.ts
@@ -1,0 +1,17 @@
+export { SettingsLayout, SettingsHeader } from './SettingsLayout';
+export type { SettingsLayoutProps, SettingsHeaderProps } from './SettingsLayout';
+
+export { SettingsSection } from './SettingsSection';
+export type { SettingsSectionProps } from './SettingsSection';
+
+export { SettingsRow } from './SettingsRow';
+export type { SettingsRowProps } from './SettingsRow';
+
+export { SettingsSidebarNav } from './SettingsSidebarNav';
+export type { SettingsSidebarNavProps, NavItem } from './SettingsSidebarNav';
+
+export { SettingsCardSection } from './SettingsCardSection';
+export type { SettingsCardSectionProps } from './SettingsCardSection';
+
+export { SettingsRowStatus } from './SettingsRowStatus';
+export type { SettingsRowStatusProps, StatusVariant } from './SettingsRowStatus';


### PR DESCRIPTION
## Summary

- Adds shared settings UI primitives (SettingsLayout, SettingsSection, SettingsRow, SettingsSidebarNav, SettingsCardSection, SettingsRowStatus)
- Restructures the settings page with sidebar navigation and anchor-based section scrolling
- Redesigns Providers as summary-first expandable rows with auth badges
- Redesigns Model Routing as preset summary + compact override table by category
- Converts Conversations and Terminal to compact row-based layouts
- Normalizes Tracker Keys, Appearance, and Maintenance sections
- Adds consistent focus-visible states and accessibility polish
- Integrates new Experimental section from main into the redesigned layout

## Test plan

- [x] TypeScript typecheck passes
- [x] ESLint passes  
- [x] 4298 tests pass (346 test files)
- [x] 22 new primitives tests pass
- [ ] Visual verification in browser
- [ ] Keyboard navigation through all sections
- [ ] Save/reset functionality
- [ ] Provider enable/disable and API key entry
- [ ] Model override edit/remove flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)