### PR TITLE
PAN-1215

### DIFF
--- a/src/cli/commands/specialists/done.ts
+++ b/src/cli/commands/specialists/done.ts
@@ -91,6 +91,10 @@ export async function doneCommand(
           const message = err instanceof Error ? err.message : String(err);
           console.warn(chalk.yellow(`  ⚠ Could not snapshot reviewedAtCommit: ${message}`));
         }
+        // Clear any stale verificationStatus='failed' so the override unblocks
+        // readyForMerge. A human passing review assumes responsibility for the gate.
+        update.verificationStatus = 'passed';
+        update.verificationNotes = 'Cleared by `pan specialists done review --status passed` override (PAN-1215)';
         console.log(chalk.green(`✓ Review passed for ${normalizedIssueId}`));
         console.log(chalk.dim('  Test agent can now proceed'));
       } else if (options.status === 'blocked') {

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -2493,6 +2493,41 @@ export async function spawnAgent(options: SpawnOptions): Promise<AgentState> {
     }
   }
 
+  // PAN-1215: One-shot cleanup of tracked workspace-only .pan/ artifacts.
+  // These files are gitignored but may still be tracked on older branches.
+  // If tracked, checkpoint commits and rebases can drop them, breaking the
+  // verification gate. Remove them from the index when the workspace is clean.
+  if (role === 'work') {
+    try {
+      const workspace = options.workspace;
+      const { stdout: trackedFiles } = await execAsync(
+        'git ls-files .pan/continue.json .pan/spec.vbrief.json',
+        { cwd: workspace },
+      );
+      if (trackedFiles.trim()) {
+        const { stdout: porcelain } = await execAsync(
+          'git status --porcelain -- .pan/',
+          { cwd: workspace },
+        );
+        if (!porcelain.trim()) {
+          await execAsync(
+            'git rm --cached --ignore-unmatch .pan/continue.json .pan/spec.vbrief.json',
+            { cwd: workspace },
+          );
+          await execAsync(
+            'git commit -m "chore: untrack workspace .pan/ artifacts (PAN-1215)"',
+            { cwd: workspace },
+          );
+          console.log(`[agents] Untracked workspace .pan/ artifacts for ${options.issueId}`);
+        } else {
+          console.warn(`[agents] Skipping .pan/ untrack for ${options.issueId} — .pan/ paths have uncommitted changes`);
+        }
+      }
+    } catch (err: any) {
+      console.warn(`[agents] .pan/ untrack cleanup failed for ${options.issueId}: ${err.message}`);
+    }
+  }
+
   // Build prompt with FPP work if available
   let prompt = options.prompt || '';
 

--- a/src/lib/checkpoint/checkpoint-manager.ts
+++ b/src/lib/checkpoint/checkpoint-manager.ts
@@ -119,11 +119,15 @@ export async function captureCheckpoint(cwd: string, agentId: string, turnId: st
     }
 
     // Explicitly exclude workspace-only .pan/ artifacts from checkpoints.
