### PR TITLE
feat(dashboard): add IssueCard primitive (PAN-1148 f6)

### DIFF
--- a/src/dashboard/frontend/src/components/primitives/IssueCard.test.tsx
+++ b/src/dashboard/frontend/src/components/primitives/IssueCard.test.tsx
@@ -1,0 +1,221 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import IssueCard from './IssueCard';
+import VerbBadge from './VerbBadge';
+import type { PhaseGlyphPhase } from './PhaseGlyph';
+
+const PHASES = ['todo', 'plan', 'work', 'review', 'ship', 'done'] satisfies PhaseGlyphPhase[];
+
+const PRIORITIES = ['urgent', 'high', 'medium', 'low'] as const;
+
+const BEAD_PHASE_FILL_CLASSES = {
+  todo: 'bg-muted-foreground',
+  plan: 'bg-signal-review',
+  work: 'bg-info',
+  review: 'bg-warning',
+  ship: 'bg-signal-review',
+  done: 'bg-success',
+} satisfies Record<PhaseGlyphPhase, string>;
+
+describe('IssueCard', () => {
+  it('renders root with data-component="issue-card"', () => {
+    render(
+      <IssueCard
+        issueId="PAN-1"
+        phase="work"
+        priority="high"
+        title="Test title"
+      />,
+    );
+
+    const card = screen.getByText('PAN-1').closest('[data-component="issue-card"]');
+    expect(card).toHaveAttribute('data-issue-id', 'PAN-1');
+    expect(card).toHaveAttribute('data-phase', 'work');
+    expect(card).toHaveAttribute('data-priority', 'high');
+  });
+
+  it('implements PRD §4.7.6 spec values', () => {
+    render(
+      <IssueCard
+        issueId="PAN-1"
+        phase="work"
+        priority="high"
+        title="Test title"
+      />,
+    );
+
+    const card = screen.getByText('PAN-1').closest('[data-component="issue-card"]');
+    expect(card).toHaveClass('rounded-[var(--radius-xl)]');
+    expect(card).toHaveClass('border');
+    expect(card).toHaveClass('p-[12px]');
+    expect(card).toHaveClass('pb-[10px]');
+    expect(card).toHaveClass('hover:border-[rgb(255_255_255_/_14%)]');
+    expect(card).toHaveStyle({ background: 'color-mix(in srgb, var(--background) 92%, white)' });
+
+    // Priority bar inset 12px
+    expect(card).toHaveClass('before:bottom-[12px]');
+    expect(card).toHaveClass('before:top-[12px]');
+  });
+
+  it('renders priority border colors for all priorities', () => {
+    const { container } = render(
+      <div>
+        {PRIORITIES.map((priority) => (
+          <IssueCard
+            key={priority}
+            issueId={`PAN-${priority}`}
+            phase="work"
+            priority={priority}
+            title="T"
+          />
+        ))}
+      </div>,
+    );
+
+    for (const priority of PRIORITIES) {
+      const card = container.querySelector(`[data-issue-id="PAN-${priority}"]`);
+      expect(card).not.toBeNull();
+    }
+
+    const urgentCard = container.querySelector('[data-priority="urgent"]');
+    expect(urgentCard).toHaveClass('before:bg-destructive');
+
+    const highCard = container.querySelector('[data-priority="high"]');
+    expect(highCard).toHaveClass('before:bg-warning');
+
+    const mediumCard = container.querySelector('[data-priority="medium"]');
+    expect(mediumCard).toHaveClass('before:bg-[rgb(255_255_255_/_22%)]');
+
+    const lowCard = container.querySelector('[data-priority="low"]');
+    expect(lowCard).toHaveClass('before:bg-transparent');
+  });
+
+  it('swaps stuck and merge-ready border colors', () => {
+    const { container } = render(
+      <div>
+        <IssueCard issueId="PAN-stuck" phase="work" priority="high" title="Stuck" stuckCard />
+        <IssueCard issueId="PAN-merge" phase="work" priority="high" title="Merge" mergeReadyCard />
+        <IssueCard issueId="PAN-normal" phase="work" priority="high" title="Normal" />
+      </div>,
+    );
+
+    const stuckCard = container.querySelector('[data-issue-id="PAN-stuck"]');
+    expect(stuckCard?.getAttribute('style')).toContain(
+      'border-color: color-mix(in srgb, var(--destructive) 32%, transparent)',
+    );
+
+    const mergeCard = container.querySelector('[data-issue-id="PAN-merge"]');
+    expect(mergeCard?.getAttribute('style')).toContain(
+      'border-color: color-mix(in srgb, var(--success) 32%, transparent)',
+    );
+
+    const normalCard = container.querySelector('[data-issue-id="PAN-normal"]');
+    expect(normalCard?.getAttribute('style')).not.toContain(
+      'border-color: color-mix(in srgb, var(--destructive) 32%, transparent)',
+    );
+    expect(normalCard?.getAttribute('style')).not.toContain(
+      'border-color: color-mix(in srgb, var(--success) 32%, transparent)',
+    );
+  });
+
+  it('renders bead progress bar with correct fill width and phase-colored fill', () => {
+    const { container } = render(
+      <div>
+        {PHASES.map((phase) => (
+          <IssueCard
+            key={phase}
+            issueId={`PAN-${phase}`}
+            phase={phase}
+            priority="medium"
+            title="T"
+            beads={{ closed: 3, total: 12 }}
+          />
+        ))}
+      </div>,
+    );
+
+    for (const phase of PHASES) {
+      const card = container.querySelector(`[data-issue-id="PAN-${phase}"]`);
+      expect(card).toHaveTextContent('Beads 3/12');
+
+      const fill = card?.querySelector('.block.h-full');
+      expect(fill).toHaveStyle({ width: '25%' });
+      expect(fill).toHaveClass(BEAD_PHASE_FILL_CLASSES[phase]);
+    }
+  });
+
+  it('composes VerbBadge and never renders status colors on labels', () => {
+    const { container } = render(
+      <IssueCard
+        issueId="PAN-1"
+        phase="work"
+        priority="high"
+        title="Test"
+        verbBadge={<VerbBadge variant="WORK RUNNING" />}
+        labels={['bug', 'frontend']}
+      />,
+    );
+
+    const verbBadge = container.querySelector('[data-component="verb-badge"]');
+    expect(verbBadge).toHaveAttribute('data-variant', 'WORK RUNNING');
+
+    const labelChips = container.querySelectorAll('.text-muted-foreground');
+    // Labels should use muted-foreground, not status colors
+    const labelTexts = Array.from(labelChips).map((el) => el.textContent);
+    expect(labelTexts).toContain('bug');
+    expect(labelTexts).toContain('frontend');
+  });
+
+  it('renders project mark, agent footer, runtime, and avatar', () => {
+    const { container } = render(
+      <IssueCard
+        issueId="PAN-1"
+        phase="work"
+        priority="high"
+        title="Test"
+        project={{ name: 'Panopticon', markClassName: 'bg-primary' }}
+        agent={{ name: 'work-agent-1', sub: 'Running' }}
+        runtime="12m"
+        assignee={{ name: 'Alex Doe' }}
+      />,
+    );
+
+    const card = container.querySelector('[data-issue-id="PAN-1"]');
+    const mark = card?.querySelector('.bg-primary');
+    expect(mark).not.toBeNull();
+    expect(screen.getByText('work-agent-1')).toBeTruthy();
+    expect(screen.getByText('Running')).toBeTruthy();
+    expect(screen.getByText('12m')).toBeTruthy();
+    expect(screen.getByText('AD')).toBeTruthy();
+  });
+
+  it('falls back to issueId for avatar initials when assignee is missing', () => {
+    render(
+      <IssueCard
+        issueId="PAN-1148"
+        phase="work"
+        priority="high"
+        title="Test"
+      />,
+    );
+
+    expect(screen.getByText('PA')).toBeTruthy();
+  });
+
+  it('calls onOpen when clicked', () => {
+    let openedId = '';
+    render(
+      <IssueCard
+        issueId="PAN-1"
+        phase="work"
+        priority="high"
+        title="Test"
+        onOpen={(id) => { openedId = id; }}
+      />,
+    );
+
+    screen.getByText('Test').closest('button')?.click();
+    expect(openedId).toBe('PAN-1');
+  });
+});

