### PR TITLE
PAN-1024

### DIFF
--- a/packages/contracts/src/event-reducers.ts
+++ b/packages/contracts/src/event-reducers.ts
@@ -127,10 +127,10 @@ export function trimTurnDiffSummaries(summaries: TurnDiffSummary[]): TurnDiffSum
 }
 
 export function omitTurnDiffSummariesForAgent(
-  turnDiffSummariesByAgentId: ReadModelState['turnDiffSummariesByAgentId'],
+  turnDiffSummariesByAgentId: ReadModelState['turnDiffSummariesByAgentId'] | undefined,
   agentId: string,
 ): ReadModelState['turnDiffSummariesByAgentId'] {
-  const { [agentId]: _removed, ...rest } = turnDiffSummariesByAgentId
+  const { [agentId]: _removed, ...rest } = turnDiffSummariesByAgentId ?? {}
   return rest
 }
 

--- a/packages/contracts/src/event-reducers.ts
+++ b/packages/contracts/src/event-reducers.ts
@@ -109,6 +109,30 @@ const MAX_AGENT_OUTPUT_LINES = 200
 const MAX_ACTIVITY_ENTRIES = 50
 const MAX_DETAILED_ENTRIES = 200
 const MAX_TTS_ENTRIES = 50
+export const DEFAULT_MAX_TURN_DIFF_SUMMARIES_PER_AGENT = 200
+
+export function getMaxTurnDiffSummariesPerAgent(): number {
+  const raw = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env?.PANOPTICON_TURN_DIFF_SUMMARY_LIMIT
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_TURN_DIFF_SUMMARIES_PER_AGENT
+}
+
+export function isTerminalTurnDiffSummaryStatus(status: unknown): boolean {
+  return status === 'stopped' || status === 'done' || status === 'archived' || status === 'closed'
+}
+
+export function trimTurnDiffSummaries(summaries: TurnDiffSummary[]): TurnDiffSummary[] {
+  const max = getMaxTurnDiffSummariesPerAgent()
+  return summaries.length > max ? summaries.slice(-max) : summaries
+}
+
+export function omitTurnDiffSummariesForAgent(
+  turnDiffSummariesByAgentId: ReadModelState['turnDiffSummariesByAgentId'],
+  agentId: string,
+): ReadModelState['turnDiffSummariesByAgentId'] {
+  const { [agentId]: _removed, ...rest } = turnDiffSummariesByAgentId
+  return rest
+}
 
 // ─── PAN-800 runtime helpers ─────────────────────────────────────────────────
 
@@ -279,12 +303,16 @@ export function applyEvent(state: ReadModelState, event: DomainEvent): ReadModel
         channelPermissionRequestIdsByAgentId: restPendingIds,
         resolvedChannelPermissionDecisionsById: nextResolvedDecisionsById,
         resolvedChannelPermissionDecisionIdsByAgentId: restResolvedIds,
+        turnDiffSummariesByAgentId: omitTurnDiffSummariesForAgent(state.turnDiffSummariesByAgentId, event.payload.agentId),
       }
     }
 
     case 'agent.status_changed': {
       const agent = state.agentsById[event.payload.agentId]
       if (!agent) return { ...state, sequence: Math.max(state.sequence, event.sequence) }
+      const nextTurnDiffSummariesByAgentId = isTerminalTurnDiffSummaryStatus(event.payload.status)
+        ? omitTurnDiffSummariesForAgent(state.turnDiffSummariesByAgentId, event.payload.agentId)
+        : state.turnDiffSummariesByAgentId
       return {
         ...state,
         sequence: Math.max(state.sequence, event.sequence),
@@ -292,6 +320,7 @@ export function applyEvent(state: ReadModelState, event: DomainEvent): ReadModel
           ...state.agentsById,
           [event.payload.agentId]: { ...agent, status: event.payload.status },
         },
+        turnDiffSummariesByAgentId: nextTurnDiffSummariesByAgentId,
       }
     }
 
