### PR TITLE
PAN-925: Complete post-merge cleanup — workspace, branches, labels

### DIFF
--- a/src/lib/cloister/merge-agent.ts
+++ b/src/lib/cloister/merge-agent.ts
@@ -424,7 +424,6 @@ export async function postMergeLifecycle(issueId: string, projectPath: string, s
   // state cleanup, and branch deletion. Steps already performed above are no-ops.
   try {
     const { teardownWorkspace } = await import('../lifecycle/teardown-workspace.js');
-    const issueLower = issueId.toLowerCase();
     const ctx = { issueId, projectPath };
     const teardownResults = await teardownWorkspace(ctx, { deleteBranches: true });
     const completedSteps = teardownResults.filter(r => r.success && !r.skipped);

--- a/src/lib/cloister/merge-agent.ts
+++ b/src/lib/cloister/merge-agent.ts
@@ -418,6 +418,48 @@ export async function postMergeLifecycle(issueId: string, projectPath: string, s
     console.warn(`[merge-agent] Docker cleanup failed (non-fatal): ${err}`);
   }
 
+  // 7. Teardown workspace directory + delete feature branches (PAN-925)
+  // Uses the consolidated teardownWorkspace module which handles: tmux sessions (idempotent
+  // with step 5), TLDR daemon, Docker (idempotent with step 6), worktree removal, agent
+  // state cleanup, and branch deletion. Steps already performed above are no-ops.
+  try {
+    const { teardownWorkspace } = await import('../lifecycle/teardown-workspace.js');
+    const issueLower = issueId.toLowerCase();
+    const ctx = { issueId, projectPath };
+    const teardownResults = await teardownWorkspace(ctx, { deleteBranches: true });
+    const completedSteps = teardownResults.filter(r => r.success && !r.skipped);
+    if (completedSteps.length > 0) {
+      const summary = completedSteps.map(r => r.details?.join('; ') || r.step).join(' | ');
+      console.log(`[merge-agent] ✓ Workspace teardown: ${summary}`);
+      logActivity('workspace_teardown', `Workspace teardown for ${issueId}: ${summary}`);
+    } else {
+      console.log(`[merge-agent] Workspace teardown: nothing to clean up for ${issueId}`);
+    }
+  } catch (err) {
+    console.warn(`[merge-agent] Workspace teardown failed (non-fatal): ${err}`);
+  }
+
+  // 8. Apply 'needs-close-out' label to signal the user that close-out ceremony is pending (PAN-925)
+  // The close-out ceremony is human-gated — it verifies PRD preservation, branch merge status,
+  // and applies the final 'closed-out' label. We don't auto-trigger it because the user must
+  // confirm the work is truly complete before final sign-off.
+  try {
+    const ghResolved = resolveGitHubIssue(issueId);
+    if (ghResolved.isGitHub) {
+      const { owner, repo, number } = ghResolved;
+      // Ensure the label exists (--force is idempotent)
+      await execAsync(
+        `gh label create "needs-close-out" --repo ${owner}/${repo} --color "fbca04" --description "Merged — awaiting close-out ceremony" --force 2>/dev/null || true`,
+      );
+      await execAsync(
+        `gh issue edit ${number} --repo ${owner}/${repo} --add-label "needs-close-out"`,
+      );
+      console.log(`[merge-agent] ✓ Applied 'needs-close-out' label on GitHub #${number}`);
+    }
+  } catch (err) {
+    console.warn(`[merge-agent] Could not apply needs-close-out label (non-fatal): ${err}`);
+  }
+
   // Mark completed BEFORE logging — prevents re-entry even if the log line triggers something
   _completedPostMerge.add(issueId);
 

--- a/src/lib/lifecycle/label-cleanup.ts
+++ b/src/lib/lifecycle/label-cleanup.ts
@@ -57,17 +57,35 @@ async function cleanupLabelsGitHub(ctx: LifecycleContext): Promise<StepResult> {
       { encoding: 'utf-8' },
     );
 
-    // Remove workflow labels (best-effort — skip if not present)
-    for (const label of LABELS_TO_REMOVE) {
+    // Fetch current labels to avoid 404 spam from removing non-existent labels (PAN-925)
+    let currentLabels: string[] = [];
+    try {
+      const { stdout: labelJson } = await execAsync(
+        `gh issue view ${number} --repo ${owner}/${repo} --json labels --jq '.labels[].name'`,
+        { encoding: 'utf-8' },
+      );
+      currentLabels = labelJson.trim().split('\n').filter(Boolean);
+    } catch {
+      // If we can't fetch labels, fall back to removing all (best-effort)
+      currentLabels = [...LABELS_TO_REMOVE];
+    }
+
+    // Remove only labels that actually exist on the issue
+    const labelsToRemove = LABELS_TO_REMOVE.filter(l => currentLabels.includes(l));
+    for (const label of labelsToRemove) {
       await execAsync(
-        `gh issue edit ${number} --repo ${owner}/${repo} --remove-label "${label}" 2>/dev/null || true`,
+        `gh issue edit ${number} --repo ${owner}/${repo} --remove-label "${label}"`,
         { encoding: 'utf-8' },
       );
     }
 
+    const removedDesc = labelsToRemove.length > 0
+      ? `Removed: ${labelsToRemove.join(', ')}`
+      : 'No workflow labels to remove';
+
     return stepOk(step, [
       `Applied '${MERGED_LABEL}' label on GitHub #${number}`,
-      `Removed: ${LABELS_TO_REMOVE.join(', ')}`,
+      removedDesc,
     ]);
   } catch (err) {
     return stepFailed(step, `Label cleanup failed: ${(err as Error).message}`);


### PR DESCRIPTION
## Summary
- Add workspace cleanup to postMergeLifecycle via `teardownWorkspace` with `deleteBranches: true` — handles worktree removal, tmux sessions, TLDR daemon, Docker containers, agent state, and local + remote branch deletion
- Fix label cleanup to check label existence before DELETE to avoid 404 spam — fetches current labels via `gh issue view --json labels` first, only removes labels that are actually present
- Apply `needs-close-out` label after merge to signal the user that the human-gated close-out ceremony is pending (close-out is NOT auto-triggered — it verifies PRD preservation and applies the final `closed-out` label)

## Test plan
- [ ] Merge a PR, verify workspace directory is cleaned up (worktree removed)
- [ ] Verify feature branches deleted (local + remote)
- [ ] Verify labels properly updated (in-review/in-progress removed, merged added, needs-close-out added)
- [ ] No 404 label-deletion spam in logs
- [ ] Verify close-out ceremony can still be triggered manually via dashboard or `pan close`

Closes #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)