### PR TITLE
PAN-945

### DIFF
--- a/.pan/continue.json
+++ b/.pan/continue.json
@@ -2,10 +2,10 @@
   "version": "1",
   "issueId": "PAN-945",
   "created": "2026-05-07T09:30:00Z",
-  "updated": "2026-05-09T01:35:25Z",
+  "updated": "2026-05-09T01:41:20Z",
   "gitState": {
     "branch": "feature/pan-945",
-    "sha": "406dedef4",
+    "sha": "f7e0507d0",
     "dirty": true
   },
   "decisions": [
@@ -44,6 +44,18 @@
       "summary": "Updated path module mocks in existing tests to include the PRD directory constants now imported by vBRIEF I/O.",
       "rationale": "Adding PRD vBRIEF discovery made `src/lib/vbrief/io.ts` import `PROJECT_DOCS_SUBDIR`, `PROJECT_PRDS_SUBDIR`, `PROJECT_PRDS_ACTIVE_SUBDIR`, and `PROJECT_PRDS_PLANNED_SUBDIR`. Several older tests mock `paths.js` narrowly for unrelated agent or lifecycle behavior, so the full suite failed at module import time even though the production constants exist. Extending those mocks keeps the tests focused on their original subjects while satisfying the expanded public surface they transitively import.",
       "recordedAt": "2026-05-09T01:35:25Z"
+    },
+    {
+      "id": "D7",
+      "summary": "Resolved the merge from `origin/main` by keeping the PAN-945 workspace continue state instead of unrelated main-branch continue state from another issue.",
+      "rationale": "The only textual merge conflict was `.pan/continue.json`. The incoming main version described PAN-1025 and would have destroyed the recovery context for this PAN-945 workspace. Keeping the PAN-945 continue state preserves the issue-specific decisions, hazards, and resume history while still allowing the rest of the main-branch code and artifact updates to merge normally.",
+      "recordedAt": "2026-05-09T01:42:00Z"
+    },
+    {
+      "id": "D8",
+      "summary": "Fixed merged `panopticon-bridge.ts` typecheck errors by importing the Node APIs used by the new channel bridge code.",
+      "rationale": "After merging `origin/main`, `npm run typecheck` failed because `panopticon-bridge.ts` referenced `timingSafeEqual` and `unlinkSync` without importing them. These were direct missing imports in the merged main changes, not PAN-945 logic. Adding `timingSafeEqual` from `node:crypto` and `unlinkSync` from `node:fs` fixes the TypeScript errors at the source and keeps the channel bridge implementation intact.",
+      "recordedAt": "2026-05-09T01:41:20Z"
     }
   ],
   "hazards": [
@@ -71,10 +83,20 @@
       "id": "H5",
       "summary": "Tests that mock `paths.js` can fail at import time when production modules add new exported path constants, even if those tests do not exercise the new behavior directly.",
       "mitigation": "The affected mocks now include the PRD path constants used by vBRIEF I/O. The previously failing suites were rerun together and passed, proving the test scaffolding matches the production module surface again."
+    },
+    {
+      "id": "H6",
+      "summary": "Main branch may contain a `.pan/continue.json` from a different issue because workspace state files are committed during agent work, creating frequent merge conflicts in recovered workspaces.",
+      "mitigation": "During the merge from `origin/main`, the PAN-945 continue state was kept and the unrelated PAN-1025 state from main was discarded for this workspace. Future cleanup should keep workspace continue files issue-scoped or avoid carrying unrelated continue state across active workspaces."
+    },
+    {
+      "id": "H7",
+      "summary": "Merging a fast-moving main branch can introduce unrelated typecheck failures that block PAN-945 submission even when PAN-945 code is already valid.",
+      "mitigation": "The merged `panopticon-bridge.ts` missing imports were fixed directly and `npm run typecheck` was rerun successfully before continuing to full gate verification."
     }
   ],
   "resumePoint": {
-    "description": "All PAN-945 beads are closed. Commit the test mock compatibility fixes, rerun the full quality gates, push `feature/pan-945`, and call `pan done PAN-945` with a terse summary if the tree is clean and the gates pass.",
+    "description": "The branch has merged `origin/main`, the `.pan/continue.json` conflict is resolved, and the merged channel bridge typecheck errors are fixed. Commit the typecheck fix, rerun full quality gates, push the branch, and rerun `pan done PAN-945`.",
     "beadId": null,
     "filesToRead": [
       "src/lib/vbrief/io.ts",
@@ -120,6 +142,18 @@
       "timestamp": "2026-05-09T01:35:25Z",
       "reason": "progress",
       "note": "The full quality gate initially failed because several unrelated tests mocked `paths.js` without the PRD path constants that `src/lib/vbrief/io.ts` now imports. I updated those mocks to include the missing constants and reran the four previously failing suites together; they all passed. The next step is to commit these test compatibility fixes and rerun the full quality gate.",
+      "agentModel": "kc@kimi-k2.6"
+    },
+    {
+      "timestamp": "2026-05-09T01:42:00Z",
+      "reason": "progress",
+      "note": "Merged `origin/main` after the first `pan done PAN-945` attempt reported a rebase conflict. The merge conflict was limited to `.pan/continue.json`; I resolved it by keeping the PAN-945 recovery state and discarding the unrelated PAN-1025 continue state from main. The merge still needs to be committed, verified, pushed, and submitted through `pan done` again.",
+      "agentModel": "kc@kimi-k2.6"
+    },
+    {
+      "timestamp": "2026-05-09T01:41:20Z",
+      "reason": "progress",
+      "note": "After the merge commit, `npm run typecheck` failed in the newly merged channel bridge code because `timingSafeEqual` and `unlinkSync` were referenced without imports. I added the missing `node:crypto` and `node:fs` imports and reran `npm run typecheck`; it passed. The next step is to commit this merged-main typecheck fix and rerun the full gate.",
       "agentModel": "kc@kimi-k2.6"
     }
   ]

--- a/.pan/continue.json
+++ b/.pan/continue.json
@@ -2,10 +2,10 @@
   "version": "1",
   "issueId": "PAN-945",
   "created": "2026-05-07T09:30:00Z",
-  "updated": "2026-05-09T01:15:27Z",
+  "updated": "2026-05-09T01:28:49Z",
   "gitState": {
     "branch": "feature/pan-945",
-    "sha": "d5db45e6f",
+    "sha": "bf16520db",
     "dirty": true
   },
   "decisions": [
@@ -26,6 +26,12 @@
       "summary": "Imported PRD-directory vBRIEFs inside the dashboard start-agent route before plan validation and beads auto-recovery run.",
       "rationale": "The start-agent endpoint already creates the workspace and then validates `.pan/spec.vbrief.json`. Copying the PRD-scoped plan into `.pan/spec.vbrief.json` at that point gives the rest of the existing route a normal workspace-local plan, including stale-issue validation, empty-plan validation, beads recovery, running-status transition, and planning-artifact commit behavior. The copy uses `fs/promises` so the dashboard request path does not block the Node.js event loop.",
       "recordedAt": "2026-05-09T01:15:27Z"
+    },
+    {
+      "id": "D4",
+      "summary": "Extracted the copy operation into `importVBriefFromPrdDirs` and tested both discovery and import behavior in the vBRIEF I/O test suite.",
+      "rationale": "Dashboard and CLI start flows need the same non-overwriting import behavior. Keeping the copy operation in `src/lib/vbrief/io.ts` prevents duplicated path logic, gives tests a focused unit-level seam, and lets both callers materialize a workspace-local `.pan/spec.vbrief.json` while preserving `findPlan` as a workspace-only lookup.",
+      "recordedAt": "2026-05-09T01:28:49Z"
     }
   ],
   "hazards": [
@@ -38,15 +44,20 @@
       "id": "H2",
       "summary": "Dashboard start-agent runs inside the HTTP server, so any import logic that reads directories or copies files synchronously could freeze polling, WebSocket traffic, and terminal streaming.",
       "mitigation": "The route keeps only the fast `existsSync` discovery helper on the synchronous side and performs directory creation plus vBRIEF copying through `fs/promises` inside `Effect.promise`. No `readFileSync`, `writeFileSync`, directory scans, or shell-based copy commands were added to the server route."
+    },
+    {
+      "id": "H3",
+      "summary": "Auto-import must not overwrite a workspace-local plan because the workspace plan may contain newer agent status, bead progress, or user edits than the PRD archive copy.",
+      "mitigation": "`importVBriefFromPrdDirs` returns null immediately when `findPlan(workspacePath)` already finds `.pan/spec.vbrief.json`. The test suite now asserts that an existing workspace plan is preserved even when a matching PRD vBRIEF exists."
     }
   ],
   "resumePoint": {
-    "description": "Finish bead workspace-qmrt by committing the dashboard start-agent PRD vBRIEF import, closing the bead for inspection, and then proceed to bead workspace-bqcl to wire the same PRD vBRIEF import behavior into the CLI `pan start` command.",
-    "beadId": "workspace-qmrt",
+    "description": "Finish bead workspace-2dp3 by committing the vBRIEF discovery and auto-import tests, closing the bead, and then proceed to bead workspace-bqcl to wire `importVBriefFromPrdDirs` into the CLI `pan start` command.",
+    "beadId": "workspace-2dp3",
     "filesToRead": [
-      "src/dashboard/server/routes/agents.ts",
-      "src/cli/commands/start.ts",
-      "src/lib/vbrief/io.ts"
+      "src/lib/vbrief/io.ts",
+      "src/lib/vbrief/__tests__/io.test.ts",
+      "src/cli/commands/start.ts"
     ]
   },
   "beadsMapping": {},
@@ -68,6 +79,12 @@
       "timestamp": "2026-05-09T01:15:27Z",
       "reason": "progress",
       "note": "Implemented dashboard start-agent auto-import for PRD-directory vBRIEFs. When a workspace has no `.pan/spec.vbrief.json`, the route now discovers a matching vBRIEF under `docs/prds/{active,planned}` or `api/docs/prds/{active,planned}`, copies it into `.pan/spec.vbrief.json` with asynchronous filesystem operations, and then lets existing validation, beads recovery, and plan status handling continue against the workspace-local plan. `npm run typecheck` passed after the route change.",
+      "agentModel": "kc@kimi-k2.6"
+    },
+    {
+      "timestamp": "2026-05-09T01:28:49Z",
+      "reason": "progress",
+      "note": "Completed the test bead by adding coverage for all supported PRD vBRIEF discovery layouts, verifying that PRD vBRIEFs are copied into `.pan/spec.vbrief.json` when missing, and verifying that an existing workspace-local plan is never overwritten. The dashboard route now calls the shared async `importVBriefFromPrdDirs` helper instead of carrying its own copy logic. `npm test -- src/lib/vbrief/__tests__/io.test.ts` and `npm run typecheck` both passed.",
       "agentModel": "kc@kimi-k2.6"
     }
   ]

--- a/.pan/continue.json
+++ b/.pan/continue.json
@@ -2,10 +2,10 @@
   "version": "1",
   "issueId": "PAN-945",
   "created": "2026-05-07T09:30:00Z",
-  "updated": "2026-05-09T01:30:53Z",
+  "updated": "2026-05-09T01:35:25Z",
   "gitState": {
     "branch": "feature/pan-945",
-    "sha": "ccf26a582",
+    "sha": "406dedef4",
     "dirty": true
   },
   "decisions": [
@@ -38,6 +38,12 @@
       "summary": "Wired `pan start` to call `importVBriefFromPrdDirs` before validating the workspace plan or recovering beads.",
       "rationale": "CLI starts need the same fixed point as dashboard starts: if a PRD-scoped vBRIEF exists and the workspace lacks `.pan/spec.vbrief.json`, the start flow must materialize the workspace-local plan before stale-plan validation, beads recovery, or simple-issue bead creation run. This prevents `pan start` from treating a PRD-first planned issue as unplanned and creating the wrong fallback bead.",
       "recordedAt": "2026-05-09T01:30:53Z"
+    },
+    {
+      "id": "D6",
+      "summary": "Updated path module mocks in existing tests to include the PRD directory constants now imported by vBRIEF I/O.",
+      "rationale": "Adding PRD vBRIEF discovery made `src/lib/vbrief/io.ts` import `PROJECT_DOCS_SUBDIR`, `PROJECT_PRDS_SUBDIR`, `PROJECT_PRDS_ACTIVE_SUBDIR`, and `PROJECT_PRDS_PLANNED_SUBDIR`. Several older tests mock `paths.js` narrowly for unrelated agent or lifecycle behavior, so the full suite failed at module import time even though the production constants exist. Extending those mocks keeps the tests focused on their original subjects while satisfying the expanded public surface they transitively import.",
+      "recordedAt": "2026-05-09T01:35:25Z"
     }
   ],
   "hazards": [
@@ -60,14 +66,20 @@
       "id": "H4",
       "summary": "If CLI import of an existing PRD vBRIEF fails, silently continuing would allow the old simple-issue fallback to create misleading beads for a planned issue.",
       "mitigation": "`pan start` now fails immediately when `importVBriefFromPrdDirs` throws. Missing PRD vBRIEFs remain non-fatal, but copy errors for discovered artifacts stop the start flow so the underlying filesystem or permissions problem is visible."
+    },
+    {
+      "id": "H5",
+      "summary": "Tests that mock `paths.js` can fail at import time when production modules add new exported path constants, even if those tests do not exercise the new behavior directly.",
+      "mitigation": "The affected mocks now include the PRD path constants used by vBRIEF I/O. The previously failing suites were rerun together and passed, proving the test scaffolding matches the production module surface again."
     }
   ],
   "resumePoint": {
-    "description": "Finish bead workspace-bqcl by committing the CLI `pan start` import wiring, closing the bead, and then resolve the remaining core discovery bead workspace-linp if it is still open because the initial helper commit predates the recovered bead close state.",
-    "beadId": "workspace-bqcl",
+    "description": "All PAN-945 beads are closed. Commit the test mock compatibility fixes, rerun the full quality gates, push `feature/pan-945`, and call `pan done PAN-945` with a terse summary if the tree is clean and the gates pass.",
+    "beadId": null,
     "filesToRead": [
-      "src/cli/commands/start.ts",
       "src/lib/vbrief/io.ts",
+      "src/cli/commands/start.ts",
+      "src/dashboard/server/routes/agents.ts",
       ".pan/continue.json"
     ]
   },
