### PR TITLE
Fix stranded review recovery

### DIFF
--- a/.pan/continue.json
+++ b/.pan/continue.json
@@ -2,10 +2,10 @@
   "version": "1",
   "issueId": "1034",
   "created": "2026-05-09T01:13:00Z",
-  "updated": "2026-05-09T01:55:28Z",
+  "updated": "2026-05-09T02:06:50Z",
   "gitState": {
     "branch": "feature/1034",
-    "sha": "c7eaa3dce",
+    "sha": "d921fe118",
     "dirty": true
   },
   "decisions": [
@@ -50,18 +50,19 @@
       "id": "H2",
       "summary": "Running the targeted Vitest suite triggered the build global setup, which regenerated `scripts/record-cost-event.js` with unrelated main-branch build output differences.",
       "mitigation": "Leave `scripts/record-cost-event.js` unstaged for this bead unless a later explicit build-artifact bead is created; avoid mixing unrelated generated-script drift into scoped review-coordinator commits."
+    },
+    {
+      "id": "H3",
+      "summary": "Production dashboard build caught a stranded-review helper type mismatch that root `npm run typecheck` did not catch because frontend workspace TypeScript is compiled during `npm run build`.",
+      "mitigation": "Reopened workspace-8pl5 and narrowed the inspector ReviewButtonInput mergeStatus/verificationStatus unions to match PipelineStateLike before rerunning build verification."
     }
   ],
   "resumePoint": {
-    "description": "Bead workspace-9gr0 is implemented and verified locally: failed/protocol review coordinator exits now preserve an inspectable shell, completed coordinator sessions are restartable on the next dispatch, and unexpected coordinator deaths emit review.coordinator.died telemetry. Next step is commit only this bead, close workspace-9gr0, then run final verification for PAN-1034.",
-    "beadId": "workspace-9gr0",
+    "description": "Build verification exposed a frontend-only TypeScript mismatch in the stranded-review dashboard helper. Bead workspace-8pl5 was reopened and the fix is implemented: ReviewButtonInput now narrows mergeStatus and verificationStatus to the same literal unions accepted by PipelineStateLike. Next step is commit only this small build fix plus continue.json, close workspace-8pl5 again, then rerun final verification.",
+    "beadId": "workspace-8pl5",
     "filesToRead": [
-      "src/lib/cloister/review-agent.ts",
-      "src/lib/pipeline-notifier.ts",
-      "src/dashboard/server/main.ts",
-      "src/dashboard/server/routes/workspaces.ts",
-      "packages/contracts/src/events.ts",
-      "packages/contracts/src/event-reducers.ts"
+      "src/dashboard/frontend/src/components/inspector/utils.ts",
+      "src/dashboard/frontend/src/lib/pipeline-state.ts"
     ]
   },
   "beadsMapping": {
@@ -102,6 +103,12 @@
       "timestamp": "2026-05-09T01:55:28Z",
       "reason": "manual",
       "note": "Implemented workspace-9gr0. The review coordinator launcher now keeps failed/protocol pan review run exits (status >=2) alive in an interactive shell for inspection, records exit markers keyed by coordinator session name so the next dispatch can kill/restart completed coordinators, and emits coordinator_died/review.coordinator.died telemetry only for sessions that disappear without an exit marker. Added focused lifecycle tests and verified with npm test -- src/lib/cloister/__tests__/review-temp-lifecycle.test.ts --run and npm run typecheck.",
+      "agentModel": "claude-code"
+    },
+    {
+      "timestamp": "2026-05-09T02:06:50Z",
+      "reason": "manual",
+      "note": "Final build verification failed in the dashboard frontend because InspectorPanel's ReviewButtonInput allowed arbitrary string mergeStatus/verificationStatus values when passed to isPendingReviewStranded. Reopened workspace-8pl5 and narrowed those fields to the PipelineStateLike literal unions so production build type-checking can accept the stranded-review helper calls.",
       "agentModel": "claude-code"
     }
   ],

--- a/.pan/continue.json
+++ b/.pan/continue.json
@@ -2,10 +2,10 @@
   "version": "1",
   "issueId": "1034",
   "created": "2026-05-09T01:13:00Z",
-  "updated": "2026-05-09T01:26:00Z",
+  "updated": "2026-05-09T01:41:00Z",
   "gitState": {
     "branch": "feature/1034",
-    "sha": "66d08100b",
+    "sha": "ac576a588",
     "dirty": true
   },
   "decisions": [
@@ -23,6 +23,11 @@
       "id": "D3",
       "summary": "Timeout telemetry uses a new domain event type `review.specialist.timed_out`, forwarded through notifyPipeline as `reviewer_timed_out`, so CLI-hosted coordinators can report timed-out reviewer attempts to the dashboard event stream without requiring an in-process server handler.",
       "recordedAt": "2026-05-09T01:26:00Z"
+    },
+    {
+      "id": "D4",
+      "summary": "Verification-failed recovery now treats verificationStatus=failed as actionable even when reviewStatus remains pending, and all verification feedback nudges explicitly tell the work agent to commit, push, and request a new review instead of stopping after fixing local verification.",
+      "recordedAt": "2026-05-09T01:41:00Z"
     }
   ],
   "hazards": [
@@ -38,23 +43,26 @@
     }
   ],
   "resumePoint": {
-    "description": "Bead workspace-6s0t is implemented locally: review specialists that time out or hit dead panes are respawned with a capped two-retry backoff, timeout attempts emit structured `review.specialist.timed_out` events through the pipeline notifier/internal endpoint, and focused tests cover the retry path. Next agent should commit only the bead files and close/inspect workspace-6s0t, then continue with the next ready bead for PAN-1034.",
-    "beadId": "workspace-6s0t",
+    "description": "Bead workspace-vaqf is implemented locally: verification failure feedback now explicitly instructs agents to commit, push, and request a new review, and deacon dead-end recovery now nudges idle agents when verificationStatus=failed while reviewStatus is still pending. Next step is verify, commit only this bead, close workspace-vaqf, then continue to the remaining dashboard/coordinator beads.",
+    "beadId": "workspace-vaqf",
     "filesToRead": [
-      "src/lib/cloister/review-agent.ts",
-      "src/lib/pipeline-notifier.ts",
-      "src/dashboard/server/main.ts",
-      "src/dashboard/server/routes/workspaces.ts",
-      "packages/contracts/src/events.ts",
-      "packages/contracts/src/event-reducers.ts",
-      "src/lib/cloister/__tests__/review-temp-lifecycle.test.ts"
+      "src/lib/cloister/verification-runner.ts",
+      "src/lib/cloister/deacon.ts"
     ]
   },
   "beadsMapping": {
-    "specialist-timeout-retry": ["workspace-6s0t"],
-    "coordinator-survival": ["workspace-9gr0"],
-    "stranded-review-dashboard": ["workspace-8pl5"],
-    "verify-failed-guidance": ["workspace-vaqf"]
+    "specialist-timeout-retry": [
+      "workspace-6s0t"
+    ],
+    "coordinator-survival": [
+      "workspace-9gr0"
+    ],
+    "stranded-review-dashboard": [
+      "workspace-8pl5"
+    ],
+    "verify-failed-guidance": [
+      "workspace-vaqf"
+    ]
   },
   "agentModel": "claude-opus-4-5",
   "sessionHistory": [
@@ -62,6 +70,12 @@
       "timestamp": "2026-05-09T01:26:00Z",
       "reason": "manual",
       "note": "Created issue-scoped beads for PAN-1034 after finding none in the active beads view. Claimed workspace-6s0t and implemented retry-on-timeout in `runParallelReview`: retryable reviewer timeouts/dead panes now respawn only the failed reviewer with two capped backoff attempts; terminal provider errors still skip respawn. Added `review.specialist.timed_out` domain telemetry via `notifyPipeline`, internal pipeline forwarding, contracts schemas/reducer no-op handling, and a focused fake-timer Vitest regression. Verified with `npm test -- src/lib/cloister/__tests__/review-temp-lifecycle.test.ts --run` and `npm run typecheck`.",
+      "agentModel": "claude-code"
+    },
+    {
+      "timestamp": "2026-05-09T01:41:00Z",
+      "reason": "manual",
+      "note": "Claimed workspace-vaqf and updated verification failure recovery. The verification runner messages now direct agents to fix, commit, push, and request a new review/pan review request rather than merely re-run verification. Deacon dead-end detection now treats verificationStatus=failed as a recovery condition even when reviewStatus remains pending, and sends a pending-review-specific nudge with the exact new-review command.",
       "agentModel": "claude-code"
     }
   ],

--- a/.pan/continue.json
+++ b/.pan/continue.json
@@ -2,7 +2,7 @@
   "version": "1",
   "issueId": "1034",
   "created": "2026-05-09T01:13:00Z",
-  "updated": "2026-05-09T01:41:00Z",
+  "updated": "2026-05-09T01:48:48Z",
   "gitState": {
     "branch": "feature/1034",
     "sha": "ac576a588",
@@ -28,6 +28,11 @@
       "id": "D4",
       "summary": "Verification-failed recovery now treats verificationStatus=failed as actionable even when reviewStatus remains pending, and all verification feedback nudges explicitly tell the work agent to commit, push, and request a new review instead of stopping after fixing local verification.",
       "recordedAt": "2026-05-09T01:41:00Z"
+    },
+    {
+      "id": "D5",
+      "summary": "Dashboard stranded-review detection is computed from reviewSpawnedAt/updatedAt: pending reviews with no active queue/specialist older than two 30-minute reviewer timeouts are treated as stranded and get a Re-request Review inspector action.",
+      "recordedAt": "2026-05-09T01:48:48Z"
     }
   ],
   "hazards": [
@@ -43,11 +48,13 @@
     }
   ],
   "resumePoint": {
-    "description": "Bead workspace-vaqf is implemented locally: verification failure feedback now explicitly instructs agents to commit, push, and request a new review, and deacon dead-end recovery now nudges idle agents when verificationStatus=failed while reviewStatus is still pending. Next step is verify, commit only this bead, close workspace-vaqf, then continue to the remaining dashboard/coordinator beads.",
-    "beadId": "workspace-vaqf",
+    "description": "Bead workspace-8pl5 is implemented and verified locally: dashboard inspector detects pending reviews stranded beyond two 30-minute reviewer timeouts, forces the rerun path, and surfaces a Re-request Review action. Next step is commit only this bead, close workspace-8pl5, then continue to coordinator-survival bead workspace-9gr0.",
+    "beadId": "workspace-8pl5",
     "filesToRead": [
-      "src/lib/cloister/verification-runner.ts",
-      "src/lib/cloister/deacon.ts"
+      "src/dashboard/frontend/src/lib/pipeline-state.ts",
+      "src/dashboard/frontend/src/components/InspectorPanel.tsx",
+      "src/dashboard/frontend/src/components/inspector/ActionsSection.tsx",
+      "src/dashboard/frontend/src/components/inspector/utils.ts"
     ]
   },
   "beadsMapping": {
@@ -76,6 +83,12 @@
       "timestamp": "2026-05-09T01:41:00Z",
       "reason": "manual",
       "note": "Claimed workspace-vaqf and updated verification failure recovery. The verification runner messages now direct agents to fix, commit, push, and request a new review/pan review request rather than merely re-run verification. Deacon dead-end detection now treats verificationStatus=failed as a recovery condition even when reviewStatus remains pending, and sends a pending-review-specific nudge with the exact new-review command.",
+      "agentModel": "claude-code"
+    },
+    {
+      "timestamp": "2026-05-09T01:48:48Z",
+      "reason": "manual",
+      "note": "Implemented workspace-8pl5. Added shared dashboard detection for pending reviews older than two 30-minute reviewer timeouts with no active queue/specialist, made the inspector force the review trigger and label the action Re-request Review, surfaced a stranded-review banner in the inspector, and covered the helper/button behavior in InspectorPanel tests. Verified with npm test -- src/dashboard/frontend/src/components/InspectorPanel.test.tsx --run and npm run typecheck.",
       "agentModel": "claude-code"
     }
   ],

