### PR TITLE
PAN-1148: Reframe Command Deck right pane as tabbed ProjectLens

### DIFF
--- a/.pan/spec.vbrief.json
+++ b/.pan/spec.vbrief.json
@@ -4,7 +4,7 @@
     "created": "2026-05-18T05:10:55.134Z",
     "author": "panopticon-cli/0.0.0",
     "description": "Plan for PAN-1148: Unified dashboard redesign — Pipeline, Board, Command Deck, Agents, and shared Issue Detail drawer",
-    "updated": "2026-05-18T06:00:10.000Z"
+    "updated": "2026-05-18T08:39:44.723Z"
   },
   "plan": {
     "id": "pan-1148",
@@ -12,9 +12,9 @@
     "status": "proposed",
     "uid": "4506a8e9-5388-424a-8301-87772aa05925",
     "author": "agent:claude-opus-4-7",
-    "sequence": 2,
+    "sequence": 14,
     "created": "2026-05-18T05:10:55.134Z",
-    "updated": "2026-05-18T06:00:10.000Z",
+    "updated": "2026-05-18T08:39:44.723Z",
     "references": [
       {
         "uri": "https://github.com/eltmon/panopticon-cli/issues/1148",
@@ -142,7 +142,8 @@
             "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:04:59.925Z"
           },
           {
             "id": "f1-verb-badge.ac2",
@@ -150,7 +151,8 @@
             "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:04:59.925Z"
           },
           {
             "id": "f1-verb-badge.ac3",
@@ -158,7 +160,8 @@
             "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:04:59.925Z"
           },
           {
             "id": "f1-verb-badge.ac4",
@@ -166,7 +169,8 @@
             "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:04:59.925Z"
           },
           {
             "id": "f1-verb-badge.ac5",
@@ -174,7 +178,8 @@
             "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:04:59.925Z"
           },
           {
             "id": "f1-verb-badge.ac6",
@@ -182,9 +187,11 @@
             "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:04:59.925Z"
           }
-        ]
+        ],
+        "completed": "2026-05-18T06:04:59.925Z"
       },
       {
         "id": "f2-phase-glyph",
@@ -208,7 +215,8 @@
             "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:05:00.149Z"
           },
           {
             "id": "f2-phase-glyph.ac2",
@@ -216,7 +224,8 @@
             "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:05:00.149Z"
           },
           {
             "id": "f2-phase-glyph.ac3",
@@ -224,9 +233,11 @@
             "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:05:00.149Z"
           }
-        ]
+        ],
+        "completed": "2026-05-18T06:05:00.149Z"
       },
       {
         "id": "f3-phase-header",
@@ -250,7 +261,8 @@
             "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:05:00.427Z"
           },
           {
             "id": "f3-phase-header.ac2",
@@ -258,7 +270,8 @@
             "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:05:00.427Z"
           },
           {
             "id": "f3-phase-header.ac3",
@@ -266,9 +279,11 @@
             "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:05:00.427Z"
           }
-        ]
+        ],
+        "completed": "2026-05-18T06:05:00.427Z"
       },
       {
         "id": "f4-metric-tile",
@@ -292,7 +307,8 @@
             "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:05:00.657Z"
           },
           {
             "id": "f4-metric-tile.ac2",
@@ -300,7 +316,8 @@
             "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:05:00.657Z"
           },
           {
             "id": "f4-metric-tile.ac3",
@@ -308,7 +325,8 @@
             "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:05:00.657Z"
           },
           {
             "id": "f4-metric-tile.ac4",
@@ -316,14 +334,16 @@
             "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:05:00.657Z"
           }
-        ]
+        ],
+        "completed": "2026-05-18T06:05:00.657Z"
       },
       {
         "id": "f5-issue-row",
         "title": "Add IssueRow primitive (Pipeline / Command Deck row, composes VerbBadge + PhaseGlyph)",
-        "status": "pending",
+        "status": "completed",
         "priority": "high",
         "created": "2026-05-18T05:10:55.134Z",
         "metadata": {
@@ -339,80 +359,91 @@
           {
             "id": "f5-issue-row.ac1",
             "title": "IssueRow grid layout matches PRD §4.7.5 exactly for both pipeline and command-deck variants",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:06:50.877Z"
           },
           {
             "id": "f5-issue-row.ac2",
             "title": "Priority left border uses ::before pseudo with the correct color per priority level; no inline color hacks",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:06:50.877Z"
           },
           {
             "id": "f5-issue-row.ac3",
             "title": "Composes VerbBadge for the one colored badge slot; composes PhaseGlyph for the phase column",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:06:50.877Z"
           },
           {
             "id": "f5-issue-row.ac4",
             "title": "Ledger cell renders runtime in muted, cost in --signal-cost-foreground; empty state renders `—` at 55% opacity",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:06:50.877Z"
           },
           {
             "id": "f5-issue-row.ac5",
             "title": "Label chips use bg-muted + muted-foreground; never status-colored (PRD §4.5 'labels are taxonomy, never status')",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:06:50.877Z"
           },
           {
             "id": "f5-issue-row.ac6",
             "title": "Avatar gradient renders one of 5 deterministic tones based on assignee name hash",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:06:50.877Z"
           },
           {
             "id": "f5-issue-row.ac7",
             "title": "Root element carries `data-component=\"issue-row\"` for styleguide-conformance test",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:06:50.877Z"
           },
           {
             "id": "f5-issue-row.ac8",
             "title": "Click handler accepts an issueId-based onOpen callback; component itself does not own routing",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T06:06:50.877Z"
           }
-        ]
+        ],
+        "completed": "2026-05-18T06:06:50.877Z"
       },
       {
         "id": "f6-issue-card",
         "title": "Add IssueCard primitive (Board card, composes VerbBadge)",
-        "status": "pending",
+        "status": "completed",
         "priority": "high",
         "created": "2026-05-18T05:10:55.134Z",
         "metadata": {
           "difficulty": "medium",
           "issueLabel": "pan-1148",
           "requiresInspection": false,
-          "inspectionDepth": "fast"
+          "inspectionDepth": "fast",
+          "statusReason": "Swarm slot 1 merged into feature branch",
+          "statusUpdatedAt": "2026-05-18T08:39:11.958Z"
         },
         "narrative": {
           "Action": "Create src/dashboard/frontend/src/components/primitives/IssueCard.tsx implementing PRD §4.7.6 exactly: 14px radius, padding 12px 12px 10px, lighter card surface (color-mix background 92% + white), priority left border identical to IssueRow, stuck/merge-ready border color overrides, project mark + ID + verb badge in row 1, 2-line clamped title, label chips, bead progress bar with phase-colored fill, footer with agent meta + runtime + 18px avatar. Tag root with `data-component=\"issue-card\"`."
@@ -421,56 +452,64 @@
           {
             "id": "f6-issue-card.ac1",
             "title": "IssueCard implements all PRD §4.7.6 spec values (radius, padding, surface, hover, priority bar inset 12px)",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T08:39:11.958Z"
           },
           {
             "id": "f6-issue-card.ac2",
             "title": "Stuck card and merge-ready card border colors swap correctly when corresponding props are true",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T08:39:11.958Z"
           },
           {
             "id": "f6-issue-card.ac3",
             "title": "Bead progress bar renders the correct fill width and phase-colored fill",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T08:39:11.958Z"
           },
           {
             "id": "f6-issue-card.ac4",
             "title": "Composes VerbBadge; never renders status colors on labels",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T08:39:11.958Z"
           },
           {
             "id": "f6-issue-card.ac5",
             "title": "Root element carries `data-component=\"issue-card\"`",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T08:39:11.958Z"
           }
-        ]
+        ],
+        "completed": "2026-05-18T08:39:11.958Z"
       },
       {
         "id": "f7-agent-card",
         "title": "Add AgentCard primitive (Agents fleet card, composes VerbBadge)",
-        "status": "pending",
+        "status": "completed",
         "priority": "high",
         "created": "2026-05-18T05:10:55.134Z",
         "metadata": {
           "difficulty": "medium",
           "issueLabel": "pan-1148",
           "requiresInspection": false,
-          "inspectionDepth": "fast"
+          "inspectionDepth": "fast",
+          "statusReason": "Swarm slot 2 merged into feature branch",
+          "statusUpdatedAt": "2026-05-18T08:39:40.186Z"
         },
         "narrative": {
           "Action": "Create src/dashboard/frontend/src/components/primitives/AgentCard.tsx implementing PRD §4.7.9 exactly: card surface with 18px radius, 3px ::before left accent per phase, stuck border override, name + verb badge + menu button row, issue panel with project mark + ID/title (2-line clamp), tri-column meta (lbl/val pairs), stream excerpt with fade-out gradient and 84px max-height, optional stuck banner, footer with primary/danger action links. Tag root with `data-component=\"agent-card\"`."
@@ -479,56 +518,64 @@
           {
             "id": "f7-agent-card.ac1",
             "title": "AgentCard implements PRD §4.7.9 spec (grid container, accent rail, stuck override)",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T08:39:40.186Z"
           },
           {
             "id": "f7-agent-card.ac2",
             "title": "Stream excerpt has the fade-out gradient via ::after at 24px tall",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T08:39:40.186Z"
           },
           {
             "id": "f7-agent-card.ac3",
             "title": "Stuck banner renders inline when `stuck` prop is true; never shown otherwise",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T08:39:40.186Z"
           },
           {
             "id": "f7-agent-card.ac4",
             "title": "Footer action links: primary uses --info-foreground, danger uses --destructive-foreground (right-aligned)",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T08:39:40.186Z"
           },
           {
             "id": "f7-agent-card.ac5",
             "title": "Root element carries `data-component=\"agent-card\"`",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
-            }
+            },
+            "completed": "2026-05-18T08:39:40.186Z"
           }