@@ -102,6 +114,12 @@
       "timestamp": "2026-05-09T01:30:53Z",
       "reason": "progress",
       "note": "Completed CLI start wiring by calling `importVBriefFromPrdDirs` after continue-state validation and before plan validation or beads recovery. This lets `pan start` import PRD-first vBRIEF plans into `.pan/spec.vbrief.json` before the runtime decides whether planning exists. `npm run typecheck` and the focused vBRIEF I/O test file both passed after the change.",
+      "agentModel": "kc@kimi-k2.6"
+    },
+    {
+      "timestamp": "2026-05-09T01:35:25Z",
+      "reason": "progress",
+      "note": "The full quality gate initially failed because several unrelated tests mocked `paths.js` without the PRD path constants that `src/lib/vbrief/io.ts` now imports. I updated those mocks to include the missing constants and reran the four previously failing suites together; they all passed. The next step is to commit these test compatibility fixes and rerun the full quality gate.",
       "agentModel": "kc@kimi-k2.6"
     }
   ]

--- a/.pan/continue.json
+++ b/.pan/continue.json
@@ -1,0 +1,23 @@
+{
+  "version": "1",
+  "issueId": "PAN-945",
+  "created": "2026-05-07T09:30:00Z",
+  "updated": "2026-05-07T09:30:00Z",
+  "gitState": { "branch": "feature/pan-945", "sha": "33b2387f6", "dirty": false },
+  "decisions": [
+    { "id": "D1", "summary": "Create findVBriefInPrdDirs helper in vbrief/io.ts to search docs/prds/planned/, docs/prds/active/, api/docs/prds/planned/, api/docs/prds/active/ for .vbrief.json files matching an issue ID.", "recordedAt": "2026-05-07T09:30:00Z" }
+  ],
+  "hazards": [
+    { "id": "H1", "summary": "PRD dir paths may not exist in all project structures", "mitigation": "Use existsSync checks and graceful fallbacks" }
+  ],
+  "resumePoint": {
+    "description": "Implement bead workspace-d5qf: add findVBriefInPrdDirs helper to src/lib/vbrief/io.ts. Then integrate into CLI start.ts and dashboard agents.ts.",
+    "beadId": "workspace-d5qf",
+    "filesToRead": ["src/lib/vbrief/io.ts", "src/cli/commands/start.ts", "src/dashboard/server/routes/agents.ts"]
+  },
+  "beadsMapping": {},
+  "agentModel": "kc@kimi-k2.6",
+  "sessionHistory": [
+    { "timestamp": "2026-05-07T09:30:00Z", "reason": "start", "note": "Started PAN-945 implementation. Rebased onto main, removed stale continue.json, created beads.", "agentModel": "kc@kimi-k2.6" }
+  ]
+}

--- a/.pan/continue.json
+++ b/.pan/continue.json
@@ -2,7 +2,7 @@
   "version": "1",
   "issueId": "PAN-945",
   "created": "2026-05-07T09:30:00Z",
-  "updated": "2026-05-09T02:22:00.000Z",
+  "updated": "2026-05-09T02:27:40.766Z",
   "gitState": {
     "branch": "feature/pan-945",
     "sha": "266e38308",
@@ -188,6 +188,11 @@
       "reason": "review-feedback",
       "note": "Resumed after CHANGES_REQUESTED review feedback. The local `.pan/feedback` files were stale PAN-1025 verification notes, so the actionable review blockers came from the resume prompt. I created and claimed bead workspace-hbu9 for the review fix, hardened PRD vBRIEF discovery and import against slug misses, symlink copying, path traversal, invalid documents, and swallowed dashboard import errors, replaced the stale workspace spec artifact with a PAN-945 vBRIEF, and verified the focused vBRIEF and agent route tests plus typecheck, lint, and the full test suite. Commit, bead close inspection, push, and submission remain pending.",
       "agentModel": "claude-opus-4-7"
+    },
+    {
+      "timestamp": "2026-05-09T02:27:40.766Z",
+      "reason": "end",
+      "note": "Fixed review blockers for PRD vBRIEF discovery/import hardening"
     }
   ],
   "feedback": []

--- a/.pan/continue.json
+++ b/.pan/continue.json
@@ -2,7 +2,7 @@
   "version": "1",
   "issueId": "PAN-945",
   "created": "2026-05-07T09:30:00Z",
-  "updated": "2026-05-09T02:27:40.766Z",
+  "updated": "2026-05-10T04:44:19.835Z",
   "gitState": {
     "branch": "feature/pan-945",
     "sha": "266e38308",
@@ -193,6 +193,11 @@
       "timestamp": "2026-05-09T02:27:40.766Z",
       "reason": "end",
       "note": "Fixed review blockers for PRD vBRIEF discovery/import hardening"
+    },
+    {
+      "timestamp": "2026-05-10T04:44:19.835Z",
+      "reason": "end",
+      "note": "Rebased onto current main and fixed checkpoint test after substrate restore"
     }
   ],
   "feedback": []

--- a/.pan/continue.json
+++ b/.pan/continue.json
@@ -2,31 +2,52 @@
   "version": "1",
   "issueId": "PAN-945",
   "created": "2026-05-07T09:30:00Z",
-  "updated": "2026-05-08T09:24:39Z",
-  "gitState": { "branch": "feature/pan-945", "sha": "12c339f08", "dirty": false },
+  "updated": "2026-05-09T01:15:27Z",
+  "gitState": {
+    "branch": "feature/pan-945",
+    "sha": "d5db45e6f",
+    "dirty": true
+  },
   "decisions": [
     {
       "id": "D1",
       "summary": "Added `findVBriefInPrdDirs` to `src/lib/vbrief/io.ts` so start flows can recover a missing workspace plan from PRD-published vBRIEF copies before the workspace `.pan/spec.vbrief.json` exists.",
+      "rationale": "PAN-945 exists because planning artifacts can live in project PRD directories while runtime code expects the workspace-local vBRIEF. A reusable discovery helper lets the start flows find the PRD-published source without broadening `findPlan`, which must remain workspace-local to avoid mutating lifecycle or archive copies by mistake.",
       "recordedAt": "2026-05-08T09:24:39Z"
     },
     {
       "id": "D2",
       "summary": "Kept discovery path checks `existsSync`-only and enumerated known layouts explicitly: flat `PAN-123-plan.vbrief.json`, lowercase flat variants, lowercase per-issue subdirectories, uppercase per-issue subdirectories, and the `api/docs/prds/*` mirror. This keeps later dashboard callers compatible with the no-blocking-server rule.",
+      "rationale": "The dashboard server may use `existsSync` for fast path existence checks but must not perform blocking file reads or directory scans on request paths. Enumerating deterministic candidate paths avoids async glob complexity and covers the historical layouts described in the issue.",
       "recordedAt": "2026-05-08T09:24:39Z"
+    },
+    {
+      "id": "D3",
+      "summary": "Imported PRD-directory vBRIEFs inside the dashboard start-agent route before plan validation and beads auto-recovery run.",
+      "rationale": "The start-agent endpoint already creates the workspace and then validates `.pan/spec.vbrief.json`. Copying the PRD-scoped plan into `.pan/spec.vbrief.json` at that point gives the rest of the existing route a normal workspace-local plan, including stale-issue validation, empty-plan validation, beads recovery, running-status transition, and planning-artifact commit behavior. The copy uses `fs/promises` so the dashboard request path does not block the Node.js event loop.",
+      "recordedAt": "2026-05-09T01:15:27Z"
     }
   ],
   "hazards": [
     {
       "id": "H1",
       "summary": "PRD-published vBRIEFs exist in multiple historical layouts and casing variants, so a narrow filename assumption would miss real plans during recovery.",
-      "mitigation": "The helper now checks both active and planned PRD roots, both flat and subdirectory formats, both lowercase and uppercase issue IDs, and the mirrored `api/docs/prds` tree before returning null."
+      "mitigation": "The helper now checks both active and planned PRD roots, both flat and subdirectory formats, both lowercase and uppercase issue IDs, and the mirrored `api/docs/prds` tree before returning null. Future route and CLI callers should use this helper instead of rebuilding path guesses locally."
+    },
+    {
+      "id": "H2",
+      "summary": "Dashboard start-agent runs inside the HTTP server, so any import logic that reads directories or copies files synchronously could freeze polling, WebSocket traffic, and terminal streaming.",
+      "mitigation": "The route keeps only the fast `existsSync` discovery helper on the synchronous side and performs directory creation plus vBRIEF copying through `fs/promises` inside `Effect.promise`. No `readFileSync`, `writeFileSync`, directory scans, or shell-based copy commands were added to the server route."
     }
   ],
   "resumePoint": {
-    "description": "Implement bead workspace-qmrt by wiring `findVBriefInPrdDirs` into the dashboard start-agent flow so the route can import a PRD-scoped vBRIEF into the workspace before plan validation runs.",
+    "description": "Finish bead workspace-qmrt by committing the dashboard start-agent PRD vBRIEF import, closing the bead for inspection, and then proceed to bead workspace-bqcl to wire the same PRD vBRIEF import behavior into the CLI `pan start` command.",
     "beadId": "workspace-qmrt",
-    "filesToRead": ["src/lib/vbrief/io.ts", "src/dashboard/server/routes/agents.ts"]
+    "filesToRead": [
+      "src/dashboard/server/routes/agents.ts",
+      "src/cli/commands/start.ts",
+      "src/lib/vbrief/io.ts"
+    ]
   },
   "beadsMapping": {},
   "agentModel": "kc@kimi-k2.6",
@@ -40,7 +61,13 @@
     {
       "timestamp": "2026-05-08T09:24:39Z",
       "reason": "progress",
-      "note": "Completed bead workspace-d5qf by adding PRD-directory vBRIEF discovery in `src/lib/vbrief/io.ts` and verified the existing vbrief I/O test suite still passes after the change.",
+      "note": "Completed the initial workspace vBRIEF discovery helper work by adding `findVBriefInPrdDirs` to `src/lib/vbrief/io.ts` and verifying that the existing vBRIEF I/O test suite still passed after the change.",
+      "agentModel": "kc@kimi-k2.6"
+    },
+    {
+      "timestamp": "2026-05-09T01:15:27Z",
+      "reason": "progress",
+      "note": "Implemented dashboard start-agent auto-import for PRD-directory vBRIEFs. When a workspace has no `.pan/spec.vbrief.json`, the route now discovers a matching vBRIEF under `docs/prds/{active,planned}` or `api/docs/prds/{active,planned}`, copies it into `.pan/spec.vbrief.json` with asynchronous filesystem operations, and then lets existing validation, beads recovery, and plan status handling continue against the workspace-local plan. `npm run typecheck` passed after the route change.",
       "agentModel": "kc@kimi-k2.6"
     }
   ]

--- a/.pan/continue.json
+++ b/.pan/continue.json
@@ -2,7 +2,7 @@
   "version": "1",
   "issueId": "PAN-945",
   "created": "2026-05-07T09:30:00Z",
-  "updated": "2026-05-09T01:41:20Z",
+  "updated": "2026-05-09T01:47:00.668Z",
   "gitState": {
     "branch": "feature/pan-945",
     "sha": "f7e0507d0",
@@ -96,14 +96,9 @@
     }
   ],
   "resumePoint": {
-    "description": "The branch has merged `origin/main`, the `.pan/continue.json` conflict is resolved, and the merged channel bridge typecheck errors are fixed. Commit the typecheck fix, rerun full quality gates, push the branch, and rerun `pan done PAN-945`.",
+    "description": "PAN-945 work is complete. All beads are closed, full quality gates passed after rebuilding the CLI dist, the branch was pushed, and `pan done PAN-945` marked the issue complete; Panopticon reported the issue was already merged and skipped the review pipeline.",
     "beadId": null,
-    "filesToRead": [
-      "src/lib/vbrief/io.ts",
-      "src/cli/commands/start.ts",
-      "src/dashboard/server/routes/agents.ts",
-      ".pan/continue.json"
-    ]
+    "filesToRead": []
   },
   "beadsMapping": {},
   "agentModel": "kc@kimi-k2.6",
@@ -155,6 +150,12 @@
       "reason": "progress",
       "note": "After the merge commit, `npm run typecheck` failed in the newly merged channel bridge code because `timingSafeEqual` and `unlinkSync` were referenced without imports. I added the missing `node:crypto` and `node:fs` imports and reran `npm run typecheck`; it passed. The next step is to commit this merged-main typecheck fix and rerun the full gate.",
       "agentModel": "kc@kimi-k2.6"
+    },
+    {
+      "timestamp": "2026-05-09T01:47:00.668Z",
+      "reason": "end",
+      "note": "Imported PRD-directory vBRIEFs into workspace plans for dashboard and CLI start flows with coverage for discovery, import, and non-overwrite behavior."
     }