-    // These files are gitignored but may still be tracked on older branches (once
-    // tracked, gitignore stops applying). Without this removal, read-tree HEAD
-    // copies them into the temp index and they leak into checkpoint commits.
-    // When the workspace is later rebased, these files can be dropped as "already
-    // upstream", causing the verification gate to lose AC progress (PAN-1215).
+    // Per CLAUDE.md's four-artifact model: spec on main is immutable;
+    // workspace-side continue state (`.pan/continue.json`) and workspace-side
+    // spec (`.pan/spec.vbrief.json`) must never escape the workspace via
+    // checkpoint commits. These files are gitignored but may still be tracked
+    // on older branches (once tracked, gitignore stops applying). Without this
+    // removal, read-tree HEAD copies them into the temp index and they leak
+    // into checkpoint commits. When the workspace is later rebased, these files
+    // can be dropped as "already upstream", causing the verification gate to
+    // lose AC progress (PAN-1215).
     try {
       await execFileAsync('git', ['rm', '--cached', '--ignore-unmatch', '.pan/continue.json', '.pan/spec.vbrief.json'], { cwd, env })
     } catch {

--- a/src/lib/checkpoint/checkpoint-manager.ts
+++ b/src/lib/checkpoint/checkpoint-manager.ts
@@ -118,6 +118,18 @@ export async function captureCheckpoint(cwd: string, agentId: string, turnId: st
       await execFileAsync('git', ['add', '-u', '--', '.'], { cwd, env })
     }
 
+    // Explicitly exclude workspace-only .pan/ artifacts from checkpoints.
+    // These files are gitignored but may still be tracked on older branches (once
+    // tracked, gitignore stops applying). Without this removal, read-tree HEAD
+    // copies them into the temp index and they leak into checkpoint commits.
+    // When the workspace is later rebased, these files can be dropped as "already
+    // upstream", causing the verification gate to lose AC progress (PAN-1215).
+    try {
+      await execFileAsync('git', ['rm', '--cached', '--ignore-unmatch', '.pan/continue.json', '.pan/spec.vbrief.json'], { cwd, env })
+    } catch {
+      // Non-fatal — files may not exist in the temp index
+    }
+
     // Write tree from temp index
     const { stdout: treeOid } = await execFileAsync('git', ['write-tree'], { cwd, env })
     const tree = treeOid.trim()

--- a/src/lib/cloister/deacon.ts
+++ b/src/lib/cloister/deacon.ts
@@ -2207,6 +2207,28 @@ export async function checkPostReviewCommits(): Promise<string[]> {
         `Reset review for ${issueId}: new commits after review passed ` +
         `(${status.reviewedAtCommit.substring(0, 8)} → ${currentHead.substring(0, 8)})`,
       );
+
+      // Redispatch a fresh review convoy. Re-read status to guard against races
+      // with other dispatch paths (HTTP request-review, manual CLI) that may have
+      // already picked up the work between the reset above and now.
+      const freshStatus = getReviewStatus(issueId);
+      if (freshStatus?.reviewStatus === 'pending') {
+        const { spawnReviewRoleForIssue } = await import('./review-agent.js');
+        const branch = `feature/${issueId.toLowerCase()}`;
+        const dispatchResult = await spawnReviewRoleForIssue({
+          issueId,
+          workspace: workspacePath,
+          branch,
+          force: true,
+        });
+        if (dispatchResult.success) {
+          actions.push(`Re-dispatched review for ${issueId}`);
+          console.log(`[deacon] Re-dispatched review convoy for ${issueId} after post-review commit reset`);
+        } else {
+          actions.push(`Failed to re-dispatch review for ${issueId}: ${dispatchResult.error || dispatchResult.message}`);
+          console.error(`[deacon] Failed to re-dispatch review for ${issueId}:`, dispatchResult.error || dispatchResult.message);
+        }
+      }
     }
   } catch (error: unknown) {
     const msg = error instanceof Error ? error.message : String(error);

--- a/src/lib/review-status.ts
+++ b/src/lib/review-status.ts
@@ -112,7 +112,7 @@ export interface ReviewStatus {
   reviewTempStashSequence?: number;
 }
 
-function verificationSatisfied(status: Pick<ReviewStatus, 'verificationStatus'>): boolean {
+export function verificationSatisfied(status: Pick<ReviewStatus, 'verificationStatus'>): boolean {
   // Only block readyForMerge if verification explicitly FAILED.
   // 'pending' means "scheduled but not yet run this cycle" — not a failure signal.
   // request-review resets verificationStatus to 'pending' as part of its cycle reset,

--- a/tests/cli/commands/specialists/done.test.ts
+++ b/tests/cli/commands/specialists/done.test.ts
@@ -85,6 +85,8 @@ describe('specialists done command', () => {
       reviewStatus: 'passed',
       reviewNotes: 'approved',
       reviewedAtCommit: undefined,
+      verificationStatus: 'passed',
+      verificationNotes: 'Cleared by `pan specialists done review --status passed` override (PAN-1215)',
     });
     expect(mockDeliverReviewVerdictFeedback).not.toHaveBeenCalled();
   });

--- a/tests/cli/commands/specialists/done.test.ts
+++ b/tests/cli/commands/specialists/done.test.ts
@@ -1,14 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { verificationSatisfied } from '../../../../src/lib/review-status.js';
 
 const { mockSetReviewStatus, mockDeliverReviewVerdictFeedback } = vi.hoisted(() => ({
   mockSetReviewStatus: vi.fn(),
   mockDeliverReviewVerdictFeedback: vi.fn(),
 }));
 
-vi.mock('../../../../src/lib/review-status.js', () => ({
-  setReviewStatus: mockSetReviewStatus,
-  getReviewStatus: vi.fn(),
-}));
+vi.mock('../../../../src/lib/review-status.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../src/lib/review-status.js')>();
+  return {
+    ...actual,
+    setReviewStatus: mockSetReviewStatus,
+    getReviewStatus: vi.fn(),
+  };
+});
 
 vi.mock('../../../../src/lib/cloister/review-verdict-feedback.js', () => ({
   deliverReviewVerdictFeedback: mockDeliverReviewVerdictFeedback,
@@ -18,13 +23,16 @@ describe('specialists done command', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(console, 'log').mockImplementation(() => {});
-    mockSetReviewStatus.mockReturnValue({
-      issueId: 'PAN-1059',
-      reviewStatus: 'blocked',
-      testStatus: 'pending',
-      updatedAt: new Date().toISOString(),
-      readyForMerge: false,
-      prUrl: 'https://github.com/eltmon/panopticon-cli/pull/1059',
+    mockSetReviewStatus.mockImplementation((_issueId: string, update: Record<string, unknown>) => {
+      return {
+        issueId: 'PAN-1059',
+        reviewStatus: 'blocked',
+        testStatus: 'pending',
+        updatedAt: new Date().toISOString(),
+        readyForMerge: false,
+        prUrl: 'https://github.com/eltmon/panopticon-cli/pull/1059',
+        ...update,
+      };
     });
     mockDeliverReviewVerdictFeedback.mockResolvedValue({
       feedbackPath: '/workspace/.pan/feedback/001-review-agent-changes-requested.md',
@@ -89,5 +97,11 @@ describe('specialists done command', () => {
       verificationNotes: 'Cleared by `pan specialists done review --status passed` override (PAN-1215)',
     });
     expect(mockDeliverReviewVerdictFeedback).not.toHaveBeenCalled();
+  });
+
+  it('verificationSatisfied is true after passed override even from failed state (AC10/AC27)', () => {
+    expect(verificationSatisfied({ verificationStatus: 'failed' })).toBe(false);
+    expect(verificationSatisfied({ verificationStatus: 'passed' })).toBe(true);
+    expect(verificationSatisfied({ verificationStatus: 'pending' })).toBe(true);
   });
 });

--- a/tests/integration/agent-spawning.test.ts
+++ b/tests/integration/agent-spawning.test.ts
@@ -16,6 +16,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { execSync } from 'child_process';
 import {
   spawnAgent,
   spawnRun,
@@ -23,6 +24,7 @@ import {
   type SpawnOptions,
   getAgentDir,
 } from '../../src/lib/agents.js';
+import { captureCheckpoint, hasCheckpoint } from '../../src/lib/checkpoint/checkpoint-manager.js';
 import type { NormalizedConfig } from '../../src/lib/config-yaml.js';
 import { DEFAULT_ROLES, DEFAULT_WORKHORSES } from '../../src/lib/config-yaml.js';
 
@@ -238,6 +240,129 @@ describe('PAN-1048 role primitive — agent spawning', () => {
       })).rejects.toThrow(/No beads tasks found/);
 
       expect(getAgentState('agent-pan-nobeads-1')).toBeNull();
+    });
+
+    // ─── PAN-1215 cleanup block ─────────────────────────────────────────────────
+
+    it('untracks workspace .pan/ artifacts when tracked and working tree is clean (AC22)', async () => {
+      const workspace = join(tmpdir(), `pan-1215-ac22-${Date.now()}`);
+      mkdirSync(join(workspace, '.pan'), { recursive: true });
+      execSync('git init', { cwd: workspace });
+      execSync('git config user.email "test@test.com"', { cwd: workspace });
+      execSync('git config user.name "Test"', { cwd: workspace });
+      writeFileSync(join(workspace, '.pan', 'continue.json'), '{"v":1}');
+      writeFileSync(join(workspace, '.pan', 'spec.vbrief.json'), '{"p":1}');
+      execSync('git add .', { cwd: workspace });
+      execSync('git commit -m "initial"', { cwd: workspace });
+
+      await spawnAgent({ issueId: 'PAN-AC22', workspace, role: 'work' });
+
+      const tracked = execSync('git ls-files .pan/continue.json .pan/spec.vbrief.json', {
+        cwd: workspace,
+        encoding: 'utf-8',
+      }).trim();
+      expect(tracked).toBe('');
+
+      const log = execSync('git log --oneline', { cwd: workspace, encoding: 'utf-8' }).trim();
+      expect(log).toContain('chore: untrack workspace .pan/ artifacts (PAN-1215)');
+
+      rmSync(workspace, { recursive: true, force: true });
+    });
+
+    it('warns and skips untrack when .pan/ paths have uncommitted changes (AC23)', async () => {
+      const workspace = join(tmpdir(), `pan-1215-ac23-${Date.now()}`);
+      mkdirSync(join(workspace, '.pan'), { recursive: true });
+      execSync('git init', { cwd: workspace });
+      execSync('git config user.email "test@test.com"', { cwd: workspace });
+      execSync('git config user.name "Test"', { cwd: workspace });
+      writeFileSync(join(workspace, '.pan', 'continue.json'), '{"v":1}');
+      execSync('git add .', { cwd: workspace });
+      execSync('git commit -m "initial"', { cwd: workspace });
+
+      // Make .pan/ dirty
+      writeFileSync(join(workspace, '.pan', 'continue.json'), '{"v":2}');
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      await spawnAgent({ issueId: 'PAN-AC23', workspace, role: 'work' });
+
+      // No untrack commit should have been made
+      const log = execSync('git log --oneline', { cwd: workspace, encoding: 'utf-8' }).trim();
+      expect(log.split('\n').length).toBe(1);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Skipping .pan/ untrack'),
+      );
+      warnSpy.mockRestore();
+
+      rmSync(workspace, { recursive: true, force: true });
+    });
+
+    it('short-cuits .pan/ cleanup when neither file is tracked (AC24)', async () => {
+      const workspace = join(tmpdir(), `pan-1215-ac24-${Date.now()}`);
+      mkdirSync(join(workspace, '.pan'), { recursive: true });
+      execSync('git init', { cwd: workspace });
+      execSync('git config user.email "test@test.com"', { cwd: workspace });
+      execSync('git config user.name "Test"', { cwd: workspace });
+      writeFileSync(join(workspace, 'readme.md'), '# test');
+      execSync('git add readme.md', { cwd: workspace });
+      execSync('git commit -m "initial"', { cwd: workspace });
+
+      // Files exist on disk but are NOT tracked
+      writeFileSync(join(workspace, '.pan', 'continue.json'), '{"v":1}');
+
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      await spawnAgent({ issueId: 'PAN-AC24', workspace, role: 'work' });
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+
+      // No new commit
+      const log = execSync('git log --oneline', { cwd: workspace, encoding: 'utf-8' }).trim();
+      expect(log.split('\n').length).toBe(1);
+
+      // No warning about skipping untrack (the dirty-path warning)
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Skipping .pan/ untrack'),
+      );
+      // No "Untracked workspace .pan/ artifacts" success log either
+      expect(logSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Untracked workspace .pan/ artifacts'),
+      );
+
+      rmSync(workspace, { recursive: true, force: true });
+    });
+
+    it('checkpoint after cleanup excludes previously tracked .pan/ artifacts (AC28)', async () => {
+      const workspace = join(tmpdir(), `pan-1215-ac28-${Date.now()}`);
+      mkdirSync(join(workspace, '.pan'), { recursive: true });
+      execSync('git init', { cwd: workspace });
+      execSync('git config user.email "test@test.com"', { cwd: workspace });
+      execSync('git config user.name "Test"', { cwd: workspace });
+      writeFileSync(join(workspace, '.pan', 'continue.json'), '{"v":1}');
+      writeFileSync(join(workspace, '.pan', 'spec.vbrief.json'), '{"p":1}');
+      writeFileSync(join(workspace, 'readme.md'), '# test');
+      execSync('git add .', { cwd: workspace });
+      execSync('git commit -m "initial"', { cwd: workspace });
+
+      await spawnAgent({ issueId: 'PAN-AC28', workspace, role: 'work' });
+
+      // Modify the now-untracked file and capture a checkpoint
+      writeFileSync(join(workspace, '.pan', 'continue.json'), '{"v":2}');
+      await captureCheckpoint(workspace, 'agent-pan-ac28', 'turn-1');
+
+      expect(await hasCheckpoint(workspace, 'agent-pan-ac28', 'turn-1')).toBe(true);
+      const ref = 'refs/pan/turn/agent-pan-ac28/turn-1';
+      const commit = execSync(`git rev-parse ${ref}`, { cwd: workspace, encoding: 'utf-8' }).trim();
+      const files = execSync(`git ls-tree -r --name-only ${commit}`, { cwd: workspace, encoding: 'utf-8' })
+        .trim()
+        .split('\n')
+        .filter(Boolean);
+
+      expect(files).not.toContain('.pan/continue.json');
+      expect(files).not.toContain('.pan/spec.vbrief.json');
+      expect(files).toContain('readme.md');
+
+      rmSync(workspace, { recursive: true, force: true });
     });
   });
 