--- a/src/dashboard/frontend/src/components/primitives/IssueCard.tsx
+++ b/src/dashboard/frontend/src/components/primitives/IssueCard.tsx
@@ -1,0 +1,205 @@
+import type { ReactNode } from 'react';
+
+import { cn } from '../../lib/utils';
+import type { PhaseGlyphPhase } from './PhaseGlyph';
+
+export type IssueCardPriority = 'urgent' | 'high' | 'medium' | 'low';
+
+export type IssueCardProject = {
+  name: ReactNode;
+  markClassName?: string;
+};
+
+export type IssueCardAgent = {
+  name?: ReactNode;
+  sub?: ReactNode;
+};
+
+export type IssueCardBeads = {
+  closed: number;
+  total: number;
+};
+
+export type IssueCardProps = {
+  issueId: string;
+  phase: PhaseGlyphPhase;
+  priority: IssueCardPriority;
+  title: ReactNode;
+  project?: IssueCardProject;
+  labels?: ReactNode[];
+  verbBadge?: ReactNode;
+  agent?: IssueCardAgent;
+  runtime?: ReactNode;
+  assignee?: { name: string };
+  beads?: IssueCardBeads;
+  stuckCard?: boolean;
+  mergeReadyCard?: boolean;
+  onOpen?: (issueId: string) => void;
+  className?: string;
+};
+
+const PRIORITY_BORDER_CLASSES = {
+  urgent: 'before:bg-destructive',
+  high: 'before:bg-warning',
+  medium: 'before:bg-[rgb(255_255_255_/_22%)]',
+  low: 'before:bg-transparent',
+} satisfies Record<IssueCardPriority, string>;
+
+const BEAD_PHASE_FILL_CLASSES = {
+  todo: 'bg-muted-foreground',
+  plan: 'bg-signal-review',
+  work: 'bg-info',
+  review: 'bg-warning',
+  ship: 'bg-signal-review',
+  done: 'bg-success',
+} satisfies Record<PhaseGlyphPhase, string>;
+
+const AVATAR_GRADIENT_CLASSES = [
+  'bg-[linear-gradient(135deg,#8b5cf6,#06b6d4)]',
+  'bg-[linear-gradient(135deg,#f59e0b,#ef4444)]',
+  'bg-[linear-gradient(135deg,#10b981,#06b6d4)]',
+  'bg-[linear-gradient(135deg,#3b82f6,#8b5cf6)]',
+  'bg-[linear-gradient(135deg,#ef4444,#f59e0b)]',
+] as const;
+
+function hashString(value: string) {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+  return hash;
+}
+
+function avatarInitials(name: string) {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  const source = parts.length > 1 ? `${parts[0][0]}${parts[1][0]}` : name.slice(0, 2);
+  return source.toUpperCase();
+}
+
+export default function IssueCard({
+  issueId,
+  phase,
+  priority,
+  title,
+  project,
+  labels = [],
+  verbBadge,
+  agent,
+  runtime,
+  assignee,
+  beads,
+  stuckCard,
+  mergeReadyCard,
+  onOpen,
+  className,
+}: IssueCardProps) {
+  const avatarName = assignee?.name ?? issueId;
+  const avatarGradient = AVATAR_GRADIENT_CLASSES[hashString(avatarName) % AVATAR_GRADIENT_CLASSES.length];
+  const hasAgent = Boolean(agent?.name);
+  const beadPct = beads && beads.total > 0 ? Math.round((beads.closed / beads.total) * 100) : 0;
+
+  const borderStyle: React.CSSProperties | undefined =
+    stuckCard
+      ? { borderColor: 'color-mix(in srgb, var(--destructive) 32%, transparent)' }
+      : mergeReadyCard
+        ? { borderColor: 'color-mix(in srgb, var(--success) 32%, transparent)' }
+        : undefined;
+
+  return (
+    <button
+      type="button"
+      data-component="issue-card"
+      data-issue-id={issueId}
+      data-phase={phase}
+      data-priority={priority}
+      className={cn(
+        'relative w-full rounded-[var(--radius-xl)] border border-border text-left transition-colors duration-200 hover:border-[rgb(255_255_255_/_14%)]',
+        'p-[12px] pb-[10px]',
+        'before:absolute before:bottom-[12px] before:left-[10px] before:top-[12px] before:w-[2px] before:rounded-[2px]',
+        PRIORITY_BORDER_CLASSES[priority],
+        className,
+      )}
+      style={{
+        background: 'color-mix(in srgb, var(--background) 92%, white)',
+        ...borderStyle,
+      }}
+      onClick={() => onOpen?.(issueId)}
+    >
+      {/* Row 1: project mark + ID + verb badge */}
+      <span className="flex items-center gap-[6px]">
+        {project && (
+          <span className={cn('h-[8px] w-[8px] shrink-0 rounded-[2px] bg-muted', project.markClassName)} />
+        )}
+        <span className="shrink-0 font-mono text-[10px] leading-none tracking-[0.02em] text-muted-foreground">
+          {issueId}
+        </span>
+        <span className="grow" />
+        {verbBadge && <span className="shrink-0">{verbBadge}</span>}
+      </span>
+
+      {/* Title */}
+      <span className="mt-[8px] block text-[13px] leading-[1.35] text-foreground line-clamp-2">
+        {title}
+      </span>
+
+      {/* Labels */}
+      {labels.length > 0 && (
+        <span className="mt-[8px] flex flex-wrap items-center gap-[4px]">
+          {labels.map((label, index) => (
+            <span
+              key={index}
+              className="rounded-[var(--radius-sm)] border border-border bg-[rgb(255_255_255_/_5%)] px-[6px] py-[1px] text-[10px] font-medium leading-none text-muted-foreground"
+            >
+              {label}
+            </span>
+          ))}
+        </span>
+      )}
+
+      {/* Bead progress */}
+      {beads && beads.total > 0 && (
+        <span className="mt-[10px] flex items-center gap-[8px]">
+          <span className="shrink-0 font-mono text-[10px] leading-none text-muted-foreground">
+            Beads {beads.closed}/{beads.total}
+          </span>
+          <span className="h-[3px] grow overflow-hidden rounded-[2px] bg-accent">
+            <span
+              className={cn('block h-full rounded-[2px]', BEAD_PHASE_FILL_CLASSES[phase])}
+              style={{ width: `${beadPct}%` }}
+            />
+          </span>
+        </span>
+      )}
+
+      {/* Foot */}
+      <span className="mt-[8px] flex items-end gap-[8px] border-t border-border pt-[8px]">
+        <span className="min-w-0 grow font-mono leading-none">
+          <span
+            className={cn(
+              'block truncate text-[11px]',
+              hasAgent ? 'text-foreground' : 'font-sans italic text-muted-foreground',
+            )}
+          >
+            {agent?.name ?? 'Unassigned'}
+          </span>
+          <span className="mt-[3px] block truncate text-[10px] text-muted-foreground">
+            {agent?.sub ?? '—'}
+          </span>
+        </span>
+        {runtime && (
+          <span className="shrink-0 font-mono text-[11px] leading-none text-muted-foreground [font-variant-numeric:tabular-nums]">
+            {runtime}
+          </span>
+        )}
+        <span
+          className={cn(
+            'flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border border-border text-[8px] font-semibold leading-none text-white',
+            avatarGradient,
+          )}
+        >
+          {avatarInitials(avatarName)}
+        </span>
+      </span>
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

Adds the `IssueCard` primitive component per PRD §4.7.6 for the unified dashboard redesign (PAN-1148).

### What's included
- `src/dashboard/frontend/src/components/primitives/IssueCard.tsx` — new presentational primitive
- `src/dashboard/frontend/src/components/primitives/IssueCard.test.tsx` — 9 tests covering all ACs

### Spec compliance
- 14px radius (`rounded-[var(--radius-xl)]`), padding `12px 12px 10px`
- Lighter surface via `color-mix(in srgb, var(--background) 92%, white)`
- Priority left border pseudo-element, inset 12px top/bottom
- Stuck / merge-ready border color overrides via inline `color-mix` values
- Row 1: project mark (8×8) + ID (SF Mono 10px muted) + VerbBadge
- 2-line clamped title, label chips with muted styling (no status colors)
- Bead progress bar with phase-colored fill
- Footer: agent two-line cell + runtime mono + 18×18 gradient avatar
- Root tagged with `data-component="issue-card"`

### Acceptance criteria
- [x] IssueCard implements all PRD §4.7.6 spec values
- [x] Stuck card and merge-ready card border colors swap correctly
- [x] Bead progress bar renders correct fill width and phase-colored fill
- [x] Composes VerbBadge; never renders status colors on labels
- [x] Root element carries `data-component="issue-card"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)