-  ]
+  ],
+  "feedback": []
 }

--- a/.pan/continue.json
+++ b/.pan/continue.json
@@ -2,22 +2,46 @@
   "version": "1",
   "issueId": "PAN-945",
   "created": "2026-05-07T09:30:00Z",
-  "updated": "2026-05-07T09:30:00Z",
-  "gitState": { "branch": "feature/pan-945", "sha": "33b2387f6", "dirty": false },
+  "updated": "2026-05-08T09:24:39Z",
+  "gitState": { "branch": "feature/pan-945", "sha": "12c339f08", "dirty": false },
   "decisions": [
-    { "id": "D1", "summary": "Create findVBriefInPrdDirs helper in vbrief/io.ts to search docs/prds/planned/, docs/prds/active/, api/docs/prds/planned/, api/docs/prds/active/ for .vbrief.json files matching an issue ID.", "recordedAt": "2026-05-07T09:30:00Z" }
+    {
+      "id": "D1",
+      "summary": "Added `findVBriefInPrdDirs` to `src/lib/vbrief/io.ts` so start flows can recover a missing workspace plan from PRD-published vBRIEF copies before the workspace `.pan/spec.vbrief.json` exists.",
+      "recordedAt": "2026-05-08T09:24:39Z"
+    },
+    {
+      "id": "D2",
+      "summary": "Kept discovery path checks `existsSync`-only and enumerated known layouts explicitly: flat `PAN-123-plan.vbrief.json`, lowercase flat variants, lowercase per-issue subdirectories, uppercase per-issue subdirectories, and the `api/docs/prds/*` mirror. This keeps later dashboard callers compatible with the no-blocking-server rule.",
+      "recordedAt": "2026-05-08T09:24:39Z"
+    }
   ],
   "hazards": [
-    { "id": "H1", "summary": "PRD dir paths may not exist in all project structures", "mitigation": "Use existsSync checks and graceful fallbacks" }
+    {
+      "id": "H1",
+      "summary": "PRD-published vBRIEFs exist in multiple historical layouts and casing variants, so a narrow filename assumption would miss real plans during recovery.",
+      "mitigation": "The helper now checks both active and planned PRD roots, both flat and subdirectory formats, both lowercase and uppercase issue IDs, and the mirrored `api/docs/prds` tree before returning null."
+    }
   ],
   "resumePoint": {
-    "description": "Implement bead workspace-d5qf: add findVBriefInPrdDirs helper to src/lib/vbrief/io.ts. Then integrate into CLI start.ts and dashboard agents.ts.",
-    "beadId": "workspace-d5qf",
-    "filesToRead": ["src/lib/vbrief/io.ts", "src/cli/commands/start.ts", "src/dashboard/server/routes/agents.ts"]
+    "description": "Implement bead workspace-qmrt by wiring `findVBriefInPrdDirs` into the dashboard start-agent flow so the route can import a PRD-scoped vBRIEF into the workspace before plan validation runs.",
+    "beadId": "workspace-qmrt",
+    "filesToRead": ["src/lib/vbrief/io.ts", "src/dashboard/server/routes/agents.ts"]
   },
   "beadsMapping": {},
   "agentModel": "kc@kimi-k2.6",
   "sessionHistory": [
-    { "timestamp": "2026-05-07T09:30:00Z", "reason": "start", "note": "Started PAN-945 implementation. Rebased onto main, removed stale continue.json, created beads.", "agentModel": "kc@kimi-k2.6" }
+    {
+      "timestamp": "2026-05-07T09:30:00Z",
+      "reason": "start",
+      "note": "Started PAN-945 implementation. Rebased onto main, removed stale continue.json, and created the bead set for the issue.",
+      "agentModel": "kc@kimi-k2.6"
+    },
+    {
+      "timestamp": "2026-05-08T09:24:39Z",
+      "reason": "progress",
+      "note": "Completed bead workspace-d5qf by adding PRD-directory vBRIEF discovery in `src/lib/vbrief/io.ts` and verified the existing vbrief I/O test suite still passes after the change.",
+      "agentModel": "kc@kimi-k2.6"
+    }
   ]
 }

--- a/.pan/continue.json
+++ b/.pan/continue.json
@@ -2,7 +2,7 @@
   "version": "1",
   "issueId": "PAN-945",
   "created": "2026-05-07T09:30:00Z",
-  "updated": "2026-05-09T01:47:00.668Z",
+  "updated": "2026-05-09T01:48:21.086Z",
   "gitState": {
     "branch": "feature/pan-945",
     "sha": "f7e0507d0",
@@ -96,7 +96,7 @@
     }
   ],
   "resumePoint": {
-    "description": "PAN-945 work is complete. All beads are closed, full quality gates passed after rebuilding the CLI dist, the branch was pushed, and `pan done PAN-945` marked the issue complete; Panopticon reported the issue was already merged and skipped the review pipeline.",
+    "description": "PAN-945 work is complete. All beads are closed, full quality gates passed after rebuilding the CLI dist, the branch was pushed, and `pan done PAN-945` marked the issue In Review. Panopticon reported the issue was already merged and skipped the review pipeline even though PR #1045 remains open, so no further work-agent changes are pending unless review feedback arrives.",
     "beadId": null,
     "filesToRead": []
   },
@@ -155,6 +155,11 @@
       "timestamp": "2026-05-09T01:47:00.668Z",
       "reason": "end",
       "note": "Imported PRD-directory vBRIEFs into workspace plans for dashboard and CLI start flows with coverage for discovery, import, and non-overwrite behavior."
+    },
+    {
+      "timestamp": "2026-05-09T01:48:21.085Z",
+      "reason": "end",
+      "note": "Final continue state pushed after completion marker; PAN-945 PR remains open for review pipeline."
     }
   ],
   "feedback": []

--- a/.pan/continue.json
+++ b/.pan/continue.json
@@ -2,10 +2,10 @@
   "version": "1",
   "issueId": "PAN-945",
   "created": "2026-05-07T09:30:00Z",
-  "updated": "2026-05-09T01:28:49Z",
+  "updated": "2026-05-09T01:30:53Z",
   "gitState": {
     "branch": "feature/pan-945",
-    "sha": "bf16520db",
+    "sha": "ccf26a582",
     "dirty": true
   },
   "decisions": [
@@ -32,6 +32,12 @@
       "summary": "Extracted the copy operation into `importVBriefFromPrdDirs` and tested both discovery and import behavior in the vBRIEF I/O test suite.",
       "rationale": "Dashboard and CLI start flows need the same non-overwriting import behavior. Keeping the copy operation in `src/lib/vbrief/io.ts` prevents duplicated path logic, gives tests a focused unit-level seam, and lets both callers materialize a workspace-local `.pan/spec.vbrief.json` while preserving `findPlan` as a workspace-only lookup.",
       "recordedAt": "2026-05-09T01:28:49Z"
+    },
+    {
+      "id": "D5",
+      "summary": "Wired `pan start` to call `importVBriefFromPrdDirs` before validating the workspace plan or recovering beads.",
+      "rationale": "CLI starts need the same fixed point as dashboard starts: if a PRD-scoped vBRIEF exists and the workspace lacks `.pan/spec.vbrief.json`, the start flow must materialize the workspace-local plan before stale-plan validation, beads recovery, or simple-issue bead creation run. This prevents `pan start` from treating a PRD-first planned issue as unplanned and creating the wrong fallback bead.",
+      "recordedAt": "2026-05-09T01:30:53Z"
     }
   ],
   "hazards": [
@@ -49,15 +55,20 @@
       "id": "H3",
       "summary": "Auto-import must not overwrite a workspace-local plan because the workspace plan may contain newer agent status, bead progress, or user edits than the PRD archive copy.",
       "mitigation": "`importVBriefFromPrdDirs` returns null immediately when `findPlan(workspacePath)` already finds `.pan/spec.vbrief.json`. The test suite now asserts that an existing workspace plan is preserved even when a matching PRD vBRIEF exists."
+    },
+    {
+      "id": "H4",
+      "summary": "If CLI import of an existing PRD vBRIEF fails, silently continuing would allow the old simple-issue fallback to create misleading beads for a planned issue.",
+      "mitigation": "`pan start` now fails immediately when `importVBriefFromPrdDirs` throws. Missing PRD vBRIEFs remain non-fatal, but copy errors for discovered artifacts stop the start flow so the underlying filesystem or permissions problem is visible."
     }
   ],
   "resumePoint": {
-    "description": "Finish bead workspace-2dp3 by committing the vBRIEF discovery and auto-import tests, closing the bead, and then proceed to bead workspace-bqcl to wire `importVBriefFromPrdDirs` into the CLI `pan start` command.",
-    "beadId": "workspace-2dp3",
+    "description": "Finish bead workspace-bqcl by committing the CLI `pan start` import wiring, closing the bead, and then resolve the remaining core discovery bead workspace-linp if it is still open because the initial helper commit predates the recovered bead close state.",
+    "beadId": "workspace-bqcl",
     "filesToRead": [
+      "src/cli/commands/start.ts",
       "src/lib/vbrief/io.ts",
-      "src/lib/vbrief/__tests__/io.test.ts",
-      "src/cli/commands/start.ts"
+      ".pan/continue.json"
     ]
   },
   "beadsMapping": {},
@@ -85,6 +96,12 @@
       "timestamp": "2026-05-09T01:28:49Z",
       "reason": "progress",
       "note": "Completed the test bead by adding coverage for all supported PRD vBRIEF discovery layouts, verifying that PRD vBRIEFs are copied into `.pan/spec.vbrief.json` when missing, and verifying that an existing workspace-local plan is never overwritten. The dashboard route now calls the shared async `importVBriefFromPrdDirs` helper instead of carrying its own copy logic. `npm test -- src/lib/vbrief/__tests__/io.test.ts` and `npm run typecheck` both passed.",
+      "agentModel": "kc@kimi-k2.6"
+    },
+    {
+      "timestamp": "2026-05-09T01:30:53Z",
+      "reason": "progress",
+      "note": "Completed CLI start wiring by calling `importVBriefFromPrdDirs` after continue-state validation and before plan validation or beads recovery. This lets `pan start` import PRD-first vBRIEF plans into `.pan/spec.vbrief.json` before the runtime decides whether planning exists. `npm run typecheck` and the focused vBRIEF I/O test file both passed after the change.",
       "agentModel": "kc@kimi-k2.6"
     }
   ]

--- a/.pan/continue.json
+++ b/.pan/continue.json
@@ -2,10 +2,10 @@
   "version": "1",
   "issueId": "PAN-945",
   "created": "2026-05-07T09:30:00Z",
-  "updated": "2026-05-09T01:48:21.086Z",
+  "updated": "2026-05-09T02:22:00.000Z",
   "gitState": {
     "branch": "feature/pan-945",
-    "sha": "f7e0507d0",
+    "sha": "266e38308",
     "dirty": true
   },
   "decisions": [
@@ -56,6 +56,12 @@
       "summary": "Fixed merged `panopticon-bridge.ts` typecheck errors by importing the Node APIs used by the new channel bridge code.",
       "rationale": "After merging `origin/main`, `npm run typecheck` failed because `panopticon-bridge.ts` referenced `timingSafeEqual` and `unlinkSync` without importing them. These were direct missing imports in the merged main changes, not PAN-945 logic. Adding `timingSafeEqual` from `node:crypto` and `unlinkSync` from `node:fs` fixes the TypeScript errors at the source and keeps the channel bridge implementation intact.",
       "recordedAt": "2026-05-09T01:41:20Z"
+    },
+    {
+      "id": "D9",
+      "summary": "Hardened PRD vBRIEF discovery and import after review feedback found slug, symlink, traversal, validation, and dashboard failure-handling gaps.",
+      "rationale": "Review correctly identified that the original helper only checked exact `PAN-945-plan.vbrief.json` paths, trusted raw issue IDs in path construction, and used a copy operation that could follow symlinks into files outside the PRD roots. The revised implementation validates issue IDs against the prefixed issue format, uses asynchronous directory scanning to discover slugged flat files such as `PAN-945-import-prd-vbrief.vbrief.json`, rejects symlinks and non-regular files before reading, verifies realpath containment under the PRD root, parses the vBRIEF before writing the workspace copy, and makes dashboard start-agent return a 422 response when an existing artifact is unsafe or invalid instead of spawning without a valid plan.",
+      "recordedAt": "2026-05-09T02:22:00.000Z"
     }
   ],
   "hazards": [
@@ -93,12 +99,28 @@
       "id": "H7",
       "summary": "Merging a fast-moving main branch can introduce unrelated typecheck failures that block PAN-945 submission even when PAN-945 code is already valid.",
       "mitigation": "The merged `panopticon-bridge.ts` missing imports were fixed directly and `npm run typecheck` was rerun successfully before continuing to full gate verification."
+    },
+    {
+      "id": "H8",
+      "summary": "PRD vBRIEF artifact import is a security boundary because files under docs/prds can be symlinks, directories, or paths derived from malicious issue IDs.",
+      "mitigation": "The import path now fails closed. It rejects unsafe issue IDs before constructing candidate paths, uses `lstat` to reject symlinks and non-regular files, checks realpath containment under the PRD status directory, opens the file with `O_NOFOLLOW`, and only creates `.pan/spec.vbrief.json` after the source parses as a vBRIEF document. Regression tests cover slug discovery, traversal rejection, symlink rejection, non-regular rejection, and invalid-document rejection without creating workspace planning artifacts."
+    },
+    {
+      "id": "H9",
+      "summary": "Dashboard start-agent previously swallowed PRD vBRIEF import failures, which could hide a broken existing artifact and let an agent spawn without the plan the user expected.",
+      "mitigation": "The dashboard route now delegates materialization to a helper that preserves missing-artifact-as-null semantics but throws on unsafe or invalid existing artifacts. The route catches that throw and returns a 422 response before spawn setup continues, matching CLI fail-closed semantics while keeping genuinely missing PRD vBRIEFs non-fatal."
     }
   ],
   "resumePoint": {
-    "description": "PAN-945 work is complete. All beads are closed, full quality gates passed after rebuilding the CLI dist, the branch was pushed, and `pan done PAN-945` marked the issue In Review. Panopticon reported the issue was already merged and skipped the review pipeline even though PR #1045 remains open, so no further work-agent changes are pending unless review feedback arrives.",
-    "beadId": null,
-    "filesToRead": []
+    "description": "Review feedback for PAN-945 has been implemented in workspace-hbu9. PRD vBRIEF discovery now supports slugged filenames, import rejects unsafe paths and invalid documents before writing workspace artifacts, dashboard start-agent fails closed on invalid existing artifacts, and the stale `.pan/spec.vbrief.json` now describes PAN-945 instead of PAN-1025. Focused tests, typecheck, lint, and full `npm test` have passed; commit, bead close inspection, push, and `pan done PAN-945` are still pending.",
+    "beadId": "workspace-hbu9",
+    "filesToRead": [
+      "src/lib/vbrief/io.ts",
+      "src/dashboard/server/routes/agents.ts",
+      "src/lib/vbrief/__tests__/io.test.ts",
+      "src/dashboard/server/routes/__tests__/agents-guardrails.test.ts",
+      ".pan/spec.vbrief.json"
+    ]
   },
   "beadsMapping": {},
   "agentModel": "kc@kimi-k2.6",
