### PR TITLE
feat(settings): narrow OpenAIModel type to five supported IDs (PAN-1122 slot-1)

### DIFF
--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -3,7 +3,7 @@ import { SETTINGS_FILE } from './paths.js';
 
 // Model identifiers
 export type AnthropicModel = 'claude-opus-4-7' | 'claude-opus-4-6' | 'claude-sonnet-4-6' | 'claude-sonnet-4-5' | 'claude-haiku-4-5';
-export type OpenAIModel = 'gpt-5.5' | 'gpt-5.5-pro' | 'gpt-5.4' | 'gpt-5.4-mini' | 'gpt-5.4-pro' | 'gpt-5.3-codex' | 'gpt-5.2' | 'o3' | 'o4-mini' | 'o3-deep-research' | 'gpt-4o' | 'gpt-4o-mini';
+export type OpenAIModel = 'gpt-5.4-nano' | 'gpt-5.4-mini' | 'gpt-5.4' | 'gpt-5.5' | 'gpt-5.5-pro';
 export type GoogleModel = 'gemini-3.1-pro-preview' | 'gemini-3.1-flash-lite-preview' | 'gemini-3-pro-preview' | 'gemini-3-flash-preview' | 'gemini-2.5-pro' | 'gemini-2.5-flash';
 export type KimiModel = 'kimi-k2.6' | 'kimi-k2.5' | 'K2.6-code-preview' | 'kimi-k2';
 export type MiniMaxModel = 'minimax-m2.7' | 'minimax-m2.7-highspeed';
@@ -220,7 +220,7 @@ export function getAvailableModels(settings: SettingsConfig): {
   ];
 
   const openaiModels: OpenAIModel[] = settings.api_keys.openai
-    ? ['gpt-5.5', 'gpt-5.5-pro', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-pro', 'gpt-5.3-codex', 'gpt-5.2', 'o3', 'o4-mini']
+    ? ['gpt-5.4-nano', 'gpt-5.4-mini', 'gpt-5.4', 'gpt-5.5', 'gpt-5.5-pro']
     : [];
 
   const googleModels: GoogleModel[] = settings.api_keys.google


### PR DESCRIPTION
## Summary

- Replaces the 12-entry `OpenAIModel` union in `src/lib/settings.ts` with exactly the five supported IDs: `gpt-5.4-nano | gpt-5.4-mini | gpt-5.4 | gpt-5.5 | gpt-5.5-pro`
- Updates the `getAvailableModels` default OpenAI array (line 223) to the same five IDs

Wave-0 slot-1 of the PAN-1122 swarm. The type narrowing is the foundation sibling slots build on — downstream typecheck errors in `model-capabilities.ts` and `router-config.ts` are expected and resolved by the other parallel slots.

## Test plan

- [x] `OpenAIModel` type lists exactly five supported IDs
- [x] Default models array at `settings.ts:223` matches the five supported IDs
- [x] `npm run typecheck` surfaces downstream errors in other slots' files (expected — those slots fix them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)