### PR TITLE
PAN-1231

### DIFF
--- a/.pan/specs/2026-05-20-pan-1231-pan-1148-follow-up-agents-page-gaps-drawer-wiring-ship-accent-topbar-segmented-control-font.vbrief.json
+++ b/.pan/specs/2026-05-20-pan-1231-pan-1148-follow-up-agents-page-gaps-drawer-wiring-ship-accent-topbar-segmented-control-font.vbrief.json
@@ -83,7 +83,7 @@
       {
         "id": "pan-1231-ship-accent",
         "title": "AgentCard ship-role accent: use --signal-review (purple), not --signal-cost (cyan)",
-        "status": "pending",
+        "status": "completed",
         "priority": "medium",
         "created": "2026-05-20T02:45:00.000Z",
         "metadata": {
@@ -99,7 +99,7 @@
           {
             "id": "pan-1231-ship-accent.ac1",
             "title": "ROLE_ACCENTS.ship === 'var(--signal-review)' in primitives/AgentCard.tsx",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -107,7 +107,7 @@
           {
             "id": "pan-1231-ship-accent.ac2",
             "title": "A unit test renders <AgentCard role='ship' /> and asserts the rendered article element's inline style includes --agent-card-accent: var(--signal-review)",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -115,7 +115,7 @@
           {
             "id": "pan-1231-ship-accent.ac3",
             "title": "No other call site of ROLE_ACCENTS regresses (plan stays --signal-review, work stays --info, review stays --warning, test stays --success, flywheel stays --primary)",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -123,7 +123,7 @@
           {
             "id": "pan-1231-ship-accent.ac4",
             "title": "npm run typecheck, npm run lint, and npm test pass",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -133,7 +133,7 @@
       {
         "id": "pan-1231-name-sf-mono",
         "title": "AgentCard H1 row name uses SF Mono (font-mono) per PRD §4.7.9",
-        "status": "pending",
+        "status": "completed",
         "priority": "low",
         "created": "2026-05-20T02:45:00.000Z",
         "metadata": {
@@ -149,7 +149,7 @@
           {
             "id": "pan-1231-name-sf-mono.ac1",
             "title": "AgentCard h3.name has the `font-mono` Tailwind class in primitives/AgentCard.tsx",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -157,7 +157,7 @@
           {
             "id": "pan-1231-name-sf-mono.ac2",
             "title": "A unit test asserts the h3 element rendering the name has the `font-mono` class applied",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -165,7 +165,7 @@
           {
             "id": "pan-1231-name-sf-mono.ac3",
             "title": "Font weight (font-semibold) and size (text-[13px]) and color/leading classes are preserved",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -173,7 +173,7 @@
           {
             "id": "pan-1231-name-sf-mono.ac4",
             "title": "npm run typecheck, npm run lint, and npm test pass",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -183,7 +183,7 @@
       {
         "id": "pan-1231-topbar-shell",
         "title": "Add TopBar shell to FleetAgentsView with Grid/Table/Timeline segmented control and Start agent button",
-        "status": "pending",
+        "status": "completed",
         "priority": "medium",
         "created": "2026-05-20T02:45:00.000Z",
         "metadata": {
@@ -199,7 +199,7 @@
           {
             "id": "pan-1231-topbar-shell.ac1",
             "title": "FleetAgentsView renders <TopBar /> with breadcrumb, meta (live fleet counts + cumulative runtime), search placeholder, segmentedControl, and Start agent button slots populated",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -207,7 +207,7 @@
           {
             "id": "pan-1231-topbar-shell.ac2",
             "title": "Segmented control has exactly three buttons labelled Grid, Table, Timeline. Clicking each sets ?view=grid|table|timeline and toggles the aria-pressed / active style on the selected segment.",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -215,7 +215,7 @@
           {
             "id": "pan-1231-topbar-shell.ac3",
             "title": "Default view (no ?view= param) is 'grid' and renders the existing AgentCard grid",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -223,7 +223,7 @@
           {
             "id": "pan-1231-topbar-shell.ac4",
             "title": "?view=table and ?view=timeline render a 'Coming soon' placeholder section (labelled, not empty) — never silently empty",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -231,7 +231,7 @@
           {
             "id": "pan-1231-topbar-shell.ac5",
             "title": "Start agent button navigates the user to the Issues (Kanban) tab. Wired via the existing activeTab state in App.tsx (passed as a prop or via store action) — no new global-start dialog is created.",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -239,7 +239,7 @@
           {
             "id": "pan-1231-topbar-shell.ac6",
             "title": "Setting ?view= preserves existing ?phase=, ?projects=, ?models= search params (additive URL state)",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -247,7 +247,7 @@
           {
             "id": "pan-1231-topbar-shell.ac7",
             "title": "FleetAgentsView.test.tsx is extended with tests covering: default grid render, segment click updates URL + active style, Table/Timeline render placeholder, Start agent click triggers tab navigation",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -255,7 +255,7 @@
           {
             "id": "pan-1231-topbar-shell.ac8",
             "title": "Playwright UAT (isolated browser instance — no shared session): navigate to /?tab=agents, click each segmented button, verify URL updates and visible label matches; click Start agent, verify the URL/UI switches to the Issues tab",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -263,7 +263,7 @@
           {
             "id": "pan-1231-topbar-shell.ac9",
             "title": "npm run typecheck, npm run lint, and npm test pass",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -273,7 +273,7 @@
       {
         "id": "pan-1231-drawer-scroll-wired",
         "title": "AgentCard 'Open issue' actually scrolls IssueDrawer to #active-agent (not just sets URL hash)",
-        "status": "pending",
+        "status": "completed",
         "priority": "high",
         "created": "2026-05-20T02:45:00.000Z",
         "metadata": {
@@ -289,7 +289,7 @@
           {
             "id": "pan-1231-drawer-scroll-wired.ac1",
             "title": "Manual Playwright UAT (isolated browser, no shared session): clicking 'Open issue' on a fleet AgentCard opens the drawer AND the Active Agent section is visible in the drawer's scroll viewport without manual scrolling. Recorded as a passing UAT step.",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -297,7 +297,7 @@
           {
             "id": "pan-1231-drawer-scroll-wired.ac2",
             "title": "A new unit test mounts FleetAgentsView + IssueDrawer + DrawerActiveAgent, spies Element.prototype.scrollIntoView, clicks 'Open issue' on a card, and asserts scrollIntoView was invoked on the element with id='active-agent'. The existing URL-hash-only test is replaced (not just supplemented) — a hash-only assertion is the original closed-without-delivery pattern and must not remain as the sole proof of delivery.",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -305,7 +305,7 @@
           {
             "id": "pan-1231-drawer-scroll-wired.ac3",
             "title": "The fix handles the async DrawerActiveAgent mount: if the element is not in the DOM when the effect first runs, the scroll is retried (e.g., via ref/observer/short polling with a small retry cap) until it succeeds or a clean timeout — never silently no-ops.",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -313,7 +313,7 @@
           {
             "id": "pan-1231-drawer-scroll-wired.ac4",
             "title": "Opening the drawer via other entry points (e.g., kanban card click without #active-agent hash) does NOT auto-scroll to the active-agent anchor — scroll behaviour is gated on the hash being present.",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }
@@ -321,7 +321,7 @@
           {
             "id": "pan-1231-drawer-scroll-wired.ac5",
             "title": "npm run typecheck, npm run lint, and npm test pass",
-            "status": "pending",
+            "status": "completed",
             "metadata": {
               "kind": "acceptance_criterion"
             }

--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -898,7 +898,7 @@ export default function App() {
         {activeTab === 'agents' && (
           <BootstrapGate fallback={<AgentsSkeleton />}>
             <div className="h-full w-full overflow-y-auto">
-              <FleetAgentsView />
+              <FleetAgentsView onNavigateToIssues={() => setActiveTab('kanban')} />
             </div>
           </BootstrapGate>
         )}

--- a/src/dashboard/frontend/src/components/Agents/FleetAgentsView.test.tsx
+++ b/src/dashboard/frontend/src/components/Agents/FleetAgentsView.test.tsx
@@ -36,7 +36,7 @@ function issue(overrides: Partial<Issue>): Issue {
   };
 }
 
-function renderFleetView() {
+function renderFleetView(props: { onNavigateToIssues?: () => void } = {}) {
   const client = new QueryClient({
     defaultOptions: {
       queries: { retry: false, staleTime: Infinity },
@@ -53,7 +53,7 @@ function renderFleetView() {
 
   return render(
     <QueryClientProvider client={client}>
-      <FleetAgentsView />
+      <FleetAgentsView {...props} />
     </QueryClientProvider>,
   );
 }
@@ -254,5 +254,65 @@ describe('FleetAgentsView', () => {
 
     const tiles = Array.from(document.querySelectorAll('[data-component="metric-tile"]'));
     expect(within(tiles[4] as HTMLElement).getByText('0m')).toBeInTheDocument();
+  });
+
+  it('renders TopBar with breadcrumb, meta, search placeholder, segmented control, and Start agent button', () => {
+    renderFleetView({ onNavigateToIssues: vi.fn() });
+
+    expect(screen.getByText('Eltmon / Agents')).toBeInTheDocument();
+    expect(screen.getByText(/1 active · 1 stuck · 3h 0m cumulative runtime/)).toBeInTheDocument();
+    expect(screen.getByText('Search agents by name, issue, model…')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Start agent' })).toBeInTheDocument();
+  });
+
+  it('defaults to grid view and renders the existing card grid', () => {
+    renderFleetView();
+
+    expect(screen.getByRole('button', { name: 'grid', pressed: true })).toBeInTheDocument();
+    expect(screen.getByText('agent-running')).toBeInTheDocument();
+  });
+
+  it('switches to table view with Coming soon placeholder and updates URL', () => {
+    renderFleetView();
+
+    fireEvent.click(screen.getByRole('button', { name: 'table' }));
+    expect(screen.getByRole('button', { name: 'table', pressed: true })).toBeInTheDocument();
+    expect(screen.getByText('Coming soon')).toBeInTheDocument();
+    expect(new URLSearchParams(window.location.search).get('view')).toBe('table');
+    expect(screen.queryByText('agent-running')).not.toBeInTheDocument();
+  });
+
+  it('switches to timeline view with Coming soon placeholder and updates URL', () => {
+    renderFleetView();
+
+    fireEvent.click(screen.getByRole('button', { name: 'timeline' }));
+    expect(screen.getByRole('button', { name: 'timeline', pressed: true })).toBeInTheDocument();
+    expect(screen.getByText('Coming soon')).toBeInTheDocument();
+    expect(new URLSearchParams(window.location.search).get('view')).toBe('timeline');
+  });
+
+  it('preserves existing filters when switching view mode', () => {
+    renderFleetView();
+
+    fireEvent.click(screen.getByRole('button', { name: 'work' }));
+    expect(window.location.search).toBe('?phase=work');
+
+    fireEvent.click(screen.getByRole('button', { name: 'table' }));
+    expect(new URLSearchParams(window.location.search).get('phase')).toBe('work');
+    expect(new URLSearchParams(window.location.search).get('view')).toBe('table');
+  });
+
+  it('calls onNavigateToIssues when Start agent is clicked', () => {
+    const onNavigateToIssues = vi.fn();
+    renderFleetView({ onNavigateToIssues });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start agent' }));
+    expect(onNavigateToIssues).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render Start agent button when onNavigateToIssues is omitted', () => {
+    renderFleetView();
+
+    expect(screen.queryByRole('button', { name: 'Start agent' })).not.toBeInTheDocument();
   });
 });

--- a/src/dashboard/frontend/src/components/Agents/FleetAgentsView.test.tsx
+++ b/src/dashboard/frontend/src/components/Agents/FleetAgentsView.test.tsx
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useDashboardStore } from '../../lib/store';
 import type { Agent, Issue } from '../../types';
 import { FleetAgentsView } from './FleetAgentsView';
+import { IssueDrawer } from '../drawer/IssueDrawer';
+import { DialogProvider } from '../DialogProvider';
 
 function agent(overrides: Partial<Agent>): Agent {
   return {
@@ -163,14 +165,51 @@ describe('FleetAgentsView', () => {
     expect(within(screen.getByText('Stuck').closest('[data-component="metric-tile"]') as HTMLElement).getByText('2')).toBeInTheDocument();
   });
 
-  it('opens the drawer from a fleet card issue action at the active-agent anchor', () => {
-    renderFleetView();
+  it('opens the drawer from a fleet card and scrolls to the active-agent element', () => {
+    const scrollSpy = vi.spyOn(Element.prototype, 'scrollIntoView');
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb(0);
+      return 0;
+    });
+    const cafSpy = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, staleTime: Infinity },
+        mutations: { retry: false },
+      },
+    });
+    client.setQueryData(['cost-stream', undefined, 500], {
+      events: [],
+      byIssue: {
+        'pan-1': [{ ts: '2026-05-18T00:00:00.000Z', model: 'opus', provider: 'anthropic', cost: 12.34, tokens: 456_000 }],
+      },
+      count: 1,
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <DialogProvider>
+          <FleetAgentsView />
+          <IssueDrawer />
+        </DialogProvider>
+      </QueryClientProvider>,
+    );
 
     fireEvent.click(screen.getAllByText('Open issue')[0]);
 
     expect(useDashboardStore.getState().drawer).toEqual({ issueId: 'PAN-1', tab: 'overview' });
     expect(window.location.search).toBe('?issue=PAN-1&tab=overview');
     expect(window.location.hash).toBe('#active-agent');
+
+    const activeAgent = document.getElementById('active-agent');
+    expect(activeAgent).toBeTruthy();
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+    expect(scrollSpy).toHaveBeenLastCalledWith({ block: 'start' });
+
+    scrollSpy.mockRestore();
+    rafSpy.mockRestore();
+    cafSpy.mockRestore();
   });
 
   it('filters the fleet grid with multi-select phase pills and syncs the URL', () => {

--- a/src/dashboard/frontend/src/components/Agents/FleetAgentsView.tsx
+++ b/src/dashboard/frontend/src/components/Agents/FleetAgentsView.tsx
@@ -9,6 +9,8 @@ import { cn } from '../../lib/utils';
 import type { Agent, Issue } from '../../types';
 import AgentCard, { type AgentCardRole } from '../primitives/AgentCard';
 import MetricStrip from '../primitives/MetricStrip';
+import TopBar from '../primitives/TopBar';
+import Button from '../primitives/Button';
 import type { VerbBadgeProps } from '../primitives/VerbBadge';
 
 const ROLE_ORDER = {
@@ -34,6 +36,27 @@ type FilterOption = {
   id: string;
   name: string;
 };
+
+type AgentsViewMode = 'grid' | 'table' | 'timeline';
+const VIEW_MODES: AgentsViewMode[] = ['grid', 'table', 'timeline'];
+
+function readViewMode(): AgentsViewMode {
+  if (typeof window === 'undefined') return 'grid';
+  const params = new URLSearchParams(window.location.search);
+  const view = params.get('view');
+  return VIEW_MODES.includes(view as AgentsViewMode) ? (view as AgentsViewMode) : 'grid';
+}
+
+function replaceViewUrl(view: AgentsViewMode) {
+  if (typeof window === 'undefined') return;
+  const url = new URL(window.location.href);
+  if (view === 'grid') {
+    url.searchParams.delete('view');
+  } else {
+    url.searchParams.set('view', view);
+  }
+  window.history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`);
+}
 
 function sumIssueCostEvents(events: CostEvent[] | undefined) {
   return (events ?? []).reduce(
@@ -219,17 +242,21 @@ function DropdownFilter({ label, selected, options, onToggle }: {
   );
 }
 
-export function FleetAgentsView() {
+export function FleetAgentsView({ onNavigateToIssues }: { onNavigateToIssues?: () => void } = {}) {
   const now = useSharedTick();
   const agents = useDashboardStore(selectAgents) as Agent[];
   const issues = useDashboardStore(selectIssues) as Issue[];
   const agentOutputById = useDashboardStore((state) => state.agentOutputById);
   const openIssue = useDashboardStore((state) => state.openIssue);
   const [filter, setFilter] = useState(readFilterState);
+  const [viewMode, setViewMode] = useState<AgentsViewMode>(readViewMode);
   const { eventsByIssue } = useCostStream({ limit: 500 });
 
   useEffect(() => {
-    const handlePopState = () => setFilter(readFilterState());
+    const handlePopState = () => {
+      setFilter(readFilterState());
+      setViewMode(readViewMode());
+    };
     window.addEventListener('popstate', handlePopState);
     return () => window.removeEventListener('popstate', handlePopState);
   }, []);
@@ -328,6 +355,11 @@ export function FleetAgentsView() {
     replaceFilterUrl(next);
   }
 
+  function updateViewMode(view: AgentsViewMode) {
+    setViewMode(view);
+    replaceViewUrl(view);
+  }
+
   function togglePhase(phase: AgentPhaseFilter) {
     updateFilter({ ...filter, phases: toggleValue(filter.phases, phase) as AgentPhaseFilter[] });
   }
@@ -351,91 +383,154 @@ export function FleetAgentsView() {
     window.history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`);
   }
 
-  if (fleetAgents.length === 0) {
-    return (
-      <section data-component="fleet-agents-view" className="p-6">
-        <div className="rounded-[18px] border border-dashed border-border bg-card px-6 py-10 text-center text-sm text-muted-foreground">
-          No running or stuck agents.
-        </div>
-      </section>
-    );
-  }
+  const runningCount = fleetAgents.filter(isRunningAgent).length;
+  const stuckCount = fleetAgents.filter((agent) => isAgentProblemStatus(agent.status) || agent.troubled).length;
+  const cumulativeRuntimeMs = fleetAgents
+    .filter(isRunningAgent)
+    .reduce((total, agent) => total + Math.max(0, now.getTime() - new Date(agent.startedAt).getTime()), 0);
+  const metaString = `${runningCount} active · ${stuckCount} stuck · ${formatDuration(cumulativeRuntimeMs)} cumulative runtime`;
 
-  return (
-    <section data-component="fleet-agents-view" className="p-6">
-      <MetricStrip tiles={metricTiles} columns={6} variant="agents" className="mb-[14px]" />
-      <div className="mb-[14px] flex flex-wrap items-center gap-[8px] rounded-[18px] border border-border bg-background/80 px-[12px] py-[10px]" data-component="agents-filter-row">
-        <div className="flex items-center gap-[4px] rounded-[var(--radius-sm)] border border-border bg-card p-[2px]" aria-label="Agents phase filter">
-          <button
-            type="button"
-            className={cn(
-              'rounded-[calc(var(--radius-sm)-2px)] px-[9px] py-[5px] text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground',
-              filter.phases.length === 0 && 'bg-accent text-foreground',
-            )}
-            aria-pressed={filter.phases.length === 0}
-            onClick={clearPhases}
-          >
-            All
-          </button>
-          {PHASE_FILTERS.map((phase) => (
+  const content = (() => {
+    if (fleetAgents.length === 0) {
+      return (
+        <div className="p-6">
+          <div className="rounded-[18px] border border-dashed border-border bg-card px-6 py-10 text-center text-sm text-muted-foreground">
+            No running or stuck agents.
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="p-6">
+        <MetricStrip tiles={metricTiles} columns={6} variant="agents" className="mb-[14px]" />
+        <div className="mb-[14px] flex flex-wrap items-center gap-[8px] rounded-[18px] border border-border bg-background/80 px-[12px] py-[10px]" data-component="agents-filter-row">
+          <div className="flex items-center gap-[4px] rounded-[var(--radius-sm)] border border-border bg-card p-[2px]" aria-label="Agents phase filter">
             <button
-              key={phase}
               type="button"
               className={cn(
-                'rounded-[calc(var(--radius-sm)-2px)] px-[9px] py-[5px] text-[11px] font-medium capitalize text-muted-foreground transition-colors hover:text-foreground',
-                filter.phases.includes(phase) && 'bg-accent text-foreground',
+                'rounded-[calc(var(--radius-sm)-2px)] px-[9px] py-[5px] text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground',
+                filter.phases.length === 0 && 'bg-accent text-foreground',
               )}
-              aria-pressed={filter.phases.includes(phase)}
-              onClick={() => togglePhase(phase)}
+              aria-pressed={filter.phases.length === 0}
+              onClick={clearPhases}
             >
-              {phase}
+              All
             </button>
-          ))}
+            {PHASE_FILTERS.map((phase) => (
+              <button
+                key={phase}
+                type="button"
+                className={cn(
+                  'rounded-[calc(var(--radius-sm)-2px)] px-[9px] py-[5px] text-[11px] font-medium capitalize text-muted-foreground transition-colors hover:text-foreground',
+                  filter.phases.includes(phase) && 'bg-accent text-foreground',
+                )}
+                aria-pressed={filter.phases.includes(phase)}
+                onClick={() => togglePhase(phase)}
+              >
+                {phase}
+              </button>
+            ))}
+          </div>
+          <DropdownFilter label="Project" selected={filter.projects} options={projectOptions} onToggle={toggleProject} />
+          <DropdownFilter label="Model" selected={filter.models} options={modelOptions} onToggle={toggleModel} />
+          <span className="ml-auto text-[11px] font-medium text-muted-foreground">{filteredAgents.length} / {fleetAgents.length} agents</span>
         </div>
-        <DropdownFilter label="Project" selected={filter.projects} options={projectOptions} onToggle={toggleProject} />
-        <DropdownFilter label="Model" selected={filter.models} options={modelOptions} onToggle={toggleModel} />
-        <span className="ml-auto text-[11px] font-medium text-muted-foreground">{filteredAgents.length} / {fleetAgents.length} agents</span>
-      </div>
-      {filteredAgents.length === 0 ? (
-        <div className="rounded-[18px] border border-dashed border-border bg-card px-6 py-10 text-center text-sm text-muted-foreground">
-          No agents match the selected filters.
-        </div>
-      ) : (
-        <div className="grid gap-[14px] [grid-template-columns:repeat(auto-fill,minmax(360px,1fr))]">
-          {filteredAgents.map((agent) => {
-            const issue = issuesById.get(issueKey(agent.issueId));
-            const role = agentRole(agent);
-            const output = agentOutputById[agent.id] ?? [];
-            const stuck = isAgentProblemStatus(agent.status) || agent.troubled;
-            const lastHeard = agent.lastActivity ? formatRelativeTime(agent.lastActivity, now) : '—';
-            const runtime = formatDuration(now.getTime() - new Date(agent.startedAt).getTime());
+        {viewMode === 'grid' && (
+          filteredAgents.length === 0 ? (
+            <div className="rounded-[18px] border border-dashed border-border bg-card px-6 py-10 text-center text-sm text-muted-foreground">
+              No agents match the selected filters.
+            </div>
+          ) : (
+            <div className="grid gap-[14px] [grid-template-columns:repeat(auto-fill,minmax(360px,1fr))]">
+              {filteredAgents.map((agent) => {
+                const issue = issuesById.get(issueKey(agent.issueId));
+                const role = agentRole(agent);
+                const output = agentOutputById[agent.id] ?? [];
+                const stuck = isAgentProblemStatus(agent.status) || agent.troubled;
+                const lastHeard = agent.lastActivity ? formatRelativeTime(agent.lastActivity, now) : '—';
+                const runtime = formatDuration(now.getTime() - new Date(agent.startedAt).getTime());
 
-            return (
-              <AgentCard
-                key={agent.id}
-                id={agent.id}
-                name={agent.issueId ?? agent.id}
-                role={role}
-                issue={agent.issueId ? {
-                  id: agent.issueId,
-                  title: issue?.title ?? agent.issueId,
-                  project: issueProject(issue),
-                } : undefined}
-                meta={[
-                  { label: 'Model', value: compactModel(agent.model) },
-                  { label: 'Runtime', value: runtime },
-                  { label: 'Last heard', value: lastHeard },
-                ]}
-                streamLines={output.slice(-8)}
-                verbBadge={verbBadgeForAgent(agent, now)}
-                stuck={stuck}
-                stuckMessage={agent.lastFailureReason ?? agent.error ?? 'Agent requires attention.'}
-                onOpenIssue={agent.issueId ? () => openAgentIssue(agent.issueId!) : undefined}
-              />
-            );
-          })}
-        </div>
-      )}
+                return (
+                  <AgentCard
+                    key={agent.id}
+                    id={agent.id}
+                    name={agent.issueId ?? agent.id}
+                    role={role}
+                    issue={agent.issueId ? {
+                      id: agent.issueId,
+                      title: issue?.title ?? agent.issueId,
+                      project: issueProject(issue),
+                    } : undefined}
+                    meta={[
+                      { label: 'Model', value: compactModel(agent.model) },
+                      { label: 'Runtime', value: runtime },
+                      { label: 'Last heard', value: lastHeard },
+                    ]}
+                    streamLines={output.slice(-8)}
+                    verbBadge={verbBadgeForAgent(agent, now)}
+                    stuck={stuck}
+                    stuckMessage={agent.lastFailureReason ?? agent.error ?? 'Agent requires attention.'}
+                    onOpenIssue={agent.issueId ? () => openAgentIssue(agent.issueId!) : undefined}
+                  />
+                );
+              })}
+            </div>
+          )
+        )}
+        {viewMode === 'table' && (
+          <div className="rounded-[18px] border border-dashed border-border bg-card px-6 py-10 text-center text-sm text-muted-foreground" data-component="agents-coming-soon">
+            Coming soon
+          </div>
+        )}
+        {viewMode === 'timeline' && (
+          <div className="rounded-[18px] border border-dashed border-border bg-card px-6 py-10 text-center text-sm text-muted-foreground" data-component="agents-coming-soon">
+            Coming soon
+          </div>
+        )}
+      </div>
+    );
+  })();
+
+  return (
+    <section data-component="fleet-agents-view" className="flex h-full w-full flex-col">
+      <TopBar
+        breadcrumb="Eltmon / Agents"
+        meta={metaString}
+        search={
+          <div className="flex items-center gap-[6px] rounded-[var(--radius-sm)] border border-border bg-card px-[10px] py-[6px] text-[12px] text-muted-foreground">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="11" cy="11" r="7" /><path d="m20 20-3.5-3.5" /></svg>
+            Search agents by name, issue, model…
+          </div>
+        }
+        segmentedControl={
+          <div className="flex items-center gap-[2px] rounded-[var(--radius-sm)] border border-border bg-card p-[2px]">
+            {VIEW_MODES.map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                className={cn(
+                  'rounded-[calc(var(--radius-sm)-2px)] px-[10px] py-[5px] text-[11px] font-medium capitalize text-muted-foreground transition-colors hover:text-foreground',
+                  viewMode === mode && 'bg-accent text-foreground',
+                )}
+                aria-pressed={viewMode === mode}
+                onClick={() => updateViewMode(mode)}
+              >
+                {mode}
+              </button>
+            ))}
+          </div>
+        }
+        actions={
+          onNavigateToIssues && (
+            <Button size="sm" variant="primary" onClick={onNavigateToIssues}>
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="mr-[6px]"><path d="M5 4 19 12 5 20Z" fill="currentColor" /></svg>
+              Start agent
+            </Button>
+          )
+        }
+      />
+      {content}
     </section>
   );
 }

--- a/src/dashboard/frontend/src/components/drawer/IssueDrawer.tsx
+++ b/src/dashboard/frontend/src/components/drawer/IssueDrawer.tsx
@@ -54,16 +54,38 @@ export function IssueDrawer() {
   useEffect(() => {
     if (!drawer.issueId) return;
 
-    const scrollToActive = () => {
+    let rafId: number | null = null;
+    let attempts = 0;
+    const maxAttempts = 30;
+
+    const tryScroll = () => {
       if (window.location.hash !== '#active-agent') return;
-      window.requestAnimationFrame(() => {
-        document.getElementById('active-agent')?.scrollIntoView({ block: 'start' });
-      });
+      const el = document.getElementById('active-agent');
+      if (el) {
+        el.scrollIntoView({ block: 'start' });
+        return;
+      }
+      attempts++;
+      if (attempts < maxAttempts) {
+        rafId = window.requestAnimationFrame(tryScroll);
+      }
+    };
+
+    const scrollToActive = () => {
+      if (rafId) {
+        window.cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+      attempts = 0;
+      tryScroll();
     };
 
     scrollToActive();
     window.addEventListener('hashchange', scrollToActive);
-    return () => window.removeEventListener('hashchange', scrollToActive);
+    return () => {
+      window.removeEventListener('hashchange', scrollToActive);
+      if (rafId) window.cancelAnimationFrame(rafId);
+    };
   }, [drawer.issueId]);
 
   if (!drawer.issueId) return null;

--- a/src/dashboard/frontend/src/components/primitives/AgentCard.test.tsx
+++ b/src/dashboard/frontend/src/components/primitives/AgentCard.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import AgentCard from './AgentCard';
+
+describe('AgentCard', () => {
+  it('renders ship role with --signal-review accent', () => {
+    render(
+      <AgentCard
+        id="agent-ship-1"
+        name="Ship Agent"
+        role="ship"
+        meta={[
+          { label: 'Cost', value: '$0.00' },
+          { label: 'Tokens', value: '0' },
+          { label: 'Runtime', value: '0m' },
+        ]}
+        verbBadge={{ variant: 'SHIP RUNNING' }}
+      />,
+    );
+
+    const card = screen.getByText('Ship Agent').closest('[data-component="agent-card"]') as HTMLElement;
+    expect(card).toHaveStyle('--agent-card-accent: var(--signal-review)');
+  });
+
+  it('preserves all role accents without regression', () => {
+    const roles = [
+      { role: 'plan' as const, accent: 'var(--signal-review)' },
+      { role: 'work' as const, accent: 'var(--info)' },
+      { role: 'review' as const, accent: 'var(--warning)' },
+      { role: 'test' as const, accent: 'var(--success)' },
+      { role: 'ship' as const, accent: 'var(--signal-review)' },
+      { role: 'flywheel' as const, accent: 'var(--primary)' },
+    ];
+
+    for (const { role, accent } of roles) {
+      const { unmount } = render(
+        <AgentCard
+          id={`agent-${role}`}
+          name={`${role} Agent`}
+          role={role}
+          meta={[
+            { label: 'Cost', value: '$0.00' },
+            { label: 'Tokens', value: '0' },
+            { label: 'Runtime', value: '0m' },
+          ]}
+          verbBadge={{ variant: 'WORK RUNNING' }}
+        />,
+      );
+
+      const card = screen.getByText(`${role} Agent`).closest('[data-component="agent-card"]') as HTMLElement;
+      expect(card).toHaveStyle(`--agent-card-accent: ${accent}`);
+      unmount();
+    }
+  });
+});

--- a/src/dashboard/frontend/src/components/primitives/AgentCard.test.tsx
+++ b/src/dashboard/frontend/src/components/primitives/AgentCard.test.tsx
@@ -53,4 +53,26 @@ describe('AgentCard', () => {
       unmount();
     }
   });
+
+  it('renders the agent name in SF Mono (font-mono)', () => {
+    render(
+      <AgentCard
+        id="agent-font-1"
+        name="Font Agent"
+        role="work"
+        meta={[
+          { label: 'Cost', value: '$0.00' },
+          { label: 'Tokens', value: '0' },
+          { label: 'Runtime', value: '0m' },
+        ]}
+        verbBadge={{ variant: 'WORK RUNNING' }}
+      />,
+    );
+
+    const name = screen.getByText('Font Agent');
+    expect(name.tagName.toLowerCase()).toBe('h3');
+    expect(name).toHaveClass('font-mono');
+    expect(name).toHaveClass('font-semibold');
+    expect(name).toHaveClass('text-[13px]');
+  });
 });

--- a/src/dashboard/frontend/src/components/primitives/AgentCard.tsx
+++ b/src/dashboard/frontend/src/components/primitives/AgentCard.tsx
@@ -76,7 +76,7 @@ function AgentCard({
       <div className="flex items-start justify-between gap-[12px] pl-[10px]">
         <div className="min-w-0">
           <div className="flex min-w-0 items-center gap-[8px]">
-            <h3 className="truncate text-[13px] font-semibold leading-none text-foreground">{name}</h3>
+            <h3 className="truncate font-mono text-[13px] font-semibold leading-none text-foreground">{name}</h3>
             <VerbBadge {...verbBadge} />
           </div>
           <p className="mt-[6px] truncate font-mono text-[10px] leading-none text-muted-foreground">{id}</p>

--- a/src/dashboard/frontend/src/components/primitives/AgentCard.tsx
+++ b/src/dashboard/frontend/src/components/primitives/AgentCard.tsx
@@ -38,7 +38,7 @@ const ROLE_ACCENTS = {
   work: 'var(--info)',
   review: 'var(--warning)',
   test: 'var(--success)',
-  ship: 'var(--signal-cost)',
+  ship: 'var(--signal-review)',
   flywheel: 'var(--primary)',
 } satisfies Record<AgentCardRole, string>;
 

--- a/src/lib/__tests__/role-definitions.test.ts
+++ b/src/lib/__tests__/role-definitions.test.ts
@@ -38,7 +38,7 @@ describe('role definitions', () => {
     expect(body).toContain('Beads');
     expect(body).toContain('pan plan finalize');
     expect(body).not.toContain('pan plan finalize <ISSUE-ID>');
-    expect(body).toMatch(/Stop after [`']?pan plan finalize[`']? returns/);
+    expect(body).toContain('Stop after `pan plan finalize` returns');
     // Status-as-field model — files do not move between directories
     expect(body).toContain('Files never move between directories');
     // Output instructions must point at the canonical .pan/specs/ path, not legacy directories

--- a/tests/e2e/styleguide-conformance.spec.ts
+++ b/tests/e2e/styleguide-conformance.spec.ts
@@ -278,4 +278,26 @@ describe('styleguide rendered surface conformance', () => {
 
     await context.close();
   }, 45_000);
+
+  it('agents page Open issue scrolls drawer to active-agent section', async () => {
+    const { context, page } = await openRoute('/agents');
+
+    await expect.poll(() => page.locator('[data-component="agent-card"]').count()).toBe(1);
+    await page.getByText('Open issue').click();
+
+    await expect.poll(() => page.locator('[data-testid="issue-drawer"]').count()).toBe(1);
+    await expect.poll(() => page.locator('#active-agent').count()).toBe(1);
+
+    const activeAgent = page.locator('#active-agent');
+    const isInViewport = await activeAgent.evaluate((node) => {
+      const rect = node.getBoundingClientRect();
+      const parent = node.closest('[class*="overflow-auto"]');
+      if (!parent) return false;
+      const parentRect = parent.getBoundingClientRect();
+      return rect.top >= parentRect.top && rect.bottom <= parentRect.bottom;
+    });
+    expect(isInViewport).toBe(true);
+
+    await context.close();
+  }, 45_000);
 });

--- a/tests/e2e/styleguide-conformance.spec.ts
+++ b/tests/e2e/styleguide-conformance.spec.ts
@@ -253,4 +253,29 @@ describe('styleguide rendered surface conformance', () => {
     expect(primaryShadow).toContain('rgba(255, 255, 255, 0.06)');
     await drawer.context.close();
   }, 45_000);
+
+  it('agents page TopBar segmented control switches views and Start agent navigates to board', async () => {
+    const { context, page } = await openRoute('/agents');
+
+    await expect.poll(() => page.locator('[data-component="top-bar-segmented-control"]').count()).toBe(1);
+    await expect.poll(() => page.locator('[data-component="agent-card"]').count()).toBe(1);
+
+    await page.getByRole('button', { name: 'table' }).click();
+    await expect.poll(() => page.url()).toContain('view=table');
+    await expect.poll(() => page.locator('[data-component="agents-coming-soon"]').count()).toBe(1);
+    await expect.poll(() => page.locator('[data-component="agent-card"]').count()).toBe(0);
+
+    await page.getByRole('button', { name: 'timeline' }).click();
+    await expect.poll(() => page.url()).toContain('view=timeline');
+    await expect.poll(() => page.locator('[data-component="agents-coming-soon"]').count()).toBe(1);
+
+    await page.getByRole('button', { name: 'grid' }).click();
+    await expect.poll(() => page.url()).not.toContain('view=');
+    await expect.poll(() => page.locator('[data-component="agent-card"]').count()).toBe(1);
+
+    await page.getByRole('button', { name: 'Start agent' }).click();
+    await expect.poll(() => page.url()).toBe(`${baseUrl}/board`);
+
+    await context.close();
+  }, 45_000);
 });


### PR DESCRIPTION
Closes #1231

## Acceptance Criteria

- [ ] AgentCard ship-role accent: use --signal-review (purple), not --signal-cost (cyan)
- [ ] AgentCard H1 row name uses SF Mono (font-mono) per PRD §4.7.9
- [ ] Add TopBar shell to FleetAgentsView with Grid/Table/Timeline segmented control and Start agent button
- [ ] AgentCard 'Open issue' actually scrolls IssueDrawer to #active-agent (not just sets URL hash)

## Implementation Tasks

- [x] AgentCard 'Open issue' actually scrolls IssueDrawer to #active-agent (not just sets URL hash)
- [x] Add TopBar shell to FleetAgentsView with Grid/Table/Timeline segmented control and Start agent button
- [x] AgentCard H1 row name uses SF Mono (font-mono) per PRD §4.7.9
- [x] AgentCard ship-role accent: use --signal-review (purple), not --signal-cost (cyan)