@@ -160,6 +182,12 @@
       "timestamp": "2026-05-09T01:48:21.085Z",
       "reason": "end",
       "note": "Final continue state pushed after completion marker; PAN-945 PR remains open for review pipeline."
+    },
+    {
+      "timestamp": "2026-05-09T02:22:00.000Z",
+      "reason": "review-feedback",
+      "note": "Resumed after CHANGES_REQUESTED review feedback. The local `.pan/feedback` files were stale PAN-1025 verification notes, so the actionable review blockers came from the resume prompt. I created and claimed bead workspace-hbu9 for the review fix, hardened PRD vBRIEF discovery and import against slug misses, symlink copying, path traversal, invalid documents, and swallowed dashboard import errors, replaced the stale workspace spec artifact with a PAN-945 vBRIEF, and verified the focused vBRIEF and agent route tests plus typecheck, lint, and the full test suite. Commit, bead close inspection, push, and submission remain pending.",
+      "agentModel": "claude-opus-4-7"
     }
   ],
   "feedback": []

--- a/.pan/spec.vbrief.json
+++ b/.pan/spec.vbrief.json
@@ -1,99 +1,44 @@
 {
   "vBRIEFInfo": {
     "version": "0.5",
-    "author": "agent:claude-code",
-    "description": "PAN-1030: Surface awaiting user input state on kanban, command deck, and inspector",
-    "created": "2026-05-09T00:00:00Z",
-    "updated": "2026-05-09T03:00:00Z"
+    "author": "agent:panopticon-agent",
+    "description": "PAN-945: Discover and safely import PRD-directory vBRIEF artifacts into workspaces before agent start.",
+    "created": "2026-05-07T13:13:37Z",
+    "updated": "2026-05-09T02:05:00.000Z"
   },
   "plan": {
-    "id": "pan-1030",
-    "title": "Surface awaiting user input state on kanban + command deck",
-    "status": "active",
-    "uid": "pan-1030-awaiting-input-indicators",
-    "author": "agent:claude-code",
-    "sequence": 17,
-    "created": "2026-05-09T00:00:00Z",
-    "updated": "2026-05-09T03:00:00Z",
-    "references": [
-      {
-        "uri": "https://github.com/eltmon/panopticon-cli/issues/1030",
-        "label": "PAN-1030",
-        "type": "issue"
-      }
-    ],
-    "tags": [
-      "dashboard",
-      "awaiting-input",
-      "kanban",
-      "command-deck",
-      "inspector"
-    ],
-    "narratives": {
-      "Problem": "Dashboard users need a clear, glanceable indication when work or planning agents are blocked on user input such as Claude Code permission prompts, planning Done prompts, Pi harness prompts, or generic y/n confirmations.",
-      "Approach": "Detect awaiting-input state observationally from existing runtime waiting signals, AskUserQuestion JSONL entries, and read-only tmux pane scans; then flow the state through agent enrichment, contracts, the read model, and existing dashboard surfaces without mutating agent state."
-    },
+    "id": "PAN-945",
+    "title": "PAN-945: Discover and safely import PRD vBRIEF artifacts",
+    "status": "completed",
     "items": [
       {
-        "id": "workspace-mla7",
-        "title": "Restore awaiting-input detection and indicators across dashboard surfaces",
-        "status": "completed",
-        "priority": "high",
-        "created": "2026-05-09T00:00:00Z",
-        "completed": "2026-05-09T02:10:38.307Z",
-        "metadata": {
-          "difficulty": "moderate",
-          "issueLabel": "PAN-1030",
-          "beadId": "workspace-mla7"
-        },
-        "narrative": {
-          "Action": "Implement read-only awaiting-input detection, expose it through agent enrichment and shared contract types, and render INPUT-style indicators with prompt context in kanban cards, Command Deck issue rows, and the issue inspector."
-        },
-        "subItems": [
-          {
-            "id": "workspace-mla7.ac1",
-            "title": "Kanban issue cards show an awaiting-input badge for blocked primary agents or planning sessions",
-            "status": "completed",
-            "metadata": { "kind": "acceptance_criterion" }
-          },
-          {
-            "id": "workspace-mla7.ac2",
-            "title": "Command Deck issue rows show the same badge in the agent column with explanatory prompt text",
-            "status": "completed",
-            "metadata": { "kind": "acceptance_criterion" }
-          },
-          {
-            "id": "workspace-mla7.ac3",
-            "title": "Issue Inspector surfaces exact prompt text and terminal attach path for answering in one click",
-            "status": "completed",
-            "metadata": { "kind": "acceptance_criterion" }
-          },
-          {
-            "id": "workspace-mla7.ac4",
-            "title": "Awaiting-input badge clears automatically after the agent moves past the prompt",
-            "status": "completed",
-            "metadata": { "kind": "acceptance_criterion" }
-          },
-          {
-            "id": "workspace-mla7.ac5",
-            "title": "Detection covers Claude Code permission prompts, planning Done prompts, Pi prompts, and generic y/n confirmations",
-            "status": "completed",
-            "metadata": { "kind": "acceptance_criterion" }
-          },
-          {
-            "id": "workspace-mla7.ac6",
-            "title": "Detection is read-only and uses capture-pane heuristics without agent state mutation",
-            "status": "completed",
-            "metadata": { "kind": "acceptance_criterion" }
-          },
-          {
-            "id": "workspace-mla7.ac7",
-            "title": "Updates flow through the existing dashboard read-model heartbeat and event stream",
-            "status": "completed",
-            "metadata": { "kind": "acceptance_criterion" }
-          }
-        ]
+        "id": "workspace-d5qf",
+        "title": "Add findVBriefInPrdDirs helper to search docs/prds for vBRIEFs",
+        "status": "completed"
+      },
+      {
+        "id": "workspace-qmrt",
+        "title": "Wire PRD vBRIEF discovery into dashboard start-agent endpoint",
+        "status": "completed"
+      },
+      {
+        "id": "workspace-bqcl",
+        "title": "Wire PRD vBRIEF discovery into CLI pan start command",
+        "status": "completed"
+      },
+      {
+        "id": "workspace-2dp3",
+        "title": "Add tests for PRD dir vBRIEF discovery and auto-import",
+        "status": "completed"
+      },
+      {
+        "id": "workspace-hbu9",
+        "title": "Address review blockers for PRD vBRIEF import safety and discovery",
+        "status": "completed"
       }
-    ]
+    ],
+    "edges": [],
+    "updated": "2026-05-09T02:05:00.000Z",
+    "sequence": 1
   }
 }

--- a/.pan/spec.vbrief.json
+++ b/.pan/spec.vbrief.json
@@ -4,7 +4,7 @@
     "author": "agent:panopticon-agent",
     "description": "PAN-945: Discover and safely import PRD-directory vBRIEF artifacts into workspaces before agent start.",
     "created": "2026-05-07T13:13:37Z",
-    "updated": "2026-05-10T04:14:46.875Z"
+    "updated": "2026-05-10T04:44:03.440Z"
   },
   "plan": {
     "id": "PAN-945",
@@ -15,25 +15,25 @@
         "id": "workspace-d5qf",
         "title": "Add findVBriefInPrdDirs helper to search docs/prds for vBRIEFs",
         "status": "completed",
-        "completed": "2026-05-10T04:14:46.875Z"
+        "completed": "2026-05-10T04:44:03.440Z"
       },
       {
         "id": "workspace-qmrt",
         "title": "Wire PRD vBRIEF discovery into dashboard start-agent endpoint",
         "status": "completed",
-        "completed": "2026-05-09T02:27:34.121Z"
+        "completed": "2026-05-10T04:44:03.440Z"
       },
       {
         "id": "workspace-bqcl",
         "title": "Wire PRD vBRIEF discovery into CLI pan start command",
         "status": "completed",
-        "completed": "2026-05-09T02:27:34.121Z"
+        "completed": "2026-05-10T04:44:03.440Z"
       },
       {
         "id": "workspace-2dp3",
         "title": "Add tests for PRD dir vBRIEF discovery and auto-import",
         "status": "completed",
-        "completed": "2026-05-09T02:27:34.120Z"
+        "completed": "2026-05-10T04:44:03.439Z"
       },
       {
         "id": "workspace-hbu9",
@@ -42,7 +42,7 @@
       }
     ],
     "edges": [],
-    "updated": "2026-05-10T04:14:46.875Z",
-    "sequence": 6
+    "updated": "2026-05-10T04:44:03.440Z",
+    "sequence": 10
   }
 }

--- a/.pan/spec.vbrief.json
+++ b/.pan/spec.vbrief.json
@@ -4,7 +4,7 @@
     "author": "agent:panopticon-agent",
     "description": "PAN-945: Discover and safely import PRD-directory vBRIEF artifacts into workspaces before agent start.",
     "created": "2026-05-07T13:13:37Z",
-    "updated": "2026-05-09T02:05:00.000Z"
+    "updated": "2026-05-09T02:27:34.122Z"
   },
   "plan": {
     "id": "PAN-945",
@@ -14,22 +14,26 @@
       {
         "id": "workspace-d5qf",
         "title": "Add findVBriefInPrdDirs helper to search docs/prds for vBRIEFs",
-        "status": "completed"
+        "status": "completed",
+        "completed": "2026-05-09T02:27:34.122Z"
       },
       {
         "id": "workspace-qmrt",
         "title": "Wire PRD vBRIEF discovery into dashboard start-agent endpoint",
-        "status": "completed"
+        "status": "completed",
+        "completed": "2026-05-09T02:27:34.121Z"
       },
       {
         "id": "workspace-bqcl",
         "title": "Wire PRD vBRIEF discovery into CLI pan start command",
-        "status": "completed"
+        "status": "completed",
+        "completed": "2026-05-09T02:27:34.121Z"
       },
       {
         "id": "workspace-2dp3",
         "title": "Add tests for PRD dir vBRIEF discovery and auto-import",
-        "status": "completed"
+        "status": "completed",
+        "completed": "2026-05-09T02:27:34.120Z"
       },
       {
         "id": "workspace-hbu9",
@@ -38,7 +42,7 @@
       }
     ],
     "edges": [],
-    "updated": "2026-05-09T02:05:00.000Z",
-    "sequence": 1
+    "updated": "2026-05-09T02:27:34.122Z",
+    "sequence": 5
   }
 }

--- a/.pan/spec.vbrief.json
+++ b/.pan/spec.vbrief.json
@@ -4,7 +4,7 @@
     "author": "agent:panopticon-agent",
     "description": "PAN-945: Discover and safely import PRD-directory vBRIEF artifacts into workspaces before agent start.",
     "created": "2026-05-07T13:13:37Z",
-    "updated": "2026-05-10T04:44:03.440Z"
+    "updated": "2026-05-10T05:10:49.891Z"
   },
   "plan": {
     "id": "PAN-945",
@@ -15,25 +15,25 @@
         "id": "workspace-d5qf",
         "title": "Add findVBriefInPrdDirs helper to search docs/prds for vBRIEFs",
         "status": "completed",
-        "completed": "2026-05-10T04:44:03.440Z"
+        "completed": "2026-05-10T05:10:49.891Z"
       },
       {
         "id": "workspace-qmrt",
         "title": "Wire PRD vBRIEF discovery into dashboard start-agent endpoint",
         "status": "completed",
-        "completed": "2026-05-10T04:44:03.440Z"
+        "completed": "2026-05-10T05:10:49.891Z"
       },
       {
         "id": "workspace-bqcl",
         "title": "Wire PRD vBRIEF discovery into CLI pan start command",
         "status": "completed",
-        "completed": "2026-05-10T04:44:03.440Z"
+        "completed": "2026-05-10T05:10:49.891Z"
       },
       {
         "id": "workspace-2dp3",
         "title": "Add tests for PRD dir vBRIEF discovery and auto-import",
         "status": "completed",
-        "completed": "2026-05-10T04:44:03.439Z"
+        "completed": "2026-05-10T05:10:49.891Z"
       },
       {
         "id": "workspace-hbu9",
@@ -42,7 +42,7 @@
       }
     ],
     "edges": [],
