### PR TITLE
PAN-1032

### DIFF
--- a/.claude/skills/pipeline-status/SKILL.md
+++ b/.claude/skills/pipeline-status/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: pipeline-status
+description: >
+  Cross-room visual status board for every active issue moving through the
+  Panopticon pipeline. One row per issue, one column per phase
+  (agent → review → test → verify → merge → ready), with a checkmark or X in
+  each cell. Designed to be readable from across the room while agents work
+  autonomously. Surface this BEFORE the verbose pan-status / agent-status
+  output whenever the user asks "where are we?" or wants a status overview.
+triggers:
+  - /pipeline-status
+  - pipeline status
+  - status board
+  - issue status
+  - kanban status
+  - cross-room status
+  - status snapshot
+  - where are we
+  - what's the pipeline doing
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# pipeline-status — Cross-Room Visual Status Board
+
+## What this skill does
+
+Produces a single dense table that shows every PAN issue currently in
+`In Progress` or `In Review` (plus any active planning sessions), with one
+column per workflow phase. The format is optimized for being readable across
+a room: short rows, one-glyph cells, no fluff.
+
+This is the **first thing** to show when the user asks for status. Anything
+more detailed (`pan status`, `agent-status`) goes underneath.
+
+## Output format
+
+```
+ISSUE      TITLE                                                  MODEL              AGENT  REVIEW  TEST  VERIFY  MERGE  READY
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+PAN-1028   TTS: first speech utterance gets clipped (PipeWire)    kimi-k2.6          ✓      ·       ·     -       ·      ·
+PAN-945    Planning artifact path mismatch                        gpt-5.4            ✓      ◐       ◐     ◐       ✓*     ·
+PAN-1024   Lazy-load per-turn diff summaries (484 MB fix)         gpt-5.4            ✓      ·       ·     -       ·      ·
+
+PLANNING (Opus drafting vBRIEFs)
+PAN-1015   Remove claudish routing in favor of CLIProxy           claude-sonnet-4-6  ◐ planning
+
+✓ done/passing  ◐ in-progress  ✗ failed/blocked  · pending/n-a
+```
+
+## Cell semantics
+
+| Glyph | Meaning |
+|-------|---------|
+| `✓`   | done / passing / running healthily |
+| `◐`   | in progress (reviewing, testing, queued, merging, verifying, pending) |
+| `✗`   | failed / blocked |
+| `·`   | pending or not applicable for this issue's current phase |
+| `*`   | flag a stale value (e.g. `mergeStatus=merged` while DB drift exists, see PAN-1027) |
+
+## Columns
+
+| Column | Source | Meaning |
+|--------|--------|---------|
+| ISSUE | `/api/issues` `identifier` | PAN-NNNN |
+| TITLE | `/api/issues` `title` | truncated to ~52 chars |
+| MODEL | `~/.panopticon/agents/agent-pan-NNN/state.json` `.model` | Which model the work agent is using |
+| AGENT | tmux + `state.json` `.status` | `✓` if agent tmux session is alive AND `status: running` |
+| REVIEW | review-status DB `.review_status` | `passed`, `reviewing`, `failed`, `blocked`, `null` |
+| TEST | review-status DB `.test_status` | `passed`, `testing`, `failed`, `null` |
+| VERIFY | review-status DB `.verification_status` (lazy — only show if review passed) | `passed`, `running`, `failed`, `null` |
+| MERGE | review-status DB `.merge_status` | `merged`, `merging`, `verifying`, `failed`, `null` |
+| READY | review-status DB `.ready_for_merge` | `✓` if `readyForMerge=true`, else `·` |
+
+Always sort by priority: P0 hotfix → P1 bug → P2 enhancement → others. Within
+each tier, sort by issue ID descending (newest first).
+
+Show a separate **PLANNING** section beneath the in-flight table for any
+`planning-pan-NNN` tmux session — those are not yet on the kanban so they
+don't appear via `/api/issues` filtering.
+
+## Steps
+
+### 1. Generate the table
+
+Run this script. It hits the local dashboard API, the SQLite review-status DB,
+and tmux + agent state files. No manual curl, no manual gh — single source
+of truth is the dashboard's existing API surface.
+
+```bash
+python3 - <<'PY'
+import json, subprocess, sqlite3, os
+from pathlib import Path
+
+PANO_DB = Path.home() / ".panopticon" / "panopticon.db"
+AGENTS = Path.home() / ".panopticon" / "agents"
+
+issues_data = json.loads(subprocess.check_output(['curl','-s','http://localhost:3011/api/issues']))
+panissues = [i for i in issues_data
+             if i.get('source')=='github' and i.get('sourceRepo')=='eltmon/panopticon-cli'
+             and ((i.get('state','') or '').lower().replace(' ','_') in ('in_progress','in_review'))]
+
+db = sqlite3.connect(PANO_DB)
+
+def review_row(issue_id):
+    r = db.execute(
+        "SELECT review_status, test_status, verification_status, merge_status, ready_for_merge "
+        "FROM review_status WHERE issue_id=?", (issue_id.upper(),)
+    ).fetchone()
+    return r if r else (None,)*5
+
+def state_json(name):
+    p = AGENTS / name / "state.json"
+    if not p.exists(): return None
+    try: return json.loads(p.read_text())
+    except: return None
+
+def has_session(name):
+    try:
+        subprocess.check_output(['tmux','-L','panopticon','has-session','-t',name],
+                                stderr=subprocess.DEVNULL)
+        return True
+    except: return False
+
+def cell(value):
+    if value is None or value == '': return '·'
+    v = str(value).lower()
+    if v in ('passed','merged','running','done','true','1'): return '✓'
+    if v in ('failed','blocked','error'): return '✗'
+    if v in ('reviewing','testing','queued','merging','verifying','pending'): return '◐'
+    return v[:3]
+
+def tier(i):
+    L = ','.join(i.get('labels',[])).lower()
+    if 'p0' in L.split(','): return 0
+    if 'bug' in L.split(',') or 'p1' in L.split(','): return 1
+    return 2
+
+panissues.sort(key=lambda i: (tier(i), -int(''.join(c for c in i['identifier'] if c.isdigit()) or 0)))
+
+W = {'id':10,'title':52,'model':22,'agent':6,'review':7,'tests':6,'verify':7,'merge':7}
+print()
+print(f"{'ISSUE':<{W['id']}}  {'TITLE':<{W['title']}}  {'MODEL':<{W['model']}}  {'AGENT':<{W['agent']}}  {'REVIEW':<{W['review']}}  {'TEST':<{W['tests']}}  {'VERIFY':<{W['verify']}}  {'MERGE':<{W['merge']}}  {'READY'}")
+print('─' * 130)
+for i in panissues:
+    iid = i['identifier']
+    review,test,verify,merge,ready = review_row(iid)
+    agent_alive = has_session(f"agent-{iid.lower()}")
+    sj = state_json(f"agent-{iid.lower()}")
+    astatus = (sj or {}).get('status','-')
+    amodel = (sj or {}).get('model','-')
+    title = i['title']
+    if len(title) > W['title']: title = title[:W['title']-1] + '…'
+    if len(amodel) > W['model']: amodel = amodel[:W['model']-1] + '…'
+    agent_cell = '✓' if agent_alive and astatus=='running' else ('◐' if astatus=='running' else '·')
+    verify_cell = '·' if (review != 'passed' and not merge) else cell(verify)
+    print(f"{iid:<{W['id']}}  {title:<{W['title']}}  {amodel:<{W['model']}}  "
+          f"{agent_cell:<{W['agent']}}  {cell(review):<{W['review']}}  {cell(test):<{W['tests']}}  "
+          f"{verify_cell:<{W['verify']}}  {cell(merge):<{W['merge']}}  "
+          f"{'✓' if ready else '·'}")
+
+print()
+print("PLANNING SESSIONS (Opus drafting vBRIEFs)")
+print('─' * 130)
+sessions = subprocess.check_output(['tmux','-L','panopticon','list-sessions','-F','#{session_name}']).decode().split('\n')
+for ps in sorted(s for s in sessions if s.startswith('planning-pan-')):
+    iid = 'PAN-' + ps.replace('planning-pan-','').upper()
+    sj = state_json(ps)
+    model = (sj or {}).get('model','?')
+    title = next((i['title'] for i in issues_data if (i.get('identifier','') or '').upper()==iid), '(unknown)')
+    if len(title) > W['title']: title = title[:W['title']-1] + '…'
+    print(f"{iid:<{W['id']}}  {title:<{W['title']}}  {model:<{W['model']}}  ◐ planning")
+
+print()
+print("✓ done/passing  ◐ in-progress  ✗ failed/blocked  · pending/n-a")
+print("Stages: AGENT (work agent alive) → REVIEW → TEST → VERIFY → MERGE → READY (Awaiting Merge)")
+PY
+```
+
+### 2. Add an Awaiting Merge summary line
+
+After the main table, count and list anything with `readyForMerge=true`:
+
+```bash
+curl -s http://localhost:3011/api/issues | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+ready = [i for i in data
+         if i.get('source')=='github' and i.get('sourceRepo')=='eltmon/panopticon-cli'
+         and i.get('readyForMerge') is True
+         and (i.get('mergeStatus') or '').lower() != 'merged']
+print(f'\\nAwaiting Merge: {len(ready)} issue(s) ready for human approval')
+for i in ready:
+    print(f'  → {i[\"identifier\"]}  {i[\"title\"][:80]}')
+"
+```
+
+### 3. (Optional) Defer to other status skills if user wants more detail
+
+If the user wants MORE than the table — system health, RAM, CPU per agent,
+specialist trees, etc. — invoke `pan-status` next. The pipeline-status table
+is the headline; everything else is the appendix.
+
+```
+For deeper detail beyond the pipeline view:
+  • pan status         — running agents overview + system health
+  • pan resources      — RAM/swap by agent
+  • agent-status       — per-tmux-session capture of recent output
+```
+
+## When to surface this
+
+- User asks "what's running?", "where are we?", "show status", "status snapshot"
+- After invoking `/all-up` to checkpoint progress
+- After spawning new agents
+- Before reporting completion of a flywheel run
+- Whenever the user says "give me a visual" or "snapshot"
+
+## When NOT to use this
+
+- During an active long-running operation (e.g. mid-merge, mid-build) — the
+  table reflects steady state and will mislead during transitions.
+- For Mind Your Now (MIN-*), Auricle (AUR-*), Krux (KRUX-*) — this skill is
+  Panopticon-specific. Other trackers have their own dashboards.
+
+## Notes
+
+- The table reads from `/api/issues` — works only when the dashboard is up on
+  `localhost:3011`. If the dashboard is down, fall back to `pan status` text.
+- A `*` after a value flags a known data-drift case (e.g. `mergeStatus=merged`
+  surviving a PR revert per PAN-1027). Document the underlying issue inline so
+  the reader knows why the cell can't be trusted.
+- This skill is **read-only**. It does not change agent state, merge anything,
+  or write to the DB. Pure observation.

