### PR TITLE
feat(dashboard): universal chrome + legacy redirect (PAN-1148)

### DIFF
--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -260,6 +260,12 @@ export default function App() {
     return <StandaloneTerminalRoute sessionName={sessionName} token={token} />;
   }
 
+  // Legacy route redirect: /awaiting-merge → /pipeline?phase=ship (PAN-1148)
+  if (terminalPath === '/awaiting-merge' || terminalPath === '/awaiting-merge/') {
+    window.location.replace('/pipeline?phase=ship');
+    return null;
+  }
+
   const [activeTab, setActiveTabState] = useState<Tab>(() => getConversationRouteState().tab);
   const [selectedAgent, setSelectedAgentState] = useState<string | null>(() => {
     const hash = window.location.hash;

--- a/src/dashboard/frontend/src/components/primitives/TopBar.tsx
+++ b/src/dashboard/frontend/src/components/primitives/TopBar.tsx
@@ -1,0 +1,79 @@
+import type { ReactNode } from 'react';
+
+import { cn } from '../../lib/utils';
+
+export type TopBarHeight = 52 | 48;
+
+export type TopBarProps = {
+  height?: TopBarHeight;
+  breadcrumb?: ReactNode;
+  meta?: ReactNode;
+  search?: ReactNode;
+  segmentedControl?: ReactNode;
+  actions?: ReactNode;
+  className?: string;
+};
+
+const HEIGHT_CLASSES = {
+  52: 'h-[52px]',
+  48: 'h-[48px]',
+} satisfies Record<TopBarHeight, string>;
+
+/** Reusable button class names for elements placed in the actions slot. */
+export const topBarButtonClasses = {
+  primary: 'btn-chrome-primary',
+  ghost: 'btn-chrome-ghost',
+} as const;
+
+export default function TopBar({
+  height = 52,
+  breadcrumb,
+  meta,
+  search,
+  segmentedControl,
+  actions,
+  className,
+}: TopBarProps) {
+  const hasLeft = Boolean(breadcrumb || meta);
+  const hasRight = Boolean(search || actions);
+
+  return (
+    <div
+      data-component="top-bar"
+      data-height={height}
+      className={cn(
+        'flex shrink-0 items-center gap-[12px] border-b border-border bg-background px-[22px]',
+        HEIGHT_CLASSES[height],
+        className,
+      )}
+    >
+      {hasLeft && (
+        <div className="flex min-w-0 items-center gap-[8px]">
+          {breadcrumb && (
+            <span className="truncate text-[13px] font-medium leading-none text-foreground">
+              {breadcrumb}
+            </span>
+          )}
+          {meta && (
+            <span className="truncate text-[12px] leading-none text-muted-foreground">
+              {meta}
+            </span>
+          )}
+        </div>
+      )}
+
+      {segmentedControl && (
+        <div className="mx-auto flex items-center">
+          {segmentedControl}
+        </div>
+      )}
+
+      {hasRight && (
+        <div className="ml-auto flex items-center gap-[8px]">
+          {search && <div className="flex items-center">{search}</div>}
+          {actions && <div className="flex items-center gap-[6px]">{actions}</div>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/dashboard/frontend/src/index.css
+++ b/src/dashboard/frontend/src/index.css
@@ -385,3 +385,57 @@ body::after {
                           background: color-mix(in srgb, currentColor 10%, transparent);
                           padding: 0.1em 0.3em; border-radius: 3px; }
 .prose-notes a          { color: var(--primary); text-decoration: underline; }
+
+/* ─── Chrome button styles (PRD §4.7.2) ───
+ * Used inside top-bar actions slots (Pipeline, Board, Agents).
+ * Height is fixed at 32px to align with search inputs. */
+@layer components {
+  .btn-chrome-primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 32px;
+    border-radius: var(--radius-sm);
+    background: var(--primary);
+    padding: 0 12px;
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1;
+    color: var(--primary-foreground);
+    transition: background-color 150ms ease;
+    box-shadow: inset 0 1px 0 rgb(255 255 255 / 6%);
+    cursor: pointer;
+    border: none;
+  }
+  .btn-chrome-primary:hover {
+    background: color-mix(in srgb, var(--primary) 90%, transparent);
+  }
+  .btn-chrome-primary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .btn-chrome-ghost {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 32px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--input);
+    background: transparent;
+    padding: 0 12px;
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1;
+    color: var(--foreground);
+    transition: background-color 150ms ease;
+    cursor: pointer;
+  }
+  .btn-chrome-ghost:hover {
+    background: var(--accent);
+  }
+  .btn-chrome-ghost:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}


### PR DESCRIPTION
## Summary
- Add TopBar component with height/breadcrumb/meta/search/segmentedControl/actions slots
- Add .btn-chrome-primary and .btn-chrome-ghost @layer component styles
- Redirect /awaiting-merge → /pipeline?phase=ship (preserves bookmarks)

## Acceptance Criteria
- [x] AC1: Fractal-noise overlay renders fixed-position at 3.5% opacity, 256px tile; does not capture pointer events
- [x] AC2: TopBar primitive supports {height, breadcrumb, meta, search, segmentedControl, actions} slots per PRD §4.7.2
- [x] AC3: Primary button uses --primary background with inset white 6% highlight; ghost button uses transparent + --input border
- [x] AC4: Legacy /awaiting-merge route redirects to /pipeline?phase=ship

🤖 Generated with [Claude Code](https://claude.com/code)