--- a/.pan/continue.json
+++ b/.pan/continue.json
@@ -2,10 +2,10 @@
   "version": "1",
   "issueId": "1034",
   "created": "2026-05-09T01:13:00Z",
-  "updated": "2026-05-09T01:48:48Z",
+  "updated": "2026-05-09T01:55:28Z",
   "gitState": {
     "branch": "feature/1034",
-    "sha": "ac576a588",
+    "sha": "c7eaa3dce",
     "dirty": true
   },
   "decisions": [
@@ -33,6 +33,11 @@
       "id": "D5",
       "summary": "Dashboard stranded-review detection is computed from reviewSpawnedAt/updatedAt: pending reviews with no active queue/specialist older than two 30-minute reviewer timeouts are treated as stranded and get a Re-request Review inspector action.",
       "recordedAt": "2026-05-09T01:48:48Z"
+    },
+    {
+      "id": "D6",
+      "summary": "Coordinator survival is handled in the tmux launcher: pan review run still exits normally for approved/changes-requested results, but failed/protocol exit codes keep an interactive shell alive with the log visible; subsequent dispatch treats sessions with exit markers as completed/restartable and emits review.coordinator.died only for sessions that died without an exit marker.",
+      "recordedAt": "2026-05-09T01:55:28Z"
     }
   ],
   "hazards": [
@@ -48,13 +53,15 @@
     }
   ],
   "resumePoint": {
-    "description": "Bead workspace-8pl5 is implemented and verified locally: dashboard inspector detects pending reviews stranded beyond two 30-minute reviewer timeouts, forces the rerun path, and surfaces a Re-request Review action. Next step is commit only this bead, close workspace-8pl5, then continue to coordinator-survival bead workspace-9gr0.",
-    "beadId": "workspace-8pl5",
+    "description": "Bead workspace-9gr0 is implemented and verified locally: failed/protocol review coordinator exits now preserve an inspectable shell, completed coordinator sessions are restartable on the next dispatch, and unexpected coordinator deaths emit review.coordinator.died telemetry. Next step is commit only this bead, close workspace-9gr0, then run final verification for PAN-1034.",
+    "beadId": "workspace-9gr0",
     "filesToRead": [
-      "src/dashboard/frontend/src/lib/pipeline-state.ts",
-      "src/dashboard/frontend/src/components/InspectorPanel.tsx",
-      "src/dashboard/frontend/src/components/inspector/ActionsSection.tsx",
-      "src/dashboard/frontend/src/components/inspector/utils.ts"
+      "src/lib/cloister/review-agent.ts",
+      "src/lib/pipeline-notifier.ts",
+      "src/dashboard/server/main.ts",
+      "src/dashboard/server/routes/workspaces.ts",
+      "packages/contracts/src/events.ts",
+      "packages/contracts/src/event-reducers.ts"
     ]
   },
   "beadsMapping": {
@@ -89,6 +96,12 @@
       "timestamp": "2026-05-09T01:48:48Z",
       "reason": "manual",
       "note": "Implemented workspace-8pl5. Added shared dashboard detection for pending reviews older than two 30-minute reviewer timeouts with no active queue/specialist, made the inspector force the review trigger and label the action Re-request Review, surfaced a stranded-review banner in the inspector, and covered the helper/button behavior in InspectorPanel tests. Verified with npm test -- src/dashboard/frontend/src/components/InspectorPanel.test.tsx --run and npm run typecheck.",
+      "agentModel": "claude-code"
+    },
+    {
+      "timestamp": "2026-05-09T01:55:28Z",
+      "reason": "manual",
+      "note": "Implemented workspace-9gr0. The review coordinator launcher now keeps failed/protocol pan review run exits (status >=2) alive in an interactive shell for inspection, records exit markers keyed by coordinator session name so the next dispatch can kill/restart completed coordinators, and emits coordinator_died/review.coordinator.died telemetry only for sessions that disappear without an exit marker. Added focused lifecycle tests and verified with npm test -- src/lib/cloister/__tests__/review-temp-lifecycle.test.ts --run and npm run typecheck.",
       "agentModel": "claude-code"
     }
   ],

--- a/.pan/continue.json
+++ b/.pan/continue.json
@@ -1,102 +1,68 @@
 {
   "version": "1",
-  "issueId": "PAN-1025",
-  "created": "2026-05-07T21:00:00.000Z",
-  "updated": "2026-05-08T05:21:30.000Z",
+  "issueId": "1034",
+  "created": "2026-05-09T01:13:00Z",
+  "updated": "2026-05-09T01:26:00Z",
   "gitState": {
-    "branch": "feature/pan-1025",
-    "sha": "1348546",
-    "dirty": false
+    "branch": "feature/1034",
+    "sha": "66d08100b",
+    "dirty": true
   },
   "decisions": [
     {
       "id": "D1",
-      "summary": "Bump MAX_BYTES from 2 MB to 8 MB. After PAN-1014 fix, snapshots are ~3 MB — the 2 MB cap strips issues preemptively every time, defeating instant-render.",
-      "recordedAt": "2026-05-07T21:00:00.000Z"
+      "summary": "Split PAN-1034 into four implementation beads: retry timed-out review specialists, keep failed coordinators inspectable, surface stranded pending reviews in the dashboard, and improve verify-failed/pending-review work-agent guidance.",
+      "recordedAt": "2026-05-09T01:13:00Z"
     },
     {
       "id": "D2",
-      "summary": "Make issues-stripping a fallback on actual QuotaExceededError rather than a preemptive size check. Try full snapshot first, catch DOMException from setItem, retry with issues stripped.",
-      "recordedAt": "2026-05-07T21:00:00.000Z"
+      "summary": "Specialist timeout retry is implemented in runParallelReview rather than in the dashboard/deacon layer so the coordinator retries only the failed reviewer output wait and preserves successful reviewer outputs from the same round.",
+      "recordedAt": "2026-05-09T01:26:00Z"
     },
     {
       "id": "D3",
-      "summary": "Removed the preemptive serialized.length > MAX_BYTES check entirely. The only size gate is now the actual localStorage.setItem call. This is simpler and avoids the UTF-16-code-unit-vs-bytes mismatch that made the old check approximate anyway.",
-      "recordedAt": "2026-05-07T21:02:00.000Z"
-    },
-    {
-      "id": "D4",
-      "summary": "Removed the MAX_BYTES constant after TS6133 build failure — it was unused after removing the preemptive check. The effective cap is now the browser's localStorage quota.",
-      "recordedAt": "2026-05-07T21:08:00.000Z"
-    },
-    {
-      "id": "D5",
-      "summary": "Broaden QuotaExceededError detection to accept plain Error objects by name, so stripped-snapshot fallback still runs outside true DOMException environments.",
-      "recordedAt": "2026-05-08T05:21:30.000Z"
-    },
-    {
-      "id": "D6",
-      "summary": "Fix the Unix socket permission race at the source: wait for Bun.serve to materialize the socket before chmod, then verify mode 0o600 instead of relying on a test-side retry loop.",
-      "recordedAt": "2026-05-08T05:21:30.000Z"
+      "summary": "Timeout telemetry uses a new domain event type `review.specialist.timed_out`, forwarded through notifyPipeline as `reviewer_timed_out`, so CLI-hosted coordinators can report timed-out reviewer attempts to the dashboard event stream without requiring an in-process server handler.",
+      "recordedAt": "2026-05-09T01:26:00Z"
     }
   ],
   "hazards": [
     {
       "id": "H1",
-      "summary": "localStorage per-origin quota varies by browser (~5-10 MB). A 3-8 MB snapshot could still fail on tight quotas.",
-      "mitigation": "Fallback path strips issues on any setItem failure, so instant-render degrades gracefully to 0 issues (same as current behavior) only when quota is actually exceeded."
+      "summary": "This workspace started with stale deleted `.beads/` and `.pan/continue.json` files from prior work and a shortened local `CLAUDE.md`, while `bd` auto-discovered the parent repository beads database.",
+      "mitigation": "Do not stage the pre-existing workspace setup deletions or CLAUDE.md change with implementation commits. Use issue label `1034` when running bd commands and stage only the files touched for the current bead plus this continue file."
+    },
+    {
+      "id": "H2",
+      "summary": "Running the targeted Vitest suite triggered the build global setup, which regenerated `scripts/record-cost-event.js` with unrelated main-branch build output differences.",
+      "mitigation": "Leave `scripts/record-cost-event.js` unstaged for this bead unless a later explicit build-artifact bead is created; avoid mixing unrelated generated-script drift into scoped review-coordinator commits."
     }
   ],
   "resumePoint": {
-    "description": "Review follow-up fixes are implemented and verified locally (typecheck, lint, full npm test). Next step is commit/review resubmission via /rebase-and-submit.",
-    "beadId": null,
-    "filesToRead": []
+    "description": "Bead workspace-6s0t is implemented locally: review specialists that time out or hit dead panes are respawned with a capped two-retry backoff, timeout attempts emit structured `review.specialist.timed_out` events through the pipeline notifier/internal endpoint, and focused tests cover the retry path. Next agent should commit only the bead files and close/inspect workspace-6s0t, then continue with the next ready bead for PAN-1034.",
+    "beadId": "workspace-6s0t",
+    "filesToRead": [
+      "src/lib/cloister/review-agent.ts",
+      "src/lib/pipeline-notifier.ts",
+      "src/dashboard/server/main.ts",
+      "src/dashboard/server/routes/workspaces.ts",
+      "packages/contracts/src/events.ts",
+      "packages/contracts/src/event-reducers.ts",
+      "src/lib/cloister/__tests__/review-temp-lifecycle.test.ts"
+    ]
   },
   "beadsMapping": {
-    "workspace-az36": "Bump MAX_BYTES to 8 MB and make issues-stripping a fallback on QuotaExceededError",
-    "workspace-rad9": "Add tests for snapshotCache QuotaExceededError fallback and 8MB cap"
+    "specialist-timeout-retry": ["workspace-6s0t"],
+    "coordinator-survival": ["workspace-9gr0"],
+    "stranded-review-dashboard": ["workspace-8pl5"],
+    "verify-failed-guidance": ["workspace-vaqf"]
   },
   "agentModel": "claude-opus-4-5",
   "sessionHistory": [
     {
-      "timestamp": "2026-05-07T21:00:00.000Z",
-      "reason": "start",
-      "note": "Fresh start for PAN-1025. No prior continue.json or beads existed. Created beads workspace-az36 and workspace-rad9. Issue: snapshotCache.ts strips issues preemptively at 2MB cap; after PAN-1014 fix snapshots are ~3MB. Need to bump cap to 8MB and make stripping a fallback on actual QuotaExceededError.",
-      "agentModel": "claude-opus-4-5"
-    },
-    {
-      "timestamp": "2026-05-07T21:02:00.000Z",
-      "reason": "bead-complete",
-      "note": "Implemented bead workspace-az36: modified snapshotCache.ts — bumped MAX_BYTES from 2MB to 8MB, restructured saveSnapshotToCache to try full write first and catch QuotaExceededError DOMException, retrying with issues stripped. Updated existing test to mock QuotaExceededError and verify fallback stripping. Added test verifying ~2.5MB snapshot is preserved under new 8MB cap. All 10 tests pass.",
-      "agentModel": "claude-opus-4-5"
-    },
-    {
-      "timestamp": "2026-05-07T21:05:00.000Z",
-      "reason": "bead-complete",
-      "note": "Implemented bead workspace-rad9: added 3 new tests for QuotaExceededError fallback — non-quota errors silently ignored, both writes failing gracefully, non-issue fields preserved after fallback. All 13 tests pass.",
-      "agentModel": "claude-opus-4-5"
-    },
-    {
-      "timestamp": "2026-05-07T21:08:00.000Z",
-      "reason": "fix",
-      "note": "Fixed TypeScript build failure (TS6133): removed unused MAX_BYTES constant after the preemptive size check was removed. Full test suite passes (990 tests), frontend build passes.",
-      "agentModel": "claude-opus-4-5"
-    },
-    {
-      "timestamp": "2026-05-08T01:14:58.698Z",
-      "reason": "end",
-      "note": "Relax localStorage 2MB cap in snapshotCache.ts: remove preemptive size check, make issues-stripping a QuotaExceededError fallback, add comprehensive tests. Full test suite passes (990 tests)."
-    },
-    {
-      "timestamp": "2026-05-08T03:34:37.223Z",
-      "reason": "end",
-      "note": "Agent signaled work complete"
-    },
-    {
-      "timestamp": "2026-05-08T05:21:30.000Z",
-      "reason": "fix",
-      "note": "Addressed review/verification follow-ups: broadened QuotaExceededError detection in snapshotCache, fixed sequence=0 cache loading, updated stale test comment, removed unused config-yaml mock from agent-state-harness tests, and moved the panopticon-bridge socket permission retry into production code by waiting for socket creation before chmod. Verified with targeted Vitest suites plus full typecheck, lint, and npm test.",
-      "agentModel": "claude-opus-4-5"
+      "timestamp": "2026-05-09T01:26:00Z",
+      "reason": "manual",
+      "note": "Created issue-scoped beads for PAN-1034 after finding none in the active beads view. Claimed workspace-6s0t and implemented retry-on-timeout in `runParallelReview`: retryable reviewer timeouts/dead panes now respawn only the failed reviewer with two capped backoff attempts; terminal provider errors still skip respawn. Added `review.specialist.timed_out` domain telemetry via `notifyPipeline`, internal pipeline forwarding, contracts schemas/reducer no-op handling, and a focused fake-timer Vitest regression. Verified with `npm test -- src/lib/cloister/__tests__/review-temp-lifecycle.test.ts --run` and `npm run typecheck`.",
+      "agentModel": "claude-code"
     }
   ],
   "feedback": []

--- a/packages/contracts/src/event-reducers.ts
+++ b/packages/contracts/src/event-reducers.ts
@@ -353,6 +353,11 @@ export function applyEvent(state: ReadModelState, event: DomainEvent): ReadModel
       }
     }
 
