### PR TITLE
Fix PAN-926 post-merge regressions

### DIFF
--- a/src/dashboard/frontend/src/components/search/SearchModal.test.tsx
+++ b/src/dashboard/frontend/src/components/search/SearchModal.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useQueryClient } from '@tanstack/react-query';
+import type { SearchResult } from '../../hooks/useSearch';
+import { SearchModal } from './SearchModal';
+
+const mockUseSearch = vi.fn();
+const mockPrefetchQuery = vi.fn().mockResolvedValue(undefined);
+
+HTMLCanvasElement.prototype.getContext = vi.fn(() => null) as any;
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: vi.fn(),
+}));
+
+vi.mock('../../hooks/useSearch', () => ({
+  useSearch: (...args: unknown[]) => mockUseSearch(...args),
+}));
+
+const searchResult: SearchResult = {
+  issue: {
+    id: '1',
+    identifier: 'PAN-123',
+    title: 'Fix dashboard search bug',
+    description: 'The search feature has a critical issue',
+    status: 'In Progress',
+    priority: 1,
+    labels: ['bug'],
+    url: 'https://example.com/PAN-123',
+    createdAt: '2024-01-01',
+    updatedAt: '2024-01-02',
+    source: 'linear',
+  },
+  score: 100,
+  matchType: 'identifier',
+};
+
+describe('SearchModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useQueryClient).mockReturnValue({
+      prefetchQuery: mockPrefetchQuery,
+    } as any);
+
+    mockUseSearch.mockImplementation((query: string) => {
+      if (query.length < 2) {
+        return {
+          groupedResults: {},
+          isSearching: false,
+          hasResults: false,
+          resultCount: 0,
+        };
+      }
+
+      return {
+        groupedResults: {
+          linear: [searchResult],
+        },
+        isSearching: false,
+        hasResults: true,
+        resultCount: 1,
+      };
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('selects issue and closes modal when search result is clicked', async () => {
+    const onClose = vi.fn();
+    const onSelectIssue = vi.fn();
+
+    render(
+      <SearchModal
+        isOpen={true}
+        onClose={onClose}
+        onSelectIssue={onSelectIssue}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Search issues...'), {
+      target: { value: 'PAN' },
+    });
+
+    fireEvent.click(await screen.findByText('Fix dashboard search bug'));
+
+    await waitFor(() => {
+      expect(onSelectIssue).toHaveBeenCalledWith('PAN-123');
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('opens tracker link without selecting issue or closing modal', async () => {
+    const onClose = vi.fn();
+    const onSelectIssue = vi.fn();
+    const windowOpen = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+    render(
+      <SearchModal
+        isOpen={true}
+        onClose={onClose}
+        onSelectIssue={onSelectIssue}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Search issues...'), {
+      target: { value: 'PAN' },
+    });
+
+    fireEvent.click(await screen.findByTitle('Open in tracker'));
+
+    expect(windowOpen).toHaveBeenCalledWith(
+      'https://example.com/PAN-123',
+      '_blank',
+      'noopener,noreferrer'
+    );
+    expect(onSelectIssue).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -2575,17 +2575,20 @@ export async function spawnAgent(options: SpawnOptions): Promise<AgentState> {
     }
   });
 
-  // Channels: dismiss the dev-channels confirmation dialog before any prompt
-  // delivery. Must run while we are still in the launch path so the channel
-  // listener is registered before deliverAgentMessage starts preferring the
-  // socket. Skipped when the agent was not eligible at launch time.
-  if (state.channelsEnabled) {
-    await dismissDevChannelsDialog(agentId);
-  }
+  // Channels: start dismissing the dev-channels confirmation dialog as soon as
+  // the tmux session exists, but only block on completion when we are about to
+  // deliver an initial prompt. Spawn-only callers should not sit in a 20s poll
+  // loop waiting for a dialog they may never need.
+  const dismissChannelsDialogPromise = state.channelsEnabled
+    ? dismissDevChannelsDialog(agentId).catch(() => undefined)
+    : null;
 
   // Send the initial prompt after Claude's interactive prompt is ready.
   // Wait for the session to be ready by polling tmux output for Claude's prompt.
   if (prompt) {
+    if (dismissChannelsDialogPromise) {
+      await dismissChannelsDialogPromise;
+    }
     // Wait for tmux session to exist and Claude to show its prompt
     let ready = false;
     for (let i = 0; i < 30; i++) {


### PR DESCRIPTION
## Summary
- add regression coverage for SearchModal result clicks vs external tracker clicks
- stop `spawnAgent()` from blocking spawn-only callers on dev-channels dialog dismissal
- land PAN-926 fixes that missed the already-merged feature branch

## Test plan
- [x] `npm run build:contracts && npm run typecheck`
- [x] `npm run lint`
- [x] `npx vitest run tests/integration/agent-spawning.test.ts src/dashboard/frontend/src/components/search/SearchModal.test.tsx --reporter=verbose`
- [ ] `npm test` *(currently fails on two unrelated latest-main tests: `tests/unit/cli/option-parsing.test.ts` and `src/lib/__tests__/agent-state-role.test.ts`)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)