### PR TITLE
PAN-1229

### DIFF
--- a/packages/contracts/src/flywheel.ts
+++ b/packages/contracts/src/flywheel.ts
@@ -68,7 +68,7 @@ export interface FlywheelPipelineItem {
   agentId?: string | undefined
   pr?: number | undefined
   mergeOrder?: number | undefined
-  conflictsWith?: string[] | undefined
+  conflictsWith?: readonly string[] | undefined
 }
 
 export const FlywheelPipelineItem = Schema.Struct({

--- a/src/dashboard/frontend/src/components/KanbanBoard.test.tsx
+++ b/src/dashboard/frontend/src/components/KanbanBoard.test.tsx
@@ -8,6 +8,7 @@ import type { Issue, Agent } from '../types';
 import { applyReviewStateToIssue, getPipelineCallToAction, groupByCanceledType, groupByLabels, groupByStatus, IssueCard, KanbanBoard, ListIssueRow, shouldShowAgentDoneBadge, shouldShowReviewReadyBadge, DivergedBadge, FeatureCard, CompactChildCard } from './KanbanBoard';
 import { useDashboardStore } from '../lib/store';
 import { DialogProvider } from './DialogProvider';
+import IssueCardPrimitive from './primitives/IssueCard';
 
 describe('groupByLabels', () => {
   const createMockIssue = (id: string, labels: string[]): Issue => ({
@@ -778,6 +779,27 @@ describe('IssueCard', () => {
     });
 
     expect(screen.getByTestId('card-cost-TEST-123')).toBeInTheDocument();
+  });
+
+  it('uses success tokens for merge-ready cards', () => {
+    renderIssueCard({
+      issue: createMockIssue({ status: 'In Review' }),
+      // Simulate merge-ready state via review status injection would require
+      // more setup; instead test the primitive directly through the board card
+      // by leveraging the fact that KanbanBoard computes mergeReadyCard from
+      // reviewStatus. We render the primitive directly for a focused assertion.
+    });
+
+    // Render the primitive directly for a focused styling test
+    const { container } = render(
+      <IssueCardPrimitive issueId="TEST-123" priority={3} mergeReadyCard={true}>
+        <div>content</div>
+      </IssueCardPrimitive>,
+    );
+
+    const card = container.querySelector('[data-merge-ready-card="true"]');
+    expect(card).toHaveClass('border-success/60', 'bg-success/10');
+    expect(card).not.toHaveClass('border-warning/60', 'bg-warning/10');
   });
 });
 

--- a/src/dashboard/frontend/src/components/KanbanBoard.test.tsx
+++ b/src/dashboard/frontend/src/components/KanbanBoard.test.tsx
@@ -731,6 +731,54 @@ describe('IssueCard', () => {
     expect(onSelect).toHaveBeenCalledTimes(1);
     expect(onPlan).not.toHaveBeenCalled();
   });
+
+  it('renders Beads N/M progress row when beadCounts is present', () => {
+    renderIssueCard({
+      issue: createMockIssue({ beadCounts: { completed: 7, total: 12 } }),
+    });
+
+    expect(screen.getByText('Beads 7/12')).toBeInTheDocument();
+    const beadProgress = screen.getByTestId('issue-card-TEST-123').querySelector('[data-component="bead-progress"]');
+    expect(beadProgress).toBeInTheDocument();
+    expect(beadProgress).toHaveAttribute('data-progress', '7');
+  });
+
+  it('hides bead progress row when beadCounts is null', () => {
+    renderIssueCard({
+      issue: createMockIssue({ beadCounts: null }),
+    });
+
+    expect(screen.queryByText(/Beads \d+\/\d+/)).not.toBeInTheDocument();
+  });
+
+  it('renders agent foot with name, sub, runtime and avatar for active agent', () => {
+    renderIssueCard({
+      workAgent: createMockAgent({ id: 'agent-test-123', model: 'claude-sonnet-4-6' }),
+    });
+
+    const card = screen.getByTestId('issue-card-TEST-123');
+    expect(card).toHaveTextContent('agent-test-123');
+    expect(card).toHaveTextContent('Sonnet 4.6');
+    expect(card.querySelector('[class*="rounded-full"][class*="grid"]')).toBeInTheDocument();
+  });
+
+  it('renders empty agent foot with no agent and tracker ref when no agent is active', () => {
+    renderIssueCard({
+      issue: createMockIssue({ source: 'github' }),
+      workAgent: undefined,
+    });
+
+    expect(screen.getByText('no agent')).toBeInTheDocument();
+    expect(screen.getByText('GitHub TEST-123')).toBeInTheDocument();
+  });
+
+  it('renders cost overlay when totalCost is greater than 0', () => {
+    renderIssueCard({
+      cost: { issueId: 'TEST-123', totalCost: 5.5, tokenCount: 1000, sessionCount: 1 },
+    });
+
+    expect(screen.getByTestId('card-cost-TEST-123')).toBeInTheDocument();
+  });
 });
 
 describe('groupByCanceledType', () => {

--- a/src/dashboard/frontend/src/components/KanbanBoard.test.tsx
+++ b/src/dashboard/frontend/src/components/KanbanBoard.test.tsx
@@ -5,10 +5,20 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { Issue, Agent } from '../types';
 // PAN-1048 — SpecialistAgent retired; specialist-style indicators now come
 // from role-tagged AgentSnapshots passed through the `specialists` prop.
-import { applyReviewStateToIssue, getPipelineCallToAction, groupByCanceledType, groupByLabels, groupByStatus, IssueCard, KanbanBoard, ListIssueRow, shouldShowAgentDoneBadge, shouldShowReviewReadyBadge, DivergedBadge, FeatureCard, CompactChildCard } from './KanbanBoard';
+import { applyReviewStateToIssue, getPipelineCallToAction, groupByCanceledType, groupByLabels, groupByStatus, IssueCard, KanbanBoard, ListIssueRow, shouldShowAgentDoneBadge, shouldShowReviewReadyBadge, DivergedBadge, FeatureCard, CompactChildCard, DroppableColumn } from './KanbanBoard';
 import { useDashboardStore } from '../lib/store';
 import { DialogProvider } from './DialogProvider';
 import IssueCardPrimitive from './primitives/IssueCard';
+
+const mockUseDroppable = vi.fn(() => ({ isOver: false, setNodeRef: vi.fn() }));
+
+vi.mock('@dnd-kit/core', async () => {
+  const actual = await vi.importActual<typeof import('@dnd-kit/core')>('@dnd-kit/core');
+  return {
+    ...actual,
+    useDroppable: (...args: Parameters<typeof import('@dnd-kit/core')['useDroppable']>) => mockUseDroppable(...args),
+  };
+});
 
 describe('groupByLabels', () => {
   const createMockIssue = (id: string, labels: string[]): Issue => ({
@@ -1373,5 +1383,54 @@ describe('CompactChildCard', () => {
     }];
     render(<CompactChildCard issue={child} agents={agents} />);
     expect(screen.getByTitle('Agent running')).toBeDefined();
+  });
+});
+
+describe('DroppableColumn', () => {
+  beforeEach(() => {
+    mockUseDroppable.mockReturnValue({ isOver: false, setNodeRef: vi.fn() });
+  });
+
+  afterEach(() => {
+    mockUseDroppable.mockClear();
+  });
+
+  it('applies blocked styles when dragging over a different column', () => {
+    mockUseDroppable.mockReturnValue({ isOver: true, setNodeRef: vi.fn() });
+    const { container } = render(
+      <DroppableColumn status="in_progress" activeDragStatus="done">
+        <div>content</div>
+      </DroppableColumn>,
+    );
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toContain('cursor-not-allowed');
+    expect(el.className).toContain('opacity-60');
+    expect(el.className).not.toContain('scale-[1.02]');
+  });
+
+  it('applies scale when dragging over the same column', () => {
+    mockUseDroppable.mockReturnValue({ isOver: true, setNodeRef: vi.fn() });
+    const { container } = render(
+      <DroppableColumn status="in_progress" activeDragStatus="in_progress">
+        <div>content</div>
+      </DroppableColumn>,
+    );
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toContain('scale-[1.02]');
+    expect(el.className).not.toContain('cursor-not-allowed');
+    expect(el.className).not.toContain('opacity-60');
+  });
+
+  it('applies no hover styles when not dragging over', () => {
+    mockUseDroppable.mockReturnValue({ isOver: false, setNodeRef: vi.fn() });
+    const { container } = render(
+      <DroppableColumn status="in_progress" activeDragStatus="done">
+        <div>content</div>
+      </DroppableColumn>,
+    );
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).not.toContain('scale-[1.02]');
+    expect(el.className).not.toContain('cursor-not-allowed');
+    expect(el.className).not.toContain('opacity-60');
   });
 });

--- a/src/dashboard/frontend/src/components/KanbanBoard.tsx
+++ b/src/dashboard/frontend/src/components/KanbanBoard.tsx
@@ -2696,7 +2696,7 @@ interface IssueCardProps {
   workspace?: WorkspaceData;
 }
 
-export function IssueCard({ issue, workAgent, workAgents = [], planningAgent, specialists = [], cost, costsLoading, isSelected, onSelect, onViewBeads, onViewVBrief, isBulkSelected, onBulkToggle, planningState: planningStateProp, workspace: workspaceProp }: IssueCardProps) {
+export function IssueCard({ issue, workAgent, workAgents = [], planningAgent, specialists = [], cost, isSelected, onSelect, isBulkSelected, onBulkToggle, workspace: workspaceProp }: IssueCardProps) {
   const [showCostModal, setShowCostModal] = useState(false);
   const cardRef = useRef<HTMLDivElement>(null);
   const stackHealth = workspaceProp?.stackHealth;

--- a/src/dashboard/frontend/src/components/KanbanBoard.tsx
+++ b/src/dashboard/frontend/src/components/KanbanBoard.tsx
@@ -10,6 +10,7 @@ import {
   useSensor,
   useSensors,
   type DragStartEvent,
+  type DragOverEvent,
   type DragEndEvent,
   defaultDropAnimationSideEffects,
   type DropAnimation,
@@ -1124,6 +1125,7 @@ export function KanbanBoard({ selectedIssue: externalSelectedIssue, onSelectIssu
 
   const [activeDragIssue, setActiveDragIssue] = useState<Issue | null>(null);
   const [activeDragStatus, setActiveDragStatus] = useState<CanonicalState | null>(null);
+  const [activeOverId, setActiveOverId] = useState<string | null>(null);
   const [columnOrderOverrides, setColumnOrderOverrides] = useState<Record<string, string[]>>({});
 
   // Undo state
@@ -1349,6 +1351,11 @@ export function KanbanBoard({ selectedIssue: externalSelectedIssue, onSelectIssu
     }
   }, [issues]);
 
+  // Handle drag over
+  const handleDragOver = useCallback((event: DragOverEvent) => {
+    setActiveOverId((event.over?.id as string) ?? null);
+  }, []);
+
   // Handle drag end
   const handleDragEnd = useCallback((event: DragEndEvent) => {
     const { active, over } = event;
@@ -1374,6 +1381,7 @@ export function KanbanBoard({ selectedIssue: externalSelectedIssue, onSelectIssu
 
     setActiveDragIssue(null);
     setActiveDragStatus(null);
+    setActiveOverId(null);
   }, [issues]);
 
   // Confirm agent warning
@@ -1839,6 +1847,7 @@ export function KanbanBoard({ selectedIssue: externalSelectedIssue, onSelectIssu
           sensors={sensors}
           collisionDetection={closestCorners}
           onDragStart={handleDragStart}
+          onDragOver={handleDragOver}
           onDragEnd={handleDragEnd}
         >
           <div className="flex gap-4 overflow-hidden pb-4">
@@ -1849,7 +1858,7 @@ export function KanbanBoard({ selectedIssue: externalSelectedIssue, onSelectIssu
             const someSelected = selectedInColumn.length > 0 && selectedInColumn.length < columnIssueIds.length;
 
             return (
-              <DroppableColumn key={status} status={status} activeDragStatus={activeDragStatus}>
+              <DroppableColumn key={status} status={status} activeDragStatus={activeDragStatus} overId={activeOverId} issueIds={sortedGrouped[status].map(i => i.id)}>
                 <div
                   className="flex-1 min-w-0"
                   data-testid={`kanban-column-${status.replace(/_/g, '-')}`}
@@ -2142,18 +2151,19 @@ function ColumnContent({
 }
 
 // DroppableColumn component
-export function DroppableColumn({ status, activeDragStatus, children }: { status: CanonicalState; activeDragStatus?: CanonicalState | null; children: React.ReactNode }) {
+export function DroppableColumn({ status, activeDragStatus, overId, issueIds, children }: { status: CanonicalState; activeDragStatus?: CanonicalState | null; overId?: string | null; issueIds?: string[]; children: React.ReactNode }) {
   const { isOver, setNodeRef } = useDroppable({
     id: status,
   });
 
-  const isBlocked = isOver && activeDragStatus !== undefined && activeDragStatus !== null && activeDragStatus !== status;
+  const isOverColumn = isOver || (overId !== undefined && overId !== null && (overId === status || issueIds?.includes(overId) === true));
+  const isBlocked = isOverColumn && activeDragStatus !== undefined && activeDragStatus !== null && activeDragStatus !== status;
 
   return (
     <div
       ref={setNodeRef}
       data-testid={`droppable-column-${status}`}
-      className={`flex-1 min-w-0 transition-all ${isBlocked ? 'cursor-not-allowed opacity-60' : isOver ? 'scale-[1.02]' : ''}`}
+      className={`flex-1 min-w-0 transition-all ${isBlocked ? 'cursor-not-allowed opacity-60' : isOverColumn ? 'scale-[1.02]' : ''}`}
     >
       {children}
     </div>

--- a/src/dashboard/frontend/src/components/KanbanBoard.tsx
+++ b/src/dashboard/frontend/src/components/KanbanBoard.tsx
@@ -2727,7 +2727,7 @@ export function IssueCard({ issue, workAgent, workAgents = [], planningAgent, sp
     canonical === 'todo' || canonical === 'backlog' ? <VerbBadge variant="QUEUED FOR PLAN" /> :
     null;
   const beadProgressColor =
-    isReadyToMerge || isMerged ? 'var(--success)' :
+    isReadyToMerge || isMerged || canonical === 'done' ? 'var(--success)' :
     canonical === 'in_review' ? 'var(--warning)' :
     canonical === 'in_progress' ? 'var(--info)' :
     canonical === 'todo' ? 'var(--signal-review)' :
@@ -2765,7 +2765,7 @@ export function IssueCard({ issue, workAgent, workAgents = [], planningAgent, sp
       <div className="relative" style={{ padding: '12px 12px 10px' }}>
         {/* Hover overlays */}
         {onBulkToggle && (
-          <div className="absolute top-2 left-2 opacity-0 group-hover:opacity-100 transition-opacity z-10">
+          <div className={`absolute top-2 left-2 transition-opacity z-10 ${isBulkSelected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}>
             <input
               type="checkbox"
               checked={isBulkSelected || false}

--- a/src/dashboard/frontend/src/components/KanbanBoard.tsx
+++ b/src/dashboard/frontend/src/components/KanbanBoard.tsx
@@ -1123,7 +1123,7 @@ export function KanbanBoard({ selectedIssue: externalSelectedIssue, onSelectIssu
   }, []);
 
   const [activeDragIssue, setActiveDragIssue] = useState<Issue | null>(null);
-  const [, setActiveDragStatus] = useState<CanonicalState | null>(null);
+  const [activeDragStatus, setActiveDragStatus] = useState<CanonicalState | null>(null);
   const [columnOrderOverrides, setColumnOrderOverrides] = useState<Record<string, string[]>>({});
 
   // Undo state
@@ -1849,7 +1849,7 @@ export function KanbanBoard({ selectedIssue: externalSelectedIssue, onSelectIssu
             const someSelected = selectedInColumn.length > 0 && selectedInColumn.length < columnIssueIds.length;
 
             return (
-              <DroppableColumn key={status} status={status}>
+              <DroppableColumn key={status} status={status} activeDragStatus={activeDragStatus}>
                 <div
                   className="flex-1 min-w-0"
                   data-testid={`kanban-column-${status.replace(/_/g, '-')}`}
@@ -2141,15 +2141,18 @@ function ColumnContent({
 }
 
 // DroppableColumn component
-function DroppableColumn({ status, children }: { status: CanonicalState; children: React.ReactNode }) {
+export function DroppableColumn({ status, activeDragStatus, children }: { status: CanonicalState; activeDragStatus?: CanonicalState | null; children: React.ReactNode }) {
   const { isOver, setNodeRef } = useDroppable({
     id: status,
   });
 
+  const isBlocked = isOver && activeDragStatus !== undefined && activeDragStatus !== null && activeDragStatus !== status;
+
   return (
     <div
       ref={setNodeRef}
-      className={`flex-1 min-w-0 transition-all ${isOver ? 'scale-[1.02]' : ''}`}
+      data-testid={`droppable-column-${status}`}
+      className={`flex-1 min-w-0 transition-all ${isBlocked ? 'cursor-not-allowed opacity-60' : isOver ? 'scale-[1.02]' : ''}`}
     >
       {children}
     </div>

--- a/src/dashboard/frontend/src/components/KanbanBoard.tsx
+++ b/src/dashboard/frontend/src/components/KanbanBoard.tsx
@@ -108,6 +108,40 @@ function getCostColor(_cost: number): string {
   return 'bg-popover text-muted-foreground';
 }
 
+function formatRuntime(startedAt: string): string {
+  const elapsed = Date.now() - new Date(startedAt).getTime();
+  const minutes = Math.floor(elapsed / 60000);
+  if (minutes < 1) return '<1 min';
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins} min`;
+}
+
+function cardAvatarInitials(name: string): string {
+  const parts = name.trim().split(/[-\s_]+/).filter(Boolean);
+  if (parts.length > 1) {
+    return (parts[0][0] + parts[1][0]).toUpperCase();
+  }
+  return name.slice(0, 2).toUpperCase();
+}
+
+const AVATAR_GRADIENTS = [
+  'linear-gradient(135deg, #a855f7, #06b6d4)',
+  'linear-gradient(135deg, #f59e0b, #ef4444)',
+  'linear-gradient(135deg, #10b981, #06b6d4)',
+  'linear-gradient(135deg, #60a5fa, #a855f7)',
+  'linear-gradient(135deg, #ef4444, #f59e0b)',
+];
+
+function avatarGradient(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i += 1) {
+    hash = (hash * 31 + name.charCodeAt(i)) >>> 0;
+  }
+  return AVATAR_GRADIENTS[hash % AVATAR_GRADIENTS.length];
+}
+
 export function applyReviewStateToIssue(
   issue: Issue,
   reviewStatus?: Pick<ReviewStatusSnapshot, 'mergeStatus' | 'readyForMerge'>,
@@ -2680,13 +2714,6 @@ export function IssueCard({ issue, workAgent, workAgents = [], planningAgent, sp
   const canonical = STATUS_LABELS[issue.status] || 'backlog';
   const isTerminal = isMerged || canonical === 'done' || canonical === 'canceled';
   const isPipelineStuck = !isTerminal && canonical === 'in_review' && isReviewPipelineStuck(reviewStatus);
-  const phaseLabel =
-    canonical === 'backlog' ? 'Backlog' :
-    canonical === 'todo' ? 'Ready to start' :
-    canonical === 'in_progress' ? (isRunning ? 'Agent active' : 'Work paused') :
-    canonical === 'in_review' ? (isReadyToMerge ? 'Awaiting merge' : isPipelineStuck ? 'Needs recovery' : 'Review pipeline') :
-    canonical === 'done' ? 'Completed' :
-    'Canceled';
   const cardVerbBadge =
     isTerminal ? <VerbBadge variant="MERGED" /> :
     isReadyToMerge ? <VerbBadge variant="READY TO MERGE" /> :
@@ -2695,17 +2722,26 @@ export function IssueCard({ issue, workAgent, workAgents = [], planningAgent, sp
     canonical === 'in_progress' && isRunning ? <VerbBadge variant="WORK RUNNING" /> :
     canonical === 'todo' || canonical === 'backlog' ? <VerbBadge variant="QUEUED FOR PLAN" /> :
     null;
-  const hasPlan = planningStateProp?.hasPlan ?? issue.hasPlan ?? false;
-  const hasBeads = planningStateProp?.hasBeads ?? issue.hasBeads ?? false;
-  const progressTotal = Math.min(3, Number(hasPlan) + Number(hasBeads) + Number(planningStateProp?.planningComplete ?? issue.planningComplete ?? false));
-  const progressPercent = `${Math.round((progressTotal / 3) * 100)}%`;
   const beadProgressColor =
     isReadyToMerge || isMerged ? 'var(--success)' :
     canonical === 'in_review' ? 'var(--warning)' :
     canonical === 'in_progress' ? 'var(--info)' :
     canonical === 'todo' ? 'var(--signal-review)' :
     'var(--muted-foreground)';
-  const issueSpecialists = specialists.filter((specialist) => specialist.status !== 'stopped');
+  const reviewSpecialists = specialists.filter((s) => s.role === 'review' && s.status !== 'stopped');
+
+  const agentSubText = activeAgent
+    ? (reviewSpecialists.length > 0 && activeAgent.role === 'review'
+      ? `${reviewSpecialists.length} reviewers · ${getFriendlyModelName(activeAgent.model)}`
+      : issue.beadCounts
+        ? `${getFriendlyModelName(activeAgent.model)} · bead ${issue.beadCounts.completed}/${issue.beadCounts.total}`
+        : getFriendlyModelName(activeAgent.model))
+    : '';
+  const trackerRef = issue.source === 'github'
+    ? `GitHub ${issue.identifier}`
+    : issue.source === 'linear'
+      ? `Linear ${issue.identifier}`
+      : issue.identifier;
 
   return (
     <IssueCardPrimitive
@@ -2722,76 +2758,136 @@ export function IssueCard({ issue, workAgent, workAgents = [], planningAgent, sp
       sessionLostCard={false}
       onClick={onSelect}
     >
-      <div className="relative p-4">
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2 flex-wrap">
-              {onBulkToggle && (
-                <input
-                  type="checkbox"
-                  checked={isBulkSelected || false}
-                  onChange={(event) => {
-                    event.stopPropagation();
-                    onBulkToggle();
-                  }}
-                  onClick={(event) => event.stopPropagation()}
-                  className="h-4 w-4 shrink-0 cursor-pointer rounded border-border text-primary focus:ring-primary"
-                  aria-label={`Select ${issue.identifier}`}
-                />
-              )}
-              <span className="text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">{phaseLabel}</span>
-              {cardVerbBadge}
-            </div>
-            <div className="mt-3 flex min-w-0 items-center gap-2">
-              <span className="shrink-0 font-mono text-sm font-semibold text-muted-foreground">{issue.identifier}</span>
-              <span className="truncate text-sm font-semibold text-foreground">{issue.title}</span>
-            </div>
-            <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
-              {issue.project && <span className="rounded-full border border-border bg-muted px-2 py-0.5">{issue.project.name}</span>}
-              <span className="rounded-full border border-border bg-muted px-2 py-0.5">beads {progressTotal}/3</span>
-              {activeAgent && <span className="rounded-full border border-border bg-muted px-2 py-0.5">{activeAgent.id} · {getFriendlyModelName(activeAgent.model)}</span>}
-              {issueSpecialists.length > 0 && <span className="rounded-full border border-border bg-muted px-2 py-0.5">{issueSpecialists.length} specialists</span>}
-            </div>
-            <div className="mt-3" data-component="bead-progress" data-progress={progressTotal}>
-              <div className="mb-1 flex items-center justify-between text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-                <span>Bead progress</span>
-                <span>{progressTotal}/3</span>
-              </div>
-              <div className="h-1.5 overflow-hidden rounded-full bg-muted">
-                <div
-                  className="h-full rounded-full transition-[width]"
-                  style={{ width: progressPercent, background: beadProgressColor }}
-                />
-              </div>
-            </div>
+      <div className="relative" style={{ padding: '12px 12px 10px' }}>
+        {/* Hover overlays */}
+        {onBulkToggle && (
+          <div className="absolute top-2 left-2 opacity-0 group-hover:opacity-100 transition-opacity z-10">
+            <input
+              type="checkbox"
+              checked={isBulkSelected || false}
+              onChange={(event) => {
+                event.stopPropagation();
+                onBulkToggle();
+              }}
+              onClick={(event) => event.stopPropagation()}
+              className="h-4 w-4 shrink-0 cursor-pointer rounded border-border text-primary focus:ring-primary"
+              aria-label={`Select ${issue.identifier}`}
+            />
           </div>
-          <div className="flex shrink-0 flex-col items-end gap-2">
-            {costsLoading && !cost && <span className="inline-block h-6 w-14 animate-pulse rounded-full bg-popover" />}
-            {cost && cost.totalCost > 0 && (
-              <button
-                type="button"
-                onClick={(event) => { event.stopPropagation(); setShowCostModal(true); }}
-                className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-semibold ${getCostColor(cost.totalCost)}`}
-                data-testid={`card-cost-${issue.identifier}`}
-              >
-                <DollarSign className="h-3 w-3" />
-                {formatCost(cost.totalCost).slice(1)}
-              </button>
-            )}
-            <div className="flex items-center gap-2">
-              {onViewBeads && (
-                <button type="button" onClick={(event) => { event.stopPropagation(); onViewBeads(issue); }} className="text-muted-foreground hover:text-foreground" aria-label={`Open beads for ${issue.identifier}`}>
-                  <List className="h-3.5 w-3.5" />
-                </button>
-              )}
-              {onViewVBrief && (
-                <button type="button" onClick={(event) => { event.stopPropagation(); onViewVBrief(issue); }} className="text-muted-foreground hover:text-foreground" aria-label={`Open vBRIEF for ${issue.identifier}`}>
-                  <ScrollText className="h-3.5 w-3.5" />
-                </button>
-              )}
-            </div>
+        )}
+        {cost && cost.totalCost > 0 && (
+          <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity z-10">
+            <button
+              type="button"
+              onClick={(event) => { event.stopPropagation(); setShowCostModal(true); }}
+              className={`inline-flex items-center gap-1 rounded-full px-2 py-1 text-[10px] font-semibold ${getCostColor(cost.totalCost)}`}
+              data-testid={`card-cost-${issue.identifier}`}
+            >
+              <DollarSign className="h-3 w-3" />
+              {formatCost(cost.totalCost).slice(1)}
+            </button>
           </div>
+        )}
+
+        {/* Row 1: project mark + ID + verb badge */}
+        <div className="flex items-center gap-2 mb-1.5">
+          {issue.project ? (
+            <div className="flex items-center gap-[5px]">
+              <span
+                className="block rounded-[2px]"
+                style={{ width: 8, height: 8, backgroundColor: issue.project.color }}
+              />
+              <span className="font-mono text-[10px] text-muted-foreground">{issue.identifier}</span>
+            </div>
+          ) : (
+            <span className="font-mono text-[10px] text-muted-foreground">{issue.identifier}</span>
+          )}
+          <span className="ml-auto">{cardVerbBadge}</span>
         </div>
+
+        {/* Title */}
+        <h3
+          className="text-[13px] leading-[1.35] text-foreground mb-2"
+          style={{
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
+        >
+          {issue.title}
+        </h3>
+
+        {/* Labels */}
+        {issue.labels.length > 0 && (
+          <div className="flex flex-wrap gap-1 mb-2.5">
+            {issue.labels.map((label) => (
+              <span
+                key={label}
+                className="text-[10px] font-medium px-[6px] py-px rounded-sm"
+                style={{
+                  background: 'rgb(255 255 255 / 5%)',
+                  border: '1px solid var(--border)',
+                  color: 'var(--muted-foreground)',
+                }}
+              >
+                {label}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Bead progress */}
+        {issue.beadCounts && (
+          <div className="flex items-center gap-2 mt-2" data-component="bead-progress" data-progress={issue.beadCounts.completed}>
+            <span className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground font-semibold">
+              Beads {issue.beadCounts.completed}/{issue.beadCounts.total}
+            </span>
+            <div
+              className="flex-1 h-[3px] rounded-[2px] overflow-hidden"
+              style={{ background: 'var(--accent)' }}
+            >
+              <div
+                className="h-full rounded-[2px]"
+                style={{
+                  width: `${(issue.beadCounts.completed / issue.beadCounts.total) * 100}%`,
+                  background: beadProgressColor,
+                }}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Foot */}
+        <div className="flex items-center gap-2 pt-2 mt-2" style={{ borderTop: '1px solid var(--border)' }}>
+          <div className="flex flex-col min-w-0 gap-0.5 flex-1">
+            {activeAgent ? (
+              <>
+                <span className="font-mono text-[10px] text-foreground truncate">{activeAgent.id}</span>
+                <span className="font-mono text-[9px] text-muted-foreground truncate">{agentSubText}</span>
+              </>
+            ) : (
+              <>
+                <span className="text-[10px] text-muted-foreground italic" style={{ fontFamily: '"DM Sans", sans-serif' }}>
+                  no agent
+                </span>
+                <span className="font-mono text-[9px] text-muted-foreground truncate">{trackerRef}</span>
+              </>
+            )}
+          </div>
+          <span className="font-mono text-[10px] text-muted-foreground tabular-nums whitespace-nowrap">
+            {activeAgent ? formatRuntime(activeAgent.startedAt) : '—'}
+          </span>
+          <span
+            className="w-[18px] h-[18px] rounded-full grid place-items-center text-[9px] font-semibold text-white border border-border shrink-0"
+            style={{
+              background: avatarGradient(activeAgent?.id ?? issue.identifier),
+            }}
+          >
+            {cardAvatarInitials(activeAgent?.id ?? issue.identifier)}
+          </span>
+        </div>
+
         <CostBreakdownModal
           issueId={issue.identifier}
           isOpen={showCostModal}

--- a/src/dashboard/frontend/src/components/KanbanBoard.tsx
+++ b/src/dashboard/frontend/src/components/KanbanBoard.tsx
@@ -1899,7 +1899,7 @@ export function KanbanBoard({ selectedIssue: externalSelectedIssue, onSelectIssu
                     planningStateById={planningStateById}
                     workspaceByIssueId={stackHealthByIssue}
                   />
-                  {/* TODO(PAN-1238): + New issue column footer button — see PRD §4.7.6 */}
+                  {/* TODO(PAN-1242): + New issue column footer button — see PRD §4.7.6 */}
                   </div>
                 </div>
               </DroppableColumn>

--- a/src/dashboard/frontend/src/components/KanbanBoard.tsx
+++ b/src/dashboard/frontend/src/components/KanbanBoard.tsx
@@ -1899,6 +1899,7 @@ export function KanbanBoard({ selectedIssue: externalSelectedIssue, onSelectIssu
                     planningStateById={planningStateById}
                     workspaceByIssueId={stackHealthByIssue}
                   />
+                  {/* TODO(PAN-1238): + New issue column footer button — see PRD §4.7.6 */}
                   </div>
                 </div>
               </DroppableColumn>

--- a/src/dashboard/frontend/src/components/primitives/IssueCard.tsx
+++ b/src/dashboard/frontend/src/components/primitives/IssueCard.tsx
@@ -46,14 +46,14 @@ const IssueCard = forwardRef<HTMLDivElement, IssueCardProps>(function IssueCard(
   const tone = unhealthyCard || stuckCard
     ? 'from-destructive/12 via-destructive/5 to-transparent'
     : mergeReadyCard
-      ? 'from-warning/20 via-warning/6 to-transparent'
+      ? 'from-success/20 via-success/6 to-transparent'
       : runningCard
         ? 'from-primary/16 via-primary/6 to-transparent'
         : 'from-surface-overlay/60 via-surface/40 to-transparent';
   const accent = unhealthyCard || stuckCard
     ? 'bg-destructive'
     : mergeReadyCard
-      ? 'bg-warning'
+      ? 'bg-success'
       : runningCard
         ? 'bg-primary'
         : (PRIORITY_ACCENT_CLASSES[priority] || 'bg-muted-foreground');
@@ -76,7 +76,7 @@ const IssueCard = forwardRef<HTMLDivElement, IssueCardProps>(function IssueCard(
           : unhealthyCard || stuckCard
             ? 'border-destructive/60 bg-destructive/10 shadow-md'
             : mergeReadyCard
-              ? 'border-warning/60 bg-warning/10 shadow-md'
+              ? 'border-success/60 bg-success/10 shadow-md'
               : bulkSelected
                 ? 'border-primary/50 bg-primary/10 shadow-sm'
                 : 'hover:-translate-y-0.5 border-border/70 hover:border-border hover:shadow-md',

--- a/src/dashboard/frontend/src/types.ts
+++ b/src/dashboard/frontend/src/types.ts
@@ -45,6 +45,7 @@ export interface Issue {
   hasBeads?: boolean;
   planningComplete?: boolean;
   workspacePath?: string;
+  beadCounts?: { completed: number; total: number } | null;
 }
 
 export interface GitStatus {

--- a/src/dashboard/server/services/__tests__/issue-data-service.test.ts
+++ b/src/dashboard/server/services/__tests__/issue-data-service.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { computeBeadCounts } from '../issue-data-service.js';
+import type { VBriefDocument } from '../../../../lib/vbrief/types.js';
+
+describe('computeBeadCounts', () => {
+  function makeDoc(items: Array<{ status: string }>): VBriefDocument {
+    return {
+      vBRIEFInfo: { version: '0.5', created: '2026-01-01T00:00:00Z' },
+      plan: {
+        id: 'plan-1',
+        title: 'Test Plan',
+        status: 'active',
+        items: items.map((it, idx) => ({
+          id: `item-${idx}`,
+          title: `Task ${idx}`,
+          status: it.status as any,
+        })),
+        edges: [],
+      },
+    };
+  }
+
+  it('returns completed and total for a plan with 7 completed of 12', () => {
+    const items = Array.from({ length: 12 }, (_, i) => ({
+      status: i < 7 ? 'completed' : 'pending',
+    }));
+    const doc = makeDoc(items);
+    expect(computeBeadCounts(doc)).toEqual({ completed: 7, total: 12 });
+  });
+
+  it('returns 0 completed for a plan with 0 of 5', () => {
+    const items = Array.from({ length: 5 }, () => ({ status: 'pending' }));
+    const doc = makeDoc(items);
+    expect(computeBeadCounts(doc)).toEqual({ completed: 0, total: 5 });
+  });
+
+  it('returns null when the plan has no items', () => {
+    const doc = makeDoc([]);
+    expect(computeBeadCounts(doc)).toBeNull();
+  });
+
+  it('returns null when the document is null', () => {
+    expect(computeBeadCounts(null)).toBeNull();
+  });
+
+  it('returns null when the document has no plan', () => {
+    const doc = {
+      vBRIEFInfo: { version: '0.5', created: '2026-01-01T00:00:00Z' },
+      plan: { id: 'plan-1', title: 'Test', status: 'active', items: [], edges: [] },
+    } as VBriefDocument;
+    expect(computeBeadCounts(doc)).toBeNull();
+  });
+});

--- a/src/dashboard/server/services/issue-data-service.ts
+++ b/src/dashboard/server/services/issue-data-service.ts
@@ -22,6 +22,17 @@ import type { GitHubConfig, RallyConfig } from './tracker-config.js';
 import { loadReviewStatusesForIssues, type ReviewStatus } from '../../../lib/review-status.js';
 import { resolveProjectFromIssue } from '../../../lib/projects.js';
 import { findPlanAsync, readWorkspacePlanAsync } from '../../../lib/vbrief/io.js';
+import type { VBriefDocument } from '../../../lib/vbrief/types.js';
+
+/**
+ * Compute bead progress counts from a cached plan document.
+ * Exported for testing.
+ */
+export function computeBeadCounts(doc: VBriefDocument | null): { completed: number; total: number } | null {
+  const items = doc?.plan?.items ?? [];
+  if (items.length === 0) return null;
+  return { completed: items.filter((i) => i.status === 'completed').length, total: items.length };
+}
 
 /**
  * Map a raw status string to its canonical state.
@@ -129,7 +140,13 @@ function mapRallyStateToCanonical(issueState: string): string {
  * change.
  */
 interface PlanningStateCacheEntry {
-  result: { hasPlan: boolean; hasBeads: boolean; planningComplete: boolean; workspacePath: string };
+  result: {
+    hasPlan: boolean;
+    hasBeads: boolean;
+    planningComplete: boolean;
+    workspacePath: string;
+    beadCounts: { completed: number; total: number } | null;
+  };
   planMtimeMs: number; // -1 when no plan file existed at compute time
 }
 const planningStateCache = new Map<string, PlanningStateCacheEntry>();
@@ -143,19 +160,20 @@ function getCachedPlanningState(identifier: string): {
   hasBeads: boolean;
   planningComplete: boolean;
   workspacePath: string;
+  beadCounts: { completed: number; total: number } | null;
 } {
   try {
     const resolved = resolveProjectFromIssue(identifier);
     const projectPath = resolved?.projectPath ?? '';
     if (!projectPath) {
-      return { hasPlan: false, hasBeads: false, planningComplete: false, workspacePath: '' };
+      return { hasPlan: false, hasBeads: false, planningComplete: false, workspacePath: '', beadCounts: null };
     }
     const issueLower = identifier.toLowerCase();
     const workspacePath = join(projectPath, 'workspaces', `feature-${issueLower}`);
     return planningStateCache.get(identifier)?.result
-      ?? { hasPlan: false, hasBeads: false, planningComplete: false, workspacePath };
+      ?? { hasPlan: false, hasBeads: false, planningComplete: false, workspacePath, beadCounts: null };
   } catch {
-    return { hasPlan: false, hasBeads: false, planningComplete: false, workspacePath: '' };
+    return { hasPlan: false, hasBeads: false, planningComplete: false, workspacePath: '', beadCounts: null };
   }
 }
 
@@ -166,7 +184,7 @@ async function refreshPlanningState(identifier: string): Promise<boolean> {
     const resolved = resolveProjectFromIssue(identifier);
     const projectPath = resolved?.projectPath ?? '';
     if (!projectPath) return updatePlanningStateCache(identifier, {
-      result: { hasPlan: false, hasBeads: false, planningComplete: false, workspacePath: '' },
+      result: { hasPlan: false, hasBeads: false, planningComplete: false, workspacePath: '', beadCounts: null },
       planMtimeMs: -1,
     });
 
@@ -174,7 +192,7 @@ async function refreshPlanningState(identifier: string): Promise<boolean> {
     const workspacePath = join(projectPath, 'workspaces', `feature-${issueLower}`);
     if (!existsSync(workspacePath)) {
       return updatePlanningStateCache(identifier, {
-        result: { hasPlan: false, hasBeads: false, planningComplete: false, workspacePath },
+        result: { hasPlan: false, hasBeads: false, planningComplete: false, workspacePath, beadCounts: null },
         planMtimeMs: -1,
       });
     }
@@ -196,13 +214,14 @@ async function refreshPlanningState(identifier: string): Promise<boolean> {
 
     const doc = planPath ? await readWorkspacePlanAsync(workspacePath) : null;
     const planningComplete = doc?.plan?.status ? PLANNING_FINISHED_STATUSES.has(doc.plan.status) : false;
+    const beadCounts = computeBeadCounts(doc);
     return updatePlanningStateCache(identifier, {
-      result: { hasPlan: planPath !== null, hasBeads: planningComplete, planningComplete, workspacePath },
+      result: { hasPlan: planPath !== null, hasBeads: planningComplete, planningComplete, workspacePath, beadCounts },
       planMtimeMs,
     });
   } catch {
     return updatePlanningStateCache(identifier, {
-      result: { hasPlan: false, hasBeads: false, planningComplete: false, workspacePath: '' },
+      result: { hasPlan: false, hasBeads: false, planningComplete: false, workspacePath: '', beadCounts: null },
       planMtimeMs: -1,
     });
   } finally {
@@ -416,6 +435,7 @@ export class IssueDataService {
         hasBeads: ps.hasBeads,
         planningComplete: ps.planningComplete,
         workspacePath: ps.workspacePath || undefined,
+        beadCounts: ps.beadCounts,
       };
     });
 

--- a/src/dashboard/server/services/issue-data-service.ts
+++ b/src/dashboard/server/services/issue-data-service.ts
@@ -148,6 +148,7 @@ interface PlanningStateCacheEntry {
     beadCounts: { completed: number; total: number } | null;
   };
   planMtimeMs: number; // -1 when no plan file existed at compute time
+  continueMtimeMs: number; // -1 when no continue.json existed at compute time
 }
 const planningStateCache = new Map<string, PlanningStateCacheEntry>();
 
@@ -186,6 +187,7 @@ async function refreshPlanningState(identifier: string): Promise<boolean> {
     if (!projectPath) return updatePlanningStateCache(identifier, {
       result: { hasPlan: false, hasBeads: false, planningComplete: false, workspacePath: '', beadCounts: null },
       planMtimeMs: -1,
+      continueMtimeMs: -1,
     });
 
     const issueLower = identifier.toLowerCase();
@@ -194,6 +196,7 @@ async function refreshPlanningState(identifier: string): Promise<boolean> {
       return updatePlanningStateCache(identifier, {
         result: { hasPlan: false, hasBeads: false, planningComplete: false, workspacePath, beadCounts: null },
         planMtimeMs: -1,
+        continueMtimeMs: -1,
       });
     }
 
@@ -207,8 +210,16 @@ async function refreshPlanningState(identifier: string): Promise<boolean> {
       }
     }
 
+    const continuePath = join(workspacePath, '.pan', 'continue.json');
+    let continueMtimeMs = -1;
+    try {
+      continueMtimeMs = (await stat(continuePath)).mtimeMs;
+    } catch {
+      continueMtimeMs = -1;
+    }
+
     const cached = planningStateCache.get(identifier);
-    if (cached && cached.planMtimeMs === planMtimeMs && cached.result.workspacePath === workspacePath) {
+    if (cached && cached.planMtimeMs === planMtimeMs && cached.continueMtimeMs === continueMtimeMs && cached.result.workspacePath === workspacePath) {
       return false;
     }
 
@@ -218,11 +229,13 @@ async function refreshPlanningState(identifier: string): Promise<boolean> {
     return updatePlanningStateCache(identifier, {
       result: { hasPlan: planPath !== null, hasBeads: planningComplete, planningComplete, workspacePath, beadCounts },
       planMtimeMs,
+      continueMtimeMs,
     });
   } catch {
     return updatePlanningStateCache(identifier, {
       result: { hasPlan: false, hasBeads: false, planningComplete: false, workspacePath: '', beadCounts: null },
       planMtimeMs: -1,
+      continueMtimeMs: -1,
     });
   } finally {
     planningStateRefreshInFlight.delete(identifier);
@@ -233,6 +246,7 @@ function updatePlanningStateCache(identifier: string, entry: PlanningStateCacheE
   const prev = planningStateCache.get(identifier);
   const changed = !prev
     || prev.planMtimeMs !== entry.planMtimeMs
+    || prev.continueMtimeMs !== entry.continueMtimeMs
     || JSON.stringify(prev.result) !== JSON.stringify(entry.result);
   planningStateCache.set(identifier, entry);
   return changed;


### PR DESCRIPTION
Closes #1229

## Acceptance Criteria

- [ ] Expose `beadCounts: { completed, total } | null` on each issue payload from the cached plan doc
- [ ] Rewrite Board Issue Card body to match PRD §4.7.6 (project mark + ID + verb badge / 2-line title / labels / Beads N/M / two-line agent foot)
- [ ] Flip merge-ready card styling from warning tokens to success tokens in the IssueCard primitive
- [ ] Cross-column drag (N-B-1): show a visual block on the destination column instead of silently snapping back
- [ ] File a follow-up GitHub issue for the '+ New issue' column-footer button (N-B-2 from the audit)

## Implementation Tasks

- [x] Rewrite Board Issue Card body to match PRD §4.7.6 (project mark + ID + verb badge / 2-line title / labels / Beads N/M / two-line agent foot)
- [x] File a follow-up GitHub issue for the '+ New issue' column-footer button (N-B-2 from the audit)
- [x] Cross-column drag (N-B-1): show a visual block on the destination column instead of silently snapping back
- [x] Flip merge-ready card styling from warning tokens to success tokens in the IssueCard primitive
- [x] Expose `beadCounts: { completed, total } | null` on each issue payload from the cached plan doc