+    case 'review.specialist.timed_out':
+      // Telemetry-only event. Sequence update lets clients observe the event
+      // stream without mutating the durable review-status snapshot.
+      return { ...state, sequence: Math.max(state.sequence, event.sequence) }
+
     case 'review.coordinator_started': {
       const { issueId, sessionName } = event.payload
       const existing = state.reviewStatusByIssueId[issueId]

--- a/packages/contracts/src/event-reducers.ts
+++ b/packages/contracts/src/event-reducers.ts
@@ -372,6 +372,11 @@ export function applyEvent(state: ReadModelState, event: DomainEvent): ReadModel
       }
     }
 
+    case 'review.coordinator.died':
+      // Telemetry-only. The durable review-status row is updated by recovery
+      // checks; keep clients in sequence so event stream subscribers can alert.
+      return { ...state, sequence: Math.max(state.sequence, event.sequence) }
+
     case 'pipeline.review-started':
     case 'pipeline.review-completed':
     case 'pipeline.test-started':

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -464,6 +464,19 @@ export const ReviewCoordinatorStartedEvent = Schema.Struct({
 })
 export type ReviewCoordinatorStartedEvent = typeof ReviewCoordinatorStartedEvent.Type
 
+/** Review coordinator died before writing a terminal exit marker. */
+export const ReviewCoordinatorDiedEvent = Schema.Struct({
+  type: Schema.Literal("review.coordinator.died"),
+  sequence: SequenceNumber,
+  timestamp: Schema.String,
+  payload: Schema.Struct({
+    issueId: IssueId,
+    sessionName: Schema.String,
+    reason: Schema.String,
+  }),
+})
+export type ReviewCoordinatorDiedEvent = typeof ReviewCoordinatorDiedEvent.Type
+
 // ─── Specialist Events ────────────────────────────────────────────────────────
 
 /** New — specialist became active */
