### PR TITLE
fix(cli): sync backend router allowed-models to five supported OpenAI IDs (PAN-1122)

### DIFF
--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -78,7 +78,7 @@ export const PROVIDERS: Record<ProviderName, ProviderConfig> = {
     name: 'openai',
     displayName: 'OpenAI',
     compatibility: 'direct',
-    models: ['gpt-5.5', 'gpt-5.5-pro', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-pro', 'gpt-5.3-codex', 'gpt-5.2', 'o3', 'o4-mini'],
+    models: ['gpt-5.4-nano', 'gpt-5.4-mini', 'gpt-5.4', 'gpt-5.5', 'gpt-5.5-pro'],
     tierModels: { opus: 'gpt-5.5-pro', sonnet: 'gpt-5.4', haiku: 'gpt-5.4-mini' },
     tested: true,
     description: 'Route through the local CLIProxyAPI Anthropic-compatible sidecar using Codex/ChatGPT subscription auth.',
@@ -177,7 +177,7 @@ export function getProviderForModel(modelId: ModelId | string): ProviderConfig {
   }
 
   // Check OpenAI models
-  if (['gpt-5.5', 'gpt-5.5-pro', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-pro', 'gpt-5.3-codex', 'gpt-5.2', 'o3', 'o4-mini', 'o3-deep-research', 'gpt-4o', 'gpt-4o-mini'].includes(modelId)) {
+  if (['gpt-5.4-nano', 'gpt-5.4-mini', 'gpt-5.4', 'gpt-5.5', 'gpt-5.5-pro'].includes(modelId)) {
     return PROVIDERS.openai;
   }
 

--- a/src/lib/router-config.ts
+++ b/src/lib/router-config.ts
@@ -64,7 +64,7 @@ export function generateRouterConfig(settings: SettingsConfig): RouterConfig {
       apiKey: settings.api_keys.openai.startsWith('$')
         ? settings.api_keys.openai
         : settings.api_keys.openai,
-      models: ['gpt-5.5', 'gpt-5.5-pro', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-pro', 'gpt-5.3-codex', 'gpt-5.2', 'o3', 'o4-mini'],
+      models: ['gpt-5.4-nano', 'gpt-5.4-mini', 'gpt-5.4', 'gpt-5.5', 'gpt-5.5-pro'],
     });
   }
 
@@ -131,7 +131,7 @@ export function generateRouterConfigFromWorkTypes(): RouterConfig {
       name: 'openai',
       baseURL: 'https://api.openai.com/v1',
       apiKey: apiKeys.openai.startsWith('$') ? apiKeys.openai : apiKeys.openai,
-      models: ['gpt-5.5', 'gpt-5.5-pro', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-pro', 'gpt-5.3-codex', 'gpt-5.2', 'o3', 'o4-mini'],
+      models: ['gpt-5.4-nano', 'gpt-5.4-mini', 'gpt-5.4', 'gpt-5.5', 'gpt-5.5-pro'],
     });
   }
 


### PR DESCRIPTION
## Summary
- Updated `PROVIDERS.openai.models` in `src/lib/providers.ts` from 9 IDs to exactly the 5 supported: `gpt-5.4-nano`, `gpt-5.4-mini`, `gpt-5.4`, `gpt-5.5`, `gpt-5.5-pro`
- Narrowed the OpenAI include-check in `getProviderForModel` (providers.ts:180) to the same 5 IDs — dropped IDs no longer route to OpenAI and fall through to a clear error
- Updated both OpenAI `models` arrays in `src/lib/router-config.ts` (lines 67 and 134) from 9 IDs to the 5 supported IDs

## Acceptance criteria
- [x] All four backend allowed-models sites list exactly the five supported IDs
- [x] Requesting a dropped OpenAI ID through the router (bypassing the redirect layer) no longer matches the OpenAI provider check and surfaces an unsupported-model error

## Test plan
- `npm run typecheck` passes (verified)
- Part of PAN-1122 swarm wave 0, slot 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)