### PR TITLE
Substrate stability: phantom-deleted beads JSONL + raise auto-requeue cap (PAN-1158)

### DIFF
--- a/src/dashboard/server/routes/workspaces.ts
+++ b/src/dashboard/server/routes/workspaces.ts
@@ -75,6 +75,7 @@ import {
 } from '../../../lib/review-status.js';
 import { gitPush, MainDivergedError } from '../../../lib/git/operations.js';
 import { listGitOperations } from '../../../lib/git-activity.js';
+import { restoreTrackedBeadsExport } from '../../../lib/beads-restore.js';
 import {
   computeQueuePositionFromStatus,
   findPositionInQueue,
@@ -3621,6 +3622,9 @@ const postWorkspaceRequestReviewRoute = HttpRouter.add(
         const workspacePathRerun = wsInfoRerun.isRemote
           ? wsInfoRerun.remotePath!
           : wsInfoRerun.localPath || join(projectPathRerun, 'workspaces', `feature-${issueLowerRerun}`);
+        if (!wsInfoRerun.isRemote) {
+          yield* Effect.promise(() => restoreTrackedBeadsExport(workspacePathRerun));
+        }
         const dirtyError = yield* Effect.promise(() => getDirtyWorkspaceErrorForReviewRequest(workspacePathRerun, wsInfoRerun));
         if (dirtyError) {
           console.log(`[request-review] Rejecting ${issueId}: dirty workspace on rerun path`);
@@ -3807,6 +3811,10 @@ const postWorkspaceRequestReviewRoute = HttpRouter.add(
         { success: false, error: 'Workspace does not exist' },
         { status: 400 }
       );
+    }
+
+    if (!workspaceInfo.isRemote) {
+      yield* Effect.promise(() => restoreTrackedBeadsExport(workspacePath));
     }
 
     const dirtyWorkspaceError = yield* Effect.promise(() => getDirtyWorkspaceErrorForReviewRequest(workspacePath, workspaceInfo));

--- a/src/lib/__tests__/beads-restore.test.ts
+++ b/src/lib/__tests__/beads-restore.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execSync } from 'child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, existsSync, unlinkSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { restoreTrackedBeadsExport } from '../beads-restore.js';
+
+describe('restoreTrackedBeadsExport', () => {
+  let workspace: string;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'beads-restore-test-'));
+    execSync('git init -q', { cwd: workspace });
+    execSync('git config user.email test@test', { cwd: workspace });
+    execSync('git config user.name test', { cwd: workspace });
+    mkdirSync(join(workspace, '.beads'), { recursive: true });
+    writeFileSync(join(workspace, '.beads', 'issues.jsonl'), '{"id":"x"}\n');
+    execSync('git add .beads/issues.jsonl', { cwd: workspace });
+    execSync('git commit -q -m init', { cwd: workspace });
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  it('restores the tracked export when it has been deleted on disk', async () => {
+    unlinkSync(join(workspace, '.beads', 'issues.jsonl'));
+    expect(existsSync(join(workspace, '.beads', 'issues.jsonl'))).toBe(false);
+
+    await restoreTrackedBeadsExport(workspace);
+
+    expect(existsSync(join(workspace, '.beads', 'issues.jsonl'))).toBe(true);
+  });
+
+  it('is a no-op when the export is present and clean', async () => {
+    const before = execSync('git status --porcelain', { cwd: workspace, encoding: 'utf-8' });
+    expect(before).toBe('');
+
+    await restoreTrackedBeadsExport(workspace);
+
+    const after = execSync('git status --porcelain', { cwd: workspace, encoding: 'utf-8' });
+    expect(after).toBe('');
+  });
+
+  it('is a no-op when the export was modified but not deleted', async () => {
+    writeFileSync(join(workspace, '.beads', 'issues.jsonl'), '{"id":"y"}\n');
+
+    await restoreTrackedBeadsExport(workspace);
+
+    // The modified content should still be there — only deletions get reverted.
+    const content = execSync('cat .beads/issues.jsonl', { cwd: workspace, encoding: 'utf-8' });
+    expect(content).toBe('{"id":"y"}\n');
+  });
+
+  it('does not throw on a non-git directory', async () => {
+    const notGit = mkdtempSync(join(tmpdir(), 'not-a-git-'));
+    try {
+      await expect(restoreTrackedBeadsExport(notGit)).resolves.toBeUndefined();
+    } finally {
+      rmSync(notGit, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lib/__tests__/beads-restore.test.ts
+++ b/src/lib/__tests__/beads-restore.test.ts
@@ -32,6 +32,22 @@ describe('restoreTrackedBeadsExport', () => {
     expect(existsSync(join(workspace, '.beads', 'issues.jsonl'))).toBe(true);
   });
 
+  it('restores the tracked export when the deletion has already been staged', async () => {
+    // `git rm` removes the file from both worktree AND index. `git restore --` alone
+    // is a no-op in this state because the index has no entry to restore from — we
+    // need `git restore --source=HEAD --staged --worktree` to recover from HEAD.
+    execSync('git rm -q .beads/issues.jsonl', { cwd: workspace });
+    const before = execSync('git status --porcelain', { cwd: workspace, encoding: 'utf-8' });
+    expect(before).toMatch(/^D\s+\.beads\/issues\.jsonl/m);
+    expect(existsSync(join(workspace, '.beads', 'issues.jsonl'))).toBe(false);
+
+    await restoreTrackedBeadsExport(workspace);
+
+    expect(existsSync(join(workspace, '.beads', 'issues.jsonl'))).toBe(true);
+    const after = execSync('git status --porcelain', { cwd: workspace, encoding: 'utf-8' });
+    expect(after).toBe('');
+  });
+
   it('is a no-op when the export is present and clean', async () => {
     const before = execSync('git status --porcelain', { cwd: workspace, encoding: 'utf-8' });
     expect(before).toBe('');

--- a/src/lib/beads-restore.ts
+++ b/src/lib/beads-restore.ts
@@ -33,8 +33,18 @@ export async function restoreTrackedBeadsExport(workspacePath: string): Promise<
       cwd: workspacePath,
       encoding: 'utf-8',
     });
-    if (stdout.split('\n').some((line) => line.slice(0, 2).includes('D'))) {
-      await execAsync('git restore -- .beads/issues.jsonl', { cwd: workspacePath });
+    // git status --porcelain shows the index column (col 0) and worktree column (col 1).
+    // - "_D" = working tree deleted (file removed but still in index)
+    // - "D_" = staged deletion (already removed from index — `git restore --` alone
+    //          is a no-op here because the index has nothing to restore from)
+    // - "DD" = staged + worktree deletion
+    // For any of these, restoring from HEAD into both the index AND worktree recovers
+    // the tracked file in every case.
+    const xy = stdout.split('\n').find((line) => line.endsWith(' .beads/issues.jsonl'));
+    if (xy && (xy[0] === 'D' || xy[1] === 'D')) {
+      await execAsync('git restore --source=HEAD --staged --worktree -- .beads/issues.jsonl', {
+        cwd: workspacePath,
+      });
     }
   } catch {
     // Best effort — never throw from the safety net.

--- a/src/lib/beads-restore.ts
+++ b/src/lib/beads-restore.ts
@@ -1,0 +1,42 @@
+/**
+ * Safety net for the workspace beads JSONL export.
+ *
+ * Workspace bd dolt databases occasionally lose state (see PAN-1158): a stale
+ * dolt-server, port collision between sibling worktrees, or partial init can
+ * leave `bd list` returning zero issues. The next `bd export` then faithfully
+ * writes a zero-issue file (which bd v1.0.4 chooses not to materialise at all),
+ * and git reports the previously-tracked `.beads/issues.jsonl` as deleted.
+ *
+ * That phantom deletion blocks every workspace path that checks `git status`
+ * before doing real work (`pan review request`, `syncMainIntoWorkspace`'s
+ * pre-flight auto-commit), and the worst case is the auto-commit catching it
+ * and propagating the deletion onto the feature branch.
+ *
+ * `restoreTrackedBeadsExport()` is the recovery primitive: if the tracked
+ * export is missing on disk, `git restore` it from the index. The real fix
+ * lives in PAN-1158 (prevent the dolt DB from going empty in the first place
+ * and refuse-empty in `bd export`). Until that lands, this primitive is the
+ * safety net we wedge into the workspace flows that get hurt today.
+ *
+ * NOTE: PR #1155 introduces an inline copy of this helper in `bd-mutex.ts`.
+ * Once both PRs land, the duplicate should be removed in favour of this file.
+ */
+
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+export async function restoreTrackedBeadsExport(workspacePath: string): Promise<void> {
+  try {
+    const { stdout } = await execAsync('git status --porcelain -- .beads/issues.jsonl', {
+      cwd: workspacePath,
+      encoding: 'utf-8',
+    });
+    if (stdout.split('\n').some((line) => line.slice(0, 2).includes('D'))) {
+      await execAsync('git restore -- .beads/issues.jsonl', { cwd: workspacePath });
+    }
+  } catch {
+    // Best effort — never throw from the safety net.
+  }
+}

--- a/src/lib/cloister/merge-agent.ts
+++ b/src/lib/cloister/merge-agent.ts
@@ -21,6 +21,7 @@ import {
 import { resolveGitHubIssue } from '../tracker-utils.js';
 
 import { resolveProjectFromIssue } from '../projects.js';
+import { restoreTrackedBeadsExport } from '../beads-restore.js';
 import { runMergeValidation, autoRevertMerge, runQualityGates } from './validation.js';
 import { loadProjectsConfig } from '../projects.js';
 import { cleanupStaleLocks } from '../git-utils.js';
@@ -1441,6 +1442,13 @@ export async function syncMainIntoWorkspace(
 ): Promise<SyncMainResult> {
   console.log(`[sync-main] Starting sync of main into workspace for ${issueId}`);
   logActivity('sync_main_start', `Starting sync for ${issueId}`);
+
+  // PAN-1158 safety net: a workspace bd dolt DB that briefly went empty can
+  // leave `.beads/issues.jsonl` reported as deleted by `git status`. The
+  // auto-commit below would then propagate that deletion onto the feature
+  // branch. Restore the tracked export first so the auto-commit only sees
+  // intentional changes.
+  await restoreTrackedBeadsExport(projectPath);
 
   // Pre-flight: auto-commit uncommitted changes before merge
   try {

--- a/src/lib/vbrief/io.ts
+++ b/src/lib/vbrief/io.ts
@@ -178,10 +178,11 @@ export function applyStatusOverrides(doc: VBriefDocument, overrides: Record<stri
       const itemId = key.slice(0, dotIndex);
       const subId = key.slice(dotIndex + 1);
       const item = merged.plan.items.find(i => i.id === itemId);
-      // SubItem IDs use format "parentId.subId" (e.g. "auto-start.ac1"),
-      // but updateSubItemStatus passes only the subId portion. Reconstruct the full
-      // ID for the lookup.
-      const fullSubId = `${itemId}.${subId}`;
+      // SubItem IDs in the spec use format "parentId.subId" (e.g. "item-1.ac1").
+      // updateSubItemStatus can pass either:
+      //   (a) just the child part ("ac1") — then we reconstruct fullId = itemId.ac1
+      //   (b) the full subItemId already ("item-1.ac1") — subId contains a dot, use as-is
+      const fullSubId = subId.includes('.') ? subId : `${itemId}.${subId}`;
       const sub = item?.subItems?.find(s => s.id === fullSubId);
       if (sub) {
         sub.status = status as VBriefItemStatus;

--- a/src/lib/vbrief/io.ts
+++ b/src/lib/vbrief/io.ts
@@ -178,11 +178,10 @@ export function applyStatusOverrides(doc: VBriefDocument, overrides: Record<stri
       const itemId = key.slice(0, dotIndex);
       const subId = key.slice(dotIndex + 1);
       const item = merged.plan.items.find(i => i.id === itemId);
-      // SubItem IDs in the spec use format "parentId.subId" (e.g. "item-1.ac1").
-      // updateSubItemStatus can pass either:
-      //   (a) just the child part ("ac1") — then we reconstruct fullId = itemId.ac1
-      //   (b) the full subItemId already ("item-1.ac1") — subId contains a dot, use as-is
-      const fullSubId = subId.includes('.') ? subId : `${itemId}.${subId}`;
+      // SubItem IDs use format "parentId.subId" (e.g. "auto-start.ac1"),
+      // but updateSubItemStatus passes only the subId portion. Reconstruct the full
+      // ID for the lookup.
+      const fullSubId = `${itemId}.${subId}`;
       const sub = item?.subItems?.find(s => s.id === fullSubId);
       if (sub) {
         sub.status = status as VBriefItemStatus;

--- a/tests/lib/cloister/deacon-ci-retry.test.ts
+++ b/tests/lib/cloister/deacon-ci-retry.test.ts
@@ -30,6 +30,7 @@ const mockGetAgentRuntimeState = vi.fn().mockReturnValue(null);
 vi.mock('../../../src/lib/review-status.js', () => ({
   setReviewStatus: (...args: unknown[]) => mockSetReviewStatus(...args),
   loadReviewStatuses: (...args: unknown[]) => mockLoadReviewStatuses(...args),
+  MAX_AUTO_REQUEUE: 25,
 }));
 
 vi.mock('../../../src/lib/tmux.js', () => ({


### PR DESCRIPTION
Closes nothing yet (PAN-1158 stays open for the real fix); narrowest possible safety net to stop the bleeding while PAN-1111 / a proper bd-export guard land.

## What this does

Adds `restoreTrackedBeadsExport(workspacePath)` in a new `src/lib/beads-restore.ts` and calls it before any dirty-check or auto-commit at the two paths that were silently propagating phantom JSONL deletions:

1. **`POST /api/review/:issueId/request`** (both the passed-state rerun path and the normal path). Today the work agent has to manually `git restore -- .beads/issues.jsonl` between commit and review request — that workaround is now unnecessary.
2. **`syncMainIntoWorkspace()` pre-flight** in `cloister/merge-agent.ts`. This is the dangerous one: the auto-commit (\`chore: auto-commit before sync with main\`) catches any uncommitted change including \`D .beads/issues.jsonl\`, and propagates the deletion onto the feature branch.

Remote (Fly) workspaces are skipped — they have their own state model and bd-restore would need to be remote-executed.

## What this does NOT do

This treats the symptom, not the cause. See PAN-1158 for the proper fix:

- Find why workspace dolt DBs go empty (suspected port collision / dolt-server race between sibling worktrees). This overlaps with **PAN-1111** (beads v1.0.4 upgrade + scaffolding removal), currently in review.
- Add a \`--refuse-empty\` guard to \`bd export\` so we never overwrite a non-empty tracked export with an empty one.

## Tests

New `src/lib/__tests__/beads-restore.test.ts` (4 cases):
- Restores a deleted-on-disk tracked export.
- No-op when clean.
- No-op when modified-but-not-deleted (only deletions get reverted).
- Does not throw on non-git directories.

Typecheck + ESLint clean on changed files.

## Coordination note

PR #1155 (in-flight PAN-913 follow-up) introduces a sister copy of \`restoreTrackedBeadsExport\` inside \`src/lib/bd-mutex.ts\`, called only from the \`pan done\` path. Once both PRs land, the duplicate should be removed and \`bd-mutex.ts\` re-exported from \`beads-restore.ts\` — that follow-up is a 5-line refactor and not in scope here.

## Related

- PAN-1158 — investigation issue
- PAN-1111 — beads v1.0.4 upgrade (real fix for the upstream side)
- PAN-1140 — auto-commit pipeline (main-only, intentionally does not cover .beads/)
- PR #1155 — PAN-913 follow-up that adds the sister helper for \`pan done\`