@@ -520,9 +549,16 @@ export function applyEvent(state: ReadModelState, event: DomainEvent): ReadModel
     case 'workspace.destroyed':
     case 'workspace.deleted': {
       const { issueId } = event.payload
+      const removedAgentIds = Object.entries(state.agentsById)
+        .filter(([, agent]) => agent.issueId === issueId)
+        .map(([agentId]) => agentId)
       const updatedAgents = Object.fromEntries(
         Object.entries(state.agentsById).filter(([, agent]) => agent.issueId !== issueId)
       )
+      let nextTurnDiffSummariesByAgentId = state.turnDiffSummariesByAgentId
+      for (const agentId of removedAgentIds) {
+        nextTurnDiffSummariesByAgentId = omitTurnDiffSummariesForAgent(nextTurnDiffSummariesByAgentId, agentId)
+      }
       const updatedIssues = (state.issuesRaw as Array<Record<string, unknown>>).map(issue => {
         if (issue['identifier'] === issueId || issue['id'] === issueId) {
           return { ...issue, status: 'Todo', canonicalStatus: 'todo', state: 'todo' }
@@ -533,6 +569,7 @@ export function applyEvent(state: ReadModelState, event: DomainEvent): ReadModel
         ...state,
         sequence: Math.max(state.sequence, event.sequence),
         agentsById: updatedAgents,
+        turnDiffSummariesByAgentId: nextTurnDiffSummariesByAgentId,
         issuesRaw: updatedIssues,
       }
     }
@@ -540,18 +577,27 @@ export function applyEvent(state: ReadModelState, event: DomainEvent): ReadModel
     case 'workspace.aborted': {
       const { issueId, sessionName } = event.payload
       let updatedAgents: typeof state.agentsById
+      let nextTurnDiffSummariesByAgentId = state.turnDiffSummariesByAgentId
       if (sessionName) {
         const { [sessionName]: _removed, ...rest } = state.agentsById
         updatedAgents = rest
+        nextTurnDiffSummariesByAgentId = omitTurnDiffSummariesForAgent(nextTurnDiffSummariesByAgentId, sessionName)
       } else {
+        const removedAgentIds = Object.entries(state.agentsById)
+          .filter(([, agent]) => agent.issueId === issueId)
+          .map(([agentId]) => agentId)
         updatedAgents = Object.fromEntries(
           Object.entries(state.agentsById).filter(([, agent]) => agent.issueId !== issueId)
         )
+        for (const agentId of removedAgentIds) {
+          nextTurnDiffSummariesByAgentId = omitTurnDiffSummariesForAgent(nextTurnDiffSummariesByAgentId, agentId)
+        }
       }
       return {
         ...state,
         sequence: Math.max(state.sequence, event.sequence),
         agentsById: updatedAgents,
+        turnDiffSummariesByAgentId: nextTurnDiffSummariesByAgentId,
       }
     }
 
@@ -959,9 +1005,11 @@ export function applyEvent(state: ReadModelState, event: DomainEvent): ReadModel
       }
       // Deduplicate by turnId — replace if exists, append otherwise
       const idx = existing.findIndex(s => s.turnId === p.turnId)
-      const updated = idx >= 0
-        ? existing.map((s, i) => i === idx ? summary : s)
-        : [...existing, summary]
+      const updated = trimTurnDiffSummaries(
+        idx >= 0
+          ? existing.map((s, i) => i === idx ? summary : s)
+          : [...existing, summary]
+      )
       return {
         ...state,
         sequence: Math.max(state.sequence, event.sequence),

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -393,7 +393,6 @@ export const DashboardSnapshot = Schema.Struct({
   reviewStatuses: Schema.Array(ReviewStatusSnapshot),
   issues: Schema.Array(Schema.Unknown),  // Issues are complex — pass through unvalidated
   resources: Schema.optional(Schema.Unknown),
-  turnDiffSummariesByAgentId: Schema.optional(Schema.Record(Schema.String, Schema.Array(TurnDiffSummary))),
   agentRuntimeById: Schema.optional(Schema.Record(Schema.String, AgentRuntimeSnapshot)),
   channelPermissionRequests: Schema.optional(Schema.Array(ChannelPermissionRequestSnapshot)),
   timestamp: Schema.String,

--- a/src/dashboard/server/__tests__/read-model-diff-summaries.test.ts
+++ b/src/dashboard/server/__tests__/read-model-diff-summaries.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest'
+import { Effect } from 'effect'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+async function withIsolatedReadModel<T>(run: (svc: {
+  getSnapshot: unknown
+  getTurnDiffSummaries: (agentId: string) => unknown
+  applyEvent: (event: unknown) => void
+}) => Promise<T>): Promise<T> {
+  const tmpHome = mkdtempSync(join(tmpdir(), 'pan-1024-read-model-'))
+  const originalHome = process.env['PANOPTICON_HOME']
+  process.env['PANOPTICON_HOME'] = tmpHome
+
+  try {
+    vi.resetModules()
+    const { ReadModelService, ReadModelServiceLive } = await import('../read-model.js')
+    const program = Effect.gen(function* () {
+      const svc = yield* ReadModelService
+      return yield* Effect.promise(() => run(svc as never))
+    })
+    return await Effect.runPromise(Effect.provide(program, ReadModelServiceLive))
+  } finally {
+    process.env['PANOPTICON_HOME'] = originalHome
+    rmSync(tmpHome, { recursive: true, force: true })
+  }
+}
+
+describe('ReadModel diff summaries', () => {
+  it('keeps turn diff summaries off the dashboard snapshot while serving them separately', async () => {
+    const timestamp = '2026-05-08T05:00:00.000Z'
+
+    const result = await withIsolatedReadModel(async (readModel) => {
+      readModel.applyEvent({
+        type: 'agent.started',
+        sequence: 1,
+        timestamp,
+        payload: {
+          agentId: 'agent-1024',
+          agent: {
+            id: 'agent-1024',
+            issueId: 'PAN-1024',
+            workspace: '/tmp/pan-1024',
+            status: 'running',
+          },
+        },
+      })
+
+      readModel.applyEvent({
+        type: 'agent.turn_diff_completed',
+        sequence: 2,
+        timestamp,
+        payload: {
+          agentId: 'agent-1024',
+          turnId: 'turn-1',
+          completedAt: timestamp,
+          files: [{ path: 'src/example.ts', additions: 3, deletions: 1 }],
+          checkpointRef: 'refs/pan/turn/turn-1',
+        },
+      })
+
+      const snapshot = await Effect.runPromise(readModel.getSnapshot as Effect.Effect<any>)
+      const summaries = await Effect.runPromise(readModel.getTurnDiffSummaries('agent-1024') as Effect.Effect<any>)
+      return { snapshot, summaries }
+    })
+
+    expect(result.snapshot).not.toHaveProperty('turnDiffSummariesByAgentId')
+    expect(result.summaries).toEqual([
+      {
+        turnId: 'turn-1',
+        completedAt: timestamp,
+        files: [{ path: 'src/example.ts', additions: 3, deletions: 1 }],
+        checkpointRef: 'refs/pan/turn/turn-1',
+      },
+    ])
+  }, 30000)
+
+  it('returns defensive copies of in-memory turn diff summaries', async () => {
+    const timestamp = '2026-05-08T05:00:00.000Z'
+
+    const result = await withIsolatedReadModel(async (readModel) => {
+      readModel.applyEvent({
+        type: 'agent.started',
+        sequence: 1,
+        timestamp,
+        payload: {
+          agentId: 'agent-1024',
+          agent: {
+            id: 'agent-1024',
+            issueId: 'PAN-1024',
+            workspace: '/tmp/pan-1024',
+            status: 'running',
+          },
+        },
+      })
+
+      readModel.applyEvent({
+        type: 'agent.turn_diff_completed',
+        sequence: 2,
+        timestamp,
+        payload: {
+          agentId: 'agent-1024',
+          turnId: 'turn-1',
+          completedAt: timestamp,
+          files: [{ path: 'src/example.ts', additions: 3, deletions: 1 }],
+        },
+      })
+
+      const first = await Effect.runPromise(readModel.getTurnDiffSummaries('agent-1024') as Effect.Effect<any>)
+      first[0].files[0].path = 'mutated.ts'
+      const second = await Effect.runPromise(readModel.getTurnDiffSummaries('agent-1024') as Effect.Effect<any>)
+      return second
+    })
+
+    expect(result[0].files[0].path).toBe('src/example.ts')
+  }, 30000)
+})

--- a/src/dashboard/server/__tests__/read-model-diff-summaries.test.ts
+++ b/src/dashboard/server/__tests__/read-model-diff-summaries.test.ts
@@ -1,8 +1,16 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { Effect } from 'effect'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { shouldSkipCheckpointReconciliation } from '../read-model.js'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.doUnmock('../../lib/agents.js')
+  vi.doUnmock('../../lib/agent-enrichment.js')
+  vi.doUnmock('../../lib/checkpoint/checkpoint-manager.js')
+})
 
 async function withIsolatedReadModel<T>(run: (svc: {
   getSnapshot: unknown
@@ -115,4 +123,54 @@ describe('ReadModel diff summaries', () => {
 
     expect(result[0].files[0].path).toBe('src/example.ts')
   }, 30000)
+
+  it('retains only the latest 200 in-memory turn diff summaries per agent', async () => {
+    const baseTimestamp = Date.parse('2026-05-08T05:00:00.000Z')
+
+    const result = await withIsolatedReadModel(async (readModel) => {
+      readModel.applyEvent({
+        type: 'agent.started',
+        sequence: 1,
+        timestamp: new Date(baseTimestamp).toISOString(),
+        payload: {
+          agentId: 'agent-1024',
+          agent: {
+            id: 'agent-1024',
+            issueId: 'PAN-1024',
+            workspace: '/tmp/pan-1024',
+            status: 'running',
+          },
+        },
+      })
+
+      for (let turn = 1; turn <= 205; turn++) {
+        const timestamp = new Date(baseTimestamp + turn * 1000).toISOString()
+        readModel.applyEvent({
+          type: 'agent.turn_diff_completed',
+          sequence: turn + 1,
+          timestamp,
+          payload: {
+            agentId: 'agent-1024',
+            turnId: `turn-${turn}`,
+            completedAt: timestamp,
+            files: [{ path: `src/example-${turn}.ts`, additions: turn, deletions: 0 }],
+          },
+        })
+      }
+
+      return Effect.runPromise(readModel.getTurnDiffSummaries('agent-1024') as Effect.Effect<any>)
+    })
+
+    expect(result).toHaveLength(200)
+    expect(result[0].turnId).toBe('turn-6')
+    expect(result.at(-1)?.turnId).toBe('turn-205')
+  }, 30000)
+})
+
+describe('shouldSkipCheckpointReconciliation', () => {
+  it('skips agents without a workspace or with terminal statuses', () => {
+    expect(shouldSkipCheckpointReconciliation({ status: 'running', workspace: undefined })).toBe(true)
+    expect(shouldSkipCheckpointReconciliation({ status: 'stopped', workspace: '/tmp/pan-1024' })).toBe(true)
+    expect(shouldSkipCheckpointReconciliation({ status: 'running', workspace: '/tmp/pan-1024' })).toBe(false)
+  })
 })

--- a/src/dashboard/server/__tests__/read-model-diff-summaries.test.ts
+++ b/src/dashboard/server/__tests__/read-model-diff-summaries.test.ts
@@ -7,22 +7,26 @@ import { shouldSkipCheckpointReconciliation } from '../read-model.js'
 
 afterEach(() => {
   vi.restoreAllMocks()
-  vi.doUnmock('../../lib/agents.js')
-  vi.doUnmock('../../lib/agent-enrichment.js')
-  vi.doUnmock('../../lib/checkpoint/checkpoint-manager.js')
+  vi.doUnmock('../../../lib/agents.js')
+  vi.doUnmock('../../../lib/agent-enrichment.js')
+  vi.doUnmock('../../../lib/checkpoint/checkpoint-manager.js')
 })
 
-async function withIsolatedReadModel<T>(run: (svc: {
-  getSnapshot: unknown
-  getTurnDiffSummaries: (agentId: string) => unknown
-  applyEvent: (event: unknown) => void
-}) => Promise<T>): Promise<T> {
+async function withIsolatedReadModel<T>(
+  run: (svc: {
+    getSnapshot: unknown
+    getTurnDiffSummaries: (agentId: string) => unknown
+    applyEvent: (event: unknown) => void
+  }) => Promise<T>,
+  options?: { setupMocks?: () => void },
+): Promise<T> {
   const tmpHome = mkdtempSync(join(tmpdir(), 'pan-1024-read-model-'))
   const originalHome = process.env['PANOPTICON_HOME']
   process.env['PANOPTICON_HOME'] = tmpHome
 
   try {
     vi.resetModules()
+    options?.setupMocks?.()
     const { ReadModelService, ReadModelServiceLive } = await import('../read-model.js')
     const program = Effect.gen(function* () {
       const svc = yield* ReadModelService
@@ -82,6 +86,76 @@ describe('ReadModel diff summaries', () => {
         checkpointRef: 'refs/pan/turn/turn-1',
       },
     ])
+  }, 30000)
+
+  it('keeps a 100+ agent serialized dashboard snapshot under 5 MB even when retained diff summaries exceed that size in memory', async () => {
+    const encoder = new TextEncoder()
+    const baseTimestamp = Date.parse('2026-05-08T05:00:00.000Z')
+    const agentCount = 101
+    const turnsPerAgent = 205
+    const filesPerTurn = 3
+
+    const result = await withIsolatedReadModel(async (readModel) => {
+      let sequence = 0
+      const agentIds: string[] = []
+
+      for (let agentIndex = 0; agentIndex < agentCount; agentIndex++) {
+        const agentId = `agent-${agentIndex + 1}`
+        agentIds.push(agentId)
+
+        sequence += 1
+        const startedAt = new Date(baseTimestamp + sequence * 1000).toISOString()
+        readModel.applyEvent({
+          type: 'agent.started',
+          sequence,
+          timestamp: startedAt,
+          payload: {
+            agentId,
+            agent: {
+              id: agentId,
+              issueId: `PAN-${2000 + agentIndex}`,
+              workspace: `/tmp/pan-${agentIndex + 1}`,
+              status: 'running',
+            },
+          },
+        })
+
+        for (let turn = 1; turn <= turnsPerAgent; turn++) {
+          sequence += 1
+          const timestamp = new Date(baseTimestamp + sequence * 1000).toISOString()
+          readModel.applyEvent({
+            type: 'agent.turn_diff_completed',
+            sequence,
+            timestamp,
+            payload: {
+              agentId,
+              turnId: `turn-${turn}`,
+              completedAt: timestamp,
+              checkpointRef: `refs/pan/turn/${agentId}/turn-${turn}`,
+              files: Array.from({ length: filesPerTurn }, (_, fileIndex) => ({
+                path: `src/features/${agentId}/turn-${turn}/deeply/nested/component-${fileIndex + 1}-${'x'.repeat(64)}.ts`,
+                additions: fileIndex + 1,
+                deletions: fileIndex % 2,
+              })),
+            },
+          })
+        }
+      }
+
+      let retainedSummaryBytes = 0
+      for (const agentId of agentIds) {
+        const summaries = await Effect.runPromise(readModel.getTurnDiffSummaries(agentId) as Effect.Effect<any>)
+        retainedSummaryBytes += encoder.encode(JSON.stringify(summaries)).length
+      }
+
+      const snapshot = await Effect.runPromise(readModel.getSnapshot as Effect.Effect<any>)
+      const serializedSnapshotBytes = encoder.encode(JSON.stringify(snapshot)).length
+      return { snapshot, retainedSummaryBytes, serializedSnapshotBytes }
+    })
+
+    expect(result.snapshot).not.toHaveProperty('turnDiffSummariesByAgentId')
+    expect(result.retainedSummaryBytes).toBeGreaterThan(5 * 1024 * 1024)
+    expect(result.serializedSnapshotBytes).toBeLessThan(5 * 1024 * 1024)
   }, 30000)
 
   it('returns defensive copies of in-memory turn diff summaries', async () => {
@@ -164,6 +238,71 @@ describe('ReadModel diff summaries', () => {
     expect(result).toHaveLength(200)
     expect(result[0].turnId).toBe('turn-6')
     expect(result.at(-1)?.turnId).toBe('turn-205')
+  }, 30000)
+})
+
+describe('ReadModel checkpoint reconciliation', () => {
+  it('caps checkpoint reconciliation before diffing old history while preserving absolute turn counts', async () => {
+    const checkpoints = Array.from({ length: 205 }, (_, index) => `turn-${index + 1}`)
+    const listCheckpoints = vi.fn().mockResolvedValue(checkpoints)
+    const diffCheckpointFiles = vi.fn().mockImplementation(async (_workspace: string, prevTurnId: string, turnId: string) => ([
+      { path: `${prevTurnId}-to-${turnId}.ts`, additions: 1, deletions: 0 },
+    ]))
+    const getCheckpointTimestamp = vi.fn().mockImplementation(async (_workspace: string, turnId: string) => {
+      const turnNumber = Number.parseInt(turnId.replace('turn-', ''), 10)
+      return new Date(Date.parse('2026-05-08T05:00:00.000Z') + turnNumber * 1000).toISOString()
+    })
+
+    const summaries = await withIsolatedReadModel(
+      async (readModel) => {
+        await vi.waitFor(async () => {
+          const reconciled = await Effect.runPromise(readModel.getTurnDiffSummaries('agent-reconcile') as Effect.Effect<any>)
+          expect(reconciled).toHaveLength(200)
+        }, { timeout: 30000 })
+
+        return Effect.runPromise(readModel.getTurnDiffSummaries('agent-reconcile') as Effect.Effect<any>)
+      },
+      {
+        setupMocks: () => {
+          vi.doMock('../../../lib/checkpoint/checkpoint-manager.js', () => ({
+            listCheckpoints,
+            diffCheckpointFiles,
+            getCheckpointTimestamp,
+          }))
+          vi.doMock('../../../lib/agent-enrichment.js', () => ({
+            computeAgentEnrichment: vi.fn().mockResolvedValue(undefined),
+          }))
+          vi.doMock('../../../lib/agents.js', () => ({
+            listRunningAgentsAsync: vi.fn().mockResolvedValue([
+              {
+                id: 'agent-reconcile',
+                issueId: 'PAN-1024',
+                workspace: '/tmp/pan-1024',
+                runtime: 'claude-code',
+                model: 'sonnet',
+                status: 'running',
+                tmuxActive: true,
+                startedAt: '2026-05-08T05:00:00.000Z',
+                lastActivity: '2026-05-08T05:00:00.000Z',
+                branch: 'feature/pan-1024',
+                costSoFar: 0,
+                sessionId: 'session-1',
+                phase: 'implementation',
+              },
+            ]),
+            warnOnBareNumericIssueIds: vi.fn(),
+          }))
+        },
+      },
+    )
+
+    expect(diffCheckpointFiles).toHaveBeenCalledTimes(200)
+    expect(diffCheckpointFiles).toHaveBeenNthCalledWith(1, '/tmp/pan-1024', 'turn-5', 'turn-6')
+    expect(diffCheckpointFiles).toHaveBeenLastCalledWith('/tmp/pan-1024', 'turn-204', 'turn-205')
+    expect(summaries[0].turnId).toBe('turn-6')
+    expect(summaries[0].checkpointTurnCount).toBe(6)
+    expect(summaries.at(-1)?.turnId).toBe('turn-205')
+    expect(summaries.at(-1)?.checkpointTurnCount).toBe(205)
   }, 30000)
 })
 

--- a/src/dashboard/server/read-model.ts
+++ b/src/dashboard/server/read-model.ts
@@ -12,7 +12,7 @@
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { Effect, Layer, Context } from 'effect';
-import type { DashboardSnapshot, DomainEvent } from '@panctl/contracts';
+import type { DashboardSnapshot, DomainEvent, TurnDiffSummary } from '@panctl/contracts';
 import { AGENTS_DIR } from '../../lib/paths.js';
 import {
   type ReadModelState,
@@ -128,6 +128,8 @@ export interface ReadModelServiceShape {
   readonly getResolvedChannelPermissionDecision: (
     requestId: string,
   ) => Effect.Effect<import('@panctl/contracts').ResolvedChannelPermissionDecision | null>;
+  /** Return in-memory turn diff summaries for a single agent. */
+  readonly getTurnDiffSummaries: (agentId: string) => Effect.Effect<TurnDiffSummary[]>;
   /** Apply a domain event to the read model (called by event store on append). */
   readonly applyEvent: (event: DomainEvent) => void;
   /** Bootstrap the read model from existing lib module state. */
@@ -149,18 +151,14 @@ export const ReadModelServiceLive = Layer.effect(
     // Reference to projection cache — set during bootstrap once the event store initializes it
     let projectionCache: import('./services/projection-cache.js').ProjectionCache | null = null;
 
-    function sanitizeTurnDiffs(
-      raw: ReadModelState['turnDiffSummariesByAgentId'],
-    ): DashboardSnapshot['turnDiffSummariesByAgentId'] {
-      const out: Record<string, Array<{ turnId: string; completedAt: string; status?: string; files: any[]; checkpointRef?: string; assistantMessageId?: string; checkpointTurnCount?: number }>> = {};
-      for (const [agentId, summaries] of Object.entries(raw)) {
-        out[agentId] = summaries.map(s => ({
-          ...s,
-          assistantMessageId: s.assistantMessageId ?? undefined,
-          checkpointRef: s.checkpointRef ?? undefined,
-        }));
-      }
-      return out;
+    function cloneTurnDiffSummaries(summaries: TurnDiffSummary[] | undefined): TurnDiffSummary[] {
+      if (!summaries || summaries.length === 0) return [];
+      return summaries.map(summary => ({
+        ...summary,
+        files: summary.files.map(file => ({ ...file })),
+        assistantMessageId: summary.assistantMessageId ?? undefined,
+        checkpointRef: summary.checkpointRef ?? undefined,
+      }));
     }
 
     function buildSnapshot(): DashboardSnapshot {
@@ -178,7 +176,6 @@ export const ReadModelServiceLive = Layer.effect(
         agents: Object.values(state.agentsById),
         specialists: Object.values(state.specialistsByName),
         reviewStatuses: Object.values(state.reviewStatusByIssueId),
-        turnDiffSummariesByAgentId: {},
         agentRuntimeById: state.agentRuntimeById,
         channelPermissionRequests: Object.values(state.channelPermissionRequestsById),
         issues: state.issuesRaw,
@@ -216,12 +213,15 @@ export const ReadModelServiceLive = Layer.effect(
     const getChannelPermissionRequest = (
       requestId: string,
     ): Effect.Effect<import('@panctl/contracts').ChannelPermissionRequestSnapshot | null> =>
-      Effect.succeed(state.channelPermissionRequestsById[requestId] ?? null);
+      Effect.succeed(state.channelPermissionRequestsById?.[requestId] ?? null);
 
     const getResolvedChannelPermissionDecision = (
       requestId: string,
     ): Effect.Effect<import('@panctl/contracts').ResolvedChannelPermissionDecision | null> =>
-      Effect.succeed(state.resolvedChannelPermissionDecisionsById[requestId] ?? null);
+      Effect.succeed(state.resolvedChannelPermissionDecisionsById?.[requestId] ?? null);
+
+    const getTurnDiffSummaries = (agentId: string): Effect.Effect<TurnDiffSummary[]> =>
+      Effect.sync(() => cloneTurnDiffSummaries(state.turnDiffSummariesByAgentId[agentId]));
 
     // ── Bootstrap inline during layer construction ───────────────────────────
     yield* Effect.gen(function* () {
@@ -337,7 +337,6 @@ export const ReadModelServiceLive = Layer.effect(
             reviewStatusByIssueId: Object.fromEntries(
               Object.values(statusMap).map((status) => [status.issueId, toReviewStatusSnapshot(status)]),
             ),
-            turnDiffSummariesByAgentId: (cached as any).turnDiffSummariesByAgentId ?? {},
             issuesRaw: cached.issues ?? [],
             resources: cached.resources,
           };
@@ -615,6 +614,7 @@ export const ReadModelServiceLive = Layer.effect(
       getSnapshot,
       getChannelPermissionRequest,
       getResolvedChannelPermissionDecision,
+      getTurnDiffSummaries,
       applyEvent,
       bootstrap: Effect.void,
     };

--- a/src/dashboard/server/read-model.ts
+++ b/src/dashboard/server/read-model.ts
@@ -183,7 +183,7 @@ export const ReadModelServiceLive = Layer.effect(
         specialists: Object.values(state.specialistsByName),
         reviewStatuses: Object.values(state.reviewStatusByIssueId),
         agentRuntimeById: state.agentRuntimeById,
-        channelPermissionRequests: Object.values(state.channelPermissionRequestsById),
+        channelPermissionRequests: Object.values(state.channelPermissionRequestsById ?? {}),
         issues: state.issuesRaw,
         resources: state.resources ?? undefined,
         timestamp: new Date().toISOString(),

--- a/src/dashboard/server/read-model.ts
+++ b/src/dashboard/server/read-model.ts
@@ -18,6 +18,8 @@ import {
   type ReadModelState,
   INITIAL_READ_MODEL_STATE,
   applyEvent as applyEventReducer,
+  isTerminalTurnDiffSummaryStatus,
+  trimTurnDiffSummaries,
 } from '@panctl/contracts';
 import type { AgentSnapshot, AgentStatus, AgentPhase, AgentResolution, ReviewStatusSnapshot, SpecialistSnapshot, SpecialistType, SpecialistState, ReviewStatusValue, TestStatusValue, MergeStatusValue, VerificationStatusValue } from '@panctl/contracts';
 import type { ReviewStatus } from '../../lib/review-status.js';
@@ -34,6 +36,10 @@ export async function discoverNewAgentIds(agentsDir: string, cachedIds: Set<stri
     return [];
   }
   return entries.filter(e => !cachedIds.has(e) && existsSync(join(agentsDir, e, 'state.json')));
+}
+
+export function shouldSkipCheckpointReconciliation(agent: Pick<AgentSnapshot, 'status' | 'workspace'>): boolean {
+  return !agent.workspace || isTerminalTurnDiffSummaryStatus(agent.status)
 }
 
 // ─── Cached event store reference (avoids async dynamic import on each pushUpdated) ──
@@ -495,10 +501,10 @@ export const ReadModelServiceLive = Layer.effect(
           const agents = Object.values(state.agentsById);
           let reconciled = 0;
           for (const agent of agents) {
-            const workspace = (agent as any).workspace as string | undefined;
-            if (!workspace) continue;
+            if (shouldSkipCheckpointReconciliation(agent)) continue;
 
-            const existingSummaries = state.turnDiffSummariesByAgentId[(agent as any).id];
+            const workspace = agent.workspace;
+            const existingSummaries = state.turnDiffSummariesByAgentId[agent.id];
             if (existingSummaries && existingSummaries.length > 0) continue;
 
             try {
@@ -538,7 +544,7 @@ export const ReadModelServiceLive = Layer.effect(
                   ...state,
                   turnDiffSummariesByAgentId: {
                     ...state.turnDiffSummariesByAgentId,
-                    [(agent as any).id]: summaries,
+                    [agent.id]: trimTurnDiffSummaries(summaries),
                   },
                 };
                 reconciled++;

--- a/src/dashboard/server/read-model.ts
+++ b/src/dashboard/server/read-model.ts
@@ -18,6 +18,7 @@ import {
   type ReadModelState,
   INITIAL_READ_MODEL_STATE,
   applyEvent as applyEventReducer,
+  getMaxTurnDiffSummariesPerAgent,
   isTerminalTurnDiffSummaryStatus,
   trimTurnDiffSummaries,
 } from '@panctl/contracts';
@@ -511,6 +512,12 @@ export const ReadModelServiceLive = Layer.effect(
               const checkpoints = await listCheckpoints(workspace);
               if (checkpoints.length === 0) continue;
 
+              const maxRetainedSummaries = getMaxTurnDiffSummariesPerAgent();
+              const retainedCheckpoints = checkpoints.length > maxRetainedSummaries
+                ? checkpoints.slice(-maxRetainedSummaries)
+                : checkpoints;
+              const checkpointOffset = checkpoints.length - retainedCheckpoints.length;
+
               const summaries: Array<{
                 turnId: string;
                 completedAt: string;
@@ -520,9 +527,10 @@ export const ReadModelServiceLive = Layer.effect(
                 checkpointTurnCount?: number;
               }> = [];
 
-              for (let i = 0; i < checkpoints.length; i++) {
-                const turnId = checkpoints[i];
-                const prevTurnId = i > 0 ? checkpoints[i - 1] : null;
+              for (let i = 0; i < retainedCheckpoints.length; i++) {
+                const absoluteIndex = checkpointOffset + i;
+                const turnId = retainedCheckpoints[i];
+                const prevTurnId = absoluteIndex > 0 ? checkpoints[absoluteIndex - 1] : null;
                 let files: Array<{ path: string; kind?: string; additions?: number; deletions?: number }> = [];
                 if (prevTurnId) {
                   try {
@@ -535,7 +543,7 @@ export const ReadModelServiceLive = Layer.effect(
                   completedAt,
                   files,
                   checkpointRef: `refs/pan/turn/${turnId}`,
-                  checkpointTurnCount: i + 1,
+                  checkpointTurnCount: absoluteIndex + 1,
                 });
               }
 

--- a/src/dashboard/server/routes/diffs.ts
+++ b/src/dashboard/server/routes/diffs.ts
@@ -55,7 +55,7 @@ const getDiffsRoute = HttpRouter.add(
         }
 
         const workspace: string | null = agent.workspace ?? null
-        const summaries = snapshot.turnDiffSummariesByAgentId?.[agentId] ?? []
+        const summaries = await Effect.runPromise(readModel.getTurnDiffSummaries(agentId))
 
         let checkpointTurns: string[] = []
         if (workspace) {

--- a/src/lib/cloister/merge-agent.ts
+++ b/src/lib/cloister/merge-agent.ts
@@ -196,17 +196,19 @@ async function verifyMergedBeforeLifecycle(issueId: string, projectPath: string,
   const refsToCheck = [branchName, `origin/${branchName}`];
   for (const ref of refsToCheck) {
     const quotedRef = shellQuote(ref);
-    const { stdout } = await execAsync(`git rev-parse --verify ${quotedRef} 2>/dev/null || true`, { cwd: projectPath });
-    if (!stdout.trim()) continue;
+    const revParseResult = await execAsync(`git rev-parse --verify ${quotedRef} 2>/dev/null || true`, { cwd: projectPath });
+    const refSha = typeof revParseResult?.stdout === 'string' ? revParseResult.stdout : '';
+    if (!refSha.trim()) continue;
 
     try {
       await execAsync(`git merge-base --is-ancestor ${quotedRef} origin/main`, { cwd: projectPath });
       return { merged: true, reason: `${ref} is an ancestor of origin/main` };
     } catch {
-      const { stdout: codeDiff } = await execAsync(
+      const diffResult = await execAsync(
         `git diff origin/main...${quotedRef} -- ':!.planning' ':!docs/prds' ':!.panopticon/prompts' 2>/dev/null || true`,
         { cwd: projectPath },
       );
+      const codeDiff = typeof diffResult?.stdout === 'string' ? diffResult.stdout : '';
       if (!codeDiff.trim()) {
         return { merged: true, reason: `${ref} has no remaining code diff against origin/main` };
       }

--- a/tests/dashboard/event-reducers.test.ts
+++ b/tests/dashboard/event-reducers.test.ts
@@ -182,6 +182,24 @@ describe('applyEvent — agent.stopped', () => {
     expect(next.agentsById['agent-2']).toEqual(agent2)
     expect(Object.keys(next.agentsById)).toHaveLength(1)
   })
+
+  it('drops stored turn diff summaries for the stopped agent', () => {
+    const state = makeState({
+      agentsById: { 'agent-1': baseAgent },
+      turnDiffSummariesByAgentId: {
+        'agent-1': [{ turnId: 'turn-1', completedAt: ts(), files: [] }],
+        'agent-2': [{ turnId: 'turn-2', completedAt: ts(), files: [] }],
+      },
+    })
+    const next = applyEvent(state, {
+      type: 'agent.stopped',
+      sequence: 4,
+      timestamp: ts(),
+      payload: { agentId: 'agent-1', issueId: 'PAN-1' },
+    })
+    expect(next.turnDiffSummariesByAgentId['agent-1']).toBeUndefined()
+    expect(next.turnDiffSummariesByAgentId['agent-2']).toEqual(state.turnDiffSummariesByAgentId['agent-2'])
+  })
 })
 
 describe('applyEvent — agent.status_changed', () => {
@@ -216,6 +234,48 @@ describe('applyEvent — agent.status_changed', () => {
       payload: { agentId: 'unknown', status: 'stopped' },
     })
     expect(next.sequence).toBe(5)
+  })
+
+  it('drops stored turn diff summaries when the agent enters a terminal status', () => {
+    const state = makeState({
+      agentsById: { 'agent-1': baseAgent },
+      turnDiffSummariesByAgentId: {
+        'agent-1': [{ turnId: 'turn-1', completedAt: ts(), files: [] }],
+      },
+    })
+    const next = applyEvent(state, {
+      type: 'agent.status_changed',
+      sequence: 5,
+      timestamp: ts(),
+      payload: { agentId: 'agent-1', status: 'stopped' },
+    })
+    expect(next.turnDiffSummariesByAgentId['agent-1']).toBeUndefined()
+  })
+})
+
+describe('applyEvent — agent.turn_diff_completed', () => {
+  it('retains only the latest 200 summaries per agent', () => {
+    const existing = Array.from({ length: 200 }, (_, index) => ({
+      turnId: `turn-${index + 1}`,
+      completedAt: `2026-05-08T05:${String(index).padStart(2, '0')}:00.000Z`,
+      files: [{ path: `src/file-${index + 1}.ts`, additions: 1, deletions: 0 }],
+    }))
+    const state = makeState({ turnDiffSummariesByAgentId: { 'agent-1': existing } })
+    const next = applyEvent(state, {
+      type: 'agent.turn_diff_completed',
+      sequence: 6,
+      timestamp: ts(),
+      payload: {
+        agentId: 'agent-1',
+        turnId: 'turn-201',
+        completedAt: '2026-05-08T09:21:00.000Z',
+        files: [{ path: 'src/file-201.ts', additions: 3, deletions: 1 }],
+      },
+    })
+
+    expect(next.turnDiffSummariesByAgentId['agent-1']).toHaveLength(200)
+    expect(next.turnDiffSummariesByAgentId['agent-1']?.[0]?.turnId).toBe('turn-2')
+    expect(next.turnDiffSummariesByAgentId['agent-1']?.at(-1)?.turnId).toBe('turn-201')
   })
 })
 
@@ -647,6 +707,25 @@ describe('applyEvent — workspace.deleted', () => {
     expect((next.issuesRaw[0] as any).canonicalStatus).toBe('todo')
     expect((next.issuesRaw[0] as any).state).toBe('todo')
   })
+
+  it('removes stored turn diff summaries for agents in the deleted workspace issue', () => {
+    const agent2: AgentSnapshot = { ...baseAgent, id: 'agent-2', issueId: 'PAN-2' }
+    const state = makeState({
+      agentsById: { 'agent-1': baseAgent, 'agent-2': agent2 },
+      turnDiffSummariesByAgentId: {
+        'agent-1': [{ turnId: 'turn-1', completedAt: ts(), files: [] }],
+        'agent-2': [{ turnId: 'turn-2', completedAt: ts(), files: [] }],
+      },
+    })
+    const next = applyEvent(state, {
+      type: 'workspace.deleted',
+      sequence: 8,
+      timestamp: ts(),
+      payload: { issueId: 'PAN-1' },
+    })
+    expect(next.turnDiffSummariesByAgentId['agent-1']).toBeUndefined()
+    expect(next.turnDiffSummariesByAgentId['agent-2']).toEqual(state.turnDiffSummariesByAgentId['agent-2'])
+  })
 })
 
 describe('applyEvent — workspace.aborted', () => {
@@ -686,5 +765,25 @@ describe('applyEvent — workspace.aborted', () => {
       payload: { issueId: 'PAN-1', sessionName: 'planning-pan-1' },
     })
     expect(next.agentsById).toEqual({})
+  })
+
+  it('removes turn diff summaries for the aborted planning session only', () => {
+    const planningAgent: AgentSnapshot = { ...baseAgent, id: 'planning-pan-1', issueId: 'PAN-1' }
+    const workAgent: AgentSnapshot = { ...baseAgent, id: 'agent-pan-1', issueId: 'PAN-1' }
+    const state = makeState({
+      agentsById: { 'planning-pan-1': planningAgent, 'agent-pan-1': workAgent },
+      turnDiffSummariesByAgentId: {
+        'planning-pan-1': [{ turnId: 'turn-plan', completedAt: ts(), files: [] }],
+        'agent-pan-1': [{ turnId: 'turn-work', completedAt: ts(), files: [] }],
+      },
+    })
+    const next = applyEvent(state, {
+      type: 'workspace.aborted',
+      sequence: 9,
+      timestamp: ts(),
+      payload: { issueId: 'PAN-1', sessionName: 'planning-pan-1' },
+    })
+    expect(next.turnDiffSummariesByAgentId['planning-pan-1']).toBeUndefined()
+    expect(next.turnDiffSummariesByAgentId['agent-pan-1']).toEqual(state.turnDiffSummariesByAgentId['agent-pan-1'])
   })
 })

--- a/tests/unit/lib/pan-444-post-merge-step0.test.ts
+++ b/tests/unit/lib/pan-444-post-merge-step0.test.ts
@@ -10,13 +10,25 @@ import { join } from 'path';
 const mockUnref = vi.hoisted(() => vi.fn());
 const mockSpawnChild = vi.hoisted(() => ({ pid: 12345, unref: mockUnref }));
 const mockSpawn = vi.hoisted(() => vi.fn(() => mockSpawnChild));
-const mockExec = vi.hoisted(() => vi.fn((_cmd: string, _opts: any, cb: any) => {
-  if (typeof _opts === 'function') _opts(null, '', '');
-  else if (cb) cb(null, '', '');
+const mockExec = vi.hoisted(() => vi.fn((cmd: string, _opts: any, cb: any) => {
+  const stdout = cmd.includes('git rev-parse --verify')
+    ? 'deadbeef\n'
+    : cmd.includes('gh pr list')
+      ? '[]'
+      : '';
+  const result = { stdout, stderr: '' };
+  if (typeof _opts === 'function') _opts(null, result);
+  else if (cb) cb(null, result);
 }));
 
 const kCustom = Symbol.for('nodejs.util.promisify.custom');
-(mockExec as any)[kCustom] = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
+(mockExec as any)[kCustom] = vi.fn(async (cmd: string) => {
+  if (cmd.includes('git rev-parse --verify')) return { stdout: 'deadbeef\n', stderr: '' };
+  if (cmd.includes('git merge-base --is-ancestor')) return { stdout: '', stderr: '' };
+  if (cmd.includes('git diff origin/main...')) return { stdout: '', stderr: '' };
+  if (cmd.includes('gh pr list')) return { stdout: '[]', stderr: '' };
+  return { stdout: '', stderr: '' };
+});
 
 vi.mock('child_process', () => ({
   spawn: mockSpawn,


### PR DESCRIPTION
Closes #1024

## Acceptance Criteria

- [x] Restore awaiting-input detection and indicators across dashboard surfaces

## Implementation Tasks

- [x] Bound per-agent turn diff history and skip terminal-agent reconciliation
- [x] Remove turn diff summaries from DashboardSnapshot and serve diffs from read-model state