### PR TITLE
fix(cloister): ship role bypasses workspace stack-health gate (PAN-1162)

### DIFF
--- a/src/lib/cloister/merge-agent.ts
+++ b/src/lib/cloister/merge-agent.ts
@@ -1145,9 +1145,17 @@ async function spawnShipRoleForTask(options: {
 
   try {
     const { spawnRun } = await import('../agents.js');
+    // Ship role delivers its rebase prompt through the work-agent's tmux session and
+    // performs git operations against the host worktree — it does not depend on the
+    // workspace's docker-compose services (server/frontend) being healthy. Pass
+    // `allowHost: true` so the stack-health pre-flight does not block ship when an
+    // ancillary container has exited (e.g. server-1 crashing on a stale init build).
+    // Blocking ship on those failures was forcing humans into a manual
+    // rebuild-and-retry loop for every merge — see PAN-1141 incident 2026-05-17.
     const run = await spawnRun(options.issueId, 'ship', {
       workspace,
       prompt: options.prompt,
+      allowHost: true,
     });
     return {
       success: true,


### PR DESCRIPTION
Closes #1162

## Summary

Ship role doesn't need the workspace docker stack — it runs git on the host worktree and delivers prompts via the existing work-agent tmux session. Currently `spawnShipRoleForTask` does NOT pass `allowHost: true`, so an unhealthy ancillary container (e.g. server-1 crash) blocks merges.

## Change

One callsite in `src/lib/cloister/merge-agent.ts:1148-1157`: add `allowHost: true` to `spawnRun(..., 'ship', ...)`. Inline comment cites the PAN-1141 incident.

## Test plan

- [ ] Merge an approved PR while workspace's server-1 container is exited — merge succeeds
- [ ] Work/test role spawns still gated on stack health (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)