--- a/.pan/continue.json
+++ b/.pan/continue.json
@@ -23,6 +23,11 @@
       "id": "D3",
       "summary": "HARNESSES.md updated, CLAUDE.md is NOT updated. Provider internals are not documented in CLAUDE.md.",
       "recordedAt": "2026-05-08T00:00:00Z"
+    },
+    {
+      "id": "D4",
+      "summary": "--model-subagent uses tierModels.haiku to mirror CLAUDE_CODE_SUBAGENT_MODEL. This is correct because claudish's subagent role maps to the fast/cheap tier. Revisit only if claudish defines a distinct subagent-specific model tier in a future release.",
+      "recordedAt": "2026-05-08T00:00:00Z"
     }
   ],
   "hazards": [
@@ -43,12 +48,12 @@
     },
     {
       "id": "H4",
-      "summary": "The subscription-oauth path in getProviderEnv returns {} (empty object). Tier-model injection must NOT apply to this path since it's the claudish subscription route with no API key.",
-      "mitigation": "The early return on line 279 (apiKey === 'subscription-oauth') already returns before any tierModels logic. This is correct behavior — confirm with a test."
+      "summary": "The subscription-oauth path in getProviderEnv (line 279) is used by Google CodeAssist OAuth (go@ prefix). Tier-model injection MUST apply here — these users route through claudish and spawn subagents that need tier-model env vars. Only the API key var is omitted, not the tier-model vars. The current `return {}` early return is WRONG and must be changed to return tierModelEnv derived from provider.tierModels.",
+      "mitigation": "In bead 'claudish-env', replace the `if (apiKey === 'subscription-oauth') { return {}; }` early return with logic that computes tierModelEnv from provider.tierModels and returns that (skipping the API key var). Add a test asserting subscription-oauth returns tier-model vars."
     }
   ],
   "resumePoint": {
-    "description": "Planning complete. Implementation agent should start with bead 'env-keys': add ANTHROPIC_DEFAULT_OPUS_MODEL, ANTHROPIC_DEFAULT_SONNET_MODEL, ANTHROPIC_SMALL_FAST_MODEL, CLAUDE_CODE_SUBAGENT_MODEL to PROVIDER_ENV_KEYS array in src/lib/agents.ts (lines 250-259) and to PROVIDER_ENV_KEYS Set in src/lib/child-env.ts (lines 23-32). Then bead 'claudish-env': add tierModels injection to the claudish branch of getProviderEnv in providers.ts (lines 274-312). Then bead 'cliproxy-env': merge tierModels into CLIProxy return in getProviderEnvForModel in agents.ts (lines 171-179). Then bead 'claudish-flags': compute and append --model-opus/sonnet/haiku/subagent to claudish command in getAgentRuntimeBaseCommand (lines 181-188). Then bead 'tests': update existing test assertions and add new ones. Finally bead 'docs': update HARNESSES.md.",
+    "description": "Planning complete. Implementation agent should start with bead 'env-keys': add ANTHROPIC_DEFAULT_OPUS_MODEL, ANTHROPIC_DEFAULT_SONNET_MODEL, ANTHROPIC_SMALL_FAST_MODEL, CLAUDE_CODE_SUBAGENT_MODEL to PROVIDER_ENV_KEYS array in src/lib/agents.ts (lines 250-259) and to PROVIDER_ENV_KEYS Set in src/lib/child-env.ts (lines 23-32); update getProviderExportsForModel test to expect 12 unset lines. Then bead 'claudish-env': add tierModels injection to the claudish branch of getProviderEnv in providers.ts (lines 274-312); CRITICAL: the subscription-oauth path (line 279) must return tierModelEnv not {} — these are Google CodeAssist OAuth users who need tier-model vars; update providers.test.ts to add tier-model vars to existing exact-match assertions. Then bead 'cliproxy-env': merge tierModels into CLIProxy return in getProviderEnvForModel in agents.ts (lines 171-179); update agents-auth-routing.test.ts GPT subscription assertion. Then bead 'claudish-flags': compute and append --model-opus/sonnet/haiku/subagent to claudish command in getAgentRuntimeBaseCommand (lines 181-188); update agents-auth-routing.test.ts claudish command string assertions. Then bead 'tests': add NEW assertions only for behaviors not yet tested (subscription-oauth tier-model, openrouter no-flags guard). Finally bead 'docs': update HARNESSES.md.",
     "beadId": null,
     "filesToRead": [
       "src/lib/agents.ts",

--- a/.pan/continue.json
+++ b/.pan/continue.json
@@ -1,110 +1,79 @@
 {
   "version": "1",
-  "issueId": "PAN-986",
-  "created": "2026-05-07T14:20:00Z",
-  "updated": "2026-05-07T15:28:32-04:00",
+  "issueId": "PAN-1032",
+  "created": "2026-05-08T00:00:00Z",
+  "updated": "2026-05-08T00:00:00Z",
   "gitState": {
-    "branch": "feature/pan-986",
-    "sha": "b3b364126",
-    "dirty": true
+    "branch": "feature/pan-1032",
+    "sha": "a8bffd787",
+    "dirty": false
   },
   "decisions": [
     {
       "id": "D1",
-      "summary": "The outbound Claude Code Channels work is being split across three beads so the bridge surface, the dashboard event plumbing, and the hook replacement each land in reviewable commits. The first bead defines the `channel_reply` MCP tool, validates its payload, and documents when Claude should emit structured status instead of relying on terminal prose alone.",
-      "recordedAt": "2026-05-07T14:20:00Z"
+      "summary": "claudish supports --model-opus, --model-sonnet, --model-haiku, --model-subagent (verified by user via claudish --help at /home/eltmon/.config/nvm/versions/node/v22.22.0/bin/claudish). Use all 4 flags in getAgentRuntimeBaseCommand.",
+      "recordedAt": "2026-05-08T00:00:00Z"
     },
     {
       "id": "D2",
-      "summary": "Accepted `channel_reply` payloads now enter the same typed runtime-event pipeline as hook heartbeats instead of being stored only in bridge-local logs. The dashboard reducer records the latest structured reply on `AgentRuntimeSnapshot.channelReply`, and the reducer also projects `done` and `needs_input` replies onto the existing runtime resolution fields so current consumers can benefit without waiting for a separate UI migration.",
-      "recordedAt": "2026-05-07T14:35:00Z"
+      "summary": "Flag values use claudish-prefixed form (e.g. kc@kimi-k2) matching getLaunchModelForModel output. --model-subagent maps to tierModels.haiku (same as CLAUDE_CODE_SUBAGENT_MODEL). Single source of truth: provider.tierModels in providers.ts.",
+      "recordedAt": "2026-05-08T00:00:00Z"
     },
     {
       "id": "D3",
-      "summary": "The work-agent stop hook now treats the latest structured `channel_reply` runtime signal as authoritative for `done` and `needs_input` before it falls back to tmux capture and LLM inference. This replaces one of the brittle pane-scrape paths the issue targeted while preserving the old heuristic as a safety net for sessions that never emit structured replies.",
-      "recordedAt": "2026-05-07T14:45:00Z"
-    },
-    {
-      "id": "D4",
-      "summary": "Repo-wide verification was blocked by two stale invariants outside the PAN-986 feature code: the desktop workspace package metadata had drifted behind the root CLI package version, and the GitHub label-cleanup unit test still assumed unconditional `--remove-label` calls even though the implementation now prefetches current labels and removes only labels that are actually present. I aligned the desktop package metadata with the rebased root release version and updated the test to mock the label-prefetch response so the quality gate exercises the current behavior instead of an obsolete assumption.",
-      "recordedAt": "2026-05-07T18:42:27Z"
-    },
-    {
-      "id": "D5",
-      "summary": "Review feedback required tightening both correctness and security around structured channel replies instead of only preserving the original feature path. I centralized channel-reply normalization and limits in the shared contracts package, reused that validator at the bridge and dashboard heartbeat ingress points, cleared stale `channelReply` state on `agent.stopped`, normalized hook log output before writing agent-supplied summaries, made the bridge direct-invocation check path-safe for relative Bun entrypoints, and hardened the related tests so the review fix covers the end-to-end data path rather than a single file-local patch.",
-      "recordedAt": "2026-05-07T15:28:32-04:00"
+      "summary": "HARNESSES.md updated, CLAUDE.md is NOT updated. Provider internals are not documented in CLAUDE.md.",
+      "recordedAt": "2026-05-08T00:00:00Z"
     }
   ],
   "hazards": [
     {
       "id": "H1",
-      "summary": "This workspace started with a deleted `.pan/continue.json` from PAN-939 and no PAN-986 issue-scoped beads, so the normal resume path was broken before implementation began.",
-      "mitigation": "I recreated PAN-986 beads locally, replaced the stale deleted continue file with PAN-986 state, and will keep this file updated after each bead so the remaining work can proceed through the standard claim, commit, close, and inspect loop."
+      "summary": "Existing providers.test.ts assertions check EXACT return values from getProviderEnv (e.g. expect(getProviderEnv(PROVIDERS.kimi, 'sk-kimi-test')).toEqual({ KIMI_CODING_API_KEY: 'sk-kimi-test' })). After bead claudish-env, these will fail because tier-model vars are now returned too. Update all 7 claudish provider tests.",
+      "mitigation": "Update tests in bead 'tests' (or update as part of bead 'claudish-env') to use expect.objectContaining or add the new vars to the expected object."
     },
     {
       "id": "H2",
-      "summary": "`pan done` attempted to rebase the branch onto `main`, but `main` had advanced the desktop release version to `0.8.17`, which conflicted with the earlier verification-fix commit that had aligned the desktop package to the older branch-local root version.",
-      "mitigation": "I manually rebased the branch onto `main`, kept the current `0.8.17` desktop version from `main`, preserved the label-cleanup test fix, and now need to update the remote branch with the rebased history before re-running `pan done`."
+      "summary": "The getProviderExportsForModel test in agents-auth-routing.test.ts asserts exactly 8 unset lines. After adding 4 new vars to PROVIDER_ENV_KEYS, this becomes 12 unset lines. The test will fail.",
+      "mitigation": "Update the test in bead 'tests' (or 'env-keys') to expect 12 unset lines."
+    },
+    {
+      "id": "H3",
+      "summary": "OpenRouter has no tierModels defined in PROVIDERS.openrouter. The claudish flag injection must guard against undefined tierModels — provider without tierModels should not append any --model-* flags.",
+      "mitigation": "Guard with if (provider.tierModels) before computing flags. Test with an OpenRouter model to confirm no flags appended."
+    },
+    {
+      "id": "H4",
+      "summary": "The subscription-oauth path in getProviderEnv returns {} (empty object). Tier-model injection must NOT apply to this path since it's the claudish subscription route with no API key.",
+      "mitigation": "The early return on line 279 (apiKey === 'subscription-oauth') already returns before any tierModels logic. This is correct behavior — confirm with a test."
     }
   ],
   "resumePoint": {
-    "description": "The review remediation pass is complete locally. The bridge, contracts, heartbeat ingestion, reducer, and stop-hook paths now enforce structured channel-reply limits, clear stale reply state on stop, sanitize logged summaries, and cover the regressions with focused tests. Local verification is green (`npm run build:contracts`, targeted Vitest for the touched surfaces, `npm run typecheck`, `npm run lint`, and full `npm test`). The remaining work is to commit these review fixes and submit `pan review request PAN-986 -m \"Fixed review issues\"`.",
+    "description": "Planning complete. Implementation agent should start with bead 'env-keys': add ANTHROPIC_DEFAULT_OPUS_MODEL, ANTHROPIC_DEFAULT_SONNET_MODEL, ANTHROPIC_SMALL_FAST_MODEL, CLAUDE_CODE_SUBAGENT_MODEL to PROVIDER_ENV_KEYS array in src/lib/agents.ts (lines 250-259) and to PROVIDER_ENV_KEYS Set in src/lib/child-env.ts (lines 23-32). Then bead 'claudish-env': add tierModels injection to the claudish branch of getProviderEnv in providers.ts (lines 274-312). Then bead 'cliproxy-env': merge tierModels into CLIProxy return in getProviderEnvForModel in agents.ts (lines 171-179). Then bead 'claudish-flags': compute and append --model-opus/sonnet/haiku/subagent to claudish command in getAgentRuntimeBaseCommand (lines 181-188). Then bead 'tests': update existing test assertions and add new ones. Finally bead 'docs': update HARNESSES.md.",
     "beadId": null,
     "filesToRead": [
-      ".pan/continue.json",
-      "packages/contracts/src/types.ts",
-      "src/lib/channels/panopticon-bridge.ts",
-      "scripts/work-agent-stop-hook"
+      "src/lib/agents.ts",
+      "src/lib/providers.ts",
+      "src/lib/child-env.ts",
+      "tests/lib/providers.test.ts",
+      "tests/lib/agents-auth-routing.test.ts",
+      "docs/HARNESSES.md"
     ]
   },
   "beadsMapping": {
-    "bridge-tool": [
-      "workspace-78h8"
-    ],
-    "event-stream": [
-      "workspace-teyh"
-    ],
-    "hook-replacement": [
-      "workspace-jyh4"
-    ]
+    "env-keys": "workspace-ikvy",
+    "claudish-env": "workspace-k9cq",
+    "cliproxy-env": "workspace-4jk2",
+    "claudish-flags": "workspace-jyy0",
+    "tests": "workspace-yu52",
+    "docs": "workspace-k0b3"
   },
-  "agentModel": "claude-code",
+  "agentModel": "claude-opus-4-6",
   "sessionHistory": [
     {
-      "timestamp": "2026-05-07T14:20:00Z",
-      "reason": "resume",
-      "note": "Recovered the PAN-986 workspace after finding a stale deleted PAN-939 continue file and no PAN-986 beads. I recreated issue-scoped beads, claimed workspace-78h8, and started implementing the outbound `channel_reply` MCP tool surface with validation and bridge tests.",
-      "agentModel": "claude-code"
-    },
-    {
-      "timestamp": "2026-05-07T14:35:00Z",
-      "reason": "manual",
-      "note": "Closed workspace-78h8 after landing the bridge tool surface. Claimed workspace-teyh and wired accepted `channel_reply` payloads into the typed runtime heartbeat path, extended the shared contracts and reducer, rebuilt `@panctl/contracts`, and verified the focused contract, bridge, and frontend reducer tests all pass.",
-      "agentModel": "claude-code"
-    },
-    {
-      "timestamp": "2026-05-07T14:45:00Z",
-      "reason": "manual",
-      "note": "Claimed workspace-jyh4 and updated `scripts/work-agent-stop-hook` so it checks the structured `channelReply` runtime snapshot before tmux pane capture and Claude fallback. Added end-to-end script tests with mocked curl, tmux, and claude commands to prove that `done` and `needs_input` replies emit the expected runtime resolution without invoking pane scraping.",
-      "agentModel": "claude-code"
-    },
-    {
-      "timestamp": "2026-05-07T18:42:27Z",
-      "reason": "manual",
-      "note": "Finished the blocked verification pass after fixing two repo-wide quality gate regressions that were unrelated to the PAN-986 feature logic. I aligned the desktop package metadata and lockfile with the root release version that existed on the branch at the time, updated the GitHub label-cleanup unit test so it mocks the implementation's current label-prefetch behavior, reran the targeted blockers, and then reran `npm run typecheck`, `npm run lint`, and the full `npm test` suite successfully.",
-      "agentModel": "claude-code"
-    },
-    {
-      "timestamp": "2026-05-07T18:46:22Z",
-      "reason": "manual",
-      "note": "Attempting `pan done pan-986 -c \"Implementation complete\"` exposed a rebase conflict because `main` had moved the desktop package version forward to `0.8.17` after the earlier verification fix. I rebased the branch manually, resolved the conflict by keeping `main`'s current desktop version while preserving the label-cleanup test fix, and confirmed the branch is now based on the latest `main` history. The remaining blocker is updating the already-pushed remote branch to match this rebased local history before re-running `pan done`.",
-      "agentModel": "claude-code"
-    },
-    {
-      "timestamp": "2026-05-07T15:28:32-04:00",
-      "reason": "manual",
-      "note": "Addressed the review findings across the structured channel-reply path. I cleared stale `channelReply` state on `agent.stopped`, centralized channel-reply normalization and size limits in the shared contracts helper, reused that validation in both the bridge tool and heartbeat ingestion route, made the bridge direct-entry detection robust for relative Bun paths, memoized bridge log-directory setup, sanitized stop-hook log summaries, mocked `pan-hook-lib.sh` directly in the hook tests, and added regression coverage for the new limits, skip behavior, direct invocation, stale-state clearing, and single-fetch stop-hook resolution path. I then rebuilt `@panctl/contracts`, reran the focused Vitest suites, ran `npm run typecheck`, ran `npm run lint`, and finished a clean full `npm test` pass.",
-      "agentModel": "claude-code"
+      "timestamp": "2026-05-08T00:00:00Z",
+      "reason": "end",
+      "note": "Planning complete for PAN-1032. Researched: claudish flag support confirmed (--model-opus/sonnet/haiku/subagent), gaps identified in providers.ts claudish branch (no tier-model env injection), agents.ts CLIProxy path (no tier-model injection), and PROVIDER_ENV_KEYS tracking (missing 4 vars). 6-bead plan written: env-keys, claudish-env, cliproxy-env, claudish-flags, tests, docs.",
+      "agentModel": "claude-opus-4-6"
     }
   ]
 }

--- a/.pan/spec.vbrief.json
+++ b/.pan/spec.vbrief.json
@@ -38,7 +38,8 @@
           "getProviderEnv for zai returns ZHIPU_API_KEY plus tier-model env vars",
           "getProviderEnv for mimo returns ANTHROPIC_API_KEY plus tier-model env vars",
           "getProviderEnv for openrouter returns OPENROUTER_API_KEY only (no tierModels)",
-          "subscription-oauth path returns empty env (unchanged)"
+          "subscription-oauth path (Google CodeAssist OAuth) returns tier-model env vars without an API key var",
+          "providers.test.ts exact-match assertions updated to include tier-model vars alongside each API key var"
         ]
       },
       {
@@ -47,7 +48,8 @@
         "status": "pending",
         "acceptanceCriteria": [
           "When OpenAI subscription login is active, getProviderEnvForModel returns cliproxy env PLUS tier-model env vars from PROVIDERS.openai.tierModels",
-          "Tier-model vars: ANTHROPIC_DEFAULT_OPUS_MODEL=gpt-5.5-pro, ANTHROPIC_DEFAULT_SONNET_MODEL=gpt-5.5, ANTHROPIC_DEFAULT_HAIKU_MODEL=gpt-5.5-mini, ANTHROPIC_SMALL_FAST_MODEL=gpt-5.5-mini, CLAUDE_CODE_SUBAGENT_MODEL=gpt-5.5-mini"
+          "Tier-model vars: ANTHROPIC_DEFAULT_OPUS_MODEL=gpt-5.5-pro, ANTHROPIC_DEFAULT_SONNET_MODEL=gpt-5.5, ANTHROPIC_DEFAULT_HAIKU_MODEL=gpt-5.5-mini, ANTHROPIC_SMALL_FAST_MODEL=gpt-5.5-mini, CLAUDE_CODE_SUBAGENT_MODEL=gpt-5.5-mini",
+          "agents-auth-routing.test.ts GPT subscription test asserts tier-model env vars in result"
         ]
       },
       {
@@ -59,19 +61,18 @@
           "getAgentRuntimeBaseCommand for minimax-m2.7 includes --model-opus mm@minimax-m2.7 --model-sonnet mm@minimax-m2.7 --model-haiku mm@minimax-m2.7-highspeed --model-subagent mm@minimax-m2.7-highspeed",
           "Provider without tierModels (openrouter bare) does not append --model-* flags",
           "Flags use claudish-prefixed form from getLaunchModelForModel (e.g. kc@kimi-k2 not bare kimi-k2)",
-          "--model-subagent maps to tierModels.haiku"
+          "--model-subagent maps to tierModels.haiku",
+          "agents-auth-routing.test.ts claudish command string tests updated to assert --model-* flags"
         ]
       },
       {
         "id": "tests",
-        "title": "Write Vitest tests covering all three routing paths",
+        "title": "Add new Vitest assertions for behaviors not covered by per-bead test updates",
         "status": "pending",
         "acceptanceCriteria": [
-          "providers.test.ts: each claudish provider test asserts tier-model env vars alongside the API key",
-          "agents-auth-routing.test.ts: claudish command strings assert --model-* flags",
-          "agents-auth-routing.test.ts: GPT subscription path asserts tier-model env vars in result",
-          "agents-auth-routing.test.ts: Anthropic direct path unchanged (no tier-model vars)",
-          "agents-auth-routing.test.ts: getProviderExportsForModel for Anthropic unsets 12 vars",
+          "New test: subscription-oauth path (google provider) returns tier-model vars (no API key var)",
+          "New test: openrouter (no tierModels) does not append --model-* flags to claudish command",
+          "New test: Anthropic direct path unchanged — no tier-model vars in env, no flags in command",
           "npm test passes"
         ]
       },

