### PR TITLE
fix: contracts editor.ts typecheck error (Schema.Literal → Schema.Literals)

### DIFF
--- a/packages/contracts/src/editor.ts
+++ b/packages/contracts/src/editor.ts
@@ -15,8 +15,18 @@ export const EDITORS = [
 export type EditorEntry = (typeof EDITORS)[number]
 export type EditorId = EditorEntry["id"]
 
-const EDITOR_IDS = EDITORS.map((e) => e.id) as unknown as [EditorId, ...EditorId[]]
-export const EditorIdSchema = Schema.Literal(...EDITOR_IDS)
+const EDITOR_IDS: [EditorId, ...EditorId[]] = [
+  "cursor",
+  "windsurf",
+  "trae",
+  "vscode",
+  "vscode-insiders",
+  "vscodium",
+  "zed",
+  "antigravity",
+  "file-manager",
+]
+export const EditorIdSchema = Schema.Literals(EDITOR_IDS)
 
 export const OpenInEditorInput = Schema.Struct({
   cwd: Schema.String,


### PR DESCRIPTION
Fixes TS2556 typecheck error in `packages/contracts/src/editor.ts`.

`Schema.Literal` in Effect v4 only accepts a single value. The existing code tried to spread an array into it, which fails under strict TypeScript. Switch to `Schema.Literals` which accepts an array, and replace the `.map() + as unknown` cast with an explicit typed tuple.

This fixes the typecheck failure discovered during PAN-951 verification.