-    "updated": "2026-05-10T04:44:03.440Z",
-    "sequence": 10
+    "updated": "2026-05-10T05:10:49.891Z",
+    "sequence": 14
   }
 }

--- a/.pan/spec.vbrief.json
+++ b/.pan/spec.vbrief.json
@@ -4,7 +4,7 @@
     "author": "agent:panopticon-agent",
     "description": "PAN-945: Discover and safely import PRD-directory vBRIEF artifacts into workspaces before agent start.",
     "created": "2026-05-07T13:13:37Z",
-    "updated": "2026-05-09T02:27:34.122Z"
+    "updated": "2026-05-10T04:14:46.875Z"
   },
   "plan": {
     "id": "PAN-945",
@@ -15,7 +15,7 @@
         "id": "workspace-d5qf",
         "title": "Add findVBriefInPrdDirs helper to search docs/prds for vBRIEFs",
         "status": "completed",
-        "completed": "2026-05-09T02:27:34.122Z"
+        "completed": "2026-05-10T04:14:46.875Z"
       },
       {
         "id": "workspace-qmrt",
@@ -42,7 +42,7 @@
       }
     ],
     "edges": [],
-    "updated": "2026-05-09T02:27:34.122Z",
-    "sequence": 5
+    "updated": "2026-05-10T04:14:46.875Z",
+    "sequence": 6
   }
 }

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -14,6 +14,7 @@ import { hasPRDDraft, getPRDDraftPath } from '../../lib/prd-draft.js';
 import { isGitHubIssue, resolveGitHubIssue } from '../../lib/tracker-utils.js';
 import { getLinearApiKey } from '../../lib/shadow-utils.js';
 import { getWorkspacePanPaths } from '../../lib/pan-dir/index.js';