--- a/.pan/spec.vbrief.json
+++ b/.pan/spec.vbrief.json
@@ -1,0 +1,97 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.5",
+    "author": "agent:claude-opus-4-6",
+    "description": "PAN-1032: claudish model-flag injection + tier-model env vars for claudish and CLIProxy paths",
+    "created": "2026-05-08T00:00:00Z"
+  },
+  "plan": {
+    "issueId": "PAN-1032",
+    "title": "claudish model-flag injection + tests (PAN-920 follow-up)",
+    "status": "proposed",
+    "sequence": 0,
+    "updated": "2026-05-08T00:00:00Z",
+    "narratives": {
+      "Overview": "PAN-920 added tierModels to all ProviderConfig entries and injected subagent tier-model env vars for direct providers. Two gaps remain: (1) claudish-backed providers receive no tier-model env vars and no CLI flags; (2) the CLIProxy path (OpenAI subscription) also misses tier-model injection. Additionally PROVIDER_ENV_KEYS in agents.ts and child-env.ts are incomplete.",
+      "Architecture": "Single source of truth: provider.tierModels. Two emit paths per spawn: CLI flags in getAgentRuntimeBaseCommand (agents.ts) and env vars in getProviderEnv (providers.ts) or getProviderEnvForModel CLIProxy path (agents.ts). PROVIDER_ENV_KEYS tracking in agents.ts and child-env.ts must include all five tier-model vars."
+    },
+    "items": [
+      {
+        "id": "env-keys",
+        "title": "Expand PROVIDER_ENV_KEYS in agents.ts and child-env.ts",
+        "status": "pending",
+        "acceptanceCriteria": [
+          "PROVIDER_ENV_KEYS array in agents.ts adds ANTHROPIC_DEFAULT_OPUS_MODEL, ANTHROPIC_DEFAULT_SONNET_MODEL, ANTHROPIC_SMALL_FAST_MODEL, CLAUDE_CODE_SUBAGENT_MODEL",
+          "PROVIDER_ENV_KEYS Set in child-env.ts adds the same four vars",
+          "getProviderExportsForModel test updated to expect 12 unset lines"
+        ]
+      },
+      {
+        "id": "claudish-env",
+        "title": "Inject tier-model env vars into claudish branch of getProviderEnv (providers.ts)",
+        "status": "pending",
+        "acceptanceCriteria": [
+          "getProviderEnv for kimi returns KIMI_CODING_API_KEY plus tier-model env vars",
+          "getProviderEnv for openai API-key returns OPENAI_API_KEY plus tier-model env vars",
+          "getProviderEnv for google returns GEMINI_API_KEY plus tier-model env vars",
+          "getProviderEnv for minimax returns MINIMAX_API_KEY plus tier-model env vars",
+          "getProviderEnv for zai returns ZHIPU_API_KEY plus tier-model env vars",
+          "getProviderEnv for mimo returns ANTHROPIC_API_KEY plus tier-model env vars",
+          "getProviderEnv for openrouter returns OPENROUTER_API_KEY only (no tierModels)",
+          "subscription-oauth path returns empty env (unchanged)"
+        ]
+      },
+      {
+        "id": "cliproxy-env",
+        "title": "Inject tier-model env vars into CLIProxy path of getProviderEnvForModel (agents.ts)",
+        "status": "pending",
+        "acceptanceCriteria": [
+          "When OpenAI subscription login is active, getProviderEnvForModel returns cliproxy env PLUS tier-model env vars from PROVIDERS.openai.tierModels",
+          "Tier-model vars: ANTHROPIC_DEFAULT_OPUS_MODEL=gpt-5.5-pro, ANTHROPIC_DEFAULT_SONNET_MODEL=gpt-5.5, ANTHROPIC_DEFAULT_HAIKU_MODEL=gpt-5.5-mini, ANTHROPIC_SMALL_FAST_MODEL=gpt-5.5-mini, CLAUDE_CODE_SUBAGENT_MODEL=gpt-5.5-mini"
+        ]
+      },
+      {
+        "id": "claudish-flags",
+        "title": "Append --model-opus/sonnet/haiku/subagent flags to claudish command in getAgentRuntimeBaseCommand",
+        "status": "pending",
+        "acceptanceCriteria": [
+          "getAgentRuntimeBaseCommand for kimi-k2.6 includes --model-opus kc@kimi-k2.6 --model-sonnet kc@kimi-k2.5 --model-haiku kc@kimi-k2 --model-subagent kc@kimi-k2",
+          "getAgentRuntimeBaseCommand for minimax-m2.7 includes --model-opus mm@minimax-m2.7 --model-sonnet mm@minimax-m2.7 --model-haiku mm@minimax-m2.7-highspeed --model-subagent mm@minimax-m2.7-highspeed",
+          "Provider without tierModels (openrouter bare) does not append --model-* flags",
+          "Flags use claudish-prefixed form from getLaunchModelForModel (e.g. kc@kimi-k2 not bare kimi-k2)",
+          "--model-subagent maps to tierModels.haiku"
+        ]
+      },
+      {
+        "id": "tests",
+        "title": "Write Vitest tests covering all three routing paths",
+        "status": "pending",
+        "acceptanceCriteria": [
+          "providers.test.ts: each claudish provider test asserts tier-model env vars alongside the API key",
+          "agents-auth-routing.test.ts: claudish command strings assert --model-* flags",
+          "agents-auth-routing.test.ts: GPT subscription path asserts tier-model env vars in result",
+          "agents-auth-routing.test.ts: Anthropic direct path unchanged (no tier-model vars)",
+          "agents-auth-routing.test.ts: getProviderExportsForModel for Anthropic unsets 12 vars",
+          "npm test passes"
+        ]
+      },
+      {
+        "id": "docs",
+        "title": "Update HARNESSES.md with claudish model-flag documentation",
+        "status": "pending",
+        "acceptanceCriteria": [
+          "HARNESSES.md has a subsection documenting --model-opus/sonnet/haiku/subagent flags",
+          "Documents that flag values come from provider.tierModels in claudish-prefixed form",
+          "Documents that env vars are also injected for in-process subagent spawning",
+          "CLAUDE.md is NOT modified"
+        ]
+      }
+    ],
+    "edges": [
+      { "from": "env-keys", "to": "tests", "label": "tests assert on unset line count which depends on PROVIDER_ENV_KEYS" },
+      { "from": "claudish-env", "to": "tests", "label": "providers.test.ts assertions depend on claudish env injection" },
+      { "from": "cliproxy-env", "to": "tests", "label": "CLIProxy test depends on CLIProxy env injection" },
+      { "from": "claudish-flags", "to": "tests", "label": "command string tests depend on flag injection" }
+    ]
+  }
+}

