### PR TITLE
Codex re-auth hardening + beads JSONL race fix (PAN-913 follow-up)

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/ && npm run lint:permissions && npm run lint:skills",
     "lint:permissions": "bash scripts/lint-permissions.sh",
+    "prelint:skills": "npm run build:contracts && npm run build:cli",
     "lint:skills": "bash scripts/lint-skills.sh",
     "pretest": "npm run build:contracts",
     "test": "vitest run",

--- a/scripts/lint-skills.sh
+++ b/scripts/lint-skills.sh
@@ -14,18 +14,31 @@ from pathlib import Path
 ROOT = Path.cwd()
 DOC = ROOT / "docs" / "SKILLS-CONVENTION.md"
 SKILLS = ROOT / "skills"
-LOCAL_PAN = [str(ROOT / "node_modules" / ".bin" / "tsx"), str(ROOT / "src" / "cli" / "index.ts")]
+LOCAL_PAN = ["node", str(ROOT / "dist" / "cli" / "index.js")]
+RUN_PAN_CACHE: dict[tuple[str, ...], str] = {}
 
 
 def run_pan(*args: str) -> str:
-    return subprocess.run(
-        [*LOCAL_PAN, *args],
-        cwd=ROOT,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        check=True,
-    ).stdout
+    key = tuple(args)
+    if key in RUN_PAN_CACHE:
+        return RUN_PAN_CACHE[key]
+
+    last: subprocess.CompletedProcess[str] | None = None
+    for _attempt in range(3):
+        last = subprocess.run(
+            [*LOCAL_PAN, *args],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+        if last.returncode == 0:
+            RUN_PAN_CACHE[key] = last.stdout
+            return last.stdout
+
+    assert last is not None
+    raise subprocess.CalledProcessError(last.returncode, last.args, output=last.stdout)
 
 
 def command_names(help_text: str) -> set[str]:
@@ -133,7 +146,11 @@ def validate_command(
                 errors.append(f"{skill}:{line_no}: {command}: unknown flag {flag!r} for {target}")
 
     if first_arg and subcommands and first_arg not in subcommands and not first_arg.startswith("--"):
-        help_text = run_pan(verb, "--help")
+        try:
+            help_text = run_pan(verb, "--help")
+        except subprocess.CalledProcessError:
+            errors.append(f"{skill}:{line_no}: {command}: could not read help for pan {verb}")
+            return errors
         usage = next((line for line in help_text.splitlines() if line.startswith("Usage:")), "")
         if "[command]" in usage and not usage_allows_positional_arg(help_text):
             errors.append(

--- a/skills/cliproxy/SKILL.md
+++ b/skills/cliproxy/SKILL.md
@@ -123,11 +123,12 @@ ChatGPT subscription tokens expire. This avoids requiring the user to run
    Dashboard calls `POST /api/settings/codex-reauth` (idempotent — returns an
    existing live session if one is already running).
 3. **Terminal login** — Backend spawns a tmux session named `reauth-<uuid>`
-   running `codex login` (or `codex login --device-auth` when headless). The
-   frontend opens `/terminal/<sessionName>?token=<token>` so the user can
-   complete OAuth in a live terminal panel.
-4. **Polling** — Frontend polls `GET /api/settings/codex-reauth/status?session=<name>`
-   every 3 s. The session is considered complete when the tmux pane exits.
+   running `codex login` (or `codex login --device-auth` when headless), sets an
+   HttpOnly `pan_codex_reauth` cookie for `/ws/terminal`, and the frontend opens
+   `/terminal/<sessionName>` so the user can complete OAuth in a live terminal panel.
+4. **Polling** — Frontend polls `POST /api/settings/codex-reauth/status` with the
+   session name and status token every 3 s. The session is considered complete when
+   the tmux pane exits.
 5. **Bridge** — On completion, the backend calls `bridgeCodexAuthToCliproxyAsync()`
    to rewrite `~/.panopticon/cliproxy/auth/codex-primary.json` from the fresh
    `~/.codex/auth.json`, then returns the updated auth status.
@@ -136,8 +137,8 @@ ChatGPT subscription tokens expire. This avoids requiring the user to run
 
 ### Security
 
-- Re-auth session tokens are single-use UUIDs invalidated on the first
-  WebSocket attach (`/ws/terminal?session=reauth-xxx&token=...`).
+- Re-auth terminal tokens are short-lived UUIDs stored only in an HttpOnly
+  cookie scoped to `/ws/terminal`; they are required for `reauth-*` WebSockets.
 - Sessions expire from the in-memory registry after 1 hour.
 - The tmux session name is a random UUID — not guessable.
 
@@ -146,8 +147,8 @@ ChatGPT subscription tokens expire. This avoids requiring the user to run
 | Method | Path | Purpose |
 |---|---|---|
 | `GET` | `/api/settings/codex-auth` | Current auth status (`valid`/`expired`/etc.) |
-| `POST` | `/api/settings/codex-reauth` | Spawn (or reuse) a re-auth tmux session |
-| `GET` | `/api/settings/codex-reauth/status?session=<name>` | Poll for completion |
+| `POST` | `/api/settings/codex-reauth` | Spawn (or reuse) a re-auth tmux session and set the terminal cookie |
+| `POST` | `/api/settings/codex-reauth/status` | Poll for completion with `{ session, token }` |
 
 ### Manual Fallback
 

--- a/src/cli/commands/done.ts
+++ b/src/cli/commands/done.ts
@@ -15,6 +15,7 @@ import { cleanupWorkflowLabels, getLinearStateName, findLinearStateByName } from
 import { getLinearApiKey } from '../../lib/shadow-utils.js';
 import { extractNumber, resolveIssueId } from '../../lib/issue-id.js';
 import { getWorkspacePanPaths, readWorkspaceContinue, writeWorkspaceContinue } from '../../lib/pan-dir/index.js';
+import { restoreTrackedBeadsExport } from '../../lib/bd-mutex.js';
 import { resolveProjectFromIssue } from '../../lib/projects.js';
 import type { MergeSet } from '../../lib/merge-set.js';
 
@@ -491,6 +492,8 @@ export async function doneCommand(id: string, options: DoneOptions = {}): Promis
       autoRequeueCount: 0,
     });
 
+    await restoreTrackedBeadsExport(workspacePath);
+
     spinner.succeed(`Work complete: ${issueId}`);
     console.log('');
 
@@ -592,6 +595,10 @@ export async function doneCommand(id: string, options: DoneOptions = {}): Promis
       // Don't fail the done command if auto-review fails
       console.log(chalk.dim(`  Could not auto-trigger review: ${error.message}`));
     }