+import { importVBriefFromPrdDirs } from '../../lib/vbrief/io.js';
 
 /**
  * Check if an issue ID is a Linear issue (has team prefix like MIN-, PAN-, etc.)
@@ -715,6 +716,20 @@ export async function issueCommand(id: string, options: IssueOptions): Promise<v
     const stateValidation = validateAndCleanStateFile(workspace, id);
     if (stateValidation.removed) {
       spinner.warn(`Cleaned stale planning state from ${stateValidation.wrongIssue}`);
+    }
+
+    // Materialize PRD-published vBRIEF copies into the workspace before validating
+    // or recovering beads. This preserves the workspace-local runtime source of
+    // truth while allowing manual/PRD-first planning flows to start normally.
+    spinner.text = 'Checking for PRD vBRIEF artifacts...';
+    try {
+      const imported = await importVBriefFromPrdDirs(projectRoot, workspace, id);
+      if (imported) {
+        spinner.text = `Imported PRD vBRIEF from ${imported.sourcePath}`;
+      }
+    } catch (importErr: any) {
+      spinner.fail(`Failed to import PRD vBRIEF for ${id}: ${importErr.message}`);
+      process.exit(1);
     }
 
     // Validate spec.vbrief.json belongs to this issue (prevent stale workspace plan state from the wrong issue)

--- a/src/dashboard/server/__tests__/read-model-diff-summaries.test.ts
+++ b/src/dashboard/server/__tests__/read-model-diff-summaries.test.ts
@@ -245,10 +245,10 @@ describe('ReadModel checkpoint reconciliation', () => {
   it('caps checkpoint reconciliation before diffing old history while preserving absolute turn counts', async () => {
     const checkpoints = Array.from({ length: 205 }, (_, index) => `turn-${index + 1}`)
     const listCheckpoints = vi.fn().mockResolvedValue(checkpoints)
-    const diffCheckpointFiles = vi.fn().mockImplementation(async (_workspace: string, prevTurnId: string, turnId: string) => ([
+    const diffCheckpointFiles = vi.fn().mockImplementation(async (_workspace: string, _agentId: string, prevTurnId: string, turnId: string) => ([
       { path: `${prevTurnId}-to-${turnId}.ts`, additions: 1, deletions: 0 },
     ]))
-    const getCheckpointTimestamp = vi.fn().mockImplementation(async (_workspace: string, turnId: string) => {
+    const getCheckpointTimestamp = vi.fn().mockImplementation(async (_workspace: string, _agentId: string, turnId: string) => {
       const turnNumber = Number.parseInt(turnId.replace('turn-', ''), 10)
       return new Date(Date.parse('2026-05-08T05:00:00.000Z') + turnNumber * 1000).toISOString()
     })
@@ -268,6 +268,7 @@ describe('ReadModel checkpoint reconciliation', () => {
             listCheckpoints,
             diffCheckpointFiles,
             getCheckpointTimestamp,
+            deleteLegacyCheckpointRefs: vi.fn().mockResolvedValue(0),
           }))
           vi.doMock('../../../lib/agent-enrichment.js', () => ({
             computeAgentEnrichment: vi.fn().mockResolvedValue(undefined),
@@ -297,8 +298,8 @@ describe('ReadModel checkpoint reconciliation', () => {
     )
 
     expect(diffCheckpointFiles).toHaveBeenCalledTimes(200)
-    expect(diffCheckpointFiles).toHaveBeenNthCalledWith(1, '/tmp/pan-1024', 'turn-5', 'turn-6')
-    expect(diffCheckpointFiles).toHaveBeenLastCalledWith('/tmp/pan-1024', 'turn-204', 'turn-205')
+    expect(diffCheckpointFiles).toHaveBeenNthCalledWith(1, '/tmp/pan-1024', 'agent-reconcile', 'turn-5', 'turn-6')
+    expect(diffCheckpointFiles).toHaveBeenLastCalledWith('/tmp/pan-1024', 'agent-reconcile', 'turn-204', 'turn-205')
     expect(summaries[0].turnId).toBe('turn-6')
     expect(summaries[0].checkpointTurnCount).toBe(6)
     expect(summaries.at(-1)?.turnId).toBe('turn-205')

--- a/src/dashboard/server/routes/__tests__/agents-guardrails.test.ts
+++ b/src/dashboard/server/routes/__tests__/agents-guardrails.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
-import { evaluateSpawnGuardrails } from '../agents.js';
+import { evaluateSpawnGuardrails, materializeStartAgentVBrief } from '../agents.js';
 import { readGlobalResourceConfig } from '../../services/system-health-service.js';
 import type { SystemHealthSnapshot } from '../../services/system-health-service.js';
 
@@ -61,6 +64,19 @@ function createHealthSnapshot(overrides: Partial<SystemHealthSnapshot> = {}): Sy
     agents: overrides.agents ?? base.agents,
     leakedSpecialists: overrides.leakedSpecialists ?? base.leakedSpecialists,
     topConsumers: overrides.topConsumers ?? base.topConsumers,
+  };
+}
+
+function makeVBrief(issueId: string) {
+  return {
+    vBRIEFInfo: { version: '0.5', created: '2026-05-08T00:00:00.000Z' },
+    plan: {
+      id: issueId,
+      title: `${issueId}: Test plan`,
+      status: 'active',
+      items: [{ id: 'item-1', title: 'Do work', status: 'pending' }],
+      edges: [],
+    },
   };
 }
 
@@ -177,5 +193,51 @@ describe('evaluateSpawnGuardrails', () => {
         }),
       ]),
     );
+  });
+});
+
+describe('materializeStartAgentVBrief', () => {
+  let testDir: string;
+
+  afterEach(() => {
+    if (testDir) rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('treats missing PRD vBRIEF artifacts as non-fatal', async () => {
+    testDir = join(tmpdir(), `agents-vbrief-missing-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const projectPath = join(testDir, 'project');
+    const workspacePath = join(projectPath, 'workspaces', 'feature-pan-945');
+    mkdirSync(workspacePath, { recursive: true });
+
+    await expect(materializeStartAgentVBrief(projectPath, workspacePath, 'PAN-945')).resolves.toEqual({ planPath: null });
+  });
+
+  it('imports valid PRD vBRIEF artifacts before start-agent spawn', async () => {
+    testDir = join(tmpdir(), `agents-vbrief-valid-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const projectPath = join(testDir, 'project');
+    const workspacePath = join(projectPath, 'workspaces', 'feature-pan-945');
+    const sourcePath = join(projectPath, 'api', 'docs', 'prds', 'planned', 'PAN-945-import-prd-vbrief.vbrief.json');
+    mkdirSync(join(sourcePath, '..'), { recursive: true });
+    mkdirSync(workspacePath, { recursive: true });
+    writeFileSync(sourcePath, JSON.stringify(makeVBrief('PAN-945'), null, 2));
+
+    const result = await materializeStartAgentVBrief(projectPath, workspacePath, 'PAN-945');
+
+    expect(result.importedSourcePath).toBe(sourcePath);
+    expect(result.planPath).toBe(join(workspacePath, '.pan', 'spec.vbrief.json'));
+    expect(existsSync(result.planPath!)).toBe(true);
+  });
+
+  it('fails closed when an existing PRD vBRIEF artifact is invalid', async () => {
+    testDir = join(tmpdir(), `agents-vbrief-invalid-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const projectPath = join(testDir, 'project');
+    const workspacePath = join(projectPath, 'workspaces', 'feature-pan-945');
+    const sourcePath = join(projectPath, 'api', 'docs', 'prds', 'planned', 'PAN-945-invalid.vbrief.json');
+    mkdirSync(join(sourcePath, '..'), { recursive: true });
+    mkdirSync(workspacePath, { recursive: true });
+    writeFileSync(sourcePath, JSON.stringify({ plan: { id: 'PAN-945' } }, null, 2));
+
+    await expect(materializeStartAgentVBrief(projectPath, workspacePath, 'PAN-945')).rejects.toThrow('Invalid vBRIEF format');
+    expect(existsSync(join(workspacePath, '.pan', 'spec.vbrief.json'))).toBe(false);
   });
 });

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -41,7 +41,7 @@ import { withBdMutex } from '../../../lib/bd-mutex.js';
 import { exec, spawn } from 'node:child_process';
 import { timingSafeEqual } from 'node:crypto';
 import { existsSync } from 'node:fs';
-import { appendFile, mkdir, open, readdir, readFile, rename, rm, stat, symlink, lstat, writeFile } from 'node:fs/promises';
+import { appendFile, copyFile, mkdir, open, readdir, readFile, rename, rm, stat, symlink, lstat, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
@@ -86,11 +86,11 @@ import { checkCodexAuthStatus } from '../../../lib/codex-auth.js';
 import { getProviderForModel } from '../../../lib/providers.js';
 import { validateProviderHealth, ProviderHealthError } from '../../../lib/provider-health.js';
 import { resolveProjectFromIssue } from '../../../lib/projects.js';
-import { findPlan, isPlanningComplete } from '../../../lib/vbrief/io.js';
+import { findPlan, findVBriefInPrdDirs, isPlanningComplete } from '../../../lib/vbrief/io.js';
 import { transitionVBriefOnMain, updatePlanStatus } from '../../../lib/vbrief/lifecycle-io.js';
 import type { ContinueState } from '../../../lib/vbrief/continue-state.js';
 import { extractPrefix } from '../../../lib/issue-id.js';
-import { PAN_CONTINUE_FILENAME, PAN_DIRNAME } from '../../../lib/pan-dir/types.js';
+import { PAN_CONTINUE_FILENAME, PAN_DIRNAME, PAN_SPEC_FILENAME } from '../../../lib/pan-dir/types.js';
 import { getGitHubConfig } from '../services/tracker-config.js';
 import { loadWorkspaceMetadata as loadWorkspaceMetadataFn } from '../../../lib/remote/workspace-metadata.js';
 import { getWorkAgentLifecycleState } from '../../../lib/work-agent-lifecycle.js';
@@ -1933,7 +1933,23 @@ const postAgentsRoute = HttpRouter.add(
       }
     }
 
-    const planPath = findPlan(workspacePath);
+    let planPath = findPlan(workspacePath);
+    if (!planPath) {
+      const prdVBriefPath = findVBriefInPrdDirs(projectPath, issueId);
+      if (prdVBriefPath) {
+        yield* Effect.promise(async () => {
+          try {
+            await mkdir(workspacePanDir, { recursive: true });
+            await copyFile(prdVBriefPath, join(workspacePanDir, PAN_SPEC_FILENAME));
+            planPath = findPlan(workspacePath);
+            console.log(`[start-agent] Imported PRD vBRIEF for ${issueId} from ${prdVBriefPath}`);
+          } catch (importErr: any) {
+            console.warn(`[start-agent] Failed to import PRD vBRIEF for ${issueId}: ${importErr?.message ?? importErr}`);
+          }
+        });
+      }
+    }
+
     const hasPlan = planPath !== null;
     // Planning has finished when plan.status is any of:
     // proposed/approved/pending/running/completed/blocked.

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -1851,6 +1851,24 @@ const getAgentCostRoute = HttpRouter.add(
 
 // ─── Route: POST /api/agents (start agent) ───────────────────────────────────
 
+export interface StartAgentVBriefMaterialization {
+  planPath: string | null;
+  importedSourcePath?: string;
+}
+
+export async function materializeStartAgentVBrief(
+  projectPath: string,
+  workspacePath: string,
+  issueId: string,
+  initialPlanPath: string | null = findPlan(workspacePath),
+): Promise<StartAgentVBriefMaterialization> {
+  if (initialPlanPath) return { planPath: initialPlanPath };
+
+  const imported = await importVBriefFromPrdDirs(projectPath, workspacePath, issueId);
+  if (!imported) return { planPath: null };
+  return { planPath: imported.workspacePlanPath, importedSourcePath: imported.sourcePath };
+}
+
 const postAgentsRoute = HttpRouter.add(
   'POST',
   '/api/agents',
@@ -1934,18 +1952,20 @@ const postAgentsRoute = HttpRouter.add(
     }
 
     let planPath = findPlan(workspacePath);
-    if (!planPath) {
-      yield* Effect.promise(async () => {
-        try {
-          const imported = await importVBriefFromPrdDirs(projectPath, workspacePath, issueId);
-          if (imported) {
-            planPath = imported.workspacePlanPath;
-            console.log(`[start-agent] Imported PRD vBRIEF for ${issueId} from ${imported.sourcePath}`);
-          }
-        } catch (importErr: any) {
-          console.warn(`[start-agent] Failed to import PRD vBRIEF for ${issueId}: ${importErr?.message ?? importErr}`);
-        }
-      });
+    try {
+      const materialized = yield* Effect.promise(() => materializeStartAgentVBrief(projectPath, workspacePath, issueId, planPath));
+      planPath = materialized.planPath;
+      if (materialized.importedSourcePath) {
+        console.log(`[start-agent] Imported PRD vBRIEF for ${issueId} from ${materialized.importedSourcePath}`);
+      }
+    } catch (importErr: any) {
+      const message = importErr?.message ?? String(importErr);
+      console.warn(`[start-agent] Failed to import PRD vBRIEF for ${issueId}: ${message}`);
+      return jsonResponse({
+        error: `Failed to import PRD vBRIEF for ${issueId}: ${message}`,
+        hint: 'Fix or remove the invalid PRD vBRIEF artifact before starting an agent. Missing PRD vBRIEF artifacts are allowed; unsafe or invalid existing artifacts are not.',
+        issueId,
+      }, { status: 422 });
     }
 
     const hasPlan = planPath !== null;
@@ -1957,31 +1977,37 @@ const postAgentsRoute = HttpRouter.add(
     void hasPlan;
     void isComplete;
 
-    try {
-      const { readPlan } = yield* Effect.promise(() => import('../../../lib/vbrief/io.js'));
-      if (!planPath) {
-        throw new Error('No workspace vBRIEF found');
-      }
-      const planDoc = readPlan(planPath);
-      const planIssueId = planDoc?.plan?.id;
-      if (planIssueId && planIssueId.toLowerCase() !== issueLower) {
+    if (planPath) {
+      try {
+        const { readPlan } = yield* Effect.promise(() => import('../../../lib/vbrief/io.js'));
+        const planDoc = readPlan(planPath);
+        const planIssueId = planDoc?.plan?.id;
+        if (planIssueId && planIssueId.toLowerCase() !== issueLower) {
+          return jsonResponse({
+            error: `Plan in workspace is for ${planIssueId.toUpperCase()}, not ${issueId}. The workspace contains stale planning artifacts from a different issue.`,
+            hint: 'Run planning for this issue first, or clean the workspace planning artifacts.',
+            issueId,
+            expectedIssue: issueId,
+            actualIssue: planIssueId.toUpperCase(),
+          }, { status: 422 });
+        }
+        const itemCount = planDoc?.plan?.items?.length ?? 0;
+        if (itemCount === 0) {
+          return jsonResponse({
+            error: 'Plan exists but contains no items. Planning may have failed or produced an empty plan.',
+            hint: 'Re-run planning to produce a plan with tasks and acceptance criteria.',
+            issueId,
+          }, { status: 422 });
+        }
+      } catch (planErr: any) {
+        const message = planErr?.message ?? String(planErr);
         return jsonResponse({
-          error: `Plan in workspace is for ${planIssueId.toUpperCase()}, not ${issueId}. The workspace contains stale planning artifacts from a different issue.`,
-          hint: 'Run planning for this issue first, or clean the workspace planning artifacts.',
+          error: `Invalid workspace vBRIEF for ${issueId}: ${message}`,
+          hint: 'Fix or remove .pan/spec.vbrief.json before starting an agent.',
           issueId,
-          expectedIssue: issueId,
-          actualIssue: planIssueId.toUpperCase(),
         }, { status: 422 });
       }
-      const itemCount = planDoc?.plan?.items?.length ?? 0;
-      if (itemCount === 0) {
-        return jsonResponse({
-          error: 'Plan exists but contains no items. Planning may have failed or produced an empty plan.',
-          hint: 'Re-run planning to produce a plan with tasks and acceptance criteria.',
-          issueId,
-        }, { status: 422 });
-      }
-    } catch {}
+    }
 
     let hasBeads = false;
     try {

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -41,7 +41,7 @@ import { withBdMutex } from '../../../lib/bd-mutex.js';
 import { exec, spawn } from 'node:child_process';
 import { timingSafeEqual } from 'node:crypto';
 import { existsSync } from 'node:fs';
-import { appendFile, copyFile, mkdir, open, readdir, readFile, rename, rm, stat, symlink, lstat, writeFile } from 'node:fs/promises';
+import { appendFile, mkdir, open, readdir, readFile, rename, rm, stat, symlink, lstat, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
@@ -86,11 +86,11 @@ import { checkCodexAuthStatus } from '../../../lib/codex-auth.js';
 import { getProviderForModel } from '../../../lib/providers.js';
 import { validateProviderHealth, ProviderHealthError } from '../../../lib/provider-health.js';
 import { resolveProjectFromIssue } from '../../../lib/projects.js';
-import { findPlan, findVBriefInPrdDirs, isPlanningComplete } from '../../../lib/vbrief/io.js';
+import { findPlan, importVBriefFromPrdDirs, isPlanningComplete } from '../../../lib/vbrief/io.js';
 import { transitionVBriefOnMain, updatePlanStatus } from '../../../lib/vbrief/lifecycle-io.js';
 import type { ContinueState } from '../../../lib/vbrief/continue-state.js';
 import { extractPrefix } from '../../../lib/issue-id.js';
-import { PAN_CONTINUE_FILENAME, PAN_DIRNAME, PAN_SPEC_FILENAME } from '../../../lib/pan-dir/types.js';
+import { PAN_CONTINUE_FILENAME, PAN_DIRNAME } from '../../../lib/pan-dir/types.js';
 import { getGitHubConfig } from '../services/tracker-config.js';
 import { loadWorkspaceMetadata as loadWorkspaceMetadataFn } from '../../../lib/remote/workspace-metadata.js';
 import { getWorkAgentLifecycleState } from '../../../lib/work-agent-lifecycle.js';
@@ -1935,19 +1935,17 @@ const postAgentsRoute = HttpRouter.add(
 
     let planPath = findPlan(workspacePath);
     if (!planPath) {
-      const prdVBriefPath = findVBriefInPrdDirs(projectPath, issueId);
-      if (prdVBriefPath) {
-        yield* Effect.promise(async () => {
-          try {
-            await mkdir(workspacePanDir, { recursive: true });
-            await copyFile(prdVBriefPath, join(workspacePanDir, PAN_SPEC_FILENAME));
-            planPath = findPlan(workspacePath);
-            console.log(`[start-agent] Imported PRD vBRIEF for ${issueId} from ${prdVBriefPath}`);
-          } catch (importErr: any) {
-            console.warn(`[start-agent] Failed to import PRD vBRIEF for ${issueId}: ${importErr?.message ?? importErr}`);
+      yield* Effect.promise(async () => {
+        try {
+          const imported = await importVBriefFromPrdDirs(projectPath, workspacePath, issueId);
+          if (imported) {
+            planPath = imported.workspacePlanPath;
+            console.log(`[start-agent] Imported PRD vBRIEF for ${issueId} from ${imported.sourcePath}`);
           }
-        });
-      }
+        } catch (importErr: any) {
+          console.warn(`[start-agent] Failed to import PRD vBRIEF for ${issueId}: ${importErr?.message ?? importErr}`);
+        }
+      });
     }
 
     const hasPlan = planPath !== null;

--- a/src/lib/__tests__/pan-871-agent-id-normalization.test.ts
+++ b/src/lib/__tests__/pan-871-agent-id-normalization.test.ts
@@ -66,7 +66,13 @@ vi.mock('../launcher-generator.js', () => ({ generateLauncherScript: vi.fn() }))
 vi.mock('../persistent-logger.js', () => ({ logAgentLifecycle: vi.fn() }));
 vi.mock('../github-app.js', () => ({ isGitHubAppConfigured: vi.fn(() => false), generateInstallationToken: vi.fn(), configureWorkspaceForBot: vi.fn() }));
 vi.mock('../workspace-manager.js', () => ({ preTrustDirectory: vi.fn() }));
-vi.mock('../paths.js', () => ({ AGENTS_DIR: '/tmp/test-agents' }));
+vi.mock('../paths.js', () => ({
+  AGENTS_DIR: '/tmp/test-agents',
+  PROJECT_DOCS_SUBDIR: 'docs',
+  PROJECT_PRDS_SUBDIR: 'prds',
+  PROJECT_PRDS_ACTIVE_SUBDIR: 'active',
+  PROJECT_PRDS_PLANNED_SUBDIR: 'planned',
+}));
 
 import { getAgentState, listRunningAgents } from '../agents.js';
 

--- a/src/lib/channels/panopticon-bridge.ts
+++ b/src/lib/channels/panopticon-bridge.ts
@@ -40,8 +40,8 @@ import {
   type Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 import { timingSafeEqual } from 'node:crypto';
-import { existsSync, unlinkSync } from 'node:fs';
 import { chmod, mkdir, unlink, appendFile, stat } from 'node:fs/promises';
+import { existsSync, unlinkSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 

--- a/src/lib/cloister/__tests__/deacon-stuck-skip.test.ts
+++ b/src/lib/cloister/__tests__/deacon-stuck-skip.test.ts
@@ -53,6 +53,8 @@ vi.mock('../config.js', () => ({
 vi.mock('../../paths.js', () => ({
   PANOPTICON_HOME: '/tmp/test-panopticon',
   AGENTS_DIR: '/tmp/test-agents',
+  PROJECT_DOCS_SUBDIR: 'docs',
+  PROJECT_PRDS_SUBDIR: 'prds',
   PROJECT_PRDS_ACTIVE_SUBDIR: 'active',
   PROJECT_PRDS_PLANNED_SUBDIR: 'planned',
   PROJECT_PRDS_COMPLETED_SUBDIR: 'completed',

--- a/src/lib/runtimes/__tests__/registry-dispatch.test.ts
+++ b/src/lib/runtimes/__tests__/registry-dispatch.test.ts
@@ -12,6 +12,8 @@ const TEST_AGENTS_DIR = '/tmp/pan-test-runtime-dispatch/agents'
 vi.mock('../../paths.js', () => ({
   PANOPTICON_HOME: '/tmp/pan-test-runtime-dispatch',
   AGENTS_DIR: '/tmp/pan-test-runtime-dispatch/agents',
+  PROJECT_DOCS_SUBDIR: 'docs',
+  PROJECT_PRDS_SUBDIR: 'prds',
   PROJECT_PRDS_ACTIVE_SUBDIR: 'active',
   PROJECT_PRDS_PLANNED_SUBDIR: 'planned',
   PROJECT_PRDS_COMPLETED_SUBDIR: 'completed',

--- a/src/lib/vbrief/__tests__/io.test.ts
+++ b/src/lib/vbrief/__tests__/io.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, writeFileSync, existsSync, rmSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { findPlan, isPlanningComplete, isPlanningProposed, readPlan, readWorkspacePlan, updateItemStatus, updateSubItemStatus } from '../io.js';
+import { findPlan, findVBriefInPrdDirs, importVBriefFromPrdDirs, isPlanningComplete, isPlanningProposed, readPlan, readWorkspacePlan, updateItemStatus, updateSubItemStatus } from '../io.js';
 import { ensureVBriefDirs, generateVBriefFilename, resolveVBriefDir } from '../lifecycle.js';
 import { PAN_DIRNAME, PAN_SPEC_FILENAME } from '../../pan-dir/index.js';
 import type { VBriefDocument } from '../types.js';
@@ -115,6 +115,73 @@ describe('findPlan', () => {
     );
 
     expect(findPlan(workspacePath)).toBeNull();
+  });
+});
+
+describe('findVBriefInPrdDirs', () => {
+  it.each([
+    ['docs planned flat uppercase', ['docs', 'prds', 'planned', 'PAN-945-plan.vbrief.json']],
+    ['docs active lowercase subdirectory', ['docs', 'prds', 'active', 'pan-945', 'plan.vbrief.json']],
+    ['api docs planned flat lowercase', ['api', 'docs', 'prds', 'planned', 'pan-945-plan.vbrief.json']],
+    ['api docs active uppercase subdirectory', ['api', 'docs', 'prds', 'active', 'PAN-945', 'plan.vbrief.json']],
+  ])('finds %s vBRIEF copies', (_name, segments) => {
+    const projectRoot = join(TEST_DIR, 'project');
+    const sourcePath = join(projectRoot, ...segments);
+    mkdirSync(join(sourcePath, '..'), { recursive: true });
+    writeFileSync(sourcePath, JSON.stringify(makePlanDoc([{ id: 'item-1' }]), null, 2));
+
+    expect(findVBriefInPrdDirs(projectRoot, 'PAN-945')).toBe(sourcePath);
+  });
+
+  it('returns null when no PRD directory vBRIEF exists for the issue', () => {
+    const projectRoot = join(TEST_DIR, 'project');
+    const otherPath = join(projectRoot, 'docs', 'prds', 'planned', 'PAN-944-plan.vbrief.json');
+    mkdirSync(join(otherPath, '..'), { recursive: true });
+    writeFileSync(otherPath, JSON.stringify(makePlanDoc(), null, 2));
+
+    expect(findVBriefInPrdDirs(projectRoot, 'PAN-945')).toBeNull();
+  });
+});
+
+describe('importVBriefFromPrdDirs', () => {
+  it('copies a matching PRD vBRIEF into the workspace-local plan path when missing', async () => {
+    const projectRoot = join(TEST_DIR, 'project');
+    const workspacePath = join(projectRoot, 'workspaces', 'feature-pan-945');
+    const sourcePath = join(projectRoot, 'api', 'docs', 'prds', 'planned', 'PAN-945-plan.vbrief.json');
+    const sourceDoc = makePlanDoc([{ id: 'item-1' }]);
+    sourceDoc.plan.id = 'PAN-945';
+    sourceDoc.plan.title = 'PRD Plan';
+    mkdirSync(join(sourcePath, '..'), { recursive: true });
+    mkdirSync(workspacePath, { recursive: true });
+    writeFileSync(sourcePath, JSON.stringify(sourceDoc, null, 2));
+
+    const imported = await importVBriefFromPrdDirs(projectRoot, workspacePath, 'PAN-945');
+
+    expect(imported).toEqual({
+      sourcePath,
+      workspacePlanPath: join(workspacePath, PAN_DIRNAME, PAN_SPEC_FILENAME),
+    });
+    expect(findPlan(workspacePath)).toBe(imported!.workspacePlanPath);
+    expect(readWorkspacePlan(workspacePath)?.plan.title).toBe('PRD Plan');
+  });
+
+  it('does not overwrite an existing workspace-local plan', async () => {
+    const projectRoot = join(TEST_DIR, 'project');
+    const workspacePath = join(projectRoot, 'workspaces', 'feature-pan-945');
+    const sourcePath = join(projectRoot, 'docs', 'prds', 'planned', 'PAN-945-plan.vbrief.json');
+    const existingDoc = makePlanDoc([{ id: 'existing' }]);
+    existingDoc.plan.title = 'Existing Workspace Plan';
+    const sourceDoc = makePlanDoc([{ id: 'source' }]);
+    sourceDoc.plan.title = 'PRD Plan';
+    mkdirSync(join(sourcePath, '..'), { recursive: true });
+    mkdirSync(workspacePath, { recursive: true });
+    writePlanDoc(workspacePath, existingDoc);
+    writeFileSync(sourcePath, JSON.stringify(sourceDoc, null, 2));
+
+    const imported = await importVBriefFromPrdDirs(projectRoot, workspacePath, 'PAN-945');
+
+    expect(imported).toBeNull();
+    expect(readWorkspacePlan(workspacePath)?.plan.title).toBe('Existing Workspace Plan');
   });
 });
 

--- a/src/lib/vbrief/__tests__/io.test.ts
+++ b/src/lib/vbrief/__tests__/io.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, writeFileSync, existsSync, rmSync, readFileSync } from 'fs';
+import { mkdirSync, writeFileSync, existsSync, rmSync, readFileSync, symlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { findPlan, findVBriefInPrdDirs, importVBriefFromPrdDirs, isPlanningComplete, isPlanningProposed, readPlan, readWorkspacePlan, updateItemStatus, updateSubItemStatus } from '../io.js';
@@ -124,22 +124,27 @@ describe('findVBriefInPrdDirs', () => {
     ['docs active lowercase subdirectory', ['docs', 'prds', 'active', 'pan-945', 'plan.vbrief.json']],
     ['api docs planned flat lowercase', ['api', 'docs', 'prds', 'planned', 'pan-945-plan.vbrief.json']],
     ['api docs active uppercase subdirectory', ['api', 'docs', 'prds', 'active', 'PAN-945', 'plan.vbrief.json']],
-  ])('finds %s vBRIEF copies', (_name, segments) => {
+    ['api docs planned slugged uppercase flat file', ['api', 'docs', 'prds', 'planned', 'PAN-945-import-prd-vbrief.vbrief.json']],
+  ])('finds %s vBRIEF copies', async (_name, segments) => {
     const projectRoot = join(TEST_DIR, 'project');
     const sourcePath = join(projectRoot, ...segments);
     mkdirSync(join(sourcePath, '..'), { recursive: true });
     writeFileSync(sourcePath, JSON.stringify(makePlanDoc([{ id: 'item-1' }]), null, 2));
 
-    expect(findVBriefInPrdDirs(projectRoot, 'PAN-945')).toBe(sourcePath);
+    await expect(findVBriefInPrdDirs(projectRoot, 'PAN-945')).resolves.toBe(sourcePath);
   });
 
-  it('returns null when no PRD directory vBRIEF exists for the issue', () => {
+  it('returns null when no PRD directory vBRIEF exists for the issue', async () => {
     const projectRoot = join(TEST_DIR, 'project');
     const otherPath = join(projectRoot, 'docs', 'prds', 'planned', 'PAN-944-plan.vbrief.json');
     mkdirSync(join(otherPath, '..'), { recursive: true });
     writeFileSync(otherPath, JSON.stringify(makePlanDoc(), null, 2));
 
-    expect(findVBriefInPrdDirs(projectRoot, 'PAN-945')).toBeNull();
+    await expect(findVBriefInPrdDirs(projectRoot, 'PAN-945')).resolves.toBeNull();
+  });
+
+  it.each(['../PAN-945', 'PAN-945/../../SECRET', 'PAN.945', `PAN-945${String.fromCharCode(0)}`])('rejects unsafe issue ID %s', async unsafeIssueId => {
+    await expect(findVBriefInPrdDirs(join(TEST_DIR, 'project'), unsafeIssueId)).rejects.toThrow('Invalid issue ID');
   });
 });
 
@@ -182,6 +187,60 @@ describe('importVBriefFromPrdDirs', () => {
 
     expect(imported).toBeNull();
     expect(readWorkspacePlan(workspacePath)?.plan.title).toBe('Existing Workspace Plan');
+  });
+
+  it('imports slugged flat vBRIEF files from api/docs/prds/planned', async () => {
+    const projectRoot = join(TEST_DIR, 'project');
+    const workspacePath = join(projectRoot, 'workspaces', 'feature-pan-945');
+    const sourcePath = join(projectRoot, 'api', 'docs', 'prds', 'planned', 'PAN-945-import-prd-vbrief.vbrief.json');
+    const sourceDoc = makePlanDoc([{ id: 'item-1' }]);
+    sourceDoc.plan.id = 'PAN-945';
+    sourceDoc.plan.title = 'Slugged PRD Plan';
+    mkdirSync(join(sourcePath, '..'), { recursive: true });
+    mkdirSync(workspacePath, { recursive: true });
+    writeFileSync(sourcePath, JSON.stringify(sourceDoc, null, 2));
+
+    const imported = await importVBriefFromPrdDirs(projectRoot, workspacePath, 'pan-945');
+
+    expect(imported?.sourcePath).toBe(sourcePath);
+    expect(readWorkspacePlan(workspacePath)?.plan.title).toBe('Slugged PRD Plan');
+  });
+
+  it('rejects symlinked PRD vBRIEF artifacts without creating .pan/spec.vbrief.json', async () => {
+    const projectRoot = join(TEST_DIR, 'project');
+    const workspacePath = join(projectRoot, 'workspaces', 'feature-pan-945');
+    const sourcePath = join(projectRoot, 'docs', 'prds', 'planned', 'PAN-945-plan.vbrief.json');
+    const secretPath = join(TEST_DIR, 'secret.vbrief.json');
+    mkdirSync(join(sourcePath, '..'), { recursive: true });
+    mkdirSync(workspacePath, { recursive: true });
+    writeFileSync(secretPath, JSON.stringify(makePlanDoc([{ id: 'secret' }]), null, 2));
+    symlinkSync(secretPath, sourcePath);
+
+    await expect(importVBriefFromPrdDirs(projectRoot, workspacePath, 'PAN-945')).rejects.toThrow('symlink');
+    expect(existsSync(join(workspacePath, PAN_DIRNAME, PAN_SPEC_FILENAME))).toBe(false);
+  });
+
+  it('rejects non-regular PRD vBRIEF artifacts without creating .pan/spec.vbrief.json', async () => {
+    const projectRoot = join(TEST_DIR, 'project');
+    const workspacePath = join(projectRoot, 'workspaces', 'feature-pan-945');
+    const sourcePath = join(projectRoot, 'docs', 'prds', 'planned', 'PAN-945-plan.vbrief.json');
+    mkdirSync(sourcePath, { recursive: true });
+    mkdirSync(workspacePath, { recursive: true });
+
+    await expect(importVBriefFromPrdDirs(projectRoot, workspacePath, 'PAN-945')).rejects.toThrow('non-regular');
+    expect(existsSync(join(workspacePath, PAN_DIRNAME, PAN_SPEC_FILENAME))).toBe(false);
+  });
+
+  it('rejects invalid existing PRD vBRIEF artifacts without creating .pan/spec.vbrief.json', async () => {
+    const projectRoot = join(TEST_DIR, 'project');
+    const workspacePath = join(projectRoot, 'workspaces', 'feature-pan-945');
+    const sourcePath = join(projectRoot, 'api', 'docs', 'prds', 'planned', 'PAN-945-invalid.vbrief.json');
+    mkdirSync(join(sourcePath, '..'), { recursive: true });
+    mkdirSync(workspacePath, { recursive: true });
+    writeFileSync(sourcePath, JSON.stringify({ plan: { id: 'PAN-945' } }, null, 2));
+
+    await expect(importVBriefFromPrdDirs(projectRoot, workspacePath, 'PAN-945')).rejects.toThrow('Invalid vBRIEF format');
+    expect(existsSync(join(workspacePath, PAN_DIRNAME, PAN_SPEC_FILENAME))).toBe(false);
   });
 });
 

--- a/src/lib/vbrief/io.ts
+++ b/src/lib/vbrief/io.ts
@@ -16,9 +16,9 @@
  * after lifecycle promotion — corrupting the archived plan.
  */
 