--- a/docs/prds/planned/PAN-1032-claudish-model-flag-injection.md
+++ b/docs/prds/planned/PAN-1032-claudish-model-flag-injection.md
@@ -1,0 +1,60 @@
+# PAN-1032: claudish --model-opus/--model-sonnet/--model-haiku/--model-subagent Flag Injection + Tests
+
+**GitHub Issue:** [#1032](https://github.com/eltmon/panopticon-cli/issues/1032)
+**Follows up:** PAN-920 (subagent tier-model env var injection for direct providers)
+
+---
+
+## Problem
+
+PAN-920 added `tierModels` to every `ProviderConfig` and injected subagent-model env vars for **direct providers** (Kimi Code Plan, MiMo, MiniMax, Z.AI). Three gaps remain:
+
+### Gap 1 — claudish providers: no env injection + no CLI flags
+
+The claudish branch of `getProviderEnv` in `src/lib/providers.ts` (lines 274–312) returns only the native API key env var. claudish itself (at `/home/eltmon/.config/nvm/versions/node/v22.22.0/bin/claudish`) accepts four CLI flags at launch time for subagent model routing:
+
+```
+--model-opus     <model>
+--model-sonnet   <model>
+--model-haiku    <model>
+--model-subagent <model>
+```
+
+These flags are not currently passed in `getAgentRuntimeBaseCommand`.
+
+### Gap 2 — CLIProxy path: no env injection
+
+When OpenAI models route through CLIProxy (subscription/OAuth), `getProviderEnvForModel` returns early with `getCliproxyClientEnv()`, skipping tier-model injection entirely.
+
+### Gap 3 — PROVIDER_ENV_KEYS tracking incomplete
+
+Four tier-model env vars are missing from PROVIDER_ENV_KEYS in agents.ts and child-env.ts: `ANTHROPIC_DEFAULT_OPUS_MODEL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL`, `CLAUDE_CODE_SUBAGENT_MODEL`. Stale values from a previous Anthropic session can leak into claudish-routed spawns.
+
+---
+
+## Solution
+
+**Single source of truth:** `provider.tierModels`. One read, two emit paths: CLI flags in `getAgentRuntimeBaseCommand`, env vars in `getProviderEnv`/`getProviderEnvForModel`.
+
+### A. Expand PROVIDER_ENV_KEYS (agents.ts + child-env.ts)
+Add the four missing vars to both tracking structures.
+
+### B. Claudish env injection (providers.ts)
+After setting the native API key in the claudish branch, apply the same tierModels injection as the direct branch.
+
+### C. CLIProxy env injection (agents.ts)
+After `getCliproxyClientEnv()`, merge tier-model env vars from `PROVIDERS.openai.tierModels`.
+
+### D. claudish CLI flags (agents.ts)
+In `getAgentRuntimeBaseCommand`, append `--model-opus <val> --model-sonnet <val> --model-haiku <val> --model-subagent <val>` from `provider.tierModels`. Flag values use the claudish-prefixed form (e.g. `kc@kimi-k2` from `getLaunchModelForModel`). `--model-subagent` maps to `tierModels.haiku`.
+
+---
+
+## Acceptance Criteria
+
+1. `getProviderEnv` for all claudish providers returns tier-model env vars alongside the native API key.
+2. `getProviderEnvForModel` for CLIProxy returns tier-model env vars alongside the cliproxy env.
+3. `getAgentRuntimeBaseCommand` for claudish models appends all four `--model-*` flags when `provider.tierModels` is defined.
+4. `PROVIDER_ENV_KEYS` in both agents.ts and child-env.ts includes all five tier-model env vars (haiku was already there).
+5. Existing tests pass. New Vitest tests cover all three routing paths.
+6. `HARNESSES.md` documents the flag injection behavior.

--- a/vbrief/proposed/2026-05-08-PAN-1032-claudish-model-flag-injection.vbrief.json
+++ b/vbrief/proposed/2026-05-08-PAN-1032-claudish-model-flag-injection.vbrief.json
@@ -1,0 +1,97 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.5",
+    "author": "agent:claude-opus-4-6",
+    "description": "PAN-1032: claudish model-flag injection + tier-model env vars for claudish and CLIProxy paths",
+    "created": "2026-05-08T00:00:00Z"
+  },
+  "plan": {
+    "issueId": "PAN-1032",
+    "title": "claudish model-flag injection + tests (PAN-920 follow-up)",
+    "status": "proposed",
+    "sequence": 0,
+    "updated": "2026-05-08T00:00:00Z",
+    "narratives": {
+      "Overview": "PAN-920 added tierModels to all ProviderConfig entries and injected subagent tier-model env vars for direct providers. Two gaps remain: (1) claudish-backed providers receive no tier-model env vars and no CLI flags; (2) the CLIProxy path (OpenAI subscription) also misses tier-model injection. Additionally PROVIDER_ENV_KEYS in agents.ts and child-env.ts are incomplete.",
+      "Architecture": "Single source of truth: provider.tierModels. Two emit paths per spawn: CLI flags in getAgentRuntimeBaseCommand (agents.ts) and env vars in getProviderEnv (providers.ts) or getProviderEnvForModel CLIProxy path (agents.ts). PROVIDER_ENV_KEYS tracking in agents.ts and child-env.ts must include all five tier-model vars."
+    },
+    "items": [
+      {
+        "id": "env-keys",
+        "title": "Expand PROVIDER_ENV_KEYS in agents.ts and child-env.ts",
+        "status": "pending",
+        "acceptanceCriteria": [
+          "PROVIDER_ENV_KEYS array in agents.ts adds ANTHROPIC_DEFAULT_OPUS_MODEL, ANTHROPIC_DEFAULT_SONNET_MODEL, ANTHROPIC_SMALL_FAST_MODEL, CLAUDE_CODE_SUBAGENT_MODEL",
+          "PROVIDER_ENV_KEYS Set in child-env.ts adds the same four vars",
+          "getProviderExportsForModel test updated to expect 12 unset lines"
+        ]
+      },
+      {
+        "id": "claudish-env",
+        "title": "Inject tier-model env vars into claudish branch of getProviderEnv (providers.ts)",
+        "status": "pending",
+        "acceptanceCriteria": [
+          "getProviderEnv for kimi returns KIMI_CODING_API_KEY plus tier-model env vars",
+          "getProviderEnv for openai API-key returns OPENAI_API_KEY plus tier-model env vars",
+          "getProviderEnv for google returns GEMINI_API_KEY plus tier-model env vars",
+          "getProviderEnv for minimax returns MINIMAX_API_KEY plus tier-model env vars",
+          "getProviderEnv for zai returns ZHIPU_API_KEY plus tier-model env vars",
+          "getProviderEnv for mimo returns ANTHROPIC_API_KEY plus tier-model env vars",
+          "getProviderEnv for openrouter returns OPENROUTER_API_KEY only (no tierModels)",
+          "subscription-oauth path returns empty env (unchanged)"
+        ]
+      },
+      {
+        "id": "cliproxy-env",
+        "title": "Inject tier-model env vars into CLIProxy path of getProviderEnvForModel (agents.ts)",
+        "status": "pending",
+        "acceptanceCriteria": [
+          "When OpenAI subscription login is active, getProviderEnvForModel returns cliproxy env PLUS tier-model env vars from PROVIDERS.openai.tierModels",
+          "Tier-model vars: ANTHROPIC_DEFAULT_OPUS_MODEL=gpt-5.5-pro, ANTHROPIC_DEFAULT_SONNET_MODEL=gpt-5.5, ANTHROPIC_DEFAULT_HAIKU_MODEL=gpt-5.5-mini, ANTHROPIC_SMALL_FAST_MODEL=gpt-5.5-mini, CLAUDE_CODE_SUBAGENT_MODEL=gpt-5.5-mini"
+        ]
+      },
+      {
+        "id": "claudish-flags",
+        "title": "Append --model-opus/sonnet/haiku/subagent flags to claudish command in getAgentRuntimeBaseCommand",
+        "status": "pending",
+        "acceptanceCriteria": [
+          "getAgentRuntimeBaseCommand for kimi-k2.6 includes --model-opus kc@kimi-k2.6 --model-sonnet kc@kimi-k2.5 --model-haiku kc@kimi-k2 --model-subagent kc@kimi-k2",
+          "getAgentRuntimeBaseCommand for minimax-m2.7 includes --model-opus mm@minimax-m2.7 --model-sonnet mm@minimax-m2.7 --model-haiku mm@minimax-m2.7-highspeed --model-subagent mm@minimax-m2.7-highspeed",
+          "Provider without tierModels (openrouter bare) does not append --model-* flags",
+          "Flags use claudish-prefixed form from getLaunchModelForModel (e.g. kc@kimi-k2 not bare kimi-k2)",
+          "--model-subagent maps to tierModels.haiku"
+        ]
+      },
+      {
+        "id": "tests",
+        "title": "Write Vitest tests covering all three routing paths",
+        "status": "pending",
+        "acceptanceCriteria": [
+          "providers.test.ts: each claudish provider test asserts tier-model env vars alongside the API key",
+          "agents-auth-routing.test.ts: claudish command strings assert --model-* flags",
+          "agents-auth-routing.test.ts: GPT subscription path asserts tier-model env vars in result",
+          "agents-auth-routing.test.ts: Anthropic direct path unchanged (no tier-model vars)",
+          "agents-auth-routing.test.ts: getProviderExportsForModel for Anthropic unsets 12 vars",
+          "npm test passes"
+        ]
+      },
+      {
+        "id": "docs",
+        "title": "Update HARNESSES.md with claudish model-flag documentation",
+        "status": "pending",
+        "acceptanceCriteria": [
+          "HARNESSES.md has a subsection documenting --model-opus/sonnet/haiku/subagent flags",
+          "Documents that flag values come from provider.tierModels in claudish-prefixed form",
+          "Documents that env vars are also injected for in-process subagent spawning",
+          "CLAUDE.md is NOT modified"
+        ]
+      }
+    ],
+    "edges": [
+      { "from": "env-keys", "to": "tests", "label": "tests assert on unset line count which depends on PROVIDER_ENV_KEYS" },
+      { "from": "claudish-env", "to": "tests", "label": "providers.test.ts assertions depend on claudish env injection" },
+      { "from": "cliproxy-env", "to": "tests", "label": "CLIProxy test depends on CLIProxy env injection" },
+      { "from": "claudish-flags", "to": "tests", "label": "command string tests depend on flag injection" }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #1032

## Acceptance Criteria

- [ ] Expand PROVIDER_ENV_KEYS in agents.ts and child-env.ts
- [ ] Inject tier-model env vars into claudish branch of getProviderEnv (providers.ts)
- [ ] Inject tier-model env vars into CLIProxy path of getProviderEnvForModel (agents.ts)
- [ ] Append --model-opus/sonnet/haiku/subagent flags to claudish command in getAgentRuntimeBaseCommand
- [ ] Add new Vitest assertions for behaviors not covered by per-bead test updates
- [ ] Update HARNESSES.md with claudish model-flag documentation

## Implementation Tasks

- [ ] Update HARNESSES.md with claudish model-flag documentation
- [ ] Write Vitest tests covering all three routing paths
- [ ] Append --model-opus/sonnet/haiku/subagent flags to claudish command
- [ ] Inject tier-model env vars into CLIProxy path of getProviderEnvForModel
- [ ] Inject tier-model env vars into claudish branch of getProviderEnv
- [ ] Expand PROVIDER_ENV_KEYS in agents.ts and child-env.ts