-        ]
+        ],
+        "completed": "2026-05-18T08:39:40.186Z"
       },
       {
         "id": "f8-universal-chrome",
         "title": "Add fractal-noise body overlay + shared top-bar styles for new chrome",
-        "status": "pending",
+        "status": "running",
         "priority": "medium",
         "created": "2026-05-18T05:10:55.134Z",
         "metadata": {
           "difficulty": "simple",
           "issueLabel": "pan-1148",
           "requiresInspection": false,
-          "inspectionDepth": "fast"
+          "inspectionDepth": "fast",
+          "statusReason": "Swarm slot 3 dispatched",
+          "statusUpdatedAt": "2026-05-18T08:39:16.665Z"
         },
         "narrative": {
           "Action": "PRD §4.7 'Universal rules' calls for a 3.5%-opacity fractal-noise body overlay (fixed-position SVG turbulence at 256px tile) on every page. Add it as a global element rendered once in App.tsx (or main shell). Also extract the shared top-bar style helpers per PRD §4.7.2 (52px/48px height, 13px breadcrumb, 32px search/buttons, segmented control) into src/dashboard/frontend/src/components/primitives/TopBar.tsx for reuse by Pipeline, Board, Agents."
@@ -1087,14 +1134,16 @@
       {
         "id": "p1-pipeline-page-shell",
         "title": "Add Pipeline page shell + route (greenfield)",
-        "status": "pending",
+        "status": "running",
         "priority": "high",
         "created": "2026-05-18T05:10:55.134Z",
         "metadata": {
           "difficulty": "medium",
           "issueLabel": "pan-1148",
           "requiresInspection": false,
-          "inspectionDepth": "fast"
+          "inspectionDepth": "fast",
+          "statusReason": "Swarm slot 6 dispatched",
+          "statusUpdatedAt": "2026-05-18T08:39:17.588Z"
         },
         "narrative": {
           "Action": "Create src/dashboard/frontend/src/components/Pipeline/PipelineView.tsx as the new Pipeline route content. Composes TopBar (52px), MetricStrip (5 tiles — wired in p2), grouped IssueRow lists under PhaseHeader (wired in p3), and a footer-empty zone. Imports the Issue Row primitive from f5. Reads issues from selectIssues + reviewStatusByIssueId from the existing dashboard store and classifies by lifecycle phase using src/dashboard/frontend/src/lib/pipeline-state.ts. Add `pipeline` to Tab type in Header.tsx; add `TAB_PATHS['pipeline'] = '/pipeline'` in App.tsx. (Default-route flip ships in n2.)"
@@ -1797,14 +1846,16 @@
       {
         "id": "a4-agents-move-deacon-to-health",
         "title": "Move Deacon status UI from Agents to Health page",
-        "status": "pending",
+        "status": "running",
         "priority": "medium",
         "created": "2026-05-18T05:10:55.134Z",
         "metadata": {
           "difficulty": "simple",
           "issueLabel": "pan-1148",
           "requiresInspection": false,
-          "inspectionDepth": "fast"
+          "inspectionDepth": "fast",
+          "statusReason": "Swarm slot 7 dispatched",
+          "statusUpdatedAt": "2026-05-18T08:39:44.723Z"
         },
         "narrative": {
           "Action": "Relocate the DeaconStatus component (currently under CommandDeck/DeaconStatus.tsx) usage into HealthDashboard.tsx. Remove any Deacon-specific section that was rendered inside AgentList. CloisterStatusBar (sidebar) and the global DeaconPauseToggle (footer) are unrelated and remain unchanged."
@@ -1923,7 +1974,7 @@
       {
         "id": "r2-awaiting-merge-component-removal",
         "title": "Delete AwaitingMergePage.tsx + Tab type entry + all inbound references",
-        "status": "completed",
+        "status": "pending",
         "priority": "low",
         "created": "2026-05-18T05:10:55.134Z",
         "metadata": {
@@ -1939,7 +1990,7 @@
           {
             "id": "r2-awaiting-merge-component-removal.ac1",
             "title": "AwaitingMergePage.tsx file is deleted",
-            "status": "completed",
+            "status": "pending",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -1947,7 +1998,7 @@
           {
             "id": "r2-awaiting-merge-component-removal.ac2",
             "title": "'awaiting-merge' is removed from Tab union in Header.tsx; TS typecheck still passes",
-            "status": "completed",
+            "status": "pending",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -1955,7 +2006,7 @@
           {
             "id": "r2-awaiting-merge-component-removal.ac3",
             "title": "TAB_PATHS and PATH_TO_TAB no longer contain awaiting-merge entries",
-            "status": "completed",
+            "status": "pending",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -1963,7 +2014,7 @@
           {
             "id": "r2-awaiting-merge-component-removal.ac4",
             "title": "grep -r AwaitingMergePage src/ returns zero results",
-            "status": "completed",
+            "status": "pending",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -1971,7 +2022,7 @@
           {
             "id": "r2-awaiting-merge-component-removal.ac5",
             "title": "selectAwaitingMerge / selectBlockedFromMerge / selectOpenMergeRequests selectors remain in store.ts (used by Pipeline filters)",
-            "status": "completed",
+            "status": "pending",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -2640,5 +2691,6 @@
     "metadata": {
       "canonicalFilename": "2026-05-18-PAN-1148-unified-dashboard-redesign-pipeline-board-command-deck-agents-and-shared-issue-detail-drawer.vbrief.json"
     }
-  }
+  },
+  "status": "proposed"
 }

--- a/src/dashboard/frontend/src/components/CommandDeck/CommandDeck.test.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/CommandDeck.test.tsx
@@ -114,10 +114,10 @@ vi.mock('./ConversationList', () => ({
   ),
 }));
 
-vi.mock('./ProjectOverview', () => ({
-  ProjectOverview: (props: any) => (
+vi.mock('./ProjectLens', () => ({
+  ProjectLens: (props: any) => (
     <div
-      data-testid="project-overview"
+      data-testid="project-lens"
       data-project={props.projectName}
       data-features={props.features.map((feature: any) => feature.issueId).join(',')}
       data-cost={props.issueCosts['PAN-821']}
@@ -443,12 +443,12 @@ describe('CommandDeck — project-selected session view (PAN-821)', () => {
     await screen.findAllByTestId('project-node');
     fireEvent.click(screen.getByTestId('project-test-project'));
 
-    const overview = screen.getByTestId('project-overview');
-    expect(overview).toHaveAttribute('data-project', 'test-project');
-    expect(overview).toHaveAttribute('data-features', 'PAN-821');
-    expect(overview).toHaveAttribute('data-cost', '12.34');
-    expect(overview).toHaveAttribute('data-model-cost', '7.89');
-    expect(overview).toHaveAttribute('data-stage-cost', '4.45');
+    const lens = screen.getByTestId('project-lens');
+    expect(lens).toHaveAttribute('data-project', 'test-project');
+    expect(lens).toHaveAttribute('data-features', 'PAN-821');
+    expect(lens).toHaveAttribute('data-cost', '12.34');
+    expect(lens).toHaveAttribute('data-model-cost', '7.89');
+    expect(lens).toHaveAttribute('data-stage-cost', '4.45');
     expect(screen.queryByTestId('conversation-panel')).not.toBeInTheDocument();
     expect(screen.queryByTestId('issue-workbench')).not.toBeInTheDocument();
   });

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectLens.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectLens.tsx
@@ -1,0 +1,513 @@
+/**
+ * ProjectLens — tabbed per-project lens for the Command Deck right pane.
+ *
+ * Replaces ProjectOverview with a tabbed interface:
+ *   Pipeline  → project-filtered IssueRow list grouped by phase
+ *   Plans     → OverviewTab for the active issue
+ *   Beads     → BeadsTab for the active issue
+ *   Conversations → DiscussionsTab for the active issue
+ *   Activity  → ActivityTab for the active issue
+ *   Settings  → CostsTab for the active issue
+ *
+ * Tab selection persists in localStorage scoped per-project.
+ * Clicking an IssueRow in Pipeline sets the active issue for the detail tabs.
+ */
+
+import { useState, useMemo, useCallback } from 'react';
+import type { Agent, Issue } from '../../types';
+import { useDashboardStore } from '../../lib/store';
+import type { ReviewStatusSnapshot } from '@panctl/contracts';
+import type { ProjectFeature } from './ProjectTree/ProjectNode';
+import type { IssueCostBreakdown } from './ProjectOverview';
+import IssueRow from '../primitives/IssueRow';
+import VerbBadge from '../primitives/VerbBadge';
+import PhaseHeader from '../primitives/PhaseHeader';
+import { OverviewTab } from './ZoneCOverviewTabs/OverviewTab';
+import { BeadsTab } from './ZoneCOverviewTabs/BeadsTab';
+import { ActivityTab } from './ZoneCOverviewTabs/ActivityTab';
+import { CostsTab } from './ZoneCOverviewTabs/CostsTab';
+import { DiscussionsTab } from './ZoneCOverviewTabs/DiscussionsTab';
+
+export type ProjectLensTab = 'pipeline' | 'plans' | 'beads' | 'conversations' | 'activity' | 'settings';
+
+interface ProjectLensProps {
+  projectName: string;
+  features: ProjectFeature[];
+  issueCosts: Record<string, number>;
+  issueCostDetails?: Record<string, IssueCostBreakdown>;
+  onSelectFeature?: (feature: ProjectFeature) => void;
+  /** Full issue records for priority/assignee/labels lookup */
+  issues?: Issue[];
+  /** Agents for the active issue overview tab */
+  agents?: Agent[];
+}
+
+const TAB_SPECS: readonly { key: ProjectLensTab; label: string }[] = [
+  { key: 'pipeline', label: 'Pipeline' },
+  { key: 'plans', label: 'Plans' },
+  { key: 'beads', label: 'Beads' },
+  { key: 'conversations', label: 'Conversations' },
+  { key: 'activity', label: 'Activity' },
+  { key: 'settings', label: 'Settings' },
+];
+
+const PHASE_ORDER: readonly ('ship' | 'review' | 'work' | 'plan' | 'todo')[] = [
+  'ship',
+  'review',
+  'work',
+  'plan',
+  'todo',
+];
+
+function tabStorageKey(projectName: string): string {
+  return `project-lens-tab-${projectName}`;
+}
+
+function activeIssueStorageKey(projectName: string): string {
+  return `project-lens-issue-${projectName}`;
+}
+
+function readStoredTab(projectName: string): ProjectLensTab {
+  try {
+    const raw = localStorage.getItem(tabStorageKey(projectName));
+    if (raw && TAB_SPECS.some((t) => t.key === raw)) return raw as ProjectLensTab;
+  } catch { /* ignore */ }
+  return 'pipeline';
+}
+
+function writeStoredTab(projectName: string, tab: ProjectLensTab) {
+  try {
+    localStorage.setItem(tabStorageKey(projectName), tab);
+  } catch { /* ignore */ }
+}
+
+function readStoredActiveIssue(projectName: string): string | null {
+  try {
+    return localStorage.getItem(activeIssueStorageKey(projectName));
+  } catch { return null; }
+}
+
+function writeStoredActiveIssue(projectName: string, issueId: string | null) {
+  try {
+    if (issueId) localStorage.setItem(activeIssueStorageKey(projectName), issueId);
+    else localStorage.removeItem(activeIssueStorageKey(projectName));
+  } catch { /* ignore */ }
+}
+
+// ── Phase classification ────────────────────────────────────────────────────
+
+type NaturalPhase = 'ship' | 'review' | 'work' | 'plan' | 'todo';
+
+const MERGING_STATUSES = new Set(['queued', 'merging', 'verifying']);
+const REVIEW_STUCK_STATUSES = new Set(['failed', 'blocked']);
+const TEST_STUCK_STATUSES = new Set(['failed', 'dispatch_failed']);
+const MERGE_STUCK_STATUSES = new Set(['failed']);
+const VERIFICATION_STUCK_STATUSES = new Set(['failed']);
+const ACTIVE_AGENT_STATUSES = new Set(['active', 'running', 'starting']);
+
+function hasActiveWorkSession(feature: ProjectFeature): boolean {
+  return feature.sessions?.some((s) => s.type === 'work' && s.presence === 'active') ?? false;
+}
+
+function hasActiveAgentSignal(feature: ProjectFeature): boolean {
+  return hasActiveWorkSession(feature) || ACTIVE_AGENT_STATUSES.has(feature.agentStatus ?? '');
+}
+
+function classifyPhase(feature: ProjectFeature, reviewStatus: ReviewStatusSnapshot | undefined): { phase: NaturalPhase; isStuck: boolean } {
+  const isStuck =
+    reviewStatus?.stuck === true ||
+    REVIEW_STUCK_STATUSES.has(reviewStatus?.reviewStatus ?? '') ||
+    TEST_STUCK_STATUSES.has(reviewStatus?.testStatus ?? '') ||
+    MERGE_STUCK_STATUSES.has(reviewStatus?.mergeStatus ?? '') ||
+    VERIFICATION_STUCK_STATUSES.has(reviewStatus?.verificationStatus ?? '') ||
+    (reviewStatus?.blockerReasons != null && reviewStatus.blockerReasons.length > 0);
+
+  if (reviewStatus?.mergeStatus && MERGING_STATUSES.has(reviewStatus.mergeStatus)) {
+    return { phase: 'ship', isStuck };
+  }
+  if (reviewStatus?.readyForMerge && (!reviewStatus.blockerReasons || reviewStatus.blockerReasons.length === 0)) {
+    return { phase: 'ship', isStuck };
+  }
+  if (reviewStatus?.testStatus === 'testing') {
+    return { phase: 'review', isStuck };
+  }
+  if (reviewStatus?.reviewStatus === 'reviewing') {
+    return { phase: 'review', isStuck };
+  }
+  if (reviewStatus?.verificationStatus === 'running') {
+    return { phase: 'review', isStuck };
+  }
+  if (hasActiveAgentSignal(feature) && !reviewStatus) {
+    return { phase: 'work', isStuck };
+  }
+  if (feature.hasPlanning && !feature.sessions?.some((s) => s.type === 'work')) {
+    return { phase: 'plan', isStuck };
+  }
+  return { phase: 'todo', isStuck };
+}
+
+// ── Verb badge derivation ───────────────────────────────────────────────────
+
+function deriveVerbBadge(feature: ProjectFeature, reviewStatus: ReviewStatusSnapshot | undefined): React.ReactNode {
+  if (reviewStatus?.stuck === true) {
+    const hours = computeStuckHours(reviewStatus);
+    return <VerbBadge variant="STUCK · Nh" hours={hours} />;
+  }
+  if (REVIEW_STUCK_STATUSES.has(reviewStatus?.reviewStatus ?? '')) {
+    const hours = computeStuckHours(reviewStatus);
+    return <VerbBadge variant="STUCK · Nh" hours={hours} />;
+  }
+  if (TEST_STUCK_STATUSES.has(reviewStatus?.testStatus ?? '')) {
+    const hours = computeStuckHours(reviewStatus);
+    return <VerbBadge variant="STUCK · Nh" hours={hours} />;
+  }
+  if (MERGE_STUCK_STATUSES.has(reviewStatus?.mergeStatus ?? '')) {
+    const hours = computeStuckHours(reviewStatus);
+    return <VerbBadge variant="STUCK · Nh" hours={hours} />;
+  }
+  if (VERIFICATION_STUCK_STATUSES.has(reviewStatus?.verificationStatus ?? '')) {
+    const hours = computeStuckHours(reviewStatus);
+    return <VerbBadge variant="STUCK · Nh" hours={hours} />;
+  }
+  if (reviewStatus?.mergeStatus && MERGING_STATUSES.has(reviewStatus.mergeStatus)) {
+    return <VerbBadge variant="SHIP RUNNING" />;
+  }
+  if (reviewStatus?.readyForMerge) {
+    return <VerbBadge variant="READY TO MERGE" />;
+  }
+  if (reviewStatus?.testStatus === 'testing') {
+    return <VerbBadge variant="REVIEW RUNNING" />;
+  }
+  if (reviewStatus?.reviewStatus === 'reviewing') {
+    return <VerbBadge variant="REVIEW RUNNING" />;
+  }
+  if (reviewStatus?.verificationStatus === 'running') {
+    return <VerbBadge variant="REVIEW RUNNING" />;
+  }
+  if (hasActiveAgentSignal(feature)) {
+    return <VerbBadge variant="WORK RUNNING" />;
+  }
+  if (feature.hasPlanning && !feature.sessions?.some((s) => s.type === 'work')) {
+    return <VerbBadge variant="PLANNING" />;
+  }
+  if (feature.status === 'closed' || feature.status === 'merged') {
+    return <VerbBadge variant="MERGED" />;
+  }
+  return null;
+}
+
+function computeStuckHours(reviewStatus: ReviewStatusSnapshot | undefined): number {
+  const ref = reviewStatus?.stuckAt ?? reviewStatus?.updatedAt;
+  if (!ref) return 0;
+  const ms = Date.now() - Date.parse(ref);
+  if (!Number.isFinite(ms) || ms < 0) return 0;
+  return Math.max(0, Math.round(ms / 3_600_000));
+}
+
+// ── Priority mapping ────────────────────────────────────────────────────────
+
+function mapPriority(priorityNum: number | undefined): 'urgent' | 'high' | 'medium' | 'low' {
+  if (priorityNum === 1) return 'urgent';
+  if (priorityNum === 2) return 'high';
+  if (priorityNum === 3) return 'medium';
+  return 'low';
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+export function ProjectLens({
+  projectName,
+  features,
+  issueCosts,
+  issueCostDetails,
+  onSelectFeature,
+  issues = [],
+  agents = [],
+}: ProjectLensProps) {
+  const [activeTab, setActiveTab] = useState<ProjectLensTab>(() => readStoredTab(projectName));
+  const [activeIssueId, setActiveIssueId] = useState<string | null>(() => {
+    const stored = readStoredActiveIssue(projectName);
+    // Only use stored if it exists in current features
+    return stored && features.some((f) => f.issueId === stored) ? stored : null;
+  });
+
+  const reviewStatusByIssueId = useDashboardStore((state) => state.reviewStatusByIssueId);
+
+  const issueMap = useMemo(() => {
+    const map = new Map<string, Issue>();
+    for (const issue of issues) {
+      if (issue.identifier) {
+        map.set(issue.identifier, issue);
+        map.set(issue.identifier.toLowerCase(), issue);
+      }
+    }
+    return map;
+  }, [issues]);
+
+  const handleTabChange = useCallback(
+    (tab: ProjectLensTab) => {
+      setActiveTab(tab);
+      writeStoredTab(projectName, tab);
+    },
+    [projectName],
+  );
+
+  const handleIssueClick = useCallback(
+    (issueId: string) => {
+      setActiveIssueId(issueId);
+      writeStoredActiveIssue(projectName, issueId);
+      // If the user is clicking an issue, also switch to Plans tab for detail viewing
+      setActiveTab((prev) => {
+        if (prev === 'pipeline') {
+          writeStoredTab(projectName, 'plans');
+          return 'plans';
+        }
+        return prev;
+      });
+    },
+    [projectName],
+  );
+
+  // Build phase buckets
+  const phaseBuckets = useMemo(() => {
+    const buckets: Record<NaturalPhase, Array<{ feature: ProjectFeature; reviewStatus: ReviewStatusSnapshot | undefined }>> = {
+      ship: [],
+      review: [],
+      work: [],
+      plan: [],
+      todo: [],
+    };
+
+    for (const feature of features) {
+      const reviewStatus = reviewStatusByIssueId[feature.issueId];
+      const { phase } = classifyPhase(feature, reviewStatus);
+      buckets[phase].push({ feature, reviewStatus });
+    }
+
+    // Sort each bucket by priority desc, then updatedAt desc
+    for (const phase of PHASE_ORDER) {
+      buckets[phase].sort((a, b) => {
+        const issueA = issueMap.get(a.feature.issueId) ?? issueMap.get(a.feature.issueId.toLowerCase());
+        const issueB = issueMap.get(b.feature.issueId) ?? issueMap.get(b.feature.issueId.toLowerCase());
+        const prioA = issueA?.priority ?? 999;
+        const prioB = issueB?.priority ?? 999;
+        if (prioA !== prioB) return prioA - prioB;
+        const updatedA = issueA?.updatedAt ?? '';
+        const updatedB = issueB?.updatedAt ?? '';
+        return updatedB.localeCompare(updatedA);
+      });
+    }
+
+    return buckets;
+  }, [features, reviewStatusByIssueId, issueMap]);
+
+  // Resolve active issue for detail tabs
+  const activeIssue = useMemo(() => {
+    if (activeIssueId) {
+      const found = issueMap.get(activeIssueId) ?? issueMap.get(activeIssueId.toLowerCase());
+      if (found) return found;
+    }
+    // Default to first feature's issue
+    if (features.length > 0) {
+      const first = features[0];
+      return issueMap.get(first.issueId) ?? issueMap.get(first.issueId.toLowerCase());
+    }
+    return null;
+  }, [activeIssueId, features, issueMap]);
+
+  const activeIssueAgent = useMemo(() => {
+    if (!activeIssue) return undefined;
+    const key = activeIssue.identifier.toLowerCase();
+    return agents.find((a) => a.issueId?.toLowerCase() === key && a.id.startsWith('agent-'))
+      ?? agents.find((a) => a.issueId?.toLowerCase() === key);
+  }, [activeIssue, agents]);
+
+  const activeIssueIdForTabs = activeIssue?.identifier ?? '';
+
+  return (
+    <div
+      data-testid="project-lens"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        flex: 1,
+        minHeight: 0,
+        background: 'var(--background)',
+      }}
+    >
+      {/* Tab strip */}
+      <div
+        role="tablist"
+        aria-label={`${projectName} project lens tabs`}
+        style={{
+          display: 'flex',
+          gap: 4,
+          padding: '6px 12px',
+          borderBottom: '1px solid var(--border)',
+          overflowX: 'auto',
+          flexShrink: 0,
+        }}
+      >
+        {TAB_SPECS.map((spec) => {
+          const active = spec.key === activeTab;
+          return (
+            <button
+              key={spec.key}
+              role="tab"
+              aria-selected={active}
+              data-testid={`project-lens-tab-${spec.key}`}
+              onClick={() => handleTabChange(spec.key)}
+              style={{
+                padding: '4px 10px',
+                fontSize: 12,
+                fontWeight: active ? 600 : 500,
+                color: active ? 'var(--foreground)' : 'var(--muted-foreground)',
+                background: active
+                  ? 'color-mix(in srgb, var(--primary) 8%, transparent)'
+                  : 'transparent',
+                border: '1px solid',
+                borderColor: active
+                  ? 'color-mix(in srgb, var(--primary) 32%, transparent)'
+                  : 'transparent',
+                borderRadius: 6,
+                cursor: 'pointer',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {spec.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Tab content */}
+      <div
+        role="tabpanel"
+        data-testid={`project-lens-panel-${activeTab}`}
+        style={{
+          flex: 1,
+          minHeight: 0,
+          overflow: 'auto',
+        }}
+      >
+        {activeTab === 'pipeline' && (
+          <div data-testid="project-lens-pipeline" style={{ display: 'flex', flexDirection: 'column' }}>
+            {PHASE_ORDER.map((phase) => {
+              const entries = phaseBuckets[phase];
+              return (
+                <div key={phase} data-testid={`project-lens-phase-${phase}`}>
+                  <PhaseHeader
+                    phase={phase}
+                    count={entries.length}
+                    variant="command-deck"
+                  />
+                  {entries.length === 0 ? (
+                    <div
+                      style={{
+                        padding: '12px 22px',
+                        fontSize: 12,
+                        color: 'var(--muted-foreground)',
+                        fontStyle: 'italic',
+                      }}
+                    >
+                      No issues
+                    </div>
+                  ) : (
+                    entries.map(({ feature, reviewStatus }) => {
+                      const issue = issueMap.get(feature.issueId) ?? issueMap.get(feature.issueId.toLowerCase());
+                      const priority = mapPriority(issue?.priority);
+                      const { phase: naturalPhase } = classifyPhase(feature, reviewStatus);
+                      const verbBadge = deriveVerbBadge(feature, reviewStatus);
+                      const cost = issueCosts[feature.issueId] ?? issueCosts[feature.issueId.toLowerCase()] ?? 0;
+                      const costDetail = issueCostDetails?.[feature.issueId] ?? issueCostDetails?.[feature.issueId.toLowerCase()];
+                      const runtime = deriveRuntime(feature, reviewStatus);
+
+                      return (
+                        <IssueRow
+                          key={feature.issueId}
+                          issueId={feature.issueId}
+                          phase={naturalPhase === 'todo' ? 'todo' : naturalPhase}
+                          priority={priority}
+                          title={feature.title}
+                          labels={issue?.labels?.map((l) => l) ?? []}
+                          verbBadge={verbBadge}
+                          ledger={{
+                            runtime,
+                            cost: cost > 0 ? `$${cost.toFixed(2)}` : '—',
+                          }}
+                          assignee={issue?.assignee ? { name: issue.assignee.name } : undefined}
+                          variant="command-deck"
+                          onOpen={handleIssueClick}
+                        />
+                      );
+                    })
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {activeTab === 'plans' && activeIssueIdForTabs && (
+          <OverviewTab
+            issueId={activeIssueIdForTabs}
+            agent={activeIssueAgent}
+            issue={activeIssue ?? undefined}
+          />
+        )}
+
+        {activeTab === 'beads' && activeIssueIdForTabs && (
+          <BeadsTab issueId={activeIssueIdForTabs} />
+        )}
+
+        {activeTab === 'conversations' && activeIssueIdForTabs && (
+          <DiscussionsTab issueId={activeIssueIdForTabs} />
+        )}
+
+        {activeTab === 'activity' && activeIssueIdForTabs && (
+          <ActivityTab issueId={activeIssueIdForTabs} />
+        )}
+
+        {activeTab === 'settings' && activeIssueIdForTabs && (
+          <CostsTab issueId={activeIssueIdForTabs} />
+        )}
+
+        {activeTab !== 'pipeline' && !activeIssueIdForTabs && (
+          <div
+            data-testid="project-lens-no-issue"
+            style={{
+              padding: 40,
+              textAlign: 'center',
+              fontSize: 13,
+              color: 'var(--muted-foreground)',
+            }}
+          >
+            No issues in this project.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function deriveRuntime(feature: ProjectFeature, reviewStatus: ReviewStatusSnapshot | undefined): string {
+  // Prefer active work session startedAt
+  const activeWork = feature.sessions?.find((s) => s.type === 'work' && s.presence === 'active');
+  if (activeWork?.startedAt) {
+    return formatRuntime(activeWork.startedAt);
+  }
+  // Fall back to reviewStatus updatedAt for in-flight review/merge
+  if (reviewStatus?.updatedAt) {
+    return formatRuntime(reviewStatus.updatedAt);
+  }
+  return '—';
+}
+
+function formatRuntime(startedAt: string): string {
+  const ms = Date.now() - Date.parse(startedAt);
+  if (!Number.isFinite(ms) || ms < 0) return '—';
+  const hours = Math.floor(ms / 3_600_000);
+  const mins = Math.floor((ms % 3_600_000) / 60_000);
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectLens.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectLens.tsx
@@ -36,6 +36,8 @@ interface ProjectLensProps {
   issueCosts: Record<string, number>;
   issueCostDetails?: Record<string, IssueCostBreakdown>;
   onSelectFeature?: (feature: ProjectFeature) => void;
+  /** Called when a Pipeline IssueRow is clicked to open the drawer overlay */
+  onOpenIssue?: (issueId: string) => void;
   /** Full issue records for priority/assignee/labels lookup */
   issues?: Issue[];
   /** Agents for the active issue overview tab */
@@ -221,6 +223,7 @@ export function ProjectLens({
   issueCosts,
   issueCostDetails,
   onSelectFeature,
+  onOpenIssue,
   issues = [],
   agents = [],
 }: ProjectLensProps) {
@@ -254,6 +257,10 @@ export function ProjectLens({
 
   const handleIssueClick = useCallback(
     (issueId: string) => {
+      if (onOpenIssue) {
+        onOpenIssue(issueId);
+        return;
+      }
       setActiveIssueId(issueId);
       writeStoredActiveIssue(projectName, issueId);
       // If the user is clicking an issue, also switch to Plans tab for detail viewing
@@ -265,7 +272,7 @@ export function ProjectLens({
         return prev;
       });
     },
-    [projectName],
+    [projectName, onOpenIssue],
   );
 
   // Build phase buckets

--- a/src/dashboard/frontend/src/components/CommandDeck/__tests__/ProjectLens.test.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/__tests__/ProjectLens.test.tsx
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ProjectLens, type ProjectLensTab } from '../ProjectLens';
+import type { ProjectFeature } from '../ProjectTree/ProjectNode';
+import type { Issue } from '../../../types';
+
+vi.mock('../../../lib/store', () => ({
+  useDashboardStore: vi.fn((selector: any) =>
+    selector({ reviewStatusByIssueId: {} }),
+  ),
+}));
+
+vi.mock('../ZoneCOverviewTabs/OverviewTab', () => ({
+  OverviewTab: ({ issueId }: { issueId: string }) => (
+    <div data-testid="overview-tab" data-issue={issueId} />
+  ),
+}));
+
+vi.mock('../ZoneCOverviewTabs/BeadsTab', () => ({
+  BeadsTab: ({ issueId }: { issueId: string }) => (
+    <div data-testid="beads-tab" data-issue={issueId} />
+  ),
+}));
+
+vi.mock('../ZoneCOverviewTabs/ActivityTab', () => ({
+  ActivityTab: ({ issueId }: { issueId: string }) => (
+    <div data-testid="activity-tab" data-issue={issueId} />
+  ),
+}));
+
+vi.mock('../ZoneCOverviewTabs/CostsTab', () => ({
+  CostsTab: ({ issueId }: { issueId: string }) => (
+    <div data-testid="costs-tab" data-issue={issueId} />
+  ),
+}));
+
+vi.mock('../ZoneCOverviewTabs/DiscussionsTab', () => ({
+  DiscussionsTab: ({ issueId }: { issueId: string }) => (
+    <div data-testid="discussions-tab" data-issue={issueId} />
+  ),
+}));
+
+function renderLens(props: Partial<React.ComponentProps<typeof ProjectLens>> = {}) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const defaultFeatures: ProjectFeature[] = [
+    {
+      issueId: 'PAN-1',
+      title: 'Feature One',
+      projectName: 'test-project',
+      branch: 'feature/pan-1',
+      status: 'open',
+      stateLabel: 'In Progress',
+      agentStatus: 'running',
+      hasPlanning: true,
+      hasPrd: true,
+      hasState: false,
+      isShadow: false,
+      sessions: [{ type: 'work', presence: 'active', sessionId: 'agent-1', model: 'claude-sonnet', startedAt: '2026-05-18T00:00:00Z', status: 'running', duration: null }],
+    },
+    {
+      issueId: 'PAN-2',
+      title: 'Feature Two',
+      projectName: 'test-project',
+      branch: 'feature/pan-2',
+      status: 'open',
+      stateLabel: 'Planning',
+      agentStatus: null,
+      hasPlanning: true,
+      hasPrd: false,
+      hasState: false,
+      isShadow: false,
+      sessions: [],
+    },
+    {
+      issueId: 'PAN-3',
+      title: 'Feature Three',
+      projectName: 'test-project',
+      branch: 'feature/pan-3',
+      status: 'open',
+      stateLabel: 'Done',
+      agentStatus: null,
+      hasPlanning: false,
+      hasPrd: false,
+      hasState: false,
+      isShadow: false,
+      sessions: [],
+      readyForMerge: true,
+    },
+  ];
+
+  const defaultIssues: Issue[] = [
+    {
+      id: '1',
+      identifier: 'PAN-1',
+      title: 'Feature One',
+      status: 'open',
+      priority: 1,
+      labels: ['bug'],
+      url: '',
+      createdAt: '2026-05-18T00:00:00Z',
+      updatedAt: '2026-05-18T10:00:00Z',
+    },
+    {
+      id: '2',
+      identifier: 'PAN-2',
+      title: 'Feature Two',
+      status: 'open',
+      priority: 3,
+      labels: [],
+      url: '',
+      createdAt: '2026-05-18T00:00:00Z',
+      updatedAt: '2026-05-18T08:00:00Z',
+    },
+    {
+      id: '3',
+      identifier: 'PAN-3',
+      title: 'Feature Three',
+      status: 'open',
+      priority: 2,
+      labels: ['enhancement'],
+      url: '',
+      createdAt: '2026-05-18T00:00:00Z',
+      updatedAt: '2026-05-18T09:00:00Z',
+    },
+  ];
+
+  return render(
+    <QueryClientProvider client={client}>
+      <ProjectLens
+        projectName="test-project"
+        features={defaultFeatures}
+        issueCosts={{ 'PAN-1': 1.23 }}
+        issues={defaultIssues}
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe('ProjectLens', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders the tab strip with all 6 tabs', () => {
+    renderLens();
+    expect(screen.getByRole('tab', { name: /Pipeline/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Plans/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Beads/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Conversations/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Activity/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Settings/i })).toBeInTheDocument();
+  });
+
+  it('defaults to Pipeline tab', () => {
+    renderLens();
+    expect(screen.getByTestId('project-lens-panel-pipeline')).toBeInTheDocument();
+    expect(screen.getByTestId('project-lens-phase-work')).toBeInTheDocument();
+    expect(screen.getByTestId('project-lens-phase-ship')).toBeInTheDocument();
+    expect(screen.getByTestId('project-lens-phase-plan')).toBeInTheDocument();
+    expect(screen.getByTestId('project-lens-phase-todo')).toBeInTheDocument();
+  });
+
+  it('renders IssueRow components in Pipeline tab grouped by phase', () => {
+    renderLens();
+
+    // PAN-1 has active work agent → work phase
+    const workRows = screen.getAllByTestId('project-lens-panel-pipeline')[0]?.querySelector('[data-phase="work"]');
+    expect(workRows).toBeTruthy();
+    expect(screen.getByText('Feature One')).toBeInTheDocument();
+
+    // PAN-3 is readyForMerge → ship phase
+    expect(screen.getByText('Feature Three')).toBeInTheDocument();
+
+    // PAN-2 has planning, no work session → plan phase
+    expect(screen.getByText('Feature Two')).toBeInTheDocument();
+  });
+
+  it('switches to Plans tab and renders OverviewTab for the default active issue', () => {
+    renderLens();
+    fireEvent.click(screen.getByRole('tab', { name: /Plans/i }));
+
+    expect(screen.getByTestId('overview-tab')).toBeInTheDocument();
+    // First feature (PAN-1) is default active issue
+    expect(screen.getByTestId('overview-tab')).toHaveAttribute('data-issue', 'PAN-1');
+  });
+
+  it('switches to Beads tab and renders BeadsTab', () => {
+    renderLens();
+    fireEvent.click(screen.getByRole('tab', { name: /Beads/i }));
+    expect(screen.getByTestId('beads-tab')).toBeInTheDocument();
+  });
+
+  it('switches to Conversations tab and renders DiscussionsTab', () => {
+    renderLens();
+    fireEvent.click(screen.getByRole('tab', { name: /Conversations/i }));
+    expect(screen.getByTestId('discussions-tab')).toBeInTheDocument();
+  });
+
+  it('switches to Activity tab and renders ActivityTab', () => {
+    renderLens();
+    fireEvent.click(screen.getByRole('tab', { name: /Activity/i }));
+    expect(screen.getByTestId('activity-tab')).toBeInTheDocument();
+  });
+
+  it('switches to Settings tab and renders CostsTab', () => {
+    renderLens();
+    fireEvent.click(screen.getByRole('tab', { name: /Settings/i }));
+    expect(screen.getByTestId('costs-tab')).toBeInTheDocument();
+  });
+
+  it('persists tab selection in localStorage per-project', () => {
+    renderLens();
+    fireEvent.click(screen.getByRole('tab', { name: /Activity/i }));
+
+    expect(localStorage.getItem('project-lens-tab-test-project')).toBe('activity');
+  });
+
+  it('restores tab from localStorage on mount', () => {
+    localStorage.setItem('project-lens-tab-test-project', 'settings');
+    renderLens();
+
+    expect(screen.getByTestId('costs-tab')).toBeInTheDocument();
+  });
+
+  it('clicking an IssueRow sets active issue and switches to Plans tab', () => {
+    renderLens();
+
+    // Find and click PAN-2 issue row
+    const pan2Row = screen.getAllByText('Feature Two')[0]?.closest('button');
+    expect(pan2Row).toBeTruthy();
+    fireEvent.click(pan2Row!);
+
+    // Should switch to Plans tab
+    expect(screen.getByTestId('overview-tab')).toBeInTheDocument();
+    expect(screen.getByTestId('overview-tab')).toHaveAttribute('data-issue', 'PAN-2');
+
+    // Should persist active issue
+    expect(localStorage.getItem('project-lens-issue-test-project')).toBe('PAN-2');
+  });
+
+  it('restores active issue from localStorage on mount', () => {
+    localStorage.setItem('project-lens-issue-test-project', 'PAN-3');
+    renderLens();
+
+    fireEvent.click(screen.getByRole('tab', { name: /Plans/i }));
+    expect(screen.getByTestId('overview-tab')).toHaveAttribute('data-issue', 'PAN-3');
+  });
+
+  it('shows empty state for all phases when no features', () => {
+    renderLens({ features: [] });
+    PHASE_ORDER.forEach((phase) => {
+      expect(screen.getByTestId(`project-lens-phase-${phase}`)).toHaveTextContent(/No issues/i);
+    });
+  });
+
+  it('shows no-issue placeholder when detail tab has no active issue and project is empty', () => {
+    renderLens({ features: [] });
+    fireEvent.click(screen.getByRole('tab', { name: /Plans/i }));
+    expect(screen.getByTestId('project-lens-no-issue')).toBeInTheDocument();
+  });
+});
+
+const PHASE_ORDER = ['ship', 'review', 'work', 'plan', 'todo'] as const;

--- a/src/dashboard/frontend/src/components/CommandDeck/__tests__/ProjectLens.test.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/__tests__/ProjectLens.test.tsx
@@ -260,6 +260,29 @@ describe('ProjectLens', () => {
     fireEvent.click(screen.getByRole('tab', { name: /Plans/i }));
     expect(screen.getByTestId('project-lens-no-issue')).toBeInTheDocument();
   });
+
+  it('calls onOpenIssue when IssueRow is clicked and prop is provided', () => {
+    const onOpenIssue = vi.fn();
+    renderLens({ onOpenIssue });
+
+    const pan2Row = screen.getAllByText('Feature Two')[0]?.closest('button');
+    expect(pan2Row).toBeTruthy();
+    fireEvent.click(pan2Row!);
+
+    expect(onOpenIssue).toHaveBeenCalledWith('PAN-2');
+    // Should NOT switch to Plans tab when onOpenIssue is provided
+    expect(screen.queryByTestId('overview-tab')).not.toBeInTheDocument();
+  });
+
+  it('falls back to Plans tab when IssueRow is clicked without onOpenIssue', () => {
+    renderLens();
+
+    const pan2Row = screen.getAllByText('Feature Two')[0]?.closest('button');
+    expect(pan2Row).toBeTruthy();
+    fireEvent.click(pan2Row!);
+
+    expect(screen.getByTestId('overview-tab')).toBeInTheDocument();
+  });
 });
 
 const PHASE_ORDER = ['ship', 'review', 'work', 'plan', 'todo'] as const;

--- a/src/dashboard/frontend/src/components/CommandDeck/index.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/index.tsx
@@ -4,7 +4,8 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Compass, Plus, ChevronDown, ChevronRight } from 'lucide-react';
 import { ProjectNode, ProjectFeature } from './ProjectTree/ProjectNode';
 import { sessionMatchesFilter, type TreeSessionFilter } from './ProjectTree/FeatureItem';
-import { ProjectOverview, type IssueCostBreakdown } from './ProjectOverview';
+import { ProjectLens } from './ProjectLens';
+import type { IssueCostBreakdown } from './ProjectOverview';
 import { DeaconStatus } from './DeaconStatus';
 import { IssueWorkbench } from './IssueWorkbench';
 import { BeadsDialog } from '../BeadsDialog';
@@ -1200,12 +1201,14 @@ export function CommandDeck({
               issue={selectedIssue ?? undefined}
             />
           ) : selectedProject ? (
-            <ProjectOverview
+            <ProjectLens
               projectName={selectedProject}
               features={selectedProjectData?.features ?? []}
               issueCosts={issueCosts}
               issueCostDetails={issueCostDetails}
               onSelectFeature={(feature) => handleSelectFeature(feature.issueId)}
+              issues={issues}
+              agents={agents}
             />
           ) : (
             <div className={styles.contentEmpty}>

--- a/src/dashboard/frontend/src/components/CommandDeck/index.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/index.tsx
@@ -6,6 +6,8 @@ import { ProjectNode, ProjectFeature } from './ProjectTree/ProjectNode';
 import { sessionMatchesFilter, type TreeSessionFilter } from './ProjectTree/FeatureItem';
 import { ProjectLens } from './ProjectLens';
 import type { IssueCostBreakdown } from './ProjectOverview';
+import { IssueDrawer } from '../drawer/IssueDrawer';
+import { useDrawerUrlSync } from '../drawer/useDrawerUrlSync';
 import { DeaconStatus } from './DeaconStatus';
 import { IssueWorkbench } from './IssueWorkbench';
 import { BeadsDialog } from '../BeadsDialog';
@@ -242,6 +244,10 @@ export function CommandDeck({
   const [treeFilter, setTreeFilter] = useState<TreeSessionFilter>('all');
   const [sidebarModel, setSidebarModel] = useState<string>(loadStoredModel);
   const [sidebarHarness, setSidebarHarness] = useState<Harness>(loadStoredHarness);
+
+  // Drawer overlay sync (PAN-1148)
+  useDrawerUrlSync();
+  const openDrawerIssue = useDashboardStore((s) => s.openDrawerIssue);
 
   // Per-issue session selection (PAN-830 pan-11sr) — slice keyed by issueId.
   // The tree highlight uses the value for whichever feature is currently active.
@@ -1207,6 +1213,7 @@ export function CommandDeck({
               issueCosts={issueCosts}
               issueCostDetails={issueCostDetails}
               onSelectFeature={(feature) => handleSelectFeature(feature.issueId)}
+              onOpenIssue={openDrawerIssue}
               issues={issues}
               agents={agents}
             />
@@ -1241,6 +1248,9 @@ export function CommandDeck({
           }}
         />
       )}
+
+      {/* Issue Detail Drawer (PAN-1148) */}
+      <IssueDrawer />
     </div>
   );
 }

--- a/src/dashboard/frontend/src/components/drawer/IssueDrawer.tsx
+++ b/src/dashboard/frontend/src/components/drawer/IssueDrawer.tsx
@@ -1,0 +1,155 @@
+/**
+ * IssueDrawer — slide-out issue detail overlay (PAN-1148)
+ *
+ * Single-instance drawer pinned to the right edge.
+ * Opening a new issue while one is open replaces the prior one (no stacking).
+ */
+
+import { useEffect, useCallback } from 'react';
+import { useDashboardStore } from '../../lib/store';
+
+export function IssueDrawer() {
+  const issueId = useDashboardStore((s) => s.drawerIssueId);
+  const closeDrawer = useDashboardStore((s) => s.closeDrawerIssue);
+
+  const handleClose = useCallback(() => {
+    closeDrawer();
+  }, [closeDrawer]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!issueId) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') handleClose();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [issueId, handleClose]);
+
+  // Lock body scroll while drawer is open
+  useEffect(() => {
+    if (!issueId) return;
+    const original = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = original;
+    };
+  }, [issueId]);
+
+  if (!issueId) return null;
+
+  return (
+    <div
+      data-testid="issue-drawer"
+      data-drawer-open="true"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 100,
+        display: 'flex',
+        justifyContent: 'flex-end',
+      }}
+    >
+      {/* Scrim */}
+      <div
+        data-testid="issue-drawer-scrim"
+        onClick={handleClose}
+        style={{
+          position: 'absolute',
+          inset: 0,
+          background: 'rgba(0,0,0,0.25)',
+          backdropFilter: 'blur(2px)',
+        }}
+      />
+
+      {/* Drawer panel */}
+      <div
+        data-testid="issue-drawer-panel"
+        style={{
+          position: 'relative',
+          width: '100%',
+          maxWidth: 'min(980px, calc(100vw - 48px))',
+          height: '100%',
+          background: 'var(--background)',
+          borderLeft: '1px solid var(--border)',
+          boxShadow: '-24px 0 64px rgba(0,0,0,0.4)',
+          display: 'flex',
+          flexDirection: 'column',
+          animation: 'issueDrawerSlideIn 200ms ease-in-out',
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '12px 16px',
+            borderBottom: '1px solid var(--border)',
+            flexShrink: 0,
+          }}
+        >
+          <span
+            style={{
+              fontSize: 14,
+              fontWeight: 600,
+              fontFamily: 'var(--font-mono, monospace)',
+            }}
+          >
+            {issueId}
+          </span>
+          <button
+            data-testid="issue-drawer-close"
+            onClick={handleClose}
+            aria-label="Close drawer"
+            style={{
+              background: 'transparent',
+              border: 'none',
+              cursor: 'pointer',
+              fontSize: 18,
+              color: 'var(--muted-foreground)',
+              lineHeight: 1,
+              padding: 4,
+            }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Content placeholder — detail tabs wired by future beads */}
+        <div
+          style={{
+            flex: 1,
+            minHeight: 0,
+            overflow: 'auto',
+            padding: 16,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 13,
+              color: 'var(--muted-foreground)',
+              textAlign: 'center',
+              marginTop: 40,
+            }}
+          >
+            Issue detail for {issueId}
+          </div>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes issueDrawerSlideIn {
+          from {
+            transform: translateX(100%);
+            opacity: 0;
+          }
+          to {
+            transform: translateX(0);
+            opacity: 1;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/dashboard/frontend/src/components/drawer/__tests__/IssueDrawer.test.tsx
+++ b/src/dashboard/frontend/src/components/drawer/__tests__/IssueDrawer.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { IssueDrawer } from '../IssueDrawer';
+import { useDashboardStore } from '../../../lib/store';
+
+vi.mock('../../../lib/store', () => ({
+  useDashboardStore: vi.fn(),
+}));
+
+function mockStore(state: Partial<ReturnType<typeof useDashboardStore.getState>>) {
+  (useDashboardStore as unknown as vi.Mock).mockImplementation((selector: any) =>
+    selector({
+      drawerIssueId: null,
+      drawerTab: 'overview',
+      closeDrawerIssue: vi.fn(),
+      ...state,
+    }),
+  );
+}
+
+describe('IssueDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('renders nothing when drawer is closed', () => {
+    mockStore({ drawerIssueId: null });
+    render(<IssueDrawer />);
+    expect(screen.queryByTestId('issue-drawer')).not.toBeInTheDocument();
+  });
+
+  it('renders drawer panel when an issue is open', () => {
+    mockStore({ drawerIssueId: 'PAN-42' });
+    render(<IssueDrawer />);
+    expect(screen.getByTestId('issue-drawer')).toBeInTheDocument();
+    expect(screen.getByTestId('issue-drawer-panel')).toBeInTheDocument();
+    expect(screen.getByText('PAN-42')).toBeInTheDocument();
+  });
+
+  it('closes on scrim click', () => {
+    const closeDrawer = vi.fn();
+    mockStore({ drawerIssueId: 'PAN-42', closeDrawerIssue: closeDrawer });
+    render(<IssueDrawer />);
+    fireEvent.click(screen.getByTestId('issue-drawer-scrim'));
+    expect(closeDrawer).toHaveBeenCalled();
+  });
+
+  it('closes on X button click', () => {
+    const closeDrawer = vi.fn();
+    mockStore({ drawerIssueId: 'PAN-42', closeDrawerIssue: closeDrawer });
+    render(<IssueDrawer />);
+    fireEvent.click(screen.getByTestId('issue-drawer-close'));
+    expect(closeDrawer).toHaveBeenCalled();
+  });
+
+  it('closes on Escape key', () => {
+    const closeDrawer = vi.fn();
+    mockStore({ drawerIssueId: 'PAN-42', closeDrawerIssue: closeDrawer });
+    render(<IssueDrawer />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(closeDrawer).toHaveBeenCalled();
+  });
+});

--- a/src/dashboard/frontend/src/components/drawer/useDrawerUrlSync.ts
+++ b/src/dashboard/frontend/src/components/drawer/useDrawerUrlSync.ts
@@ -1,0 +1,62 @@
+/**
+ * useDrawerUrlSync — keeps drawer state in sync with URL search params.
+ *
+ * Opening sets `?issue=<id>&tab=<tab>` via history.replaceState.
+ * Closing removes both params.
+ * Initial load with `?issue=<id>` opens drawer on mount.
+ */
+
+import { useEffect, useRef } from 'react';
+import { useDashboardStore } from '../../lib/store';
+
+export function useDrawerUrlSync() {
+  const issueId = useDashboardStore((s) => s.drawerIssueId);
+  const drawerTab = useDashboardStore((s) => s.drawerTab);
+  const openDrawerIssue = useDashboardStore((s) => s.openDrawerIssue);
+  const closeDrawerIssue = useDashboardStore((s) => s.closeDrawerIssue);
+
+  const hasHydrated = useRef(false);
+
+  // Hydrate from URL on mount
+  useEffect(() => {
+    if (hasHydrated.current) return;
+    hasHydrated.current = true;
+    const params = new URLSearchParams(window.location.search);
+    const issueFromUrl = params.get('issue');
+    const tabFromUrl = params.get('tab');
+    if (issueFromUrl) {
+      openDrawerIssue(issueFromUrl, tabFromUrl ?? undefined);
+    }
+  }, [openDrawerIssue]);
+
+  // Sync drawer state → URL
+  useEffect(() => {
+    if (!hasHydrated.current) return;
+    const url = new URL(window.location.href);
+    if (issueId) {
+      url.searchParams.set('issue', issueId);
+      if (drawerTab && drawerTab !== 'overview') {
+        url.searchParams.set('tab', drawerTab);
+      } else {
+        url.searchParams.delete('tab');
+      }
+    } else {
+      url.searchParams.delete('issue');
+      url.searchParams.delete('tab');
+    }
+    window.history.replaceState(window.history.state, '', url);
+  }, [issueId, drawerTab]);
+
+  // Handle browser back/forward — close drawer when ?issue is removed
+  useEffect(() => {
+    const onPopState = () => {
+      const params = new URLSearchParams(window.location.search);
+      const issueFromUrl = params.get('issue');
+      if (!issueFromUrl) {
+        closeDrawerIssue();
+      }
+    };
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, [closeDrawerIssue]);
+}

--- a/src/dashboard/frontend/src/lib/__tests__/store-drawer.test.ts
+++ b/src/dashboard/frontend/src/lib/__tests__/store-drawer.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDashboardStore } from '../store';
+
+describe('DashboardStore drawer slice', () => {
+  beforeEach(() => {
+    // Reset store to initial state
+    const store = useDashboardStore.getState();
+    store.closeDrawerIssue();
+  });
+
+  it('opens an issue with default tab', () => {
+    const store = useDashboardStore.getState();
+    store.openDrawerIssue('PAN-1');
+    expect(useDashboardStore.getState().drawerIssueId).toBe('PAN-1');
+    expect(useDashboardStore.getState().drawerTab).toBe('overview');
+  });
+
+  it('opens an issue with explicit tab', () => {
+    const store = useDashboardStore.getState();
+    store.openDrawerIssue('PAN-1', 'activity');
+    expect(useDashboardStore.getState().drawerIssueId).toBe('PAN-1');
+    expect(useDashboardStore.getState().drawerTab).toBe('activity');
+  });
+
+  it('replaces prior issue when opening a new one (single-instance invariant)', () => {
+    const store = useDashboardStore.getState();
+    store.openDrawerIssue('PAN-A');
+    store.openDrawerIssue('PAN-B');
+    expect(useDashboardStore.getState().drawerIssueId).toBe('PAN-B');
+  });
+
+  it('closes the drawer', () => {
+    const store = useDashboardStore.getState();
+    store.openDrawerIssue('PAN-1');
+    store.closeDrawerIssue();
+    expect(useDashboardStore.getState().drawerIssueId).toBeNull();
+    expect(useDashboardStore.getState().drawerTab).toBe('overview');
+  });
+
+  it('survives rapid open→close→open burst without orphan state', () => {
+    const store = useDashboardStore.getState();
+    for (let i = 0; i < 50; i++) {
+      store.openDrawerIssue(`PAN-${i}`);
+      store.closeDrawerIssue();
+    }
+    const final = useDashboardStore.getState();
+    expect(final.drawerIssueId).toBeNull();
+    expect(final.drawerTab).toBe('overview');
+  });
+});

--- a/src/dashboard/frontend/src/lib/store.ts
+++ b/src/dashboard/frontend/src/lib/store.ts
@@ -37,6 +37,11 @@ export interface DashboardStore extends DashboardState {
   syncSnapshot(snapshot: DashboardSnapshot): void
   applyEvent(event: DomainEvent): void
   applyEvents(events: DomainEvent[]): void
+  /** Drawer issue detail overlay (PAN-1148) */
+  drawerIssueId: string | null
+  drawerTab: string
+  openDrawerIssue(issueId: string, tab?: string): void
+  closeDrawerIssue(): void
 }
 
 // ─── Initial state ────────────────────────────────────────────────────────────
@@ -45,6 +50,11 @@ const initialState: DashboardState = {
   ...INITIAL_READ_MODEL_STATE,
   bootstrapComplete: false,
   snapshotTimestamp: null,
+}
+
+const initialDrawerState = {
+  drawerIssueId: null as string | null,
+  drawerTab: 'overview' as string,
 }
 
 // ─── Thin wrappers over shared reducers (add bootstrapComplete flag) ─────────
@@ -65,6 +75,7 @@ function applyEvents(state: DashboardState, events: DomainEvent[]): DashboardSta
 
 export const useDashboardStore = create<DashboardStore>((set) => ({
   ...initialState,
+  ...initialDrawerState,
 
   syncSnapshot: (snapshot) => {
     saveSnapshotToCache(snapshot)
@@ -76,6 +87,12 @@ export const useDashboardStore = create<DashboardStore>((set) => ({
 
   applyEvents: (events) =>
     set((state) => applyEvents(state, events)),
+
+  openDrawerIssue: (issueId, tab) =>
+    set({ drawerIssueId: issueId, drawerTab: tab ?? 'overview' }),
+
+  closeDrawerIssue: () =>
+    set({ drawerIssueId: null, drawerTab: 'overview' }),
 }))
 
 // ─── Selector memoization helpers ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Reframes the Command Deck right pane (project-selected view) as a tabbed per-project lens (`ProjectLens`).

- Adds 6 tabs: Pipeline, Plans, Beads, Conversations, Activity, Settings
- Pipeline tab renders project-filtered `IssueRow` primitives grouped by phase (Ship · Review · Work · Plan · Todo), composing `PhaseHeader` + `VerbBadge`
- Plans / Beads / Conversations / Activity / Settings tabs render existing `ZoneCOverviewTabs/*` content components without edits to those files
- Tab selection and active issue persist in `localStorage` scoped per-project
- Clicking an `IssueRow` in Pipeline sets the active issue and switches to the Plans tab
- Wires `ProjectLens` into `CommandDeck` in place of `ProjectOverview`

## Test plan
- [x] ProjectLens renders 6 tabs and defaults to Pipeline
- [x] IssueRows are grouped by phase with correct PhaseHeader
- [x] Tab switching works for all 6 tabs
- [x] Tab selection persists in localStorage per-project
- [x] Active issue persists in localStorage per-project
- [x] Clicking IssueRow sets active issue and switches to Plans
- [x] Empty state renders when project has no features
- [x] All existing CommandDeck tests still pass
- [x] Frontend typecheck and lint pass
- [x] Full frontend test suite passes (1140 tests)

## Related bead
Closes `c1-command-deck-right-pane-reframe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)