-import { existsSync, readFileSync, renameSync, writeFileSync } from 'fs';
-import { copyFile, mkdir } from 'fs/promises';
-import { dirname, join } from 'path';
+import { constants, existsSync, readFileSync, renameSync, writeFileSync } from 'fs';
+import { lstat, mkdir, open, readdir, realpath, writeFile } from 'fs/promises';
+import { dirname, isAbsolute, join, relative, resolve } from 'path';
 import {
   PROJECT_DOCS_SUBDIR,
   PROJECT_PRDS_ACTIVE_SUBDIR,
@@ -43,32 +43,104 @@ const PRD_VBRIEF_ROOTS = [
   [PROJECT_DOCS_SUBDIR, PROJECT_PRDS_SUBDIR],
   ['api', PROJECT_DOCS_SUBDIR, PROJECT_PRDS_SUBDIR],
 ] as const;
+const ISSUE_ID_PATTERN = /^[A-Z][A-Z0-9]*-\d+$/i;
 
-/**
- * Returns a PRD-scoped vBRIEF path for an issue when the workspace-local
- * `.pan/spec.vbrief.json` has not been materialized yet.
- *
- * Supports both legacy flat files (`docs/prds/active/PAN-123-plan.vbrief.json`)
- * and canonical subdirectory files (`docs/prds/active/pan-123/plan.vbrief.json`),
- * including the historical uppercase-directory variant and the `api/docs/prds/*`
- * mirror used by some projects.
- */
-export function findVBriefInPrdDirs(projectRoot: string, issueId: string): string | null {
+interface PrdVBriefCandidate {
+  sourcePath: string;
+  rootRealPath: string;
+}
+
+function assertValidIssueId(issueId: string): void {
+  if (!ISSUE_ID_PATTERN.test(issueId)) {
+    throw new Error(
+      `Invalid issue ID "${issueId}": expected PREFIX-123 format with letters, numbers, and a single hyphen.`,
+    );
+  }
+}
+
+function isPathInside(parentPath: string, childPath: string): boolean {
+  const relativePath = relative(parentPath, childPath);
+  return relativePath === '' || (relativePath !== '' && !relativePath.startsWith('..') && !isAbsolute(relativePath));
+}
+
+async function getPrdRootRealPath(root: string): Promise<string | null> {
+  try {
+    const stats = await lstat(root);
+    if (stats.isSymbolicLink()) {
+      throw new Error(`PRD vBRIEF root is a symlink and will not be scanned: ${root}`);
+    }
+    if (!stats.isDirectory()) {
+      throw new Error(`PRD vBRIEF root is not a directory: ${root}`);
+    }
+    return await realpath(root);
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+async function checkedPrdVBriefFile(sourcePath: string, rootRealPath: string): Promise<string | null> {
+  let stats;
+  try {
+    stats = await lstat(sourcePath);
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') return null;
+    throw err;
+  }
+
+  if (stats.isSymbolicLink()) {
+    throw new Error(`Refusing to import PRD vBRIEF symlink: ${sourcePath}`);
+  }
+  if (!stats.isFile()) {
+    throw new Error(`Refusing to import non-regular PRD vBRIEF file: ${sourcePath}`);
+  }
+
+  const sourceRealPath = await realpath(sourcePath);
+  if (!isPathInside(rootRealPath, sourceRealPath)) {
+    throw new Error(`Refusing to import PRD vBRIEF outside PRD root: ${sourcePath}`);
+  }
+
+  return sourcePath;
+}
+
+async function findPrdVBriefCandidate(projectRoot: string, issueId: string): Promise<PrdVBriefCandidate | null> {
+  assertValidIssueId(issueId);
+
   const issueIdLower = issueId.toLowerCase();
   const issueIdUpper = issueId.toUpperCase();
 
   for (const prdRoot of PRD_VBRIEF_ROOTS) {
     for (const statusDir of PRD_VBRIEF_STATUS_DIRS) {
-      const root = join(projectRoot, ...prdRoot, statusDir);
-      const candidates = [
+      const root = resolve(projectRoot, ...prdRoot, statusDir);
+      const rootRealPath = await getPrdRootRealPath(root);
+      if (!rootRealPath) continue;
+
+      const exactCandidates = [
         join(root, `${issueIdUpper}-plan.vbrief.json`),
         join(root, `${issueIdLower}-plan.vbrief.json`),
         join(root, issueIdLower, 'plan.vbrief.json'),
         join(root, issueIdUpper, 'plan.vbrief.json'),
       ];
 
-      for (const candidate of candidates) {
-        if (existsSync(candidate)) return candidate;
+      for (const sourcePath of exactCandidates) {
+        const checked = await checkedPrdVBriefFile(sourcePath, rootRealPath);
+        if (checked) return { sourcePath: checked, rootRealPath };
+      }
+
+      const entries = await readdir(root, { withFileTypes: true });
+      const slugPrefix = `${issueIdLower}-`;
+      const slugMatches = entries
+        .map(entry => entry.name)
+        .filter(name => {
+          const lowerName = name.toLowerCase();
+          return lowerName.startsWith(slugPrefix) && lowerName.endsWith('.vbrief.json');
+        })
+        .sort((a, b) => a.localeCompare(b));
+
+      for (const name of slugMatches) {
+        const sourcePath = join(root, name);
+        const checked = await checkedPrdVBriefFile(sourcePath, rootRealPath);
+        if (checked) return { sourcePath: checked, rootRealPath };
       }
     }
   }
@@ -76,9 +148,44 @@ export function findVBriefInPrdDirs(projectRoot: string, issueId: string): strin
   return null;
 }
 
+/**
+ * Returns a PRD-scoped vBRIEF path for an issue when the workspace-local
+ * `.pan/spec.vbrief.json` has not been materialized yet.
+ *
+ * Supports both legacy flat files (`docs/prds/active/PAN-123-plan.vbrief.json`),
+ * slugged flat files (`docs/prds/active/PAN-123-my-feature.vbrief.json`),
+ * and canonical subdirectory files (`docs/prds/active/pan-123/plan.vbrief.json`),
+ * including the historical uppercase-directory variant and the `api/docs/prds/*`
+ * mirror used by some projects.
+ */
+export async function findVBriefInPrdDirs(projectRoot: string, issueId: string): Promise<string | null> {
+  const candidate = await findPrdVBriefCandidate(projectRoot, issueId);
+  return candidate?.sourcePath ?? null;
+}
+
 export interface ImportedPrdVBrief {
   sourcePath: string;
   workspacePlanPath: string;
+}
+
+async function readCheckedPrdVBrief(candidate: PrdVBriefCandidate): Promise<VBriefDocument> {
+  const handle = await open(candidate.sourcePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const stats = await handle.stat();
+    if (!stats.isFile()) {
+      throw new Error(`Refusing to import non-regular PRD vBRIEF file: ${candidate.sourcePath}`);
+    }
+
+    const sourceRealPath = await realpath(candidate.sourcePath);
+    if (!isPathInside(candidate.rootRealPath, sourceRealPath)) {
+      throw new Error(`Refusing to import PRD vBRIEF outside PRD root: ${candidate.sourcePath}`);
+    }
+
+    const raw = await handle.readFile({ encoding: 'utf-8' });
+    return parseVBriefDocument(raw, candidate.sourcePath);
+  } finally {
+    await handle.close();
+  }
 }
 
 /**
@@ -94,21 +201,30 @@ export async function importVBriefFromPrdDirs(
 ): Promise<ImportedPrdVBrief | null> {
   if (findPlan(workspacePath)) return null;
 
-  const sourcePath = findVBriefInPrdDirs(projectRoot, issueId);
-  if (!sourcePath) return null;
+  const candidate = await findPrdVBriefCandidate(projectRoot, issueId);
+  if (!candidate) return null;
+
+  const document = await readCheckedPrdVBrief(candidate);
+  const planIssueId = typeof document.plan?.id === 'string' ? document.plan.id : null;
+  if (planIssueId && planIssueId.toLowerCase() !== issueId.toLowerCase()) {
+    throw new Error(
+      `PRD vBRIEF ${candidate.sourcePath} is for ${planIssueId.toUpperCase()}, not ${issueId.toUpperCase()}.`,
+    );
+  }
 
   const workspacePlanPath = join(workspacePath, PAN_DIRNAME, PAN_SPEC_FILENAME);
   await mkdir(dirname(workspacePlanPath), { recursive: true });
-  await copyFile(sourcePath, workspacePlanPath);
+  if (findPlan(workspacePath)) return null;
+  await writeFile(workspacePlanPath, `${JSON.stringify(document, null, 2)}\n`, { encoding: 'utf-8', flag: 'wx' });
 
-  return { sourcePath, workspacePlanPath };
+  return { sourcePath: candidate.sourcePath, workspacePlanPath };
 }
 
 /**
  * Reads and parses plan.vbrief.json from the given path.
- * Handles both standard format ({ vBRIEFInfo, plan: {...} }) and flat format
- * ({ issue, title, items, edges? }) produced by some planning prompts.
- * Throws if the file does not exist or is invalid JSON.
+ * Accepts the vBRIEF v0.5 document shape ({ vBRIEFInfo, plan: {...} }).
+ * Throws if the file does not exist, contains invalid JSON, or does not match
+ * the required top-level vBRIEF shape.
  */
 export class VBriefMergeConflictError extends Error {
   constructor(planPath: string) {
@@ -120,15 +236,21 @@ export class VBriefMergeConflictError extends Error {
   }
 }
 
-export function readPlan(planPath: string): VBriefDocument {
-  const raw = readFileSync(planPath, 'utf-8');
+export function parseVBriefDocument(raw: string, planPath: string): VBriefDocument {
   if (raw.includes('<<<<<<<') && raw.includes('=======') && raw.includes('>>>>>>>')) {
     throw new VBriefMergeConflictError(planPath);
   }
   const parsed = JSON.parse(raw);
 
   // vBRIEF v0.5 requires exactly two top-level keys: vBRIEFInfo and plan
-  if (parsed.vBRIEFInfo && parsed.plan) {
+  if (
+    parsed &&
+    typeof parsed === 'object' &&
+    parsed.vBRIEFInfo &&
+    typeof parsed.vBRIEFInfo === 'object' &&
+    parsed.plan &&
+    typeof parsed.plan === 'object'
+  ) {
     return parsed as VBriefDocument;
   }
 
@@ -138,6 +260,10 @@ export function readPlan(planPath: string): VBriefDocument {
     `vBRIEF v0.5 requires exactly { "vBRIEFInfo": { "version": "0.5" }, "plan": { ... } }. ` +
     `See docs/VBRIEF.md for the correct format.`
   );
+}
+
+export function readPlan(planPath: string): VBriefDocument {
+  return parseVBriefDocument(readFileSync(planPath, 'utf-8'), planPath);
 }
 
 /**

--- a/src/lib/vbrief/io.ts
+++ b/src/lib/vbrief/io.ts
@@ -18,6 +18,12 @@
 
 import { existsSync, readFileSync, renameSync, writeFileSync } from 'fs';
 import { join } from 'path';
+import {
+  PROJECT_DOCS_SUBDIR,
+  PROJECT_PRDS_ACTIVE_SUBDIR,
+  PROJECT_PRDS_PLANNED_SUBDIR,
+  PROJECT_PRDS_SUBDIR,
+} from '../paths.js';
 import { PAN_DIRNAME, PAN_SPEC_FILENAME } from '../pan-dir/types.js';
 import type { VBriefDocument, VBriefItemStatus } from './types.js';
 
@@ -29,6 +35,44 @@ import type { VBriefDocument, VBriefItemStatus } from './types.js';
 export function findPlan(workspacePath: string): string | null {
   const panPlanPath = join(workspacePath, PAN_DIRNAME, PAN_SPEC_FILENAME);
   return existsSync(panPlanPath) ? panPlanPath : null;
+}
+
+const PRD_VBRIEF_STATUS_DIRS = [PROJECT_PRDS_ACTIVE_SUBDIR, PROJECT_PRDS_PLANNED_SUBDIR] as const;
+const PRD_VBRIEF_ROOTS = [
+  [PROJECT_DOCS_SUBDIR, PROJECT_PRDS_SUBDIR],
+  ['api', PROJECT_DOCS_SUBDIR, PROJECT_PRDS_SUBDIR],
+] as const;
+
+/**
+ * Returns a PRD-scoped vBRIEF path for an issue when the workspace-local
+ * `.pan/spec.vbrief.json` has not been materialized yet.
+ *
+ * Supports both legacy flat files (`docs/prds/active/PAN-123-plan.vbrief.json`)
+ * and canonical subdirectory files (`docs/prds/active/pan-123/plan.vbrief.json`),
+ * including the historical uppercase-directory variant and the `api/docs/prds/*`
+ * mirror used by some projects.
+ */
+export function findVBriefInPrdDirs(projectRoot: string, issueId: string): string | null {
+  const issueIdLower = issueId.toLowerCase();
+  const issueIdUpper = issueId.toUpperCase();
+
+  for (const prdRoot of PRD_VBRIEF_ROOTS) {
+    for (const statusDir of PRD_VBRIEF_STATUS_DIRS) {
+      const root = join(projectRoot, ...prdRoot, statusDir);
+      const candidates = [
+        join(root, `${issueIdUpper}-plan.vbrief.json`),
+        join(root, `${issueIdLower}-plan.vbrief.json`),
+        join(root, issueIdLower, 'plan.vbrief.json'),
+        join(root, issueIdUpper, 'plan.vbrief.json'),
+      ];
+
+      for (const candidate of candidates) {
+        if (existsSync(candidate)) return candidate;
+      }
+    }
+  }
+
+  return null;
 }
 
 /**

--- a/src/lib/vbrief/io.ts
+++ b/src/lib/vbrief/io.ts
@@ -17,7 +17,8 @@
  */
 
 import { existsSync, readFileSync, renameSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { copyFile, mkdir } from 'fs/promises';
+import { dirname, join } from 'path';
 import {
   PROJECT_DOCS_SUBDIR,
   PROJECT_PRDS_ACTIVE_SUBDIR,
@@ -73,6 +74,34 @@ export function findVBriefInPrdDirs(projectRoot: string, issueId: string): strin
   }
 
   return null;
+}
+
+export interface ImportedPrdVBrief {
+  sourcePath: string;
+  workspacePlanPath: string;
+}
+
+/**
+ * Copies a matching PRD-scoped vBRIEF into the workspace-local plan location
+ * when `.pan/spec.vbrief.json` has not been materialized yet.
+ *
+ * Returns null when the workspace already has a plan or no PRD vBRIEF exists.
+ */
+export async function importVBriefFromPrdDirs(
+  projectRoot: string,
+  workspacePath: string,
+  issueId: string,
+): Promise<ImportedPrdVBrief | null> {
+  if (findPlan(workspacePath)) return null;
+
+  const sourcePath = findVBriefInPrdDirs(projectRoot, issueId);
+  if (!sourcePath) return null;
+
+  const workspacePlanPath = join(workspacePath, PAN_DIRNAME, PAN_SPEC_FILENAME);
+  await mkdir(dirname(workspacePlanPath), { recursive: true });
+  await copyFile(sourcePath, workspacePlanPath);
+
+  return { sourcePath, workspacePlanPath };
 }
 
 /**

--- a/tests/unit/lib/lifecycle/teardown-workspace.test.ts
+++ b/tests/unit/lib/lifecycle/teardown-workspace.test.ts
@@ -26,6 +26,7 @@ vi.mock('../../../../src/lib/tmux.js', () => ({
 vi.mock('../../../../src/lib/paths.js', () => ({
   AGENTS_DIR: join(tmpdir(), 'panopticon-test-agents'),
   PANOPTICON_HOME: join(tmpdir(), 'panopticon-test-home'),
+  PROJECT_DOCS_SUBDIR: 'docs',
   PROJECT_PRDS_SUBDIR: 'prds',
   PROJECT_PRDS_ACTIVE_SUBDIR: 'active',
   PROJECT_PRDS_PLANNED_SUBDIR: 'planned',


### PR DESCRIPTION
Closes #945

## Acceptance Criteria

- [x] Bump MAX_BYTES to 8 MB and make issues-stripping a fallback on QuotaExceededError
- [x] Add tests for snapshotCache QuotaExceededError fallback and 8MB cap

## Implementation Tasks

- [x] Add tests for PRD dir vBRIEF discovery and auto-import
- [x] Wire PRD vBRIEF discovery into dashboard start-agent endpoint
- [x] Wire PRD vBRIEF discovery into CLI pan start command
- [x] Add findVBriefInPrdDirs helper to search docs/prds for vBRIEFs
- [x] Discover and import vBRIEF from PRD dirs when plan missing in workspace