+
+    await restoreTrackedBeadsExport(workspacePath);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await restoreTrackedBeadsExport(workspacePath);
 
   } catch (error: any) {
     spinner.fail(error.message);

--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -236,6 +236,16 @@ async function restartCliproxy(): Promise<void> {
   if (!res.ok) throw new Error('Failed to restart CLIProxy');
 }
 
+function StandaloneTerminalRoute({ sessionName, token }: { sessionName: string; token?: string }) {
+  useCodexAutoRetry();
+  return (
+    <div className="h-screen overflow-hidden bg-[#0d1117]">
+      <EventRouter />
+      <StandaloneTerminal sessionName={sessionName} token={token} />
+    </div>
+  );
+}
+
 export default function App() {
   const terminalPath = window.location.pathname;
   const terminalSession = new URLSearchParams(window.location.search).get('terminal');
@@ -244,12 +254,7 @@ export default function App() {
       ? terminalPath.replace('/terminal/', '')
       : terminalSession!;
     const token = new URLSearchParams(window.location.search).get('token') ?? undefined;
-    return (
-      <div className="h-screen overflow-hidden bg-[#0d1117]">
-        <EventRouter />
-        <StandaloneTerminal sessionName={sessionName} token={token} />
-      </div>
-    );
+    return <StandaloneTerminalRoute sessionName={sessionName} token={token} />;
   }
 
   const [activeTab, setActiveTabState] = useState<Tab>(() => getConversationRouteState().tab);

--- a/src/dashboard/frontend/src/components/CodexAuthBanner.tsx
+++ b/src/dashboard/frontend/src/components/CodexAuthBanner.tsx
@@ -3,7 +3,7 @@ import { toast } from 'sonner';
 import { AlertTriangle, Loader2, ExternalLink } from 'lucide-react';
 import { SensitiveText } from './SensitiveText';
 import { useCodexAuthStatus } from '../hooks/useCodexAuthStatus';
-import { setReauthSessionName } from '../lib/pending-codex-spawn';
+import { setReauthSession } from '../lib/pending-codex-spawn';
 
 export function CodexAuthBanner() {
   const { data: authStatus } = useCodexAuthStatus();
@@ -22,10 +22,10 @@ export function CodexAuthBanner() {
         const body = await res.json().catch(() => ({}));
         throw new Error(body.error || `Failed to spawn re-auth session (${res.status})`);
       }
-      const { sessionName, token } = await res.json() as { sessionName: string; token: string };
-      setReauthSessionName(sessionName);
+      const { sessionName, statusToken } = await res.json() as { sessionName: string; statusToken: string };
+      setReauthSession(sessionName, statusToken);
       toast.success('Re-authentication session started — opening terminal…');
-      window.location.href = `/terminal/${sessionName}?token=${encodeURIComponent(token)}`;
+      window.location.href = `/terminal/${sessionName}`;
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to start re-authentication');
     } finally {

--- a/src/dashboard/frontend/src/components/Settings/SettingsPage.tsx
+++ b/src/dashboard/frontend/src/components/Settings/SettingsPage.tsx
@@ -33,6 +33,7 @@ import { SettingsConfig, Provider, ModelId } from './types';
 import { useUIPreferences } from '../../hooks/useUIPreferences';
 import { useDiffPreferences } from '../../hooks/useDiffPreferences';
 import { useCodexAuthStatus } from '../../hooks/useCodexAuthStatus';
+import { setReauthSession } from '../../lib/pending-codex-spawn';
 import { OpenRouterPage } from './OpenRouterPage';
 import { SensitiveText } from '../SensitiveText';
 import { DesktopSettingsSection } from './DesktopSettingsSection';
@@ -645,7 +646,7 @@ export function SettingsPage() {
                         {codexAuth?.status === 'valid' ? (
                           <div className="flex items-center gap-2 text-xs text-muted-foreground">
                             <div className="w-1.5 h-1.5 rounded-full bg-success" />
-                            <span>OAuth active</span>
+                            <span>Subscription OAuth active</span>
                             {codexAuth.email && (
                               <SensitiveText value={codexAuth.email} className="text-[10px] text-muted-foreground" />
                             )}
@@ -661,8 +662,9 @@ export function SettingsPage() {
                                     const body = await res.json().catch(() => ({}));
                                     throw new Error(body.error || `Failed (${res.status})`);
                                   }
-                                  const { sessionName, token } = await res.json() as { sessionName: string; token: string };
-                                  window.location.href = `/terminal/${sessionName}?token=${encodeURIComponent(token)}`;
+                                  const { sessionName, statusToken } = await res.json() as { sessionName: string; statusToken: string };
+                                  setReauthSession(sessionName, statusToken);
+                                  window.location.href = `/terminal/${sessionName}`;
                                 } catch (err) {
                                   toast.error(err instanceof Error ? err.message : 'Failed to start re-authentication');
                                 }

--- a/src/dashboard/frontend/src/components/Settings/SettingsPage.tsx
+++ b/src/dashboard/frontend/src/components/Settings/SettingsPage.tsx
@@ -173,6 +173,13 @@ async function testApiKey(provider: string, apiKey: string, model?: string): Pro
   return res.json();
 }
 
+function formatCodexExpiry(expiresAt?: string): string | null {
+  if (!expiresAt) return null;
+  const date = new Date(expiresAt);
+  if (Number.isNaN(date.getTime())) return null;
+  return `Expires ${date.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}`;
+}
+
 // Provider definitions
 const PROVIDERS: { id: Provider; name: string; icon: any; placeholder: string }[] = [
   { id: 'anthropic', name: 'Anthropic', icon: Code, placeholder: 'sk-ant-...' },
@@ -650,10 +657,19 @@ export function SettingsPage() {
                             {codexAuth.email && (
                               <SensitiveText value={codexAuth.email} className="text-[10px] text-muted-foreground" />
                             )}
+                            {formatCodexExpiry(codexAuth.expiresAt) && (
+                              <span className="text-[10px] text-muted-foreground">{formatCodexExpiry(codexAuth.expiresAt)}</span>
+                            )}
                           </div>
                         ) : (codexAuth?.status === 'expired' || codexAuth?.status === 'burned') ? (
                           <div className="flex items-center gap-2">
                             <span className="text-xs text-warning capitalize">{codexAuth.status}</span>
+                            {codexAuth.email && (
+                              <SensitiveText value={codexAuth.email} className="text-[10px] text-muted-foreground" />
+                            )}
+                            {formatCodexExpiry(codexAuth.expiresAt) && (
+                              <span className="text-[10px] text-muted-foreground">{formatCodexExpiry(codexAuth.expiresAt)}</span>
+                            )}
                             <button
                               onClick={async () => {
                                 try {

--- a/src/dashboard/frontend/src/hooks/useCodexAutoRetry.ts
+++ b/src/dashboard/frontend/src/hooks/useCodexAutoRetry.ts
@@ -5,6 +5,7 @@ import { useCodexAuthStatus } from './useCodexAuthStatus';
 import {
   getPendingCodexSpawn,
   clearPendingCodexSpawn,
+  clearPendingCodexReauthSession,
 } from '../lib/pending-codex-spawn';
 import { refreshDashboardState } from '../lib/refresh-dashboard-state';
 import type { StartAgentResponse } from '../types';
@@ -17,7 +18,9 @@ export function useCodexAutoRetry() {
   // Poll the re-auth completion endpoint when a pending spawn has a session name.
   useEffect(() => {
     const pending = getPendingCodexSpawn();
-    if (!pending?.reauthSessionName) return;
+    if (!pending?.reauthSessionName || !pending.reauthStatusToken) return;
+    const reauthSessionName = pending.reauthSessionName;
+    const reauthStatusToken = pending.reauthStatusToken;
 
     if (intervalRef.current) {
       clearInterval(intervalRef.current);
@@ -25,17 +28,39 @@ export function useCodexAutoRetry() {
 
     intervalRef.current = setInterval(async () => {
       try {
-        const res = await fetch(
-          `/api/settings/codex-reauth/status?session=${encodeURIComponent(pending.reauthSessionName!)}`,
-        );
+        const res = await fetch('/api/settings/codex-reauth/status', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ session: reauthSessionName, token: reauthStatusToken }),
+        });
         if (!res.ok) return;
-        const data = (await res.json()) as { completed?: boolean };
+        const data = (await res.json()) as {
+          completed?: boolean;
+          success?: boolean;
+          authStatus?: { status?: string; message?: string };
+          error?: string;
+        };
         if (data.completed) {
           if (intervalRef.current) {
             clearInterval(intervalRef.current);
             intervalRef.current = null;
           }
-          retryPendingSpawn(pending.requestBody, queryClient);
+          if (data.success !== true || data.authStatus?.status !== 'valid') {
+            clearPendingCodexReauthSession();
+            toast.error(
+              data.error || data.authStatus?.message || 'Codex re-authentication did not produce valid auth',
+              { duration: 8000 },
+            );
+            await refreshDashboardState(queryClient);
+            return;
+          }
+          if (pending.requestBody) {
+            retryPendingSpawn(pending.requestBody, queryClient);
+          } else {
+            clearPendingCodexSpawn();
+            toast.success('Codex re-authentication completed');
+            await refreshDashboardState(queryClient);
+          }
         }
       } catch {
         // Ignore polling errors; next tick will retry.
@@ -53,7 +78,7 @@ export function useCodexAutoRetry() {
   // Fallback: retry when auth status becomes valid without a re-auth session.
   useEffect(() => {
     const pending = getPendingCodexSpawn();
-    if (!pending || pending.reauthSessionName) return;
+    if (!pending?.requestBody || pending.reauthSessionName) return;
     if (authStatus?.status !== 'valid') return;
 
     retryPendingSpawn(pending.requestBody, queryClient);

--- a/src/dashboard/frontend/src/lib/pending-codex-spawn.ts
+++ b/src/dashboard/frontend/src/lib/pending-codex-spawn.ts
@@ -1,44 +1,97 @@
 import type { StartAgentResponse } from '../types';
 
 interface PendingSpawn {
-  requestBody: Record<string, unknown>;
+  requestBody?: Record<string, unknown>;
   timestamp: number;
   reauthSessionName?: string;
+  reauthStatusToken?: string;
 }
 
 let pendingSpawn: PendingSpawn | null = null;
 
 const MAX_AGE_MS = 30 * 60 * 1000; // 30 minutes
+const STORAGE_KEY = 'panopticon.codex.pendingSpawn';
 
-export function setPendingCodexSpawn(requestBody: Record<string, unknown>) {
-  pendingSpawn = { requestBody, timestamp: Date.now() };
+function readStoredPendingSpawn(): PendingSpawn | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) as PendingSpawn : null;
+  } catch {
+    return null;
+  }
 }
 
-export function setReauthSessionName(sessionName: string) {
-  if (!pendingSpawn) return;
-  pendingSpawn.reauthSessionName = sessionName;
+function writeStoredPendingSpawn(value: PendingSpawn | null) {
+  pendingSpawn = value;
+  try {
+    if (value) sessionStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+    else sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // In-memory state still works when sessionStorage is unavailable.
+  }
+}
+
+function currentPendingSpawn(): PendingSpawn | null {
+  return pendingSpawn ?? readStoredPendingSpawn();
+}
+
+export function setPendingCodexSpawn(requestBody: Record<string, unknown>) {
+  const existing = currentPendingSpawn();
+  writeStoredPendingSpawn({
+    ...existing,
+    requestBody,
+    timestamp: Date.now(),
+  });
+}
+
+export function setReauthSession(sessionName: string, statusToken: string) {
+  const existing = currentPendingSpawn();
+  writeStoredPendingSpawn({
+    ...existing,
+    timestamp: existing?.timestamp ?? Date.now(),
+    reauthSessionName: sessionName,
+    reauthStatusToken: statusToken,
+  });
 }
 
 export function getPendingCodexSpawn(): PendingSpawn | null {
-  if (!pendingSpawn) return null;
-  if (Date.now() - pendingSpawn.timestamp > MAX_AGE_MS) {
-    pendingSpawn = null;
+  const current = currentPendingSpawn();
+  if (!current) return null;
+  if (Date.now() - current.timestamp > MAX_AGE_MS) {
+    writeStoredPendingSpawn(null);
     return null;
   }
-  return pendingSpawn;
+  pendingSpawn = current;
+  return current;
 }
 
 export function clearPendingCodexSpawn() {
-  pendingSpawn = null;
+  writeStoredPendingSpawn(null);
+}
+
+export function clearPendingCodexReauthSession() {
+  const existing = currentPendingSpawn();
+  if (!existing?.requestBody) {
+    writeStoredPendingSpawn(null);
+    return;
+  }
+  writeStoredPendingSpawn({
+    requestBody: existing.requestBody,
+    timestamp: Date.now(),
+  });
 }
 
 export function hasPendingCodexSpawn(): boolean {
-  return getPendingCodexSpawn() !== null;
+  return !!getPendingCodexSpawn()?.requestBody;
 }
 
 export function isCodexBlockedResponse(
   res: Response,
   data: StartAgentResponse | Record<string, unknown>,
 ): boolean {
-  return res.status === 429 && (data as StartAgentResponse).blocked === true;
+  const response = data as StartAgentResponse;
+  return res.status === 429
+    && response.blocked === true
+    && typeof response.error === 'string'
+    && response.error.startsWith('Codex authentication ');
 }

--- a/src/dashboard/server/http-helpers.ts
+++ b/src/dashboard/server/http-helpers.ts
@@ -8,12 +8,13 @@
  */
 import { HttpServerResponse } from 'effect/unstable/http';
 
-export function jsonResponse(data: unknown, options?: { status?: number }): typeof HttpServerResponse.Type {
+export function jsonResponse(data: unknown, options?: { status?: number; headers?: Record<string, string> }): typeof HttpServerResponse.Type {
   return HttpServerResponse.text(
     JSON.stringify(data),
-    { 
+    {
       status: options?.status ?? 200,
       contentType: 'application/json',
+      headers: options?.headers,
     }
   );
 }

--- a/src/dashboard/server/pty-hub.ts
+++ b/src/dashboard/server/pty-hub.ts
@@ -13,11 +13,12 @@ import type * as pty from '@homebridge/node-pty-prebuilt-multiarch';
 
 /** A shared PTY hub: one PTY process serving multiple WebSocket clients. */
 export interface PtyHub {
-  pty: pty.IPty;
+  pty: pty.IPty | null;
   clients: Set<WebSocket>;
   /** Current PTY dimensions — set by first client, updated by any resize event. */
   cols: number;
   rows: number;
+  pendingInput: string[];
   /**
    * The client whose keystrokes are forwarded to the PTY.
    * Always the most recently connected client. When it disconnects, falls back
@@ -130,7 +131,7 @@ export function removeClientFromHub(
     // glitch (Claude Code truncating to the smaller window, dashboards
     // displaying at the larger client dims).
     try {
-      hub.pty.kill();
+      hub.pty?.kill();
     } catch {
       // PTY may already have exited; nothing to do.
     }

--- a/src/dashboard/server/routes/codex-auth.ts
+++ b/src/dashboard/server/routes/codex-auth.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Option } from 'effect';
+import { Effect, Layer } from 'effect';
 import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
 import { homedir } from 'node:os';
 import { randomUUID } from 'node:crypto';
@@ -7,33 +7,54 @@ import { httpHandler } from './http-handler.js';
 import { checkCodexAuthStatus } from '../../../lib/codex-auth.js';
 import { bridgeCodexAuthToCliproxyAsync } from '../../../lib/cliproxy.js';
 import { createSessionAsync, sessionExistsAsync, listSessionNamesAsync } from '../../../lib/tmux.js';
+import { validateOrigin } from './origin-validation.js';
 
 // ─── Re-auth session registry ──────────────────────────────────────────────────
 
 interface ReauthSession {
-  token: string;
+  terminalToken: string;
+  statusToken: string;
   createdAt: number;
 }
 
 const reauthSessions = new Map<string, ReauthSession>();
 const SESSION_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour
 
-function generateReauthSession(): { sessionName: string; token: string } {
-  const sessionName = `reauth-${randomUUID()}`;
-  const token = randomUUID();
-  reauthSessions.set(sessionName, { token, createdAt: Date.now() });
-  return { sessionName, token };
+const readJsonBody = Effect.gen(function* () {
+  const request = yield* HttpServerRequest.HttpServerRequest;
+  const text = yield* request.text;
+  return text ? JSON.parse(text) as Record<string, unknown> : {};
+});
+
+function rejectInvalidOrigin(request: HttpServerRequest.HttpServerRequest): ReturnType<typeof jsonResponse> | null {
+  const originCheck = validateOrigin(request);
+  if (!originCheck.ok) {
+    return jsonResponse({ error: originCheck.error }, { status: 403 });
+  }
+  return null;
 }
 
-function validateReauthToken(sessionName: string, token: string): boolean {
+function generateReauthSession(): { sessionName: string; terminalToken: string; statusToken: string } {
+  const sessionName = `reauth-${randomUUID()}`;
+  const terminalToken = randomUUID();
+  const statusToken = randomUUID();
+  reauthSessions.set(sessionName, { terminalToken, statusToken, createdAt: Date.now() });
+  return { sessionName, terminalToken, statusToken };
+}
+
+function getLiveReauthSession(sessionName: string): ReauthSession | undefined {
   const session = reauthSessions.get(sessionName);
-  if (!session) return false;
-  if (session.token !== token) return false;
+  if (!session) return undefined;
   if (Date.now() - session.createdAt > SESSION_MAX_AGE_MS) {
     reauthSessions.delete(sessionName);
-    return false;
+    return undefined;
   }
-  return true;
+  return session;
+}
+
+function validateReauthStatusToken(sessionName: string, token: string): boolean {
+  const session = getLiveReauthSession(sessionName);
+  return !!session && session.statusToken === token;
 }
 
 function cleanupExpiredReauthSessions(): void {
@@ -45,18 +66,16 @@ function cleanupExpiredReauthSessions(): void {
   }
 }
 
-export function getReauthSessionToken(sessionName: string): string | undefined {
-  const session = reauthSessions.get(sessionName);
-  if (!session) return undefined;
-  if (Date.now() - session.createdAt > SESSION_MAX_AGE_MS) {
-    reauthSessions.delete(sessionName);
-    return undefined;
-  }
-  return session.token;
+export function consumeReauthTerminalToken(sessionName: string, token: string | undefined): boolean {
+  const session = getLiveReauthSession(sessionName);
+  if (!session || !token || session.terminalToken !== token) return false;
+  session.terminalToken = '';
+  return true;
 }
 
-export function invalidateReauthToken(sessionName: string): void {
-  reauthSessions.delete(sessionName);
+function buildTerminalCookie(sessionName: string, terminalToken: string): string {
+  const value = encodeURIComponent(`${sessionName}:${terminalToken}`);
+  return `pan_codex_reauth=${value}; HttpOnly; SameSite=Strict; Path=/ws/terminal; Max-Age=${Math.floor(SESSION_MAX_AGE_MS / 1000)}`;
 }
 
 // ─── Route: GET /api/settings/codex-auth ───────────────────────────────────────
@@ -74,13 +93,11 @@ const getCodexAuthRoute = HttpRouter.add(
 
 // ─── Route: POST /api/settings/codex-reauth ────────────────────────────────────
 
-async function findExistingLiveReauthSession(): Promise<{ sessionName: string; token: string } | null> {
+async function getExistingLiveReauthSession(): Promise<{ sessionName: string; session: ReauthSession } | null> {
   cleanupExpiredReauthSessions();
   const sessions = await listSessionNamesAsync();
-  for (const [name, session] of reauthSessions.entries()) {
-    if (sessions.includes(name)) {
-      return { sessionName: name, token: session.token };
-    }
+  for (const [sessionName, session] of reauthSessions.entries()) {
+    if (sessions.includes(sessionName)) return { sessionName, session };
   }
   return null;
 }
@@ -90,16 +107,22 @@ const postCodexReauthRoute = HttpRouter.add(
   '/api/settings/codex-reauth',
   httpHandler(
     Effect.gen(function* () {
-      const existing = yield* Effect.promise(() => findExistingLiveReauthSession());
+      const request = yield* HttpServerRequest.HttpServerRequest;
+      const originError = rejectInvalidOrigin(request);
+      if (originError) return originError;
+
+      const existing = yield* Effect.promise(() => getExistingLiveReauthSession());
       if (existing) {
-        return jsonResponse({
-          sessionName: existing.sessionName,
-          token: existing.token,
-          headless: !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY,
-        });
+        const headless = !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY;
+        return jsonResponse(
+          { sessionName: existing.sessionName, statusToken: existing.session.statusToken, headless, existing: true },
+          existing.session.terminalToken
+            ? { headers: { 'Set-Cookie': buildTerminalCookie(existing.sessionName, existing.session.terminalToken) } }
+            : undefined,
+        );
       }
 
-      const { sessionName, token } = generateReauthSession();
+      const { sessionName, terminalToken, statusToken } = generateReauthSession();
 
       const headless = !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY;
       const command = headless ? 'codex login --device-auth' : 'codex login';
@@ -110,24 +133,32 @@ const postCodexReauthRoute = HttpRouter.add(
         }),
       );
 
-      return jsonResponse({ sessionName, token, headless });
+      return jsonResponse(
+        { sessionName, statusToken, headless },
+        { headers: { 'Set-Cookie': buildTerminalCookie(sessionName, terminalToken) } },
+      );
     }),
   ),
 );
 
-// ─── Route: GET /api/settings/codex-reauth/status ──────────────────────────────
+// ─── Route: POST /api/settings/codex-reauth/status ─────────────────────────────
 
-const getCodexReauthStatusRoute = HttpRouter.add(
-  'GET',
+const postCodexReauthStatusRoute = HttpRouter.add(
+  'POST',
   '/api/settings/codex-reauth/status',
   httpHandler(
     Effect.gen(function* () {
       const request = yield* HttpServerRequest.HttpServerRequest;
-      const urlOpt = HttpServerRequest.toURL(request);
-      const searchParams = Option.isSome(urlOpt)
-        ? urlOpt.value.searchParams
-        : new URLSearchParams();
-      const sessionName = searchParams.get('session') ?? '';
+      const originError = rejectInvalidOrigin(request);
+      if (originError) return originError;
+
+      const body = yield* readJsonBody;
+      const sessionName = typeof body.session === 'string' ? body.session : '';
+      const token = typeof body.token === 'string' ? body.token : '';
+
+      if (!validateReauthStatusToken(sessionName, token)) {
+        return jsonResponse({ completed: false });
+      }
 
       const exists = yield* Effect.promise(() => sessionExistsAsync(sessionName));
       if (exists) {
@@ -136,8 +167,17 @@ const getCodexReauthStatusRoute = HttpRouter.add(
 
       yield* Effect.promise(() => bridgeCodexAuthToCliproxyAsync());
       const authStatus = yield* Effect.promise(() => checkCodexAuthStatus());
+      if (authStatus.status !== 'valid') {
+        return jsonResponse({
+          completed: true,
+          success: false,
+          authStatus,
+          error: authStatus.message || `Codex authentication is ${authStatus.status}`,
+        });
+      }
+
       reauthSessions.delete(sessionName);
-      return jsonResponse({ completed: true, authStatus });
+      return jsonResponse({ completed: true, success: true, authStatus });
     }),
   ),
 );
@@ -145,5 +185,5 @@ const getCodexReauthStatusRoute = HttpRouter.add(
 export const codexAuthRouteLayer = Layer.mergeAll(
   getCodexAuthRoute,
   postCodexReauthRoute,
-  getCodexReauthStatusRoute,
+  postCodexReauthStatusRoute,
 );

--- a/src/dashboard/server/routes/codex-auth.ts
+++ b/src/dashboard/server/routes/codex-auth.ts
@@ -2,10 +2,12 @@ import { Effect, Layer } from 'effect';
 import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
 import { homedir } from 'node:os';
 import { randomUUID } from 'node:crypto';
+import { readFile, stat } from 'node:fs/promises';
+import { join } from 'node:path';
 import { jsonResponse } from '../http-helpers.js';
 import { httpHandler } from './http-handler.js';
 import { checkCodexAuthStatus } from '../../../lib/codex-auth.js';
-import { bridgeCodexAuthToCliproxyAsync } from '../../../lib/cliproxy.js';
+import { bridgeCodexAuthToCliproxyAsync, getCliproxyAuthDir } from '../../../lib/cliproxy.js';
 import { createSessionAsync, sessionExistsAsync, listSessionNamesAsync } from '../../../lib/tmux.js';
 import { getDashboardApiUrl } from '../../../lib/config.js';
 import { validateOrigin } from './origin-validation.js';
@@ -76,6 +78,20 @@ function buildTerminalCookie(sessionName: string, terminalToken: string): string
   const value = encodeURIComponent(`${sessionName}:${terminalToken}`);
   const secure = getDashboardApiUrl().startsWith('https://') ? '; Secure' : '';
   return `pan_codex_reauth=${value}; HttpOnly; SameSite=Strict; Path=/ws/terminal; Max-Age=${Math.floor(SESSION_MAX_AGE_MS / 1000)}${secure}`;
+}
+
+async function readBridgedCodexCredential(): Promise<{ accessToken: string | null; mtimeMs: number | null }> {
+  const path = join(getCliproxyAuthDir(), 'codex-primary.json');
+  try {
+    const [raw, fileStat] = await Promise.all([readFile(path, 'utf8'), stat(path)]);
+    const parsed = JSON.parse(raw) as { access_token?: unknown };
+    return {
+      accessToken: typeof parsed.access_token === 'string' ? parsed.access_token : null,
+      mtimeMs: fileStat.mtimeMs,
+    };
+  } catch {
+    return { accessToken: null, mtimeMs: null };
+  }
 }
 
 // ─── Route: GET /api/settings/codex-auth ───────────────────────────────────────
@@ -157,7 +173,7 @@ const postCodexReauthStatusRoute = HttpRouter.add(
       const session = getLiveReauthSession(sessionName);
 
       if (!validateReauthStatusToken(sessionName, token) || !session) {
-        return jsonResponse({ completed: false });
+        return jsonResponse({ completed: true, success: false, error: 'Re-auth session expired or invalid' });
       }
 
       const exists = yield* Effect.promise(() => sessionExistsAsync(sessionName));
@@ -165,14 +181,22 @@ const postCodexReauthStatusRoute = HttpRouter.add(
         return jsonResponse({ completed: false });
       }
 
-      yield* Effect.promise(() => bridgeCodexAuthToCliproxyAsync());
-      const authStatus = yield* Effect.promise(() => checkCodexAuthStatus({ ignoreBurnBefore: session.createdAt }));
-      if (authStatus.status !== 'valid') {
+      const beforeCredential = yield* Effect.promise(() => readBridgedCodexCredential());
+      const bridged = yield* Effect.promise(() => bridgeCodexAuthToCliproxyAsync());
+      const afterCredential = yield* Effect.promise(() => readBridgedCodexCredential());
+      const refreshedCredential = bridged && (
+        (beforeCredential.accessToken !== null && afterCredential.accessToken !== beforeCredential.accessToken) ||
+        (afterCredential.mtimeMs !== null && afterCredential.mtimeMs >= session.createdAt)
+      );
+      const authStatus = yield* Effect.promise(() => checkCodexAuthStatus(
+        refreshedCredential ? { ignoreBurnBefore: session.createdAt } : undefined,
+      ));
+      if (!refreshedCredential || authStatus.status !== 'valid') {
         return jsonResponse({
           completed: true,
           success: false,
           authStatus,
-          error: authStatus.message || `Codex authentication is ${authStatus.status}`,
+          error: !bridged ? 'Codex credentials were not bridged' : (authStatus.message || `Codex authentication is ${authStatus.status}`),
         });
       }
 

--- a/src/dashboard/server/routes/codex-auth.ts
+++ b/src/dashboard/server/routes/codex-auth.ts
@@ -7,6 +7,7 @@ import { httpHandler } from './http-handler.js';
 import { checkCodexAuthStatus } from '../../../lib/codex-auth.js';
 import { bridgeCodexAuthToCliproxyAsync } from '../../../lib/cliproxy.js';
 import { createSessionAsync, sessionExistsAsync, listSessionNamesAsync } from '../../../lib/tmux.js';
+import { getDashboardApiUrl } from '../../../lib/config.js';
 import { validateOrigin } from './origin-validation.js';
 
 // ─── Re-auth session registry ──────────────────────────────────────────────────
@@ -68,14 +69,13 @@ function cleanupExpiredReauthSessions(): void {
 
 export function consumeReauthTerminalToken(sessionName: string, token: string | undefined): boolean {
   const session = getLiveReauthSession(sessionName);
-  if (!session || !token || session.terminalToken !== token) return false;
-  session.terminalToken = '';
-  return true;
+  return !!session && !!token && session.terminalToken === token;
 }
 
 function buildTerminalCookie(sessionName: string, terminalToken: string): string {
   const value = encodeURIComponent(`${sessionName}:${terminalToken}`);
-  return `pan_codex_reauth=${value}; HttpOnly; SameSite=Strict; Path=/ws/terminal; Max-Age=${Math.floor(SESSION_MAX_AGE_MS / 1000)}`;
+  const secure = getDashboardApiUrl().startsWith('https://') ? '; Secure' : '';
+  return `pan_codex_reauth=${value}; HttpOnly; SameSite=Strict; Path=/ws/terminal; Max-Age=${Math.floor(SESSION_MAX_AGE_MS / 1000)}${secure}`;
 }
 
 // ─── Route: GET /api/settings/codex-auth ───────────────────────────────────────
@@ -114,11 +114,10 @@ const postCodexReauthRoute = HttpRouter.add(
       const existing = yield* Effect.promise(() => getExistingLiveReauthSession());
       if (existing) {
         const headless = !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY;
+        existing.session.terminalToken = randomUUID();
         return jsonResponse(
           { sessionName: existing.sessionName, statusToken: existing.session.statusToken, headless, existing: true },
-          existing.session.terminalToken
-            ? { headers: { 'Set-Cookie': buildTerminalCookie(existing.sessionName, existing.session.terminalToken) } }
-            : undefined,
+          { headers: { 'Set-Cookie': buildTerminalCookie(existing.sessionName, existing.session.terminalToken) } },
         );
       }
 
@@ -155,8 +154,9 @@ const postCodexReauthStatusRoute = HttpRouter.add(
       const body = yield* readJsonBody;
       const sessionName = typeof body.session === 'string' ? body.session : '';
       const token = typeof body.token === 'string' ? body.token : '';
+      const session = getLiveReauthSession(sessionName);
 
-      if (!validateReauthStatusToken(sessionName, token)) {
+      if (!validateReauthStatusToken(sessionName, token) || !session) {
         return jsonResponse({ completed: false });
       }
 
@@ -166,7 +166,7 @@ const postCodexReauthStatusRoute = HttpRouter.add(
       }
 
       yield* Effect.promise(() => bridgeCodexAuthToCliproxyAsync());
-      const authStatus = yield* Effect.promise(() => checkCodexAuthStatus());
+      const authStatus = yield* Effect.promise(() => checkCodexAuthStatus({ ignoreBurnBefore: session.createdAt }));
       if (authStatus.status !== 'valid') {
         return jsonResponse({
           completed: true,

--- a/src/dashboard/server/routes/workspaces.ts
+++ b/src/dashboard/server/routes/workspaces.ts
@@ -115,6 +115,7 @@ import { getWorkAgentLifecycleState } from '../../../lib/work-agent-lifecycle.js
 import { enrichReviewStatusFromSessions } from '../../../lib/review-status-enrichment.js';
 import { createRecoveryBranchFromStash, dropStash, isSalvageableStash, listStashes } from '../../../lib/stashes.js';
 import { PAN_CONTINUE_FILENAME, PAN_DIRNAME } from '../../../lib/pan-dir/types.js';
+import { restoreTrackedBeadsExport } from '../../../lib/bd-mutex.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -593,6 +594,10 @@ async function getDirtyWorkspaceErrorForReviewRequest(
   workspaceInfo: WorkspaceInfo,
 ): Promise<string | null> {
   try {
+    if (!workspaceInfo.isRemote) {
+      await restoreTrackedBeadsExport(workspacePath);
+    }
+
     const statusCmd = 'git status --porcelain -uno';
     const status = workspaceInfo.isRemote && workspaceInfo.vmName
       ? (await execAsync(

--- a/src/dashboard/server/ws-terminal.ts
+++ b/src/dashboard/server/ws-terminal.ts
@@ -20,61 +20,14 @@ import { homedir } from 'node:os';
 import { WebSocketServer, WebSocket } from 'ws';
 import * as pty from '@homebridge/node-pty-prebuilt-multiarch';
 import { activePtyHubs, addClientToHub, broadcastToHub, removeClientFromHub, setClientReady, type PtyHub } from './pty-hub.js';
-import { buildTmuxArgs, capturePaneAsync, getWindowDimensionsAsync, resizeWindowAsync, sessionExistsAsync } from '../../lib/tmux.js';
-import { getReauthSessionToken, invalidateReauthToken } from './routes/codex-auth.js';
+import { buildTmuxCommandString, buildTmuxArgs, capturePaneAsync, getWindowDimensionsAsync, listSessionNamesAsync, resizeWindowAsync, sessionExistsAsync } from '../../lib/tmux.js';
+import { consumeReauthTerminalToken } from './routes/codex-auth.js';
 import { buildChildEnvWithoutTmux } from '../../lib/child-env.js';
 
 type ClientControlMessage =
   | { type: 'attach'; cols: number; rows: number }
   | { type: 'ready' }
   | { type: 'resize'; cols: number; rows: number };
-
-// Optional /ws/terminal cold-path + accumulation profiling. Enable with
-// PANOPTICON_TERMINAL_PROFILE=1. Per-connection phase timings + a periodic
-// snapshot (heap / hub-count / upgrade-listener / event-loop lag) so a
-// slow-over-time regression can be triaged from the dashboard log alone.
-const TERMINAL_PROFILE_ENABLED = process.env.PANOPTICON_TERMINAL_PROFILE === '1';
-
-function profMark(sessionName: string, t0: bigint, label: string, extra?: string): void {
-  if (!TERMINAL_PROFILE_ENABLED) return;
-  const ms = Number(process.hrtime.bigint() - t0) / 1e6;
-  console.log(`[ws-terminal-prof] ${sessionName} +${ms.toFixed(1)}ms ${label}${extra ? ' ' + extra : ''}`);
-}
-
-async function profStep<T>(sessionName: string, t0: bigint, label: string, fn: () => Promise<T>): Promise<T> {
-  if (!TERMINAL_PROFILE_ENABLED) return fn();
-  const start = process.hrtime.bigint();
-  try {
-    const result = await fn();
-    const dur = Number(process.hrtime.bigint() - start) / 1e6;
-    const elapsed = Number(process.hrtime.bigint() - t0) / 1e6;
-    console.log(`[ws-terminal-prof] ${sessionName} +${elapsed.toFixed(1)}ms ${label} took=${dur.toFixed(1)}ms`);
-    return result;
-  } catch (err) {
-    const dur = Number(process.hrtime.bigint() - start) / 1e6;
-    console.log(`[ws-terminal-prof] ${sessionName} ${label} FAILED after ${dur.toFixed(1)}ms: ${err}`);
-    throw err;
-  }
-}
-
-const PROF_DASHBOARD_START = Date.now();
-let PROF_CONNECTION_COUNT = 0;
-let PROF_LAST_EL_LAG_MS = 0;
-function measureEventLoopLag(): void {
-  if (!TERMINAL_PROFILE_ENABLED) return;
-  const t = process.hrtime.bigint();
-  setImmediate(() => {
-    PROF_LAST_EL_LAG_MS = Number(process.hrtime.bigint() - t) / 1e6;
-  });
-}
-function getAccumStateLine(httpServer: http.Server): string {
-  const heap = process.memoryUsage();
-  const heapMB = (heap.heapUsed / 1024 / 1024).toFixed(1);
-  const rssMB = (heap.rss / 1024 / 1024).toFixed(1);
-  const upMin = ((Date.now() - PROF_DASHBOARD_START) / 60000).toFixed(1);
-  const upgradeListeners = httpServer.listenerCount('upgrade');
-  return `up=${upMin}min conns=${PROF_CONNECTION_COUNT} hubs=${activePtyHubs.size} heap=${heapMB}MB rss=${rssMB}MB upListeners=${upgradeListeners} elLag=${PROF_LAST_EL_LAG_MS.toFixed(1)}ms`;
-}
 
 function parseControlMessage(message: string): ClientControlMessage | null {
   if (!message.startsWith('{')) return null;
@@ -124,19 +77,11 @@ async function captureFreshSnapshot(
   requestedCols: number,
   requestedRows: number,
 ): Promise<{ cols: number; rows: number; data: string }> {
-  // Dimensions and pane content are independent reads — run in parallel so the
-  // snapshot's wall-time is max(getWindowDimensions, capturePane), not sum.
-  const tPar = TERMINAL_PROFILE_ENABLED ? process.hrtime.bigint() : 0n;
-  const [dims, data] = await Promise.all([
-    getWindowDimensionsAsync(sessionName),
-    capturePaneAsync(sessionName, SNAPSHOT_SCROLLBACK_LINES, { escapeSequences: true }),
-  ]);
-  if (TERMINAL_PROFILE_ENABLED) {
-    console.log(`[ws-terminal-prof] ${sessionName}   parallel(dims+capture lines=${SNAPSHOT_SCROLLBACK_LINES},esc) took=${(Number(process.hrtime.bigint() - tPar) / 1e6).toFixed(1)}ms bytes=${data.length}`);
-  }
+  const dims = await getWindowDimensionsAsync(sessionName);
   if (!dims) {
     return { cols: requestedCols, rows: requestedRows, data: '' };
   }
+  const data = await capturePaneAsync(sessionName, SNAPSHOT_SCROLLBACK_LINES, { escapeSequences: true });
   return { cols: dims.cols, rows: dims.rows, data };
 }
 
@@ -188,16 +133,7 @@ export function setupTerminalWebSocket(server: http.Server): void {
     }
   });
 
-  // Periodic accumulation snapshot — opt-in via PANOPTICON_TERMINAL_PROFILE=1.
-  if (TERMINAL_PROFILE_ENABLED) {
-    setInterval(() => {
-      measureEventLoopLag();
-      console.log(`[ws-terminal-accum] ${getAccumStateLine(server)}`);
-    }, 30000);
-  }
-
   wss.on('connection', (ws: WebSocket, req: http.IncomingMessage) => {
-    const tProf = process.hrtime.bigint();
     const url = new URL(req.url || '', `http://${req.headers.host}`);
     const sessionName = url.searchParams.get('session');
 
@@ -206,24 +142,28 @@ export function setupTerminalWebSocket(server: http.Server): void {
       return;
     }
 
-    // Re-auth sessions require a valid one-time token to prevent hijacking.
+    // Re-auth sessions require a server-issued one-time terminal token to prevent hijacking.
     if (sessionName.startsWith('reauth-')) {
-      const token = url.searchParams.get('token');
-      const expected = getReauthSessionToken(sessionName);
-      if (!token || !expected || expected !== token) {
+      const cookie = req.headers.cookie ?? '';
+      const token = cookie
+        .split(';')
+        .map((part) => part.trim())
+        .find((part) => part.startsWith('pan_codex_reauth='))
+        ?.slice('pan_codex_reauth='.length);
+      let decodedToken = '';
+      try {
+        decodedToken = token ? decodeURIComponent(token) : '';
+      } catch {
+        decodedToken = '';
+      }
+      const [cookieSessionName, terminalToken] = decodedToken.split(':');
+      if (cookieSessionName !== sessionName || !consumeReauthTerminalToken(sessionName, terminalToken)) {
         ws.close(1008, 'Invalid or missing re-auth token');
         return;
       }
-      invalidateReauthToken(sessionName);
     }
 
     console.log(`[ws-terminal] WebSocket connected for session: ${sessionName}`);
-    if (TERMINAL_PROFILE_ENABLED) {
-      PROF_CONNECTION_COUNT += 1;
-      measureEventLoopLag();
-      console.log(`[ws-terminal-accum] @connect ${sessionName} ${getAccumStateLine(server)}`);
-    }
-    profMark(sessionName, tProf, 'connection');
 
     // Buffer messages immediately to avoid losing them during async setup.
     // The client sends resize dimensions immediately on connect, but we have async
@@ -249,18 +189,16 @@ export function setupTerminalWebSocket(server: http.Server): void {
       }
     });
 
-    // Check if tmux session exists and set up PTY (async).
-    // Use a targeted `has-session` (sessionExistsAsync) instead of listing all
-    // sessions — same answer, one short tmux call vs. enumerating every session.
+    // Check if tmux session exists and set up PTY (async)
     (async () => {
       try {
-        const exists = await profStep(sessionName, tProf, 'sessionExistsAsync', () => sessionExistsAsync(sessionName));
-        if (!exists) {
+        const sessions = await listSessionNamesAsync();
+        if (!sessions.includes(sessionName)) {
           ws.close(4404, 'session-not-found');
           return;
         }
       } catch (err) {
-        ws.close(1008, `Failed to check tmux session: ${err}`);
+        ws.close(1008, `Failed to list tmux sessions: ${err}`);
         return;
       }
 
@@ -297,7 +235,6 @@ export function setupTerminalWebSocket(server: http.Server): void {
       if (!attachMessage) {
         return;
       }
-      profMark(sessionName, tProf, 'attach received', `cols=${attachMessage.cols} rows=${attachMessage.rows}`);
 
       const requestedCols = attachMessage.cols;
       const requestedRows = attachMessage.rows;
@@ -305,7 +242,6 @@ export function setupTerminalWebSocket(server: http.Server): void {
       const existingHub = activePtyHubs.get(sessionName);
       if (existingHub) {
         console.log(`[ws-terminal] Joining existing PTY hub for ${sessionName} (${existingHub.clients.size} existing clients)`);
-        profMark(sessionName, tProf, 'existing-hub branch', `clients=${existingHub.clients.size}`);
         addClientToHub(existingHub, ws, false);
         existingHub.inputClient = ws;
 
@@ -316,8 +252,7 @@ export function setupTerminalWebSocket(server: http.Server): void {
           // content and hand it to the new client directly. The captured
           // content is valid at both the hub and the client's dims (same
           // number), so it paints cleanly and no resize dance is needed.
-          const snapshot = await profStep(sessionName, tProf, 'captureViewportSnapshot', () => captureViewportSnapshot(sessionName));
-          profMark(sessionName, tProf, 'sending snapshot (hub-join)', `bytes=${snapshot.length}`);
+          const snapshot = await captureViewportSnapshot(sessionName);
           sendControl(ws, { type: 'snapshot', cols: existingHub.cols, rows: existingHub.rows, data: snapshot });
         } else {
           // Hub is at different dims than the new client needs. Sending the
@@ -424,13 +359,24 @@ export function setupTerminalWebSocket(server: http.Server): void {
 
       const startLocalPty = async () => {
         if (ptyStarted) return;
-        // The session-exists check at the top of the connection handler already
-        // verified the session is present. A second `has-session` here was pure
-        // duplication. If the session vanished between the two checks, the PTY
-        // spawn will fail immediately and `onExit` cleans up.
+        try {
+          const exists = await sessionExistsAsync(sessionName);
+          if (!exists) {
+            console.log(`[ws-terminal] Session ${sessionName} does not exist — closing without PTY spawn`);
+            // Use 4404 (private-use range) so the client can distinguish
+            // "session doesn't exist" from "normal disconnect". The client
+            // should NOT retry on 4404 — the session is gone.
+            ws.close(4404, 'session-not-found');
+            return;
+          }
+        } catch {
+          console.log(`[ws-terminal] Session ${sessionName} does not exist — closing without PTY spawn`);
+          ws.close(4404, 'session-not-found');
+          return;
+        }
+
         ptyStarted = true;
         console.log(`[ws-terminal] Starting local PTY for ${sessionName} at ${hub.cols}x${hub.rows}`);
-        profMark(sessionName, tProf, 'pty.spawn begin');
         // Strip TMUX/TMUX_PANE from inherited env so `tmux attach-session` doesn't refuse
         // with "sessions should be nested with care, unset $TMUX to force" when the
         // dashboard server itself was launched from inside a tmux pane.
@@ -448,11 +394,9 @@ export function setupTerminalWebSocket(server: http.Server): void {
 
         hub.pty = ptyProcess;
         activePtyHubs.set(sessionName, hub);
-        profMark(sessionName, tProf, 'pty.spawn complete');
 
         let ptyChunks = 0;
         let ptyBytes = 0;
-        let firstByteLogged = false;
         const ptyDiagInterval = setInterval(() => {
           if (ptyChunks === 0) return;
           const maxBuf = Math.max(...[...hub.clients].map(c => c.bufferedAmount));
@@ -462,10 +406,6 @@ export function setupTerminalWebSocket(server: http.Server): void {
         }, 5000);
 
         ptyProcess.onData((data) => {
-          if (!firstByteLogged) {
-            firstByteLogged = true;
-            profMark(sessionName, tProf, 'first PTY data byte', `len=${data.length}`);
-          }
           ptyChunks++;
           ptyBytes += data.length;
           broadcastToHub(hub, data);
@@ -490,8 +430,7 @@ export function setupTerminalWebSocket(server: http.Server): void {
         pendingInput.length = 0;
       };
 
-      const snapshot = await profStep(sessionName, tProf, 'captureFreshSnapshot', () => captureFreshSnapshot(sessionName, requestedCols, requestedRows));
-      profMark(sessionName, tProf, 'sending snapshot (fresh)', `bytes=${snapshot.data.length}`);
+      const snapshot = await captureFreshSnapshot(sessionName, requestedCols, requestedRows);
       sendControl(ws, { type: 'snapshot', cols: snapshot.cols, rows: snapshot.rows, data: snapshot.data });
       // Start PTY immediately — don't wait for client 'ready'. The hub buffers
       // live data for not-yet-ready clients (pty-hub.ts broadcastToHub), so data

--- a/src/dashboard/server/ws-terminal.ts
+++ b/src/dashboard/server/ws-terminal.ts
@@ -29,6 +29,10 @@ type ClientControlMessage =
   | { type: 'ready' }
   | { type: 'resize'; cols: number; rows: number };
 
+const ATTACH_TIMEOUT_MS = 5000;
+const PRE_ATTACH_MAX_MESSAGES = 32;
+const PRE_ATTACH_MAX_BYTES = 64 * 1024;
+
 function parseControlMessage(message: string): ClientControlMessage | null {
   if (!message.startsWith('{')) return null;
   try {
@@ -169,15 +173,25 @@ export function setupTerminalWebSocket(server: http.Server): void {
     // The client sends resize dimensions immediately on connect, but we have async
     // operations (tmux checks) that take time. Without buffering, messages are lost.
     const earlyMessages: string[] = [];
+    let preAttachBytes = 0;
     let messageHandler: ((data: string) => void) | null = null;
     let resolvePendingAttach: ((attach: Extract<ClientControlMessage, { type: 'attach' }> | null) => void) | null = null;
+
+    const bufferPreAttachMessage = (message: string): boolean => {
+      preAttachBytes += Buffer.byteLength(message);
+      if (earlyMessages.length >= PRE_ATTACH_MAX_MESSAGES || preAttachBytes > PRE_ATTACH_MAX_BYTES) {
+        ws.close(1008, 'attach-handshake-too-large');
+        return false;
+      }
+      earlyMessages.push(message);
+      return true;
+    };
 
     ws.on('message', (data) => {
       const message = data.toString();
       if (messageHandler) {
         messageHandler(message);
-      } else {
-        earlyMessages.push(message);
+      } else if (bufferPreAttachMessage(message)) {
         console.log(`[ws-terminal] Buffered early message for ${sessionName}: ${message.slice(0, 50)}...`);
       }
     });
@@ -203,16 +217,26 @@ export function setupTerminalWebSocket(server: http.Server): void {
       }
 
       let attachMessage: Extract<ClientControlMessage, { type: 'attach' }> | null = null;
+      let attachTimer: ReturnType<typeof setTimeout> | null = null;
       const attachPromise = new Promise<Extract<ClientControlMessage, { type: 'attach' }> | null>((resolve) => {
         resolvePendingAttach = resolve;
+        attachTimer = setTimeout(() => {
+          ws.close(1008, 'attach-handshake-timeout');
+          resolve(null);
+        }, ATTACH_TIMEOUT_MS);
       });
       const remainingMessages: string[] = [];
+      let remainingBytes = 0;
       for (const msg of earlyMessages) {
         const parsed = parseControlMessage(msg);
         if (!attachMessage && parsed?.type === 'attach') {
           attachMessage = parsed;
-        } else {
+        } else if (remainingMessages.length < PRE_ATTACH_MAX_MESSAGES && remainingBytes <= PRE_ATTACH_MAX_BYTES) {
+          remainingBytes += Buffer.byteLength(msg);
           remainingMessages.push(msg);
+        } else {
+          ws.close(1008, 'attach-handshake-too-large');
+          return;
         }
       }
       earlyMessages.length = 0;
@@ -221,7 +245,15 @@ export function setupTerminalWebSocket(server: http.Server): void {
         const parsed = parseControlMessage(message);
         if (!attachMessage && parsed?.type === 'attach') {
           attachMessage = parsed;
+          if (attachTimer) clearTimeout(attachTimer);
           resolvePendingAttach?.(parsed);
+          resolvePendingAttach = null;
+          return;
+        }
+        remainingBytes += Buffer.byteLength(message);
+        if (remainingMessages.length >= PRE_ATTACH_MAX_MESSAGES || remainingBytes > PRE_ATTACH_MAX_BYTES) {
+          ws.close(1008, 'attach-handshake-too-large');
+          resolvePendingAttach?.(null);
           resolvePendingAttach = null;
           return;
         }
@@ -232,6 +264,7 @@ export function setupTerminalWebSocket(server: http.Server): void {
       if (!attachMessage) {
         attachMessage = await attachPromise;
       }
+      if (attachTimer) clearTimeout(attachTimer);
       if (!attachMessage) {
         return;
       }
@@ -271,7 +304,7 @@ export function setupTerminalWebSocket(server: http.Server): void {
           existingHub.cols = requestedCols;
           existingHub.rows = requestedRows;
           try {
-            existingHub.pty.resize(requestedCols, requestedRows);
+            existingHub.pty?.resize(requestedCols, requestedRows);
           } catch {
             // PTY may be mid-teardown; subsequent operations will notice.
           }
@@ -299,7 +332,7 @@ export function setupTerminalWebSocket(server: http.Server): void {
             existingHub.cols = parsed.cols;
             existingHub.rows = parsed.rows;
             try {
-              existingHub.pty.resize(parsed.cols, parsed.rows);
+              existingHub.pty?.resize(parsed.cols, parsed.rows);
             } catch {
               return;
             }
@@ -314,6 +347,10 @@ export function setupTerminalWebSocket(server: http.Server): void {
             return;
           }
           if (existingHub.inputClient !== ws) return;
+          if (!existingHub.pty) {
+            existingHub.pendingInput.push(message);
+            return;
+          }
           try {
             existingHub.pty.write(message);
           } catch {
@@ -344,17 +381,18 @@ export function setupTerminalWebSocket(server: http.Server): void {
 
       let ptyProcess: pty.IPty | null = null;
       let ptyStarted = false;
-      const pendingInput: string[] = [];
 
       const hub: PtyHub = {
-        pty: null as unknown as pty.IPty,
+        pty: null,
         clients: new Set(),
         cols: requestedCols,
         rows: requestedRows,
+        pendingInput: [],
         inputClient: ws,
         clientStates: new Map(),
       };
 
+      activePtyHubs.set(sessionName, hub);
       addClientToHub(hub, ws, false);
 
       const startLocalPty = async () => {
@@ -366,11 +404,13 @@ export function setupTerminalWebSocket(server: http.Server): void {
             // Use 4404 (private-use range) so the client can distinguish
             // "session doesn't exist" from "normal disconnect". The client
             // should NOT retry on 4404 — the session is gone.
+            activePtyHubs.delete(sessionName);
             ws.close(4404, 'session-not-found');
             return;
           }
         } catch {
           console.log(`[ws-terminal] Session ${sessionName} does not exist — closing without PTY spawn`);
+          activePtyHubs.delete(sessionName);
           ws.close(4404, 'session-not-found');
           return;
         }
@@ -393,7 +433,6 @@ export function setupTerminalWebSocket(server: http.Server): void {
         });
 
         hub.pty = ptyProcess;
-        activePtyHubs.set(sessionName, hub);
 
         let ptyChunks = 0;
         let ptyBytes = 0;
@@ -424,13 +463,20 @@ export function setupTerminalWebSocket(server: http.Server): void {
           hub.clientStates.clear();
         });
 
-        for (const input of pendingInput) {
+        for (const input of hub.pendingInput) {
           ptyProcess.write(input);
         }
-        pendingInput.length = 0;
+        hub.pendingInput.length = 0;
       };
 
-      const snapshot = await captureFreshSnapshot(sessionName, requestedCols, requestedRows);
+      let snapshot: { cols: number; rows: number; data: string };
+      try {
+        snapshot = await captureFreshSnapshot(sessionName, requestedCols, requestedRows);
+      } catch (err) {
+        activePtyHubs.delete(sessionName);
+        ws.close(1008, `Failed to capture terminal snapshot: ${err}`);
+        return;
+      }
       sendControl(ws, { type: 'snapshot', cols: snapshot.cols, rows: snapshot.rows, data: snapshot.data });
       // Start PTY immediately — don't wait for client 'ready'. The hub buffers
       // live data for not-yet-ready clients (pty-hub.ts broadcastToHub), so data
@@ -470,7 +516,7 @@ export function setupTerminalWebSocket(server: http.Server): void {
         if (ptyProcess) {
           ptyProcess.write(message);
         } else {
-          pendingInput.push(message);
+          hub.pendingInput.push(message);
         }
       };
 

--- a/src/lib/bd-mutex.ts
+++ b/src/lib/bd-mutex.ts
@@ -10,6 +10,11 @@
  * preventing lock contention and process pile-up.
  */
 
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
 let pending: Promise<void> = Promise.resolve();
 
 /**
@@ -26,4 +31,26 @@ export async function withBdMutex<T>(fn: () => Promise<T>): Promise<T> {
   // Update pending to track this operation's completion (success or failure)
   pending = result.then(() => {}, () => {});
   return result;
+}
+
+export async function restoreTrackedBeadsExport(workspacePath: string): Promise<void> {
+  try {
+    const { stdout } = await execAsync('git status --porcelain -- .beads/issues.jsonl', {
+      cwd: workspacePath,
+      encoding: 'utf-8',
+    });
+    if (stdout.split('\n').some((line) => line.slice(0, 2).includes('D'))) {
+      await execAsync('git restore -- .beads/issues.jsonl', { cwd: workspacePath });
+    }
+  } catch {}
+}
+
+export async function withWorkspaceBdMutex<T>(workspacePath: string, fn: () => Promise<T>): Promise<T> {
+  return withBdMutex(async () => {
+    try {
+      return await fn();
+    } finally {
+      await restoreTrackedBeadsExport(workspacePath);
+    }
+  });
 }

--- a/src/lib/cliproxy.ts
+++ b/src/lib/cliproxy.ts
@@ -241,7 +241,7 @@ export async function bridgeCodexAuthToCliproxyAsync(): Promise<boolean> {
     disabled: false,
   };
 
-  ensureDirs();
+  await ensureDirsAsync();
   const target = getCliproxyCodexCredPath();
 
   const serialized = JSON.stringify(creds, null, 2) + '\n';

--- a/src/lib/codex-auth.ts
+++ b/src/lib/codex-auth.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'fs/promises';
+import { open, readFile } from 'fs/promises';
 import { join } from 'path';
 import { decodeJwtPayload, getCliproxyAuthDir, getCliproxyLogPath } from './cliproxy.js';
 
@@ -31,6 +31,10 @@ export interface CodexAuthUnknown {
 
 export type CodexAuthStatus = CodexAuthValid | CodexAuthExpired | CodexAuthBurned | CodexAuthMissing | CodexAuthUnknown;
 
+interface CheckCodexAuthOptions {
+  ignoreBurnBefore?: number;
+}
+
 interface CliproxyCodexCredentials {
   access_token?: string;
   email?: string;
@@ -43,7 +47,7 @@ interface CliproxyCodexCredentials {
  * Reads ~/.panopticon/cliproxy/auth/codex-primary.json, decodes the JWT
  * access_token exp claim, and compares it to the current time.
  */
-export async function checkCodexAuthStatus(): Promise<CodexAuthStatus> {
+export async function checkCodexAuthStatus(options: CheckCodexAuthOptions = {}): Promise<CodexAuthStatus> {
   const credPath = join(getCliproxyAuthDir(), 'codex-primary.json');
 
   let raw: string;
@@ -83,7 +87,7 @@ export async function checkCodexAuthStatus(): Promise<CodexAuthStatus> {
   }
 
   const jwtStatus: CodexAuthStatus = { status: 'valid', email, expiresAt };
-  return await applyBurnedTokenOverride(jwtStatus, email, expiresAt);
+  return await applyBurnedTokenOverride(jwtStatus, email, expiresAt, options);
 }
 
 /**
@@ -108,16 +112,31 @@ export async function checkCodexAuthStatus(): Promise<CodexAuthStatus> {
  * 401s (it needs real OAuth, not the local key) and would generate
  * spurious log lines on every dashboard load.
  */
+async function readLogTail(path: string): Promise<string> {
+  const TAIL_BYTES = 128 * 1024;
+  const file = await open(path, 'r');
+  try {
+    const stat = await file.stat();
+    const length = Math.min(stat.size, TAIL_BYTES);
+    const buffer = Buffer.alloc(length);
+    await file.read(buffer, 0, length, stat.size - length);
+    return buffer.toString('utf8');
+  } finally {
+    await file.close();
+  }
+}
+
 async function applyBurnedTokenOverride(
   baseStatus: CodexAuthStatus,
   email: string,
   expiresAt: string,
+  options: CheckCodexAuthOptions,
 ): Promise<CodexAuthStatus> {
   const logPath = getCliproxyLogPath();
 
   let logRaw: string;
   try {
-    logRaw = await readFile(logPath, 'utf8');
+    logRaw = await readLogTail(logPath);
   } catch {
     return baseStatus;
   }
@@ -154,11 +173,11 @@ async function applyBurnedTokenOverride(
   // A successful LLM call came AFTER the burn line → auto-retry worked.
   if (lastSuccessIdx > lastBurnIdx) return baseStatus;
 
-  // Burn is the most recent signal. But if it's older than 5 minutes with
-  // no traffic since, treat it as stale (the user hasn't actually tried
-  // anything yet; banner would be a false alarm). The JWT exp check has
-  // already covered actually-expired tokens.
-  const BURN_STALENESS_MS = 5 * 60 * 1000;
+  if (lastBurnTimestamp !== null && options.ignoreBurnBefore !== undefined && lastBurnTimestamp < options.ignoreBurnBefore) {
+    return baseStatus;
+  }
+
+  const BURN_STALENESS_MS = 60 * 60 * 1000;
   if (lastBurnTimestamp !== null && Date.now() - lastBurnTimestamp > BURN_STALENESS_MS) {
     return baseStatus;
   }

--- a/src/lib/work/done-preflight.ts
+++ b/src/lib/work/done-preflight.ts
@@ -1,4 +1,5 @@
 import { existsSync, readdirSync } from 'fs';
+import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
@@ -9,6 +10,8 @@ const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 
 const BD_LIST_TIMEOUT_MS = 10_000;
+
+type BeadRecord = Record<string, unknown>;
 
 function errorCode(error: unknown): unknown {
   return error instanceof Error
@@ -30,11 +33,33 @@ function isTimeout(error: unknown): boolean {
     /timed out|timeout/i.test(error.message);
 }
 
+async function readIssueBeadsFromJsonl(workspacePath: string, issueId: string): Promise<BeadRecord[] | null> {
+  const jsonlPath = join(workspacePath, '.beads', 'issues.jsonl');
+  if (!existsSync(jsonlPath)) return null;
+
+  const label = issueId.toLowerCase();
+  return (await readFile(jsonlPath, 'utf-8'))
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as BeadRecord)
+    .filter((bead) => Array.isArray(bead.labels) && bead.labels.map(String).includes(label));
+}
+
 async function listBeadsByStatus(
   workspacePath: string,
   issueId: string,
   status: 'open' | 'closed',
+  preloadedBeads?: BeadRecord[] | null,
 ): Promise<string> {
+  if (preloadedBeads !== undefined && preloadedBeads !== null) {
+    return JSON.stringify(preloadedBeads.filter((bead) => bead.status === status));
+  }
+
+  const jsonlBeads = await readIssueBeadsFromJsonl(workspacePath, issueId);
+  if (jsonlBeads !== null) {
+    return JSON.stringify(jsonlBeads.filter((bead) => bead.status === status));
+  }
+
   const { stdout } = await execFileAsync(
     'bd',
     ['list', '--status', status, '-l', issueId.toLowerCase(), '--limit', '0', '--json'],
@@ -53,10 +78,10 @@ async function listBeadsByStatus(
  *
  * Returns an array of failure lines (empty = pass).
  */
-export async function checkOpenBeads(workspacePath: string, issueId: string): Promise<string[]> {
+export async function checkOpenBeads(workspacePath: string, issueId: string, preloadedBeads?: BeadRecord[] | null): Promise<string[]> {
   let stdout: string;
   try {
-    stdout = await listBeadsByStatus(workspacePath, issueId, 'open');
+    stdout = await listBeadsByStatus(workspacePath, issueId, 'open', preloadedBeads);
   } catch (error: unknown) {
     if (isMissingCommand(error)) return [];
     if (isTimeout(error)) {
@@ -183,8 +208,10 @@ export function checkVBriefACStatus(workspacePath: string): string[] {
 export async function runPreflightChecks(workspacePath: string, issueId: string): Promise<string[]> {
   const failures: string[] = [];
 
+  const issueBeads = await readIssueBeadsFromJsonl(workspacePath, issueId);
+
   // Check 1: Open beads
-  const beadFailures = await checkOpenBeads(workspacePath, issueId);
+  const beadFailures = await checkOpenBeads(workspacePath, issueId, issueBeads);
   failures.push(...beadFailures);
 
   // Check 2: Uncommitted changes
@@ -193,7 +220,7 @@ export async function runPreflightChecks(workspacePath: string, issueId: string)
 
   // Sync closed beads to vBRIEF before AC check
   try {
-    const stdout = await listBeadsByStatus(workspacePath, issueId, 'closed');
+    const stdout = await listBeadsByStatus(workspacePath, issueId, 'closed', issueBeads);
     const closedBeads = JSON.parse(stdout || '[]');
     let synced = 0;
     for (const bead of closedBeads) {

--- a/tests/cli/commands/work/done.test.ts
+++ b/tests/cli/commands/work/done.test.ts
@@ -190,6 +190,9 @@ describe('doneCommand --force bypass', () => {
   it('does NOT call process.exit(1) from pre-flight when --force is set', async () => {
     // With force, pre-flight is bypassed entirely — bd list is never called
     mockGetAgentState.mockReturnValue(makeAgentState(tempDir));
+    mockExecFn.mockImplementation((_cmd: string, _opts: unknown, cb: Function) => {
+      cb(null, { stdout: '', stderr: '' });
+    });
     mockShouldSkipTrackerUpdate.mockResolvedValue(true);
     mockUpdateShadowState.mockResolvedValue(undefined);
 

--- a/tests/unit/lib/pan-639-beads-tracking.test.ts
+++ b/tests/unit/lib/pan-639-beads-tracking.test.ts
@@ -6,11 +6,16 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 
 const ROOT = join(__dirname, '..', '..', '..');
 const gitignorePath = join(ROOT, '.gitignore');
+
+function restoreTrackedExport(path: string): void {
+  execFileSync('git', ['restore', '--', path], { cwd: ROOT, stdio: 'ignore' });
+}
 
 describe('PAN-639: beads git tracking', () => {
   it('.beads/ must NOT be gitignored', () => {
@@ -41,6 +46,9 @@ describe('PAN-639: beads git tracking', () => {
   });
 
   it('.beads/issues.jsonl must exist', () => {
+    const tracked = execFileSync('git', ['ls-files', '--error-unmatch', '.beads/issues.jsonl'], { cwd: ROOT, encoding: 'utf-8' });
+    expect(tracked.trim()).toBe('.beads/issues.jsonl');
+    restoreTrackedExport('.beads/issues.jsonl');
     expect(existsSync(join(ROOT, '.beads', 'issues.jsonl'))).toBe(true);
   });
 });


### PR DESCRIPTION
The original PAN-913 work (auto-detect expired Codex auth + spawn re-auth flow) is already merged on main as `938d3e007`. PR #916 carried that plus 5 weeks of hardening fixes that never landed because the original PR was reopened-by-mistake after a substrate bug. This is the narrowly-scoped re-extraction of the still-valuable parts.

## Why a new PR instead of finishing #916

PR #916 had:
- 7 hard merge conflicts with PAN-1067 / PAN-1125 / PAN-1134 / PAN-1140 / PAN-1143
- A silent-overwrite regression risk on `CodexAuthBanner.tsx` and `src/lib/codex-auth.ts` — the branch's pre-PAN-1067 versions would have replaced main's improved banner copy and burn-vs-success log heuristic without conflicting
- Plus an inadvertent revert of PAN-1124 in `src/cli/commands/done.ts` (re-introducing a `chore: sync planning artifacts` commit step)

This PR cherry-picks only the security/persistence/race-safety improvements and reconciles them with current main.

## Two commits

### 1. `feat(dashboard): harden Codex re-auth flow`
- Split single re-auth token into `terminalToken` (HttpOnly cookie, single-use, scoped to `/ws/terminal`) and `statusToken` (JSON, used to poll completion)
- Origin validation on the mutation routes
- `/api/settings/codex-reauth/status` moved from GET-with-query-string to POST-with-body — the token never appears in URLs or access logs
- Re-auth-completed-but-still-invalid case now surfaces a toast instead of pretending it succeeded
- `pending-codex-spawn` persists across reload via sessionStorage — survives the navigation away to `/terminal/*`
- `StandaloneTerminalRoute` factored out so `useCodexAutoRetry` runs on the terminal route too (cross-window handshake)
- Preserves PAN-1067's banner copy and `src/lib/codex-auth.ts` burn-detection logic

### 2. `fix(beads): avoid mutating tracked JSONL export during done preflight`
- `done-preflight.ts` reads `.beads/issues.jsonl` directly when it exists, skipping the `bd list` invocation that triggered the race
- New `restoreTrackedBeadsExport(workspacePath)` + `withWorkspaceBdMutex` helpers in `bd-mutex.ts`
- `done` command calls `restoreTrackedBeadsExport` after autonomous-state writes and brackets the dashboard auto-trigger call to undo any deletion that slipped through

## Tests

- `tests/cli/commands/work/done.test.ts` passes (14/14) with mock extended for the new exec call under `--force`
- Full typecheck (root + frontend) and ESLint pass on changed files
- No new test files — the codex-auth/pending-spawn paths have no dedicated unit tests on main either, so this PR preserves the existing testing surface

Closes the work that PR #916 was carrying. PR #916 will be closed.