--- a/tests/integration/post-review-rebase-scenario.test.ts
+++ b/tests/integration/post-review-rebase-scenario.test.ts
@@ -1,0 +1,320 @@
+/**
+ * PAN-1215 Integration Test: Full post-review-rebase scenario end-to-end
+ *
+ * Covers three substrate gaps that compose into one failure mode:
+ *   A) Deacon redispatches review convoy after post-review reset
+ *   B) Checkpoint excludes workspace-only .pan/ artifacts from commits
+ *   C) Review override clears stale verificationStatus
+ *
+ * Scenario: review passes → main drifts → rebase → deacon resets → convoy
+ * redispatches → AC gate passes → readyForMerge=true.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { initSchema } from '../../src/lib/database/schema.js';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execSync } from 'child_process';
+
+// ─── In-memory DB injection ───────────────────────────────────────────────────
+
+let testDb: Database.Database;
+
+vi.mock('../../src/lib/database/index.js', () => ({
+  getDatabase: () => testDb,
+}));
+
+// ─── Mock exec for deacon's git calls ─────────────────────────────────────────
+
+const mockExecCallback = vi.fn();
+let mockExecHeadSha = 'newsha99';
+let mockOldTreeSha = 'old-tree';
+let mockNewTreeSha = 'new-tree';
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    exec: (...args: unknown[]) => {
+      const command = String(args[0] ?? '');
+      const callback = args[args.length - 1] as (
+        err: null,
+        result: { stdout: string; stderr: string },
+      ) => void;
+      mockExecCallback(...args);
+      const stdout = command.includes('^{tree}')
+        ? command.includes('oldsha1') ? mockOldTreeSha : mockNewTreeSha
+        : mockExecHeadSha;
+      callback(null, { stdout: `${stdout}\n`, stderr: '' });
+      return {} as ReturnType<typeof actual['exec']>;
+    },
+  };
+});
+
+// ─── Stub modules that deacon and done.ts import ──────────────────────────────
+
+const mockResolveProject = vi.fn();
+
+vi.mock('../../src/lib/projects.js', () => ({
+  resolveProjectFromIssue: (...args: unknown[]) => mockResolveProject(...args),
+}));
+
+vi.mock('../../src/lib/activity-logger.js', () => ({
+  emitActivityEntry: vi.fn(),
+  emitActivityTts: vi.fn(),
+}));
+
+vi.mock('../../src/lib/pipeline-notifier.js', () => ({
+  notifyPipeline: vi.fn(),
+}));
+
+vi.mock('../../src/dashboard/server/event-store.js', () => ({
+  EventStoreService: {},
+  getEventStore: () => ({
+    append: vi.fn().mockResolvedValue(undefined),
+    getSnapshot: vi.fn().mockResolvedValue({ events: [] }),
+    subscribe: vi.fn().mockReturnValue({ [Symbol.asyncIterator]: async function* () {} }),
+  }),
+}));
+
+vi.mock('../../src/lib/tmux.js', () => ({
+  sessionExists: vi.fn(),
+  sendKeysAsync: vi.fn(),
+  sessionExistsAsync: vi.fn().mockResolvedValue(false),
+  buildTmuxCommandString: vi.fn(),
+  capturePaneAsync: vi.fn(),
+  createSessionAsync: vi.fn(),
+  killSession: vi.fn(),
+  killSessionAsync: vi.fn(),
+  listPaneValues: vi.fn(),
+  listPaneValuesAsync: vi.fn().mockResolvedValue([]),
+  listSessionNamesAsync: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../src/lib/cloister/specialists.js', () => ({
+  getEnabledSpecialists: vi.fn().mockReturnValue([]),
+  getTmuxSessionName: vi.fn(),
+  isRunning: vi.fn().mockResolvedValue(false),
+  initializeSpecialist: vi.fn(),
+  spawnEphemeralSpecialist: vi.fn(),
+  getAllProjectSpecialistStatuses: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../src/lib/agents.js', () => ({
+  getAgentRuntimeState: vi.fn().mockReturnValue(null),
+  saveAgentRuntimeState: vi.fn(),
+  saveSessionId: vi.fn(),
+  listRunningAgents: vi.fn().mockResolvedValue([]),
+  getAgentDir: vi.fn().mockReturnValue('/tmp'),
+  getAgentState: vi.fn().mockReturnValue(null),
+  messageAgent: vi.fn(),
+  spawnAgent: vi.fn(),
+  transitionIssueToInReview: vi.fn(),
+}));
+
+vi.mock('../../src/lib/cloister/feedback-writer.js', () => ({
+  writeFeedbackFile: vi.fn(),
+}));
+
+vi.mock('node:fs', async (importActual) => {
+  const actual = await importActual<typeof import('node:fs')>();
+  return { ...actual, existsSync: vi.fn().mockReturnValue(true) };
+});
+
+// Mock review-agent.js to capture spawnReviewRoleForIssue calls
+const mockSpawnReviewRoleForIssue = vi
+  .fn()
+  .mockResolvedValue({ success: true, message: 'spawned' });
+
+vi.mock('../../src/lib/cloister/review-agent.js', () => ({
+  spawnReviewRoleForIssue: (...args: unknown[]) => mockSpawnReviewRoleForIssue(...args),
+}));
+
+vi.mock('../../src/lib/cloister/review-verdict-feedback.js', () => ({
+  deliverReviewVerdictFeedback: vi.fn().mockResolvedValue({
+    feedbackPath: '/workspace/.pan/feedback/001-review-agent-passed.md',
+    prCommentPosted: true,
+    agentMessageSent: true,
+  }),
+}));
+
+// ─── Imports after mocks ──────────────────────────────────────────────────────
+
+import { setReviewStatus, getReviewStatus } from '../../src/lib/review-status.js';
+import { checkPostReviewCommits } from '../../src/lib/cloister/deacon.js';
+import { doneCommand } from '../../src/cli/commands/specialists/done.js';
+import { captureCheckpoint, hasCheckpoint } from '../../src/lib/checkpoint/checkpoint-manager.js';
+
+describe('PAN-1215 post-review-rebase scenario', () => {
+  let testRepoDir: string;
+
+  beforeEach(() => {
+    testDb = new Database(':memory:');
+    testDb.pragma('foreign_keys = ON');
+    initSchema(testDb);
+    vi.clearAllMocks();
+    mockExecHeadSha = 'newsha99';
+    mockOldTreeSha = 'old-tree';
+    mockNewTreeSha = 'new-tree';
+    mockSpawnReviewRoleForIssue.mockResolvedValue({ success: true, message: 'spawned' });
+    mockResolveProject.mockReturnValue({ projectPath: '/fake/project' });
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    // Create a real git repo for checkpoint and git-utils tests
+    testRepoDir = mkdtempSync(join(tmpdir(), 'pan-1215-test-'));
+    execSync('git init', { cwd: testRepoDir });
+    execSync('git config user.email "test@test.com"', { cwd: testRepoDir });
+    execSync('git config user.name "Test"', { cwd: testRepoDir });
+
+    // Seed with a tracked .pan/continue.json (simulates pre-fix branch state)
+    mkdirSync(join(testRepoDir, '.pan'), { recursive: true });
+    writeFileSync(join(testRepoDir, '.pan', 'continue.json'), '{"version":"1"}');
+    writeFileSync(join(testRepoDir, '.pan', 'spec.vbrief.json'), '{"plan":{}}');
+    writeFileSync(join(testRepoDir, 'readme.md'), '# test');
+    execSync('git add .', { cwd: testRepoDir });
+    execSync('git commit -m "initial"', { cwd: testRepoDir });
+
+    // Add gitignore (mimics the real repo where these are ignored)
+    writeFileSync(
+      join(testRepoDir, '.gitignore'),
+      '.pan/continue.json\n.pan/spec.vbrief.json\n',
+    );
+    execSync('git add .gitignore', { cwd: testRepoDir });
+    execSync('git commit -m "add gitignore"', { cwd: testRepoDir });
+  });
+
+  afterEach(() => {
+    testDb.close();
+    if (existsSync(testRepoDir)) {
+      rmSync(testRepoDir, { recursive: true, force: true });
+    }
+  });
+
+  // ─── Gap A: Deacon redispatches review convoy after post-review reset ───────
+
+  it('resets review and redispatches convoy after tree-changing rebase', async () => {
+    setReviewStatus('PAN-1215-A', {
+      reviewStatus: 'passed',
+      testStatus: 'passed',
+      readyForMerge: true,
+      reviewedAtCommit: 'oldsha1',
+    });
+
+    const actions = await checkPostReviewCommits();
+
+    // AC1 + AC4: actions include both reset and re-dispatch lines
+    expect(
+      actions.some((a) => a.includes('PAN-1215-A') && a.includes('Reset review')),
+    ).toBe(true);
+    expect(
+      actions.some((a) => a.includes('PAN-1215-A') && a.includes('Re-dispatched review')),
+    ).toBe(true);
+
+    // AC2: review status reset to pending, readyForMerge cleared
+    const after = getReviewStatus('PAN-1215-A');
+    expect(after?.reviewStatus).toBe('pending');
+    expect(after?.testStatus).toBe('pending');
+    expect(after?.readyForMerge).toBe(false);
+    expect(after?.reviewedAtCommit).toBeUndefined();
+
+    // AC5 + AC6: spawn called exactly once with correct args including force:true
+    expect(mockSpawnReviewRoleForIssue).toHaveBeenCalledTimes(1);
+    expect(mockSpawnReviewRoleForIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issueId: 'PAN-1215-A',
+        branch: 'feature/pan-1215-a',
+        force: true,
+      }),
+    );
+  });
+
+  it('does NOT redispatch on tree-identical rebases (PAN-1213 short-circuit)', async () => {
+    setReviewStatus('PAN-1215-A2', {
+      reviewStatus: 'passed',
+      testStatus: 'passed',
+      readyForMerge: true,
+      reviewedAtCommit: 'oldsha1',
+    });
+
+    // Force identical tree SHAs by making the module-level mock variables equal
+    mockOldTreeSha = 'sametree';
+    mockNewTreeSha = 'sametree';
+
+    const actions = await checkPostReviewCommits();
+
+    expect(actions.filter((a) => a.includes('PAN-1215-A2'))).toHaveLength(0);
+    expect(mockSpawnReviewRoleForIssue).not.toHaveBeenCalled();
+
+    const after = getReviewStatus('PAN-1215-A2');
+    expect(after?.reviewStatus).toBe('passed');
+    expect(after?.reviewedAtCommit).toBe('newsha99');
+  });
+
+  // ─── Gap C: Review override clears stale verificationStatus ─────────────────
+
+  it('clears stale verificationStatus when review override signals passed', async () => {
+    // Pre-seed a status with failed verification (e.g. from a prior cycle)
+    setReviewStatus('PAN-1215-C', {
+      reviewStatus: 'pending',
+      testStatus: 'pending',
+      verificationStatus: 'failed',
+      readyForMerge: false,
+    });
+
+    // Point the project resolver at the real test repo so getWorkspaceGitInfo works
+    mockResolveProject.mockReturnValue({ projectPath: testRepoDir });
+    vi.mocked(existsSync).mockImplementation((p) => {
+      if (typeof p === 'string' && p.includes('feature-pan-1215-c')) {
+        return true;
+      }
+      return true;
+    });
+
+    await doneCommand('review', 'pan-1215-c', { status: 'passed' });
+
+    const after = getReviewStatus('PAN-1215-C');
+    expect(after?.reviewStatus).toBe('passed');
+    expect(after?.verificationStatus).toBe('passed');
+    expect(after?.verificationNotes).toContain('PAN-1215');
+    expect(after?.verificationNotes).toContain('override');
+  });
+
+  // ─── Gap B.1: Checkpoint excludes workspace-only .pan/ artifacts ────────────
+
+  it('excludes .pan/continue.json and .pan/spec.vbrief.json from checkpoint commits', async () => {
+    // Modify the tracked workspace-only files
+    writeFileSync(join(testRepoDir, '.pan', 'continue.json'), '{"version":"2"}');
+    writeFileSync(join(testRepoDir, '.pan', 'spec.vbrief.json'), '{"plan":{"updated":true}}');
+
+    // Capture a checkpoint
+    await captureCheckpoint(testRepoDir, 'agent-pan-1215', 'turn-1');
+
+    // Verify the checkpoint ref was created
+    expect(await hasCheckpoint(testRepoDir, 'agent-pan-1215', 'turn-1')).toBe(true);
+
+    // List files in the checkpoint tree
+    const ref = 'refs/pan/turn/agent-pan-1215/turn-1';
+    const commit = execSync(`git rev-parse ${ref}`, {
+      cwd: testRepoDir,
+      encoding: 'utf-8',
+    }).trim();
+
+    const files = execSync(`git ls-tree -r --name-only ${commit}`, {
+      cwd: testRepoDir,
+      encoding: 'utf-8',
+    })
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+
+    // These files should NOT be in the checkpoint tree
+    expect(files).not.toContain('.pan/continue.json');
+    expect(files).not.toContain('.pan/spec.vbrief.json');
+
+    // Other files should still be present
+    expect(files).toContain('readme.md');
+    expect(files).toContain('.gitignore');
+  });
+});

--- a/tests/integration/post-review-rebase-scenario.test.ts
+++ b/tests/integration/post-review-rebase-scenario.test.ts
@@ -142,7 +142,7 @@ vi.mock('../../src/lib/cloister/review-verdict-feedback.js', () => ({
 
 // ─── Imports after mocks ──────────────────────────────────────────────────────
 
-import { setReviewStatus, getReviewStatus } from '../../src/lib/review-status.js';
+import { setReviewStatus, getReviewStatus, verificationSatisfied } from '../../src/lib/review-status.js';
 import { checkPostReviewCommits } from '../../src/lib/cloister/deacon.js';
 import { doneCommand } from '../../src/cli/commands/specialists/done.js';
 import { captureCheckpoint, hasCheckpoint } from '../../src/lib/checkpoint/checkpoint-manager.js';
@@ -279,6 +279,7 @@ describe('PAN-1215 post-review-rebase scenario', () => {
     expect(after?.verificationStatus).toBe('passed');
     expect(after?.verificationNotes).toContain('PAN-1215');
     expect(after?.verificationNotes).toContain('override');
+    expect(verificationSatisfied(after!)).toBe(true);
   });
 
   // ─── Gap B.1: Checkpoint excludes workspace-only .pan/ artifacts ────────────
@@ -316,5 +317,52 @@ describe('PAN-1215 post-review-rebase scenario', () => {
     // Other files should still be present
     expect(files).toContain('readme.md');
     expect(files).toContain('.gitignore');
+  });
+
+  it('excludes untracked-on-disk .pan/continue.json from checkpoint commits (AC15)', async () => {
+    // Remove the tracked file from the index so it exists on disk but is untracked
+    execSync('git rm --cached .pan/continue.json', { cwd: testRepoDir });
+    writeFileSync(join(testRepoDir, '.pan', 'continue.json'), '{"version":"untracked"}');
+    // Ensure it is not in the index
+    const tracked = execSync('git ls-files .pan/continue.json', { cwd: testRepoDir, encoding: 'utf-8' }).trim();
+    expect(tracked).toBe('');
+
+    await captureCheckpoint(testRepoDir, 'agent-pan-1215', 'turn-untracked');
+
+    const ref = 'refs/pan/turn/agent-pan-1215/turn-untracked';
+    const commit = execSync(`git rev-parse ${ref}`, { cwd: testRepoDir, encoding: 'utf-8' }).trim();
+    const files = execSync(`git ls-tree -r --name-only ${commit}`, { cwd: testRepoDir, encoding: 'utf-8' })
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+
+    expect(files).not.toContain('.pan/continue.json');
+  });
+
+  it('after cleanup, checkpoint no longer includes previously tracked .pan/ artifacts (AC28)', async () => {
+    // Seed a tracked .pan/continue.json (simulates pre-fix branch state)
+    writeFileSync(join(testRepoDir, '.pan', 'continue.json'), '{"version":"3"}');
+    execSync('git add .pan/continue.json', { cwd: testRepoDir });
+    execSync('git commit -m "tracked continue"', { cwd: testRepoDir });
+
+    // Run the cleanup logic (same commands spawnAgent uses)
+    execSync('git rm --cached --ignore-unmatch .pan/continue.json .pan/spec.vbrief.json', { cwd: testRepoDir });
+    execSync('git commit -m "chore: untrack workspace .pan/ artifacts (PAN-1215)"', { cwd: testRepoDir });
+
+    // Modify the now-untracked file
+    writeFileSync(join(testRepoDir, '.pan', 'continue.json'), '{"version":"4"}');
+
+    // Capture checkpoint — file should be excluded because it is no longer tracked
+    await captureCheckpoint(testRepoDir, 'agent-pan-1215', 'turn-post-cleanup');
+
+    const ref = 'refs/pan/turn/agent-pan-1215/turn-post-cleanup';
+    const commit = execSync(`git rev-parse ${ref}`, { cwd: testRepoDir, encoding: 'utf-8' }).trim();
+    const files = execSync(`git ls-tree -r --name-only ${commit}`, { cwd: testRepoDir, encoding: 'utf-8' })
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+
+    expect(files).not.toContain('.pan/continue.json');
+    expect(files).toContain('readme.md');
   });
 });

--- a/tests/unit/dashboard/server/routes/specialists-reviewed-at-commit.test.ts
+++ b/tests/unit/dashboard/server/routes/specialists-reviewed-at-commit.test.ts
@@ -111,6 +111,10 @@ vi.mock('../../../../../src/lib/cloister/feedback-writer.js', () => ({
   writeFeedbackFile: vi.fn(),
 }));
 
+vi.mock('../../../../../src/lib/cloister/review-agent.js', () => ({
+  spawnReviewRoleForIssue: vi.fn().mockResolvedValue({ success: true, message: 'spawned' }),
+}));
+
 vi.mock('node:fs', async (importActual) => {
   const actual = await importActual<typeof import('node:fs')>();
   return { ...actual, existsSync: vi.fn().mockReturnValue(true) };


### PR DESCRIPTION
Closes #1215

## Acceptance Criteria

- [x] Deacon redispatches review convoy after post-review reset (Gap A)
- [x] `pan specialists done review --status passed` clears stale verificationStatus (Gap C)
- [x] `pan checkpoint` does not capture workspace-only .pan/ artifacts (Gap B.1 root)
- [x] Work-agent startup untracks .pan/continue.json on branches where it leaked (Gap B.1 cleanup)
- [x] Integration test: full post-review-rebase scenario end-to-end

## Implementation Tasks

- [x] Integration test: full post-review-rebase scenario end-to-end
- [ ] Work-agent startup untracks .pan/continue.json on branches where it leaked (Gap B.1 cleanup)
- [ ] `pan checkpoint` does not capture workspace-only .pan/ artifacts (Gap B.1 root)
- [ ] `pan specialists done review --status passed` clears stale verificationStatus (Gap C)
- [ ] Deacon redispatches review convoy after post-review reset (Gap A)