### PR TITLE
PAN-1140

### DIFF
--- a/.claude/rules/single-deacon-invariant.md
+++ b/.claude/rules/single-deacon-invariant.md
@@ -4,6 +4,9 @@ Only one Deacon may run at a time per `~/.panopticon` state directory. Mounting
 `${HOME}/.panopticon` into a workspace devcontainer that also runs
 `dist/dashboard/server.js` creates a second Deacon racing the host's.
 
+For the broader workspace container contract, stack-health surfaces, and recovery
+commands, see `docs/WORKSPACE-CONTAINERS.md`.
+
 ### What goes wrong
 
 The container has its own tmux server. The host has its own tmux server. Both

--- a/.pan/spec.vbrief.json
+++ b/.pan/spec.vbrief.json
@@ -104,7 +104,7 @@
       {
         "id": "drop-desktop-devdeps-from-containers",
         "title": "Stop installing desktop-only deps (electron family) inside workspace containers",
-        "status": "pending",
+        "status": "completed",
         "priority": "medium",
         "created": "2026-05-16T22:05:00.000Z",
         "metadata": {
@@ -120,19 +120,19 @@
           {
             "id": "drop-desktop-devdeps-from-containers.ac1",
             "title": "Workspace init container logs contain no electron-related install warnings or postinstall failures after the change.",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "drop-desktop-devdeps-from-containers.ac2",
             "title": "`apps/desktop` build still succeeds on host (electron deps remain available where they're needed).",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "drop-desktop-devdeps-from-containers.ac3",
             "title": "Root `package.json` devDependencies no longer contain electron-family packages (if they were there to begin with).",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           }
         ]

--- a/.pan/spec.vbrief.json
+++ b/.pan/spec.vbrief.json
@@ -13,7 +13,7 @@
     "author": "agent:claude-opus-4-7",
     "sequence": 1,
     "created": "2026-05-16T22:05:00.000Z",
-    "updated": "2026-05-16T22:05:00.000Z",
+    "updated": "2026-05-16T22:17:35.204Z",
     "references": [
       { "uri": "https://github.com/eltmon/panopticon-cli/issues/1140", "label": "PAN-1140", "type": "issue" },
       { "uri": "infra/.devcontainer-template/docker-compose.devcontainer.yml.template", "label": "compose template", "type": "code" },
@@ -56,7 +56,7 @@
       {
         "id": "fix-init-script",
         "title": "Fix workspace init container so bun install + builds succeed (exit 0)",
-        "status": "pending",
+        "status": "completed",
         "priority": "high",
         "created": "2026-05-16T22:05:00.000Z",
         "metadata": {
@@ -72,31 +72,31 @@
           {
             "id": "fix-init-script.ac1",
             "title": "Init container in a fresh workspace exits 0 within 5 minutes of `docker compose ... up -d --build` (verified in this workspace's own stack as the acceptance target).",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "fix-init-script.ac2",
             "title": "Frontend and server containers transition from `Created` to `Up` (Running) after init succeeds, confirmed via `docker compose ps`.",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "fix-init-script.ac3",
             "title": "Template file (`infra/.devcontainer-template/docker-compose.devcontainer.yml.template`) and the rendered workspace copy both reflect the fix; no $HOME/.panopticon mount appears on the server service; PANOPTICON_DISABLE_DEACON=1 remains set on the server service.",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "fix-init-script.ac4",
             "title": "Init logs no longer show `husky: command not found` or `tsdown: command not found`; `bun install` resolves significantly more than 22 packages (devDeps included).",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "fix-init-script.ac5",
             "title": "Host-side `bun install` in the worktree still works after the change (verified by running it and confirming the husky git hooks installed correctly on the host).",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           }
         ]

--- a/.pan/spec.vbrief.json
+++ b/.pan/spec.vbrief.json
@@ -13,7 +13,7 @@
     "author": "agent:claude-opus-4-7",
     "sequence": 1,
     "created": "2026-05-16T22:05:00.000Z",
-    "updated": "2026-05-16T22:35:12.000Z",
+    "updated": "2026-05-16T22:42:15.000Z",
     "references": [
       { "uri": "https://github.com/eltmon/panopticon-cli/issues/1140", "label": "PAN-1140", "type": "issue" },
       { "uri": "infra/.devcontainer-template/docker-compose.devcontainer.yml.template", "label": "compose template", "type": "code" },
@@ -296,7 +296,7 @@
       {
         "id": "verify-rebuild-cmd",
         "title": "Verify (or add) `pan workspace rebuild <id>` for resetting a single stuck stack cleanly",
-        "status": "pending",
+        "status": "completed",
         "priority": "medium",
         "created": "2026-05-16T22:05:00.000Z",
         "metadata": {
@@ -312,19 +312,19 @@
           {
             "id": "verify-rebuild-cmd.ac1",
             "title": "`pan workspace rebuild <issue-id>` exists, is documented in `pan-workspace` skill, and successfully resets a stuck stack to a healthy state in a manual test.",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "verify-rebuild-cmd.ac2",
             "title": "The spawn-gate rejection message from `gate-agent-spawn-on-stack-health` references this command by exact name.",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "verify-rebuild-cmd.ac3",
             "title": "`pan workspace rebuild --help` is accurate; `scripts/lint-skills.sh` passes.",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           }
         ]

--- a/.pan/spec.vbrief.json
+++ b/.pan/spec.vbrief.json
@@ -332,7 +332,7 @@
       {
         "id": "docs-workspace-containers",
         "title": "Document the workspace container contract, failure surfaces, and break-glass flags",
-        "status": "pending",
+        "status": "completed",
         "priority": "low",
         "created": "2026-05-16T22:05:00.000Z",
         "metadata": {
@@ -348,13 +348,13 @@
           {
             "id": "docs-workspace-containers.ac1",
             "title": "New doc `docs/WORKSPACE-CONTAINERS.md` exists and covers init contract, stack health surfacing, spawn gate + --host, and the reap/rebuild commands.",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "docs-workspace-containers.ac2",
             "title": "CLAUDE.md links to the new doc; `.claude/rules/single-deacon-invariant.md` cross-links to it.",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           }
         ]

--- a/.pan/spec.vbrief.json
+++ b/.pan/spec.vbrief.json
@@ -1,78 +1,376 @@
 {
   "vBRIEFInfo": {
     "version": "0.5",
-    "author": "agent:claude-code",
-    "description": "PAN-977: Durable vBRIEF task graph control plane",
-    "created": "2026-05-09T00:00:00Z",
-    "updated": "2026-05-09T19:15:00Z"
+    "created": "2026-05-16T22:05:00.000Z",
+    "author": "panopticon-cli/0.0.0",
+    "description": "Plan for PAN-1140: Workspace init container fails on every workspace: husky + tsdown not found (exit 127)"
   },
   "plan": {
-    "id": "PAN-977",
-    "title": "Durable vBRIEF task graph control plane",
-    "status": "active",
-    "uid": "pan-977-durable-vbrief-task-graph",
-    "author": "agent:claude-code",
+    "id": "pan-1140",
+    "title": "Workspace init container fails on every workspace: husky + tsdown not found (exit 127)",
+    "status": "approved",
+    "uid": "c2a47e91-3d8f-4b6a-9c1e-2f5d8a3b6e9c",
+    "author": "agent:claude-opus-4-7",
     "sequence": 1,
-    "created": "2026-05-09T00:00:00Z",
-    "updated": "2026-05-09T19:15:00Z",
+    "created": "2026-05-16T22:05:00.000Z",
+    "updated": "2026-05-16T22:05:00.000Z",
     "references": [
-      { "uri": "https://github.com/eltmon/panopticon-cli/issues/977", "label": "PAN-977", "type": "issue" }
+      { "uri": "https://github.com/eltmon/panopticon-cli/issues/1140", "label": "PAN-1140", "type": "issue" },
+      { "uri": "infra/.devcontainer-template/docker-compose.devcontainer.yml.template", "label": "compose template", "type": "code" },
+      { "uri": "src/lib/agents.ts", "label": "spawnAgent / spawnRun", "type": "code" },
+      { "uri": "src/lib/cloister/deacon.ts", "label": "checkWorkspaceContainerHealth", "type": "code" },
+      { "uri": ".claude/rules/single-deacon-invariant.md", "label": "single-deacon invariant", "type": "doc" }
     ],
-    "tags": ["PAN-977", "vbrief", "swarm", "task-graph"],
-    "metadata": {
-      "pipeline": {
-        "phase": "phase-1-sqlite-authoritative",
-        "issueId": "PAN-977",
-        "sqliteAuthoritative": true,
-        "updatedAt": "2026-05-09T19:15:00Z"
-      }
-    },
+    "tags": ["docker", "workspace", "container", "init", "spawn-gating", "isolation"],
     "narratives": {
-      "Problem": "Panopticon swarm execution needs a durable task graph rooted in vBRIEF so agents can answer next/show/claim/done/block without relying on Beads as the canonical source of truth.",
-      "Proposal": "Add vBRIEF-native dispatch helpers, bounded active slices, persisted task operations with CAS and atomic writes, continue-state swarm runtime persistence, and pipeline mirror metadata while keeping SQLite authoritative for Phase 1 live runtime state."
+      "Problem": "Every workspace docker stack built in the past ~4 weeks has an init container exiting code 127 because `bun install` inside the container runs the `prepare: husky` script while husky (and tsdown) live in devDependencies that aren't getting installed. The frontend and server services hard-depend on `init: service_completed_successfully` and stay stuck in `Created` state forever, while the host-side agent spawn path is completely unaware of this failure and keeps spawning agents on the host. The user perceived they had docker workspace isolation; they did not.",
+      "Proposal": "Three-part fix scoped to NOT refactor host-side workspace lifecycle: (1) Make the init container actually succeed by setting NODE_ENV=development + HUSKY=0 and dropping desktop-only devDeps from container installs. (2) Add a workspace-stack health surface so init failures are loudly visible in pan status and the dashboard, not silent. (3) Gate the host-side agent spawn on workspace stack health for any project that has a compose_template configured — refuse spawn with a clear error when the stack is broken, and provide a `--host` break-glass flag with interactive confirmation for the explicit override case. Complete the cleanup story with `pan workspace reap` (remove orphaned Created-state stacks) and verify `pan workspace rebuild` exists for resetting a single stuck stack."
     },
+    "autoDecisions": [
+      {
+        "summary": "Interpret 'no silent host fallback' as a spawn-gate, not a process-relocation.",
+        "rationale": "Issue 'Out of scope' explicitly excludes refactoring the host-side workspace lifecycle and replacing the devcontainer pattern. Moving agent tmux sessions into containers would touch both. Gating the existing host spawn on workspace stack health respects scope while satisfying the strengthened acceptance criterion ('agent must not be spawned on the host as a fallback' when the stack is broken). Host execution behind an explicit `--host` flag is the documented break-glass."
+      },
+      {
+        "summary": "Combine NODE_ENV=development + HUSKY=0 + drop-desktop-devdeps as defense-in-depth in the init service rather than picking one.",
+        "rationale": "Each fix addresses a distinct failure mode visible in the issue logs (prod-only install resolving 22 packages → NODE_ENV; husky exit 127 → HUSKY=0; @electron/get postinstall error → desktop deps audit). All three are cheap, additive, and verifiable in isolation, so there is no benefit to gambling on one."
+      },
+      {
+        "summary": "Place reap/rebuild under existing `pan workspace` subcommand group, not new top-level verbs.",
+        "rationale": "Matches CLAUDE.md's skills↔CLI convention (`pan <verb>` => `pan-<verb>` skill) and avoids inflating the top-level verb namespace for a maintenance operation."
+      },
+      {
+        "summary": "Use `workspace.docker.compose_template` presence in project config as the trigger for spawn gating — no new global toggle.",
+        "rationale": "Projects without docker compose templates (plain forks, simple repos) keep current host-only behavior unchanged. Adding a new toggle would be a footgun. Projects that opt into docker isolation get the gate automatically."
+      },
+      {
+        "summary": "Stack-health snapshot reuses the existing docker-stats poller rather than calling `docker ps` per spawn.",
+        "rationale": "docker-stats already polls container state on a cadence. Spawn-gate decision should be O(1) read of in-memory state, not a fresh process spawn — satisfies CLAUDE.md's 'No Blocking Calls in Dashboard Server Code' rule and keeps spawn latency unchanged for the happy path."
+      },
+      {
+        "summary": "`pan workspace reap` defaults to dry-run; `--apply` is required to actually `docker compose down -v`.",
+        "rationale": "Destructive container teardown should never run by default. The user's stash-hygiene policy in CLAUDE.md ('measure twice, cut once') is the same posture. A dry-run preview is also useful as a diagnostic."
+      }
+    ],
     "items": [
       {
-        "id": "pan-977-task-graph",
-        "title": "Add vBRIEF-native task graph and persisted task operations",
-        "status": "completed",
-        "priority": "critical",
-        "metadata": { "difficulty": "complex", "issueLabel": "PAN-977", "files_scope": ["src/lib/vbrief/**"] },
-        "narrative": { "Action": "Implement next/show/claim/done/block semantics on vBRIEF items, including CAS, single-writer ownership, atomic write-back to .pan/spec.vbrief.json, and blocked-item dispatch exclusion." },
+        "id": "fix-init-script",
+        "title": "Fix workspace init container so bun install + builds succeed (exit 0)",
+        "status": "pending",
+        "priority": "high",
+        "created": "2026-05-16T22:05:00.000Z",
+        "metadata": {
+          "difficulty": "medium",
+          "issueLabel": "pan-1140",
+          "requiresInspection": true,
+          "inspectionDepth": "fast"
+        },
+        "narrative": {
+          "Action": "Edit `infra/.devcontainer-template/docker-compose.devcontainer.yml.template` (and the rendered copy at `.devcontainer/docker-compose.devcontainer.yml` in this workspace, so the agent can verify against its own stack) to add `NODE_ENV=development` and `HUSKY=0` to the `init` service `environment:` block, and tighten the install command so the husky `prepare` script is a no-op inside the container. Inspect `scripts/postinstall.mjs` first to decide whether bun's `--ignore-scripts` is safe; if postinstall is needed, prefer HUSKY=0 alone over --ignore-scripts. Keep the existing `PANOPTICON_DISABLE_DEACON=1` and no-${HOME}/.panopticon-mount invariants on the `server` service untouched."
+        },
         "subItems": [
-          { "id": "pan-977-task-graph.ac1", "title": "getDispatchableItems and task graph views exclude running, completed, cancelled, and blocked items", "status": "completed", "metadata": { "kind": "acceptance_criterion" } },
-          { "id": "pan-977-task-graph.ac2", "title": "Task operations mutate plan item and subItem status durably with expected sequence checks", "status": "completed", "metadata": { "kind": "acceptance_criterion" } },
-          { "id": "pan-977-task-graph.ac3", "title": "Plan writes use temp-file then rename and enforce one writer per worktree", "status": "completed", "metadata": { "kind": "acceptance_criterion" } }
+          {
+            "id": "fix-init-script.ac1",
+            "title": "Init container in a fresh workspace exits 0 within 5 minutes of `docker compose ... up -d --build` (verified in this workspace's own stack as the acceptance target).",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "fix-init-script.ac2",
+            "title": "Frontend and server containers transition from `Created` to `Up` (Running) after init succeeds, confirmed via `docker compose ps`.",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "fix-init-script.ac3",
+            "title": "Template file (`infra/.devcontainer-template/docker-compose.devcontainer.yml.template`) and the rendered workspace copy both reflect the fix; no $HOME/.panopticon mount appears on the server service; PANOPTICON_DISABLE_DEACON=1 remains set on the server service.",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "fix-init-script.ac4",
+            "title": "Init logs no longer show `husky: command not found` or `tsdown: command not found`; `bun install` resolves significantly more than 22 packages (devDeps included).",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "fix-init-script.ac5",
+            "title": "Host-side `bun install` in the worktree still works after the change (verified by running it and confirming the husky git hooks installed correctly on the host).",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          }
         ]
       },
       {
-        "id": "pan-977-active-slice",
-        "title": "Wire bounded active slices into work-agent prompts",
-        "status": "completed",
-        "priority": "high",
-        "metadata": { "difficulty": "medium", "issueLabel": "PAN-977", "files_scope": ["src/lib/cloister/work-agent-prompt.ts", "src/lib/vbrief/**"] },
-        "narrative": { "Action": "Generate work-agent prompt context from active vBRIEF slices by default and verify large-plan prompt-size reduction." },
+        "id": "drop-desktop-devdeps-from-containers",
+        "title": "Stop installing desktop-only deps (electron family) inside workspace containers",
+        "status": "pending",
+        "priority": "medium",
+        "created": "2026-05-16T22:05:00.000Z",
+        "metadata": {
+          "difficulty": "simple",
+          "issueLabel": "pan-1140",
+          "requiresInspection": false,
+          "inspectionDepth": "fast"
+        },
+        "narrative": {
+          "Action": "Identify devDependencies that are only needed for `apps/desktop` (electron, @electron/get, electron-builder, etc.) and verify they are scoped to the `apps/desktop` workspace package, not the root. If they live at the root, move them into `apps/desktop/package.json` devDeps. Re-verify init container logs show no `@electron/get missing` / electron-postinstall errors."
+        },
         "subItems": [
-          { "id": "pan-977-active-slice.ac1", "title": "Prompt generation includes bounded target item, dependency, acceptance criteria, and synthesis context instead of full-plan payloads", "status": "completed", "metadata": { "kind": "acceptance_criterion" } },
-          { "id": "pan-977-active-slice.ac2", "title": "Large outlier plan verification proves active slice payloads stay substantially smaller than full plan JSON", "status": "completed", "metadata": { "kind": "acceptance_criterion" } }
+          {
+            "id": "drop-desktop-devdeps-from-containers.ac1",
+            "title": "Workspace init container logs contain no electron-related install warnings or postinstall failures after the change.",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "drop-desktop-devdeps-from-containers.ac2",
+            "title": "`apps/desktop` build still succeeds on host (electron deps remain available where they're needed).",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "drop-desktop-devdeps-from-containers.ac3",
+            "title": "Root `package.json` devDependencies no longer contain electron-family packages (if they were there to begin with).",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          }
         ]
       },
       {
-        "id": "pan-977-pipeline-mirror",
-        "title": "Mirror pipeline state into vBRIEF metadata with SQLite authority boundary",
-        "status": "completed",
+        "id": "surface-init-failures",
+        "title": "Surface workspace stack health (init failure, stuck Created) in pan status and dashboard",
+        "status": "pending",
         "priority": "high",
-        "metadata": { "difficulty": "medium", "issueLabel": "PAN-977", "files_scope": ["src/lib/review-status.ts", "src/lib/vbrief/**"] },
-        "narrative": { "Action": "Write schema-conforming plan.metadata.pipeline mirrors on Cloister status transitions while documenting SQLite remains authoritative for live Phase 1 state." },
+        "created": "2026-05-16T22:05:00.000Z",
+        "metadata": {
+          "difficulty": "medium",
+          "issueLabel": "pan-1140",
+          "requiresInspection": false,
+          "inspectionDepth": "fast"
+        },
+        "narrative": {
+          "Action": "Add a `getWorkspaceStackHealth(issueId)` function (location: `src/lib/workspace/stack-health.ts` or co-located with `src/lib/docker-stats.ts`) that returns `{ healthy: boolean, reasons: string[], lastObserved: ISO8601 }`. Inputs: presence of `workspace.docker.compose_template` for the project, current docker-stats snapshot, and a stuck-Created threshold (default 120s). Outputs: healthy=false when init exited non-zero OR services are in Created/Exited state. Surface in (a) `pan status` text output (red line per broken workspace), (b) dashboard workspace card via a new field on the workspace snapshot RPC, and (c) activity stream as a single emit when health transitions from healthy → unhealthy."
+        },
         "subItems": [
-          { "id": "pan-977-pipeline-mirror.ac1", "title": "Nested pipeline mirror records verification, review, test, uat, merge, readyForMerge, and PR URL fields", "status": "completed", "metadata": { "kind": "acceptance_criterion" } },
-          { "id": "pan-977-pipeline-mirror.ac2", "title": "pan-oversee and dashboard readers can use the mirror as corroborating input without replacing SQLite", "status": "completed", "metadata": { "kind": "acceptance_criterion" } }
+          {
+            "id": "surface-init-failures.ac1",
+            "title": "`pan status` shows an explicit `STACK BROKEN` (or equivalent red) line for any workspace whose init exited non-zero or whose services are stuck in Created > 120s.",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "surface-init-failures.ac2",
+            "title": "Dashboard workspace card shows a visible error state (red badge or banner) for broken stacks within 30s of the failure being observable to docker-stats.",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "surface-init-failures.ac3",
+            "title": "Activity stream emits exactly one `workspace-stack-unhealthy` event per healthy→unhealthy transition (not on every poll cycle).",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "surface-init-failures.ac4",
+            "title": "No new execSync / readFileSync calls introduced into server-reachable code (lint passes; rule `no-execsync-server.md` honored).",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "surface-init-failures.ac5",
+            "title": "Unit test covers the threshold logic (Created < 120s = healthy, Created ≥ 120s = unhealthy, Exited non-zero = unhealthy, Up = healthy).",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          }
+        ]
+      },
+      {
+        "id": "gate-agent-spawn-on-stack-health",
+        "title": "Gate agent spawn on workspace docker stack health; add --host break-glass flag",
+        "status": "pending",
+        "priority": "high",
+        "created": "2026-05-16T22:05:00.000Z",
+        "metadata": {
+          "difficulty": "complex",
+          "issueLabel": "pan-1140",
+          "requiresInspection": true,
+          "inspectionDepth": "deep"
+        },
+        "narrative": {
+          "Action": "In `src/lib/agents.ts` `spawnAgent` AND `spawnRun`, before creating the tmux session: if the project for `options.issueId` has `workspace.docker.compose_template` configured and `options.allowHost !== true`, call `getWorkspaceStackHealth(issueId)`. If unhealthy, throw a clear error: `Workspace docker stack for ${issueId} is not healthy: ${reasons.join('; ')}. Run 'pan workspace rebuild ${issueId}' or retry with --host to override.` Add `--host` flag to the relevant CLI commands (`pan start`, `pan work`, and any direct spawn entrypoints) that maps to `allowHost: true` AND requires interactive confirmation (`Are you sure? This bypasses workspace isolation. (y/N)`); CI/non-TTY contexts also require `--yes`. Emit a `agent-spawn-blocked-stack-unhealthy` activity event when the gate blocks. Audit every call site that constructs an agent process (grep for `spawnAgent`, `spawnRun`, `createSessionAsync(.*agent-`) and document the audit result in a new `docs/SPAWN-GATING.md` note. Add a vitest case asserting that `spawnAgent` rejects when the stack is broken and the project has docker configured."
+        },
+        "subItems": [
+          {
+            "id": "gate-agent-spawn-on-stack-health.ac1",
+            "title": "`spawnAgent` and `spawnRun` reject (throw) when the project has compose_template configured AND `getWorkspaceStackHealth` returns unhealthy AND `allowHost` is not true.",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "gate-agent-spawn-on-stack-health.ac2",
+            "title": "The rejection message names the issue ID, lists the unhealthy reasons, and tells the operator the exact next step (`pan workspace rebuild <id>` or `--host`).",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "gate-agent-spawn-on-stack-health.ac3",
+            "title": "`--host` flag is wired through every CLI surface that can spawn an agent (`pan start`, `pan work` if present, dashboard spawn endpoints). Interactive use requires y/N confirmation; non-TTY requires explicit `--yes`.",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "gate-agent-spawn-on-stack-health.ac4",
+            "title": "Projects WITHOUT a `workspace.docker.compose_template` keep current behavior — no gate, no flag required, no regression in spawn latency.",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "gate-agent-spawn-on-stack-health.ac5",
+            "title": "Audit doc (`docs/SPAWN-GATING.md`) lists every spawn entrypoint reachable today and states whether it goes through the gate, with file:line references.",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "gate-agent-spawn-on-stack-health.ac6",
+            "title": "Vitest unit test asserts both branches: (a) stack unhealthy + docker project → spawn rejected; (b) stack unhealthy + `allowHost: true` → spawn proceeds with a logged warning.",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "gate-agent-spawn-on-stack-health.ac7",
+            "title": "Activity stream emits `agent-spawn-blocked-stack-unhealthy` (or equivalent) when the gate blocks, observable in the dashboard activity feed.",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "gate-agent-spawn-on-stack-health.ac8",
+            "title": "No code path inside `src/lib/agents.ts` calls `createSessionAsync(agentId, workspace, ...)` for a work/role agent without first either passing the gate or honoring `allowHost`; restartAgent and session-rotation paths are included in the audit.",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          }
+        ]
+      },
+      {
+        "id": "reap-stuck-workspace-stacks",
+        "title": "Add `pan workspace reap` to clean up orphaned Created-state workspace stacks",
+        "status": "pending",
+        "priority": "medium",
+        "created": "2026-05-16T22:05:00.000Z",
+        "metadata": {
+          "difficulty": "simple",
+          "issueLabel": "pan-1140",
+          "requiresInspection": false,
+          "inspectionDepth": "fast"
+        },
+        "narrative": {
+          "Action": "Add a `pan workspace reap [--days N] [--apply] [--yes]` subcommand that lists workspace docker stacks (containers matching `panopticon-feature-*`) in `Created` or `Exited (non-zero)` state older than N days (default 7). Default behavior is dry-run; `--apply` actually runs `docker compose down -v --remove-orphans` against the matching stack. Skip any stack whose `issueId` has an active agent state file in `~/.panopticon/agents/`. Update the `pan-workspace` skill (or sub-wrapper) so `scripts/lint-skills.sh` continues to pass."
+        },
+        "subItems": [
+          {
+            "id": "reap-stuck-workspace-stacks.ac1",
+            "title": "`pan workspace reap` lists candidates without modifying anything when run without `--apply`.",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "reap-stuck-workspace-stacks.ac2",
+            "title": "`pan workspace reap --apply` tears down each candidate via `docker compose down -v --remove-orphans` and prints success/failure per stack.",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "reap-stuck-workspace-stacks.ac3",
+            "title": "Stacks whose `issueId` has an active agent state file are skipped (never reaped automatically); skipped stacks are listed with a reason.",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "reap-stuck-workspace-stacks.ac4",
+            "title": "`pan workspace reap --help` is self-documenting and `scripts/lint-skills.sh` passes (skill ↔ CLI parity preserved).",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          }
+        ]
+      },
+      {
+        "id": "verify-rebuild-cmd",
+        "title": "Verify (or add) `pan workspace rebuild <id>` for resetting a single stuck stack cleanly",
+        "status": "pending",
+        "priority": "medium",
+        "created": "2026-05-16T22:05:00.000Z",
+        "metadata": {
+          "difficulty": "simple",
+          "issueLabel": "pan-1140",
+          "requiresInspection": false,
+          "inspectionDepth": "fast"
+        },
+        "narrative": {
+          "Action": "Inspect existing CLI for a `pan workspace rebuild` (or similarly named) verb. If it exists and works on a stuck stack, document it in the skill and reference it from the spawn-gate error message. If it does NOT exist, add a minimal command that: tears down the stack (`docker compose down -v --remove-orphans`), re-runs `ensureDevcontainer`, then `docker compose up -d --build` with the same compose file. Single-stack scope; not a bulk operation."
+        },
+        "subItems": [
+          {
+            "id": "verify-rebuild-cmd.ac1",
+            "title": "`pan workspace rebuild <issue-id>` exists, is documented in `pan-workspace` skill, and successfully resets a stuck stack to a healthy state in a manual test.",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "verify-rebuild-cmd.ac2",
+            "title": "The spawn-gate rejection message from `gate-agent-spawn-on-stack-health` references this command by exact name.",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "verify-rebuild-cmd.ac3",
+            "title": "`pan workspace rebuild --help` is accurate; `scripts/lint-skills.sh` passes.",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          }
+        ]
+      },
+      {
+        "id": "docs-workspace-containers",
+        "title": "Document the workspace container contract, failure surfaces, and break-glass flags",
+        "status": "pending",
+        "priority": "low",
+        "created": "2026-05-16T22:05:00.000Z",
+        "metadata": {
+          "difficulty": "simple",
+          "issueLabel": "pan-1140",
+          "requiresInspection": false,
+          "inspectionDepth": "fast"
+        },
+        "narrative": {
+          "Action": "Add or update `docs/WORKSPACE-CONTAINERS.md` covering: the init→frontend/server dependency chain; HUSKY=0 + NODE_ENV=development requirement for the init service; the single-deacon invariant cross-link; how stack health is surfaced (pan status + dashboard); the spawn gate behavior and `--host` break-glass; `pan workspace reap` and `pan workspace rebuild` usage. Cross-link from CLAUDE.md's existing workspace section and from `.claude/rules/single-deacon-invariant.md`."
+        },
+        "subItems": [
+          {
+            "id": "docs-workspace-containers.ac1",
+            "title": "New doc `docs/WORKSPACE-CONTAINERS.md` exists and covers init contract, stack health surfacing, spawn gate + --host, and the reap/rebuild commands.",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          },
+          {
+            "id": "docs-workspace-containers.ac2",
+            "title": "CLAUDE.md links to the new doc; `.claude/rules/single-deacon-invariant.md` cross-links to it.",
+            "status": "pending",
+            "metadata": { "kind": "acceptance_criterion" }
+          }
         ]
       }
     ],
     "edges": [
-      { "from": "pan-977-task-graph", "to": "pan-977-active-slice", "type": "blocks" },
-      { "from": "pan-977-task-graph", "to": "pan-977-pipeline-mirror", "type": "blocks" }
+      { "from": "fix-init-script", "to": "surface-init-failures", "type": "blocks" },
+      { "from": "fix-init-script", "to": "gate-agent-spawn-on-stack-health", "type": "blocks" },
+      { "from": "fix-init-script", "to": "verify-rebuild-cmd", "type": "blocks" },
+      { "from": "fix-init-script", "to": "reap-stuck-workspace-stacks", "type": "blocks" },
+      { "from": "drop-desktop-devdeps-from-containers", "to": "fix-init-script", "type": "informs" },
+      { "from": "surface-init-failures", "to": "gate-agent-spawn-on-stack-health", "type": "blocks" },
+      { "from": "verify-rebuild-cmd", "to": "gate-agent-spawn-on-stack-health", "type": "informs" },
+      { "from": "gate-agent-spawn-on-stack-health", "to": "docs-workspace-containers", "type": "informs" },
+      { "from": "reap-stuck-workspace-stacks", "to": "docs-workspace-containers", "type": "informs" },
+      { "from": "verify-rebuild-cmd", "to": "docs-workspace-containers", "type": "informs" }
     ]
   }
 }

--- a/.pan/spec.vbrief.json
+++ b/.pan/spec.vbrief.json
@@ -188,7 +188,7 @@
       {
         "id": "gate-agent-spawn-on-stack-health",
         "title": "Gate agent spawn on workspace docker stack health; add --host break-glass flag",
-        "status": "pending",
+        "status": "completed",
         "priority": "high",
         "created": "2026-05-16T22:05:00.000Z",
         "metadata": {
@@ -204,49 +204,49 @@
           {
             "id": "gate-agent-spawn-on-stack-health.ac1",
             "title": "`spawnAgent` and `spawnRun` reject (throw) when the project has compose_template configured AND `getWorkspaceStackHealth` returns unhealthy AND `allowHost` is not true.",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "gate-agent-spawn-on-stack-health.ac2",
             "title": "The rejection message names the issue ID, lists the unhealthy reasons, and tells the operator the exact next step (`pan workspace rebuild <id>` or `--host`).",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "gate-agent-spawn-on-stack-health.ac3",
             "title": "`--host` flag is wired through every CLI surface that can spawn an agent (`pan start`, `pan work` if present, dashboard spawn endpoints). Interactive use requires y/N confirmation; non-TTY requires explicit `--yes`.",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "gate-agent-spawn-on-stack-health.ac4",
             "title": "Projects WITHOUT a `workspace.docker.compose_template` keep current behavior — no gate, no flag required, no regression in spawn latency.",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "gate-agent-spawn-on-stack-health.ac5",
             "title": "Audit doc (`docs/SPAWN-GATING.md`) lists every spawn entrypoint reachable today and states whether it goes through the gate, with file:line references.",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "gate-agent-spawn-on-stack-health.ac6",
             "title": "Vitest unit test asserts both branches: (a) stack unhealthy + docker project → spawn rejected; (b) stack unhealthy + `allowHost: true` → spawn proceeds with a logged warning.",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "gate-agent-spawn-on-stack-health.ac7",
             "title": "Activity stream emits `agent-spawn-blocked-stack-unhealthy` (or equivalent) when the gate blocks, observable in the dashboard activity feed.",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "gate-agent-spawn-on-stack-health.ac8",
             "title": "No code path inside `src/lib/agents.ts` calls `createSessionAsync(agentId, workspace, ...)` for a work/role agent without first either passing the gate or honoring `allowHost`; restartAgent and session-rotation paths are included in the audit.",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           }
         ]

--- a/.pan/spec.vbrief.json
+++ b/.pan/spec.vbrief.json
@@ -13,7 +13,7 @@
     "author": "agent:claude-opus-4-7",
     "sequence": 1,
     "created": "2026-05-16T22:05:00.000Z",
-    "updated": "2026-05-16T22:17:35.204Z",
+    "updated": "2026-05-16T22:35:12.000Z",
     "references": [
       { "uri": "https://github.com/eltmon/panopticon-cli/issues/1140", "label": "PAN-1140", "type": "issue" },
       { "uri": "infra/.devcontainer-template/docker-compose.devcontainer.yml.template", "label": "compose template", "type": "code" },
@@ -254,7 +254,7 @@
       {
         "id": "reap-stuck-workspace-stacks",
         "title": "Add `pan workspace reap` to clean up orphaned Created-state workspace stacks",
-        "status": "pending",
+        "status": "completed",
         "priority": "medium",
         "created": "2026-05-16T22:05:00.000Z",
         "metadata": {
@@ -270,25 +270,25 @@
           {
             "id": "reap-stuck-workspace-stacks.ac1",
             "title": "`pan workspace reap` lists candidates without modifying anything when run without `--apply`.",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "reap-stuck-workspace-stacks.ac2",
             "title": "`pan workspace reap --apply` tears down each candidate via `docker compose down -v --remove-orphans` and prints success/failure per stack.",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "reap-stuck-workspace-stacks.ac3",
             "title": "Stacks whose `issueId` has an active agent state file are skipped (never reaped automatically); skipped stacks are listed with a reason.",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "reap-stuck-workspace-stacks.ac4",
             "title": "`pan workspace reap --help` is self-documenting and `scripts/lint-skills.sh` passes (skill ↔ CLI parity preserved).",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           }
         ]

--- a/.pan/spec.vbrief.json
+++ b/.pan/spec.vbrief.json
@@ -140,7 +140,7 @@
       {
         "id": "surface-init-failures",
         "title": "Surface workspace stack health (init failure, stuck Created) in pan status and dashboard",
-        "status": "pending",
+        "status": "completed",
         "priority": "high",
         "created": "2026-05-16T22:05:00.000Z",
         "metadata": {
@@ -156,31 +156,31 @@
           {
             "id": "surface-init-failures.ac1",
             "title": "`pan status` shows an explicit `STACK BROKEN` (or equivalent red) line for any workspace whose init exited non-zero or whose services are stuck in Created > 120s.",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "surface-init-failures.ac2",
             "title": "Dashboard workspace card shows a visible error state (red badge or banner) for broken stacks within 30s of the failure being observable to docker-stats.",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "surface-init-failures.ac3",
             "title": "Activity stream emits exactly one `workspace-stack-unhealthy` event per healthy→unhealthy transition (not on every poll cycle).",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "surface-init-failures.ac4",
             "title": "No new execSync / readFileSync calls introduced into server-reachable code (lint passes; rule `no-execsync-server.md` honored).",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           },
           {
             "id": "surface-init-failures.ac5",
             "title": "Unit test covers the threshold logic (Created < 120s = healthy, Created ≥ 120s = unhealthy, Exited non-zero = unhealthy, Up = healthy).",
-            "status": "pending",
+            "status": "completed",
             "metadata": { "kind": "acceptance_criterion" }
           }
         ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,9 @@ own `node_modules` created by `bun install` — **never symlink node_modules fro
 Symlinks break local workspace package resolution (e.g., `@panctl/contracts` would
 resolve to the main repo's stale build instead of the worktree's version).
 
+See [docs/WORKSPACE-CONTAINERS.md](docs/WORKSPACE-CONTAINERS.md) for the workspace
+container contract, stack-health surfaces, spawn gate, and recovery commands.
+
 **Before running builds or tests in a workspace:**
 1. Run `bun install` from the workspace root (creates correct workspace-aware node_modules)
 2. If you modified `packages/contracts/`, rebuild: `cd packages/contracts && npm run build`

--- a/docs/QUICK-REFERENCE.md
+++ b/docs/QUICK-REFERENCE.md
@@ -38,7 +38,7 @@ Act on an issue. `<id>` is the universal object.
 | `pan recover <id>` | Recover a crashed or stopped agent |
 | `pan kill <id>` | Stop the agent (workspace preserved) |
 | `pan sync-main <id>` | Merge latest `main` into the workspace branch |
-| `pan swarm <id>` | Per-item DAG dispatch across plan items (slot-per-item). See [SWARM.md](./SWARM.md). `--dry-run`, `--max-slots`, `--auto-advance`, `--task <next\|show\|claim\|done\|block\|unblock\|cancel>` |
+| `pan swarm <id>` | Per-item DAG dispatch across plan items (slot-per-item). See [SWARM.md](./SWARM.md). `--dry-run`, `--max-slots`, `--auto-advance`, `--host`, `--task <next\|show\|claim\|done\|block\|unblock\|cancel>` |
 | `pan done <id>` | Mark work complete → tracker "In Review". Agent stays on standby for UAT tweaks via `pan tell`. |
 | Dashboard MERGE | Click MERGE button when review passes (handles rebase, verify, merge, cleanup) |
 | `pan inspect <id>` | Request human inspection before proceeding |

--- a/docs/SPAWN-GATING.md
+++ b/docs/SPAWN-GATING.md
@@ -16,8 +16,8 @@ If `allowHost` is true, the gate emits `agent-spawn-host-override` and persists 
 ## CLI and dashboard break-glass
 
 - `src/cli/index.ts:410` registers `pan start <id>`.
-- `src/cli/index.ts:413` adds `--host`; `src/cli/index.ts:414` adds `--yes` for non-interactive confirmation.
-- `src/cli/commands/start.ts:124` prompts `Are you sure? This bypasses workspace isolation. (y/N)` for interactive `--host` and requires `--yes` when stdin is not a TTY.
+- `src/cli/index.ts:413` adds `--host`; `src/cli/index.ts:414` adds `--yes` to confirm without an interactive prompt.
+- `src/cli/commands/start.ts:124` accepts explicit `--host --yes` before prompting; otherwise it prompts `Are you sure? This bypasses workspace isolation. (y/N)` for interactive `--host` and requires `--yes` when stdin is not a TTY.
 - `src/cli/commands/start.ts:1009` passes `allowHost` into `spawnAgent()`.
 - `src/cli/index.ts:418` registers `pan swarm <id>`.
 - `src/cli/index.ts:426` adds `--host`; `src/cli/index.ts:427` adds `--yes` for non-interactive confirmation.

--- a/docs/SPAWN-GATING.md
+++ b/docs/SPAWN-GATING.md
@@ -16,8 +16,8 @@ If `allowHost` is true, the gate emits `agent-spawn-host-override` and persists 
 ## CLI and dashboard break-glass
 
 - `src/cli/index.ts:410` registers `pan start <id>`.
-- `src/cli/index.ts:413` adds `--host`; `src/cli/index.ts:414` adds `--yes` to confirm without an interactive prompt.
-- `src/cli/commands/start.ts:124` accepts explicit `--host --yes` before prompting; otherwise it prompts `Are you sure? This bypasses workspace isolation. (y/N)` for interactive `--host` and requires `--yes` when stdin is not a TTY.
+- `src/cli/index.ts:413` adds `--host`; `src/cli/index.ts:414` adds `--yes` for non-interactive confirmation.
+- `src/cli/commands/start.ts:124` always prompts `Are you sure? This bypasses workspace isolation. (y/N)` for interactive `--host`, even when `--yes` is present, and requires `--yes` when stdin is not a TTY.
 - `src/cli/commands/start.ts:1009` passes `allowHost` into `spawnAgent()`.
 - `src/cli/index.ts:418` registers `pan swarm <id>`.
 - `src/cli/index.ts:426` adds `--host`; `src/cli/index.ts:427` adds `--yes` for non-interactive confirmation.

--- a/docs/SPAWN-GATING.md
+++ b/docs/SPAWN-GATING.md
@@ -9,17 +9,19 @@ Agent starts for projects with `workspace.docker.compose_template` must pass wor
 - `src/lib/agents.ts:2102` gates `spawnAgent()` before hook initialization, beads checks, state writes, or work-agent tmux creation.
 - `src/lib/agents.ts:2704`, `src/lib/agents.ts:2873`, `src/lib/agents.ts:3032`, and `src/lib/agents.ts:3198` gate fallback relaunch, resume, restart, and crash recovery before they create replacement tmux sessions.
 
+The spawn gate reads the cached Docker lifecycle snapshot maintained by `DockerStatsCollector`; it does not run `docker ps` or any Docker subprocess on the spawn path. CLI/status/manual diagnostics can still collect Docker state explicitly and pass it into stack-health evaluation.
+
 If `allowHost` is true, the gate emits `agent-spawn-host-override` and persists `hostOverride` on the agent state so later resume/restart/recovery paths honor the same operator decision.
 
 ## CLI and dashboard break-glass
 
-- `src/cli/index.ts:403` registers `pan start <id>`.
+- `src/cli/index.ts:410` registers `pan start <id>`.
 - `src/cli/index.ts:413` adds `--host`; `src/cli/index.ts:414` adds `--yes` for non-interactive confirmation.
-- `src/cli/commands/start.ts:121` prompts `Are you sure? This bypasses workspace isolation. (y/N)` for interactive `--host` and requires `--yes` when stdin is not a TTY.
-- `src/cli/commands/start.ts:965` passes `allowHost` into `spawnAgent()`.
+- `src/cli/commands/start.ts:124` prompts `Are you sure? This bypasses workspace isolation. (y/N)` for interactive `--host` and requires `--yes` when stdin is not a TTY.
+- `src/cli/commands/start.ts:972` passes `allowHost` into `spawnAgent()`.
 - `src/dashboard/server/routes/agents.ts:1765` accepts an explicit dashboard host override request.
-- `src/dashboard/server/routes/agents.ts:2551` and `src/dashboard/server/routes/agents.ts:2609` pass `--host --yes` to the detached `pan start` child only when the request explicitly set `host` or `allowHost`.
-- `src/dashboard/server/services/agent-spawner.ts:166` passes `allowHost` through its direct `spawnAgent()` service path.
+- `src/dashboard/server/routes/agents.ts:2554` and `src/dashboard/server/routes/agents.ts:2612` pass `--host --yes` to the detached `pan start` child only when the request explicitly set `host` or `allowHost`.
+- `src/dashboard/server/services/agent-spawner.ts:172` passes `allowHost` through its direct `spawnAgent()` service path.
 
 There is no `pan work` spawn command today; the CLI audit found only `pan start <id>` as the direct work-agent start surface.
 

--- a/docs/SPAWN-GATING.md
+++ b/docs/SPAWN-GATING.md
@@ -1,0 +1,45 @@
+# Spawn Gating
+
+Agent starts for projects with `workspace.docker.compose_template` must pass workspace stack health before creating a tmux session. The gate refuses unhealthy Docker-backed workspaces and tells the operator to run `pan workspace rebuild <issue-id>` or explicitly retry with `--host`.
+
+## Central gate
+
+- `src/lib/agents.ts:1808` defines `assertWorkspaceStackHealthyForSpawn(issueId, role, allowHost)`.
+- `src/lib/agents.ts:1864` gates `spawnRun()` before role-run state or tmux session creation.
+- `src/lib/agents.ts:2102` gates `spawnAgent()` before hook initialization, beads checks, state writes, or work-agent tmux creation.
+- `src/lib/agents.ts:2704`, `src/lib/agents.ts:2873`, `src/lib/agents.ts:3032`, and `src/lib/agents.ts:3198` gate fallback relaunch, resume, restart, and crash recovery before they create replacement tmux sessions.
+
+If `allowHost` is true, the gate emits `agent-spawn-host-override` and persists `hostOverride` on the agent state so later resume/restart/recovery paths honor the same operator decision.
+
+## CLI and dashboard break-glass
+
+- `src/cli/index.ts:403` registers `pan start <id>`.
+- `src/cli/index.ts:413` adds `--host`; `src/cli/index.ts:414` adds `--yes` for non-interactive confirmation.
+- `src/cli/commands/start.ts:121` prompts `Are you sure? This bypasses workspace isolation. (y/N)` for interactive `--host` and requires `--yes` when stdin is not a TTY.
+- `src/cli/commands/start.ts:965` passes `allowHost` into `spawnAgent()`.
+- `src/dashboard/server/routes/agents.ts:1765` accepts an explicit dashboard host override request.
+- `src/dashboard/server/routes/agents.ts:2551` and `src/dashboard/server/routes/agents.ts:2609` pass `--host --yes` to the detached `pan start` child only when the request explicitly set `host` or `allowHost`.
+- `src/dashboard/server/services/agent-spawner.ts:166` passes `allowHost` through its direct `spawnAgent()` service path.
+
+There is no `pan work` spawn command today; the CLI audit found only `pan start <id>` as the direct work-agent start surface.
+
+## Spawn entrypoint audit
+
+- `src/lib/agents.ts:1844` `spawnRun()` is the role-run choke point for review, test, and ship roles; it gates non-work roles directly and delegates work to `spawnAgent()`.
+- `src/lib/agents.ts:2091` `spawnAgent()` is the work-agent choke point; dashboard direct services, swarm slots, merge-prep recovery, and handoff all flow through it.
+- `src/lib/cloister/review-agent.ts:335` and `src/lib/cloister/review-agent.ts:525` start review roles through `spawnRun()`.
+- `src/lib/cloister/test-agent-queue.ts:85`, `src/lib/cloister/deacon.ts:1568`, `src/lib/cloister/deacon.ts:1745`, and `src/dashboard/server/routes/workspaces.ts:3602` start test roles through `spawnRun()`.
+- `src/lib/cloister/merge-agent.ts:1149` starts ship roles through `spawnRun()`.
+- `src/lib/cloister/service.ts:350` starts reactive lifecycle roles through `spawnRun()`.
+- `src/dashboard/server/services/agent-spawner.ts:166`, `src/dashboard/server/routes/workspaces.ts:267`, `src/dashboard/server/routes/swarm.ts:1009`, and `src/lib/cloister/handoff.ts:136` start work agents through `spawnAgent()`.
+- `src/dashboard/server/routes/agents.ts:2551` and `src/dashboard/server/routes/agents.ts:2609` shell out to `pan start`, which reaches `spawnAgent()`.
+
+## Non-agent tmux sessions
+
+The following `createSessionAsync()` uses do not create work or role agents and are outside the stack-health gate:
+
+- `src/lib/planning/spawn-planning-session.ts:557` creates planning sessions. Planning is intentionally exempt because it produces the workspace plan before work starts.
+- `src/lib/cloister/inspect-agent.ts:263` creates inspection sessions after work; inspection is not a work/role spawn path.
+- `src/lib/cloister/deacon.ts:812` resumes an existing agent launcher path from saved runtime state rather than constructing a fresh work/role spawn.
+- `src/lib/runtimes/pi.ts:338`, `src/lib/runtimes/claude-code.ts:340`, and `src/lib/runtime/claude.ts:72` are runtime abstractions not used by the Panopticon work/role spawn chokepoints documented above.
+- Dashboard utility sessions under `src/dashboard/server/routes/misc.ts`, `src/dashboard/server/routes/codex-auth.ts`, and `src/dashboard/server/routes/conversations.ts` are interactive/user utility sessions, not autonomous work/role agents.

--- a/docs/SPAWN-GATING.md
+++ b/docs/SPAWN-GATING.md
@@ -18,9 +18,9 @@ If `allowHost` is true, the gate emits `agent-spawn-host-override` and persists 
 - `src/cli/index.ts:410` registers `pan start <id>`.
 - `src/cli/index.ts:413` adds `--host`; `src/cli/index.ts:414` adds `--yes` for non-interactive confirmation.
 - `src/cli/commands/start.ts:124` prompts `Are you sure? This bypasses workspace isolation. (y/N)` for interactive `--host` and requires `--yes` when stdin is not a TTY.
-- `src/cli/commands/start.ts:972` passes `allowHost` into `spawnAgent()`.
-- `src/dashboard/server/routes/agents.ts:1765` accepts an explicit dashboard host override request.
-- `src/dashboard/server/routes/agents.ts:2554` and `src/dashboard/server/routes/agents.ts:2612` pass `--host --yes` to the detached `pan start` child only when the request explicitly set `host` or `allowHost`.
+- `src/cli/commands/start.ts:1009` passes `allowHost` into `spawnAgent()`.
+- `src/dashboard/server/routes/agents.ts:1818` accepts an explicit dashboard host override request after origin validation and confirmation phrase validation.
+- `src/dashboard/server/routes/agents.ts:2640` and `src/dashboard/server/routes/agents.ts:2698` pass `--host --yes` to the detached `pan start` child only when the request explicitly set and confirmed `host` or `allowHost`.
 - `src/dashboard/server/services/agent-spawner.ts:172` passes `allowHost` through its direct `spawnAgent()` service path.
 
 There is no `pan work` spawn command today; the CLI audit found only `pan start <id>` as the direct work-agent start surface.
@@ -34,7 +34,7 @@ There is no `pan work` spawn command today; the CLI audit found only `pan start 
 - `src/lib/cloister/merge-agent.ts:1149` starts ship roles through `spawnRun()`.
 - `src/lib/cloister/service.ts:350` starts reactive lifecycle roles through `spawnRun()`.
 - `src/dashboard/server/services/agent-spawner.ts:166`, `src/dashboard/server/routes/workspaces.ts:267`, `src/dashboard/server/routes/swarm.ts:1009`, and `src/lib/cloister/handoff.ts:136` start work agents through `spawnAgent()`.
-- `src/dashboard/server/routes/agents.ts:2551` and `src/dashboard/server/routes/agents.ts:2609` shell out to `pan start`, which reaches `spawnAgent()`.
+- `src/dashboard/server/routes/agents.ts:2637` and `src/dashboard/server/routes/agents.ts:2695` shell out to `pan start`, which reaches `spawnAgent()`.
 
 ## Non-agent tmux sessions
 

--- a/docs/SPAWN-GATING.md
+++ b/docs/SPAWN-GATING.md
@@ -4,10 +4,10 @@ Agent starts for projects with `workspace.docker.compose_template` must pass wor
 
 ## Central gate
 
-- `src/lib/agents.ts:1808` defines `assertWorkspaceStackHealthyForSpawn(issueId, role, allowHost)`.
-- `src/lib/agents.ts:1864` gates `spawnRun()` before role-run state or tmux session creation.
-- `src/lib/agents.ts:2102` gates `spawnAgent()` before hook initialization, beads checks, state writes, or work-agent tmux creation.
-- `src/lib/agents.ts:2704`, `src/lib/agents.ts:2873`, `src/lib/agents.ts:3032`, and `src/lib/agents.ts:3198` gate fallback relaunch, resume, restart, and crash recovery before they create replacement tmux sessions.
+- `src/lib/agents.ts:1814` defines `assertWorkspaceStackHealthyForSpawn(issueId, role, allowHost)`.
+- `src/lib/agents.ts:1872` gates `spawnRun()` before role-run state or tmux session creation.
+- `src/lib/agents.ts:2117` gates `spawnAgent()` before hook initialization, beads checks, state writes, or work-agent tmux creation.
+- `src/lib/agents.ts:2719`, `src/lib/agents.ts:2890`, `src/lib/agents.ts:3051`, and `src/lib/agents.ts:3219` gate fallback relaunch, resume, restart, and crash recovery before they create replacement tmux sessions.
 
 The spawn gate reads the cached Docker lifecycle snapshot maintained by `DockerStatsCollector`; it does not run `docker ps` or any Docker subprocess on the spawn path. CLI/status/manual diagnostics can still collect Docker state explicitly and pass it into stack-health evaluation.
 
@@ -31,8 +31,8 @@ There is no `pan work` spawn command today; the CLI audit found `pan start <id>`
 
 ## Spawn entrypoint audit
 
-- `src/lib/agents.ts:1844` `spawnRun()` is the role-run choke point for review, test, and ship roles; it gates non-work roles directly and delegates work to `spawnAgent()`.
-- `src/lib/agents.ts:2091` `spawnAgent()` is the work-agent choke point; dashboard direct services, swarm slots, merge-prep recovery, and handoff all flow through it.
+- `src/lib/agents.ts:1851` `spawnRun()` is the role-run choke point for review, test, and ship roles; it gates non-work roles directly and delegates work to `spawnAgent()`.
+- `src/lib/agents.ts:2106` `spawnAgent()` is the work-agent choke point; dashboard direct services, swarm slots, merge-prep recovery, and handoff all flow through it.
 - `src/lib/cloister/review-agent.ts:335` and `src/lib/cloister/review-agent.ts:525` start review roles through `spawnRun()`.
 - `src/lib/cloister/test-agent-queue.ts:85`, `src/lib/cloister/deacon.ts:1568`, `src/lib/cloister/deacon.ts:1745`, and `src/dashboard/server/routes/workspaces.ts:3602` start test roles through `spawnRun()`.
 - `src/lib/cloister/merge-agent.ts:1149` starts ship roles through `spawnRun()`.

--- a/docs/SPAWN-GATING.md
+++ b/docs/SPAWN-GATING.md
@@ -20,8 +20,9 @@ If `allowHost` is true, the gate emits `agent-spawn-host-override` and persists 
 - `src/cli/commands/start.ts:124` prompts `Are you sure? This bypasses workspace isolation. (y/N)` for interactive `--host` and requires `--yes` when stdin is not a TTY.
 - `src/cli/commands/start.ts:1009` passes `allowHost` into `spawnAgent()`.
 - `src/dashboard/server/routes/agents.ts:1818` accepts an explicit dashboard host override request after origin validation and confirmation phrase validation.
-- `src/dashboard/server/routes/agents.ts:2640` and `src/dashboard/server/routes/agents.ts:2698` pass `--host --yes` to the detached `pan start` child only when the request explicitly set and confirmed `host` or `allowHost`.
+- `src/dashboard/server/routes/agents.ts:2652` and `src/dashboard/server/routes/agents.ts:2712` pass `--host --yes` to the `pan start` child only when the request explicitly set and confirmed `host` or `allowHost`.
 - `src/dashboard/server/services/agent-spawner.ts:172` passes `allowHost` through its direct `spawnAgent()` service path.
+- `src/dashboard/server/routes/swarm.ts:1743` requires the same confirmation phrase before `POST /api/swarm` accepts `host` or `allowHost`, and `src/dashboard/server/routes/swarm.ts:1014` passes `allowHost` into each swarm slot spawn only after confirmation.
 
 There is no `pan work` spawn command today; the CLI audit found only `pan start <id>` as the direct work-agent start surface.
 
@@ -34,7 +35,7 @@ There is no `pan work` spawn command today; the CLI audit found only `pan start 
 - `src/lib/cloister/merge-agent.ts:1149` starts ship roles through `spawnRun()`.
 - `src/lib/cloister/service.ts:350` starts reactive lifecycle roles through `spawnRun()`.
 - `src/dashboard/server/services/agent-spawner.ts:166`, `src/dashboard/server/routes/workspaces.ts:267`, `src/dashboard/server/routes/swarm.ts:1009`, and `src/lib/cloister/handoff.ts:136` start work agents through `spawnAgent()`.
-- `src/dashboard/server/routes/agents.ts:2637` and `src/dashboard/server/routes/agents.ts:2695` shell out to `pan start`, which reaches `spawnAgent()`.
+- `src/dashboard/server/routes/agents.ts:2649` and `src/dashboard/server/routes/agents.ts:2709` shell out to `pan start`, which reaches `spawnAgent()`.
 
 ## Non-agent tmux sessions
 

--- a/docs/SPAWN-GATING.md
+++ b/docs/SPAWN-GATING.md
@@ -19,12 +19,15 @@ If `allowHost` is true, the gate emits `agent-spawn-host-override` and persists 
 - `src/cli/index.ts:413` adds `--host`; `src/cli/index.ts:414` adds `--yes` for non-interactive confirmation.
 - `src/cli/commands/start.ts:124` prompts `Are you sure? This bypasses workspace isolation. (y/N)` for interactive `--host` and requires `--yes` when stdin is not a TTY.
 - `src/cli/commands/start.ts:1009` passes `allowHost` into `spawnAgent()`.
+- `src/cli/index.ts:418` registers `pan swarm <id>`.
+- `src/cli/index.ts:426` adds `--host`; `src/cli/index.ts:427` adds `--yes` for non-interactive confirmation.
+- `src/cli/commands/swarm.ts:89` prompts with the same interactive `--host` confirmation, requires `--yes` when stdin is not a TTY, and `src/cli/commands/swarm.ts:144` sends the server confirmation phrase to `POST /api/swarm`.
 - `src/dashboard/server/routes/agents.ts:1818` accepts an explicit dashboard host override request after origin validation and confirmation phrase validation.
 - `src/dashboard/server/routes/agents.ts:2652` and `src/dashboard/server/routes/agents.ts:2712` pass `--host --yes` to the `pan start` child only when the request explicitly set and confirmed `host` or `allowHost`.
 - `src/dashboard/server/services/agent-spawner.ts:172` passes `allowHost` through its direct `spawnAgent()` service path.
-- `src/dashboard/server/routes/swarm.ts:1743` requires the same confirmation phrase before `POST /api/swarm` accepts `host` or `allowHost`, and `src/dashboard/server/routes/swarm.ts:1014` passes `allowHost` into each swarm slot spawn only after confirmation.
+- `src/dashboard/server/routes/swarm.ts:1749` requires the same confirmation phrase before `POST /api/swarm` accepts `host` or `allowHost`, `src/dashboard/server/routes/swarm.ts:1095` persists the confirmed host override in swarm runtime state, and `src/dashboard/server/routes/swarm.ts:1020` passes `allowHost` into each swarm slot spawn only after confirmation.
 
-There is no `pan work` spawn command today; the CLI audit found only `pan start <id>` as the direct work-agent start surface.
+There is no `pan work` spawn command today; the CLI audit found `pan start <id>` and `pan swarm <id>` as direct work-agent start surfaces.
 
 ## Spawn entrypoint audit
 
@@ -36,6 +39,7 @@ There is no `pan work` spawn command today; the CLI audit found only `pan start 
 - `src/lib/cloister/service.ts:350` starts reactive lifecycle roles through `spawnRun()`.
 - `src/dashboard/server/services/agent-spawner.ts:166`, `src/dashboard/server/routes/workspaces.ts:267`, `src/dashboard/server/routes/swarm.ts:1009`, and `src/lib/cloister/handoff.ts:136` start work agents through `spawnAgent()`.
 - `src/dashboard/server/routes/agents.ts:2649` and `src/dashboard/server/routes/agents.ts:2709` shell out to `pan start`, which reaches `spawnAgent()`.
+- `src/cli/commands/swarm.ts:121` calls `POST /api/swarm`, which reaches `spawnAgent()` for each slot.
 
 ## Non-agent tmux sessions
 

--- a/docs/SWARM.md
+++ b/docs/SWARM.md
@@ -29,7 +29,7 @@ When a slot branch merges into the feature branch, the merge-agent fires a loopb
 
 ## CLI
 
-All swarm operations go through `pan swarm <id>`. Mutating operations forward to the dashboard's `POST /api/swarm` endpoint over the internal-token authenticated path; read-only and task-mutation operations resolve the workspace directly.
+All swarm operations go through `pan swarm <id>`. Mutating operations forward to the dashboard's `POST /api/swarm` endpoint over the internal-token authenticated path; read-only and task-mutation operations resolve the workspace directly. `--host` is a confirmed break-glass path for unhealthy Docker-backed workspace stacks; with `--auto-advance`, the confirmed override is persisted in swarm runtime state so later auto-dispatched slots use the same operator decision.
 
 ### Dispatch
 
@@ -41,6 +41,8 @@ pan swarm <id> --max-slots <n>       # Cap concurrency
 pan swarm <id> --model <model>       # Override slot-agent model (default kimi-k2.6)
 pan swarm <id> --auto-advance        # Auto-dispatch newly-ready items as slots merge
 pan swarm <id> --no-auto-advance     # Manual mode; explicit `pan swarm <id>` per wave
+pan swarm <id> --host                # Confirmed break-glass: bypass workspace stack-health gate
+pan swarm <id> --host --yes          # Non-interactive host override confirmation
 ```
 
 ### Task operations (vBRIEF item state)

--- a/docs/WORKSPACE-CONTAINERS.md
+++ b/docs/WORKSPACE-CONTAINERS.md
@@ -1,0 +1,67 @@
+# Workspace Containers
+
+Panopticon workspaces are host git worktrees with an optional Docker Compose stack for project services. The host remains the orchestrator: agents, tmux sessions, Cloister, and Deacon state live on the host, while the workspace stack provides project-local init, frontend, and server services.
+
+## Compose contract
+
+A workspace stack is rendered from `workspace.docker.compose_template` into the workspace's `.devcontainer/docker-compose.devcontainer.yml`. The expected service chain is:
+
+1. `init` installs workspace dependencies and performs any setup/build steps required before services start.
+2. `frontend` depends on `init: service_completed_successfully`, so it must stay in `Created` until `init` exits 0.
+3. `server` depends on `init: service_completed_successfully`, so it must also stay in `Created` until `init` exits 0.
+
+A non-zero `init` exit is a broken stack, not a successful host fallback. If `init` fails, dependent services staying in `Created` is the correct Docker behavior and should be surfaced loudly.
+
+The `init` service must install development dependencies and must not try to install host git hooks inside the container:
+
+- `NODE_ENV=development` keeps devDependencies available for scripts such as `husky` and `tsdown`.
+- `HUSKY=0` makes Husky's prepare script a no-op inside the container while preserving host-side hook installation.
+- Do not replace this with a global removal of the `prepare` script; host installs still need hooks.
+
+## Single-deacon invariant
+
+Workspace containers must never mount `${HOME}/.panopticon`, and the container `server` service must set `PANOPTICON_DISABLE_DEACON=1`. The container server is a development-time read/UI peer, not a second orchestrator.
+
+See `.claude/rules/single-deacon-invariant.md` for the full invariant and failure history.
+
+## Health surfaces
+
+Workspace stack health is reported as `{ healthy, reasons, lastObserved }` for projects with `workspace.docker.compose_template` configured.
+
+A stack is unhealthy when:
+
+- an `init` container exits non-zero;
+- a service container exits non-zero;
+- a container remains in `Created` for at least 120 seconds;
+- container creation time is unavailable while the container is already observable as `Created`.
+
+Operators see this in two places:
+
+- `pan status` prints a red `STACK BROKEN` line with the health reasons.
+- The dashboard workspace surfaces show a red stack-broken state from `/api/workspaces/:issueId`.
+
+The activity stream emits one `workspace-stack-unhealthy` entry per healthy-to-unhealthy transition rather than on every poll.
+
+## Spawn gate and break-glass
+
+For projects that opt into workspace Docker isolation through `workspace.docker.compose_template`, agent spawn must pass the workspace stack-health gate before creating the host tmux session. If the stack is unhealthy, spawn should fail before the agent starts and tell the operator to run:
+
+```bash
+pan workspace rebuild <issue-id>
+```
+
+The break-glass path is `--host`. It is for explicit operator override only: interactive use requires confirmation, and non-interactive use requires the corresponding explicit yes/confirmation flag. `--host` bypasses workspace isolation, so use it only when the operator has intentionally decided that host execution is safer than blocking on Docker repair.
+
+Projects without `workspace.docker.compose_template` keep host-only behavior and do not require the gate or `--host`.
+
+## Recovery commands
+
+Use `pan workspace rebuild <issue-id>` to reset one workspace stack:
+
+1. tear down that stack with Docker Compose;
+2. re-render the workspace `.devcontainer` from the template;
+3. restart the stack with `docker compose up -d --build`.
+
+Use `pan workspace reap` for bulk cleanup of orphaned broken stacks. It is dry-run by default and lists candidate workspace stacks without modifying Docker state. `pan workspace reap --apply` performs teardown for candidates, and active-agent stacks are skipped so in-progress work is not destroyed accidentally.
+
+Use rebuild for the workspace you are actively repairing. Use reap for stale, orphaned stacks after reviewing the dry-run output.

--- a/infra/.devcontainer-template/devcontainer.json.template
+++ b/infra/.devcontainer-template/devcontainer.json.template
@@ -5,7 +5,7 @@
   ],
   "service": "dev",
   "workspaceFolder": "/workspaces/panopticon",
-  "postCreateCommand": "bun install",
+  "postCreateCommand": "bun install --filter '@panctl/cli' --filter '@panctl/contracts' --filter '@panopticon/pi-extension' --filter 'panopticon-server' --filter 'panopticon-dashboard'",
   "customizations": {
     "vscode": {
       "settings": {

--- a/infra/.devcontainer-template/docker-compose.devcontainer.yml.template
+++ b/infra/.devcontainer-template/docker-compose.devcontainer.yml.template
@@ -30,6 +30,7 @@ services:
     environment:
       - NODE_ENV=development
       - HUSKY=0
+      - PANOPTICON_SKIP_NATIVE_POSTINSTALL=1
     command: >
       sh -c "
         echo 'Installing dependencies...' &&

--- a/infra/.devcontainer-template/docker-compose.devcontainer.yml.template
+++ b/infra/.devcontainer-template/docker-compose.devcontainer.yml.template
@@ -19,7 +19,7 @@ services:
       - devnet
       - panopticon
 
-  # Init service: runs npm install + server build once for all workspaces
+  # Init service: runs bun install + server build once for all workspaces
   # Frontend and server depend on this completing successfully
   init:
     build:
@@ -27,10 +27,13 @@ services:
       dockerfile: Dockerfile
     user: node
     working_dir: /workspaces/panopticon
+    environment:
+      - NODE_ENV=development
+      - HUSKY=0
     command: >
       sh -c "
-        echo 'Installing dependencies...' ;
-        bun install ;
+        echo 'Installing dependencies...' &&
+        bun install &&
         echo 'Rebuilding native Node.js addons...' &&
         npm rebuild better-sqlite3 2>&1 &&
         echo 'Building contracts...' &&

--- a/infra/.devcontainer-template/docker-compose.devcontainer.yml.template
+++ b/infra/.devcontainer-template/docker-compose.devcontainer.yml.template
@@ -19,7 +19,7 @@ services:
       - devnet
       - panopticon
 
-  # Init service: runs bun install + server build once for all workspaces
+  # Init service: runs filtered bun install + server build once for all workspaces
   # Frontend and server depend on this completing successfully
   init:
     build:
@@ -33,7 +33,7 @@ services:
     command: >
       sh -c "
         echo 'Installing dependencies...' &&
-        bun install &&
+        bun install --filter '@panctl/cli' --filter '@panctl/contracts' --filter '@panopticon/pi-extension' --filter 'panopticon-server' --filter 'panopticon-dashboard' &&
         echo 'Rebuilding native Node.js addons...' &&
         npm rebuild better-sqlite3 2>&1 &&
         echo 'Building contracts...' &&

--- a/infra/.devcontainer-template/docker-compose.devcontainer.yml.template
+++ b/infra/.devcontainer-template/docker-compose.devcontainer.yml.template
@@ -125,10 +125,8 @@ services:
     environment:
       - NODE_ENV=development
       - PORT=3011
-      # Single-deacon invariant: the host's `pan up` owns agent lifecycle. The
-      # workspace devcontainer mounts the same ~/.panopticon directory but its
-      # tmux server is isolated, so a second deacon would see every agent as
-      # orphaned and resume them every cycle — duelling the host. Container
+      # Single-deacon invariant: the host's `pan up` owns agent lifecycle.
+      # Workspace devcontainers must not mount ~/.panopticon; the container
       # dashboard runs as a read/UI peer only.
       - PANOPTICON_DISABLE_DEACON=1
       - LINEAR_API_KEY=${LINEAR_API_KEY}

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -50,6 +50,10 @@ function syncHooksIfInitialized() {
 }
 
 function rebuildNativeModules() {
+  if (process.env.PANOPTICON_SKIP_NATIVE_POSTINSTALL === '1') {
+    return;
+  }
+
   const npmExecPath = process.env.npm_execpath;
   const userAgent = process.env.npm_config_user_agent || '';
   const packageManager = userAgent.startsWith('bun/') ? 'bun' : 'npm';

--- a/skills/pan-help/SKILL.md
+++ b/skills/pan-help/SKILL.md
@@ -66,6 +66,7 @@ Panopticon is a multi-agent orchestration framework for AI coding assistants. Th
 | `pan workspace create <id>` | Create workspace for issue (without spawning agent) | `pan workspace create PAN-3` |
 | `pan workspace list` | List all workspaces | `pan workspace list` |
 | `pan workspace destroy <id>` | Destroy workspace and containers | `pan workspace destroy PAN-3` |
+| `pan workspace rebuild <id>` | Reset one workspace Docker stack from the template | `pan workspace rebuild PAN-3` |
 | `pan workspace reap` | Dry-run cleanup candidates for stuck Docker stacks | `pan workspace reap --days 7` |
 
 ### Configuration

--- a/skills/pan-help/SKILL.md
+++ b/skills/pan-help/SKILL.md
@@ -66,6 +66,7 @@ Panopticon is a multi-agent orchestration framework for AI coding assistants. Th
 | `pan workspace create <id>` | Create workspace for issue (without spawning agent) | `pan workspace create PAN-3` |
 | `pan workspace list` | List all workspaces | `pan workspace list` |
 | `pan workspace destroy <id>` | Destroy workspace and containers | `pan workspace destroy PAN-3` |
+| `pan workspace reap` | Dry-run cleanup candidates for stuck Docker stacks | `pan workspace reap --days 7` |
 
 ### Configuration
 

--- a/skills/pan-start/SKILL.md
+++ b/skills/pan-start/SKILL.md
@@ -35,8 +35,8 @@ an autonomous Claude Code agent in a tmux session (`agent-<id>`). The agent load
 issue spec, creates a plan, and begins implementation.
 
 For projects with workspace Docker configured, `pan start` checks stack health before
-spawning. Use `--host` only as an explicit break-glass override; pass `--yes` to confirm
-without an interactive prompt.
+spawning. Use `--host` only as an explicit break-glass override; interactive shells always
+prompt, while non-interactive callers must pass `--yes` to confirm.
 
 ## When to Use
 

--- a/skills/pan-start/SKILL.md
+++ b/skills/pan-start/SKILL.md
@@ -35,8 +35,8 @@ an autonomous Claude Code agent in a tmux session (`agent-<id>`). The agent load
 issue spec, creates a plan, and begins implementation.
 
 For projects with workspace Docker configured, `pan start` checks stack health before
-spawning. Use `--host` only as an explicit break-glass override; interactive use asks for
-confirmation, and non-interactive use requires `--yes`.
+spawning. Use `--host` only as an explicit break-glass override; pass `--yes` to confirm
+without an interactive prompt.
 
 ## When to Use
 

--- a/skills/pan-start/SKILL.md
+++ b/skills/pan-start/SKILL.md
@@ -25,6 +25,7 @@ pan start <issue-id>
 ```
 pan start PAN-123          # Spawn agent for issue PAN-123
 pan start MIN-456          # Works with any tracker prefix
+pan start PAN-123 --host   # Break-glass: bypass workspace Docker stack-health gate
 ```
 
 ## What It Does
@@ -32,6 +33,10 @@ pan start MIN-456          # Works with any tracker prefix
 Creates a git worktree at `workspaces/feature-<id>/`, installs dependencies, then spawns
 an autonomous Claude Code agent in a tmux session (`agent-<id>`). The agent loads the
 issue spec, creates a plan, and begins implementation.
+
+For projects with workspace Docker configured, `pan start` checks stack health before
+spawning. Use `--host` only as an explicit break-glass override; interactive use asks for
+confirmation, and non-interactive use requires `--yes`.
 
 ## When to Use
 

--- a/skills/pan-workspace-config/SKILL.md
+++ b/skills/pan-workspace-config/SKILL.md
@@ -284,6 +284,23 @@ Uses `/etc/hosts` directly (requires sudo for initial setup).
 
 Uses `/etc/hosts` or dnsmasq depending on configuration.
 
+## Recovery Commands
+
+Docker-backed workspaces use stack-health gates before agents start. If a stack is unhealthy:
+
+```bash
+# Rebuild one workspace Docker stack from the configured compose template
+pan workspace rebuild MIN-123
+
+# Dry-run cleanup for stale stuck workspace Docker stacks
+pan workspace reap --days 7
+
+# Apply stale stack cleanup after reviewing the dry-run output
+pan workspace reap --days 7 --apply
+```
+
+Use `pan workspace rebuild <issueId>` for the active issue the gate reports. Use `pan workspace reap` for old orphaned stacks, not for active agents.
+
 ## Related Commands
 
 ```bash

--- a/skills/pan-workspace-config/SKILL.md
+++ b/skills/pan-workspace-config/SKILL.md
@@ -296,6 +296,12 @@ pan workspace create MIN-123 --docker
 # Remove workspace
 pan workspace destroy MIN-123
 
+# Reset one Docker workspace stack from the template
+pan workspace rebuild MIN-123
+
+# List stale stuck Docker workspace stacks before applying cleanup
+pan workspace reap --days 7
+
 # List workspaces across all projects
 pan workspace list --all
 ```

--- a/src/cli/commands/__tests__/start-harness.test.ts
+++ b/src/cli/commands/__tests__/start-harness.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 
+const readlineMocks = vi.hoisted(() => ({
+  question: vi.fn(),
+  close: vi.fn(),
+}))
+
+vi.mock('readline/promises', () => ({
+  createInterface: vi.fn(() => ({
+    question: readlineMocks.question,
+    close: readlineMocks.close,
+  })),
+}))
+
 // Replace heavy dependencies with pure stubs. We only want to verify that
 // (a) --harness pi + Anthropic model + subscription auth exits non-zero with
 // the canUseHarness reason on stderr, and (b) --harness flows through to
@@ -22,8 +34,12 @@ vi.mock('../../../lib/harness-policy.js', async () => {
 describe('pan start --harness flag (PAN-636)', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>
   let stderrSpy: ReturnType<typeof vi.spyOn>
+  let stdinIsTTYDescriptor: PropertyDescriptor | undefined
 
   beforeEach(() => {
+    stdinIsTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY')
+    readlineMocks.question.mockReset()
+    readlineMocks.close.mockReset()
     exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
       throw new Error(`__exit__:${code}`)
     }) as never)
@@ -33,6 +49,11 @@ describe('pan start --harness flag (PAN-636)', () => {
   afterEach(() => {
     exitSpy.mockRestore()
     stderrSpy.mockRestore()
+    if (stdinIsTTYDescriptor) {
+      Object.defineProperty(process.stdin, 'isTTY', stdinIsTTYDescriptor)
+    } else {
+      delete (process.stdin as NodeJS.ReadStream & { isTTY?: boolean }).isTTY
+    }
     vi.resetModules()
   })
 
@@ -48,6 +69,23 @@ describe('pan start --harness flag (PAN-636)', () => {
     const written = stderrSpy.mock.calls.map(call => String(call[0])).join('')
     expect(written.toLowerCase()).toContain('pi')
     expect(written.toLowerCase()).toContain('anthropic')
+  })
+
+  it('prompts for interactive --host --yes instead of silently accepting it', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+    readlineMocks.question.mockResolvedValueOnce('n')
+
+    const { issueCommand } = await import('../start.js')
+    await expect(
+      issueCommand('PAN-X', {
+        model: '',
+        host: true,
+        yes: true,
+      } as any),
+    ).rejects.toThrow(/__exit__:1/)
+
+    expect(readlineMocks.question).toHaveBeenCalledWith(expect.stringContaining('Are you sure?'))
+    expect(readlineMocks.close).toHaveBeenCalled()
   })
 
   it('rejects an unknown --harness value with non-zero exit', async () => {

--- a/src/cli/commands/__tests__/status-harness.test.ts
+++ b/src/cli/commands/__tests__/status-harness.test.ts
@@ -13,15 +13,30 @@ vi.mock('../../../lib/tldr-daemon.js', () => ({
   getTldrMetrics: vi.fn(() => ({ interceptions: 0, bypasses: 0, estimatedTokensSaved: 0 })),
   getTldrDaemonService: vi.fn(),
 }))
+vi.mock('../../../lib/workspace/stack-health.js', () => ({
+  collectDockerContainerLifecycleSnapshot: vi.fn(async () => []),
+  getWorkspaceStackHealth: vi.fn(async () => ({ healthy: true, reasons: [], lastObserved: '2026-05-17T00:00:00.000Z' })),
+  inferIssueIdFromStackContainerName: vi.fn((name: string) => {
+    const match = name.toLowerCase().match(/(?:^|[-_])feature-([a-z]+-\d+)(?=$|[-_])/)
+    return match?.[1]?.toUpperCase() ?? null
+  }),
+}))
 
 import { statusCommand } from '../status.js'
 import { listRunningAgents } from '../../../lib/agents.js'
+import { collectDockerContainerLifecycleSnapshot, getWorkspaceStackHealth } from '../../../lib/workspace/stack-health.js'
 
 describe('pan status — harness column (PAN-636 workspace-dbf)', () => {
   let logSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    ;(collectDockerContainerLifecycleSnapshot as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([])
+    ;(getWorkspaceStackHealth as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      healthy: true,
+      reasons: [],
+      lastObserved: '2026-05-17T00:00:00.000Z',
+    })
   })
 
   afterEach(() => {
@@ -88,5 +103,29 @@ describe('pan status — harness column (PAN-636 workspace-dbf)', () => {
     const out = logSpy.mock.calls.map(c => String(c[0])).join('\n')
     // The first call is the JSON dump — it must contain `"harness":"pi"`.
     expect(out).toMatch(/"harness":\s*"pi"/)
+  })
+
+  it('prints broken Docker workspace stacks without agent state', async () => {
+    ;(listRunningAgents as unknown as ReturnType<typeof vi.fn>).mockReturnValue([])
+    ;(collectDockerContainerLifecycleSnapshot as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        id: 'init1',
+        name: 'panopticon-feature-pan-1140-init-1',
+        status: 'Exited (1) 2 minutes ago',
+        state: 'exited',
+      },
+    ])
+    ;(getWorkspaceStackHealth as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      healthy: false,
+      reasons: ['panopticon-feature-pan-1140-init-1 init exited non-zero (1)'],
+      lastObserved: '2026-05-17T00:00:00.000Z',
+    })
+
+    await statusCommand({} as any)
+
+    const out = logSpy.mock.calls.map(c => String(c[0])).join('\n')
+    expect(out).toContain('Broken Workspace Stacks')
+    expect(out).toContain('PAN-1140')
+    expect(out).toContain('STACK BROKEN')
   })
 })

--- a/src/cli/commands/__tests__/workspace-reap.test.ts
+++ b/src/cli/commands/__tests__/workspace-reap.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  collectWorkspaceReapCandidatesFromInspect,
+  parseReapDays,
+} from '../workspace-reap.js';
+
+describe('workspace reap', () => {
+  it('requires --days to be a non-negative integer', () => {
+    expect(parseReapDays(undefined)).toBe(7);
+    expect(parseReapDays('0')).toBe(0);
+    expect(parseReapDays('14')).toBe(14);
+    expect(() => parseReapDays('-1')).toThrow('--days must be a non-negative integer');
+    expect(() => parseReapDays('1.5')).toThrow('--days must be a non-negative integer');
+  });
+
+  it('groups old Created and non-zero Exited workspace containers by compose project', () => {
+    const now = Date.parse('2026-05-16T12:00:00.000Z');
+    const cutoff = now - 7 * 86_400_000;
+
+    const candidates = collectWorkspaceReapCandidatesFromInspect([
+      {
+        Id: 'init-id',
+        Name: '/panopticon-feature-pan-1140-init-1',
+        Created: '2026-05-01T12:00:00.000000000Z',
+        Config: {
+          Labels: {
+            'com.docker.compose.project': 'panopticon-feature-pan-1140',
+            'com.docker.compose.project.config_files': '/repo/workspaces/feature-pan-1140/.devcontainer/docker-compose.devcontainer.yml',
+            'com.docker.compose.project.working_dir': '/repo/workspaces/feature-pan-1140/.devcontainer',
+          },
+        },
+        State: { Status: 'created', ExitCode: 0 },
+      },
+      {
+        Id: 'server-id',
+        Name: '/panopticon-feature-pan-1140-server-1',
+        Created: '2026-05-01T12:00:00.000000000Z',
+        Config: {
+          Labels: {
+            'com.docker.compose.project': 'panopticon-feature-pan-1140',
+          },
+        },
+        State: { Status: 'exited', ExitCode: 127 },
+      },
+      {
+        Id: 'healthy-id',
+        Name: '/panopticon-feature-pan-1-server-1',
+        Created: '2026-05-01T12:00:00.000000000Z',
+        Config: {
+          Labels: {
+            'com.docker.compose.project': 'panopticon-feature-pan-1',
+          },
+        },
+        State: { Status: 'running', ExitCode: 0 },
+      },
+      {
+        Id: 'fresh-id',
+        Name: '/panopticon-feature-pan-2-init-1',
+        Created: '2026-05-15T12:00:00.000000000Z',
+        Config: {
+          Labels: {
+            'com.docker.compose.project': 'panopticon-feature-pan-2',
+          },
+        },
+        State: { Status: 'created', ExitCode: 0 },
+      },
+    ], cutoff, now);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      project: 'panopticon-feature-pan-1140',
+      issueId: 'pan-1140',
+      ageDays: 15,
+    });
+    expect(candidates[0].reason).toContain('Created');
+    expect(candidates[0].reason).toContain('Exited (127)');
+    expect(candidates[0].containers.map(container => container.id)).toEqual(['init-id', 'server-id']);
+  });
+});

--- a/src/cli/commands/__tests__/workspace-rebuild.test.ts
+++ b/src/cli/commands/__tests__/workspace-rebuild.test.ts
@@ -13,7 +13,7 @@ describe('workspace rebuild', () => {
     }
   });
 
-  it('derives the compose project name from the rendered dev script', () => {
+  it('accepts a rendered dev script only when it declares the expected compose project name', () => {
     const workspace = mkdtempSync(join(tmpdir(), 'pan-workspace-rebuild-'));
     tempDirs.push(workspace);
     mkdirSync(join(workspace, '.devcontainer'), { recursive: true });
@@ -23,6 +23,20 @@ describe('workspace rebuild', () => {
     );
 
     expect(composeProjectNameForWorkspace(workspace, 'PAN-1140')).toBe('panopticon-feature-pan-1140');
+  });
+
+  it('refuses a workspace-controlled compose project name mismatch', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'pan-workspace-rebuild-'));
+    tempDirs.push(workspace);
+    mkdirSync(join(workspace, '.devcontainer'), { recursive: true });
+    writeFileSync(
+      join(workspace, '.devcontainer', 'dev'),
+      'FEATURE_FOLDER="feature-pan-1140"\nexport COMPOSE_PROJECT_NAME="victim-project"\n',
+    );
+
+    expect(() => composeProjectNameForWorkspace(workspace, 'PAN-1140')).toThrow(
+      'Refusing workspace rebuild',
+    );
   });
 
   it('falls back to the canonical panopticon feature project name', () => {

--- a/src/cli/commands/__tests__/workspace-rebuild.test.ts
+++ b/src/cli/commands/__tests__/workspace-rebuild.test.ts
@@ -1,0 +1,34 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { composeProjectNameForWorkspace } from '../workspace-rebuild.js';
+
+describe('workspace rebuild', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('derives the compose project name from the rendered dev script', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'pan-workspace-rebuild-'));
+    tempDirs.push(workspace);
+    mkdirSync(join(workspace, '.devcontainer'), { recursive: true });
+    writeFileSync(
+      join(workspace, '.devcontainer', 'dev'),
+      'FEATURE_FOLDER="feature-pan-1140"\nexport COMPOSE_PROJECT_NAME="panopticon-${FEATURE_FOLDER}"\n',
+    );
+
+    expect(composeProjectNameForWorkspace(workspace, 'PAN-1140')).toBe('panopticon-feature-pan-1140');
+  });
+
+  it('falls back to the canonical panopticon feature project name', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'pan-workspace-rebuild-'));
+    tempDirs.push(workspace);
+
+    expect(composeProjectNameForWorkspace(workspace, 'PAN-1140')).toBe('panopticon-feature-pan-1140');
+  });
+});

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -79,6 +79,7 @@ import { isRemoteAvailable } from '../../lib/remote/index.js';
 import type { RemoteWorkspaceMetadata } from '../../lib/remote/interface.js';
 import type { SpawnRemoteAgentOptions } from '../../lib/remote/remote-agents.js';
 import { assertCanStartFresh } from '../../lib/work-agent-lifecycle.js';
+import { normalizeModelOverride } from '../../lib/model-validation.js';
 
 interface IssueOptions {
   model: string;
@@ -669,6 +670,14 @@ async function failPostCreateValidation(options: PostCreateValidationFailureOpti
 }
 
 export async function issueCommand(id: string, options: IssueOptions): Promise<void> {
+  try {
+    const model = normalizeModelOverride(options.model);
+    if (model) options.model = model;
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  }
+
   if (!(await confirmHostOverride(options))) {
     process.exit(1);
   }

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -3,6 +3,7 @@ import ora, { type Ora } from 'ora';
 import { existsSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { homedir } from 'os';
+import { createInterface } from 'readline/promises';
 import { promisify } from 'util';
 import { exec, execFile, execFileSync } from 'child_process';
 
@@ -88,6 +89,8 @@ interface IssueOptions {
   remote?: boolean;
   local?: boolean;
   auto?: boolean;
+  host?: boolean;
+  yes?: boolean;
 }
 
 /**
@@ -116,6 +119,27 @@ function determineWorkspaceLocation(options: IssueOptions): 'local' | 'remote' |
 
   // Default: check both (local takes precedence if both exist)
   return null;
+}
+
+async function confirmHostOverride(options: IssueOptions): Promise<boolean> {
+  if (!options.host) return true;
+
+  if (!process.stdin.isTTY) {
+    if (options.yes) {
+      console.warn(chalk.yellow('--host --yes given in a non-interactive context; bypassing workspace isolation.'));
+      return true;
+    }
+    console.error(chalk.red('Error: --host requires an interactive confirmation, or pass --yes for non-interactive use.'));
+    return false;
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (await rl.question(chalk.bold('Are you sure? This bypasses workspace isolation. (y/N) '))).trim().toLowerCase();
+    return answer === 'y' || answer === 'yes';
+  } finally {
+    rl.close();
+  }
 }
 
 /**
@@ -645,6 +669,10 @@ async function failPostCreateValidation(options: PostCreateValidationFailureOpti
 }
 
 export async function issueCommand(id: string, options: IssueOptions): Promise<void> {
+  if (!(await confirmHostOverride(options))) {
+    process.exit(1);
+  }
+
   // PAN-636 — validate --harness up front. canUseHarness gates the
   // {harness, model, authMode} combination; invalid combos exit non-zero
   // with the human-readable reason text on stderr (no spinner, no
@@ -978,6 +1006,7 @@ export async function issueCommand(id: string, options: IssueOptions): Promise<v
       model: options.model,
       role: 'work',
       prompt,
+      allowHost: options.host,
     });
 
     spinner.succeed(`Agent spawned: ${agent.id}`);

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -125,12 +125,13 @@ function determineWorkspaceLocation(options: IssueOptions): 'local' | 'remote' |
 async function confirmHostOverride(options: IssueOptions): Promise<boolean> {
   if (!options.host) return true;
 
+  if (options.yes) {
+    console.warn(chalk.yellow('--host --yes given; bypassing workspace isolation.'));
+    return true;
+  }
+
   if (!process.stdin.isTTY) {
-    if (options.yes) {
-      console.warn(chalk.yellow('--host --yes given in a non-interactive context; bypassing workspace isolation.'));
-      return true;
-    }
-    console.error(chalk.red('Error: --host requires an interactive confirmation, or pass --yes for non-interactive use.'));
+    console.error(chalk.red('Error: --host requires an interactive confirmation, or pass --yes.'));
     return false;
   }
 

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -125,13 +125,12 @@ function determineWorkspaceLocation(options: IssueOptions): 'local' | 'remote' |
 async function confirmHostOverride(options: IssueOptions): Promise<boolean> {
   if (!options.host) return true;
 
-  if (options.yes) {
-    console.warn(chalk.yellow('--host --yes given; bypassing workspace isolation.'));
-    return true;
-  }
-
   if (!process.stdin.isTTY) {
-    console.error(chalk.red('Error: --host requires an interactive confirmation, or pass --yes.'));
+    if (options.yes) {
+      console.warn(chalk.yellow('--host --yes given in a non-interactive context; bypassing workspace isolation.'));
+      return true;
+    }
+    console.error(chalk.red('Error: --host requires an interactive confirmation, or pass --yes for non-interactive use.'));
     return false;
   }
 

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -4,12 +4,20 @@ import { join, basename } from 'path';
 import { listRunningAgents, getAgentDir } from '../../lib/agents.js';
 import { isShadowed, getShadowState } from '../../lib/shadow-state.js';
 import { getTldrMetrics, getTldrDaemonService } from '../../lib/tldr-daemon.js';
-import { collectDockerContainerLifecycleSnapshot, getWorkspaceStackHealth } from '../../lib/workspace/stack-health.js';
+import {
+  collectDockerContainerLifecycleSnapshot,
+  getWorkspaceStackHealth,
+  inferIssueIdFromStackContainerName,
+} from '../../lib/workspace/stack-health.js';
 
 interface StatusOptions {
   json?: boolean;
   tldr?: boolean;
   context?: boolean;
+}
+
+function issueKey(issueId: string): string {
+  return issueId.toUpperCase();
 }
 
 export function readContextPercent(agentId: string): number | null {
@@ -36,12 +44,26 @@ export async function statusCommand(options: StatusOptions): Promise<void> {
     agent.id && agent.issueId && agent.workspace
   );
   const dockerContainers = await collectDockerContainerLifecycleSnapshot();
+  const issueIds = new Map<string, string>();
+  for (const agent of agents) {
+    issueIds.set(issueKey(agent.issueId!), agent.issueId!);
+  }
+  for (const container of dockerContainers) {
+    const issueId = inferIssueIdFromStackContainerName(container.name);
+    if (issueId) issueIds.set(issueKey(issueId), issueId);
+  }
+
   const stackHealthByIssue = new Map(await Promise.all(
-    agents.map(async agent => [
-      agent.issueId!,
-      await getWorkspaceStackHealth(agent.issueId!, { containers: dockerContainers }),
+    Array.from(issueIds, async ([key, issueId]) => [
+      key,
+      await getWorkspaceStackHealth(issueId, { containers: dockerContainers }),
     ] as const)
   ));
+  const agentIssueKeys = new Set(agents.map(agent => issueKey(agent.issueId!)));
+  const brokenStacksWithoutAgent = Array.from(issueIds)
+    .filter(([key]) => !agentIssueKeys.has(key))
+    .map(([key, issueId]) => ({ issueId, stackHealth: stackHealthByIssue.get(key) }))
+    .filter((entry): entry is { issueId: string; stackHealth: NonNullable<typeof entry.stackHealth> } => Boolean(entry.stackHealth && !entry.stackHealth.healthy));
 
   if (options.json) {
     // Add shadow mode info and optional context % to JSON output
@@ -53,7 +75,7 @@ export async function statusCommand(options: StatusOptions): Promise<void> {
         shadowMode: shadowed,
         shadowStatus: shadowState?.shadowStatus,
         trackerStatus: shadowState?.trackerStatus,
-        stackHealth: agent.issueId ? stackHealthByIssue.get(agent.issueId) : undefined,
+        stackHealth: agent.issueId ? stackHealthByIssue.get(issueKey(agent.issueId)) : undefined,
         ...(options.context ? { contextPercent: readContextPercent(agent.id) } : {}),
       };
     }));
@@ -61,13 +83,15 @@ export async function statusCommand(options: StatusOptions): Promise<void> {
     return;
   }
 
-  if (agents.length === 0) {
+  if (agents.length === 0 && brokenStacksWithoutAgent.length === 0) {
     console.log(chalk.dim('No running agents.'));
     console.log(chalk.dim('Use "pan start <id>" to spawn one.'));
     return;
   }
 
-  console.log(chalk.bold('\nRunning Agents\n'));
+  if (agents.length > 0) {
+    console.log(chalk.bold('\nRunning Agents\n'));
+  }
 
   for (const agent of agents) {
     const statusColor = agent.tmuxActive ? chalk.green : chalk.red;
@@ -101,7 +125,7 @@ export async function statusCommand(options: StatusOptions): Promise<void> {
     console.log(`  Duration: ${duration} min`);
     console.log(`  Workspace: ${chalk.dim(agent.workspace)}`);
 
-    const stackHealth = agent.issueId ? stackHealthByIssue.get(agent.issueId) : undefined;
+    const stackHealth = agent.issueId ? stackHealthByIssue.get(issueKey(agent.issueId)) : undefined;
     if (stackHealth && !stackHealth.healthy) {
       console.log(`  Stack:    ${chalk.red('STACK BROKEN')} ${stackHealth.reasons.join('; ')}`);
     }
@@ -117,6 +141,15 @@ export async function statusCommand(options: StatusOptions): Promise<void> {
     } catch { /* non-fatal — workspace may not have TLDR */ }
 
     console.log('');
+  }
+
+  if (brokenStacksWithoutAgent.length > 0) {
+    console.log(chalk.bold('Broken Workspace Stacks\n'));
+    for (const { issueId, stackHealth } of brokenStacksWithoutAgent) {
+      console.log(`${chalk.cyan(issueId)}`);
+      console.log(`  Stack:    ${chalk.red('STACK BROKEN')} ${stackHealth.reasons.join('; ')}`);
+      console.log('');
+    }
   }
 
   // Show legend

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -4,6 +4,7 @@ import { join, basename } from 'path';
 import { listRunningAgents, getAgentDir } from '../../lib/agents.js';
 import { isShadowed, getShadowState } from '../../lib/shadow-state.js';
 import { getTldrMetrics, getTldrDaemonService } from '../../lib/tldr-daemon.js';
+import { collectDockerContainerLifecycleSnapshot, getWorkspaceStackHealth } from '../../lib/workspace/stack-health.js';
 
 interface StatusOptions {
   json?: boolean;
@@ -34,6 +35,13 @@ export async function statusCommand(options: StatusOptions): Promise<void> {
   const agents = listRunningAgents().filter(agent =>
     agent.id && agent.issueId && agent.workspace
   );
+  const dockerContainers = await collectDockerContainerLifecycleSnapshot();
+  const stackHealthByIssue = new Map(await Promise.all(
+    agents.map(async agent => [
+      agent.issueId!,
+      await getWorkspaceStackHealth(agent.issueId!, { containers: dockerContainers }),
+    ] as const)
+  ));
 
   if (options.json) {
     // Add shadow mode info and optional context % to JSON output
@@ -45,6 +53,7 @@ export async function statusCommand(options: StatusOptions): Promise<void> {
         shadowMode: shadowed,
         shadowStatus: shadowState?.shadowStatus,
         trackerStatus: shadowState?.trackerStatus,
+        stackHealth: agent.issueId ? stackHealthByIssue.get(agent.issueId) : undefined,
         ...(options.context ? { contextPercent: readContextPercent(agent.id) } : {}),
       };
     }));
@@ -91,6 +100,11 @@ export async function statusCommand(options: StatusOptions): Promise<void> {
     console.log(`  Role:     ${agent.role}`);
     console.log(`  Duration: ${duration} min`);
     console.log(`  Workspace: ${chalk.dim(agent.workspace)}`);
+
+    const stackHealth = agent.issueId ? stackHealthByIssue.get(agent.issueId) : undefined;
+    if (stackHealth && !stackHealth.healthy) {
+      console.log(`  Stack:    ${chalk.red('STACK BROKEN')} ${stackHealth.reasons.join('; ')}`);
+    }
 
     // Show TLDR session metrics if a .tldr/ dir exists in the workspace
     try {

--- a/src/cli/commands/swarm.ts
+++ b/src/cli/commands/swarm.ts
@@ -24,6 +24,7 @@ import { readWorkspacePlan } from '../../lib/vbrief/io.js';
 import { groupItemsByWave, getDispatchableItems, createActiveSlice, verifyActiveSlicePromptReduction, isTaskCommand, type TaskCommand, type Wave } from '../../lib/vbrief/dag.js';
 import { runTaskCommand } from '../../lib/vbrief/dag-cli.js';
 import { INTERNAL_TOKEN_HEADER, ensureInternalToken } from '../../lib/internal-token.js';
+import { normalizeModelOverride } from '../../lib/model-validation.js';
 
 const DASHBOARD_URL = getDashboardApiUrl();
 
@@ -116,6 +117,13 @@ export async function swarmCommand(
   parseFiniteInteger(options.wave, '--wave');
   parseFiniteInteger(options.maxSlots, '--max-slots');
   parseFiniteInteger(options.sequence, '--sequence');
+  try {
+    const model = normalizeModelOverride(options.model);
+    if (model) options.model = model;
+  } catch (err) {
+    console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+    process.exit(1);
+  }
 
   if (options.task) {
     return taskOperation(issueId, options);

--- a/src/cli/commands/swarm.ts
+++ b/src/cli/commands/swarm.ts
@@ -9,12 +9,15 @@
  * --model:   override model for work slots (default: kimi-k2.6)
  * --max-slots: max concurrent agents (default: respects guardrails)
  * --auto-advance: dispatch next wave automatically when the current wave completes
+ * --host: bypass workspace docker stack-health gate after explicit confirmation
+ * --yes: confirm --host in non-interactive contexts
  */
 
 import chalk from 'chalk';
 import ora from 'ora';
 import { join } from 'path';
 import { existsSync } from 'fs';
+import { createInterface } from 'readline/promises';
 import { getDashboardApiUrl } from '../../lib/config.js';
 import { resolveProjectFromIssue } from '../../lib/projects.js';
 import { readWorkspacePlan } from '../../lib/vbrief/io.js';
@@ -65,9 +68,48 @@ function printWavePlan(waves: Wave[], issueId: string): void {
   console.log(chalk.dim(`  Critical depth: ${waves.length} sequential waves`));
 }
 
+interface SwarmCommandOptions {
+  dryRun?: boolean;
+  wave?: string;
+  model?: string;
+  maxSlots?: string;
+  autoAdvance?: boolean;
+  task?: string;
+  item?: string;
+  reason?: string;
+  sequence?: string;
+  host?: boolean;
+  yes?: boolean;
+}
+
+function buildHostOverrideConfirmation(issueId: string): string {
+  return `I understand this bypasses workspace isolation for ${issueId.toUpperCase()}`;
+}
+
+async function confirmHostOverride(options: SwarmCommandOptions): Promise<boolean> {
+  if (!options.host) return true;
+
+  if (!process.stdin.isTTY) {
+    if (options.yes) {
+      console.warn(chalk.yellow('--host --yes given in a non-interactive context; bypassing workspace isolation.'));
+      return true;
+    }
+    console.error(chalk.red('Error: --host requires an interactive confirmation, or pass --yes for non-interactive use.'));
+    return false;
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (await rl.question(chalk.bold('Are you sure? This bypasses workspace isolation. (y/N) '))).trim().toLowerCase();
+    return answer === 'y' || answer === 'yes';
+  } finally {
+    rl.close();
+  }
+}
+
 export async function swarmCommand(
   id: string,
-  options: { dryRun?: boolean; wave?: string; model?: string; maxSlots?: string; autoAdvance?: boolean; task?: string; item?: string; reason?: string; sequence?: string },
+  options: SwarmCommandOptions,
 ): Promise<void> {
   const issueId = id.toUpperCase();
 
@@ -83,6 +125,10 @@ export async function swarmCommand(
     return dryRun(issueId);
   }
 
+  if (!(await confirmHostOverride(options))) {
+    process.exit(1);
+  }
+
   const spinner = ora(`Dispatching swarm for ${issueId}...`).start();
 
   try {
@@ -93,6 +139,10 @@ export async function swarmCommand(
     if (options.model) body.model = options.model;
     if (maxSlots !== undefined) body.maxSlots = maxSlots;
     if (options.autoAdvance !== undefined) body.autoAdvance = options.autoAdvance;
+    if (options.host) {
+      body.host = true;
+      body.hostOverrideConfirmation = buildHostOverrideConfirmation(issueId);
+    }
 
     // PAN-977 blocker #3: POST /api/swarm is privileged. Send the internal
     // token so the dashboard auth gate accepts the request.

--- a/src/cli/commands/workspace-reap.ts
+++ b/src/cli/commands/workspace-reap.ts
@@ -1,0 +1,316 @@
+import { execFile } from 'child_process';
+import { existsSync, readdirSync, readFileSync } from 'fs';
+import { createInterface } from 'readline/promises';
+import { promisify } from 'util';
+import { join } from 'path';
+import chalk from 'chalk';
+import { getPanopticonHome } from '../../lib/paths.js';
+
+const execFileAsync = promisify(execFile);
+const WORKSPACE_PROJECT_PREFIX = 'panopticon-feature-';
+const ACTIVE_AGENT_STATUSES = new Set(['running', 'starting']);
+
+export interface WorkspaceReapOptions {
+  days?: string;
+  apply?: boolean;
+  yes?: boolean;
+}
+
+interface DockerInspectContainer {
+  Id?: string;
+  Name?: string;
+  Created?: string;
+  Config?: {
+    Labels?: Record<string, string>;
+  };
+  State?: {
+    Status?: string;
+    ExitCode?: number;
+  };
+}
+
+export interface ReapCandidate {
+  project: string;
+  issueId: string;
+  reason: string;
+  ageDays: number;
+  containers: Array<{
+    id: string;
+    name: string;
+    status: string;
+    exitCode: number;
+    createdAt: string;
+  }>;
+  composeFiles: string[];
+  workingDir?: string;
+}
+
+interface CandidateGroup {
+  project: string;
+  issueId: string;
+  containers: ReapCandidate['containers'];
+  composeFiles: Set<string>;
+  workingDir?: string;
+  reasons: string[];
+  oldestBadCreatedMs: number;
+}
+
+export function parseReapDays(value: string | undefined): number {
+  const raw = value ?? '7';
+  const days = Number.parseInt(raw, 10);
+  if (!Number.isInteger(days) || days < 0 || String(days) !== raw.trim()) {
+    throw new Error(`--days must be a non-negative integer, got ${JSON.stringify(raw)}`);
+  }
+  return days;
+}
+
+function normalizeIssueId(value: string): string {
+  return value.toLowerCase().replace(/^feature-/, '').replace(/[^a-z0-9-]/g, '-');
+}
+
+function issueIdFromProject(project: string): string {
+  const lower = project.toLowerCase();
+  if (lower.startsWith(WORKSPACE_PROJECT_PREFIX)) {
+    return normalizeIssueId(lower.slice(WORKSPACE_PROJECT_PREFIX.length));
+  }
+  return normalizeIssueId(lower);
+}
+
+function parseComposeFiles(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map(file => file.trim())
+    .filter(Boolean);
+}
+
+function isBadContainer(status: string, exitCode: number): string | null {
+  if (status === 'created') return 'Created';
+  if (status === 'exited' && exitCode !== 0) return `Exited (${exitCode})`;
+  return null;
+}
+
+export function collectWorkspaceReapCandidatesFromInspect(
+  containers: DockerInspectContainer[],
+  cutoffMs: number,
+  nowMs: number = Date.now(),
+): ReapCandidate[] {
+  const groups = new Map<string, CandidateGroup>();
+
+  for (const container of containers) {
+    const labels = container.Config?.Labels ?? {};
+    const name = (container.Name ?? '').replace(/^\//, '');
+    const project = labels['com.docker.compose.project'] ?? name.split('-').slice(0, -2).join('-');
+    if (!name.includes(WORKSPACE_PROJECT_PREFIX) && !project.startsWith(WORKSPACE_PROJECT_PREFIX)) {
+      continue;
+    }
+
+    const status = (container.State?.Status ?? '').toLowerCase();
+    const exitCode = container.State?.ExitCode ?? 0;
+    const reason = isBadContainer(status, exitCode);
+    if (!reason) continue;
+
+    const createdMs = Date.parse(container.Created ?? '');
+    if (!Number.isFinite(createdMs) || createdMs > cutoffMs) continue;
+
+    const id = container.Id ?? '';
+    if (!id) continue;
+
+    let group = groups.get(project);
+    if (!group) {
+      group = {
+        project,
+        issueId: issueIdFromProject(project),
+        containers: [],
+        composeFiles: new Set(),
+        workingDir: labels['com.docker.compose.project.working_dir'],
+        reasons: [],
+        oldestBadCreatedMs: createdMs,
+      };
+      groups.set(project, group);
+    }
+
+    for (const file of parseComposeFiles(labels['com.docker.compose.project.config_files'])) {
+      if (existsSync(file)) group.composeFiles.add(file);
+    }
+    if (!group.workingDir && labels['com.docker.compose.project.working_dir']) {
+      group.workingDir = labels['com.docker.compose.project.working_dir'];
+    }
+    group.oldestBadCreatedMs = Math.min(group.oldestBadCreatedMs, createdMs);
+    group.containers.push({
+      id,
+      name,
+      status,
+      exitCode,
+      createdAt: container.Created ?? '',
+    });
+    group.reasons.push(`${name}: ${reason}`);
+  }
+
+  return [...groups.values()]
+    .map(group => ({
+      project: group.project,
+      issueId: group.issueId,
+      reason: group.reasons.join(', '),
+      ageDays: Math.floor((nowMs - group.oldestBadCreatedMs) / 86_400_000),
+      containers: group.containers,
+      composeFiles: [...group.composeFiles],
+      workingDir: group.workingDir,
+    }))
+    .sort((a, b) => b.ageDays - a.ageDays || a.project.localeCompare(b.project));
+}
+
+function hasActiveAgentForIssue(issueId: string): boolean {
+  const agentsDir = join(getPanopticonHome(), 'agents');
+  if (!existsSync(agentsDir)) return false;
+
+  for (const dir of readdirSync(agentsDir)) {
+    const stateFile = join(agentsDir, dir, 'state.json');
+    if (!existsSync(stateFile)) continue;
+    try {
+      const state = JSON.parse(readFileSync(stateFile, 'utf-8')) as {
+        issueId?: string;
+        status?: string;
+      };
+      if (!state.issueId || !state.status) continue;
+      if (normalizeIssueId(state.issueId) === issueId && ACTIVE_AGENT_STATUSES.has(state.status)) {
+        return true;
+      }
+    } catch {}
+  }
+
+  return false;
+}
+
+async function listMatchingContainerIds(): Promise<string[]> {
+  const { stdout } = await execFileAsync('docker', [
+    'ps',
+    '-a',
+    '--filter',
+    `name=${WORKSPACE_PROJECT_PREFIX}`,
+    '--format',
+    '{{.ID}}',
+  ], { encoding: 'utf-8' });
+  return stdout.trim().split('\n').map(line => line.trim()).filter(Boolean);
+}
+
+async function inspectContainers(ids: string[]): Promise<DockerInspectContainer[]> {
+  if (ids.length === 0) return [];
+  const { stdout } = await execFileAsync('docker', [
+    'inspect',
+    ...ids,
+    '--format',
+    '{{json .}}',
+  ], { encoding: 'utf-8', maxBuffer: 20 * 1024 * 1024 });
+  return stdout.trim().split('\n').filter(Boolean).map(line => JSON.parse(line));
+}
+
+async function confirmApply(candidates: ReapCandidate[], yes: boolean | undefined): Promise<boolean> {
+  if (yes) {
+    console.log(chalk.dim('  --yes given; skipping interactive confirmation.'));
+    return true;
+  }
+
+  if (!process.stdin.isTTY) {
+    console.error(chalk.red('✗ --apply requires an interactive terminal, or pass --yes for non-interactive use.'));
+    return false;
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const expected = String(candidates.length);
+    const answer = (
+      await rl.question(chalk.bold(`Type "${expected}" to reap these workspace stack(s), anything else to cancel: `))
+    ).trim();
+    return answer === expected;
+  } finally {
+    rl.close();
+  }
+}
+
+async function composeDown(candidate: ReapCandidate): Promise<void> {
+  const args = [
+    'compose',
+    ...candidate.composeFiles.flatMap(file => ['-f', file]),
+    '-p',
+    candidate.project,
+    'down',
+    '-v',
+    '--remove-orphans',
+  ];
+  await execFileAsync('docker', args, {
+    cwd: candidate.workingDir && existsSync(candidate.workingDir) ? candidate.workingDir : process.cwd(),
+    encoding: 'utf-8',
+    timeout: 60_000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+}
+
+function printCandidates(candidates: ReapCandidate[], apply: boolean | undefined): void {
+  if (candidates.length === 0) {
+    console.log(chalk.green('No orphaned workspace Docker stacks found.'));
+    return;
+  }
+
+  console.log(chalk.bold(`${apply ? 'Will reap' : 'Would reap'} ${candidates.length} workspace Docker stack(s):`));
+  console.log('');
+  for (const candidate of candidates) {
+    console.log(`${chalk.cyan(candidate.project)} (${candidate.issueId.toUpperCase()}, ${candidate.ageDays}d old)`);
+    console.log(`  ${candidate.reason}`);
+    if (candidate.composeFiles.length > 0) {
+      console.log(chalk.dim(`  compose: ${candidate.composeFiles.join(', ')}`));
+    } else {
+      console.log(chalk.yellow('  compose: no existing config file label found; using project-name cleanup'));
+    }
+  }
+  console.log('');
+  if (!apply) {
+    console.log(chalk.dim('Dry run only. Re-run with --apply to run docker compose down -v --remove-orphans.'));
+  }
+}
+
+export async function workspaceReapCommand(options: WorkspaceReapOptions = {}): Promise<void> {
+  let days: number;
+  try {
+    days = parseReapDays(options.days);
+  } catch (error: any) {
+    console.error(chalk.red(`✗ ${error.message}`));
+    process.exit(1);
+  }
+
+  const cutoffMs = Date.now() - days * 86_400_000;
+  let containers: DockerInspectContainer[];
+  try {
+    const ids = await listMatchingContainerIds();
+    containers = await inspectContainers(ids);
+  } catch (error: any) {
+    console.error(chalk.red(`✗ Failed to query Docker containers: ${error.message ?? error}`));
+    process.exit(1);
+  }
+
+  const candidates = collectWorkspaceReapCandidatesFromInspect(containers, cutoffMs)
+    .filter(candidate => {
+      if (!hasActiveAgentForIssue(candidate.issueId)) return true;
+      console.log(chalk.yellow(`Skipping ${candidate.project}: active agent state exists for ${candidate.issueId.toUpperCase()}`));
+      return false;
+    });
+
+  printCandidates(candidates, options.apply);
+  if (!options.apply || candidates.length === 0) return;
+
+  const confirmed = await confirmApply(candidates, options.yes);
+  if (!confirmed) {
+    console.log(chalk.green('Cancelled — no Docker stacks were reaped.'));
+    return;
+  }
+
+  for (const candidate of candidates) {
+    try {
+      await composeDown(candidate);
+      console.log(chalk.green(`✓ Reaped ${candidate.project}`));
+    } catch (error: any) {
+      console.error(chalk.red(`✗ Failed to reap ${candidate.project}: ${error.message ?? error}`));
+      process.exitCode = 1;
+    }
+  }
+}

--- a/src/cli/commands/workspace-reap.ts
+++ b/src/cli/commands/workspace-reap.ts
@@ -160,9 +160,10 @@ export function collectWorkspaceReapCandidatesFromInspect(
     .sort((a, b) => b.ageDays - a.ageDays || a.project.localeCompare(b.project));
 }
 
-function hasActiveAgentForIssue(issueId: string): boolean {
+function collectActiveAgentIssueIds(): Set<string> {
+  const activeIssues = new Set<string>();
   const agentsDir = join(getPanopticonHome(), 'agents');
-  if (!existsSync(agentsDir)) return false;
+  if (!existsSync(agentsDir)) return activeIssues;
 
   for (const dir of readdirSync(agentsDir)) {
     const stateFile = join(agentsDir, dir, 'state.json');
@@ -172,14 +173,12 @@ function hasActiveAgentForIssue(issueId: string): boolean {
         issueId?: string;
         status?: string;
       };
-      if (!state.issueId || !state.status) continue;
-      if (normalizeIssueId(state.issueId) === issueId && ACTIVE_AGENT_STATUSES.has(state.status)) {
-        return true;
-      }
+      if (!state.issueId || !state.status || !ACTIVE_AGENT_STATUSES.has(state.status)) continue;
+      activeIssues.add(normalizeIssueId(state.issueId));
     } catch {}
   }
 
-  return false;
+  return activeIssues;
 }
 
 async function listMatchingContainerIds(): Promise<string[]> {
@@ -288,9 +287,10 @@ export async function workspaceReapCommand(options: WorkspaceReapOptions = {}): 
     process.exit(1);
   }
 
+  const activeAgentIssueIds = collectActiveAgentIssueIds();
   const candidates = collectWorkspaceReapCandidatesFromInspect(containers, cutoffMs)
     .filter(candidate => {
-      if (!hasActiveAgentForIssue(candidate.issueId)) return true;
+      if (!activeAgentIssueIds.has(candidate.issueId)) return true;
       console.log(chalk.yellow(`Skipping ${candidate.project}: active agent state exists for ${candidate.issueId.toUpperCase()}`));
       return false;
     });

--- a/src/cli/commands/workspace-rebuild.ts
+++ b/src/cli/commands/workspace-rebuild.ts
@@ -17,19 +17,28 @@ const COMPOSE_FILES = [
   'compose.yaml',
 ];
 
+function declaredComposeProjectName(content: string, featureFolder: string): string | null {
+  const templatedMatch = content.match(/COMPOSE_PROJECT_NAME="([^$"]*)\$\{FEATURE_FOLDER\}"/);
+  if (templatedMatch) return `${templatedMatch[1]}${featureFolder}`;
+  const literalMatch = content.match(/COMPOSE_PROJECT_NAME="([^"]+)"/);
+  return literalMatch?.[1] ?? null;
+}
+
 export function composeProjectNameForWorkspace(workspacePath: string, issueId: string): string {
   const featureFolder = `feature-${issueId.toLowerCase()}`;
+  const expected = `panopticon-${featureFolder}`;
   for (const devPath of [join(workspacePath, '.devcontainer', 'dev'), join(workspacePath, 'dev')]) {
     if (!existsSync(devPath)) continue;
     try {
-      const content = readFileSync(devPath, 'utf-8');
-      const match = content.match(/COMPOSE_PROJECT_NAME="([^$"]*)\$\{FEATURE_FOLDER\}"/);
-      if (match) return `${match[1]}${featureFolder}`;
-      const literalMatch = content.match(/COMPOSE_PROJECT_NAME="([^"]+)"/);
-      if (literalMatch) return literalMatch[1];
-    } catch {}
+      const declared = declaredComposeProjectName(readFileSync(devPath, 'utf-8'), featureFolder);
+      if (declared && declared !== expected) {
+        throw new Error(`Refusing workspace rebuild: ${devPath} declares COMPOSE_PROJECT_NAME=${declared}, expected ${expected}`);
+      }
+    } catch (err: any) {
+      if (err?.message?.startsWith('Refusing workspace rebuild:')) throw err;
+    }
   }
-  return `panopticon-${featureFolder}`;
+  return expected;
 }
 
 function findDevcontainerComposeFile(workspacePath: string): string | null {

--- a/src/cli/commands/workspace-rebuild.ts
+++ b/src/cli/commands/workspace-rebuild.ts
@@ -5,7 +5,7 @@ import { dirname, join } from 'path';
 import chalk from 'chalk';
 import ora from 'ora';
 import { ensureDevcontainer } from '../../lib/workspace/ensure-devcontainer.js';
-import { extractTeamPrefix, findProjectByTeam } from '../../lib/projects.js';
+import { getProject, resolveProjectFromIssue } from '../../lib/projects.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -52,9 +52,9 @@ async function dockerCompose(args: string[], cwd: string): Promise<void> {
 
 export async function workspaceRebuildCommand(issueId: string): Promise<void> {
   const normalizedIssueId = issueId.toLowerCase();
-  const teamPrefix = extractTeamPrefix(issueId);
-  const projectConfig = teamPrefix ? findProjectByTeam(teamPrefix) : null;
-  if (!projectConfig) {
+  const resolvedProject = resolveProjectFromIssue(issueId);
+  const projectConfig = resolvedProject ? getProject(resolvedProject.projectKey) : null;
+  if (!resolvedProject || !projectConfig) {
     console.error(chalk.red(`✗ No project found for issue ${issueId}`));
     process.exit(1);
   }
@@ -64,7 +64,7 @@ export async function workspaceRebuildCommand(issueId: string): Promise<void> {
     process.exit(1);
   }
 
-  const workspacePath = join(projectConfig.path, 'workspaces', `feature-${normalizedIssueId}`);
+  const workspacePath = join(resolvedProject.projectPath, 'workspaces', `feature-${normalizedIssueId}`);
   if (!existsSync(workspacePath)) {
     console.error(chalk.red(`✗ Workspace not found: ${workspacePath}`));
     process.exit(1);

--- a/src/cli/commands/workspace-rebuild.ts
+++ b/src/cli/commands/workspace-rebuild.ts
@@ -1,0 +1,124 @@
+import { execFile } from 'child_process';
+import { existsSync, readFileSync, rmSync } from 'fs';
+import { promisify } from 'util';
+import { dirname, join } from 'path';
+import chalk from 'chalk';
+import ora from 'ora';
+import { ensureDevcontainer } from '../../lib/workspace/ensure-devcontainer.js';
+import { extractTeamPrefix, findProjectByTeam } from '../../lib/projects.js';
+
+const execFileAsync = promisify(execFile);
+
+const COMPOSE_FILES = [
+  'docker-compose.devcontainer.yml',
+  'docker-compose.yml',
+  'docker-compose.yaml',
+  'compose.yml',
+  'compose.yaml',
+];
+
+export function composeProjectNameForWorkspace(workspacePath: string, issueId: string): string {
+  const featureFolder = `feature-${issueId.toLowerCase()}`;
+  for (const devPath of [join(workspacePath, '.devcontainer', 'dev'), join(workspacePath, 'dev')]) {
+    if (!existsSync(devPath)) continue;
+    try {
+      const content = readFileSync(devPath, 'utf-8');
+      const match = content.match(/COMPOSE_PROJECT_NAME="([^$"]*)\$\{FEATURE_FOLDER\}"/);
+      if (match) return `${match[1]}${featureFolder}`;
+      const literalMatch = content.match(/COMPOSE_PROJECT_NAME="([^"]+)"/);
+      if (literalMatch) return literalMatch[1];
+    } catch {}
+  }
+  return `panopticon-${featureFolder}`;
+}
+
+function findDevcontainerComposeFile(workspacePath: string): string | null {
+  const devcontainerDir = join(workspacePath, '.devcontainer');
+  for (const file of COMPOSE_FILES) {
+    const fullPath = join(devcontainerDir, file);
+    if (existsSync(fullPath)) return fullPath;
+  }
+  return null;
+}
+
+async function dockerCompose(args: string[], cwd: string): Promise<void> {
+  await execFileAsync('docker', ['compose', ...args], {
+    cwd,
+    encoding: 'utf-8',
+    timeout: 300_000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+}
+
+export async function workspaceRebuildCommand(issueId: string): Promise<void> {
+  const normalizedIssueId = issueId.toLowerCase();
+  const teamPrefix = extractTeamPrefix(issueId);
+  const projectConfig = teamPrefix ? findProjectByTeam(teamPrefix) : null;
+  if (!projectConfig) {
+    console.error(chalk.red(`✗ No project found for issue ${issueId}`));
+    process.exit(1);
+  }
+
+  if (!projectConfig.workspace?.docker?.compose_template) {
+    console.error(chalk.red(`✗ Project ${projectConfig.name} has no workspace docker compose_template configured`));
+    process.exit(1);
+  }
+
+  const workspacePath = join(projectConfig.path, 'workspaces', `feature-${normalizedIssueId}`);
+  if (!existsSync(workspacePath)) {
+    console.error(chalk.red(`✗ Workspace not found: ${workspacePath}`));
+    process.exit(1);
+  }
+
+  const spinner = ora(`Rebuilding workspace stack for ${issueId.toUpperCase()}...`).start();
+  try {
+    const composeProjectName = composeProjectNameForWorkspace(workspacePath, normalizedIssueId);
+    const existingComposeFile = findDevcontainerComposeFile(workspacePath);
+    if (existingComposeFile) {
+      spinner.text = 'Tearing down existing workspace stack...';
+      await dockerCompose([
+        '-f',
+        existingComposeFile,
+        '-p',
+        composeProjectName,
+        'down',
+        '-v',
+        '--remove-orphans',
+      ], dirname(existingComposeFile));
+    }
+
+    spinner.text = 'Re-rendering .devcontainer/ from template...';
+    const devcontainerDir = join(workspacePath, '.devcontainer');
+    if (existsSync(devcontainerDir)) {
+      rmSync(devcontainerDir, { recursive: true, force: true });
+    }
+    const ensured = ensureDevcontainer({ workspacePath, issueId: normalizedIssueId });
+    if (!ensured.step.success) {
+      throw new Error(ensured.step.error ?? 'Failed to render .devcontainer/');
+    }
+
+    const composeFile = findDevcontainerComposeFile(workspacePath);
+    if (!composeFile) {
+      throw new Error(`No devcontainer compose file found in ${devcontainerDir}`);
+    }
+
+    spinner.text = 'Starting workspace stack...';
+    await dockerCompose([
+      '-f',
+      composeFile,
+      '-p',
+      composeProjectName,
+      'up',
+      '-d',
+      '--build',
+    ], dirname(composeFile));
+
+    spinner.succeed(`Workspace stack rebuilt for ${issueId.toUpperCase()}`);
+    console.log(chalk.dim(`  workspace: ${workspacePath}`));
+    console.log(chalk.dim(`  compose:   ${composeFile}`));
+    console.log(chalk.dim(`  project:   ${composeProjectName}`));
+  } catch (error: any) {
+    spinner.fail(`Workspace rebuild failed: ${error.message ?? error}`);
+    process.exit(1);
+  }
+}

--- a/src/cli/commands/workspace-rebuild.ts
+++ b/src/cli/commands/workspace-rebuild.ts
@@ -73,7 +73,11 @@ export async function workspaceRebuildCommand(issueId: string): Promise<void> {
     process.exit(1);
   }
 
-  const workspacePath = join(resolvedProject.projectPath, 'workspaces', `feature-${normalizedIssueId}`);
+  const workspacePath = join(
+    resolvedProject.projectPath,
+    projectConfig.workspace?.workspaces_dir ?? 'workspaces',
+    `feature-${normalizedIssueId}`,
+  );
   if (!existsSync(workspacePath)) {
     console.error(chalk.red(`✗ Workspace not found: ${workspacePath}`));
     process.exit(1);

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -251,6 +251,17 @@ export function registerWorkspaceCommands(program: Command): void {
     });
 
   workspace
+    .command('reap')
+    .description('List or remove orphaned unhealthy workspace Docker stacks')
+    .option('--days <days>', 'Minimum age in days', '7')
+    .option('--apply', 'Run docker compose down -v --remove-orphans for candidates')
+    .option('--yes', 'Skip confirmation when using --apply')
+    .action(async (opts: { days?: string; apply?: boolean; yes?: boolean }) => {
+      const { workspaceReapCommand } = await import('./workspace-reap.js');
+      await workspaceReapCommand(opts);
+    });
+
+  workspace
     .command('update <issueId>')
     .description('Update skills/agents/rules in an existing workspace')
     .option('--force', 'Overwrite user-modified files')

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -251,6 +251,14 @@ export function registerWorkspaceCommands(program: Command): void {
     });
 
   workspace
+    .command('rebuild <issueId>')
+    .description('Tear down, re-render, and restart a single workspace Docker stack')
+    .action(async (issueId: string) => {
+      const { workspaceRebuildCommand } = await import('./workspace-rebuild.js');
+      await workspaceRebuildCommand(issueId);
+    });
+
+  workspace
     .command('reap')
     .description('List or remove orphaned unhealthy workspace Docker stacks')
     .option('--days <days>', 'Minimum age in days', '7')

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -411,7 +411,7 @@ program
   .option('--local', 'Use local workspace (explicit override)')
   .option('--auto', 'Skip planning agent by synthesizing a minimal vBRIEF and beads from the issue title/body')
   .option('--host', 'Bypass workspace docker stack-health gate and spawn on the host')
-  .option('--yes', 'Confirm --host in non-interactive contexts')
+  .option('--yes', 'Confirm --host without an interactive prompt')
   .action(startCommand);
 
 program

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -410,6 +410,8 @@ program
   .option('--remote', 'Use remote workspace (Fly.io)')
   .option('--local', 'Use local workspace (explicit override)')
   .option('--auto', 'Skip planning agent by synthesizing a minimal vBRIEF and beads from the issue title/body')
+  .option('--host', 'Bypass workspace docker stack-health gate and spawn on the host')
+  .option('--yes', 'Confirm --host in non-interactive contexts')
   .action(startCommand);
 
 program

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -423,6 +423,8 @@ program
   .option('--max-slots <n>', 'Max concurrent agents')
   .option('--auto-advance', 'Automatically dispatch the next wave when the current one completes')
   .option('--no-auto-advance', 'Disable automatic next-wave dispatching for this swarm')
+  .option('--host', 'Bypass workspace docker stack-health gate and spawn swarm slots on the host')
+  .option('--yes', 'Confirm --host in non-interactive contexts')
   .option('--task <op>', 'vBRIEF task operation: next | show | claim | done | block | unblock | cancel')
   .option('--item <id>', 'vBRIEF item ID for show/claim/done/block operations')
   .option('--reason <text>', 'Reason for task status mutation')

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -411,7 +411,7 @@ program
   .option('--local', 'Use local workspace (explicit override)')
   .option('--auto', 'Skip planning agent by synthesizing a minimal vBRIEF and beads from the issue title/body')
   .option('--host', 'Bypass workspace docker stack-health gate and spawn on the host')
-  .option('--yes', 'Confirm --host without an interactive prompt')
+  .option('--yes', 'Confirm --host in non-interactive contexts')
   .action(startCommand);
 
 program

--- a/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/OverviewTab.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/OverviewTab.tsx
@@ -956,6 +956,18 @@ export function OverviewTab({ issueId, onSwitchTab, issue, agent }: OverviewTabP
         </Tile>
       </div>
 
+      {workspace.data?.stackHealth && !workspace.data.stackHealth.healthy && (
+        <Section title="Workspace Stack">
+          <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', padding: 10, borderRadius: 10, border: '1px solid color-mix(in srgb, var(--destructive) 40%, transparent)', background: 'color-mix(in srgb, var(--destructive) 10%, transparent)', color: 'var(--destructive)', fontSize: 12 }}>
+            <AlertCircle size={14} style={{ flexShrink: 0, marginTop: 1 }} />
+            <div>
+              <div style={{ fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.4 }}>STACK BROKEN</div>
+              <div style={{ color: 'var(--muted-foreground)', marginTop: 3 }}>{workspace.data.stackHealth.reasons.join('; ')}</div>
+            </div>
+          </div>
+        </Section>
+      )}
+
       {/* 3. Containers */}
       {workspace.data?.containers && Object.keys(workspace.data.containers).length > 0 && (
         <Section title="Containers" rightSlot={<span style={{ fontSize: 10, color: 'var(--muted-foreground)' }}>right-click</span>}>

--- a/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/queries.ts
+++ b/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/queries.ts
@@ -336,6 +336,12 @@ export interface WorkspaceContainerStatus {
   status?: string;
 }
 
+export interface WorkspaceStackHealth {
+  healthy: boolean;
+  reasons: string[];
+  lastObserved: string;
+}
+
 export interface WorkspaceData {
   exists: boolean;
   issueId: string;
@@ -351,6 +357,7 @@ export interface WorkspaceData {
   repoGit?: { ahead: number; behind: number; branch: string; dirty: boolean } | null;
   services?: Array<{ name: string; url?: string }>;
   containers?: Record<string, WorkspaceContainerStatus> | null;
+  stackHealth?: WorkspaceStackHealth;
   hasDocker?: boolean;
   canContainerize?: boolean;
   pendingOperation?: string | null;

--- a/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/queries.ts
+++ b/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/queries.ts
@@ -368,10 +368,14 @@ export interface WorkspaceData {
   corrupted?: boolean;
 }
 
-export function useWorkspaceQuery(issueId: string): UseQueryResult<WorkspaceData> {
+export function useWorkspaceQuery(
+  issueId: string,
+  options?: Omit<UseQueryOptions<WorkspaceData>, 'queryKey' | 'queryFn'>,
+): UseQueryResult<WorkspaceData> {
   return useQuery({
     queryKey: ['workspace', issueId],
     queryFn: () => fetchJson<WorkspaceData>(`/api/workspaces/${issueId}`),
     refetchInterval: 30_000,
+    ...options,
   });
 }

--- a/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/queries.ts
+++ b/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/queries.ts
@@ -368,6 +368,10 @@ export interface WorkspaceData {
   corrupted?: boolean;
 }
 
+export interface WorkspaceStackHealthBatchResponse {
+  workspaces: Record<string, WorkspaceData>;
+}
+
 export function useWorkspaceQuery(
   issueId: string,
   options?: Omit<UseQueryOptions<WorkspaceData>, 'queryKey' | 'queryFn'>,
@@ -375,6 +379,22 @@ export function useWorkspaceQuery(
   return useQuery({
     queryKey: ['workspace', issueId],
     queryFn: () => fetchJson<WorkspaceData>(`/api/workspaces/${issueId}`),
+    refetchInterval: 30_000,
+    ...options,
+  });
+}
+
+export function useWorkspaceStackHealthQuery(
+  issueIds: string[],
+  options?: Omit<UseQueryOptions<WorkspaceStackHealthBatchResponse>, 'queryKey' | 'queryFn'>,
+): UseQueryResult<WorkspaceStackHealthBatchResponse> {
+  const normalizedIds = Array.from(new Set(issueIds.filter(Boolean).map((id) => id.toUpperCase()))).sort();
+  return useQuery({
+    queryKey: ['workspace-stack-health', normalizedIds],
+    queryFn: () => fetchJson<WorkspaceStackHealthBatchResponse>(
+      `/api/workspace-stack-health?issueIds=${encodeURIComponent(normalizedIds.join(','))}`,
+    ),
+    enabled: normalizedIds.length > 0,
     refetchInterval: 30_000,
     ...options,
   });

--- a/src/dashboard/frontend/src/components/InspectorPanel.tsx
+++ b/src/dashboard/frontend/src/components/InspectorPanel.tsx
@@ -853,6 +853,18 @@ export function InspectorPanel({ agent, workAgents = [], issueId, issueUrl, issu
           </div>
         )}
 
+        {workspace?.stackHealth && !workspace.stackHealth.healthy && (
+          <div className="px-3 py-2 border-b border-destructive/40 bg-destructive/10">
+            <div className="flex items-center gap-2 mb-1.5">
+              <AlertTriangle className="w-3.5 h-3.5 text-destructive shrink-0" />
+              <span className="text-xs font-bold uppercase tracking-wide text-destructive">Workspace Stack Broken</span>
+            </div>
+            <p className="text-[10px] text-muted-foreground" title={workspace.stackHealth.reasons.join('; ')}>
+              {workspace.stackHealth.reasons.join('; ')}
+            </p>
+          </div>
+        )}
+
         {/* Awaiting input banner */}
         {agent && awaitingInput && (
           <div className="px-3 py-2 border-b border-warning/40 bg-warning/10" data-testid={`inspector-input-${issueId}`}>

--- a/src/dashboard/frontend/src/components/KanbanBoard.test.tsx
+++ b/src/dashboard/frontend/src/components/KanbanBoard.test.tsx
@@ -548,6 +548,7 @@ describe('IssueCard', () => {
       isSelected: false,
       onSelect: vi.fn(),
       onPlan: vi.fn(),
+      workspace: { exists: false, issueId: 'TEST-123' },
       ...props,
     };
 
@@ -593,6 +594,24 @@ describe('IssueCard', () => {
       expect(startCall).toBeTruthy();
       expect(JSON.parse((startCall?.[1] as RequestInit).body as string)).toMatchObject({ auto: true });
     });
+  });
+
+  it('shows unhealthy workspace stack state on the card', () => {
+    renderIssueCard({
+      workspace: {
+        exists: true,
+        issueId: 'TEST-123',
+        stackHealth: {
+          healthy: false,
+          reasons: ['test-stack-server stuck Created for 120s'],
+          lastObserved: new Date().toISOString(),
+        },
+      },
+    });
+
+    const badge = screen.getByTestId('card-stack-health-TEST-123');
+    expect(badge).toHaveTextContent('Workspace unhealthy');
+    expect(badge).toHaveAttribute('title', 'test-stack-server stuck Created for 120s');
   });
 
   it('opens the inspector rather than the planning dialog for planning-only input', () => {

--- a/src/dashboard/frontend/src/components/KanbanBoard.tsx
+++ b/src/dashboard/frontend/src/components/KanbanBoard.tsx
@@ -49,7 +49,7 @@ import { BulkAgentWarningDialog } from './BulkAgentWarningDialog';
 import { BulkCloseOutProgress, type BulkCloseResult } from './BulkCloseOutProgress';
 import { COMMAND_DECK_SURFACE_REGISTRY } from '../lib/commandDeckSurfaceRegistry';
 import { ModelHarnessPicker, useAvailableModels, type Harness } from './shared/ModelPicker';
-import { useWorkspaceQuery, type WorkspaceData } from './CommandDeck/ZoneCOverviewTabs/queries';
+import { useWorkspaceStackHealthQuery, type WorkspaceData } from './CommandDeck/ZoneCOverviewTabs/queries';
 
 
 // Parity registry anchor — keeps the card action surface tied to the
@@ -1648,6 +1648,14 @@ export function KanbanBoard({ selectedIssue: externalSelectedIssue, onSelectIssu
     return result;
   }, [grouped, planningStateById]);
 
+  const kanbanIssueIds = useMemo(() => {
+    if (cycleFilter === 'all' || cycleFilter === 'backlog' || cycleFilter === 'canceled') return [];
+    return STATUS_ORDER
+      .filter((status) => status !== 'backlog')
+      .flatMap((status) => sortedGrouped[status].map((issue) => issue.identifier));
+  }, [cycleFilter, sortedGrouped]);
+  const stackHealthByIssue = useWorkspaceStackHealthQuery(kanbanIssueIds).data?.workspaces ?? {};
+
   return (
     <KanbanTickContext.Provider value={kanbanTick}>
     <div className="space-y-4">
@@ -1931,6 +1939,7 @@ export function KanbanBoard({ selectedIssue: externalSelectedIssue, onSelectIssu
                     bulkSelectedIds={bulkSelection.selectedIds}
                     onBulkToggle={bulkSelection.toggle}
                     planningStateById={planningStateById}
+                    workspaceByIssueId={stackHealthByIssue}
                   />
                 </div>
               </div>
@@ -2042,6 +2051,7 @@ function ColumnContent({
   bulkSelectedIds,
   onBulkToggle,
   planningStateById,
+  workspaceByIssueId,
 }: {
   issues: Issue[];
   issueWorkAgentsById: Map<string, Agent[]>;
@@ -2060,6 +2070,7 @@ function ColumnContent({
   bulkSelectedIds?: Set<string>;
   onBulkToggle?: (issueId: string) => void;
   planningStateById?: Record<string, PlanningState>;
+  workspaceByIssueId?: Record<string, WorkspaceData>;
 }) {
   // Check if any Rally issues with hierarchy exist
   const hasRallyHierarchy = issues.some(i => i.artifactType?.includes('PortfolioItem'));
@@ -2096,6 +2107,7 @@ function ColumnContent({
         isBulkSelected={bulkSelectedIds?.has(issue.identifier)}
         onBulkToggle={onBulkToggle ? () => onBulkToggle(issue.identifier) : undefined}
         planningState={planningStateById?.[issue.identifier]}
+        workspace={workspaceByIssueId?.[issue.identifier.toUpperCase()]}
       />
     );
   };
@@ -2718,11 +2730,7 @@ export function IssueCard({ issue, workAgent, workAgents = [], planningAgent, sp
   const cardRef = useRef<HTMLDivElement>(null);
   const { prefs: _prefs } = useUIPreferences();
   const { groups: modelGroups, defaultModel, harnessPolicy } = useAvailableModels();
-  const workspaceQuery = useWorkspaceQuery(issue.identifier || '', {
-    enabled: !workspaceProp && !!issue.identifier,
-  });
-  const workspace = workspaceProp ?? workspaceQuery.data;
-  const stackHealth = workspace?.stackHealth;
+  const stackHealth = workspaceProp?.stackHealth;
   const isStackUnhealthy = stackHealth?.healthy === false;
   const stackHealthDetails = stackHealth?.reasons.join('; ');
   const [launchModel, setLaunchModel] = useState(defaultModel);

--- a/src/dashboard/frontend/src/components/KanbanBoard.tsx
+++ b/src/dashboard/frontend/src/components/KanbanBoard.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useEffect, useRef, createContext, useContext } from 'react';
+import { useState, useMemo, useCallback, useEffect, useRef, createContext, useContext, type ReactNode } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useDashboardStore, selectAgentList, selectIssuesByCycle, selectReviewStatus } from '../lib/store';
@@ -104,6 +104,14 @@ function LiveLastHeardBadge({ lastActivity }: { lastActivity?: string }) {
 // Shared one-second tick for all KanbanBoard child components (eliminates
 // N independent setInterval timers when many agent cards are visible).
 const KanbanTickContext = createContext<number>(Date.now());
+function KanbanTickProvider({ children }: { children: ReactNode }) {
+  const [kanbanTick, setKanbanTick] = useState(Date.now());
+  useEffect(() => {
+    const t = setInterval(() => setKanbanTick(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, []);
+  return <KanbanTickContext.Provider value={kanbanTick}>{children}</KanbanTickContext.Provider>;
+}
 function useKanbanTick() {
   return useContext(KanbanTickContext);
 }
@@ -1143,13 +1151,6 @@ export function KanbanBoard({ selectedIssue: externalSelectedIssue, onSelectIssu
   // Rally feature expand/collapse state (lifted from ColumnContent for expand/collapse all)
   const [collapsedFeatures, setCollapsedFeatures] = useState<Set<string>>(new Set());
 
-  // Shared one-second tick for all child badges (eliminates per-badge intervals)
-  const [kanbanTick, setKanbanTick] = useState(Date.now());
-  useEffect(() => {
-    const t = setInterval(() => setKanbanTick(Date.now()), 1000);
-    return () => clearInterval(t);
-  }, []);
-
   const toggleFeature = useCallback((featureId: string) => {
     setCollapsedFeatures(prev => {
       const next = new Set(prev);
@@ -1657,7 +1658,7 @@ export function KanbanBoard({ selectedIssue: externalSelectedIssue, onSelectIssu
   const stackHealthByIssue = useWorkspaceStackHealthQuery(kanbanIssueIds).data?.workspaces ?? {};
 
   return (
-    <KanbanTickContext.Provider value={kanbanTick}>
+    <KanbanTickProvider>
     <div className="space-y-4">
       {/* Filter bar */}
       <div className="flex flex-col gap-2">
@@ -2029,7 +2030,7 @@ export function KanbanBoard({ selectedIssue: externalSelectedIssue, onSelectIssu
         onClose={handleCloseProgress}
       />
     </div>
-    </KanbanTickContext.Provider>
+    </KanbanTickProvider>
   );
 }
 

--- a/src/dashboard/frontend/src/components/KanbanBoard.tsx
+++ b/src/dashboard/frontend/src/components/KanbanBoard.tsx
@@ -49,6 +49,7 @@ import { BulkAgentWarningDialog } from './BulkAgentWarningDialog';
 import { BulkCloseOutProgress, type BulkCloseResult } from './BulkCloseOutProgress';
 import { COMMAND_DECK_SURFACE_REGISTRY } from '../lib/commandDeckSurfaceRegistry';
 import { ModelHarnessPicker, useAvailableModels, type Harness } from './shared/ModelPicker';
+import { useWorkspaceQuery, type WorkspaceData } from './CommandDeck/ZoneCOverviewTabs/queries';
 
 
 // Parity registry anchor — keeps the card action surface tied to the
@@ -2707,15 +2708,23 @@ interface IssueCardProps {
   isBulkSelected?: boolean;
   onBulkToggle?: () => void;
   planningState?: PlanningState;
+  workspace?: WorkspaceData;
 }
 
-export function IssueCard({ issue, workAgent, workAgents = [], planningAgent, specialists = [], cost, costsLoading, isSelected, onSelect, onPlan, onViewBeads, onViewVBrief, isBulkSelected, onBulkToggle, planningState: planningStateProp }: IssueCardProps) {
+export function IssueCard({ issue, workAgent, workAgents = [], planningAgent, specialists = [], cost, costsLoading, isSelected, onSelect, onPlan, onViewBeads, onViewVBrief, isBulkSelected, onBulkToggle, planningState: planningStateProp, workspace: workspaceProp }: IssueCardProps) {
   const queryClient = useQueryClient();
   const showAlert = useAlert();
   const [showCostModal, setShowCostModal] = useState(false);
   const cardRef = useRef<HTMLDivElement>(null);
   const { prefs: _prefs } = useUIPreferences();
   const { groups: modelGroups, defaultModel, harnessPolicy } = useAvailableModels();
+  const workspaceQuery = useWorkspaceQuery(issue.identifier || '', {
+    enabled: !workspaceProp && !!issue.identifier,
+  });
+  const workspace = workspaceProp ?? workspaceQuery.data;
+  const stackHealth = workspace?.stackHealth;
+  const isStackUnhealthy = stackHealth?.healthy === false;
+  const stackHealthDetails = stackHealth?.reasons.join('; ');
   const [launchModel, setLaunchModel] = useState(defaultModel);
   const [launchHarness, setLaunchHarness] = useState<Harness>('claude-code');
 
@@ -2798,7 +2807,7 @@ export function IssueCard({ issue, workAgent, workAgents = [], planningAgent, sp
     canonical === 'in_review' ? (isReadyToMerge ? 'Awaiting merge' : isPipelineStuck ? 'Needs recovery' : 'Review pipeline') :
     canonical === 'done' ? 'Completed' :
     'Canceled';
-  const cardTone = isPipelineStuck
+  const cardTone = isStackUnhealthy || isPipelineStuck
     ? 'from-destructive/12 via-destructive/5 to-transparent'
     : isReadyToMerge
       ? 'from-warning/20 via-warning/6 to-transparent'
@@ -3070,15 +3079,17 @@ export function IssueCard({ issue, workAgent, workAgents = [], planningAgent, sp
       className={`group relative overflow-hidden rounded-2xl border cursor-pointer transition-all shadow-[0_6px_22px_rgba(0,0,0,0.08)] ${isSessionLost ? 'border-warning/50' : ''} ${
         isSelected
           ? 'ring-2 ring-warning/70 shadow-[0_12px_30px_rgba(245,158,11,0.18)]'
-          : isBulkSelected
-            ? 'border-primary/50 bg-primary/[0.03] shadow-[0_6px_22px_rgba(0,0,0,0.08)]'
-            : 'hover:-translate-y-0.5 border-border/70 hover:border-border hover:shadow-[0_12px_28px_rgba(0,0,0,0.12)]'
+          : isStackUnhealthy
+            ? 'border-destructive/60 bg-destructive/[0.03] shadow-[0_10px_26px_rgba(239,68,68,0.14)]'
+            : isBulkSelected
+              ? 'border-primary/50 bg-primary/[0.03] shadow-[0_6px_22px_rgba(0,0,0,0.08)]'
+              : 'hover:-translate-y-0.5 border-border/70 hover:border-border hover:shadow-[0_12px_28px_rgba(0,0,0,0.12)]'
       } bg-[linear-gradient(145deg,var(--color-surface)_0%,rgba(255,255,255,0.03)_100%)]`}
     >
       <div className={`pointer-events-none absolute inset-x-0 top-0 h-20 bg-gradient-to-br ${cardTone}`} />
       <div
         className={`absolute inset-y-0 left-0 w-1.5 ${
-          isPipelineStuck
+          isStackUnhealthy || isPipelineStuck
             ? 'bg-destructive'
             : isReadyToMerge
               ? 'bg-warning'
@@ -3340,6 +3351,16 @@ export function IssueCard({ issue, workAgent, workAgents = [], planningAgent, sp
               >
                 <AlertCircle className="w-3 h-3" />
                 {pipelineCallToAction.label}
+              </span>
+            )}
+            {isStackUnhealthy && (
+              <span
+                className="flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium badge-bg-destructive text-destructive-foreground border border-destructive/50"
+                title={stackHealthDetails || 'Workspace Docker stack is unhealthy'}
+                data-testid={`card-stack-health-${issue.identifier}`}
+              >
+                <AlertTriangle className="w-3 h-3" />
+                Workspace unhealthy
               </span>
             )}
             {/* Lifecycle resolution badges (PAN-309) */}

--- a/src/dashboard/frontend/src/components/inspector/types.ts
+++ b/src/dashboard/frontend/src/components/inspector/types.ts
@@ -54,6 +54,12 @@ export interface ContainerStatus {
   lastFailureReason?: string;
 }
 
+export interface WorkspaceStackHealth {
+  healthy: boolean;
+  reasons: string[];
+  lastObserved: string;
+}
+
 export interface PendingOperation {
   type: 'approve' | 'close' | 'containerize' | 'start' | 'review' | 'merge';
   issueId: string;
@@ -80,6 +86,7 @@ export interface WorkspaceInfo {
   frontendUrl?: string;
   apiUrl?: string;
   containers?: Record<string, ContainerStatus> | null;
+  stackHealth?: WorkspaceStackHealth;
   hasDocker?: boolean;
   canContainerize?: boolean;
   pendingOperation?: PendingOperation | null;

--- a/src/dashboard/server/routes/__tests__/agents-delivery-method.test.ts
+++ b/src/dashboard/server/routes/__tests__/agents-delivery-method.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { validateAgentDeliveryMethodOrigin } from '../agents.js';
+import { _resetTrustedOriginsForTests } from '../origin-validation.js';
+
+describe('agent delivery-method route', () => {
+  beforeEach(() => {
+    delete process.env.NODE_ENV;
+    process.env.PORT = '3011';
+    delete process.env.DASHBOARD_URL;
+    _resetTrustedOriginsForTests();
+  });
+
+  it('rejects cross-origin POSTs before mutating delivery method', () => {
+    const result = validateAgentDeliveryMethodOrigin({
+      method: 'POST',
+      headers: {
+        origin: 'https://evil.example',
+      },
+    } as any);
+
+    expect(result).toEqual({
+      ok: false,
+      status: 403,
+      body: { error: 'forbidden' },
+    });
+  });
+});

--- a/src/dashboard/server/routes/__tests__/swarm.test.ts
+++ b/src/dashboard/server/routes/__tests__/swarm.test.ts
@@ -308,6 +308,7 @@ describe('swarm route helpers', () => {
       totalWaves: 2,
       model: 'kimi-k2.6',
       autoAdvance: true,
+      hostOverride: true,
       slots: [
         {
           slot: 1,
@@ -348,11 +349,15 @@ describe('swarm route helpers', () => {
     // PAN-977 blocker #4: prior slots are persisted cumulatively, so the new
     // dispatch appears alongside the prior completed slot.
     expect(nextState.autoAdvance).toBe(true);
+    expect(nextState.hostOverride).toBe(true);
     const newSlot = nextState.slots.find((s) => s.itemId === 'wave-1-item');
     expect(newSlot).toBeTruthy();
     expect(newSlot?.itemTitle).toBe('Dispatch next wave');
     expect(newSlot?.status).toBe('running');
     expect(agents.spawnAgent).toHaveBeenCalledTimes(1);
+    expect(agents.spawnAgent).toHaveBeenCalledWith(expect.objectContaining({
+      allowHost: true,
+    }));
   });
 
   // PAN-977 round-12 blocker #1: regression — onSlotMergeComplete must not
@@ -700,6 +705,8 @@ describe('swarm route helpers', () => {
       issueId: 'PAN-971',
       allowHost: true,
     }));
+    const state = await __testInternals.loadSwarmState('PAN-971');
+    expect(state?.hostOverride).toBe(true);
   });
 
   it('does not advance while current wave still has running slots', async () => {

--- a/src/dashboard/server/routes/__tests__/swarm.test.ts
+++ b/src/dashboard/server/routes/__tests__/swarm.test.ts
@@ -685,6 +685,23 @@ describe('swarm route helpers', () => {
     expect(newDispatch?.status).toBe('running');
   });
 
+  it('passes confirmed host override into swarm slot spawns', async () => {
+    vi.mocked(tmux.listSessionNamesAsync).mockResolvedValue([]);
+
+    const { __testInternals } = await import('../swarm.js');
+    const result = await __testInternals.dispatchSwarmWave({
+      issueId: 'PAN-971',
+      wave: 0,
+      allowHost: true,
+    });
+
+    expect(result.status).toBe(200);
+    expect(agents.spawnAgent).toHaveBeenCalledWith(expect.objectContaining({
+      issueId: 'PAN-971',
+      allowHost: true,
+    }));
+  });
+
   it('does not advance while current wave still has running slots', async () => {
     const swarmStatePath = join(testHome, '.panopticon', 'swarms', 'pan-971.json');
     writeFileSync(swarmStatePath, JSON.stringify({

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -2539,7 +2539,7 @@ const postAgentsRoute = HttpRouter.add(
                       startedAt: new Date().toISOString(),
                       workspace: workspacePath,
                       role,
-                      message: 'Container startup timed out before work agent spawn',
+                      message: `Container startup timed out before work agent spawn. Run pan workspace rebuild ${issueId} to reset the stack.`,
                       error: `Containers for ${issueId} did not become healthy within ${maxWaitMs}ms`,
                       ...(preSpawnStashRef ? { preSpawnStashRef } : {}),
                       ...(preSpawnStashMessage ? { preSpawnStashMessage } : {}),

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -2088,29 +2088,31 @@ const postAgentsRoute = HttpRouter.add(
       throw err;
     }
 
-    const stackHealth = yield* Effect.promise(() => getWorkspaceStackHealth(issueId, { projectConfig, workspacePath }));
-    if (!stackHealth.healthy) {
-      yield* Effect.promise(() => appendAgentLifecycleLog(agentSessionName, 'agent.start_blocked_stack_unhealthy', {
-        issueId,
-        reasons: stackHealth.reasons,
-        lastObserved: stackHealth.lastObserved,
-      }));
-      if (!allowHost) {
-        emitActivityEntry({
-          source: 'dashboard',
-          level: 'error',
-          issueId: issueId.toUpperCase(),
-          message: `agent-spawn-blocked-stack-unhealthy: ${issueId.toUpperCase()}`,
-          details: stackHealth.reasons.join('; '),
-        });
-        return jsonResponse({
-          success: false,
-          blocked: true,
-          skipped: true,
-          error: `Workspace docker stack for ${issueId} is not healthy: ${stackHealth.reasons.join('; ')}`,
-          hint: `Run 'pan workspace rebuild ${issueId}' or use the CLI break-glass path: pan start ${issueId} --host.`,
-          stackHealth,
-        }, { status: 422 });
+    if (!isRemote) {
+      const stackHealth = yield* Effect.promise(() => getWorkspaceStackHealth(issueId, { projectConfig, workspacePath }));
+      if (!stackHealth.healthy) {
+        yield* Effect.promise(() => appendAgentLifecycleLog(agentSessionName, 'agent.start_blocked_stack_unhealthy', {
+          issueId,
+          reasons: stackHealth.reasons,
+          lastObserved: stackHealth.lastObserved,
+        }));
+        if (!allowHost) {
+          emitActivityEntry({
+            source: 'dashboard',
+            level: 'error',
+            issueId: issueId.toUpperCase(),
+            message: `agent-spawn-blocked-stack-unhealthy: ${issueId.toUpperCase()}`,
+            details: stackHealth.reasons.join('; '),
+          });
+          return jsonResponse({
+            success: false,
+            blocked: true,
+            skipped: true,
+            error: `Workspace docker stack for ${issueId} is not healthy: ${stackHealth.reasons.join('; ')}`,
+            hint: `Run 'pan workspace rebuild ${issueId}' or use the CLI break-glass path: pan start ${issueId} --host.`,
+            stackHealth,
+          }, { status: 422 });
+        }
       }
     }
 

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -2088,7 +2088,7 @@ const postAgentsRoute = HttpRouter.add(
       throw err;
     }
 
-    const stackHealth = yield* Effect.promise(() => getWorkspaceStackHealth(issueId, { projectConfig }));
+    const stackHealth = yield* Effect.promise(() => getWorkspaceStackHealth(issueId, { projectConfig, stackExpected: false }));
     if (!stackHealth.healthy) {
       yield* Effect.promise(() => appendAgentLifecycleLog(agentSessionName, 'agent.start_blocked_stack_unhealthy', {
         issueId,

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -2404,18 +2404,6 @@ const postAgentsRoute = HttpRouter.add(
         detached: true,
         stdio: ['ignore', spawnLogHandle.fd, spawnLogHandle.fd],
       });
-      child.on('error', (error) => {
-        void appendAgentLifecycleLog(agentSessionName, 'agent.work_spawn_process_error', {
-          issueId,
-          role,
-          workspacePath,
-          activityId,
-          error: error.message,
-          args,
-          cwd: cwd || workspacePath,
-          spawnLogPath,
-        }).catch(() => undefined);
-      });
       child.once('spawn', () => {
         void appendAgentLifecycleLog(agentSessionName, 'agent.work_spawn_process_spawned', {
           issueId,
@@ -2428,22 +2416,46 @@ const postAgentsRoute = HttpRouter.add(
           spawnLogPath,
         }).catch(() => undefined);
       });
-      child.once('close', (code, signal) => {
-        void appendAgentLifecycleLog(agentSessionName, 'agent.work_spawn_process_closed', {
-          issueId,
-          role,
-          workspacePath,
-          activityId,
-          code,
-          signal,
-          args,
-          cwd: cwd || workspacePath,
-          spawnLogPath,
-        }).catch(() => undefined);
-      });
-      child.unref();
-      await spawnLogHandle.close();
-      return activityId;
+      try {
+        const result = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+          child.once('error', (error) => {
+            void appendAgentLifecycleLog(agentSessionName, 'agent.work_spawn_process_error', {
+              issueId,
+              role,
+              workspacePath,
+              activityId,
+              error: error.message,
+              args,
+              cwd: cwd || workspacePath,
+              spawnLogPath,
+            }).catch(() => undefined);
+            reject(error);
+          });
+          child.once('close', (code, signal) => {
+            void appendAgentLifecycleLog(agentSessionName, 'agent.work_spawn_process_closed', {
+              issueId,
+              role,
+              workspacePath,
+              activityId,
+              code,
+              signal,
+              args,
+              cwd: cwd || workspacePath,
+              spawnLogPath,
+            }).catch(() => undefined);
+            resolve({ code, signal });
+          });
+        });
+        if (result.code !== 0) {
+          const output = await readFile(spawnLogPath, 'utf-8').catch(() => '');
+          const error = new Error(output.trim() || `pan ${args.join(' ')} exited with code ${result.code ?? 'null'}`);
+          Object.assign(error, { activityId, spawnLogPath, code: result.code, signal: result.signal, output });
+          throw error;
+        }
+        return activityId;
+      } finally {
+        await spawnLogHandle.close();
+      }
     };
 
     // Use IssueLifecycle service to transition issue to "In Progress" (PAN-449)
@@ -2692,12 +2704,45 @@ const postAgentsRoute = HttpRouter.add(
       role,
       workspacePath,
     }));
-    const activityId = yield* Effect.promise(() => spawnPanCommand(
-      ['start', issueId, '--local', '--model', spawnModel,
-        ...(effectiveHarness ? ['--harness', effectiveHarness] : []),
-        ...(allowHost ? ['--host', '--yes'] : [])],
-      workspacePath,
-    ));
+    let activityId: string;
+    try {
+      activityId = yield* Effect.promise(() => spawnPanCommand(
+        ['start', issueId, '--local', '--model', spawnModel,
+          ...(effectiveHarness ? ['--harness', effectiveHarness] : []),
+          ...(allowHost ? ['--host', '--yes'] : [])],
+        workspacePath,
+      ));
+    } catch (error: any) {
+      const output = String(error?.output ?? error?.message ?? '');
+      if (output.includes(`Workspace docker stack for ${issueId}`) && output.includes('is not healthy')) {
+        const failedStackHealth = yield* Effect.promise(() => getWorkspaceStackHealth(issueId, { projectConfig }));
+        emitActivityEntry({
+          source: 'dashboard',
+          level: 'error',
+          issueId: issueId.toUpperCase(),
+          message: `agent-spawn-blocked-stack-unhealthy: ${issueId.toUpperCase()}`,
+          details: failedStackHealth.reasons.length > 0 ? failedStackHealth.reasons.join('; ') : output.trim(),
+        });
+        return jsonResponse({
+          success: false,
+          blocked: true,
+          skipped: true,
+          error: failedStackHealth.reasons.length > 0
+            ? `Workspace docker stack for ${issueId} is not healthy: ${failedStackHealth.reasons.join('; ')}`
+            : output.trim(),
+          hint: `Run 'pan workspace rebuild ${issueId}' or retry with a confirmed host override.`,
+          stackHealth: failedStackHealth,
+          activityId: error?.activityId,
+        }, { status: 422 });
+      }
+      return jsonResponse({
+        success: false,
+        blocked: true,
+        skipped: true,
+        error: output.trim() || `Failed to start agent for ${issueId}`,
+        activityId: error?.activityId,
+      }, { status: 500 });
+    }
 
     // Write early state.json so the dashboard immediately shows agent-<id> as the
     // active agent. Without this there's a race window between spawnPanCommand returning

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -1763,6 +1763,7 @@ const postAgentsRoute = HttpRouter.add(
     const { issueId, projectId } = body as any;
     const autoStart = (body as any).auto === true;
     const guardrailAcknowledged = (body as any).guardrailAcknowledged === true;
+    const allowHost = (body as any).host === true || (body as any).allowHost === true;
 
     if (!issueId) {
       return jsonResponse({ error: 'issueId required' }, { status: 400 });
@@ -2468,6 +2469,7 @@ const postAgentsRoute = HttpRouter.add(
             startedAt: new Date().toISOString(),
             workspace: workspacePath,
             role,
+            hostOverride: allowHost || undefined,
             message: 'Waiting for containers to start...',
             ...(preSpawnStashRef ? { preSpawnStashRef } : {}),
             ...(preSpawnStashMessage ? { preSpawnStashMessage } : {}),
@@ -2573,7 +2575,8 @@ const postAgentsRoute = HttpRouter.add(
                   });
                   await spawnPanCommand(
                     ['start', issueId, '--local', '--model', spawnModel,
-                      ...(effectiveHarness ? ['--harness', effectiveHarness] : [])],
+                      ...(effectiveHarness ? ['--harness', effectiveHarness] : []),
+                      ...(allowHost ? ['--host', '--yes'] : [])],
                     workspacePath,
                   );
                   await updateIssueStatus();
@@ -2630,7 +2633,8 @@ const postAgentsRoute = HttpRouter.add(
     }));
     const activityId = yield* Effect.promise(() => spawnPanCommand(
       ['start', issueId, '--local', '--model', spawnModel,
-        ...(effectiveHarness ? ['--harness', effectiveHarness] : [])],
+        ...(effectiveHarness ? ['--harness', effectiveHarness] : []),
+        ...(allowHost ? ['--host', '--yes'] : [])],
       workspacePath,
     ));
 
@@ -2652,6 +2656,7 @@ const postAgentsRoute = HttpRouter.add(
       startedAt: new Date().toISOString(),
       workspace: workspacePath,
       role,
+      hostOverride: allowHost || undefined,
       message: 'Work agent spawn requested',
       ...(preSpawnStashRef ? { preSpawnStashRef } : {}),
       ...(preSpawnStashMessage ? { preSpawnStashMessage } : {}),

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -2961,10 +2961,24 @@ const postAgentResetSessionRoute = HttpRouter.add(
 // ─── Route: POST /api/agents/:id/delivery-method ─────────────────────────────
 // Updates the agent's delivery method (auto | channels | tmux) in state.json.
 
+export function validateAgentDeliveryMethodOrigin(
+  request: HttpServerRequest.HttpServerRequest,
+): { ok: true } | { ok: false; status: 403; body: { error: 'forbidden' } } {
+  const originCheck = validateOrigin(request);
+  if (originCheck.ok) return { ok: true };
+  return { ok: false, status: 403, body: { error: 'forbidden' } };
+}
+
 const postAgentDeliveryMethodRoute = HttpRouter.add(
   'POST',
   '/api/agents/:id/delivery-method',
   httpHandler(Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const originDecision = validateAgentDeliveryMethodOrigin(request);
+    if (!originDecision.ok) {
+      return jsonResponse(originDecision.body, { status: originDecision.status });
+    }
+
     const params = yield* HttpRouter.params;
     const id = params['id'] ?? '';
     const body = yield* readJsonBody;

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -87,8 +87,9 @@ import { checkCodexAuthStatus } from '../../../lib/codex-auth.js';
 import { canUseHarness } from '../../../lib/harness-policy.js';
 import { getProviderForModel } from '../../../lib/providers.js';
 import { validateProviderHealth, ProviderHealthError } from '../../../lib/provider-health.js';
-import { resolveProjectFromIssue } from '../../../lib/projects.js';
+import { getProject, resolveProjectFromIssue } from '../../../lib/projects.js';
 import { findPlanAsync, readPlanAsync } from '../../../lib/vbrief/io.js';
+import { getWorkspaceStackHealth } from '../../../lib/workspace/stack-health.js';
 import { writeAutoStartVBrief } from '../../../lib/vbrief/auto-synthesize.js';
 import { transitionVBriefOnMain, updatePlanStatus } from '../../../lib/vbrief/lifecycle-io.js';
 import type { ContinueState } from '../../../lib/vbrief/continue-state.js';
@@ -198,6 +199,10 @@ const readJsonBody = Effect.gen(function* () {
     return {};
   }
 });
+
+function buildHostOverrideConfirmation(issueId: string): string {
+  return `I understand this bypasses workspace isolation for ${issueId.toUpperCase()}`;
+}
 
 function getProjectPath(linearProjectId?: string, issuePrefix?: string): string {
   if (issuePrefix) {
@@ -1769,7 +1774,7 @@ const postAgentsRoute = HttpRouter.add(
     const { issueId, projectId } = body as any;
     const autoStart = (body as any).auto === true;
     const guardrailAcknowledged = (body as any).guardrailAcknowledged === true;
-    const allowHost = (body as any).host === true || (body as any).allowHost === true;
+    const requestedHostOverride = (body as any).host === true || (body as any).allowHost === true;
 
     if (!issueId) {
       return jsonResponse({ error: 'issueId required' }, { status: 400 });
@@ -1810,6 +1815,18 @@ const postAgentsRoute = HttpRouter.add(
       );
     }
 
+    const hostOverrideConfirmation = buildHostOverrideConfirmation(String(issueId));
+    const allowHost = requestedHostOverride && (body as any).hostOverrideConfirmation === hostOverrideConfirmation;
+    if (requestedHostOverride && !allowHost) {
+      return jsonResponse({
+        success: false,
+        error: 'host_override_confirmation_required',
+        requiresHostConfirmation: true,
+        confirmation: hostOverrideConfirmation,
+        hint: `Host override bypasses workspace isolation. Retry only after explicitly confirming: ${hostOverrideConfirmation}`,
+      }, { status: 409 });
+    }
+
     // Guard: reject starting agents for already-closed issues
     const issueDataService = getIssueDataService();
     const cachedIssues = issueDataService.getIssues();
@@ -1833,7 +1850,9 @@ const postAgentsRoute = HttpRouter.add(
     const isRemote = workspaceMetadata?.location === 'remote';
 
     const issuePrefix = extractPrefix(issueId) ?? issueId.split('-')[0];
-    const projectPath = getProjectPath(projectId, issuePrefix);
+    const resolvedProject = resolveProjectFromIssue(String(issueId));
+    const projectConfig = resolvedProject ? getProject(resolvedProject.projectKey) : null;
+    const projectPath = projectConfig?.path ?? getProjectPath(projectId, issuePrefix);
 
     const workspacePath = join(projectPath, 'workspaces', `feature-${issueLower}`);
     if (!existsSync(workspacePath)) {
@@ -2046,6 +2065,42 @@ const postAgentsRoute = HttpRouter.add(
         }, { status: 429 });
       }
       throw err;
+    }
+
+    const stackHealth = yield* Effect.promise(() => getWorkspaceStackHealth(issueId, { projectConfig }));
+    if (!stackHealth.healthy) {
+      yield* Effect.promise(() => appendAgentLifecycleLog(agentSessionName, 'agent.start_blocked_stack_unhealthy', {
+        issueId,
+        reasons: stackHealth.reasons,
+        lastObserved: stackHealth.lastObserved,
+      }));
+      if (!allowHost) {
+        emitActivityEntry({
+          source: 'dashboard',
+          level: 'error',
+          issueId: issueId.toUpperCase(),
+          message: `agent-spawn-blocked-stack-unhealthy: ${issueId.toUpperCase()}`,
+          details: stackHealth.reasons.join('; '),
+        });
+        return jsonResponse({
+          success: false,
+          blocked: true,
+          skipped: true,
+          error: `Workspace docker stack for ${issueId} is not healthy: ${stackHealth.reasons.join('; ')}`,
+          hint: `Run 'pan workspace rebuild ${issueId}' or retry with a confirmed host override.`,
+          stackHealth,
+        }, { status: 422 });
+      }
+    }
+
+    if (allowHost) {
+      emitActivityEntry({
+        source: 'dashboard',
+        level: 'warn',
+        issueId: issueId.toUpperCase(),
+        message: `agent-spawn-host-override: ${issueId.toUpperCase()}`,
+        details: 'Dashboard request included confirmed host override.',
+      });
     }
 
     if (existsSync(workspacePanContinuePath) || existsSync(workspacePanDir)) {

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -90,6 +90,7 @@ import { validateProviderHealth, ProviderHealthError } from '../../../lib/provid
 import { getProject, resolveProjectFromIssue } from '../../../lib/projects.js';
 import { findPlanAsync, readPlanAsync } from '../../../lib/vbrief/io.js';
 import { getWorkspaceStackHealth } from '../../../lib/workspace/stack-health.js';
+import { normalizeModelOverride, requireModelOverride } from '../../../lib/model-validation.js';
 import { writeAutoStartVBrief } from '../../../lib/vbrief/auto-synthesize.js';
 import { transitionVBriefOnMain, updatePlanStatus } from '../../../lib/vbrief/lifecycle-io.js';
 import type { ContinueState } from '../../../lib/vbrief/continue-state.js';
@@ -1360,6 +1361,12 @@ const postAgentResumeRoute = HttpRouter.add(
     const body = yield* readJsonBody;
 
     const { message, model } = body as any;
+    let resumeModel: string | undefined;
+    try {
+      resumeModel = normalizeModelOverride(model);
+    } catch (err) {
+      return jsonResponse({ error: err instanceof Error ? err.message : String(err) }, { status: 400 });
+    }
     const eventStore = yield* EventStoreService;
     // Snapshot lifecycle state BEFORE taking any action so callers can see the
     // temporal context (why was this resume allowed) without recomputing state.
@@ -1373,10 +1380,10 @@ const postAgentResumeRoute = HttpRouter.add(
 
     yield* Effect.promise(() => appendAgentLifecycleLog(id, 'agent.resume_requested', {
       hasMessage: !!message,
-      model: model || undefined,
+      model: resumeModel || undefined,
       lifecycle: lifecycleBefore,
     }));
-    const result = yield* Effect.promise(() => resumeAgent(id, message, model ? { model } : undefined));
+    const result = yield* Effect.promise(() => resumeAgent(id, message, resumeModel ? { model: resumeModel } : undefined));
     if (result.success) {
       // Emit agent.started event so the read model transitions agent status
       // from 'stopped' → 'running' and the frontend updates immediately.
@@ -1446,6 +1453,12 @@ const postAgentRestartRoute = HttpRouter.add(
       graceful?: boolean;
       message?: string;
     };
+    let restartModel: string | undefined;
+    try {
+      restartModel = normalizeModelOverride(model);
+    } catch (err) {
+      return jsonResponse({ error: err instanceof Error ? err.message : String(err) }, { status: 400 });
+    }
 
     const agentState = yield* Effect.promise(() => getAgentStateAsync(id));
     if (!agentState) {
@@ -1453,7 +1466,7 @@ const postAgentRestartRoute = HttpRouter.add(
     }
 
     yield* Effect.promise(() => appendAgentLifecycleLog(id, 'agent.restart_requested', {
-      model: model || agentState.model,
+      model: restartModel || agentState.model,
       graceful,
       hasMessage: !!message,
     }));
@@ -1468,7 +1481,7 @@ const postAgentRestartRoute = HttpRouter.add(
             payload: { agentId: id, issueId: agentState.issueId },
           }));
 
-          const result = await restartAgent(id, { model, harness, graceful: true, message });
+          const result = await restartAgent(id, { model: restartModel, harness, graceful: true, message });
 
           if (result.success) {
             const updatedState = getAgentState(id);
@@ -1487,7 +1500,7 @@ const postAgentRestartRoute = HttpRouter.add(
                   // below — surface the actual harness so Pi agents do not
                   // get mis-labelled as Claude Code on graceful restart.
                   runtime: updatedState?.harness ?? agentState.harness ?? 'claude-code',
-                  model: model || updatedState?.model || agentState.model,
+                  model: restartModel || updatedState?.model || agentState.model,
                   status: 'running',
                   startedAt: updatedState?.startedAt || agentState.startedAt,
                   lastActivity: new Date().toISOString(),
@@ -1512,7 +1525,7 @@ const postAgentRestartRoute = HttpRouter.add(
     }
 
     // Quick restart — synchronous
-    const result = yield* Effect.promise(() => restartAgent(id, { model, graceful: false, message }));
+    const result = yield* Effect.promise(() => restartAgent(id, { model: restartModel, graceful: false, message }));
 
     if (result.success) {
       const updatedState = yield* Effect.promise(() => getAgentStateAsync(id));
@@ -1537,7 +1550,7 @@ const postAgentRestartRoute = HttpRouter.add(
             // is what getHarness() reads, so a Pi agent restarted through
             // this path was being mis-labelled as Claude Code.
             runtime: updatedState?.harness ?? agentState.harness ?? 'claude-code',
-            model: model || updatedState?.model || agentState.model,
+            model: restartModel || updatedState?.model || agentState.model,
             status: 'running',
             startedAt: updatedState?.startedAt || agentState.startedAt,
             lastActivity: new Date().toISOString(),
@@ -1546,7 +1559,7 @@ const postAgentRestartRoute = HttpRouter.add(
         },
       })));
       invalidateAgentsCache();
-      return jsonResponse({ success: true, restarted: true, agentId: id, model: model || agentState.model });
+      return jsonResponse({ success: true, restarted: true, agentId: id, model: restartModel || agentState.model });
     }
 
     return jsonResponse({ error: result.error }, { status: 500 });
@@ -1632,12 +1645,15 @@ const postAgentHandoffRoute = HttpRouter.add(
     const body = yield* readJsonBody;
 
     const { toModel, reason } = body as any;
-    if (!toModel) {
-      return jsonResponse({ error: 'toModel is required' }, { status: 400 });
+    let targetModel: string;
+    try {
+      targetModel = requireModelOverride(toModel);
+    } catch (err) {
+      return jsonResponse({ error: err instanceof Error ? err.message : String(err) }, { status: 400 });
     }
 
     const result = yield* Effect.promise(() => performHandoff(id, {
-      targetModel: toModel,
+      targetModel,
       reason: reason || 'Manual handoff from dashboard',
     }));
 
@@ -2022,10 +2038,15 @@ const postAgentsRoute = HttpRouter.add(
       }, { status: spawnGuardrails.status });
     }
 
-    const spawnModel = determineModel({
-      model: (body as any).model,
-      role,
-    });
+    let spawnModel: string;
+    try {
+      spawnModel = determineModel({
+        model: (body as any).model,
+        role,
+      });
+    } catch (err) {
+      return jsonResponse({ error: err instanceof Error ? err.message : String(err) }, { status: 400 });
+    }
     const providerAuthMode = yield* Effect.promise(() => getProviderAuthMode(spawnModel));
     if (providerAuthMode === 'subscription') {
       const codexAuth = yield* Effect.promise(() => checkCodexAuthStatus());
@@ -2087,7 +2108,7 @@ const postAgentsRoute = HttpRouter.add(
           blocked: true,
           skipped: true,
           error: `Workspace docker stack for ${issueId} is not healthy: ${stackHealth.reasons.join('; ')}`,
-          hint: `Run 'pan workspace rebuild ${issueId}' or retry with a confirmed host override.`,
+          hint: `Run 'pan workspace rebuild ${issueId}' or use the CLI break-glass path: pan start ${issueId} --host.`,
           stackHealth,
         }, { status: 422 });
       }
@@ -2730,7 +2751,7 @@ const postAgentsRoute = HttpRouter.add(
           error: failedStackHealth.reasons.length > 0
             ? `Workspace docker stack for ${issueId} is not healthy: ${failedStackHealth.reasons.join('; ')}`
             : output.trim(),
-          hint: `Run 'pan workspace rebuild ${issueId}' or retry with a confirmed host override.`,
+          hint: `Run 'pan workspace rebuild ${issueId}' or use the CLI break-glass path: pan start ${issueId} --host.`,
           stackHealth: failedStackHealth,
           activityId: error?.activityId,
         }, { status: 422 });
@@ -3014,9 +3035,12 @@ const postAgentSwitchModelRoute = HttpRouter.add(
     const body = yield* readJsonBody;
     const eventStore = yield* EventStoreService;
 
-    const { model: newModel } = body as { model?: string; message?: string };
-    if (!newModel || typeof newModel !== 'string' || !newModel.trim()) {
-      return jsonResponse({ error: 'model is required' }, { status: 400 });
+    const { model: rawNewModel } = body as { model?: string; message?: string };
+    let newModel: string;
+    try {
+      newModel = requireModelOverride(rawNewModel);
+    } catch (err) {
+      return jsonResponse({ error: err instanceof Error ? err.message : String(err) }, { status: 400 });
     }
 
     const agentState = yield* Effect.promise(() => getAgentStateAsync(id));
@@ -3063,7 +3087,7 @@ const postAgentSwitchModelRoute = HttpRouter.add(
       try {
         const stateContent = yield* Effect.promise(() => readFile(stateFile, 'utf-8'));
         const state = JSON.parse(stateContent);
-        state.model = newModel.trim();
+        state.model = newModel;
         yield* Effect.promise(() => writeFile(stateFile, JSON.stringify(state, null, 2)));
       } catch { /* non-fatal */ }
     }

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -2088,7 +2088,7 @@ const postAgentsRoute = HttpRouter.add(
       throw err;
     }
 
-    const stackHealth = yield* Effect.promise(() => getWorkspaceStackHealth(issueId, { projectConfig, stackExpected: false }));
+    const stackHealth = yield* Effect.promise(() => getWorkspaceStackHealth(issueId, { projectConfig, workspacePath }));
     if (!stackHealth.healthy) {
       yield* Effect.promise(() => appendAgentLifecycleLog(agentSessionName, 'agent.start_blocked_stack_unhealthy', {
         issueId,
@@ -2736,7 +2736,7 @@ const postAgentsRoute = HttpRouter.add(
     } catch (error: any) {
       const output = String(error?.output ?? error?.message ?? '');
       if (output.includes(`Workspace docker stack for ${issueId}`) && output.includes('is not healthy')) {
-        const failedStackHealth = yield* Effect.promise(() => getWorkspaceStackHealth(issueId, { projectConfig }));
+        const failedStackHealth = yield* Effect.promise(() => getWorkspaceStackHealth(issueId, { projectConfig, workspacePath }));
         emitActivityEntry({
           source: 'dashboard',
           level: 'error',

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -2496,30 +2496,44 @@ const postAgentsRoute = HttpRouter.add(
       } catch {}
 
       if (dockerRunning) {
-        const getComposeProjectName = async (id: string, pPath?: string): Promise<string> => {
-          const lower = id.toLowerCase();
-          const featureFolder = `feature-${lower}`;
-          if (pPath) {
-            const devScriptPaths = [
-              join(pPath, 'workspaces', featureFolder, '.devcontainer', 'dev'),
-              join(pPath, 'workspaces', featureFolder, 'dev'),
-            ];
-            for (const devPath of devScriptPaths) {
-              try {
-                if (existsSync(devPath)) {
-                  const content = await readFile(devPath, 'utf-8');
-                  const match = content.match(/COMPOSE_PROJECT_NAME="([^$"]*)\$\{FEATURE_FOLDER\}"/);
-                  if (match) return `${match[1]}${featureFolder}`;
-                  const literalMatch = content.match(/COMPOSE_PROJECT_NAME="([^"]+)"/);
-                  if (literalMatch) return literalMatch[1];
-                }
-              } catch {}
+        const getComposeProjectName = async (id: string, wPath: string): Promise<string> => {
+          const featureFolder = `feature-${id.toLowerCase()}`;
+          const expected = `panopticon-${featureFolder}`;
+          const validate = (value: string, devPath: string): string => {
+            if (value !== expected) {
+              throw new Error(`Invalid COMPOSE_PROJECT_NAME in ${devPath}: expected ${expected}`);
+            }
+            return value;
+          };
+
+          const devScriptPaths = [join(wPath, '.devcontainer', 'dev'), join(wPath, 'dev')];
+          for (const devPath of devScriptPaths) {
+            try {
+              if (existsSync(devPath)) {
+                const content = await readFile(devPath, 'utf-8');
+                const match = content.match(/COMPOSE_PROJECT_NAME="([^$"]*)\$\{FEATURE_FOLDER\}"/);
+                if (match) return validate(`${match[1]}${featureFolder}`, devPath);
+                const literalMatch = content.match(/COMPOSE_PROJECT_NAME="([^"]+)"/);
+                if (literalMatch) return validate(literalMatch[1], devPath);
+              }
+            } catch (error) {
+              if (error instanceof Error && error.message.startsWith('Invalid COMPOSE_PROJECT_NAME')) throw error;
             }
           }
-          return featureFolder;
+          return expected;
         };
 
-        const featureName = yield* Effect.promise(() => getComposeProjectName(issueId, projectPath));
+        let featureName: string;
+        try {
+          featureName = yield* Effect.promise(() => getComposeProjectName(issueId, workspacePath));
+        } catch (error) {
+          return jsonResponse({
+            success: false,
+            blocked: true,
+            skipped: true,
+            error: error instanceof Error ? error.message : String(error),
+          }, { status: 422 });
+        }
         yield* Effect.promise(() => appendAgentLifecycleLog(agentSessionName, 'agent.start_container_check', {
           issueId,
           featureName,
@@ -2528,8 +2542,9 @@ const postAgentsRoute = HttpRouter.add(
         let containersReady = false;
 
         try {
-          const { stdout: existing } = yield* Effect.promise(() => execAsync(
-            `docker ps --filter "name=${featureName}" --format "{{.Names}}|{{.Status}}"`,
+          const { stdout: existing } = yield* Effect.promise(() => execFileAsync(
+            'docker',
+            ['ps', '--filter', `name=${featureName}`, '--format', '{{.Names}}|{{.Status}}'],
             { encoding: 'utf-8' }
           ));
           const runningContainers = existing.trim().split('\n').filter(Boolean);
@@ -2605,8 +2620,9 @@ const postAgentsRoute = HttpRouter.add(
 
                   while (Date.now() - startTime < maxWaitMs) {
                     try {
-                      const { stdout } = await execAsync(
-                        `docker ps --filter "name=${featureName}" --format "{{.Names}}|{{.Status}}"`,
+                      const { stdout } = await execFileAsync(
+                        'docker',
+                        ['ps', '--filter', `name=${featureName}`, '--format', '{{.Names}}|{{.Status}}'],
                         { encoding: 'utf-8' }
                       );
                       const containers = stdout.trim().split('\n').filter(Boolean);

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -2450,7 +2450,7 @@ const postAgentsRoute = HttpRouter.add(
           containersReady,
         }));
 
-        if (!containersReady) {
+        if (!containersReady && !allowHost) {
           const earlyAgentId = agentSessionName;
           const earlyStateDir = join(homedir(), '.panopticon', 'agents', earlyAgentId);
           yield* Effect.promise(() => mkdir(earlyStateDir, { recursive: true }));

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -1755,6 +1755,12 @@ const postAgentsRoute = HttpRouter.add(
   'POST',
   '/api/agents',
   httpHandler(Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const originCheck = validateOrigin(request);
+    if (!originCheck.ok) {
+      return jsonResponse({ ok: false, error: originCheck.error }, { status: 403 });
+    }
+
     const body = yield* readJsonBody;
     const eventStore = yield* EventStoreService;
     const lifecycle = yield* IssueLifecycle;

--- a/src/dashboard/server/routes/swarm.ts
+++ b/src/dashboard/server/routes/swarm.ts
@@ -89,6 +89,9 @@ interface SwarmDispatchRequest {
   model?: string;
   maxSlots?: number;
   autoAdvance?: boolean;
+  host?: boolean;
+  allowHost?: boolean;
+  hostOverrideConfirmation?: string;
 }
 
 const ISSUE_KEY_PATTERN = /^[A-Z][A-Z0-9]*-\d+$/;
@@ -102,6 +105,10 @@ function canonicalIssueId(value: unknown): string | null {
   if (typeof value !== 'string') return null;
   const canonical = value.trim().toUpperCase();
   return ISSUE_KEY_PATTERN.test(canonical) ? canonical : null;
+}
+
+function buildHostOverrideConfirmation(issueId: string): string {
+  return `I understand this bypasses workspace isolation for ${issueId.toUpperCase()}`;
 }
 
 function validateModelId(value: unknown): { ok: true; value: string | undefined } | { ok: false; error: string } {
@@ -565,7 +572,7 @@ async function refreshSwarmSlotStatuses(
 async function dispatchSwarmWave(
   request: SwarmDispatchRequest,
 ): Promise<{ status: number; body: SwarmDispatchResponseBody }> {
-  const { wave: requestedWave, model: requestedModel, maxSlots, autoAdvance } = request;
+  const { wave: requestedWave, model: requestedModel, maxSlots, autoAdvance, allowHost } = request;
   const issueUpper = canonicalIssueId(request.issueId);
   if (!issueUpper) {
     return { status: 400, body: { error: 'issueId must be a tracker key like PAN-977.' } };
@@ -1004,6 +1011,7 @@ async function dispatchSwarmWave(
           swarmItemId: item.id,
           prompt: itemPrompt,
           phase: dispatchSynthesisFirst ? 'synthesis' : 'implementation',
+          ...(allowHost ? { allowHost: true } : {}),
         };
 
         await spawnAgent(spawnOptions);
@@ -1716,7 +1724,8 @@ const postSwarmRoute = HttpRouter.add(
 
     const body = yield* readJsonBody;
     const { wave, model, maxSlots, autoAdvance } = body as SwarmDispatchRequest;
-    const issueId = canonicalIssueId((body as Record<string, unknown>)['issueId']);
+    const rawBody = body as Record<string, unknown>;
+    const issueId = canonicalIssueId(rawBody['issueId']);
 
     if (!issueId) {
       return jsonResponse({ error: 'issueId must be a tracker key like PAN-977.' }, { status: 400 });
@@ -1731,6 +1740,18 @@ const postSwarmRoute = HttpRouter.add(
     if (!modelCheck.ok) {
       return jsonResponse({ error: modelCheck.error }, { status: 400 });
     }
+    const requestedHostOverride = rawBody.host === true || rawBody.allowHost === true;
+    const hostOverrideConfirmation = buildHostOverrideConfirmation(issueId);
+    const allowHost = requestedHostOverride && rawBody.hostOverrideConfirmation === hostOverrideConfirmation;
+    if (requestedHostOverride && !allowHost) {
+      return jsonResponse({
+        success: false,
+        error: 'host_override_confirmation_required',
+        requiresHostConfirmation: true,
+        confirmation: hostOverrideConfirmation,
+        hint: `Host override bypasses workspace isolation. Retry only after explicitly confirming: ${hostOverrideConfirmation}`,
+      }, { status: 409 });
+    }
 
     const result = yield* Effect.promise(() => dispatchSwarmWave({
       issueId,
@@ -1738,6 +1759,7 @@ const postSwarmRoute = HttpRouter.add(
       model: modelCheck.value,
       maxSlots,
       autoAdvance,
+      allowHost,
     }));
 
     return jsonResponse(result.body, { status: result.status });

--- a/src/dashboard/server/routes/swarm.ts
+++ b/src/dashboard/server/routes/swarm.ts
@@ -29,6 +29,7 @@ import { readContinueStateAsync, writeContinueStateAsync, type ContinueState, ty
 import { getDispatchableItems, groupItemsByWave, hasFileOverlap, blockingParentCount, deriveSynthesisMetadata, applyTaskOperationToPlanFileAsync, compileGlob, type Wave, type WaveItem } from '../../../lib/vbrief/dag.js';
 import type { VBriefDocument, VBriefItem } from '../../../lib/vbrief/types.js';
 import { spawnAgent, type SpawnOptions } from '../../../lib/agents.js';
+import { normalizeModelOverride } from '../../../lib/model-validation.js';
 import { listSessionNamesAsync, isPaneDeadAsync, killSessionAsync, listPaneValuesAsync } from '../../../lib/tmux.js';
 
 const execFileAsync = promisify(execFile);
@@ -96,11 +97,6 @@ interface SwarmDispatchRequest {
 }
 
 const ISSUE_KEY_PATTERN = /^[A-Z][A-Z0-9]*-\d+$/;
-// Strict, conservative grammar for model identifiers passed to runtime launchers.
-// Runtime launchers (claude/pi/codex) interpolate `model` into shell command strings,
-// so we MUST refuse anything outside this safe alphabet at the API boundary to defeat
-// command injection. This is the only place model strings cross the dashboard API.
-const MODEL_ID_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,63})$/;
 
 function canonicalIssueId(value: unknown): string | null {
   if (typeof value !== 'string') return null;
@@ -113,14 +109,11 @@ function buildHostOverrideConfirmation(issueId: string): string {
 }
 
 function validateModelId(value: unknown): { ok: true; value: string | undefined } | { ok: false; error: string } {
-  if (value === undefined) return { ok: true, value: undefined };
-  if (typeof value !== 'string') return { ok: false, error: 'model must be a string.' };
-  const trimmed = value.trim();
-  if (trimmed.length === 0) return { ok: true, value: undefined };
-  if (!MODEL_ID_PATTERN.test(trimmed)) {
-    return { ok: false, error: 'model must match [A-Za-z0-9._-]{1,64} (no whitespace, slashes, or shell metacharacters).' };
+  try {
+    return { ok: true, value: normalizeModelOverride(value) };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }
-  return { ok: true, value: trimmed };
 }
 
 function assertPathInside(parent: string, child: string): void {

--- a/src/dashboard/server/routes/swarm.ts
+++ b/src/dashboard/server/routes/swarm.ts
@@ -74,6 +74,7 @@ interface SwarmState {
   totalWaves: number;
   model: string;
   autoAdvance?: boolean;
+  hostOverride?: boolean;
   autoAdvanceFailureCount?: number;
   autoAdvanceRetryAfter?: string;
   lastAutoAdvanceError?: string;
@@ -262,6 +263,7 @@ function stateFromRuntime(issueId: string, runtime: SwarmRuntime): SwarmState {
     totalWaves: runtime.totalWaves ?? 0,
     model: runtime.model,
     autoAdvance: runtime.autoAdvance,
+    hostOverride: runtime.hostOverride,
     autoAdvanceFailureCount: runtime.autoAdvanceFailureCount,
     autoAdvanceRetryAfter: runtime.autoAdvanceRetryAfter,
     lastAutoAdvanceError: runtime.lastAutoAdvanceError,
@@ -295,6 +297,7 @@ function runtimeFromState(state: SwarmState, existing?: SwarmRuntime): SwarmRunt
     currentWave: state.currentWave,
     totalWaves: state.totalWaves,
     autoAdvance: state.autoAdvance,
+    hostOverride: state.hostOverride,
     autoAdvanceFailureCount: state.autoAdvanceFailureCount,
     autoAdvanceRetryAfter: state.autoAdvanceRetryAfter,
     lastAutoAdvanceError: state.lastAutoAdvanceError,
@@ -1089,6 +1092,7 @@ async function dispatchSwarmWave(
     totalWaves: waves.length,
     model: swarmModel,
     autoAdvance: autoAdvance ?? existingState?.autoAdvance ?? false,
+    hostOverride: allowHost || existingState?.hostOverride || false,
     autoAdvanceFailureCount: 0,
     autoAdvanceRetryAfter: undefined,
     lastAutoAdvanceError: undefined,
@@ -1305,7 +1309,7 @@ async function onSlotMergeComplete(issueId: string, itemId: string, slotId: numb
       // dispatchSwarmWave with an undefined `wave` falls through to
       // getDispatchableItems(), which reflects the durable mutation we just
       // applied above.
-      const result = await dispatchSwarmWave({ issueId: issueUpper, model: nextState.model, autoAdvance: true });
+      const result = await dispatchSwarmWave({ issueId: issueUpper, model: nextState.model, autoAdvance: true, allowHost: nextState.hostOverride });
       if (result.status >= 400) ensureSwarmAutoAdvanceLoop();
       else dispatched = true;
     }
@@ -1518,6 +1522,7 @@ async function pollSwarmAutoAdvance(): Promise<void> {
         issueId: state.issueId,
         model: state.model,
         autoAdvance: true,
+        allowHost: state.hostOverride,
       });
       if (result.status >= 400) {
         const error = result.body.error ?? 'unknown error';

--- a/src/dashboard/server/routes/workspaces.ts
+++ b/src/dashboard/server/routes/workspaces.ts
@@ -1328,10 +1328,16 @@ const getWorkspaceStackHealthBatchRoute = HttpRouter.add(
       return jsonResponse({ error: `Invalid issue ID: ${invalid.issueId}` }, { status: 400 });
     }
 
-    const entries = yield* Effect.promise(() => Promise.all(parsedIds.map(async ({ issueId, parsed }) => {
+    const entries = yield* Effect.promise(() => Promise.all(parsedIds.map(async ({ parsed }) => {
       const normalizedIssueId = parsed!.raw.toUpperCase();
-      const workspaceInfo = getWorkspaceInfoForIssue(normalizedIssueId);
-      if (workspaceInfo.isRemote) {
+      const workspaceMetadata = (() => {
+        try {
+          return loadWorkspaceMetadata(normalizedIssueId);
+        } catch {
+          return null;
+        }
+      })();
+      if (workspaceMetadata?.location === 'remote') {
         return [normalizedIssueId, { exists: true, issueId: normalizedIssueId, location: 'remote', isRemote: true }] as const;
       }
 

--- a/src/dashboard/server/routes/workspaces.ts
+++ b/src/dashboard/server/routes/workspaces.ts
@@ -121,6 +121,7 @@ const execFileAsync = promisify(execFile);
 const MAX_PROBED_PORTS = 5;
 const MAX_PROBED_CONTAINERS = 10;
 const PROBE_CACHE_TTL_MS = 30_000;
+const PROBE_CACHE_MAX_ENTRIES = MAX_PROBED_CONTAINERS * MAX_PROBED_PORTS * 20;
 
 function safeToISOString(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
@@ -136,18 +137,45 @@ interface ProbeCacheEntry {
 
 const probeCache = new Map<string, ProbeCacheEntry>();
 
+function pruneProbeCache(
+  now = Date.now(),
+  runningNames?: Set<string>,
+  shouldPruneContainer?: (containerName: string) => boolean,
+): void {
+  for (const [key, entry] of probeCache) {
+    const containerName = key.split('::', 1)[0] ?? '';
+    const expired = now - entry.cachedAt > PROBE_CACHE_TTL_MS;
+    const absent = runningNames && shouldPruneContainer?.(containerName) === true && !runningNames.has(containerName);
+    if (expired || absent) {
+      probeCache.delete(key);
+    }
+  }
+
+  while (probeCache.size > PROBE_CACHE_MAX_ENTRIES) {
+    const oldestKey = probeCache.keys().next().value;
+    if (typeof oldestKey !== 'string') break;
+    probeCache.delete(oldestKey);
+  }
+}
+
 function getCachedProbe(key: string): { healthy: boolean; reason?: string } | undefined {
   const entry = probeCache.get(key);
   if (!entry) return undefined;
-  if (Date.now() - entry.cachedAt > PROBE_CACHE_TTL_MS) {
+  const now = Date.now();
+  if (now - entry.cachedAt > PROBE_CACHE_TTL_MS) {
     probeCache.delete(key);
     return undefined;
   }
+  probeCache.delete(key);
+  probeCache.set(key, entry);
   return entry.result;
 }
 
 function setCachedProbe(key: string, result: { healthy: boolean; reason?: string }): void {
-  probeCache.set(key, { result, cachedAt: Date.now() });
+  const now = Date.now();
+  pruneProbeCache(now);
+  probeCache.set(key, { result, cachedAt: now });
+  pruneProbeCache(now);
 }
 
 export function getWorkspacePathForIssue(projectPath: string, rawIssueId: string): { parsedIssueId: string; workspacePath: string } {
@@ -709,6 +737,11 @@ async function getContainerStatusAsync(
     const runningNames = Object.entries(result)
       .filter(([, info]) => info.running)
       .map(([name]) => name);
+    pruneProbeCache(
+      Date.now(),
+      new Set(runningNames),
+      (containerName) => containerName.toLowerCase().includes(search),
+    );
 
     if (runningNames.length > 0) {
       let inspectByName = new Map<string, any>();

--- a/src/dashboard/server/routes/workspaces.ts
+++ b/src/dashboard/server/routes/workspaces.ts
@@ -107,6 +107,7 @@ import { loadWorkspaceMetadata } from '../../../lib/remote/workspace-metadata.js
 import { extractPrefix, extractNumber, parseIssueId } from '../../../lib/issue-id.js';
 import { getContainersReferencingWorkspacePath } from '../../../lib/workspace-manager.js';
 import { DEVCONTAINER_DIRNAME } from '../../../lib/workspace/devcontainer-renderer.js';
+import { getWorkspaceStackHealth } from '../../../lib/workspace/stack-health.js';
 import { setMergeQueueTriggerHandler } from '../services/merge-queue-service.js';
 import { getWorkAgentLifecycleState } from '../../../lib/work-agent-lifecycle.js';
 import { enrichReviewStatusFromSessions } from '../../../lib/review-status-enrichment.js';
@@ -1414,10 +1415,11 @@ const getWorkspaceRoute = HttpRouter.add(
         const canContainerize = false;
 
         const agentSession = `agent-${issueLower}`;
-        const [git, repoGit, containers, mrUrl, sessionNames, paneOutput] = yield* Effect.promise(() => Promise.all([
+        const [git, repoGit, containers, stackHealth, mrUrl, sessionNames, paneOutput] = yield* Effect.promise(() => Promise.all([
           getGitStatusAsync(workspacePath),
           getRepoGitStatusAsync(workspacePath),
           hasDocker ? getContainerStatusAsync(issueId, projectPath) : Promise.resolve(null),
+          getWorkspaceStackHealth(issueId, { emitTransitionActivity: true }),
           getMrUrlAsync(issueId, workspacePath),
           listSessionNamesAsync(),
           capturePaneAsync(agentSession, 50).catch(() => ''),
@@ -1488,6 +1490,7 @@ const getWorkspaceRoute = HttpRouter.add(
           repoGit,
           services,
           containers,
+          stackHealth,
           hasDocker,
           canContainerize,
           pendingOperation,

--- a/src/dashboard/server/routes/workspaces.ts
+++ b/src/dashboard/server/routes/workspaces.ts
@@ -1419,7 +1419,7 @@ const getWorkspaceRoute = HttpRouter.add(
           getGitStatusAsync(workspacePath),
           getRepoGitStatusAsync(workspacePath),
           hasDocker ? getContainerStatusAsync(issueId, projectPath) : Promise.resolve(null),
-          getWorkspaceStackHealth(issueId, { emitTransitionActivity: true }),
+          getWorkspaceStackHealth(issueId, { projectConfig, emitTransitionActivity: true }),
           getMrUrlAsync(issueId, workspacePath),
           listSessionNamesAsync(),
           capturePaneAsync(agentSession, 50).catch(() => ''),

--- a/src/dashboard/server/routes/workspaces.ts
+++ b/src/dashboard/server/routes/workspaces.ts
@@ -7,6 +7,7 @@ import { buildChildEnvWithoutTmux } from '../../../lib/child-env.js';
  * Workspaces + lifecycle + review HTTP routes.
  *
  * Workspace data endpoints (/api/workspaces/):
+ *   GET    /api/workspace-stack-health
  *   GET    /api/workspaces/:issueId
  *   POST   /api/workspaces
  *   GET    /api/workspaces/:issueId/plan
@@ -53,6 +54,7 @@ import { HttpRouter, HttpServerRequest, HttpServerResponse } from 'effect/unstab
 
 import {
   resolveProjectFromIssue,
+  getProject,
   listProjects,
   findProjectByTeam,
   extractTeamPrefix,
@@ -1272,6 +1274,67 @@ const readJsonBody = Effect.gen(function* () {
     return {};
   }
 });
+
+// ─── Route: GET /api/workspace-stack-health ──────────────────────────────────
+
+const getWorkspaceStackHealthBatchRoute = HttpRouter.add(
+  'GET',
+  '/api/workspace-stack-health',
+  httpHandler(Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const url = new URL(request.url, 'http://localhost');
+    const issueIds = Array.from(new Set((url.searchParams.get('issueIds') ?? '')
+      .split(',')
+      .map((id) => id.trim())
+      .filter(Boolean)))
+      .slice(0, 100);
+
+    const parsedIds = issueIds.map((issueId) => ({ issueId, parsed: parseIssueId(issueId) }));
+    const invalid = parsedIds.find(({ parsed }) => !parsed);
+    if (invalid) {
+      return jsonResponse({ error: `Invalid issue ID: ${invalid.issueId}` }, { status: 400 });
+    }
+
+    const entries = yield* Effect.promise(() => Promise.all(parsedIds.map(async ({ issueId, parsed }) => {
+      const normalizedIssueId = parsed!.raw.toUpperCase();
+      const workspaceInfo = getWorkspaceInfoForIssue(normalizedIssueId);
+      if (workspaceInfo.isRemote) {
+        return [normalizedIssueId, { exists: true, issueId: normalizedIssueId, location: 'remote', isRemote: true }] as const;
+      }
+
+      const resolved = resolveProjectFromIssue(normalizedIssueId);
+      if (!resolved) {
+        return [normalizedIssueId, { exists: false, issueId: normalizedIssueId }] as const;
+      }
+
+      const projectConfig = getProject(resolved.projectKey);
+      const workspacePath = join(
+        resolved.projectPath,
+        projectConfig.workspace?.workspaces_dir ?? 'workspaces',
+        `feature-${parsed!.normalized}`,
+      );
+      if (!existsSync(workspacePath)) {
+        return [normalizedIssueId, { exists: false, issueId: normalizedIssueId }] as const;
+      }
+
+      const stackHealth = await getWorkspaceStackHealth(normalizedIssueId, {
+        projectConfig: { ...projectConfig, path: resolved.projectPath },
+        workspacePath,
+      });
+
+      return [normalizedIssueId, {
+        exists: true,
+        issueId: normalizedIssueId,
+        path: workspacePath,
+        stackHealth,
+        hasDocker: Boolean(projectConfig.workspace?.docker?.compose_template),
+        location: 'local',
+      }] as const;
+    })));
+
+    return jsonResponse({ workspaces: Object.fromEntries(entries) });
+  })),
+);
 
 // ─── Route: GET /api/workspaces/:issueId ─────────────────────────────────────
 
@@ -5828,6 +5891,7 @@ const postInternalPipelineNotifyRoute = HttpRouter.add(
 );
 
 export const workspacesRouteLayer = Layer.mergeAll(
+  getWorkspaceStackHealthBatchRoute,
   getWorkspaceRoute,
   postWorkspacesRoute,
   getWorkspaceStateMdRoute,

--- a/src/dashboard/server/routes/workspaces.ts
+++ b/src/dashboard/server/routes/workspaces.ts
@@ -109,7 +109,7 @@ import { loadWorkspaceMetadata } from '../../../lib/remote/workspace-metadata.js
 import { extractPrefix, extractNumber, parseIssueId } from '../../../lib/issue-id.js';
 import { getContainersReferencingWorkspacePath } from '../../../lib/workspace-manager.js';
 import { DEVCONTAINER_DIRNAME } from '../../../lib/workspace/devcontainer-renderer.js';
-import { getWorkspaceStackHealth } from '../../../lib/workspace/stack-health.js';
+import { collectDockerContainerLifecycleSnapshot, getWorkspaceStackHealth } from '../../../lib/workspace/stack-health.js';
 import { setMergeQueueTriggerHandler } from '../services/merge-queue-service.js';
 import { getWorkAgentLifecycleState } from '../../../lib/work-agent-lifecycle.js';
 import { enrichReviewStatusFromSessions } from '../../../lib/review-status-enrichment.js';
@@ -1328,7 +1328,7 @@ const getWorkspaceStackHealthBatchRoute = HttpRouter.add(
       return jsonResponse({ error: `Invalid issue ID: ${invalid.issueId}` }, { status: 400 });
     }
 
-    const entries = yield* Effect.promise(() => Promise.all(parsedIds.map(async ({ parsed }) => {
+    const workspaceRequests = parsedIds.map(({ parsed }) => {
       const normalizedIssueId = parsed!.raw.toUpperCase();
       const workspaceMetadata = (() => {
         try {
@@ -1338,12 +1338,20 @@ const getWorkspaceStackHealthBatchRoute = HttpRouter.add(
         }
       })();
       if (workspaceMetadata?.location === 'remote') {
-        return [normalizedIssueId, { exists: true, issueId: normalizedIssueId, location: 'remote', isRemote: true }] as const;
+        return {
+          kind: 'response' as const,
+          normalizedIssueId,
+          response: { exists: true, issueId: normalizedIssueId, location: 'remote', isRemote: true },
+        };
       }
 
       const resolved = resolveProjectFromIssue(normalizedIssueId);
       if (!resolved) {
-        return [normalizedIssueId, { exists: false, issueId: normalizedIssueId }] as const;
+        return {
+          kind: 'response' as const,
+          normalizedIssueId,
+          response: { exists: false, issueId: normalizedIssueId },
+        };
       }
 
       const projectConfig = getProject(resolved.projectKey);
@@ -1353,23 +1361,50 @@ const getWorkspaceStackHealthBatchRoute = HttpRouter.add(
         `feature-${parsed!.normalized}`,
       );
       if (!existsSync(workspacePath)) {
-        return [normalizedIssueId, { exists: false, issueId: normalizedIssueId }] as const;
+        return {
+          kind: 'response' as const,
+          normalizedIssueId,
+          response: { exists: false, issueId: normalizedIssueId },
+        };
       }
 
-      const stackHealth = await getWorkspaceStackHealth(normalizedIssueId, {
-        projectConfig: { ...projectConfig, path: resolved.projectPath },
+      return {
+        kind: 'local' as const,
+        normalizedIssueId,
+        projectConfig,
+        projectPath: resolved.projectPath,
         workspacePath,
-      });
+      };
+    });
 
-      return [normalizedIssueId, {
-        exists: true,
-        issueId: normalizedIssueId,
-        path: workspacePath,
-        stackHealth,
-        hasDocker: Boolean(projectConfig.workspace?.docker?.compose_template),
-        location: 'local',
-      }] as const;
-    })));
+    const entries = yield* Effect.promise(async () => {
+      const containers = workspaceRequests.some((request) =>
+        request.kind === 'local' && Boolean(request.projectConfig.workspace?.docker?.compose_template)
+      )
+        ? await collectDockerContainerLifecycleSnapshot()
+        : undefined;
+
+      return Promise.all(workspaceRequests.map(async (request) => {
+        if (request.kind === 'response') {
+          return [request.normalizedIssueId, request.response] as const;
+        }
+
+        const stackHealth = await getWorkspaceStackHealth(request.normalizedIssueId, {
+          projectConfig: { ...request.projectConfig, path: request.projectPath },
+          workspacePath: request.workspacePath,
+          containers,
+        });
+
+        return [request.normalizedIssueId, {
+          exists: true,
+          issueId: request.normalizedIssueId,
+          path: request.workspacePath,
+          stackHealth,
+          hasDocker: Boolean(request.projectConfig.workspace?.docker?.compose_template),
+          location: 'local',
+        }] as const;
+      }));
+    });
 
     return jsonResponse({ workspaces: Object.fromEntries(entries) });
   })),

--- a/src/dashboard/server/services/agent-spawner.ts
+++ b/src/dashboard/server/services/agent-spawner.ts
@@ -23,6 +23,7 @@ export interface StartWorkOptions {
   readonly phase?: 'exploration' | 'implementation' | 'testing' | 'documentation' | 'review-response';
   readonly prompt?: string;
   readonly agentType?: 'review-agent' | 'test-agent' | 'merge-agent' | 'work-agent';
+  readonly allowHost?: boolean;
 }
 
 export interface StartPlanningOptions {
@@ -168,6 +169,7 @@ export const AgentSpawnerLive = Layer.effect(
             model: opts.model,
             role: 'work',
             prompt: opts.prompt,
+            allowHost: opts.allowHost,
           });
 
           return {

--- a/src/dashboard/server/services/workspace-service.ts
+++ b/src/dashboard/server/services/workspace-service.ts
@@ -202,11 +202,8 @@ export const WorkspaceServiceLive = Layer.effect(
           try: async () => {
             const { workspacePath } = getWorkspacePath(issueId);
             const issueLower = issueId.toLowerCase();
-            const project = resolveProjectFromIssue(issueId);
-            const projectName = project?.name ?? issueId;
-
             const { stopWorkspaceDocker } = await import('../../../lib/workspace-manager.js');
-            await stopWorkspaceDocker(workspacePath, projectName, issueLower);
+            await stopWorkspaceDocker(workspacePath, issueLower);
           },
           catch: () => undefined, // non-fatal
         }).pipe(Effect.ignore),

--- a/src/lib/__tests__/agent-state-harness.test.ts
+++ b/src/lib/__tests__/agent-state-harness.test.ts
@@ -31,12 +31,12 @@ describe('getAgentRuntimeBaseCommand harness routing (PAN-636)', () => {
 
   it('claude-code branch builds the legacy "claude --dangerously-skip-permissions ... --model X" command for an Anthropic model', async () => {
     const cmd = await getAgentRuntimeBaseCommand('claude-sonnet-4-6', undefined, undefined, 'claude-code')
-    expect(cmd).toBe('claude --dangerously-skip-permissions --permission-mode bypassPermissions --model claude-sonnet-4-6')
+    expect(cmd).toBe("claude --dangerously-skip-permissions --permission-mode bypassPermissions --model 'claude-sonnet-4-6'")
   })
 
   it('pi harness emits a `pi --mode rpc --model <model>` command (AC4)', async () => {
     const cmd = await getAgentRuntimeBaseCommand('claude-sonnet-4-6', undefined, undefined, 'pi')
-    expect(cmd).toBe('pi --mode rpc --model claude-sonnet-4-6')
+    expect(cmd).toBe("pi --mode rpc --model 'claude-sonnet-4-6'")
   })
 
   it('pi harness emits no claude permission flags', async () => {
@@ -67,7 +67,7 @@ describe('getAgentRuntimeBaseCommand permission-mode integration', () => {
 
   it('production default emits --permission-mode auto for an Anthropic model', async () => {
     const cmd = await getAgentRuntimeBaseCommand('claude-sonnet-4-6')
-    expect(cmd).toBe('claude --permission-mode auto --model claude-sonnet-4-6')
+    expect(cmd).toBe("claude --permission-mode auto --model 'claude-sonnet-4-6'")
     expect(cmd).not.toMatch(/--dangerously-skip-permissions/)
     expect(cmd).not.toMatch(/bypassPermissions/)
   })
@@ -75,6 +75,6 @@ describe('getAgentRuntimeBaseCommand permission-mode integration', () => {
   it('PAN_YOLO=true produces the legacy bypass command', async () => {
     process.env.PAN_YOLO = 'true'
     const cmd = await getAgentRuntimeBaseCommand('claude-sonnet-4-6')
-    expect(cmd).toBe('claude --dangerously-skip-permissions --permission-mode bypassPermissions --model claude-sonnet-4-6')
+    expect(cmd).toBe("claude --dangerously-skip-permissions --permission-mode bypassPermissions --model 'claude-sonnet-4-6'")
   })
 })

--- a/src/lib/__tests__/agent-state-role.test.ts
+++ b/src/lib/__tests__/agent-state-role.test.ts
@@ -149,7 +149,13 @@ describe('AgentState role persistence', () => {
     const emitActivityEntry = vi.fn();
     vi.doMock('../projects.js', async (importOriginal) => ({
       ...((await importOriginal()) as typeof import('../projects.js')),
-      findProjectByTeam: vi.fn(() => ({ workspace: { docker: { compose_template: 'infra/.devcontainer-template' } } })),
+      resolveProjectFromIssue: vi.fn(() => ({
+        projectKey: 'panopticon',
+        projectName: 'Panopticon',
+        projectPath: workspace,
+        linearTeam: 'PAN',
+      })),
+      getProject: vi.fn(() => ({ workspace: { docker: { compose_template: 'infra/.devcontainer-template' } } })),
     }));
     vi.doMock('../tmux.js', async (importOriginal) => ({
       ...((await importOriginal()) as typeof import('../tmux.js')),

--- a/src/lib/__tests__/agent-state-role.test.ts
+++ b/src/lib/__tests__/agent-state-role.test.ts
@@ -16,6 +16,9 @@ describe('AgentState role persistence', () => {
   afterEach(() => {
     vi.doUnmock('../config-yaml.js');
     vi.doUnmock('../tmux.js');
+    vi.doUnmock('../workspace/stack-health.js');
+    vi.doUnmock('../beads-query.js');
+    vi.doUnmock('../activity-logger.js');
     delete process.env.PANOPTICON_HOME;
     rmSync(tempHome, { recursive: true, force: true });
   });
@@ -137,6 +140,107 @@ describe('AgentState role persistence', () => {
       eligible: false,
       reason: 'harness-pi',
     });
+  });
+
+  it('blocks spawnAgent before side effects when the workspace stack is unhealthy', async () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'pan-stack-gate-'));
+    const createSessionAsync = vi.fn();
+    const emitActivityEntry = vi.fn();
+    vi.doMock('../workspace/stack-health.js', () => ({
+      getWorkspaceStackHealth: vi.fn(async () => ({
+        healthy: false,
+        reasons: ['panopticon-feature-pan-1140-init init exited non-zero (1)'],
+        lastObserved: '2026-05-16T00:00:00.000Z',
+      })),
+    }));
+    vi.doMock('../tmux.js', async (importOriginal) => ({
+      ...((await importOriginal()) as typeof import('../tmux.js')),
+      sessionExistsAsync: vi.fn(async () => false),
+      createSessionAsync,
+    }));
+    vi.doMock('../beads-query.js', () => ({ assertIssueHasBeads: vi.fn(async () => undefined) }));
+    vi.doMock('../activity-logger.js', async (importOriginal) => ({
+      ...((await importOriginal()) as typeof import('../activity-logger.js')),
+      emitActivityEntry,
+    }));
+
+    const { spawnAgent } = await import('../agents.js');
+
+    await expect(spawnAgent({
+      issueId: 'PAN-1140',
+      workspace,
+      role: 'work',
+      model: 'claude-sonnet-4-6',
+    })).rejects.toThrow("Workspace docker stack for PAN-1140 is not healthy: panopticon-feature-pan-1140-init init exited non-zero (1). Run 'pan workspace rebuild PAN-1140' or retry with --host to override.");
+
+    expect(createSessionAsync).not.toHaveBeenCalled();
+    expect(emitActivityEntry).toHaveBeenCalledWith(expect.objectContaining({
+      level: 'error',
+      issueId: 'PAN-1140',
+      message: 'agent-spawn-blocked-stack-unhealthy: PAN-1140',
+    }));
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  it('allows explicit host override when the workspace stack is unhealthy', async () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'pan-stack-host-'));
+    const createSessionAsync = vi.fn(async () => undefined);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const emitActivityEntry = vi.fn();
+    vi.doMock('../config-yaml.js', async (importOriginal) => ({
+      ...((await importOriginal()) as typeof import('../config-yaml.js')),
+      isClaudeCodeChannelsEnabled: () => false,
+    }));
+    vi.doMock('../workspace/stack-health.js', () => ({
+      getWorkspaceStackHealth: vi.fn(async () => ({
+        healthy: false,
+        reasons: ['panopticon-feature-pan-1140-server stuck Created for 180s'],
+        lastObserved: '2026-05-16T00:00:00.000Z',
+      })),
+    }));
+    vi.doMock('../tmux.js', async (importOriginal) => ({
+      ...((await importOriginal()) as typeof import('../tmux.js')),
+      sessionExistsAsync: vi.fn(async () => false),
+      sessionExists: vi.fn(() => false),
+      createSessionAsync,
+      capturePaneAsync: vi.fn(async () => 'Claude Code'),
+    }));
+    vi.doMock('../beads-query.js', () => ({ assertIssueHasBeads: vi.fn(async () => undefined) }));
+    vi.doMock('../activity-logger.js', async (importOriginal) => ({
+      ...((await importOriginal()) as typeof import('../activity-logger.js')),
+      emitActivityEntry,
+      emitActivityTts: vi.fn(),
+    }));
+
+    const { spawnAgent } = await import('../agents.js');
+
+    const state = await spawnAgent({
+      issueId: 'PAN-1140',
+      workspace,
+      role: 'work',
+      model: 'claude-sonnet-4-6',
+      allowHost: true,
+    });
+
+    expect(state.hostOverride).toBe(true);
+    expect(createSessionAsync).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('retry with --host to override'));
+    expect(emitActivityEntry).toHaveBeenCalledWith(expect.objectContaining({
+      level: 'warn',
+      issueId: 'PAN-1140',
+      message: 'agent-spawn-host-override: PAN-1140',
+    }));
+    warnSpy.mockRestore();
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  it('does not block when workspace stack health is healthy', async () => {
+    vi.doMock('../workspace/stack-health.js', () => ({
+      getWorkspaceStackHealth: vi.fn(async () => ({ healthy: true, reasons: [], lastObserved: '2026-05-16T00:00:00.000Z' })),
+    }));
+    const { assertWorkspaceStackHealthyForSpawn } = await import('../agents.js');
+
+    await expect(assertWorkspaceStackHealthyForSpawn('MIN-1', 'work')).resolves.toBeUndefined();
   });
 
   it('treats state.json without a valid role as missing', async () => {

--- a/src/lib/__tests__/agent-state-role.test.ts
+++ b/src/lib/__tests__/agent-state-role.test.ts
@@ -52,7 +52,7 @@ describe('AgentState role persistence', () => {
 
     const command = await getRoleRuntimeBaseCommand('claude-opus-4-7', 'agent-pan-1048-review', 'review');
     expect(command).toContain('--agent roles/review.md');
-    expect(command).toContain('--model claude-opus-4-7');
+    expect(command).toContain("--model 'claude-opus-4-7'");
     expect(command).toContain('--name agent-pan-1048-review');
     expect(command).not.toContain('pan-review-agent');
   });
@@ -72,7 +72,7 @@ describe('AgentState role persistence', () => {
       );
       expect(command).not.toContain('--agent');
       expect(command).not.toContain('.claude/agents');
-      expect(command).toContain('--model claude-sonnet-4-6');
+      expect(command).toContain("--model 'claude-sonnet-4-6'");
       expect(command).toContain(`--name agent-pan-1059-review-${subRole}`);
     }
   });

--- a/src/lib/__tests__/agent-state-role.test.ts
+++ b/src/lib/__tests__/agent-state-role.test.ts
@@ -19,6 +19,7 @@ describe('AgentState role persistence', () => {
     vi.doUnmock('../workspace/stack-health.js');
     vi.doUnmock('../beads-query.js');
     vi.doUnmock('../activity-logger.js');
+    vi.doUnmock('../projects.js');
     delete process.env.PANOPTICON_HOME;
     rmSync(tempHome, { recursive: true, force: true });
   });
@@ -140,6 +141,51 @@ describe('AgentState role persistence', () => {
       eligible: false,
       reason: 'harness-pi',
     });
+  });
+
+  it('blocks spawnAgent from cached stack health before side effects', async () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'pan-stack-cache-gate-'));
+    const createSessionAsync = vi.fn();
+    const emitActivityEntry = vi.fn();
+    vi.doMock('../projects.js', async (importOriginal) => ({
+      ...((await importOriginal()) as typeof import('../projects.js')),
+      findProjectByTeam: vi.fn(() => ({ workspace: { docker: { compose_template: 'infra/.devcontainer-template' } } })),
+    }));
+    vi.doMock('../tmux.js', async (importOriginal) => ({
+      ...((await importOriginal()) as typeof import('../tmux.js')),
+      sessionExistsAsync: vi.fn(async () => false),
+      createSessionAsync,
+    }));
+    vi.doMock('../beads-query.js', () => ({ assertIssueHasBeads: vi.fn(async () => undefined) }));
+    vi.doMock('../activity-logger.js', async (importOriginal) => ({
+      ...((await importOriginal()) as typeof import('../activity-logger.js')),
+      emitActivityEntry,
+    }));
+    const { recordDockerContainerLifecycleSnapshot } = await import('../docker-stats.js');
+    recordDockerContainerLifecycleSnapshot([{
+      id: 'abc123',
+      name: 'panopticon-feature-pan-1140-init-1',
+      status: 'Exited (1) 5 minutes ago',
+      state: 'exited',
+      createdAt: '2026-05-16T00:00:00.000Z',
+    }], '2026-05-16T00:00:00.000Z');
+
+    const { spawnAgent } = await import('../agents.js');
+
+    await expect(spawnAgent({
+      issueId: 'PAN-1140',
+      workspace,
+      role: 'work',
+      model: 'claude-sonnet-4-6',
+    })).rejects.toThrow("Workspace docker stack for PAN-1140 is not healthy: panopticon-feature-pan-1140-init-1 init exited non-zero (1). Run 'pan workspace rebuild PAN-1140' or retry with --host to override.");
+
+    expect(createSessionAsync).not.toHaveBeenCalled();
+    expect(emitActivityEntry).toHaveBeenCalledWith(expect.objectContaining({
+      level: 'error',
+      issueId: 'PAN-1140',
+      message: 'agent-spawn-blocked-stack-unhealthy: PAN-1140',
+    }));
+    rmSync(workspace, { recursive: true, force: true });
   });
 
   it('blocks spawnAgent before side effects when the workspace stack is unhealthy', async () => {

--- a/src/lib/__tests__/launcher-generator.test.ts
+++ b/src/lib/__tests__/launcher-generator.test.ts
@@ -66,7 +66,7 @@ describe('generateLauncherScript', () => {
       command -v mkcert >/dev/null 2>&1 && export NODE_EXTRA_CA_CERTS="$(mkcert -CAROOT)/rootCA.pem"
       cd -- '/workspace/project'
       export ANTHROPIC_BASE_URL="http://proxy"
-      exec claude --agent pan-work-agent --resume 'sess-123' --model gpt-5.4
+      exec claude --agent pan-work-agent --resume 'sess-123' --model 'gpt-5.4'
       "
     `);
   });
@@ -152,7 +152,7 @@ describe('generateLauncherScript', () => {
       export ANTHROPIC_BASE_URL="http://proxy"
       export CAVEMAN_DEFAULT_MODE="active"
       prompt=$(cat '/tmp/prompt.md')
-      exec claude --dangerously-skip-permissions --permission-mode bypassPermissions --session-id 'sess-abc' --model claude-sonnet-4-6 "$prompt"
+      exec claude --dangerously-skip-permissions --permission-mode bypassPermissions --session-id 'sess-abc' --model 'claude-sonnet-4-6' "$prompt"
       "
     `);
   });
@@ -236,7 +236,7 @@ describe('generateLauncherScript', () => {
       unset CLAUDE_CODE_API_KEY_HELPER_TTL_MS
       export ANTHROPIC_BASE_URL="http://proxy"
       prompt=$(cat '/tmp/identity.md')
-      exec claude --dangerously-skip-permissions --permission-mode bypassPermissions --session-id 'sess-xyz' --model claude-sonnet-4-6 "$prompt"
+      exec claude --dangerously-skip-permissions --permission-mode bypassPermissions --session-id 'sess-xyz' --model 'claude-sonnet-4-6' "$prompt"
       "
     `);
   });
@@ -610,7 +610,7 @@ describe('generateLauncherWrapper', () => {
         channelsBridgeMcpConfig: '/tmp/agent-y/.mcp.json',
       });
       expect(script).toContain(
-        "claude --mcp-config '/tmp/agent-y/.mcp.json' --dangerously-load-development-channels server:panopticon-bridge --session-id 'sess-spec' --model claude-sonnet-4-6",
+        "claude --mcp-config '/tmp/agent-y/.mcp.json' --dangerously-load-development-channels server:panopticon-bridge --session-id 'sess-spec' --model 'claude-sonnet-4-6'",
       );
       expect(script).not.toContain('--strict-mcp-config');
     });
@@ -649,7 +649,7 @@ describe('generateLauncherScript — Pi harness (PAN-636)', () => {
       command -v mkcert >/dev/null 2>&1 && export NODE_EXTRA_CA_CERTS="$(mkcert -CAROOT)/rootCA.pem"
       cd -- '/workspace/project'
       prompt=$(cat '/tmp/prompt.txt')
-      exec pi --mode rpc --model anthropic/claude-sonnet-4-6 --session-dir '/home/u/.panopticon/agents/agent-pan-636/sessions' --extension '/abs/packages/pi-extension/dist/index.js' --no-context-files --append-system-prompt "$prompt" <> '/home/u/.panopticon/agents/agent-pan-636/rpc.in'
+      exec pi --mode rpc --model 'anthropic/claude-sonnet-4-6' --session-dir '/home/u/.panopticon/agents/agent-pan-636/sessions' --extension '/abs/packages/pi-extension/dist/index.js' --no-context-files --append-system-prompt "$prompt" <> '/home/u/.panopticon/agents/agent-pan-636/rpc.in'
       "
     `);
   });
@@ -685,7 +685,7 @@ describe('generateLauncherScript — Pi harness (PAN-636)', () => {
       resumeSessionId: 'sess-pi-123',
     });
     expect(script).toMatch(/--session 'sess-pi-123'/);
-    expect(script).toMatch(/exec pi --mode rpc --model gpt-5.4-mini/);
+    expect(script).toMatch(/exec pi --mode rpc --model 'gpt-5.4-mini'/);
   });
 
   it('throws when pi launcher is missing required path config', () => {

--- a/src/lib/__tests__/model-validation.test.ts
+++ b/src/lib/__tests__/model-validation.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildAgentLaunchConfig,
+  determineModel,
+  getAgentRuntimeBaseCommand,
+  getRoleRuntimeBaseCommand,
+  restartAgent,
+  resumeAgent,
+  spawnRun,
+} from '../agents.js';
+import { normalizeModelOverride, requireModelOverride, shellQuoteModelId } from '../model-validation.js';
+
+const MALICIOUS_MODEL = 'claude-sonnet-4-6; touch /tmp/pan-model-pwned #';
+
+function expectModelRejection(fn: () => unknown | Promise<unknown>) {
+  return expect(fn()).rejects.toThrow(/model must match/);
+}
+
+describe('model override validation', () => {
+  it('normalizes safe provider model identifiers and rejects shell metacharacters', () => {
+    expect(normalizeModelOverride(' qwen/qwen3.6-plus:free ')).toBe('qwen/qwen3.6-plus:free');
+    expect(normalizeModelOverride('')).toBeUndefined();
+    expect(() => normalizeModelOverride(MALICIOUS_MODEL)).toThrow(/model must match/);
+    expect(() => normalizeModelOverride('claude-sonnet-4-6 && whoami')).toThrow(/model must match/);
+    expect(() => normalizeModelOverride('claude-sonnet-4-6\nwhoami')).toThrow(/model must match/);
+  });
+
+  it('quotes validated model ids before launcher command interpolation', () => {
+    expect(requireModelOverride('claude-sonnet-4-6')).toBe('claude-sonnet-4-6');
+    expect(shellQuoteModelId('qwen/qwen3.6-plus:free')).toBe("'qwen/qwen3.6-plus:free'");
+  });
+
+  it('rejects malicious model overrides in agent model resolution', () => {
+    expect(() => determineModel({ role: 'work', model: MALICIOUS_MODEL })).toThrow(/model must match/);
+  });
+
+  it('rejects malicious model overrides in runtime command builders', async () => {
+    await expectModelRejection(() => getAgentRuntimeBaseCommand(MALICIOUS_MODEL));
+    await expectModelRejection(() => getRoleRuntimeBaseCommand(MALICIOUS_MODEL, 'agent-pan-1140-review', 'review'));
+  });
+
+  it('emits shell-quoted model arguments in runtime command builders', async () => {
+    await expect(getAgentRuntimeBaseCommand('claude-sonnet-4-6')).resolves.toContain("--model 'claude-sonnet-4-6'");
+    await expect(getRoleRuntimeBaseCommand('claude-opus-4-7', 'agent-pan-1140-review', 'review')).resolves.toContain("--model 'claude-opus-4-7'");
+  });
+
+  it('rejects malicious model overrides before launch config generation', async () => {
+    await expectModelRejection(() => buildAgentLaunchConfig({
+      agentId: 'agent-pan-1140',
+      model: MALICIOUS_MODEL,
+      workspace: '/tmp/pan-workspace',
+      role: 'work',
+    }));
+  });
+
+  it('rejects malicious model overrides in resume and restart requests', async () => {
+    await expectModelRejection(() => resumeAgent('agent-pan-1140', undefined, { model: MALICIOUS_MODEL }));
+    await expectModelRejection(() => restartAgent('agent-pan-1140', { model: MALICIOUS_MODEL }));
+  });
+
+  it('rejects malicious model overrides in spawnRun before role-run side effects', async () => {
+    await expectModelRejection(() => spawnRun('PAN-1140', 'review', {
+      workspace: '/tmp/pan-workspace',
+      model: MALICIOUS_MODEL,
+    }));
+  });
+});

--- a/src/lib/__tests__/model-validation.test.ts
+++ b/src/lib/__tests__/model-validation.test.ts
@@ -20,6 +20,7 @@ function expectModelRejection(fn: () => unknown | Promise<unknown>) {
 describe('model override validation', () => {
   it('normalizes safe provider model identifiers and rejects shell metacharacters', () => {
     expect(normalizeModelOverride(' qwen/qwen3.6-plus:free ')).toBe('qwen/qwen3.6-plus:free');
+    expect(normalizeModelOverride(' oai@gpt-5.5 ')).toBe('oai@gpt-5.5');
     expect(normalizeModelOverride('')).toBeUndefined();
     expect(() => normalizeModelOverride(MALICIOUS_MODEL)).toThrow(/model must match/);
     expect(() => normalizeModelOverride('claude-sonnet-4-6 && whoami')).toThrow(/model must match/);

--- a/src/lib/__tests__/permission-mode-leak.test.ts
+++ b/src/lib/__tests__/permission-mode-leak.test.ts
@@ -34,7 +34,7 @@ describe('Permission-mode leak prevention — DSP must NEVER appear under Auto',
   it('Anthropic + Auto + work role: uses roles/work.md, preserves model override, and no DSP or permission flag', async () => {
     const cmd = await getAgentRuntimeBaseCommand('claude-sonnet-4-6', 'agent-pan-1', 'roles/work.md')
     expect(cmd).toMatch(/--agent roles\/work\.md/)
-    expect(cmd).toMatch(/--model claude-sonnet-4-6/)
+    expect(cmd).toMatch(/--model 'claude-sonnet-4-6'/)
     expect(cmd).not.toMatch(/--agent pan-work-agent/)
     expect(cmd).not.toMatch(/--dangerously-skip-permissions/)
     expect(cmd).not.toMatch(/bypassPermissions/)
@@ -51,7 +51,7 @@ describe('Permission-mode leak prevention — DSP must NEVER appear under Auto',
   it('Kimi direct + Auto: no DSP, --permission-mode auto', async () => {
     const cmd = await getAgentRuntimeBaseCommand('kimi-k2.6')
     expect(cmd).toMatch(/^claude /)
-    expect(cmd).toMatch(/--model kimi-k2\.6/)
+    expect(cmd).toMatch(/--model 'kimi-k2\.6'/)
     expect(cmd).toMatch(/--permission-mode auto/)
     expect(cmd).not.toMatch(/--dangerously-skip-permissions/)
     expect(cmd).not.toMatch(/bypassPermissions/)
@@ -60,7 +60,7 @@ describe('Permission-mode leak prevention — DSP must NEVER appear under Auto',
   it('Z.AI direct + Auto: no DSP, --permission-mode auto', async () => {
     const cmd = await getAgentRuntimeBaseCommand('glm-4.7')
     expect(cmd).toMatch(/^claude /)
-    expect(cmd).toMatch(/--model glm-4\.7/)
+    expect(cmd).toMatch(/--model 'glm-4\.7'/)
     expect(cmd).toMatch(/--permission-mode auto/)
     expect(cmd).not.toMatch(/--dangerously-skip-permissions/)
     expect(cmd).not.toMatch(/bypassPermissions/)
@@ -69,7 +69,7 @@ describe('Permission-mode leak prevention — DSP must NEVER appear under Auto',
   it('MiniMax direct + Auto: no DSP, --permission-mode auto', async () => {
     const cmd = await getAgentRuntimeBaseCommand('minimax-m2.7')
     expect(cmd).toMatch(/^claude /)
-    expect(cmd).toMatch(/--model minimax-m2\.7/)
+    expect(cmd).toMatch(/--model 'minimax-m2\.7'/)
     expect(cmd).toMatch(/--permission-mode auto/)
     expect(cmd).not.toMatch(/--dangerously-skip-permissions/)
     expect(cmd).not.toMatch(/bypassPermissions/)
@@ -78,7 +78,7 @@ describe('Permission-mode leak prevention — DSP must NEVER appear under Auto',
   it('Mimo direct + Auto: no DSP, --permission-mode auto', async () => {
     const cmd = await getAgentRuntimeBaseCommand('mimo-v2.5')
     expect(cmd).toMatch(/^claude /)
-    expect(cmd).toMatch(/--model mimo-v2\.5/)
+    expect(cmd).toMatch(/--model 'mimo-v2\.5'/)
     expect(cmd).toMatch(/--permission-mode auto/)
     expect(cmd).not.toMatch(/--dangerously-skip-permissions/)
     expect(cmd).not.toMatch(/bypassPermissions/)
@@ -87,7 +87,7 @@ describe('Permission-mode leak prevention — DSP must NEVER appear under Auto',
   it('OpenRouter direct + Auto: no DSP, --permission-mode auto', async () => {
     const cmd = await getAgentRuntimeBaseCommand('qwen/qwen3.6-plus:free')
     expect(cmd).toMatch(/^claude /)
-    expect(cmd).toMatch(/--model qwen\/qwen3\.6-plus:free/)
+    expect(cmd).toMatch(/--model 'qwen\/qwen3\.6-plus:free'/)
     expect(cmd).toMatch(/--permission-mode auto/)
     expect(cmd).not.toMatch(/--dangerously-skip-permissions/)
     expect(cmd).not.toMatch(/bypassPermissions/)
@@ -99,7 +99,7 @@ describe('Permission-mode leak prevention — DSP must NEVER appear under Auto',
     process.env.PAN_YOLO = 'true'
     const cmd = await getAgentRuntimeBaseCommand('kimi-k2.6')
     expect(cmd).toMatch(/^claude /)
-    expect(cmd).toMatch(/--model kimi-k2\.6/)
+    expect(cmd).toMatch(/--model 'kimi-k2\.6'/)
     expect(cmd).toMatch(/--dangerously-skip-permissions/)
     expect(cmd).toMatch(/bypassPermissions/)
   })

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -37,6 +37,7 @@ import { canUseHarness } from './harness-policy.js';
 import type { RuntimeName } from './runtimes/types.js';
 import { createPiFifo, piFifoPaths, writePiCommand, PiNotReady } from './runtimes/pi-fifo.js';
 import { assertIssueHasBeads } from './beads-query.js';
+import { getWorkspaceStackHealth } from './workspace/stack-health.js';
 
 const execAsync = promisify(exec);
 
@@ -581,6 +582,7 @@ export interface AgentState {
   reviewSynthesisAgentId?: string;
   reviewDeadlineAt?: string;
   reviewMonitorSignaled?: 'ready' | 'failed' | 'timeout';
+  hostOverride?: boolean;
 }
 
 export function getAgentDir(agentId: string): string {
@@ -619,6 +621,7 @@ function cleanAgentState(raw: AgentState): AgentState {
     reviewSynthesisAgentId: raw.reviewSynthesisAgentId,
     reviewDeadlineAt: raw.reviewDeadlineAt,
     reviewMonitorSignaled: raw.reviewMonitorSignaled,
+    hostOverride: raw.hostOverride,
   };
 }
 
@@ -1457,6 +1460,7 @@ export interface SpawnOptions {
   // and the one-agent-per-issue uniqueness check is scoped to the slot.
   slotId?: number;
   swarmItemId?: string; // vBRIEF item ID this slot is working on
+  allowHost?: boolean;
 }
 
 export interface SpawnRunOptions {
@@ -1480,6 +1484,7 @@ export interface SpawnRunOptions {
    */
   reviewSynthesisAgentId?: string;
   reviewOutputPath?: string;
+  allowHost?: boolean;
 }
 
 /**
@@ -1800,6 +1805,42 @@ function runAgentId(issueId: string, role: Role, subRole?: string): string {
  */
 const REVIEW_SUBROLE_TIMEOUT_SECONDS = 20 * 60;
 
+export async function assertWorkspaceStackHealthyForSpawn(
+  issueId: string,
+  role: Role,
+  allowHost = false,
+): Promise<void> {
+  if (role === 'plan') return;
+
+  const health = await getWorkspaceStackHealth(issueId);
+  if (health.healthy) return;
+
+  const normalizedIssue = issueId.toUpperCase();
+  const details = health.reasons.join('; ');
+  const message = `Workspace docker stack for ${normalizedIssue} is not healthy: ${details}. Run 'pan workspace rebuild ${normalizedIssue}' or retry with --host to override.`;
+
+  if (allowHost) {
+    console.warn(`[agents] ${message}`);
+    emitActivityEntry({
+      source: role,
+      level: 'warn',
+      issueId: normalizedIssue,
+      message: `agent-spawn-host-override: ${normalizedIssue}`,
+      details,
+    });
+    return;
+  }
+
+  emitActivityEntry({
+    source: role,
+    level: 'error',
+    issueId: normalizedIssue,
+    message: `agent-spawn-blocked-stack-unhealthy: ${normalizedIssue}`,
+    details,
+  });
+  throw new Error(message);
+}
+
 export async function spawnRun(issueId: string, role: Role, options: SpawnRunOptions = {}): Promise<AgentState> {
   const workspace = options.workspace ?? defaultRunWorkspace(issueId);
 
@@ -1811,6 +1852,7 @@ export async function spawnRun(issueId: string, role: Role, options: SpawnRunOpt
       model: options.model,
       prompt: options.prompt,
       role: 'work',
+      allowHost: options.allowHost,
     });
   }
 
@@ -1818,6 +1860,8 @@ export async function spawnRun(issueId: string, role: Role, options: SpawnRunOpt
   if (await sessionExistsAsync(agentId)) {
     throw new Error(`Role run ${agentId} already running. Use 'pan tell' to message it.`);
   }
+
+  await assertWorkspaceStackHealthyForSpawn(issueId, role, options.allowHost);
 
   initHook(agentId);
   const selectedModel = determineModel({ model: options.model, role });
@@ -1864,6 +1908,7 @@ export async function spawnRun(issueId: string, role: Role, options: SpawnRunOpt
     status: 'starting',
     startedAt: new Date().toISOString(),
     costSoFar: 0,
+    hostOverride: options.allowHost || undefined,
   };
   // PAN-1048 P1: spawnRun is on the dashboard hot path (Effect routes,
   // reactive Cloister scheduler). All disk I/O here uses async fs/promises
@@ -2055,16 +2100,18 @@ export async function spawnAgent(options: SpawnOptions): Promise<AgentState> {
   const agentId = options.slotId != null
     ? `agent-${options.issueId.toLowerCase()}-${options.slotId}`
     : `agent-${options.issueId.toLowerCase()}`;
+  const role: 'work' = options.role ?? 'work';
 
   // Check if already running (scoped to the exact session name, including slot suffix)
   if (await sessionExistsAsync(agentId)) {
     throw new Error(`Agent ${agentId} already running. Use 'pan tell' to message it.`);
   }
 
+  await assertWorkspaceStackHealthyForSpawn(options.issueId, role, options.allowHost);
+
   // Initialize hook for this agent (FPP support)
   initHook(agentId);
 
-  const role: 'work' = options.role ?? 'work';
   await assertIssueHasBeads(options.workspace, options.issueId);
 
   // Determine model based on role configuration
@@ -2119,6 +2166,7 @@ export async function spawnAgent(options: SpawnOptions): Promise<AgentState> {
     preSpawnStashRef: existingState?.preSpawnStashRef,
     preSpawnStashMessage: existingState?.preSpawnStashMessage,
     preSpawnBaselineHead: existingState?.preSpawnBaselineHead,
+    hostOverride: options.allowHost || undefined,
   };
 
   saveAgentState(state);
@@ -2661,6 +2709,11 @@ export async function messageAgent(agentId: string, message: string): Promise<vo
     // emitted a launcher that would crash on resume for any Pi role agent.
     const resumeModel = agentState.model || 'claude-sonnet-4-6';
     const fallbackHarness = agentState.harness ?? 'claude-code';
+    await assertWorkspaceStackHealthyForSpawn(
+      agentState.issueId || normalizedId.replace(/^agent-/, '').toUpperCase(),
+      resumeRole,
+      agentState.hostOverride === true,
+    );
     const fallbackPiFields = fallbackHarness === 'pi'
       ? await getPiLauncherFields(normalizedId, resumeModel)
       : {};
@@ -2824,6 +2877,18 @@ export async function resumeAgent(agentId: string, message?: string, opts?: { mo
     };
   }
 
+  try {
+    await assertWorkspaceStackHealthyForSpawn(
+      agentState.issueId || normalizedId.replace(/^agent-/, '').toUpperCase(),
+      agentState.role ?? 'work',
+      agentState.hostOverride === true,
+    );
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    logAgentLifecycle(normalizedId, `resumeAgent BLOCKED: ${reason}`);
+    return { success: false, error: reason };
+  }
+
   // Kill any zombie tmux session (crashed agent left behind)
   if (await sessionExistsAsync(normalizedId)) {
     try {
@@ -2970,6 +3035,18 @@ export async function restartAgent(
   }
 
   logAgentLifecycle(normalizedId, `restartAgent called (graceful=${graceful}, model=${newModel || 'unchanged'}, harness=${newHarness || 'unchanged'})`);
+
+  try {
+    await assertWorkspaceStackHealthyForSpawn(
+      agentState.issueId || normalizedId.replace(/^agent-/, '').toUpperCase(),
+      agentState.role ?? 'work',
+      agentState.hostOverride === true,
+    );
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    logAgentLifecycle(normalizedId, `restartAgent BLOCKED: ${reason}`);
+    return { success: false, error: reason };
+  }
 
   if (graceful && await sessionExistsAsync(normalizedId)) {
     const warning = 'Restarting in 30s. Update .pan/continue.json now with all progress, decisions, hazards, and resume point.';
@@ -3123,6 +3200,20 @@ export async function recoverAgent(
     return null;
   }
 
+  const recoveryRole: Role = state.role
+    ?? (normalizedId.startsWith('planning-') ? 'plan' : 'work');
+  try {
+    await assertWorkspaceStackHealthyForSpawn(
+      state.issueId || normalizedId.replace(/^agent-/, '').toUpperCase(),
+      recoveryRole,
+      state.hostOverride === true,
+    );
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    logAgentLifecycle(normalizedId, `recoverAgent BLOCKED: ${reason}`);
+    return null;
+  }
+
   // Check if already running — session may exist with only a bare shell
   // after Claude exited (zombie session). Kill it and recover.
   if (sessionExists(normalizedId)) {
@@ -3165,8 +3256,6 @@ export async function recoverAgent(
   // the saved AgentState (or the session-id heuristic for legacy planning-* IDs)
   // and route through getRoleRuntimeBaseCommand so review/test/ship don't get
   // resurrected as work agents.
-  const recoveryRole: Role = state.role
-    ?? (normalizedId.startsWith('planning-') ? 'plan' : 'work');
   const recoveryHarness: RuntimeName = (state.harness === 'pi' || state.harness === 'claude-code')
     ? state.harness
     : 'claude-code';

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -1815,10 +1815,11 @@ export async function assertWorkspaceStackHealthyForSpawn(
   issueId: string,
   role: Role,
   allowHost = false,
+  workspacePath?: string,
 ): Promise<void> {
   if (role === 'plan') return;
 
-  const health = await getWorkspaceStackHealth(issueId, { stackExpected: false });
+  const health = await getWorkspaceStackHealth(issueId, { workspacePath });
   if (health.healthy) return;
 
   const normalizedIssue = issueId.toUpperCase();
@@ -1868,7 +1869,7 @@ export async function spawnRun(issueId: string, role: Role, options: SpawnRunOpt
     throw new Error(`Role run ${agentId} already running. Use 'pan tell' to message it.`);
   }
 
-  await assertWorkspaceStackHealthyForSpawn(issueId, role, options.allowHost);
+  await assertWorkspaceStackHealthyForSpawn(issueId, role, options.allowHost, workspace);
 
   initHook(agentId);
 
@@ -2113,7 +2114,7 @@ export async function spawnAgent(options: SpawnOptions): Promise<AgentState> {
     throw new Error(`Agent ${agentId} already running. Use 'pan tell' to message it.`);
   }
 
-  await assertWorkspaceStackHealthyForSpawn(options.issueId, role, options.allowHost);
+  await assertWorkspaceStackHealthyForSpawn(options.issueId, role, options.allowHost, options.workspace);
 
   // Initialize hook for this agent (FPP support)
   initHook(agentId);
@@ -2719,6 +2720,7 @@ export async function messageAgent(agentId: string, message: string): Promise<vo
       agentState.issueId || normalizedId.replace(/^agent-/, '').toUpperCase(),
       resumeRole,
       agentState.hostOverride === true,
+      agentState.workspace,
     );
     const fallbackPiFields = fallbackHarness === 'pi'
       ? await getPiLauncherFields(normalizedId, resumeModel)
@@ -2889,6 +2891,7 @@ export async function resumeAgent(agentId: string, message?: string, opts?: { mo
       agentState.issueId || normalizedId.replace(/^agent-/, '').toUpperCase(),
       agentState.role ?? 'work',
       agentState.hostOverride === true,
+      agentState.workspace,
     );
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
@@ -3049,6 +3052,7 @@ export async function restartAgent(
       agentState.issueId || normalizedId.replace(/^agent-/, '').toUpperCase(),
       agentState.role ?? 'work',
       agentState.hostOverride === true,
+      agentState.workspace,
     );
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
@@ -3216,6 +3220,7 @@ export async function recoverAgent(
       state.issueId || normalizedId.replace(/^agent-/, '').toUpperCase(),
       recoveryRole,
       state.hostOverride === true,
+      state.workspace,
     );
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -1818,7 +1818,7 @@ export async function assertWorkspaceStackHealthyForSpawn(
 ): Promise<void> {
   if (role === 'plan') return;
 
-  const health = await getWorkspaceStackHealth(issueId);
+  const health = await getWorkspaceStackHealth(issueId, { stackExpected: false });
   if (health.healthy) return;
 
   const normalizedIssue = issueId.toUpperCase();

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -38,6 +38,7 @@ import type { RuntimeName } from './runtimes/types.js';
 import { createPiFifo, piFifoPaths, writePiCommand, PiNotReady } from './runtimes/pi-fifo.js';
 import { assertIssueHasBeads } from './beads-query.js';
 import { getWorkspaceStackHealth } from './workspace/stack-health.js';
+import { normalizeModelOverride, requireModelOverride, shellQuoteModelId } from './model-validation.js';
 
 const execAsync = promisify(exec);
 
@@ -212,12 +213,14 @@ export async function getAgentRuntimeBaseCommand(
   agentDefinition?: string,
   harness: 'claude-code' | 'pi' = 'claude-code',
 ): Promise<string> {
+  const validatedModel = requireModelOverride(model);
+  const quotedModel = shellQuoteModelId(validatedModel);
   if (harness === 'pi') {
-    return `pi --mode rpc --model ${model}`;
+    return `pi --mode rpc --model ${quotedModel}`;
   }
 
 
-  const provider = getProviderForModel(model);
+  const provider = getProviderForModel(validatedModel);
   const permissionFlags = getClaudePermissionFlagsString();
   // PAN-982: --name <agentId> creates a human-readable Claude session name discoverable via
   // `claude --resume`.
@@ -240,14 +243,14 @@ export async function getAgentRuntimeBaseCommand(
   // Anthropic-compatible /v1/messages endpoint, so Claude Code can drive
   // gpt-* models directly via ANTHROPIC_BASE_URL (no wrapper process).
   // The provider env vars are injected separately by getProviderEnvForModel.
-  if (provider.name === 'openai' && (await getProviderAuthMode(model)) === 'subscription') {
+  if (provider.name === 'openai' && (await getProviderAuthMode(validatedModel)) === 'subscription') {
     // CLIProxy supports gpt-5.x but not the -pro variant; map aliases to real names.
-    const resolvedModel = CLI_PROXY_MODEL_ALIASES[model] ?? model;
+    const resolvedModel = CLI_PROXY_MODEL_ALIASES[validatedModel] ?? validatedModel;
     if (agentDefinition) {
       // CLIProxy: --agent + --model override (frontmatter model: only accepts Anthropic ids).
-      return `claude${bypassWithAgent}${agentFlag} --model ${resolvedModel}${nameFlag}`;
+      return `claude${bypassWithAgent}${agentFlag} --model ${shellQuoteModelId(resolvedModel)}${nameFlag}`;
     }
-    return `claude ${permissionFlags} --model ${resolvedModel}${nameFlag}`;
+    return `claude ${permissionFlags} --model ${shellQuoteModelId(resolvedModel)}${nameFlag}`;
   }
 
   if (agentDefinition) {
@@ -257,9 +260,9 @@ export async function getAgentRuntimeBaseCommand(
     // launches silently fall back to the frontmatter model and ignore the
     // user's selection — observed when switching PAN-977 to Opus 4.7 left
     // the launcher running Sonnet.
-    return `claude${bypassWithAgent}${agentFlag} --model ${model}${nameFlag}`;
+    return `claude${bypassWithAgent}${agentFlag} --model ${quotedModel}${nameFlag}`;
   }
-  return `claude ${permissionFlags} --model ${model}${nameFlag}`;
+  return `claude ${permissionFlags} --model ${quotedModel}${nameFlag}`;
 }
 
 /**
@@ -296,11 +299,13 @@ export async function getRoleRuntimeBaseCommand(
   harness: 'claude-code' | 'pi' = 'claude-code',
   subRole?: string,
 ): Promise<string> {
+  const validatedModel = requireModelOverride(model);
+  const quotedModel = shellQuoteModelId(validatedModel);
   if (harness === 'pi') {
-    return `pi --mode rpc --model ${model}`;
+    return `pi --mode rpc --model ${quotedModel}`;
   }
 
-  const provider = getProviderForModel(model);
+  const provider = getProviderForModel(validatedModel);
   const definitionPath = roleAgentDefinitionPath(role, subRole);
   const agentFlag = definitionPath ? ` --agent ${definitionPath}` : '';
   const nameFlag = ` --name ${agentName}`;
@@ -313,12 +318,12 @@ export async function getRoleRuntimeBaseCommand(
 
   const printFlag = role === 'review' && subRole ? ' --print' : '';
 
-  if (provider.name === 'openai' && (await getProviderAuthMode(model)) === 'subscription') {
-    const resolvedModel = CLI_PROXY_MODEL_ALIASES[model] ?? model;
-    return `claude${bypassWithAgent}${printFlag}${agentFlag}${permissionFlags} --model ${resolvedModel}${nameFlag}`;
+  if (provider.name === 'openai' && (await getProviderAuthMode(validatedModel)) === 'subscription') {
+    const resolvedModel = CLI_PROXY_MODEL_ALIASES[validatedModel] ?? validatedModel;
+    return `claude${bypassWithAgent}${printFlag}${agentFlag}${permissionFlags} --model ${shellQuoteModelId(resolvedModel)}${nameFlag}`;
   }
 
-  return `claude${bypassWithAgent}${printFlag}${agentFlag}${permissionFlags} --model ${model}${nameFlag}`;
+  return `claude${bypassWithAgent}${printFlag}${agentFlag}${permissionFlags} --model ${quotedModel}${nameFlag}`;
 }
 
 /** Known agent ID prefixes — IDs with these prefixes are already normalized */
@@ -1537,11 +1542,12 @@ export async function buildCavemanExports(
  * is a real configuration bug the user must see.
  */
 export function determineModel(options: { model?: string; role?: Role } = {}): string {
-  if (options.model) {
-    return options.model;
+  const modelOverride = normalizeModelOverride(options.model);
+  if (modelOverride) {
+    return modelOverride;
   }
 
-  return resolveModel(options.role ?? 'work', undefined, loadYamlConfig().config);
+  return requireModelOverride(resolveModel(options.role ?? 'work', undefined, loadYamlConfig().config));
 }
 
 /**
@@ -1662,7 +1668,7 @@ export async function buildAgentLaunchConfig(opts: {
    */
   harness?: 'claude-code' | 'pi';
 }): Promise<AgentLaunchConfig> {
-  const model = opts.model;
+  const model = requireModelOverride(opts.model);
 
   // Substrate guard: inject permission deny rules for Panopticon infrastructure
   // paths (.claude/agents/, .claude/hooks/, ~/.panopticon/, JSONL session dirs)
@@ -1843,13 +1849,14 @@ export async function assertWorkspaceStackHealthyForSpawn(
 
 export async function spawnRun(issueId: string, role: Role, options: SpawnRunOptions = {}): Promise<AgentState> {
   const workspace = options.workspace ?? defaultRunWorkspace(issueId);
+  const selectedModel = determineModel({ model: options.model, role });
 
   if (role === 'work') {
     return spawnAgent({
       issueId,
       workspace,
       harness: options.harness,
-      model: options.model,
+      model: selectedModel,
       prompt: options.prompt,
       role: 'work',
       allowHost: options.allowHost,
@@ -1864,7 +1871,6 @@ export async function spawnRun(issueId: string, role: Role, options: SpawnRunOpt
   await assertWorkspaceStackHealthyForSpawn(issueId, role, options.allowHost);
 
   initHook(agentId);
-  const selectedModel = determineModel({ model: options.model, role });
 
   // PAN-1048 C5: Resolve the harness for this role from config.roles[role].harness
   // before falling back to claude-code. Explicit options.harness takes precedence
@@ -2830,6 +2836,7 @@ export async function messageAgent(agentId: string, message: string): Promise<vo
  */
 export async function resumeAgent(agentId: string, message?: string, opts?: { model?: string }): Promise<{ success: boolean; messageDelivered?: boolean; error?: string }> {
   const normalizedId = normalizeAgentId(agentId);
+  const requestedModel = normalizeModelOverride(opts?.model);
   logAgentLifecycle(normalizedId, `resumeAgent called (message=${message ? 'yes' : 'no'})`);
 
   // Check runtime state — allow both suspended (auto-suspend) and stopped/idle (manual stop, crash)
@@ -2922,9 +2929,9 @@ export async function resumeAgent(agentId: string, message?: string, opts?: { mo
     // Clear ready signal before resuming (clean slate for PAN-87 fix)
     clearReadySignal(normalizedId);
 
-    const model = opts?.model || agentState.model || 'claude-sonnet-4-6';
-    if (opts?.model && opts.model !== agentState.model) {
-      agentState.model = opts.model;
+    const model = requestedModel || requireModelOverride(agentState.model || 'claude-sonnet-4-6');
+    if (requestedModel && requestedModel !== agentState.model) {
+      agentState.model = requestedModel;
       saveAgentState(agentState);
     }
     const effectiveHarness = await resolveEffectiveHarness(agentState.harness, model);
@@ -3024,7 +3031,8 @@ export async function restartAgent(
   opts: RestartAgentOptions = {},
 ): Promise<{ success: boolean; error?: string }> {
   const normalizedId = normalizeAgentId(agentId);
-  const { graceful = true, model: newModel, harness: newHarness, message } = opts;
+  const { graceful = true, model: rawNewModel, harness: newHarness, message } = opts;
+  const newModel = normalizeModelOverride(rawNewModel);
 
   const agentState = getAgentState(normalizedId);
   if (!agentState) {
@@ -3068,7 +3076,7 @@ export async function restartAgent(
 
   await stopAgentAsync(normalizedId);
 
-  const effectiveModel = newModel || agentState.model || 'claude-sonnet-4-6';
+  const effectiveModel = newModel || requireModelOverride(agentState.model || 'claude-sonnet-4-6');
   const requestedHarness = newHarness ?? agentState.harness;
   const effectiveHarness = await resolveEffectiveHarness(requestedHarness, effectiveModel);
   if (newModel && newModel !== agentState.model) {
@@ -3189,9 +3197,10 @@ export async function recoverAgent(
 
   // Runtime state files may lack required fields (PAN-150)
   if (!state.id) state.id = normalizedId;
-  if (opts.modelOverride) {
-    state.model = opts.modelOverride;
-    logAgentLifecycle(normalizedId, `recoverAgent: model overridden → ${opts.modelOverride}`);
+  const modelOverride = normalizeModelOverride(opts.modelOverride);
+  if (modelOverride) {
+    state.model = modelOverride;
+    logAgentLifecycle(normalizedId, `recoverAgent: model overridden → ${modelOverride}`);
   }
   if (!state.workspace || !state.model) {
     const reason = `[agents] Cannot recover ${normalizedId}: state.json missing workspace or model`;

--- a/src/lib/cloister/handoff.ts
+++ b/src/lib/cloister/handoff.ts
@@ -13,6 +13,7 @@ import { getAgentState, saveAgentState, stopAgent, spawnAgent, spawnRun, getAgen
 import type { HandoffContext } from './handoff-context.js';
 import { captureHandoffContext, buildHandoffPrompt } from './handoff-context.js';
 import { sessionExists } from '../tmux.js';
+import { requireModelOverride } from '../model-validation.js';
 
 /**
  * Handoff method type
@@ -67,10 +68,21 @@ export async function performHandoff(
     };
   }
 
+  let targetModel: string;
+  try {
+    targetModel = requireModelOverride(options.targetModel);
+  } catch (error) {
+    return {
+      success: false,
+      method: 'kill-spawn',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
   // Legacy specialist wake has been deleted; normalize all handoffs to role respawn.
   const method = options.method === 'specialist-wake' ? 'kill-spawn' : (options.method || detectHandoffMethod(agentId));
 
-  return await performKillAndSpawn(state, { ...options, method });
+  return await performKillAndSpawn(state, { ...options, targetModel, method });
 }
 
 /**

--- a/src/lib/cloister/handoff.ts
+++ b/src/lib/cloister/handoff.ts
@@ -152,6 +152,7 @@ async function performKillAndSpawn(
       model: options.targetModel,
       role: 'work',
       prompt,
+      allowHost: state.hostOverride === true,
     });
 
     // Preserve accumulated cost without reintroducing legacy phase/complexity routing fields.

--- a/src/lib/cloister/merge-agent.ts
+++ b/src/lib/cloister/merge-agent.ts
@@ -575,8 +575,7 @@ export async function postMergeLifecycle(issueId: string, projectPath: string, s
     const issueLower = issueId.toLowerCase();
     const workspacePath = findWorkspacePath(projectPath, issueLower);
     if (workspacePath) {
-      const projName = basename(projectPath);
-      const dockerResult = await stopWorkspaceDocker(workspacePath, projName, issueLower);
+      const dockerResult = await stopWorkspaceDocker(workspacePath, issueLower);
       if (dockerResult.containersFound) {
         console.log(`[merge-agent] ✓ Stopped Docker containers: ${dockerResult.steps.join('; ')}`);
         logActivity('docker_cleanup', `Stopped Docker for ${issueId}: ${dockerResult.steps.join('; ')}`);

--- a/src/lib/cloister/review-agent.ts
+++ b/src/lib/cloister/review-agent.ts
@@ -40,8 +40,8 @@
  */
 
 import { exec } from 'child_process';
-import { readFile, rm } from 'fs/promises';
-import { join } from 'path';
+import { mkdir, readFile, rm } from 'fs/promises';
+import { dirname, join } from 'path';
 import { promisify } from 'util';
 import { killSessionAsync, listSessionNamesAsync, isPaneDeadAsync } from '../tmux.js';
 import { emitActivityEntry } from '../activity-logger.js';
@@ -76,8 +76,8 @@ function reviewerAgentId(issueId: string, subRole: ReviewSubRole): string {
   return `agent-${issueId.toLowerCase()}-review-${subRole}`;
 }
 
-function reviewerAgentOutputPath(issueId: string, subRole: ReviewSubRole): string {
-  return join(AGENTS_DIR, reviewerAgentId(issueId, subRole), `review-${subRole}.md`);
+function reviewerAgentOutputPath(workspace: string, runId: string, subRole: ReviewSubRole): string {
+  return join(workspace, PAN_DIRNAME, 'review', runId, `${subRole}.md`);
 }
 
 async function ensureReviewTempStash(issueId: string, workspace: string): Promise<{ ref: string; message: string; sequence: number } | null> {
@@ -218,7 +218,7 @@ function buildReviewRolePrompt(opts: {
   contextManifestPath?: string;
   tier1Summary?: string;
 }): string {
-  const subRoleFiles = REVIEW_SUB_ROLES.map(r => `  ${join(AGENTS_DIR, `agent-${opts.issueId.toLowerCase()}-review-${r}`, `review-${r}.md`)}`).join('\n');
+  const subRoleFiles = REVIEW_SUB_ROLES.map(r => `  ${join(opts.reviewDir, `${r}.md`)}`).join('\n');
   const expectedSignals = REVIEW_SUB_ROLES.map(r => `  REVIEWER_READY ${r} <outputPath> or REVIEWER_FAILED ${r} <reason> or REVIEWER_TIMEOUT ${r} <reason>`).join('\n');
   const synthesisPath = join(opts.reviewDir, 'synthesis.md');
   const prompt = [
@@ -306,11 +306,15 @@ export async function spawnReviewSubRoleForIssue(opts: {
   try {
     const { saveAgentStateAsync, spawnRun } = await import('../agents.js');
     const cfg = loadYamlConfig().config;
-    const outputPath = opts.outputPath ?? reviewerAgentOutputPath(opts.issueId, opts.subRole);
+    const outputPath = opts.outputPath ?? reviewerAgentOutputPath(opts.workspace, opts.runId, opts.subRole);
     const synthesisAgentId = opts.synthesisAgentId ?? `agent-${opts.issueId.toLowerCase()}-review`;
     const model = opts.model ?? resolveModel('review', opts.subRole, cfg);
+    const reviewerDir = join(AGENTS_DIR, reviewerAgentId(opts.issueId, opts.subRole));
 
+    await mkdir(dirname(outputPath), { recursive: true });
     await rm(outputPath, { force: true });
+    await rm(join(reviewerDir, 'reviewer-signaled'), { force: true });
+    await rm(join(reviewerDir, 'reviewer-launcher.pid'), { force: true });
 
     // Build Tier-1 inline summary from manifest when available (PAN-1125)
     let tier1Summary: string | undefined;
@@ -541,7 +545,7 @@ export async function spawnReviewRoleForIssue(
     emitActivityEntry({ source: 'review', level: 'info', message: `Review role spawned for ${opts.issueId}: ${run.id}`, issueId: opts.issueId });
 
     const reviewerResults = await Promise.all(REVIEW_SUB_ROLES.map(async (subRole) => {
-      const outputPath = reviewerAgentOutputPath(opts.issueId, subRole);
+      const outputPath = reviewerAgentOutputPath(opts.workspace, runId, subRole);
       const result = await spawnReviewSubRoleForIssue({
         issueId: opts.issueId,
         workspace: opts.workspace,

--- a/src/lib/close-out.ts
+++ b/src/lib/close-out.ts
@@ -273,8 +273,7 @@ export async function executeCloseOut(ctx: CloseOutContext): Promise<CloseOutRes
     if (workspacePath && existsSync(workspacePath)) {
       try {
         const { stopWorkspaceDocker } = await import('./workspace-manager.js');
-        const projectName = extractPrefix(ctx.issueId)?.toLowerCase() ?? ctx.issueId.toLowerCase();
-        await stopWorkspaceDocker(workspacePath, projectName, issueLower);
+        await stopWorkspaceDocker(workspacePath, issueLower);
         cleaned = true;
       } catch { /* Docker may not be running */ }
 

--- a/src/lib/docker-stats.ts
+++ b/src/lib/docker-stats.ts
@@ -22,6 +22,14 @@ export interface ContainerStats {
   status: 'running' | 'stopped' | 'unhealthy' | 'restarting';
 }
 
+export interface DockerContainerLifecycle {
+  id: string;
+  name: string;
+  status: string;
+  state?: string;
+  createdAt?: string;
+}
+
 export interface ContainerHistory {
   timestamps: number[];   // unix ms
   cpuPercent: number[];
@@ -37,7 +45,39 @@ interface DockerStatsRaw {
   NetIO: string;     // "1.23kB / 456B"
 }
 
+interface DockerPsRaw {
+  ID?: string;
+  Names?: string;
+  Name?: string;
+  Status?: string;
+  State?: string;
+  CreatedAt?: string;
+}
+
 const HISTORY_MAX = 60; // 5 min at 5s intervals
+let cachedContainerLifecycleSnapshot: DockerContainerLifecycle[] = [];
+let cachedContainerLifecycleObservedAt: string | null = null;
+
+export function getCachedDockerContainerLifecycleSnapshot(): DockerContainerLifecycle[] {
+  return cachedContainerLifecycleSnapshot.map(container => ({ ...container }));
+}
+
+export function getCachedDockerContainerLifecycleObservedAt(): string | null {
+  return cachedContainerLifecycleObservedAt;
+}
+
+export function resetCachedDockerContainerLifecycleSnapshotForTests(): void {
+  cachedContainerLifecycleSnapshot = [];
+  cachedContainerLifecycleObservedAt = null;
+}
+
+export function recordDockerContainerLifecycleSnapshot(
+  containers: DockerContainerLifecycle[],
+  observedAt = new Date().toISOString(),
+): void {
+  cachedContainerLifecycleSnapshot = containers.map(container => ({ ...container }));
+  cachedContainerLifecycleObservedAt = observedAt;
+}
 
 function parsePercent(s: string): number {
   return parseFloat(s.replace('%', '')) || 0;
@@ -107,21 +147,34 @@ export class DockerStatsCollector {
           encoding: 'utf-8',
           timeout: 10000,
         }).catch(() => ({ stdout: '', stderr: '' })),
-        execAsync(`docker ps -a --format '{{.ID}}\t{{.Names}}\t{{.Status}}' 2>/dev/null`, {
+        execAsync(`docker ps -a --format '{{json .}}' 2>/dev/null`, {
           encoding: 'utf-8',
           timeout: 5000,
         }).catch(() => ({ stdout: '', stderr: '' })),
       ]);
 
-      // Parse `docker ps -a` output for status
+      const lifecycleContainers: DockerContainerLifecycle[] = [];
       this.containerStatuses.clear();
       for (const line of psResult.stdout.trim().split('\n')) {
         if (!line.trim()) continue;
-        const [id, name, ...rest] = line.split('\t');
-        if (id && name) {
-          this.containerStatuses.set(name, rest.join('\t').toLowerCase());
+        try {
+          const raw = JSON.parse(line) as DockerPsRaw;
+          const name = raw.Names ?? raw.Name;
+          if (!raw.ID || !name) continue;
+          const container: DockerContainerLifecycle = {
+            id: raw.ID,
+            name,
+            status: raw.Status ?? '',
+            state: raw.State,
+            createdAt: raw.CreatedAt,
+          };
+          lifecycleContainers.push(container);
+          this.containerStatuses.set(name, container.status.toLowerCase());
+        } catch {
+          // Skip malformed JSON lines.
         }
       }
+      recordDockerContainerLifecycleSnapshot(lifecycleContainers);
 
       const now = Date.now();
       for (const line of statsResult.stdout.trim().split('\n')) {

--- a/src/lib/launcher-generator.ts
+++ b/src/lib/launcher-generator.ts
@@ -1,4 +1,5 @@
 import type { Role } from './agents.js';
+import { shellQuoteModelId } from './model-validation.js';
 
 export type LauncherSpawnMode = 'conversation' | 'remote' | 'resume';
 
@@ -466,7 +467,7 @@ function buildNonConversationCommand(config: LauncherConfig, useExec: boolean): 
     cmd += ` --session-id ${shellQuote(config.sessionId)}`;
   }
   if (config.model) {
-    cmd += ` --model ${config.model}`;
+    cmd += ` --model ${shellQuoteModelId(config.model)}`;
   }
   if (config.extraArgs) {
     cmd += ` ${config.extraArgs}`;
@@ -532,7 +533,7 @@ function buildPiCommand(config: LauncherConfig, useExec: boolean): string[] {
     tokens.push('--mode', 'rpc');
   }
   if (config.model) {
-    tokens.push('--model', config.model);
+    tokens.push('--model', shellQuoteModelId(config.model));
   }
   tokens.push('--session-dir', shellQuote(config.piSessionDir));
   if (config.piExtensionPath) {

--- a/src/lib/lifecycle/teardown-workspace.ts
+++ b/src/lib/lifecycle/teardown-workspace.ts
@@ -21,7 +21,6 @@ import { killSessionAsync, sessionExists, listSessionNamesAsync } from '../tmux.
 import type { LifecycleContext, StepResult, TeardownOptions } from './types.js';
 import { stepOk, stepSkipped, stepFailed } from './types.js';
 import { findAllWorkspacePaths, findWorkspacePath } from './archive-planning.js';
-import { extractPrefix } from '../issue-id.js';
 import { getContainersReferencingWorkspacePath } from '../workspace-manager.js';
 import { DEVCONTAINER_DIRNAME } from '../workspace/devcontainer-renderer.js';
 
@@ -120,13 +119,12 @@ async function stopTldrDaemon(workspacePath: string): Promise<StepResult> {
  */
 async function stopDocker(
   workspacePath: string,
-  projectName: string,
   issueLower: string,
 ): Promise<StepResult> {
   const step = 'teardown:docker';
   try {
     const { stopWorkspaceDocker } = await import('../workspace-manager.js');
-    await stopWorkspaceDocker(workspacePath, projectName, issueLower);
+    await stopWorkspaceDocker(workspacePath, issueLower);
     return stepOk(step, ['Stopped Docker containers']);
   } catch {
     return stepSkipped(step, ['Docker cleanup skipped (not running or failed)']);
@@ -505,7 +503,6 @@ export async function teardownWorkspace(
   opts: TeardownOptions = {},
 ): Promise<StepResult[]> {
   const issueLower = ctx.issueId.toLowerCase();
-  const projName = opts.projectName || ctx.projectName || (extractPrefix(ctx.issueId)?.toLowerCase() ?? ctx.issueId);
   const workspacePath = findWorkspacePath(ctx.projectPath, issueLower);
   const shouldDeleteWorkspace = opts.deleteWorkspace !== false; // default true
   const results: StepResult[] = [];
@@ -528,7 +525,7 @@ export async function teardownWorkspace(
 
     // 5. Stop Docker containers (only if deleting workspace)
     if (shouldDeleteWorkspace && !opts.skipDocker) {
-      results.push(await stopDocker(workspacePath, projName, issueLower));
+      results.push(await stopDocker(workspacePath, issueLower));
     }
 
     // 5b. Kill orphaned host processes (Vite, node) that survive Docker teardown

--- a/src/lib/model-validation.ts
+++ b/src/lib/model-validation.ts
@@ -1,4 +1,4 @@
-export const MODEL_ID_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9._:/-]{0,127})$/;
+export const MODEL_ID_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9._:/@-]{0,127})$/;
 
 export function normalizeModelOverride(value: unknown): string | undefined {
   if (value === undefined || value === null) return undefined;
@@ -8,7 +8,7 @@ export function normalizeModelOverride(value: unknown): string | undefined {
   const trimmed = value.trim();
   if (trimmed.length === 0) return undefined;
   if (!MODEL_ID_PATTERN.test(trimmed)) {
-    throw new Error('model must match [A-Za-z0-9._:/-]{1,128} with no whitespace or shell metacharacters.');
+    throw new Error('model must match [A-Za-z0-9._:/@-]{1,128} with no whitespace or shell metacharacters.');
   }
   return trimmed;
 }

--- a/src/lib/model-validation.ts
+++ b/src/lib/model-validation.ts
@@ -1,0 +1,27 @@
+export const MODEL_ID_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9._:/-]{0,127})$/;
+
+export function normalizeModelOverride(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'string') {
+    throw new Error('model must be a string.');
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  if (!MODEL_ID_PATTERN.test(trimmed)) {
+    throw new Error('model must match [A-Za-z0-9._:/-]{1,128} with no whitespace or shell metacharacters.');
+  }
+  return trimmed;
+}
+
+export function requireModelOverride(value: unknown): string {
+  const model = normalizeModelOverride(value);
+  if (!model) {
+    throw new Error('model is required');
+  }
+  return model;
+}
+
+export function shellQuoteModelId(model: string): string {
+  const normalized = requireModelOverride(model);
+  return `'${normalized.replace(/'/g, `'\\''`)}'`;
+}

--- a/src/lib/vbrief/continue-state.ts
+++ b/src/lib/vbrief/continue-state.ts
@@ -196,6 +196,8 @@ export interface SwarmRuntime {
   totalWaves?: number;
   /** Whether event/polling auto-advance is enabled. */
   autoAdvance?: boolean;
+  /** Whether this swarm was explicitly confirmed to bypass workspace isolation. */
+  hostOverride?: boolean;
   autoAdvanceFailureCount?: number;
   autoAdvanceRetryAfter?: string;
   lastAutoAdvanceError?: string;

--- a/src/lib/workspace-manager.ts
+++ b/src/lib/workspace-manager.ts
@@ -1291,7 +1291,6 @@ export async function getContainersReferencingWorkspacePath(
  */
 export async function stopWorkspaceDocker(
   workspacePath: string,
-  projectName: string,
   featureName: string,
 ): Promise<DockerCleanupResult> {
   const result: DockerCleanupResult = {
@@ -1327,7 +1326,8 @@ export async function stopWorkspaceDocker(
     }
   }
 
-  const composeProjectName = `${projectName}-feature-${featureName}`;
+  const featureFolder = `feature-${featureName}`;
+  const composeProjectName = `panopticon-${featureFolder}`;
   const devScriptPaths = [
     join(workspacePath, DEVCONTAINER_DIRNAME, 'dev'),
     join(workspacePath, 'dev'),
@@ -1336,7 +1336,6 @@ export async function stopWorkspaceDocker(
     try {
       if (!existsSync(devPath)) continue;
       const content = readFileSync(devPath, 'utf-8');
-      const featureFolder = `feature-${featureName}`;
       const templatedMatch = content.match(/COMPOSE_PROJECT_NAME="([^$"]*)\$\{FEATURE_FOLDER\}"/);
       const declared = templatedMatch
         ? `${templatedMatch[1]}${featureFolder}`
@@ -1448,7 +1447,7 @@ export async function removeWorkspace(options: WorkspaceRemoveOptions): Promise<
   }
 
   // Stop Docker containers and clean up Docker-created files
-  const dockerResult = await stopWorkspaceDocker(workspacePath, projectConfig.name || 'workspace', featureName);
+  const dockerResult = await stopWorkspaceDocker(workspacePath, featureName);
   result.steps.push(...dockerResult.steps);
 
   // Remove worktrees

--- a/src/lib/workspace-manager.ts
+++ b/src/lib/workspace-manager.ts
@@ -1327,30 +1327,25 @@ export async function stopWorkspaceDocker(
     }
   }
 
-  // Derive compose project name from the dev script (same logic as dashboard)
-  // or fall back to "{projectName}-feature-{featureName}" convention.
-  let composeProjectName = `${projectName}-feature-${featureName}`;
+  const composeProjectName = `${projectName}-feature-${featureName}`;
   const devScriptPaths = [
     join(workspacePath, DEVCONTAINER_DIRNAME, 'dev'),
     join(workspacePath, 'dev'),
   ];
   for (const devPath of devScriptPaths) {
     try {
-      if (existsSync(devPath)) {
-        const content = readFileSync(devPath, 'utf-8');
-        const match = content.match(/COMPOSE_PROJECT_NAME="([^$"]*)\$\{FEATURE_FOLDER\}"/);
-        if (match) {
-          composeProjectName = `${match[1]}feature-${featureName}`;
-          break;
-        }
-        const literalMatch = content.match(/COMPOSE_PROJECT_NAME="([^"]+)"/);
-        if (literalMatch) {
-          composeProjectName = literalMatch[1];
-          break;
-        }
+      if (!existsSync(devPath)) continue;
+      const content = readFileSync(devPath, 'utf-8');
+      const featureFolder = `feature-${featureName}`;
+      const templatedMatch = content.match(/COMPOSE_PROJECT_NAME="([^$"]*)\$\{FEATURE_FOLDER\}"/);
+      const declared = templatedMatch
+        ? `${templatedMatch[1]}${featureFolder}`
+        : content.match(/COMPOSE_PROJECT_NAME="([^"]+)"/)?.[1];
+      if (declared && declared !== composeProjectName) {
+        throw new Error(`${devPath} declares COMPOSE_PROJECT_NAME=${declared}, expected ${composeProjectName}`);
       }
-    } catch {
-      // Fall through to default
+    } catch (error: any) {
+      if (error?.message?.includes('declares COMPOSE_PROJECT_NAME=')) throw error;
     }
   }
 

--- a/src/lib/workspace/__tests__/stack-health.test.ts
+++ b/src/lib/workspace/__tests__/stack-health.test.ts
@@ -8,6 +8,7 @@ import type { ProjectConfig } from '../../projects.js';
 import {
   evaluateWorkspaceStackHealth,
   getWorkspaceStackHealth,
+  inferIssueIdFromStackContainerName,
   recordWorkspaceStackHealthTransition,
   resetWorkspaceStackHealthTransitionsForTests,
   type DockerContainerLifecycle,
@@ -85,6 +86,24 @@ describe('evaluateWorkspaceStackHealth', () => {
 
     expect(health.healthy).toBe(true);
     expect(health.reasons).toEqual([]);
+  });
+
+  it('does not match overlapping issue IDs by substring', () => {
+    const health = evaluateWorkspaceStackHealth('PAN-1140', dockerProject, [
+      container({
+        name: 'panopticon-feature-pan-11400-init-1',
+        status: 'Exited (1) 3 minutes ago',
+        state: 'exited',
+      }),
+    ], { now });
+
+    expect(health.healthy).toBe(true);
+    expect(health.reasons).toEqual([]);
+  });
+
+  it('infers issue IDs from workspace stack container names', () => {
+    expect(inferIssueIdFromStackContainerName('panopticon-feature-pan-1140-init-1')).toBe('PAN-1140');
+    expect(inferIssueIdFromStackContainerName('panopticon-feature-pan-11400-init-1')).toBe('PAN-11400');
   });
 
   it('uses the cached Docker lifecycle snapshot when containers are omitted', async () => {

--- a/src/lib/workspace/__tests__/stack-health.test.ts
+++ b/src/lib/workspace/__tests__/stack-health.test.ts
@@ -88,6 +88,13 @@ describe('evaluateWorkspaceStackHealth', () => {
     expect(health.reasons).toEqual([]);
   });
 
+  it('marks a Docker workspace unhealthy when no stack containers are observed', () => {
+    const health = evaluateWorkspaceStackHealth('PAN-1140', dockerProject, [], { now });
+
+    expect(health.healthy).toBe(false);
+    expect(health.reasons).toEqual(['No Docker containers found for workspace stack pan-1140']);
+  });
+
   it('does not match overlapping issue IDs by substring', () => {
     const health = evaluateWorkspaceStackHealth('PAN-1140', dockerProject, [
       container({
@@ -97,8 +104,8 @@ describe('evaluateWorkspaceStackHealth', () => {
       }),
     ], { now });
 
-    expect(health.healthy).toBe(true);
-    expect(health.reasons).toEqual([]);
+    expect(health.healthy).toBe(false);
+    expect(health.reasons).toEqual(['No Docker containers found for workspace stack pan-1140']);
   });
 
   it('infers issue IDs from workspace stack container names', () => {

--- a/src/lib/workspace/__tests__/stack-health.test.ts
+++ b/src/lib/workspace/__tests__/stack-health.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  evaluateWorkspaceStackHealth,
+  recordWorkspaceStackHealthTransition,
+  resetWorkspaceStackHealthTransitionsForTests,
+  type DockerContainerLifecycle,
+} from '../stack-health.js';
+import type { ProjectConfig } from '../../projects.js';
+
+const dockerProject: ProjectConfig = {
+  name: 'Panopticon',
+  path: '/repo',
+  workspace: {
+    docker: { compose_template: 'infra/.devcontainer-template' },
+  },
+};
+
+const now = new Date('2026-05-16T23:00:00.000Z');
+
+function container(overrides: Partial<DockerContainerLifecycle>): DockerContainerLifecycle {
+  return {
+    id: 'abc123',
+    name: 'panopticon-feature-pan-1140-server-1',
+    status: 'Up 10 seconds',
+    state: 'running',
+    createdAt: '2026-05-16T22:59:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('evaluateWorkspaceStackHealth', () => {
+  it('keeps a recently Created container healthy before the threshold', () => {
+    const health = evaluateWorkspaceStackHealth('PAN-1140', dockerProject, [
+      container({
+        status: 'Created',
+        state: 'created',
+        createdAt: '2026-05-16T22:58:30.001Z',
+      }),
+    ], { now, stuckCreatedThresholdMs: 120_000 });
+
+    expect(health.healthy).toBe(true);
+    expect(health.reasons).toEqual([]);
+  });
+
+  it('marks a Created container unhealthy at the threshold', () => {
+    const health = evaluateWorkspaceStackHealth('PAN-1140', dockerProject, [
+      container({
+        status: 'Created',
+        state: 'created',
+        createdAt: '2026-05-16T22:58:00.000Z',
+      }),
+    ], { now, stuckCreatedThresholdMs: 120_000 });
+
+    expect(health.healthy).toBe(false);
+    expect(health.reasons[0]).toContain('stuck Created');
+  });
+
+  it('marks an exited non-zero container unhealthy', () => {
+    const health = evaluateWorkspaceStackHealth('PAN-1140', dockerProject, [
+      container({
+        name: 'panopticon-feature-pan-1140-init-1',
+        status: 'Exited (127) 2 minutes ago',
+        state: 'exited',
+      }),
+    ], { now });
+
+    expect(health.healthy).toBe(false);
+    expect(health.reasons[0]).toContain('init exited non-zero (127)');
+  });
+
+  it('keeps Up containers healthy', () => {
+    const health = evaluateWorkspaceStackHealth('PAN-1140', dockerProject, [
+      container({ status: 'Up 2 minutes', state: 'running' }),
+    ], { now });
+
+    expect(health.healthy).toBe(true);
+    expect(health.reasons).toEqual([]);
+  });
+
+  it('emits only on healthy to unhealthy transitions', () => {
+    resetWorkspaceStackHealthTransitionsForTests();
+
+    expect(recordWorkspaceStackHealthTransition('PAN-1140', { healthy: true, reasons: [], lastObserved: now.toISOString() })).toBe(false);
+    expect(recordWorkspaceStackHealthTransition('PAN-1140', { healthy: false, reasons: ['broken'], lastObserved: now.toISOString() })).toBe(true);
+    expect(recordWorkspaceStackHealthTransition('PAN-1140', { healthy: false, reasons: ['still broken'], lastObserved: now.toISOString() })).toBe(false);
+    expect(recordWorkspaceStackHealthTransition('PAN-1140', { healthy: true, reasons: [], lastObserved: now.toISOString() })).toBe(false);
+    expect(recordWorkspaceStackHealthTransition('PAN-1140', { healthy: false, reasons: ['broken again'], lastObserved: now.toISOString() })).toBe(true);
+  });
+});

--- a/src/lib/workspace/__tests__/stack-health.test.ts
+++ b/src/lib/workspace/__tests__/stack-health.test.ts
@@ -83,6 +83,33 @@ describe('evaluateWorkspaceStackHealth', () => {
     expect(health.reasons[0]).toContain('init exited non-zero (127)');
   });
 
+  it('keeps init containers healthy when they exit zero', () => {
+    const health = evaluateWorkspaceStackHealth('PAN-1140', dockerProject, [
+      container({
+        name: 'panopticon-feature-pan-1140-init-1',
+        status: 'Exited (0) 2 minutes ago',
+        state: 'exited',
+      }),
+      container({ status: 'Up 2 minutes', state: 'running' }),
+    ], { now });
+
+    expect(health.healthy).toBe(true);
+    expect(health.reasons).toEqual([]);
+  });
+
+  it('marks service containers unhealthy when they exit zero', () => {
+    const health = evaluateWorkspaceStackHealth('PAN-1140', dockerProject, [
+      container({
+        name: 'panopticon-feature-pan-1140-server-1',
+        status: 'Exited (0) 2 minutes ago',
+        state: 'exited',
+      }),
+    ], { now });
+
+    expect(health.healthy).toBe(false);
+    expect(health.reasons).toEqual(['panopticon-feature-pan-1140-server-1 service exited (0)']);
+  });
+
   it('keeps Up containers healthy', () => {
     const health = evaluateWorkspaceStackHealth('PAN-1140', dockerProject, [
       container({ status: 'Up 2 minutes', state: 'running' }),

--- a/src/lib/workspace/__tests__/stack-health.test.ts
+++ b/src/lib/workspace/__tests__/stack-health.test.ts
@@ -1,12 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import {
+  recordDockerContainerLifecycleSnapshot,
+  resetCachedDockerContainerLifecycleSnapshotForTests,
+} from '../../docker-stats.js';
+import type { ProjectConfig } from '../../projects.js';
+import {
   evaluateWorkspaceStackHealth,
+  getWorkspaceStackHealth,
   recordWorkspaceStackHealthTransition,
   resetWorkspaceStackHealthTransitionsForTests,
   type DockerContainerLifecycle,
 } from '../stack-health.js';
-import type { ProjectConfig } from '../../projects.js';
 
 const dockerProject: ProjectConfig = {
   name: 'Panopticon',
@@ -17,6 +22,10 @@ const dockerProject: ProjectConfig = {
 };
 
 const now = new Date('2026-05-16T23:00:00.000Z');
+
+afterEach(() => {
+  resetCachedDockerContainerLifecycleSnapshotForTests();
+});
 
 function container(overrides: Partial<DockerContainerLifecycle>): DockerContainerLifecycle {
   return {
@@ -76,6 +85,24 @@ describe('evaluateWorkspaceStackHealth', () => {
 
     expect(health.healthy).toBe(true);
     expect(health.reasons).toEqual([]);
+  });
+
+  it('uses the cached Docker lifecycle snapshot when containers are omitted', async () => {
+    recordDockerContainerLifecycleSnapshot([
+      container({
+        name: 'panopticon-feature-pan-1140-init-1',
+        status: 'Exited (1) 3 minutes ago',
+        state: 'exited',
+      }),
+    ], '2026-05-16T23:01:00.000Z');
+
+    const health = await getWorkspaceStackHealth('PAN-1140', { projectConfig: dockerProject });
+
+    expect(health).toEqual({
+      healthy: false,
+      reasons: ['panopticon-feature-pan-1140-init-1 init exited non-zero (1)'],
+      lastObserved: '2026-05-16T23:01:00.000Z',
+    });
   });
 
   it('emits only on healthy to unhealthy transitions', () => {

--- a/src/lib/workspace/__tests__/stack-health.test.ts
+++ b/src/lib/workspace/__tests__/stack-health.test.ts
@@ -1,3 +1,7 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
@@ -88,11 +92,18 @@ describe('evaluateWorkspaceStackHealth', () => {
     expect(health.reasons).toEqual([]);
   });
 
-  it('marks a Docker workspace unhealthy when no stack containers are observed', () => {
-    const health = evaluateWorkspaceStackHealth('PAN-1140', dockerProject, [], { now });
+  it('marks a Docker workspace unhealthy when no expected stack containers are observed', () => {
+    const health = evaluateWorkspaceStackHealth('PAN-1140', dockerProject, [], { now, stackExpected: true });
 
     expect(health.healthy).toBe(false);
     expect(health.reasons).toEqual(['No Docker containers found for workspace stack pan-1140']);
+  });
+
+  it('allows a Docker workspace before its stack has been created', () => {
+    const health = evaluateWorkspaceStackHealth('PAN-1140', dockerProject, [], { now, stackExpected: false });
+
+    expect(health.healthy).toBe(true);
+    expect(health.reasons).toEqual([]);
   });
 
   it('does not match overlapping issue IDs by substring', () => {
@@ -129,6 +140,49 @@ describe('evaluateWorkspaceStackHealth', () => {
       reasons: ['panopticon-feature-pan-1140-init-1 init exited non-zero (1)'],
       lastObserved: '2026-05-16T23:01:00.000Z',
     });
+  });
+
+  it('allows a missing stack when the workspace has not rendered devcontainer state', async () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'pan-stack-health-'));
+    try {
+      const workspacePath = join(projectRoot, 'workspaces', 'feature-pan-1140');
+      mkdirSync(workspacePath, { recursive: true });
+
+      const health = await getWorkspaceStackHealth('PAN-1140', {
+        projectConfig: { ...dockerProject, path: projectRoot },
+        containers: [],
+        now,
+      });
+
+      expect(health).toEqual({
+        healthy: true,
+        reasons: [],
+        lastObserved: now.toISOString(),
+      });
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('marks a missing stack unhealthy after devcontainer state exists', async () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'pan-stack-health-'));
+    try {
+      mkdirSync(join(projectRoot, 'workspaces', 'feature-pan-1140', '.devcontainer'), { recursive: true });
+
+      const health = await getWorkspaceStackHealth('PAN-1140', {
+        projectConfig: { ...dockerProject, path: projectRoot },
+        containers: [],
+        now,
+      });
+
+      expect(health).toEqual({
+        healthy: false,
+        reasons: ['No Docker containers found for workspace stack pan-1140'],
+        lastObserved: now.toISOString(),
+      });
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
   });
 
   it('emits only on healthy to unhealthy transitions', () => {

--- a/src/lib/workspace/ensure-devcontainer.ts
+++ b/src/lib/workspace/ensure-devcontainer.ts
@@ -32,7 +32,7 @@ import {
   renderDevcontainer,
   type DevcontainerRenderResult,
 } from './devcontainer-renderer.js';
-import { extractTeamPrefix, findProjectByTeam } from '../projects.js';
+import { getProject, resolveProjectFromIssue } from '../projects.js';
 
 export interface EnsureDevcontainerInput {
   /** Absolute workspace path. e.g. `/home/x/Projects/myn/workspaces/feature-min-846`. */
@@ -80,8 +80,8 @@ export function ensureDevcontainer(
     };
   }
 
-  const teamPrefix = extractTeamPrefix(input.issueId);
-  const projectConfig = teamPrefix ? findProjectByTeam(teamPrefix) : null;
+  const resolvedProject = resolveProjectFromIssue(input.issueId);
+  const projectConfig = resolvedProject ? getProject(resolvedProject.projectKey) : null;
   if (!projectConfig) {
     return {
       step: stepFailed(

--- a/src/lib/workspace/stack-health.ts
+++ b/src/lib/workspace/stack-health.ts
@@ -2,6 +2,11 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
 import { emitActivityEntry } from '../activity-logger.js';
+import {
+  getCachedDockerContainerLifecycleObservedAt,
+  getCachedDockerContainerLifecycleSnapshot,
+  type DockerContainerLifecycle,
+} from '../docker-stats.js';
 import { parseIssueId } from '../issue-id.js';
 import { findProjectByTeam } from '../projects.js';
 
@@ -9,13 +14,7 @@ const execFileAsync = promisify(execFile);
 
 export const DEFAULT_STUCK_CREATED_THRESHOLD_MS = 120_000;
 
-export interface DockerContainerLifecycle {
-  id: string;
-  name: string;
-  status: string;
-  state?: string;
-  createdAt?: string;
-}
+export type { DockerContainerLifecycle } from '../docker-stats.js';
 
 export interface WorkspaceStackHealth {
   healthy: boolean;
@@ -160,17 +159,21 @@ export async function getWorkspaceStackHealth(
   options: WorkspaceStackHealthOptions = {},
 ): Promise<WorkspaceStackHealth> {
   const projectConfig = options.projectConfig ?? resolveStackProject(issueId);
-  const containers = options.containers ?? await collectDockerContainerLifecycleSnapshot();
+  const cachedObservedAt = getCachedDockerContainerLifecycleObservedAt();
+  const containers = options.containers ?? getCachedDockerContainerLifecycleSnapshot();
   const health = evaluateWorkspaceStackHealth(issueId, projectConfig, containers, {
     now: options.now,
     stuckCreatedThresholdMs: options.stuckCreatedThresholdMs,
   });
+  const observedHealth = cachedObservedAt && !options.now
+    ? { ...health, lastObserved: cachedObservedAt }
+    : health;
 
   if (options.emitTransitionActivity) {
-    recordWorkspaceStackHealthTransition(issueId, health);
+    recordWorkspaceStackHealthTransition(issueId, observedHealth);
   }
 
-  return health;
+  return observedHealth;
 }
 
 export function recordWorkspaceStackHealthTransition(issueId: string, health: WorkspaceStackHealth): boolean {

--- a/src/lib/workspace/stack-health.ts
+++ b/src/lib/workspace/stack-health.ts
@@ -1,0 +1,195 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { emitActivityEntry } from '../activity-logger.js';
+import { parseIssueId } from '../issue-id.js';
+import { findProjectByTeam } from '../projects.js';
+
+const execFileAsync = promisify(execFile);
+
+export const DEFAULT_STUCK_CREATED_THRESHOLD_MS = 120_000;
+
+export interface DockerContainerLifecycle {
+  id: string;
+  name: string;
+  status: string;
+  state?: string;
+  createdAt?: string;
+}
+
+export interface WorkspaceStackHealth {
+  healthy: boolean;
+  reasons: string[];
+  lastObserved: string;
+}
+
+export interface WorkspaceStackProject {
+  workspace?: { docker?: { compose_template?: string } };
+}
+
+export interface WorkspaceStackHealthOptions {
+  projectConfig?: WorkspaceStackProject | null;
+  containers?: DockerContainerLifecycle[];
+  now?: Date;
+  stuckCreatedThresholdMs?: number;
+  emitTransitionActivity?: boolean;
+}
+
+interface DockerPsJson {
+  ID?: string;
+  Names?: string;
+  Name?: string;
+  Status?: string;
+  State?: string;
+  CreatedAt?: string;
+}
+
+const lastHealthByIssue = new Map<string, boolean>();
+
+function normalizeIssue(issueId: string): string {
+  return parseIssueId(issueId)?.normalized ?? issueId.toLowerCase();
+}
+
+function resolveStackProject(issueId: string): WorkspaceStackProject | null {
+  const prefix = parseIssueId(issueId)?.prefix ?? issueId.split('-')[0];
+  return prefix ? findProjectByTeam(prefix) ?? null : null;
+}
+
+function hasDockerWorkspace(projectConfig: WorkspaceStackProject | null | undefined): boolean {
+  return Boolean(projectConfig?.workspace?.docker?.compose_template);
+}
+
+function isStackContainer(container: DockerContainerLifecycle, issueId: string): boolean {
+  const normalized = normalizeIssue(issueId);
+  const name = container.name.toLowerCase();
+  return name.includes(`feature-${normalized}`) || name.includes(normalized);
+}
+
+function isInitContainer(name: string): boolean {
+  return /(^|[-_])init($|[-_])/.test(name.toLowerCase());
+}
+
+function parseExitCode(status: string): number | null {
+  const match = status.match(/exited \((\d+)\)/i);
+  return match ? Number.parseInt(match[1], 10) : null;
+}
+
+function isCreated(container: DockerContainerLifecycle): boolean {
+  return container.state?.toLowerCase() === 'created' || /^created\b/i.test(container.status);
+}
+
+function isExited(container: DockerContainerLifecycle): boolean {
+  return container.state?.toLowerCase() === 'exited' || /^exited\b/i.test(container.status);
+}
+
+function createdAgeMs(container: DockerContainerLifecycle, now: Date): number | null {
+  if (!container.createdAt) return null;
+  const created = new Date(container.createdAt).getTime();
+  if (Number.isNaN(created)) return null;
+  return now.getTime() - created;
+}
+
+export function evaluateWorkspaceStackHealth(
+  issueId: string,
+  projectConfig: WorkspaceStackProject | null | undefined,
+  containers: DockerContainerLifecycle[],
+  options: { now?: Date; stuckCreatedThresholdMs?: number } = {},
+): WorkspaceStackHealth {
+  const now = options.now ?? new Date();
+  const lastObserved = now.toISOString();
+  if (!hasDockerWorkspace(projectConfig)) {
+    return { healthy: true, reasons: [], lastObserved };
+  }
+
+  const thresholdMs = options.stuckCreatedThresholdMs ?? DEFAULT_STUCK_CREATED_THRESHOLD_MS;
+  const stackContainers = containers.filter((container) => isStackContainer(container, issueId));
+  const reasons: string[] = [];
+
+  for (const container of stackContainers) {
+    const exitCode = parseExitCode(container.status);
+    if (isExited(container) && exitCode !== null && exitCode !== 0) {
+      const role = isInitContainer(container.name) ? 'init' : 'service';
+      reasons.push(`${container.name} ${role} exited non-zero (${exitCode})`);
+      continue;
+    }
+
+    if (isCreated(container)) {
+      const ageMs = createdAgeMs(container, now);
+      if (ageMs === null || ageMs >= thresholdMs) {
+        const age = ageMs === null ? 'unknown age' : `${Math.floor(ageMs / 1000)}s`;
+        reasons.push(`${container.name} stuck Created for ${age}`);
+      }
+    }
+  }
+
+  return { healthy: reasons.length === 0, reasons, lastObserved };
+}
+
+export async function collectDockerContainerLifecycleSnapshot(): Promise<DockerContainerLifecycle[]> {
+  try {
+    const { stdout } = await execFileAsync('docker', ['ps', '-a', '--format', '{{json .}}'], {
+      encoding: 'utf-8',
+      timeout: 5_000,
+    });
+    const containers: DockerContainerLifecycle[] = [];
+    for (const line of stdout.trim().split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const raw = JSON.parse(line) as DockerPsJson;
+        const name = raw.Names ?? raw.Name;
+        if (!raw.ID || !name) continue;
+        containers.push({
+          id: raw.ID,
+          name,
+          status: raw.Status ?? '',
+          state: raw.State,
+          createdAt: raw.CreatedAt,
+        });
+      } catch {
+        // Ignore malformed docker rows.
+      }
+    }
+    return containers;
+  } catch {
+    return [];
+  }
+}
+
+export async function getWorkspaceStackHealth(
+  issueId: string,
+  options: WorkspaceStackHealthOptions = {},
+): Promise<WorkspaceStackHealth> {
+  const projectConfig = options.projectConfig ?? resolveStackProject(issueId);
+  const containers = options.containers ?? await collectDockerContainerLifecycleSnapshot();
+  const health = evaluateWorkspaceStackHealth(issueId, projectConfig, containers, {
+    now: options.now,
+    stuckCreatedThresholdMs: options.stuckCreatedThresholdMs,
+  });
+
+  if (options.emitTransitionActivity) {
+    recordWorkspaceStackHealthTransition(issueId, health);
+  }
+
+  return health;
+}
+
+export function recordWorkspaceStackHealthTransition(issueId: string, health: WorkspaceStackHealth): boolean {
+  const key = normalizeIssue(issueId);
+  const previous = lastHealthByIssue.get(key);
+  lastHealthByIssue.set(key, health.healthy);
+
+  if (previous !== true || health.healthy) return false;
+
+  emitActivityEntry({
+    source: 'cloister',
+    level: 'error',
+    issueId: issueId.toUpperCase(),
+    message: `workspace-stack-unhealthy: ${issueId.toUpperCase()}`,
+    details: health.reasons.join('; '),
+  });
+  return true;
+}
+
+export function resetWorkspaceStackHealthTransitionsForTests(): void {
+  lastHealthByIssue.clear();
+}

--- a/src/lib/workspace/stack-health.ts
+++ b/src/lib/workspace/stack-health.ts
@@ -5,6 +5,7 @@ import { emitActivityEntry } from '../activity-logger.js';
 import {
   getCachedDockerContainerLifecycleObservedAt,
   getCachedDockerContainerLifecycleSnapshot,
+  recordDockerContainerLifecycleSnapshot,
   type DockerContainerLifecycle,
 } from '../docker-stats.js';
 import { parseIssueId } from '../issue-id.js';
@@ -58,10 +59,27 @@ function hasDockerWorkspace(projectConfig: WorkspaceStackProject | null | undefi
   return Boolean(projectConfig?.workspace?.docker?.compose_template);
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function hasNameToken(name: string, token: string): boolean {
+  return new RegExp(`(^|[-_])${escapeRegExp(token)}($|[-_])`).test(name);
+}
+
+export function inferIssueIdFromStackContainerName(name: string): string | null {
+  const lower = name.toLowerCase();
+  const standard = lower.match(/(?:^|[-_])feature-([a-z]+-\d+)(?=$|[-_])/) ?? lower.match(/(?:^|[-_])([a-z]+-\d+)(?=$|[-_])/);
+  if (standard?.[1]) return standard[1].toUpperCase();
+
+  const rally = lower.match(/(?:^|[-_])feature-((?:f|us|de|ta|tc)\d+)(?=$|[-_])/) ?? lower.match(/(?:^|[-_])((?:f|us|de|ta|tc)\d+)(?=$|[-_])/);
+  return rally?.[1]?.toUpperCase() ?? null;
+}
+
 function isStackContainer(container: DockerContainerLifecycle, issueId: string): boolean {
   const normalized = normalizeIssue(issueId);
   const name = container.name.toLowerCase();
-  return name.includes(`feature-${normalized}`) || name.includes(normalized);
+  return hasNameToken(name, `feature-${normalized}`) || hasNameToken(name, normalized);
 }
 
 function isInitContainer(name: string): boolean {
@@ -159,14 +177,27 @@ export async function getWorkspaceStackHealth(
   options: WorkspaceStackHealthOptions = {},
 ): Promise<WorkspaceStackHealth> {
   const projectConfig = options.projectConfig ?? resolveStackProject(issueId);
-  const cachedObservedAt = getCachedDockerContainerLifecycleObservedAt();
-  const containers = options.containers ?? getCachedDockerContainerLifecycleSnapshot();
+  let observedAt: string | null = null;
+  let containers = options.containers;
+
+  if (!containers) {
+    observedAt = getCachedDockerContainerLifecycleObservedAt();
+    containers = observedAt ? getCachedDockerContainerLifecycleSnapshot() : undefined;
+  }
+
+  if (!containers) {
+    const observed = options.now ?? new Date();
+    containers = await collectDockerContainerLifecycleSnapshot();
+    observedAt = observed.toISOString();
+    recordDockerContainerLifecycleSnapshot(containers, observedAt);
+  }
+
   const health = evaluateWorkspaceStackHealth(issueId, projectConfig, containers, {
     now: options.now,
     stuckCreatedThresholdMs: options.stuckCreatedThresholdMs,
   });
-  const observedHealth = cachedObservedAt && !options.now
-    ? { ...health, lastObserved: cachedObservedAt }
+  const observedHealth = observedAt && !options.now
+    ? { ...health, lastObserved: observedAt }
     : health;
 
   if (options.emitTransitionActivity) {

--- a/src/lib/workspace/stack-health.ts
+++ b/src/lib/workspace/stack-health.ts
@@ -1,4 +1,6 @@
 import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { promisify } from 'node:util';
 
 import { emitActivityEntry } from '../activity-logger.js';
@@ -24,7 +26,8 @@ export interface WorkspaceStackHealth {
 }
 
 export interface WorkspaceStackProject {
-  workspace?: { docker?: { compose_template?: string } };
+  path?: string;
+  workspace?: { workspaces_dir?: string; docker?: { compose_template?: string } };
 }
 
 export interface WorkspaceStackHealthOptions {
@@ -33,6 +36,8 @@ export interface WorkspaceStackHealthOptions {
   now?: Date;
   stuckCreatedThresholdMs?: number;
   emitTransitionActivity?: boolean;
+  workspacePath?: string;
+  stackExpected?: boolean;
 }
 
 interface DockerPsJson {
@@ -57,6 +62,25 @@ function resolveStackProject(issueId: string): WorkspaceStackProject | null {
 
 function hasDockerWorkspace(projectConfig: WorkspaceStackProject | null | undefined): boolean {
   return Boolean(projectConfig?.workspace?.docker?.compose_template);
+}
+
+function defaultWorkspacePath(issueId: string, projectConfig: WorkspaceStackProject | null | undefined): string | null {
+  if (!projectConfig?.path) return null;
+  return join(
+    projectConfig.path,
+    projectConfig.workspace?.workspaces_dir ?? 'workspaces',
+    `feature-${normalizeIssue(issueId)}`,
+  );
+}
+
+function isWorkspaceStackExpected(
+  issueId: string,
+  projectConfig: WorkspaceStackProject | null | undefined,
+  workspacePath?: string,
+): boolean {
+  const resolvedWorkspacePath = workspacePath ?? defaultWorkspacePath(issueId, projectConfig);
+  if (!resolvedWorkspacePath) return true;
+  return existsSync(join(resolvedWorkspacePath, '.devcontainer'));
 }
 
 function escapeRegExp(value: string): string {
@@ -110,7 +134,7 @@ export function evaluateWorkspaceStackHealth(
   issueId: string,
   projectConfig: WorkspaceStackProject | null | undefined,
   containers: DockerContainerLifecycle[],
-  options: { now?: Date; stuckCreatedThresholdMs?: number } = {},
+  options: { now?: Date; stuckCreatedThresholdMs?: number; stackExpected?: boolean } = {},
 ): WorkspaceStackHealth {
   const now = options.now ?? new Date();
   const lastObserved = now.toISOString();
@@ -122,7 +146,7 @@ export function evaluateWorkspaceStackHealth(
   const stackContainers = containers.filter((container) => isStackContainer(container, issueId));
   const reasons: string[] = [];
 
-  if (stackContainers.length === 0) {
+  if (stackContainers.length === 0 && options.stackExpected !== false) {
     reasons.push(`No Docker containers found for workspace stack ${normalizeIssue(issueId)}`);
   }
 
@@ -203,6 +227,7 @@ export async function getWorkspaceStackHealth(
   const health = evaluateWorkspaceStackHealth(issueId, projectConfig, containers, {
     now: options.now,
     stuckCreatedThresholdMs: options.stuckCreatedThresholdMs,
+    stackExpected: options.stackExpected ?? isWorkspaceStackExpected(issueId, projectConfig, options.workspacePath),
   });
   const observedHealth = observedAt && !options.now
     ? { ...health, lastObserved: observedAt }

--- a/src/lib/workspace/stack-health.ts
+++ b/src/lib/workspace/stack-health.ts
@@ -122,6 +122,10 @@ export function evaluateWorkspaceStackHealth(
   const stackContainers = containers.filter((container) => isStackContainer(container, issueId));
   const reasons: string[] = [];
 
+  if (stackContainers.length === 0) {
+    reasons.push(`No Docker containers found for workspace stack ${normalizeIssue(issueId)}`);
+  }
+
   for (const container of stackContainers) {
     const exitCode = parseExitCode(container.status);
     if (isExited(container) && exitCode !== null && exitCode !== 0) {

--- a/src/lib/workspace/stack-health.ts
+++ b/src/lib/workspace/stack-health.ts
@@ -152,9 +152,15 @@ export function evaluateWorkspaceStackHealth(
 
   for (const container of stackContainers) {
     const exitCode = parseExitCode(container.status);
-    if (isExited(container) && exitCode !== null && exitCode !== 0) {
-      const role = isInitContainer(container.name) ? 'init' : 'service';
-      reasons.push(`${container.name} ${role} exited non-zero (${exitCode})`);
+    if (isExited(container)) {
+      if (isInitContainer(container.name)) {
+        if (exitCode !== null && exitCode !== 0) {
+          reasons.push(`${container.name} init exited non-zero (${exitCode})`);
+        }
+      } else {
+        const exit = exitCode === null ? 'unknown' : String(exitCode);
+        reasons.push(`${container.name} service exited (${exit})`);
+      }
       continue;
     }
 

--- a/src/lib/workspace/stack-health.ts
+++ b/src/lib/workspace/stack-health.ts
@@ -9,7 +9,7 @@ import {
   type DockerContainerLifecycle,
 } from '../docker-stats.js';
 import { parseIssueId } from '../issue-id.js';
-import { findProjectByTeam } from '../projects.js';
+import { getProject, resolveProjectFromIssue } from '../projects.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -51,8 +51,8 @@ function normalizeIssue(issueId: string): string {
 }
 
 function resolveStackProject(issueId: string): WorkspaceStackProject | null {
-  const prefix = parseIssueId(issueId)?.prefix ?? issueId.split('-')[0];
-  return prefix ? findProjectByTeam(prefix) ?? null : null;
+  const resolved = resolveProjectFromIssue(issueId);
+  return resolved ? getProject(resolved.projectKey) : null;
 }
 
 function hasDockerWorkspace(projectConfig: WorkspaceStackProject | null | undefined): boolean {
@@ -177,6 +177,10 @@ export async function getWorkspaceStackHealth(
   options: WorkspaceStackHealthOptions = {},
 ): Promise<WorkspaceStackHealth> {
   const projectConfig = options.projectConfig ?? resolveStackProject(issueId);
+  if (!hasDockerWorkspace(projectConfig)) {
+    return { healthy: true, reasons: [], lastObserved: (options.now ?? new Date()).toISOString() };
+  }
+
   let observedAt: string | null = null;
   let containers = options.containers;
 

--- a/tests/integration/agent-spawning.test.ts
+++ b/tests/integration/agent-spawning.test.ts
@@ -237,12 +237,8 @@ describe('PAN-1048 role primitive — agent spawning', () => {
       expect(state.harness).toBe(DEFAULT_ROLES[role].harness ?? 'claude-code');
     });
 
-    it('launches review sub-roles in headless print mode and delivers prompt via tmux', async () => {
+    it('launches review sub-roles in headless print mode with the prompt as an argument', async () => {
       const tmux = await import('../../src/lib/tmux.js');
-      vi.mocked(tmux.sessionExistsAsync)
-        .mockResolvedValueOnce(false)
-        .mockResolvedValue(true);
-      vi.mocked(tmux.capturePaneAsync).mockResolvedValue('Claude Code');
 
       await spawnRun('PAN-SUBREVIEW-1', 'review', {
         workspace: '/tmp/test-workspace',
@@ -254,11 +250,11 @@ describe('PAN-1048 role primitive — agent spawning', () => {
 
       expect(launcher).toContain('exec claude --print');
       expect(launcher).toContain("--name agent-pan-subreview-1-review-security --session-id '");
+      expect(launcher).toContain("prompt=$(cat '");
+      expect(launcher).toContain("initial-prompt.md')");
+      expect(launcher).toContain('"$prompt"');
       expect(launcher).not.toContain("< '");
-      expect(launcher).not.toContain("initial-prompt.md'");
-      expect(launcher).not.toContain('prompt=$(cat');
-      expect(launcher).not.toContain('"$prompt"');
-      expect(tmux.sendKeysAsync).toHaveBeenCalledWith(
+      expect(tmux.sendKeysAsync).not.toHaveBeenCalledWith(
         'agent-pan-subreview-1-review-security',
         'review this diff',
       );

--- a/tests/lib/agents-auth-routing.test.ts
+++ b/tests/lib/agents-auth-routing.test.ts
@@ -132,7 +132,7 @@ describe('agents auth routing', () => {
     mockOpenAIAuthStatus.mockReturnValue({ loggedIn: true });
 
     expect(await getAgentRuntimeBaseCommand('gpt-5.4')).toBe(
-      'claude --dangerously-skip-permissions --permission-mode bypassPermissions --model gpt-5.4'
+      "claude --dangerously-skip-permissions --permission-mode bypassPermissions --model 'gpt-5.4'"
     );
   });
 
@@ -140,7 +140,7 @@ describe('agents auth routing', () => {
     mockOpenAIAuthStatus.mockReturnValue({ loggedIn: true });
 
     expect(await getAgentRuntimeBaseCommand('gpt-5.4-pro')).toBe(
-      'claude --dangerously-skip-permissions --permission-mode bypassPermissions --model gpt-5.4'
+      "claude --dangerously-skip-permissions --permission-mode bypassPermissions --model 'gpt-5.4'"
     );
   });
 
@@ -164,43 +164,43 @@ describe('agents auth routing', () => {
 
   it('launches Gemini models with Claude Code through CLIProxy-compatible direct routing', async () => {
     expect(await getAgentRuntimeBaseCommand('gemini-3-flash-preview')).toBe(
-      'claude --dangerously-skip-permissions --permission-mode bypassPermissions --model gemini-3-flash-preview'
+      "claude --dangerously-skip-permissions --permission-mode bypassPermissions --model 'gemini-3-flash-preview'"
     );
   });
 
   it('launches MiniMax models directly with Claude Code', async () => {
     expect(await getAgentRuntimeBaseCommand('minimax-m2.7')).toBe(
-      'claude --dangerously-skip-permissions --permission-mode bypassPermissions --model minimax-m2.7'
+      "claude --dangerously-skip-permissions --permission-mode bypassPermissions --model 'minimax-m2.7'"
     );
   });
 
   it('launches Kimi models directly with Claude Code', async () => {
     expect(await getAgentRuntimeBaseCommand('kimi-k2.6')).toBe(
-      'claude --dangerously-skip-permissions --permission-mode bypassPermissions --model kimi-k2.6'
+      "claude --dangerously-skip-permissions --permission-mode bypassPermissions --model 'kimi-k2.6'"
     );
   });
 
   it('launches Z.AI models directly with Claude Code', async () => {
     expect(await getAgentRuntimeBaseCommand('glm-4.7')).toBe(
-      'claude --dangerously-skip-permissions --permission-mode bypassPermissions --model glm-4.7'
+      "claude --dangerously-skip-permissions --permission-mode bypassPermissions --model 'glm-4.7'"
     );
   });
 
   it('launches OpenRouter models directly with Claude Code and preserves slash model IDs', async () => {
     expect(await getAgentRuntimeBaseCommand('qwen/qwen3.6-plus:free')).toBe(
-      'claude --dangerously-skip-permissions --permission-mode bypassPermissions --model qwen/qwen3.6-plus:free'
+      "claude --dangerously-skip-permissions --permission-mode bypassPermissions --model 'qwen/qwen3.6-plus:free'"
     );
   });
 
   it('launches Mimo models directly with Claude Code', async () => {
     expect(await getAgentRuntimeBaseCommand('mimo-v2.5')).toBe(
-      'claude --dangerously-skip-permissions --permission-mode bypassPermissions --model mimo-v2.5'
+      "claude --dangerously-skip-permissions --permission-mode bypassPermissions --model 'mimo-v2.5'"
     );
   });
 
   it('keeps role agent definition and --name for direct Kimi launches', async () => {
     expect(await getAgentRuntimeBaseCommand('kimi-k2.6', 'agent-pan-964', 'roles/work.md')).toBe(
-      'claude --dangerously-skip-permissions --agent roles/work.md --model kimi-k2.6 --name agent-pan-964'
+      "claude --dangerously-skip-permissions --agent roles/work.md --model 'kimi-k2.6' --name agent-pan-964"
     );
   });
 

--- a/tests/lib/cloister/review-agent.test.ts
+++ b/tests/lib/cloister/review-agent.test.ts
@@ -525,13 +525,32 @@ describe('convoy orchestration', () => {
     expect(prompt).not.toContain('.claude/reviews/');
   });
 
+  it('uses run-scoped output paths by default', async () => {
+    const result = await spawnReviewSubRoleForIssue({
+      issueId: 'PAN-1059',
+      workspace: '/tmp/pan-review-agent-default',
+      subRole: 'security',
+      runId: 'agent-pan-1059-review-abcdef12',
+      contextManifestPath: '/tmp/pan-review-agent-default/.pan/review/agent-pan-1059-review-abcdef12/context.json',
+    });
+
+    expect(result.success).toBe(true);
+    const expectedOutput = '/tmp/pan-review-agent-default/.pan/review/agent-pan-1059-review-abcdef12/security.md';
+    expect(mockSpawnRun).toHaveBeenCalledWith('PAN-1059', 'review', expect.objectContaining({
+      reviewOutputPath: expectedOutput,
+    }));
+    expect(mockSaveAgentStateAsync).toHaveBeenCalledWith(expect.objectContaining({
+      reviewOutputPath: expectedOutput,
+    }));
+  });
+
   it('spawns a reviewer as a review sub-role session with the resolved model', async () => {
     const result = await spawnReviewSubRoleForIssue({
       issueId: 'PAN-1059',
       workspace: '/workspace',
       subRole: 'security',
       runId: 'agent-pan-1059-review-abcdef12',
-      outputPath: '/workspace/.pan/review/agent-pan-1059-review-abcdef12/security.md',
+      outputPath: '/tmp/pan-review-agent-test-security.md',
       contextManifestPath: '/workspace/.pan/review/agent-pan-1059-review-abcdef12/context.json',
     });
 
@@ -549,7 +568,7 @@ describe('convoy orchestration', () => {
       id: 'agent-pan-1059-review-security',
       reviewSubRole: 'security',
       reviewRunId: 'agent-pan-1059-review-abcdef12',
-      reviewOutputPath: '/workspace/.pan/review/agent-pan-1059-review-abcdef12/security.md',
+      reviewOutputPath: '/tmp/pan-review-agent-test-security.md',
       reviewSynthesisAgentId: 'agent-pan-1059-review',
       reviewDeadlineAt: expect.any(String),
     }));

--- a/tests/lib/workspace-manager.test.ts
+++ b/tests/lib/workspace-manager.test.ts
@@ -3,6 +3,26 @@ import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from 'fs'
 import { join } from 'path';
 import { tmpdir } from 'os';
 
+const { mockExecAsync } = vi.hoisted(() => ({
+  mockExecAsync: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+}));
+
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  return {
+    ...actual,
+    exec: vi.fn(),
+  };
+});
+
+vi.mock('util', async () => {
+  const actual = await vi.importActual<typeof import('util')>('util');
+  return {
+    ...actual,
+    promisify: () => mockExecAsync,
+  };
+});
+
 let mockHomedir = '';
 vi.mock('os', async () => {
   const actual = await vi.importActual<typeof import('os')>('os');
@@ -28,6 +48,8 @@ describe('copyPanopticonSettingsToWorkspace', () => {
     mkdirSync(join(homeDir, '.claude'), { recursive: true });
     mkdirSync(join(homeDir, '.panopticon'), { recursive: true });
 
+    mockExecAsync.mockReset();
+    mockExecAsync.mockResolvedValue({ stdout: '', stderr: '' });
     vi.resetModules();
   });
 
@@ -190,5 +212,52 @@ describe('copyPanopticonSettingsToWorkspace', () => {
 
     const workspaceSettings = JSON.parse(readFileSync(join(workspaceDir, '.claude', 'settings.json'), 'utf8'));
     expect(workspaceSettings.hooks).toBeUndefined();
+  });
+});
+
+describe('stopWorkspaceDocker', () => {
+  let tempDir: string;
+  let workspaceDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'pan-wm-docker-test-'));
+    workspaceDir = join(tempDir, 'workspace');
+    mkdirSync(join(workspaceDir, '.devcontainer'), { recursive: true });
+    writeFileSync(join(workspaceDir, '.devcontainer', 'docker-compose.devcontainer.yml'), 'services: {}\n', 'utf8');
+    mockExecAsync.mockReset();
+    mockExecAsync.mockResolvedValue({ stdout: '', stderr: '' });
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('uses the canonical rendered compose project name for teardown', async () => {
+    writeFileSync(
+      join(workspaceDir, '.devcontainer', 'dev'),
+      'FEATURE_FOLDER="feature-pan-1140"\nexport COMPOSE_PROJECT_NAME="panopticon-${FEATURE_FOLDER}"\n',
+      'utf8',
+    );
+
+    const { stopWorkspaceDocker } = await import('../../src/lib/workspace-manager.js');
+    await stopWorkspaceDocker(workspaceDir, 'pan-1140');
+
+    const composeCall = mockExecAsync.mock.calls.find(([command]) => String(command).startsWith('docker compose'));
+    expect(composeCall?.[0]).toContain('-p "panopticon-feature-pan-1140" down -v --remove-orphans');
+  });
+
+  it('rejects workspace-controlled compose project name mismatches before teardown', async () => {
+    writeFileSync(
+      join(workspaceDir, '.devcontainer', 'dev'),
+      'FEATURE_FOLDER="feature-pan-1140"\nexport COMPOSE_PROJECT_NAME="victim-project"\n',
+      'utf8',
+    );
+
+    const { stopWorkspaceDocker } = await import('../../src/lib/workspace-manager.js');
+    await expect(stopWorkspaceDocker(workspaceDir, 'pan-1140')).rejects.toThrow(
+      'declares COMPOSE_PROJECT_NAME=victim-project, expected panopticon-feature-pan-1140',
+    );
+    expect(mockExecAsync).not.toHaveBeenCalledWith(expect.stringContaining('docker compose'), expect.anything());
   });
 });

--- a/tests/unit/lib/sync-remove-legacy-skills.test.ts
+++ b/tests/unit/lib/sync-remove-legacy-skills.test.ts
@@ -121,7 +121,7 @@ describe('removeLegacySkills070', () => {
     expect(existsSync(join(mockClaudeSkills, 'bug-fix'))).toBe(true);
   });
 
-  it('is idempotent — second call is a no-op after the first call removes everything', () => {
+  it('is idempotent — second call is a no-op after the first call removes legacy skills', () => {
     makeLegacySkill('pan-tldr');
     makeLegacySkill('pan-setup');
 


### PR DESCRIPTION
Closes #1140

## Acceptance Criteria

- [ ] Fix workspace init container so bun install + builds succeed (exit 0)
- [ ] Stop installing desktop-only deps (electron family) inside workspace containers
- [ ] Surface workspace stack health (init failure, stuck Created) in pan status and dashboard
- [ ] Gate agent spawn on workspace docker stack health; add --host break-glass flag
- [ ] Add `pan workspace reap` to clean up orphaned Created-state workspace stacks
- [ ] Verify (or add) `pan workspace rebuild <id>` for resetting a single stuck stack cleanly
- [ ] Document the workspace container contract, failure surfaces, and break-glass flags

## Implementation Tasks

- [x] Gate agent spawn on workspace docker stack health; add --host break-glass flag
- [x] Add `pan workspace reap` to clean up orphaned Created-state workspace stacks
- [x] Verify (or add) `pan workspace rebuild <id>` for resetting a single stuck stack cleanly
- [x] Surface workspace stack health (init failure, stuck Created) in pan status and dashboard
- [x] Document the workspace container contract, failure surfaces, and break-glass flags
- [x] Stop installing desktop-only deps (electron family) inside workspace containers
- [x] Fix workspace init container so bun install + builds succeed (exit 0)