@@ -796,6 +809,7 @@ export const DomainEvent = Schema.Union([
   ReviewReviewerCompletedEvent,
   ReviewSpecialistTimedOutEvent,
   ReviewCoordinatorStartedEvent,
+  ReviewCoordinatorDiedEvent,
   SpecialistStartedEvent,
   SpecialistCompletedEvent,
   SpecialistFailedEvent,

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -429,6 +429,26 @@ export const ReviewReviewerCompletedEvent = Schema.Struct({
 export type ReviewReviewerCompletedEvent = typeof ReviewReviewerCompletedEvent.Type
 
 /**
+ * Review specialist timeout telemetry. Emitted once per timed-out reviewer wait
+ * attempt so operators can distinguish transient auto-retries from terminal
+ * review failures.
+ */
+export const ReviewSpecialistTimedOutEvent = Schema.Struct({
+  type: Schema.Literal("review.specialist.timed_out"),
+  sequence: SequenceNumber,
+  timestamp: Schema.String,
+  payload: Schema.Struct({
+    issueId: IssueId,
+    role: Schema.String,
+    sessionName: Schema.String,
+    attempt: Schema.Number,
+    maxRetries: Schema.Number,
+    willRetry: Schema.Boolean,
+  }),
+})
+export type ReviewSpecialistTimedOutEvent = typeof ReviewSpecialistTimedOutEvent.Type
+
+/**
  * PAN-915 — review coordinator session spawned. Surfaces in the dashboard so
  * the kanban card can show "review in progress" the instant the coordinator
  * starts, not after the first reviewer finishes.
@@ -774,6 +794,7 @@ export const DomainEvent = Schema.Union([
   PipelineTestCompletedEvent,
   ReviewReviewerStartedEvent,
   ReviewReviewerCompletedEvent,
+  ReviewSpecialistTimedOutEvent,
   ReviewCoordinatorStartedEvent,
   SpecialistStartedEvent,
   SpecialistCompletedEvent,

--- a/src/dashboard/frontend/src/components/InspectorPanel.test.tsx
+++ b/src/dashboard/frontend/src/components/InspectorPanel.test.tsx
@@ -5,7 +5,7 @@
  * queuePosition / reviewStatus / testStatus combinations.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { getReviewButtonState } from './InspectorPanel';
 import { shouldForceReviewTrigger } from './inspector/utils';
 
@@ -155,6 +155,30 @@ describe('getReviewButtonState', () => {
     expect(state.disabled).toBe(false);
     expect(state.spinning).toBe(false);
   });
+
+  it('shows "Re-request Review" for a stranded pending review', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-05-09T03:00:00Z'));
+      const state = getReviewButtonState(
+        {
+          reviewStatus: 'pending',
+          testStatus: 'pending',
+          queuePosition: null,
+          activeSpecialist: null,
+          readyForMerge: false,
+          reviewSpawnedAt: '2026-05-09T01:59:59Z',
+          updatedAt: '2026-05-09T02:30:00Z',
+        },
+        false
+      );
+      expect(state.label).toBe('Re-request Review');
+      expect(state.disabled).toBe(false);
+      expect(state.spinning).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('shouldForceReviewTrigger', () => {
@@ -181,5 +205,35 @@ describe('shouldForceReviewTrigger', () => {
       testStatus: 'pending',
       readyForMerge: false,
     })).toBe(false);
+  });
+
+  it('forces rerun for a pending review stranded beyond two specialist timeouts', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-05-09T03:00:00Z'));
+      expect(shouldForceReviewTrigger({
+        reviewStatus: 'pending',
+        testStatus: 'pending',
+        readyForMerge: false,
+        reviewSpawnedAt: '2026-05-09T01:59:59Z',
+      })).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not force rerun for a pending review inside the timeout window', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-05-09T03:00:00Z'));
+      expect(shouldForceReviewTrigger({
+        reviewStatus: 'pending',
+        testStatus: 'pending',
+        readyForMerge: false,
+        reviewSpawnedAt: '2026-05-09T02:10:00Z',
+      })).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/dashboard/frontend/src/components/InspectorPanel.tsx
+++ b/src/dashboard/frontend/src/components/InspectorPanel.tsx
@@ -26,7 +26,7 @@ import ReactMarkdown from 'react-markdown';
 import rehypeSanitize from 'rehype-sanitize';
 import { Agent, Issue, WorkAgentLifecycle, type StartAgentResponse } from '../types';
 import type { ContainerStatus, ReviewStatus, SalvageableStashInfo, WorkspaceInfo } from './inspector/types';
-import { getFriendlyModelName, shouldForceReviewTrigger } from './inspector/utils';
+import { formatRelativeTime, getFriendlyModelName, shouldForceReviewTrigger } from './inspector/utils';
 import { useAlert } from './DialogProvider';
 import { BeadsDialog } from './BeadsDialog';
 import { VBriefDialog } from './vbrief/VBriefDialog';
@@ -34,7 +34,7 @@ import { PlanDialog } from './PlanDialog';
 import { useConfirm } from './DialogProvider';
 import { refreshDashboardState } from '../lib/refresh-dashboard-state';
 import { isCodexBlockedResponse, setPendingCodexSpawn } from '../lib/pending-codex-spawn';
-import { isReviewPipelineStuck } from '../lib/pipeline-state';
+import { isPendingReviewStranded, isReviewPipelineStuck } from '../lib/pipeline-state';
 import { RecoverButton } from './RecoverButton';
 import { AgentInfoSection } from './inspector/AgentInfoSection';
 import { PanOpenInPicker } from './PanOpenInPicker';
@@ -194,6 +194,13 @@ export function InspectorPanel({ agent, workAgents = [], issueId, issueUrl, issu
 
   const reviewStatus = reviewStatusProp ?? fetchedReviewStatus;
   const reviewStatusLoading = reviewStatusLoadingProp ?? fetchedReviewStatusLoading ?? false;
+  const pendingReviewStranded = isPendingReviewStranded(reviewStatus);
+  const pendingReviewStrandedSince = pendingReviewStranded
+    ? (reviewStatus?.reviewSpawnedAt ?? reviewStatus?.updatedAt)
+    : undefined;
+  const pendingReviewStrandedAge = pendingReviewStrandedSince
+    ? formatRelativeTime(pendingReviewStrandedSince)
+    : 'over an hour ago';
 
   useEffect(() => {
     if (!agentLaunchState) return;
@@ -612,11 +619,16 @@ export function InspectorPanel({ agent, workAgents = [], issueId, issueUrl, issu
   };
 
   const handleReview = async () => {
+    const strandedPendingReview = isPendingReviewStranded(reviewStatus);
     const forceReview = shouldForceReviewTrigger(reviewStatus);
-    const message = forceReview
-      ? `Re-run review & test pipeline for ${issueId}?`
-      : `Start review & test pipeline for ${issueId}?`;
-    if (await confirm({ title: forceReview ? 'Re-run Review' : 'Start Review', message, confirmLabel: forceReview ? 'Re-run' : 'Start Review' })) {
+    const title = strandedPendingReview ? 'Re-request Review' : forceReview ? 'Re-run Review' : 'Start Review';
+    const message = strandedPendingReview
+      ? `Pending review for ${issueId} appears stranded (${pendingReviewStrandedAge}). Re-request the review now?`
+      : forceReview
+        ? `Re-run review & test pipeline for ${issueId}?`
+        : `Start review & test pipeline for ${issueId}?`;
+    const confirmLabel = strandedPendingReview ? 'Re-request Review' : forceReview ? 'Re-run' : 'Start Review';
+    if (await confirm({ title, message, confirmLabel })) {
       forceReviewRef.current = forceReview;
       reviewMutation.mutate();
     }
@@ -762,7 +774,7 @@ export function InspectorPanel({ agent, workAgents = [], issueId, issueUrl, issu
         )}
 
         {/* Pipeline stuck banner */}
-        {reviewStatusProp && isReviewPipelineStuck(reviewStatusProp) && (
+        {reviewStatus && isReviewPipelineStuck(reviewStatus) && (
           <div className="px-3 py-2 border-b border-border bg-warning/10">
             <div className="flex items-center gap-2 mb-1.5">
               <AlertTriangle className="w-3.5 h-3.5 text-warning shrink-0" />
@@ -771,7 +783,29 @@ export function InspectorPanel({ agent, workAgents = [], issueId, issueUrl, issu
             <p className="text-[10px] text-muted-foreground mb-2">
               Review/test/merge pipeline is stuck and needs recovery.
             </p>
-            <RecoverButton issueId={issueId} reviewStatus={reviewStatusProp} variant="inspector" />
+            <RecoverButton issueId={issueId} reviewStatus={reviewStatus} variant="inspector" />
+          </div>
+        )}
+
+        {/* PAN-1034: pending review stranded beyond 2x reviewer timeout. */}
+        {pendingReviewStranded && (
+          <div className="px-3 py-2 border-b border-border bg-amber-500/10">
+            <div className="flex items-center gap-2 mb-1.5">
+              <AlertTriangle className="w-3.5 h-3.5 text-amber-300 shrink-0" />
+              <span className="text-xs font-medium text-amber-200">Pending Review Stranded</span>
+            </div>
+            <p className="text-[10px] text-muted-foreground mb-2">
+              Pending review started {pendingReviewStrandedAge} and no reviewer is queued or active. Re-request review to restart the pipeline.
+            </p>
+            <button
+              onClick={handleReview}
+              disabled={reviewMutation.isPending}
+              className="flex items-center justify-center gap-1 px-2 py-1 rounded text-xs bg-amber-500/20 text-amber-100 hover:bg-amber-500/30 border border-amber-500/40 disabled:opacity-50 w-full"
+              data-testid="stranded-review-request-btn"
+            >
+              {reviewMutation.isPending ? <Loader2 className="w-3 h-3 animate-spin" /> : <RefreshCw className="w-3 h-3" />}
+              Re-request Review
+            </button>
           </div>
         )}
 

--- a/src/dashboard/frontend/src/components/inspector/ActionsSection.tsx
+++ b/src/dashboard/frontend/src/components/inspector/ActionsSection.tsx
@@ -6,7 +6,7 @@ import type { UseMutationResult } from '@tanstack/react-query';
 import { Agent, WorkAgentLifecycle, STATUS_LABELS } from '../../types';
 import type { ReviewStatus, WorkspaceInfo } from './types';
 import { ReviewPipelineSection } from './ReviewPipelineSection';
-import { isReviewPipelineStuck } from '../../lib/pipeline-state';
+import { isPendingReviewStranded, isReviewPipelineStuck } from '../../lib/pipeline-state';
 import { ResetIssueButton } from '../ResetIssueButton';
 import { StopAgentButton } from '../StopAgentButton';
 import { MergeButton } from '../MergeButton';
@@ -110,15 +110,24 @@ export function ActionsSection({
   const { switchMutation, isPending: isSwitchingModel } = useSwitchModel(agent?.id, issueId);
 
   const isPipelineStuck = isReviewPipelineStuck(reviewStatus);
+  const pendingReviewStranded = isPendingReviewStranded(reviewStatus);
   const hasVerificationState = !!reviewStatus?.verificationStatus && reviewStatus.verificationStatus !== 'pending';
   const showPipelineStatus = !!reviewStatus && (
-    reviewStatus.reviewStatus !== 'pending'
+    pendingReviewStranded
+    || reviewStatus.reviewStatus !== 'pending'
     || reviewStatus.testStatus !== 'pending'
     || hasVerificationState
   );
   const isReReview = reviewStatus?.readyForMerge
     || (reviewStatus?.reviewStatus === 'passed' && reviewStatus?.testStatus === 'passed' && reviewStatus?.mergeStatus === 'failed');
   const reviewActionHint = !reviewStatus ? null : (() => {
+    if (pendingReviewStranded) {
+      return {
+        label: 'Next: Re-request Review',
+        detail: 'Pending review has exceeded the reviewer timeout recovery window.',
+        title: 'Review is pending with no queued or active specialist — re-request review to restart the pipeline.',
+      };
+    }
     if (reviewStatus.verificationStatus === 'failed') {
       return {
         label: 'Fix build gate errors, then re-run',
@@ -230,7 +239,7 @@ export function ActionsSection({
           >
             {(reviewMutation.isPending || reviewStatus?.reviewStatus === 'reviewing' || reviewStatus?.testStatus === 'testing') ?
               <Loader2 className="w-3 h-3 animate-spin" /> : <RefreshCw className="w-3 h-3" />}
-            {isReReview ? 'Re-Review' : 'Review & Test'}
+            {pendingReviewStranded ? 'Re-request Review' : isReReview ? 'Re-Review' : 'Review & Test'}
           </button>
 
           {/* Stop Agent — hidden for features (features are planned, not executed) */}

--- a/src/dashboard/frontend/src/components/inspector/types.ts
+++ b/src/dashboard/frontend/src/components/inspector/types.ts
@@ -25,6 +25,8 @@ export interface ReviewStatus {
   mergeNotes?: string;
   mergeRetryCount?: number;
   updatedAt: string;
+  /** Timestamp when the current/last review fan-out was dispatched. */
+  reviewSpawnedAt?: string;
   readyForMerge: boolean;
   autoRequeueCount?: number;
   history?: StatusHistoryEntry[];

--- a/src/dashboard/frontend/src/components/inspector/utils.ts
+++ b/src/dashboard/frontend/src/components/inspector/utils.ts
@@ -28,8 +28,8 @@ export interface ReviewButtonState {
 interface ReviewButtonInput {
   reviewStatus: 'pending' | 'reviewing' | 'passed' | 'failed' | 'blocked';
   testStatus: 'pending' | 'testing' | 'passed' | 'failed' | 'skipped' | 'dispatch_failed';
-  mergeStatus?: string;
-  verificationStatus?: string;
+  mergeStatus?: 'pending' | 'queued' | 'merging' | 'verifying' | 'merged' | 'failed';
+  verificationStatus?: 'pending' | 'running' | 'passed' | 'failed' | 'skipped';
   updatedAt?: string;
   reviewSpawnedAt?: string;
   queuePosition?: number | null;

--- a/src/dashboard/frontend/src/components/inspector/utils.ts
+++ b/src/dashboard/frontend/src/components/inspector/utils.ts
@@ -1,3 +1,5 @@
+import { isPendingReviewStranded } from '../../lib/pipeline-state';
+
 export function formatRelativeTime(isoString: string): string {
   const now = Date.now();
   const then = new Date(isoString).getTime();
@@ -24,10 +26,12 @@ export interface ReviewButtonState {
 }
 
 interface ReviewButtonInput {
-  reviewStatus: string;
-  testStatus: string;
+  reviewStatus: 'pending' | 'reviewing' | 'passed' | 'failed' | 'blocked';
+  testStatus: 'pending' | 'testing' | 'passed' | 'failed' | 'skipped' | 'dispatch_failed';
   mergeStatus?: string;
   verificationStatus?: string;
+  updatedAt?: string;
+  reviewSpawnedAt?: string;
   queuePosition?: number | null;
   activeSpecialist?: string | null;
   readyForMerge: boolean;
@@ -37,6 +41,7 @@ export function shouldForceReviewTrigger(status: ReviewButtonInput | undefined):
   if (!status) return false;
 
   return (
+    isPendingReviewStranded(status) ||
     status.readyForMerge ||
     status.reviewStatus === 'passed' ||
     status.reviewStatus === 'failed' ||
@@ -82,6 +87,9 @@ export function getReviewButtonState(
     }
     const n = status.queuePosition;
     return { label: `Queued (${n}${getOrdinalSuffix(n)})`, disabled: true, spinning: false };
+  }
+  if (isPendingReviewStranded(status)) {
+    return { label: 'Re-request Review', disabled: false, spinning: false };
   }
   if (status.readyForMerge || (status.reviewStatus === 'passed' && status.testStatus === 'passed' && status.mergeStatus === 'failed')) {
     return { label: 'Re-Review', disabled: false, spinning: false };

--- a/src/dashboard/frontend/src/lib/pipeline-state.ts
+++ b/src/dashboard/frontend/src/lib/pipeline-state.ts
@@ -7,6 +7,11 @@ type PipelineStateLike = {
   inspectStatus?: 'pending' | 'inspecting' | 'passed' | 'failed';
   uatStatus?: 'pending' | 'testing' | 'passed' | 'failed';
   verificationStatus?: 'pending' | 'running' | 'passed' | 'failed' | 'skipped';
+  updatedAt?: string;
+  reviewSpawnedAt?: string;
+  readyForMerge?: boolean;
+  queuePosition?: number | null;
+  activeSpecialist?: string | null;
   // PAN-794: persistent stuck flag + reason set by the deacon/breaker or main-diverged flow.
   stuck?: boolean;
   stuckReason?: string;
@@ -16,6 +21,10 @@ type PipelineStateLike = {
   deaconIgnoredAt?: string;
   deaconIgnoredReason?: string;
 };
+
+// Keep in sync with the review coordinator's longest specialist timeout.
+export const REVIEW_SPECIALIST_TIMEOUT_MS = 30 * 60 * 1000;
+export const PENDING_REVIEW_STRANDED_MS = REVIEW_SPECIALIST_TIMEOUT_MS * 2;
 
 export function hasActualPendingQuestion(agent?: Pick<Agent, 'hasPendingQuestion' | 'pendingQuestionCount'> | null): boolean {
   return agent?.hasPendingQuestion === true && (agent.pendingQuestionCount ?? 0) > 0;
@@ -44,6 +53,27 @@ export function isReviewPipelineStuck(status?: PipelineStateLike | null): boolea
  */
 export function isReviewInfraStuck(status?: PipelineStateLike | null): boolean {
   return status?.stuck === true && status.stuckReason === 'review_infrastructure_failure';
+}
+
+/**
+ * PAN-1034: a pending review with no active queue/specialist for more than 2x
+ * the longest specialist timeout is stranded. This is distinct from a fresh
+ * pending state while dispatch/verification is still starting up.
+ */
+export function isPendingReviewStranded(status?: PipelineStateLike | null, now = Date.now()): boolean {
+  if (!status) return false;
+  if (status.reviewStatus !== 'pending') return false;
+  if (status.stuck) return false;
+  if (status.readyForMerge) return false;
+  if (status.queuePosition != null || status.activeSpecialist) return false;
+
+  const reference = status.reviewSpawnedAt ?? status.updatedAt;
+  if (!reference) return false;
+
+  const referenceMs = Date.parse(reference);
+  if (!Number.isFinite(referenceMs)) return false;
+
+  return now - referenceMs >= PENDING_REVIEW_STRANDED_MS;
 }
 
 /**

--- a/src/dashboard/server/main.ts
+++ b/src/dashboard/server/main.ts
@@ -154,6 +154,27 @@ setPipelineHandler((event) => {
       return;
     }
 
+    case 'reviewer_timed_out': {
+      try {
+        const es = getEventStore();
+        es.append({
+          type: 'review.specialist.timed_out',
+          timestamp: new Date().toISOString(),
+          payload: {
+            issueId: event.issueId,
+            role: event.role,
+            sessionName: event.sessionName,
+            attempt: event.attempt,
+            maxRetries: event.maxRetries,
+            willRetry: event.willRetry,
+          },
+        } as any);
+      } catch (err) {
+        console.error('[pipeline] Failed to append reviewer_timed_out event:', err);
+      }
+      return;
+    }
+
     case 'coordinator_started': {
       try {
         const es = getEventStore();

--- a/src/dashboard/server/main.ts
+++ b/src/dashboard/server/main.ts
@@ -188,6 +188,20 @@ setPipelineHandler((event) => {
       }
       return;
     }
+
+    case 'coordinator_died': {
+      try {
+        const es = getEventStore();
+        es.append({
+          type: 'review.coordinator.died',
+          timestamp: new Date().toISOString(),
+          payload: { issueId: event.issueId, sessionName: event.sessionName, reason: event.reason },
+        } as any);
+      } catch (err) {
+        console.error('[pipeline] Failed to append coordinator_died event:', err);
+      }
+      return;
+    }
   }
 });
 console.log('[panopticon] Pipeline notifier → domain events wired');

--- a/src/dashboard/server/routes/workspaces.ts
+++ b/src/dashboard/server/routes/workspaces.ts
@@ -5634,6 +5634,7 @@ const getMergeQueueRoute = HttpRouter.add(
 //   { type: 'task_queued', specialist, issueId }
 //   { type: 'reviewer_started', issueId, role, sessionName }
 //   { type: 'reviewer_completed', issueId, role }
+//   { type: 'reviewer_timed_out', issueId, role, sessionName, attempt, maxRetries, willRetry }
 //   { type: 'coordinator_started', issueId, sessionName }
 //     — Forwarded verbatim to the in-process handler.
 
@@ -5706,6 +5707,19 @@ const postInternalPipelineNotifyRoute = HttpRouter.add(
           return jsonResponse({ ok: false, error: 'reviewer_completed requires issueId, role' }, 400);
         }
         notifyPipeline({ type: 'reviewer_completed', issueId, role });
+        return jsonResponse({ ok: true });
+      }
+      case 'reviewer_timed_out': {
+        const issueId = event.issueId as string | undefined;
+        const role = event.role as string | undefined;
+        const sessionName = event.sessionName as string | undefined;
+        const attempt = typeof event.attempt === 'number' ? event.attempt : undefined;
+        const maxRetries = typeof event.maxRetries === 'number' ? event.maxRetries : undefined;
+        const willRetry = typeof event.willRetry === 'boolean' ? event.willRetry : undefined;
+        if (!issueId || !role || !sessionName || attempt === undefined || maxRetries === undefined || willRetry === undefined) {
+          return jsonResponse({ ok: false, error: 'reviewer_timed_out requires issueId, role, sessionName, attempt, maxRetries, willRetry' }, 400);
+        }
+        notifyPipeline({ type: 'reviewer_timed_out', issueId, role, sessionName, attempt, maxRetries, willRetry });
         return jsonResponse({ ok: true });
       }
       case 'coordinator_started': {

--- a/src/dashboard/server/routes/workspaces.ts
+++ b/src/dashboard/server/routes/workspaces.ts
@@ -5636,6 +5636,7 @@ const getMergeQueueRoute = HttpRouter.add(
 //   { type: 'reviewer_completed', issueId, role }
 //   { type: 'reviewer_timed_out', issueId, role, sessionName, attempt, maxRetries, willRetry }
 //   { type: 'coordinator_started', issueId, sessionName }
+//   { type: 'coordinator_died', issueId, sessionName, reason }
 //     — Forwarded verbatim to the in-process handler.
 
 const postInternalPipelineNotifyRoute = HttpRouter.add(
@@ -5729,6 +5730,16 @@ const postInternalPipelineNotifyRoute = HttpRouter.add(
           return jsonResponse({ ok: false, error: 'coordinator_started requires issueId, sessionName' }, 400);
         }
         notifyPipeline({ type: 'coordinator_started', issueId, sessionName });
+        return jsonResponse({ ok: true });
+      }
+      case 'coordinator_died': {
+        const issueId = event.issueId as string | undefined;
+        const sessionName = event.sessionName as string | undefined;
+        const reason = event.reason as string | undefined;
+        if (!issueId || !sessionName || !reason) {
+          return jsonResponse({ ok: false, error: 'coordinator_died requires issueId, sessionName, reason' }, 400);
+        }
+        notifyPipeline({ type: 'coordinator_died', issueId, sessionName, reason });
         return jsonResponse({ ok: true });
       }
       default:

--- a/src/lib/channels/panopticon-bridge.ts
+++ b/src/lib/channels/panopticon-bridge.ts
@@ -39,8 +39,9 @@ import {
   type ListToolsResult,
   type Tool,
 } from '@modelcontextprotocol/sdk/types.js';
+import { timingSafeEqual } from 'node:crypto';
+import { existsSync, unlinkSync } from 'node:fs';
 import { chmod, mkdir, unlink, appendFile, stat } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 

--- a/src/lib/cloister/__tests__/review-temp-lifecycle.test.ts
+++ b/src/lib/cloister/__tests__/review-temp-lifecycle.test.ts
@@ -70,7 +70,7 @@ vi.mock('../feedback-writer.js', () => ({
   writeFeedbackFile: vi.fn(async () => {}),
 }));
 
-vi.mock('../pipeline-notifier.js', () => ({ notifyPipeline: vi.fn() }));
+vi.mock('../../pipeline-notifier.js', () => ({ notifyPipeline: vi.fn() }));
 vi.mock('../../activity-logger.js', () => ({ emitActivityEntry: vi.fn(), emitActivityTts: vi.fn() }));
 vi.mock('../../projects.js', () => ({ resolveProjectFromIssue: vi.fn(() => ({ projectKey: 'panopticon' })) }));
 vi.mock('../specialists.js', () => ({
@@ -98,6 +98,7 @@ vi.mock('../../paths.js', () => ({
 }));
 
 import { dispatchParallelReview, runParallelReview } from '../review-agent.js';
+import { notifyPipeline } from '../../pipeline-notifier.js';
 
 describe('review-temp stash lifecycle', () => {
   beforeEach(() => {
@@ -165,7 +166,7 @@ describe('review-temp stash lifecycle', () => {
       reviewTempStashSequence: 3,
     });
 
-    const waitFn = vi.fn(async () => 'failed' as const);
+    const waitFn = vi.fn(async () => ({ status: 'failed' as const, reason: 'session_exited' as const }));
 
     const { result } = await runParallelReview(
       {
@@ -179,7 +180,7 @@ describe('review-temp stash lifecycle', () => {
       {
         spawnFn: vi.fn(async () => {}),
         waitFn,
-        waitSynthesisFn: vi.fn(async () => 'completed' as const),
+        waitSynthesisFn: vi.fn(async () => ({ status: 'completed' as const })),
         parseSynthesisFn: vi.fn(async () => ({ success: true, reviewResult: 'APPROVED' as const })),
         postReviewFn: vi.fn(async () => {}),
         resolvePromptTemplateFn: vi.fn(() => '/tmp/template.md'),
@@ -188,5 +189,62 @@ describe('review-temp stash lifecycle', () => {
 
     expect(result.success).toBe(false);
     expect(reviewStatusState.get('PAN-2')?.reviewTempStashRef).toBeUndefined();
+  });
+
+  it('retries a timed-out reviewer twice before synthesis', async () => {
+    vi.useFakeTimers();
+    try {
+      const spawnFn = vi.fn(async () => {});
+      const waitFn = vi.fn()
+        .mockResolvedValueOnce({ status: 'failed' as const, reason: 'timeout' as const })
+        .mockResolvedValueOnce({ status: 'failed' as const, reason: 'timeout' as const })
+        .mockResolvedValueOnce({ status: 'completed' as const });
+      const waitSynthesisFn = vi.fn(async () => ({ status: 'completed' as const }));
+      const resultPromise = runParallelReview(
+        {
+          issueId: 'PAN-3',
+          projectPath: '/tmp/workspace',
+          prUrl: 'https://example.test/pr/3',
+          branch: 'feature/pan-3',
+        },
+        ['src/file.ts'],
+        [{ name: 'security' } as any],
+        {
+          spawnFn,
+          waitFn,
+          waitSynthesisFn,
+          parseSynthesisFn: vi.fn(async () => ({ success: true, reviewResult: 'APPROVED' as const })),
+          postReviewFn: vi.fn(async () => {}),
+          resolvePromptTemplateFn: vi.fn(() => '/tmp/template.md'),
+        },
+      );
+
+      await vi.runAllTimersAsync();
+      const { result } = await resultPromise;
+
+      expect(result.success).toBe(true);
+      expect(waitFn).toHaveBeenCalledTimes(3);
+      expect(spawnFn).toHaveBeenCalledTimes(4);
+      expect(spawnFn.mock.calls.filter(([session]) => String(session).endsWith('-security'))).toHaveLength(3);
+      expect(waitSynthesisFn).toHaveBeenCalledTimes(1);
+      expect(notifyPipeline).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'reviewer_timed_out',
+        issueId: 'PAN-3',
+        role: 'security',
+        attempt: 1,
+        maxRetries: 2,
+        willRetry: true,
+      }));
+      expect(notifyPipeline).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'reviewer_timed_out',
+        issueId: 'PAN-3',
+        role: 'security',
+        attempt: 2,
+        maxRetries: 2,
+        willRetry: true,
+      }));
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/lib/cloister/__tests__/review-temp-lifecycle.test.ts
+++ b/src/lib/cloister/__tests__/review-temp-lifecycle.test.ts
@@ -97,8 +97,9 @@ vi.mock('../../paths.js', () => ({
   packageRoot: '/tmp/pkg',
 }));
 
-import { dispatchParallelReview, runParallelReview } from '../review-agent.js';
+import { dispatchParallelReview, runParallelReview, spawnReviewCoordinatorSession } from '../review-agent.js';
 import { notifyPipeline } from '../../pipeline-notifier.js';
+import { createSessionAsync, isPaneDeadAsync, killSessionAsync, listSessionNamesAsync } from '../../tmux.js';
 
 describe('review-temp stash lifecycle', () => {
   beforeEach(() => {
@@ -152,6 +153,43 @@ describe('review-temp stash lifecycle', () => {
     expect(reviewStatusState.get('PAN-9')?.reviewTempStashRef).toBeUndefined();
     expect(reviewStatusState.get('PAN-9')?.reviewTempStashMessage).toBeUndefined();
     expect(reviewStatusState.get('PAN-9')?.reviewTempStashSequence).toBeUndefined();
+  });
+
+  it('keeps failed coordinator sessions alive for inspection', async () => {
+    const { sessionName } = await spawnReviewCoordinatorSession({
+      issueId: 'PAN-4',
+      workspace: '/tmp/workspace',
+    });
+
+    const command = vi.mocked(createSessionAsync).mock.calls[0]?.[2] as string;
+    expect(sessionName).toMatch(/^review-coordinator-PAN-4-/);
+    expect(command).toContain(`${sessionName}.exit`);
+    expect(command).toContain('if [ "$status" -lt 2 ]; then exit "$status"; fi');
+    expect(command).toContain('exec bash -li');
+  });
+
+  it('emits coordinator_died telemetry before replacing an unexpectedly dead coordinator', async () => {
+    execMock.mockImplementation((cmd: string, _opts: unknown, cb?: (err: Error | null, result?: { stdout: string; stderr: string }) => void) => {
+      const callback = (typeof _opts === 'function' ? _opts : cb)!;
+      if (cmd === 'git status --porcelain') return callback(null, { stdout: ' M file.ts\n', stderr: '' });
+      callback(new Error(`unexpected command: ${cmd}`));
+    });
+    vi.mocked(listSessionNamesAsync).mockResolvedValueOnce(['review-coordinator-PAN-5-1']);
+    vi.mocked(isPaneDeadAsync).mockResolvedValueOnce(true);
+
+    const result = await dispatchParallelReview(
+      { issueId: 'PAN-5', workspace: '/tmp/workspace', branch: 'feature/pan-5' },
+      { coordinatorSpawnFn: async () => ({ sessionName: 'review-coordinator-PAN-5-2' }) },
+    );
+
+    expect(result.success).toBe(true);
+    expect(killSessionAsync).toHaveBeenCalledWith('review-coordinator-PAN-5-1');
+    expect(notifyPipeline).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'coordinator_died',
+      issueId: 'PAN-5',
+      sessionName: 'review-coordinator-PAN-5-1',
+      reason: 'pane_dead',
+    }));
   });
 
   it('drops persisted review-temp stash in runParallelReview finally block', async () => {

--- a/src/lib/cloister/deacon.ts
+++ b/src/lib/cloister/deacon.ts
@@ -2413,11 +2413,12 @@ export async function checkDeadEndAgents(): Promise<string[]> {
       // 'failed' covers verification gate errors (e.g. JSON parse error in `.pan/spec.vbrief.json`)
       // that prevent the review specialist from running at all.
       const isReviewBlocked = status.reviewStatus === 'blocked' || status.reviewStatus === 'failed';
+      const isVerificationFailed = status.verificationStatus === 'failed';
       const isTestFailed = status.testStatus === 'failed';
       const isMergeCiFailed = status.mergeStatus === 'failed' &&
         typeof status.mergeNotes === 'string' &&
         status.mergeNotes.includes('failing required checks');
-      if (!isReviewBlocked && !isTestFailed && !isMergeCiFailed) continue;
+      if (!isReviewBlocked && !isVerificationFailed && !isTestFailed && !isMergeCiFailed) continue;
 
       // Skip merged/completed issues
       if (status.mergeStatus === 'merged' || status.readyForMerge) continue;
@@ -2468,6 +2469,10 @@ export async function checkDeadEndAgents(): Promise<string[]> {
       let statusType: string;
       if (isReviewBlocked) {
         statusType = status.reviewStatus === 'failed' ? 'review failed' : 'review blocked';
+      } else if (isVerificationFailed) {
+        statusType = status.reviewStatus === 'pending'
+          ? 'verification failed while review pending'
+          : 'verification failed';
       } else if (isTestFailed) {
         statusType = 'tests failed';
       } else {
@@ -2524,7 +2529,9 @@ export async function checkDeadEndAgents(): Promise<string[]> {
           ? `Review verification failed for ${issueId}.${feedbackPart}\n\nCommon cause: merge conflict markers in .pan/spec.vbrief.json — fix by resolving conflicts in that file, then run: pan review request ${issueId} -m "Fixed verification error"`
           : isReviewBlocked
             ? `The review agent found issues in your code.${feedbackPart}\n\nFix every issue listed, commit all changes, then run: pan review request ${issueId} -m "Fixed review issues". Do NOT stop until pan review request completes successfully.`
-            : `Tests failed for your changes.${feedbackPart}\n\nFix the failures, commit, then run: pan review request ${issueId} -m "Fixed test failures". Do NOT stop until pan review request completes successfully.`;
+            : isVerificationFailed
+              ? `Verification failed for ${issueId} while review is pending.${feedbackPart}\n\nFix the failing verification check, commit every change, push your branch, then request a new review with: pan review request ${issueId} -m "Fixed verification failure". Do NOT stop until pan review request completes successfully.`
+              : `Tests failed for your changes.${feedbackPart}\n\nFix the failures, commit, then run: pan review request ${issueId} -m "Fixed test failures". Do NOT stop until pan review request completes successfully.`;
 
         await sendKeysAsync(agentSessionName, nudgeMessage);
         actions.push(`Dead-end recovery: nudged ${agentSessionName} (${statusType}, idle for ${Math.round((now - new Date(status.updatedAt || '').getTime()) / 60000)}m)`);

--- a/src/lib/cloister/review-agent.ts
+++ b/src/lib/cloister/review-agent.ts
@@ -839,6 +839,27 @@ async function isCoordinatorAliveAsync(sessionName: string): Promise<boolean> {
   }
 }
 
+async function coordinatorExitStatus(opts: { workspace: string; sessionName: string }): Promise<number | null> {
+  try {
+    const exitPath = join(opts.workspace, '.pan', 'review', 'coordinator', `${opts.sessionName}.exit`);
+    if (!existsSync(exitPath)) return null;
+    const raw = await readFile(exitPath, 'utf-8');
+    const parsed = Number.parseInt(raw.trim(), 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function emitCoordinatorDied(issueId: string, sessionName: string, reason: string): Promise<void> {
+  try {
+    const { notifyPipeline } = await import('../pipeline-notifier.js');
+    notifyPipeline({ type: 'coordinator_died', issueId, sessionName, reason });
+  } catch {
+    // Non-fatal: event emission is best-effort.
+  }
+}
+
 /**
  * Kill ALL review-related tmux sessions on the panopticon socket.
  *
@@ -1632,10 +1653,16 @@ export async function dispatchParallelReview(
       (s) => s.startsWith(`review-coordinator-${opts.issueId}-`),
     );
     if (existingCoordinator) {
+      const exitStatus = await coordinatorExitStatus({ workspace: opts.workspace, sessionName: existingCoordinator });
       const paneDead = await isPaneDeadAsync(existingCoordinator);
       const actuallyAlive = !paneDead && (await isCoordinatorAliveAsync(existingCoordinator));
-      if (paneDead || !actuallyAlive) {
-        console.log(`[review-agent] Idempotency guard: coordinator ${existingCoordinator} is dead (paneDead=${paneDead}, alive=${actuallyAlive}) — killing stale session and proceeding with dispatch`);
+      if (exitStatus !== null) {
+        console.log(`[review-agent] Idempotency guard: coordinator ${existingCoordinator} already exited with status ${exitStatus} — killing inspectable session and proceeding with dispatch`);
+        await killSessionAsync(existingCoordinator).catch(() => {});
+      } else if (paneDead || !actuallyAlive) {
+        const reason = paneDead ? 'pane_dead' : 'process_not_alive';
+        console.log(`[review-agent] Idempotency guard: coordinator ${existingCoordinator} died unexpectedly (${reason}; alive=${actuallyAlive}) — killing stale session and proceeding with dispatch`);
+        await emitCoordinatorDied(opts.issueId, existingCoordinator, reason);
         await killSessionAsync(existingCoordinator).catch(() => {});
       } else {
         console.log(`[review-agent] Idempotency guard: coordinator ${existingCoordinator} already running for ${opts.issueId} — skipping dispatch`);
@@ -1754,14 +1781,15 @@ export async function spawnReviewCoordinatorSession(opts: {
   workspace: string;
   model?: string;
 }): Promise<{ sessionName: string }> {
-  const sessionName = `review-coordinator-${opts.issueId}-${Date.now()}`;
+  const runId = Date.now();
+  const sessionName = `review-coordinator-${opts.issueId}-${runId}`;
   const logDir = join(opts.workspace, '.pan', 'review', 'coordinator');
   await mkdir(logDir, { recursive: true });
-  const logStem = `${opts.issueId}-${Date.now()}`;
+  const logStem = sessionName;
   const logFile = join(logDir, `${logStem}.log`);
   const exitCodeFile = join(logDir, `${logStem}.exit`);
   const panBin = join(dirname(process.execPath), 'pan');
-  const command = `bash -lc 'set -o pipefail; ${panBin} review run ${opts.issueId} 2>&1 | tee -a "${logFile}"; status=\${PIPESTATUS[0]}; printf "%s\\n" "$status" > "${exitCodeFile}"; printf "\\n[pan review run exit %s at %s]\\n" "$status" "$(date -Is)" >> "${logFile}"; exit "$status"'`;
+  const command = `bash -lc 'set -o pipefail; ${panBin} review run ${opts.issueId} 2>&1 | tee -a "${logFile}"; status=\${PIPESTATUS[0]}; printf "%s\\n" "$status" > "${exitCodeFile}"; printf "\\n[pan review run exit %s at %s]\\n" "$status" "$(date -Is)" >> "${logFile}"; if [ "$status" -lt 2 ]; then exit "$status"; fi; printf "\\n[coordinator preserved after failed review exit %s at %s]\\n" "$status" "$(date -Is)" | tee -a "${logFile}"; printf "Inspect the log above, then re-request review from the dashboard or run: pan review request ${opts.issueId} -m \\\"Retry review\\\"\\n"; exec bash -li'`;
   const env: Record<string, string> = {
     ...BLANKED_PROVIDER_ENV,
     PANOPTICON_AGENT_ID: '',

--- a/src/lib/cloister/review-agent.ts
+++ b/src/lib/cloister/review-agent.ts
@@ -74,6 +74,20 @@ interface ReviewHistoryEntry {
  * Performance reviewers of large PRs can need 20+ minutes of analysis time.
  */
 const REVIEW_TIMEOUT_MS = 30 * 60 * 1000;
+const MAX_REVIEWER_TIMEOUT_RETRIES = 2;
+const REVIEWER_TIMEOUT_RETRY_BACKOFF_MS = [2_000, 5_000];
+
+function reviewerRetryBackoffMs(attempt: number): number {
+  return REVIEWER_TIMEOUT_RETRY_BACKOFF_MS[Math.min(attempt - 1, REVIEWER_TIMEOUT_RETRY_BACKOFF_MS.length - 1)] ?? 5_000;
+}
+
+function isRetryableReviewerFailure(reason?: ReviewerFailureReason): boolean {
+  return reason === 'timeout' || reason === 'pane_dead';
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
 
 /**
  * Default reviewer agents used when specialists.review_agents is not configured.
@@ -1130,8 +1144,27 @@ export async function runParallelReview(
       // Non-fatal: event emission is best-effort
     }
   };
-  let reviewerResults: ReviewerOutcome[] = await Promise.all(
-    reviewerSessions.map(({ sessionName, outputFile, role }) =>
+  const emitReviewerTimedOut = async (outcome: ReviewerOutcome, attempt: number, willRetry: boolean) => {
+    if (outcome.status !== 'failed' || outcome.failureReason !== 'timeout' || !outcome.sessionName) return;
+    try {
+      const { notifyPipeline } = await import('../pipeline-notifier.js');
+      notifyPipeline({
+        type: 'reviewer_timed_out',
+        issueId: context.issueId,
+        role: outcome.role,
+        sessionName: outcome.sessionName,
+        attempt,
+        maxRetries: MAX_REVIEWER_TIMEOUT_RETRIES,
+        willRetry,
+      });
+    } catch {
+      // Non-fatal: event emission is best-effort
+    }
+  };
+  const waitForReviewerSessions = async (
+    sessions: Array<{ sessionName: string; outputFile: string; role: string }>,
+  ): Promise<ReviewerOutcome[]> => Promise.all(
+    sessions.map(({ sessionName, outputFile, role }) =>
       waitFn(sessionName, outputFile, REVIEW_TIMEOUT_MS)
         .then(async (waitResult): Promise<ReviewerOutcome> => {
           if (waitResult.status === 'completed') {
@@ -1150,84 +1183,69 @@ export async function runParallelReview(
     ),
   );
 
-  // ── Phase 2b: One auto-respawn for reviewers that failed with a dead pane.
-  // Transient failures (e.g. 503 auth_unavailable that kills the pane) recover
-  // on respawn ~90% of the time. We retry once to avoid burning a full review
-  // cycle for a blip. We ONLY retry when the pane is dead AND the failure was
-  // not a terminal-API error — if the session is gone entirely, the pane is
-  // still alive, or the upstream provider returned a non-recoverable error
-  // (quota exhausted, login required), respawn won't help.
-  const failedReviewerResults = reviewerResults.filter(r => r.status === 'failed');
-  if (failedReviewerResults.length > 0) {
-    const retryable: typeof failedReviewerResults = [];
+  let reviewerResults: ReviewerOutcome[] = await waitForReviewerSessions(reviewerSessions);
+
+  // ── Phase 2b: Auto-respawn reviewers that fail from retryable transient states.
+  // Timeouts were previously terminal and stranded issues with review=pending until
+  // a human manually restarted the review. Retry the specific timed-out/dead-pane
+  // reviewer only, with a capped two-retry backoff, while still skipping terminal
+  // provider errors because the same auth/quota/login problem would recur.
+  for (let attempt = 1; attempt <= MAX_REVIEWER_TIMEOUT_RETRIES; attempt++) {
+    const failedReviewerResults = reviewerResults.filter(r => r.status === 'failed');
+    const retryable = failedReviewerResults.filter(r => isRetryableReviewerFailure(r.failureReason));
     for (const failed of failedReviewerResults) {
-      // Skip respawn for terminal API errors — same provider/quota/auth
-      // problem will hit again immediately. Surface the error to the user
-      // instead.
+      await emitReviewerTimedOut(failed, attempt, retryable.includes(failed));
       if (failed.failureReason === 'terminal_api_error') {
         console.log(`[review-agent] Skipping respawn for ${failed.sessionName} — terminal API error: ${failed.apiError?.summary ?? 'unknown'}`);
-        continue;
       }
-      const paneDead = failed.sessionName ? await isPaneDeadAsync(failed.sessionName) : false;
-      if (!paneDead) continue;
+    }
+    if (retryable.length === 0) break;
 
+    await delay(reviewerRetryBackoffMs(attempt));
+
+    const retrySessions: Array<{ sessionName: string; outputFile: string; role: string }> = [];
+    for (const failed of retryable) {
       const agent = agents.find(a => a.name === failed.role);
-      if (!agent) continue;
+      if (!agent || !failed.sessionName) continue;
       const promptName = `code-review-${agent.name}`;
       const promptTemplatePath = resolvePromptTemplateFn(promptName, context.projectPath);
       const template = await parseReviewerTemplate(promptTemplatePath);
       const model = resolveReviewerModel(agent, template.model);
       const promptFile = join(outputDir, `${agent.name}-prompt.md`);
 
-      console.log(`[review-agent] Auto-respawning dead reviewer ${failed.sessionName} for retry`);
-      emitActivityEntry({ source: 'review-specialist', level: 'warn', message: `${context.issueId} — auto-respawning dead reviewer ${failed.role}`, issueId: context.issueId });
+      console.log(`[review-agent] Auto-respawning reviewer ${failed.sessionName} after ${failed.failureReason} (attempt ${attempt}/${MAX_REVIEWER_TIMEOUT_RETRIES})`);
+      emitActivityEntry({
+        source: 'review-specialist',
+        level: 'warn',
+        message: `${context.issueId} — auto-respawning ${failed.role} reviewer after ${failed.failureReason} (attempt ${attempt}/${MAX_REVIEWER_TIMEOUT_RETRIES})`,
+        issueId: context.issueId,
+      });
 
-      // Kill stale session (if any) and respawn fresh
-      if (failed.sessionName) {
-        try { await killSessionAsync(failed.sessionName); } catch { /* ignore */ }
-        try { await spawnFn(failed.sessionName, model, promptFile, context.projectPath); } catch (err) {
-          console.error(`[review-agent] Respawn of ${failed.sessionName} failed:`, err);
-          continue;
-        }
-        try { await setOptionAsync(failed.sessionName, 'remain-on-exit', 'on'); } catch { /* ignore */ }
-        // PAN-915 — respawned reviewer is running again
-        try {
-          const { notifyPipeline } = await import('../pipeline-notifier.js');
-          notifyPipeline({
-            type: 'reviewer_started',
-            issueId: context.issueId,
-            role: failed.role,
-            sessionName: failed.sessionName,
-          });
-        } catch { /* non-fatal */ }
+      try { await killSessionAsync(failed.sessionName); } catch { /* ignore */ }
+      try { await spawnFn(failed.sessionName, model, promptFile, context.projectPath); } catch (err) {
+        console.error(`[review-agent] Respawn of ${failed.sessionName} failed:`, err);
+        continue;
       }
-      retryable.push(failed);
+      try { await setOptionAsync(failed.sessionName, 'remain-on-exit', 'on'); } catch { /* ignore */ }
+      try {
+        const { notifyPipeline } = await import('../pipeline-notifier.js');
+        notifyPipeline({
+          type: 'reviewer_started',
+          issueId: context.issueId,
+          role: failed.role,
+          sessionName: failed.sessionName,
+        });
+      } catch { /* non-fatal */ }
+      retrySessions.push({ sessionName: failed.sessionName, outputFile: failed.outputFile, role: failed.role });
     }
 
-    if (retryable.length > 0) {
-      const retryResults: ReviewerOutcome[] = await Promise.all(
-        retryable.map(({ sessionName, outputFile, role }) =>
-          waitFn(sessionName!, outputFile, REVIEW_TIMEOUT_MS)
-            .then(async (waitResult): Promise<ReviewerOutcome> => {
-              if (waitResult.status === 'completed') {
-                await emitReviewerCompleted(role);
-                return { role, status: 'completed', outputFile, sessionName };
-              }
-              return {
-                role,
-                status: 'failed',
-                outputFile,
-                sessionName,
-                failureReason: waitResult.reason,
-                apiError: waitResult.apiError,
-              };
-            }),
-        ),
-      );
-      // Merge retry results back into the main result set
-      const retryMap = new Map(retryResults.map(r => [r.role, r]));
-      reviewerResults = reviewerResults.map(r => (r.status === 'failed' && retryMap.has(r.role) ? retryMap.get(r.role)! : r));
-    }
+    if (retrySessions.length === 0) break;
+    const retryResults = await waitForReviewerSessions(retrySessions);
+    const retryMap = new Map(retryResults.map(r => [r.role, r]));
+    reviewerResults = reviewerResults.map(r => (r.status === 'failed' && retryMap.has(r.role) ? retryMap.get(r.role)! : r));
+  }
+  for (const failed of reviewerResults.filter(r => r.status === 'failed' && r.failureReason === 'timeout')) {
+    await emitReviewerTimedOut(failed, MAX_REVIEWER_TIMEOUT_RETRIES + 1, false);
   }
 
   // ── Phase 3: Synthesis ────────────────────────────────────────────────────

--- a/src/lib/cloister/verification-runner.ts
+++ b/src/lib/cloister/verification-runner.ts
@@ -256,7 +256,7 @@ export async function runVerificationForIssue(
               const agentId = `agent-${issueId.toLowerCase()}`;
               const hasConflicts = failures.some(f => f.hasConflicts);
               const repoList = isPolyrepo ? failures.map(f => f.repoName).join(', ') : basename(workspacePath);
-              const msg = `VERIFICATION FAILED for ${issueId}.\nFailed check: ${failedCheck}${hasConflicts ? ' — merge conflicts' : ''} in ${repoList}.\n\nMUST READ: ${fileResult.filePath}\n\nUse your Read tool to open this file, read every line, then fix the sync issues and re-run verification. Do NOT stop at the prompt — keep working until verification passes.`;
+              const msg = `VERIFICATION FAILED for ${issueId}.\nFailed check: ${failedCheck}${hasConflicts ? ' — merge conflicts' : ''} in ${repoList}.\n\nMUST READ: ${fileResult.filePath}\n\nUse your Read tool to open this file, read every line, fix the sync issues, commit and push every change, then request a new review with pan review request. Do NOT stop at the prompt — keep working until pan review request completes successfully.`;
               await messageAgent(agentId, msg);
               console.log(`[${logPrefix}] Sync failed for ${issueId} — sent feedback to ${agentId}`);
             }
@@ -358,7 +358,7 @@ export async function runVerificationForIssue(
         verificationMaxCycles: VERIFICATION_MAX_CYCLES,
       });
 
-      const feedbackBody = `VERIFICATION FAILED for ${issueId} (attempt ${newCycleCount}/${VERIFICATION_MAX_CYCLES}):\n\nFailed check: ${failedCheck}\n\n${summary}\n\n## REQUIRED: Fix the failing check, then invoke the /rebase-and-submit skill\n\n1. Read the error output above carefully\n2. Fix the code causing the failure\n3. Run the failing check locally to verify it passes\n4. Commit every change\n5. Invoke the /rebase-and-submit skill for ${issueId} — this is an atomic task. Because verification already ran once (a PR exists), the skill will run \`pan review request ${issueId} -m "Fixed ${failedCheck}"\` for you. NEVER curl \`/api/review/...\` or any dashboard endpoint — \`pan review request\` is the only supported re-entry point.\n\nDo NOT stop between steps. Do NOT run git push manually — the skill handles it. Do NOT stop until \`pan review request\` has completed successfully.`;
+      const feedbackBody = `VERIFICATION FAILED for ${issueId} (attempt ${newCycleCount}/${VERIFICATION_MAX_CYCLES}):\n\nFailed check: ${failedCheck}\n\n${summary}\n\n## REQUIRED: Fix the failing check, push, and request a new review\n\n1. Read the error output above carefully\n2. Fix the code causing the failure\n3. Run the failing check locally to verify it passes\n4. Commit every change\n5. Invoke the /rebase-and-submit skill for ${issueId} — this is an atomic task. Because verification already ran once (a PR exists), the skill will push your branch and run \`pan review request ${issueId} -m "Fixed ${failedCheck}"\` for you. NEVER curl \`/api/review/...\` or any dashboard endpoint — \`pan review request\` is the only supported re-entry point.\n\nDo NOT stop between steps. Do NOT stop after pushing. Do NOT stop until \`pan review request\` has completed successfully.`;
 
       try {
         const fileResult = await writeFeedbackFile({
@@ -371,7 +371,7 @@ export async function runVerificationForIssue(
         });
         if (fileResult.success) {
           const agentId = `agent-${issueId.toLowerCase()}`;
-          const msg = `VERIFICATION FAILED for ${issueId}.\nFailed check: ${failedCheck}.\n\nMUST READ: ${fileResult.filePath}\n\nUse your Read tool to open this file, read every line, then fix the failing check and re-run verification. Do NOT stop at the prompt — keep working until verification passes.`;
+          const msg = `VERIFICATION FAILED for ${issueId}.\nFailed check: ${failedCheck}.\n\nMUST READ: ${fileResult.filePath}\n\nUse your Read tool to open this file, read every line, fix the failing check, commit every change, and invoke /rebase-and-submit. The skill will push and request a new review with pan review request. Do NOT stop at the prompt — keep working until pan review request completes successfully.`;
           await messageAgent(agentId, msg);
           console.log(`[${logPrefix}] Verification failed for ${issueId} — sent feedback to ${agentId}`);
         }
@@ -412,7 +412,7 @@ export async function runVerificationForIssue(
           });
           if (fileResult.success) {
             const agentId = `agent-${issueId.toLowerCase()}`;
-            const msg = `VERIFICATION FAILED for ${issueId}.\nFailed check: ${failedCheck} — plan.vbrief.json has merge conflict markers.\n\nMUST READ: ${fileResult.filePath}\n\nUse your Read tool to open this file, read every line, then resolve the merge conflict markers and re-run verification. Do NOT stop at the prompt — keep working until verification passes.`;
+            const msg = `VERIFICATION FAILED for ${issueId}.\nFailed check: ${failedCheck} — plan.vbrief.json has merge conflict markers.\n\nMUST READ: ${fileResult.filePath}\n\nUse your Read tool to open this file, read every line, resolve the merge conflict markers, commit and push the fix, then request a new review with pan review request. Do NOT stop at the prompt — keep working until pan review request completes successfully.`;
             await messageAgent(agentId, msg);
             console.log(`[${logPrefix}] vBRIEF conflict detected for ${issueId} — sent feedback to ${agentId}`);
           }
@@ -459,7 +459,7 @@ export async function runVerificationForIssue(
         });
         if (fileResult.success) {
           const agentId = `agent-${issueId.toLowerCase()}`;
-          const msg = `VERIFICATION FAILED for ${issueId}.\nFailed check: ${failedCheck} — ${acStatus.totalPending} AC incomplete.\n\nMUST READ: ${fileResult.filePath}\n\nUse your Read tool to open this file, read every line, then complete all pending acceptance criteria and re-run verification. Do NOT stop at the prompt — keep working until verification passes.`;
+          const msg = `VERIFICATION FAILED for ${issueId}.\nFailed check: ${failedCheck} — ${acStatus.totalPending} AC incomplete.\n\nMUST READ: ${fileResult.filePath}\n\nUse your Read tool to open this file, read every line, complete all pending acceptance criteria, commit and push every change, then request a new review with pan review request. Do NOT stop at the prompt — keep working until pan review request completes successfully.`;
           await messageAgent(agentId, msg);
           console.log(`[${logPrefix}] AC verification failed for ${issueId} — sent feedback to ${agentId}`);
         }

--- a/src/lib/pipeline-notifier.ts
+++ b/src/lib/pipeline-notifier.ts
@@ -23,7 +23,8 @@ export type PipelineEvent =
   | { type: 'reviewer_started'; issueId: string; role: string; sessionName: string }
   | { type: 'reviewer_completed'; issueId: string; role: string }
   | { type: 'reviewer_timed_out'; issueId: string; role: string; sessionName: string; attempt: number; maxRetries: number; willRetry: boolean }
-  | { type: 'coordinator_started'; issueId: string; sessionName: string };
+  | { type: 'coordinator_started'; issueId: string; sessionName: string }
+  | { type: 'coordinator_died'; issueId: string; sessionName: string; reason: string };
 
 type Handler = (event: PipelineEvent) => void;
 let handler: Handler | null = null;

--- a/src/lib/pipeline-notifier.ts
+++ b/src/lib/pipeline-notifier.ts
@@ -22,6 +22,7 @@ export type PipelineEvent =
   | { type: 'task_queued'; specialist: string; issueId: string }
   | { type: 'reviewer_started'; issueId: string; role: string; sessionName: string }
   | { type: 'reviewer_completed'; issueId: string; role: string }
+  | { type: 'reviewer_timed_out'; issueId: string; role: string; sessionName: string; attempt: number; maxRetries: number; willRetry: boolean }
   | { type: 'coordinator_started'; issueId: string; sessionName: string };
 
 type Handler = (event: PipelineEvent) => void;


### PR DESCRIPTION
## Summary
- Retry timed-out/dead review specialists individually with capped backoff and structured timeout telemetry.
- Keep failed/protocol review coordinator sessions inspectable, distinguish restartable exit markers from unexpected deaths, and emit coordinator death telemetry.
- Surface stranded pending reviews in the dashboard inspector with a forced Re-request Review path and update verify-failed guidance to request a new review after push.

## Test plan
- [x] npm test -- src/lib/cloister/__tests__/review-temp-lifecycle.test.ts --run
- [x] npm test -- src/dashboard/frontend/src/components/InspectorPanel.test.tsx --run
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run build
- [ ] npm test -- --run (fails on pre-existing workspace/env drift: deprecated gemini-3-flash-preview fixture, synced skills fixture drift, claudish auto-permission integration setup, and missing .beads files in the dirty workspace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)