### PR TITLE
feat(dashboard): trim OpenAI dropdown to five supported models (PAN-1122)

### DIFF
--- a/src/dashboard/frontend/src/components/Settings/modelCatalog.ts
+++ b/src/dashboard/frontend/src/components/Settings/modelCatalog.ts
@@ -42,16 +42,9 @@ export const MODELS_BY_PROVIDER: Record<string, ProviderDef> = {
     models: [
       { id: 'gpt-5.5-pro' as ModelId, name: 'GPT-5.5 Pro', icon: Gem, tier: 'premium', costPer1MTokens: 119, capabilities: ['reasoning', 'code', 'vision', 'agentic', 'large-context'], description: 'Most advanced GPT-5.5 model. EXTREMELY expensive — only for hardest problems.' },
       { id: 'gpt-5.5' as ModelId, name: 'GPT-5.5', icon: Gem, tier: 'premium', costPer1MTokens: 10.5, capabilities: ['reasoning', 'code', 'vision', 'agentic', 'large-context'], description: 'Latest OpenAI flagship. Enhanced reasoning and coding.' },
-      { id: 'gpt-5.5-mini' as ModelId, name: 'GPT-5.5 Mini', icon: FlaskConical, tier: 'fast', costPer1MTokens: 1.25, capabilities: ['fast', 'cost-efficient', 'code'], description: 'Fast GPT-5.5 variant.' },
-      { id: 'gpt-5.5-nano' as ModelId, name: 'GPT-5.5 Nano', icon: Zap, tier: 'fast', costPer1MTokens: 0.875, capabilities: ['fast', 'cost-efficient'], description: 'Most efficient GPT-5.5 variant.' },
-      { id: 'gpt-5.4-pro' as ModelId, name: 'GPT-5.4 Pro', icon: Gem, tier: 'premium', costPer1MTokens: 105, capabilities: ['reasoning', 'code', 'vision', 'agentic', 'large-context'], description: 'Most advanced GPT-5.4 model. Pro subscribers only.' },
       { id: 'gpt-5.4' as ModelId, name: 'GPT-5.4', icon: Sparkles, tier: 'balanced', costPer1MTokens: 8.75, capabilities: ['reasoning', 'code', 'vision', 'agentic', 'large-context'], description: 'OpenAI flagship. 1.05M context, strong coding.' },
       { id: 'gpt-5.4-mini' as ModelId, name: 'GPT-5.4 Mini', icon: FlaskConical, tier: 'fast', costPer1MTokens: 1, capabilities: ['fast', 'cost-efficient', 'code'], description: 'Fast and efficient. 400K context.' },
       { id: 'gpt-5.4-nano' as ModelId, name: 'GPT-5.4 Nano', icon: Zap, tier: 'fast', costPer1MTokens: 0.7, capabilities: ['fast', 'cost-efficient'], description: 'Fastest GPT-5.4 model. API-only.' },
-      { id: 'o3' as ModelId, name: 'O3', icon: Gem, tier: 'premium', costPer1MTokens: 5, capabilities: ['reasoning', 'code', 'agentic'], description: 'Deep reasoning. Best for debugging and complex analysis.' },
-      { id: 'o4-mini' as ModelId, name: 'O4 Mini', icon: Sparkles, tier: 'balanced', costPer1MTokens: 2.75, capabilities: ['reasoning', 'code', 'fast'], description: 'Compact reasoning model. Fast, cost-efficient.' },
-      { id: 'gpt-4o' as ModelId, name: 'GPT-4o', icon: FlaskConical, tier: 'balanced', costPer1MTokens: 7.5, capabilities: ['reasoning', 'code', 'vision'], description: 'Versatile multimodal model' },
-      { id: 'gpt-4o-mini' as ModelId, name: 'GPT-4o Mini', icon: Zap, tier: 'fast', costPer1MTokens: 0.6, capabilities: ['fast', 'cost-efficient'], description: 'Budget option for simple tasks' },
     ],
   },
   google: {


### PR DESCRIPTION
## Summary
- Removes 7 unsupported models from `MODELS_BY_PROVIDER.openai` in `modelCatalog.ts`
- Dropped: `gpt-5.5-mini`, `gpt-5.5-nano`, `gpt-5.4-pro`, `o3`, `o4-mini`, `gpt-4o`, `gpt-4o-mini`
- Remaining five: `gpt-5.5-pro`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`

## Test plan
- [ ] `MODELS_BY_PROVIDER.openai` has exactly 5 entries
- [ ] Settings page OpenAI provider dropdown renders exactly 5 models

Closes `frontend-catalog` task in PAN-1122 swarm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)