### PR TITLE
feat(models): remove stale dropped OpenAI IDs, add gpt-5.4-nano (PAN-1122 slot-5)

### DIFF
--- a/src/dashboard/frontend/src/lib/dashboard-utils.ts
+++ b/src/dashboard/frontend/src/lib/dashboard-utils.ts
@@ -115,24 +115,15 @@ export function getFriendlyModelName(fullModel: string | undefined | null): stri
   if (backingModel.includes('haiku-3')) return 'Haiku 3';
   if (backingModel.includes('haiku')) return 'Haiku 4.5';
 
-  // OpenAI models
+  // OpenAI models (supported catalog — PAN-1122)
   if (backingModel.includes('gpt-5.5-pro')) return 'GPT-5.5 Pro';
   if (backingModel.includes('gpt-5.5')) return 'GPT-5.5';
-  if (backingModel.includes('gpt-5.4-pro')) return 'GPT-5.4 Pro';
+  if (backingModel.includes('gpt-5.4-nano')) return 'GPT-5.4 Nano';
   if (backingModel.includes('gpt-5.4-mini')) return 'GPT-5.4 Mini';
   if (backingModel.includes('gpt-5.4')) return 'GPT-5.4';
-  if (backingModel.includes('gpt-5.3-codex')) return 'GPT-5.3 Codex';
-  if (backingModel.includes('gpt-5.3')) return 'GPT-5.3';
-  if (backingModel.includes('gpt-5.2')) return 'GPT-5.2';
-  if (backingModel.includes('gpt-5.1')) return 'GPT-5.1';
   if (backingModel.includes('gpt-5')) return 'GPT-5';
-  if (backingModel.includes('gpt-4o')) return 'GPT-4o';
   if (backingModel.includes('gpt-4')) return 'GPT-4';
   if (backingModel.includes('gpt-3')) return 'GPT-3';
-  if (backingModel.includes('o4-mini') || backingModel === 'o4-mini') return 'O4 Mini';
-  if (backingModel.includes('o3-mini')) return 'O3 Mini';
-  if (backingModel.includes('o3')) return 'O3';
-  if (backingModel.includes('o1')) return 'O1';
 
   // Google models
   if (backingModel.includes('gemini-3.1-pro-preview') || backingModel.includes('gemini-3.1-pro')) return 'Gemini 3.1 Pro';

--- a/src/dashboard/frontend/tests/multi-model-settings.spec.ts
+++ b/src/dashboard/frontend/tests/multi-model-settings.spec.ts
@@ -101,7 +101,7 @@ test.describe('Multi-Model Settings', () => {
     await page.waitForTimeout(1000); // Wait for models to refresh
     console.log('  ✓ API key saved, OpenAI models now available');
 
-    // 5. Configure review agent to use gpt-4o
+    // 5. Configure review agent to use gpt-5.4-mini
     console.log('\n[5/6] Configuring review agent model...');
 
     // Find the review agent dropdown (should be in Specialist Models section)
@@ -118,8 +118,8 @@ test.describe('Multi-Model Settings', () => {
     const currentValue = await reviewAgentSelect.inputValue();
     console.log(`  Current review agent model: ${currentValue}`);
 
-    // Select gpt-4o (if not already selected, choose something different)
-    const targetModel = currentValue === 'gpt-4o' ? 'claude-sonnet-4-5' : 'gpt-4o';
+    // Select gpt-5.4-mini (if not already selected, choose something different)
+    const targetModel = currentValue === 'gpt-5.4-mini' ? 'claude-sonnet-4-5' : 'gpt-5.4-mini';
     await reviewAgentSelect.selectOption(targetModel);
 
     console.log(`  ✓ Model changed to: ${targetModel}`);

--- a/src/dashboard/server/routes/settings.ts
+++ b/src/dashboard/server/routes/settings.ts
@@ -53,22 +53,12 @@ const readJsonBody = Effect.gen(function* () {
 
 /** Model ID to API model ID mapping */
 const MODEL_API_IDS: Record<string, { apiModel: string; endpoint?: string }> = {
-  // OpenAI models — gpt-5.x are real OpenAI model IDs (identity map).
-  // Codex sign-in routes through CLIProxy; API key routes direct.
+  // OpenAI models — five supported IDs (PAN-1122). Identity map.
   'gpt-5.5-pro': { apiModel: 'gpt-5.5-pro' },
   'gpt-5.5': { apiModel: 'gpt-5.5' },
-  'gpt-5.4-pro': { apiModel: 'gpt-5.4-pro' },
   'gpt-5.4': { apiModel: 'gpt-5.4' },
   'gpt-5.4-mini': { apiModel: 'gpt-5.4-mini' },
-  'gpt-5.3-codex': { apiModel: 'gpt-5.3-codex' },
-  'gpt-5.2': { apiModel: 'gpt-5.2' },
-  'o3': { apiModel: 'o3' },
-  'o4-mini': { apiModel: 'o4-mini' },
-  'o3-deep-research': { apiModel: 'gpt-4o' },
-  'gpt-4o': { apiModel: 'gpt-4o' },
-  'gpt-4o-mini': { apiModel: 'gpt-4o-mini' },
-  'o1': { apiModel: 'gpt-4o' },
-  'o3-mini': { apiModel: 'gpt-4o-mini' },
+  'gpt-5.4-nano': { apiModel: 'gpt-5.4-nano' },
   // Google models
   'gemini-3-pro-preview': { apiModel: 'gemini-1.5-pro' },
   'gemini-3-flash-preview': { apiModel: 'gemini-1.5-flash' },
@@ -186,7 +176,7 @@ const postTestApiKeyRoute = HttpRouter.add(
 
       switch (provider) {
         case 'openai': {
-          const apiModel = model ? (MODEL_API_IDS[model]?.apiModel || 'gpt-4o-mini') : 'gpt-4o-mini';
+          const apiModel = model ? (MODEL_API_IDS[model]?.apiModel || 'gpt-5.4-mini') : 'gpt-5.4-mini';
           try {
             const resp = await fetch('https://api.openai.com/v1/chat/completions', {
               method: 'POST',

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -191,11 +191,9 @@ export async function getProviderAuthMode(model: string): Promise<AuthMode | und
   return undefined;
 }
 
-/** Map abstract/future model names to CLIProxy-supported names.
- *  The CLIProxy registry has gpt-5.4 but not gpt-5.4-pro. */
+/** Map model names to CLIProxy-supported names where the registry uses a different ID. */
 const CLI_PROXY_MODEL_ALIASES: Record<string, string> = {
   'gpt-5.5-pro': 'gpt-5.5',
-  'gpt-5.4-pro': 'gpt-5.4',
 };
 
 /**

--- a/src/lib/cost.ts
+++ b/src/lib/cost.ts
@@ -99,11 +99,7 @@ export const DEFAULT_PRICING: ModelPricing[] = [
   { provider: 'openai', model: 'gpt-5.5-pro', inputPer1k: 0.030, outputPer1k: 0.180, currency: 'USD' },
   { provider: 'openai', model: 'gpt-5.4', inputPer1k: 0.0025, outputPer1k: 0.015, cacheReadPer1k: 0.00025, currency: 'USD' },
   { provider: 'openai', model: 'gpt-5.4-mini', inputPer1k: 0.00075, outputPer1k: 0.0045, cacheReadPer1k: 0.000075, currency: 'USD' },
-  { provider: 'openai', model: 'gpt-5.4-pro', inputPer1k: 0.030, outputPer1k: 0.180, currency: 'USD' },
-  { provider: 'openai', model: 'gpt-5.3-codex', inputPer1k: 0.00175, outputPer1k: 0.014, cacheReadPer1k: 0.000175, currency: 'USD' },
-  { provider: 'openai', model: 'gpt-5.2', inputPer1k: 0.00125, outputPer1k: 0.010, currency: 'USD' },
-  { provider: 'openai', model: 'o3', inputPer1k: 0.002, outputPer1k: 0.008, currency: 'USD' },
-  { provider: 'openai', model: 'o4-mini', inputPer1k: 0.004, outputPer1k: 0.016, cacheReadPer1k: 0.001, currency: 'USD' },
+  { provider: 'openai', model: 'gpt-5.4-nano', inputPer1k: 0.000075, outputPer1k: 0.00045, cacheReadPer1k: 0.0000075, currency: 'USD' },
   // Google
   { provider: 'google', model: 'gemini-3.1-pro-preview', inputPer1k: 0.002, outputPer1k: 0.012, currency: 'USD' },
   { provider: 'google', model: 'gemini-3-flash-preview', inputPer1k: 0.00015, outputPer1k: 0.0006, currency: 'USD' },

--- a/src/lib/costs/__tests__/cost-calculation.test.ts
+++ b/src/lib/costs/__tests__/cost-calculation.test.ts
@@ -307,9 +307,9 @@ describe('Cost Calculation Accuracy', () => {
     });
 
     it('should handle models without cache pricing', () => {
-      // gpt-5.2 has no cache pricing in our table — used here to verify the
+      // gpt-5.5-pro has no cache pricing in our table — used here to verify the
       // calculator correctly skips cache tokens when no cache rate exists.
-      const pricing = getPricing('openai', 'gpt-5.2');
+      const pricing = getPricing('openai', 'gpt-5.5-pro');
       expect(pricing).toBeDefined();
 
       const usage: TokenUsage = {
@@ -322,8 +322,8 @@ describe('Cost Calculation Accuracy', () => {
       const cost = calculateCost(usage, pricing!);
 
       // Should only calculate input/output, ignore cache tokens
-      // (1000/1M)*1.25 + (500/1M)*10 = 0.00125 + 0.005 = 0.00625
-      expect(cost).toBeCloseTo(0.00625, 6);
+      // (1000/1k)*0.030 + (500/1k)*0.180 = 0.030 + 0.090 = 0.120
+      expect(cost).toBeCloseTo(0.120, 6);
     });
   });
 

--- a/src/lib/model-capabilities.ts
+++ b/src/lib/model-capabilities.ts
@@ -34,19 +34,7 @@ export const MODEL_DEPRECATIONS: Record<string, ModelId> = {
   'claude-opus-4-5': 'claude-opus-4-7',
   'claude-sonnet-4-5': 'claude-sonnet-4-6',
   // OpenAI retired/superseded models
-  'gpt-5.2-codex': 'gpt-5.3-codex', // superseded by gpt-5.3-codex (April 2026)
-  'gpt-5.4-nano': 'gpt-5.4-mini',   // hallucinated tier — never shipped
-  // OpenAI IDs dropped from Panopticon catalog (PAN-1122) — redirect to balanced default
-  'gpt-5.5-mini': 'gpt-5.4',
-  'gpt-5.5-nano': 'gpt-5.4',
-  'gpt-5.4-pro': 'gpt-5.4',
-  'o3': 'gpt-5.4',
-  'o4-mini': 'gpt-5.4',
-  'gpt-4o': 'gpt-5.4',
-  'gpt-4o-mini': 'gpt-5.4',
-  'o3-deep-research': 'gpt-5.4',
-  'gpt-5.3-codex': 'gpt-5.4',
-  'gpt-5.2': 'gpt-5.4',
+  'gpt-5.2-codex': 'gpt-5.4', // superseded by gpt-5.3-codex then dropped (PAN-1122)
   // Google deprecated models
   'gemini-3-pro-preview': 'gemini-3.1-pro-preview',
   'gemini-3-flash': 'gemini-3-flash-preview',
@@ -311,73 +299,27 @@ export const MODEL_CAPABILITIES: Record<ModelId, ModelCapability> = {
     notes: 'Fast and efficient. 400K context. Available in ChatGPT Free/Plus tiers.',
   },
 
-  'o3': {
-    model: 'o3',
+  'gpt-5.4-nano': {
+    model: 'gpt-5.4-nano',
     provider: 'openai',
-    displayName: 'O3',
-    costPer1MTokens: 5.0, // $2 in / $8 out
+    displayName: 'GPT-5.4 Nano',
+    costPer1MTokens: 0.25, // $0.075 in / $0.45 out
     contextWindow: 200000,
-    minTier: 'plus', // ChatGPT Plus/Pro only
+    minTier: 'free',
     skills: {
-      'code-generation': 90,
-      'code-review': 95,
-      debugging: 98, // Best for debugging
-      planning: 95,
-      documentation: 88,
-      testing: 88,
-      security: 92,
-      performance: 92,
-      synthesis: 95,
-      speed: 25, // Slow (reasoning chains)
-      'context-length': 95,
+      'code-generation': 68,
+      'code-review': 62,
+      debugging: 60,
+      planning: 55,
+      documentation: 66,
+      testing: 60,
+      security: 50,
+      performance: 55,
+      synthesis: 60,
+      speed: 98,
+      'context-length': 85,
     },
-    notes: 'Deep reasoning model. Excels at complex debugging, math, scientific reasoning.',
-  },
-
-  'o4-mini': {
-    model: 'o4-mini',
-    provider: 'openai',
-    displayName: 'O4 Mini',
-    costPer1MTokens: 2.75, // $1.10 in / $4.40 out
-    contextWindow: 200000,
-    minTier: 'plus', // ChatGPT Plus/Pro only
-    skills: {
-      'code-generation': 85,
-      'code-review': 90,
-      debugging: 94,
-      planning: 88,
-      documentation: 84,
-      testing: 85,
-      security: 86,
-      performance: 88,
-      synthesis: 88,
-      speed: 70, // Fast for a reasoning model
-      'context-length': 90,
-    },
-    notes: 'Compact reasoning model (April 2025). Fast, cost-efficient, tool-use capable.',
-  },
-
-  'gpt-5.4-pro': {
-    model: 'gpt-5.4-pro',
-    provider: 'openai',
-    displayName: 'GPT-5.4 Pro',
-    costPer1MTokens: 105.0, // $15 in / $195 out
-    contextWindow: 1050000,
-    minTier: 'pro', // ChatGPT Pro only
-    skills: {
-      'code-generation': 98,
-      'code-review': 98,
-      debugging: 98,
-      planning: 99,
-      documentation: 96,
-      testing: 96,
-      security: 96,
-      performance: 95,
-      synthesis: 99,
-      speed: 45,
-      'context-length': 100,
-    },
-    notes: 'Most advanced OpenAI model. Enhanced reasoning and agentic capabilities over GPT-5.4. Pro subscribers only.',
+    notes: 'Ultra-cheap OpenAI model for simple tasks. Fastest in the GPT-5.4 family.',
   },
 
   'gpt-5.5': {
@@ -425,57 +367,6 @@ export const MODEL_CAPABILITIES: Record<ModelId, ModelCapability> = {
     },
     notes: 'Most advanced OpenAI model. Enhanced reasoning and agentic capabilities over GPT-5.5. Pro subscribers only.',
   },
-
-  'gpt-5.3-codex': {
-    model: 'gpt-5.3-codex',
-    provider: 'openai',
-    displayName: 'GPT-5.3 Codex',
-    costPer1MTokens: 7.875, // $1.75 in / $14.00 out
-    contextWindow: 400000,
-    skills: {
-      'code-generation': 96,
-      'code-review': 95,
-      debugging: 94,
-      planning: 90,
-      documentation: 88,
-      testing: 90,
-      security: 86,
-      performance: 88,
-      synthesis: 92,
-      speed: 75,
-      'context-length': 90,
-    },
-    notes: 'Industry-leading agentic coding model (2026). Available via Codex CLI/IDE/cloud and the Responses API.',
-  },
-
-  'gpt-5.2': {
-    model: 'gpt-5.2',
-    provider: 'openai',
-    displayName: 'GPT-5.2',
-    costPer1MTokens: 5.625, // $1.25 in / $10 out (estimate)
-    contextWindow: 200000,
-    skills: {
-      'code-generation': 88,
-      'code-review': 86,
-      debugging: 84,
-      planning: 82,
-      documentation: 84,
-      testing: 82,
-      security: 78,
-      performance: 80,
-      synthesis: 84,
-      speed: 70,
-      'context-length': 85,
-    },
-    notes: 'Previous-generation general-purpose model (Oct 2025). Superseded by GPT-5.4.',
-  },
-
-  // Retired OpenAI model IDs — kept for backward compat
-  'o3-deep-research': { model: 'o3-deep-research', provider: 'openai', displayName: 'O3 Deep Research (deprecated)', costPer1MTokens: 5.0, contextWindow: 200000, skills: { 'code-generation': 88, 'code-review': 95, debugging: 98, planning: 95, documentation: 88, testing: 88, security: 92, performance: 92, synthesis: 95, speed: 25, 'context-length': 95 } },
-  // Active OpenAI API names — NOT deprecated. Kept in MODEL_CAPABILITIES for backward compat
-  // with saved configs. These are real OpenAI model IDs that still work via the OpenAI API.
-  'gpt-4o': { model: 'gpt-4o', provider: 'openai', displayName: 'GPT-4o', costPer1MTokens: 7.5, contextWindow: 128000, skills: { 'code-generation': 82, 'code-review': 80, debugging: 78, planning: 76, documentation: 80, testing: 76, security: 74, performance: 74, synthesis: 80, speed: 75, 'context-length': 75 } },
-  'gpt-4o-mini': { model: 'gpt-4o-mini', provider: 'openai', displayName: 'GPT-4o Mini', costPer1MTokens: 0.6, contextWindow: 128000, skills: { 'code-generation': 68, 'code-review': 64, debugging: 60, planning: 56, documentation: 66, testing: 60, security: 52, performance: 56, synthesis: 62, speed: 92, 'context-length': 75 } },
 
   // ═══════════════════════════════════════════════════════════════════════════
   // GOOGLE MODELS

--- a/src/lib/model-fallback.ts
+++ b/src/lib/model-fallback.ts
@@ -26,21 +26,12 @@ const MODEL_PROVIDERS: Record<ModelId, ModelProvider> = {
   'claude-sonnet-4-5': 'anthropic',
   'claude-haiku-4-5': 'anthropic',
 
-  // OpenAI models (current — per developers.openai.com/codex/models)
+  // OpenAI models (supported catalog — PAN-1122)
   'gpt-5.5': 'openai',
   'gpt-5.5-pro': 'openai',
   'gpt-5.4': 'openai',
   'gpt-5.4-mini': 'openai',
-  'gpt-5.4-pro': 'openai',
-  'gpt-5.3-codex': 'openai',
-  'gpt-5.2': 'openai',
-  'o3': 'openai',
-  'o4-mini': 'openai',
-
-  // OpenAI legacy (for backward compat with existing configs/tests)
-  'o3-deep-research': 'openai',
-  'gpt-4o': 'openai',
-  'gpt-4o-mini': 'openai',
+  'gpt-5.4-nano': 'openai',
 
   // Google models (current)
   'gemini-3.1-pro-preview': 'google',
@@ -87,22 +78,12 @@ const MODEL_PROVIDERS: Record<ModelId, ModelProvider> = {
  * Users who want Opus can explicitly set it in their config.
  */
 const FALLBACK_MAP: Record<string, AnthropicModel> = {
-  // OpenAI → Anthropic
-  'gpt-5.5': 'claude-sonnet-4-6', // Flagship model → Sonnet
-  'gpt-5.5-pro': 'claude-sonnet-4-6', // Top-tier model → Sonnet
-  'gpt-5.4': 'claude-sonnet-4-6', // Flagship model → Sonnet
-  'gpt-5.4-mini': 'claude-haiku-4-5', // Mid-tier → Haiku
-  'gpt-5.4-pro': 'claude-sonnet-4-6', // Top-tier model → Sonnet
-  'gpt-5.3-codex': 'claude-sonnet-4-6', // Coding flagship → Sonnet
-  'gpt-5.2': 'claude-sonnet-4-6', // Previous-gen flagship → Sonnet
-  'o3': 'claude-sonnet-4-6', // Reasoning model → Sonnet
-  'o4-mini': 'claude-sonnet-4-6', // Compact reasoning model → Sonnet
-  // Retired OpenAI IDs — mappings preserve semantic tier intent
-  'o3-deep-research': 'claude-sonnet-4-6',
-  // Active OpenAI API names — NOT deprecated. Included here so configs using these
-  // IDs still fall back correctly if the OpenAI provider is disabled.
-  'gpt-4o': 'claude-sonnet-4-6', // flagship-tier → Sonnet
-  'gpt-4o-mini': 'claude-haiku-4-5', // economy-tier → Haiku
+  // OpenAI → Anthropic (supported catalog — PAN-1122)
+  'gpt-5.5': 'claude-sonnet-4-6',
+  'gpt-5.5-pro': 'claude-sonnet-4-6',
+  'gpt-5.4': 'claude-sonnet-4-6',
+  'gpt-5.4-mini': 'claude-haiku-4-5',
+  'gpt-5.4-nano': 'claude-haiku-4-5',
 
   // Google → Anthropic
   'gemini-3.1-pro-preview': 'claude-sonnet-4-6', // Flagship → Sonnet
@@ -149,16 +130,12 @@ const DEFAULT_FALLBACK: AnthropicModel = 'claude-sonnet-4-6';
  * Used for within-provider tier-aware fallback.
  */
 const MODEL_TIER_RANK: Record<string, number> = {
-  // OpenAI tiers
+  // OpenAI tiers (supported catalog — PAN-1122)
   'gpt-5.5-pro': 3,
   'gpt-5.5': 2,
-  'gpt-5.4-pro': 3,
   'gpt-5.4': 2,
-  'gpt-5.3-codex': 2,
-  'gpt-5.2': 2,
-  'o3': 2,
-  'o4-mini': 1,
   'gpt-5.4-mini': 0,
+  'gpt-5.4-nano': 0,
 };
 
 /**

--- a/src/lib/router-config.ts
+++ b/src/lib/router-config.ts
@@ -32,7 +32,7 @@ export interface RouterConfig {
  */
 function getModelProvider(modelId: ModelId): 'anthropic' | 'openai' | 'google' {
   if (modelId.startsWith('claude-')) return 'anthropic';
-  if (modelId.startsWith('gpt-') || modelId === 'o3') return 'openai';
+  if (modelId.startsWith('gpt-')) return 'openai';
   if (modelId.startsWith('gemini-')) return 'google';
   // Default to anthropic for unknown models
   return 'anthropic';

--- a/src/lib/settings-api.ts
+++ b/src/lib/settings-api.ts
@@ -879,14 +879,10 @@ export function getAvailableModelsApi(): {
     }
   }
 
-  // Order OpenAI models with latest family first: 5.5 (current default) → 5.4 → 5.3-codex → 5.2 → o-series → gpt-4o legacy.
+  // Order OpenAI models: 5.5 flagship first, then 5.4 family by cost descending.
   const openaiOrder: Record<string, number> = {
-    'gpt-5.5': 0, 'gpt-5.5-pro': 1,
-    'gpt-5.4': 10, 'gpt-5.4-pro': 11, 'gpt-5.4-mini': 12,
-    'gpt-5.3-codex': 20,
-    'gpt-5.2': 30,
-    'o3': 40, 'o4-mini': 41,
-    'gpt-4o': 50, 'gpt-4o-mini': 51,
+    'gpt-5.5-pro': 0, 'gpt-5.5': 1,
+    'gpt-5.4': 10, 'gpt-5.4-mini': 11, 'gpt-5.4-nano': 12,
   };
   result.openai.sort((a, b) => (openaiOrder[a.id] ?? 99) - (openaiOrder[b.id] ?? 99));
 

--- a/tests/lib/agents-auth-routing.test.ts
+++ b/tests/lib/agents-auth-routing.test.ts
@@ -139,8 +139,8 @@ describe('agents auth routing', () => {
   it('maps OpenAI -pro aliases to CLIProxy-supported model IDs', async () => {
     mockOpenAIAuthStatus.mockReturnValue({ loggedIn: true });
 
-    expect(await getAgentRuntimeBaseCommand('gpt-5.4-pro')).toBe(
-      "claude --dangerously-skip-permissions --permission-mode bypassPermissions --model 'gpt-5.4'"
+    expect(await getAgentRuntimeBaseCommand('gpt-5.5-pro')).toBe(
+      "claude --dangerously-skip-permissions --permission-mode bypassPermissions --model 'gpt-5.5'"
     );
   });
 

--- a/tests/lib/model-fallback.test.ts
+++ b/tests/lib/model-fallback.test.ts
@@ -33,10 +33,10 @@ describe('model-fallback', () => {
     });
 
     it('should return openai for OpenAI models', () => {
-      expect(getModelProvider('gpt-5.3-codex')).toBe('openai');
-      expect(getModelProvider('o3-deep-research')).toBe('openai');
-      expect(getModelProvider('gpt-4o')).toBe('openai');
-      expect(getModelProvider('gpt-4o-mini')).toBe('openai');
+      expect(getModelProvider('gpt-5.4')).toBe('openai');
+      expect(getModelProvider('gpt-5.4-nano')).toBe('openai');
+      expect(getModelProvider('gpt-5.5')).toBe('openai');
+      expect(getModelProvider('gpt-5.5-pro')).toBe('openai');
     });
 
     it('should return google for Gemini models', () => {
@@ -57,8 +57,8 @@ describe('model-fallback', () => {
     });
 
     it('should return true for OpenAI models', () => {
-      expect(requiresExternalKey('gpt-5.3-codex')).toBe(true);
-      expect(requiresExternalKey('gpt-4o')).toBe(true);
+      expect(requiresExternalKey('gpt-5.4')).toBe(true);
+      expect(requiresExternalKey('gpt-5.4-nano')).toBe(true);
     });
 
     it('should return true for Google models', () => {
@@ -88,15 +88,8 @@ describe('model-fallback', () => {
       expect(models).toContain('gpt-5.5-pro');
       expect(models).toContain('gpt-5.4');
       expect(models).toContain('gpt-5.4-mini');
-      expect(models).toContain('gpt-5.4-pro');
-      expect(models).toContain('gpt-5.3-codex');
-      expect(models).toContain('gpt-5.2');
-      expect(models).toContain('o3');
-      expect(models).toContain('o4-mini');
-      expect(models).toContain('o3-deep-research'); // legacy
-      expect(models).toContain('gpt-4o'); // legacy
-      expect(models).toContain('gpt-4o-mini'); // legacy
-      expect(models).toHaveLength(12);
+      expect(models).toContain('gpt-5.4-nano');
+      expect(models).toHaveLength(5);
     });
 
     it('should return all Google models', () => {
@@ -177,28 +170,28 @@ describe('model-fallback', () => {
   describe('applyFallback', () => {
     it('should return original model if provider is enabled', () => {
       const enabled = new Set<ModelProvider>(['anthropic', 'openai']);
-      expect(applyFallback('gpt-5.3-codex', enabled)).toBe('gpt-5.3-codex');
+      expect(applyFallback('gpt-5.4', enabled)).toBe('gpt-5.4');
       expect(applyFallback('claude-opus-4-6', enabled)).toBe('claude-opus-4-6');
     });
 
-    it('should fallback GPT-5.2 Codex to Sonnet', () => {
+    it('should fallback GPT-5.4 to Sonnet when OpenAI disabled', () => {
       const enabled = new Set<ModelProvider>(['anthropic']);
-      expect(applyFallback('gpt-5.3-codex', enabled)).toBe('claude-sonnet-4-6');
+      expect(applyFallback('gpt-5.4', enabled)).toBe('claude-sonnet-4-6');
     });
 
-    it('should fallback O3 Deep Research to Sonnet', () => {
+    it('should fallback GPT-5.5 to Sonnet when OpenAI disabled', () => {
       const enabled = new Set<ModelProvider>(['anthropic']);
-      expect(applyFallback('o3-deep-research', enabled)).toBe('claude-sonnet-4-6');
+      expect(applyFallback('gpt-5.5', enabled)).toBe('claude-sonnet-4-6');
     });
 
-    it('should fallback GPT-4o to Sonnet', () => {
+    it('should fallback GPT-5.5-Pro to Sonnet when OpenAI disabled', () => {
       const enabled = new Set<ModelProvider>(['anthropic']);
-      expect(applyFallback('gpt-4o', enabled)).toBe('claude-sonnet-4-6');
+      expect(applyFallback('gpt-5.5-pro', enabled)).toBe('claude-sonnet-4-6');
     });
 
-    it('should fallback GPT-4o-mini to Haiku', () => {
+    it('should fallback GPT-5.4-Nano to Haiku when OpenAI disabled', () => {
       const enabled = new Set<ModelProvider>(['anthropic']);
-      expect(applyFallback('gpt-4o-mini', enabled)).toBe('claude-haiku-4-5');
+      expect(applyFallback('gpt-5.4-nano', enabled)).toBe('claude-haiku-4-5');
     });
 
     it('should fallback Gemini Pro to Sonnet', () => {
@@ -213,10 +206,10 @@ describe('model-fallback', () => {
 
     it('should log warning when applying fallback', () => {
       const enabled = new Set<ModelProvider>(['anthropic']);
-      applyFallback('gpt-5.3-codex', enabled);
+      applyFallback('gpt-5.4', enabled);
 
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Model gpt-5.3-codex requires openai API key')
+        expect.stringContaining('Model gpt-5.4 requires openai API key')
       );
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('falling back to claude-sonnet-4-6')
@@ -225,7 +218,7 @@ describe('model-fallback', () => {
 
     it('should not log warning when provider is enabled', () => {
       const enabled = new Set<ModelProvider>(['anthropic', 'openai']);
-      applyFallback('gpt-5.3-codex', enabled);
+      applyFallback('gpt-5.4', enabled);
 
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
@@ -246,10 +239,11 @@ describe('model-fallback', () => {
     });
 
     it('should return fallback for OpenAI models', () => {
-      expect(getFallbackModel('gpt-5.3-codex')).toBe('claude-sonnet-4-6');
-      expect(getFallbackModel('o3-deep-research')).toBe('claude-sonnet-4-6');
-      expect(getFallbackModel('gpt-4o')).toBe('claude-sonnet-4-6');
-      expect(getFallbackModel('gpt-4o-mini')).toBe('claude-haiku-4-5');
+      expect(getFallbackModel('gpt-5.4')).toBe('claude-sonnet-4-6');
+      expect(getFallbackModel('gpt-5.5')).toBe('claude-sonnet-4-6');
+      expect(getFallbackModel('gpt-5.5-pro')).toBe('claude-sonnet-4-6');
+      expect(getFallbackModel('gpt-5.4-mini')).toBe('claude-haiku-4-5');
+      expect(getFallbackModel('gpt-5.4-nano')).toBe('claude-haiku-4-5');
     });
 
     it('should return fallback for Google models', () => {
@@ -323,13 +317,13 @@ describe('model-fallback', () => {
       const enabled = new Set<ModelProvider>(['anthropic']);
       const models: ModelId[] = [
         'claude-opus-4-6',
-        'gpt-5.3-codex',
+        'gpt-5.4',
         'gemini-3-pro-preview',
       ];
 
       const filtered = filterAvailableModels(models, enabled);
       expect(filtered).toContain('claude-opus-4-6');
-      expect(filtered).not.toContain('gpt-5.3-codex');
+      expect(filtered).not.toContain('gpt-5.4');
       expect(filtered).not.toContain('gemini-3-pro-preview');
     });
 
@@ -337,7 +331,7 @@ describe('model-fallback', () => {
       const enabled = new Set<ModelProvider>(['anthropic', 'openai', 'google']);
       const models: ModelId[] = [
         'claude-opus-4-6',
-        'gpt-5.3-codex',
+        'gpt-5.4',
         'gemini-3-pro-preview',
       ];
 
@@ -349,13 +343,13 @@ describe('model-fallback', () => {
       const enabled = new Set<ModelProvider>(['anthropic', 'openai']);
       const models: ModelId[] = [
         'claude-opus-4-6',
-        'gpt-5.3-codex',
+        'gpt-5.4',
         'gemini-3-pro-preview',
       ];
 
       const filtered = filterAvailableModels(models, enabled);
       expect(filtered).toContain('claude-opus-4-6');
-      expect(filtered).toContain('gpt-5.3-codex');
+      expect(filtered).toContain('gpt-5.4');
       expect(filtered).not.toContain('gemini-3-pro-preview');
     });
   });
@@ -377,7 +371,7 @@ describe('model-fallback', () => {
       const enabled = new Set<ModelProvider>(['anthropic', 'openai', 'google', 'kimi']);
       const models = getAvailableModels(enabled);
 
-      expect(models.length).toBe(27); // 5 Anthropic + 12 OpenAI + 6 Google + 4 Kimi
+      expect(models.length).toBe(20); // 5 Anthropic + 5 OpenAI + 6 Google + 4 Kimi
     });
 
     it('should include OpenAI models when OpenAI enabled', () => {
@@ -386,10 +380,10 @@ describe('model-fallback', () => {
 
       expect(models).toContain('gpt-5.5');
       expect(models).toContain('gpt-5.4');
-      expect(models).toContain('o3');
-      expect(models).toContain('gpt-5.3-codex');
-      expect(models).toContain('gpt-4o');
-      expect(models.length).toBe(17); // 5 Anthropic + 12 OpenAI
+      expect(models).toContain('gpt-5.4-mini');
+      expect(models).toContain('gpt-5.4-nano');
+      expect(models).toContain('gpt-5.5-pro');
+      expect(models.length).toBe(10); // 5 Anthropic + 5 OpenAI
     });
 
     it('should include Google models when Google enabled', () => {
@@ -408,24 +402,24 @@ describe('model-fallback', () => {
   describe('fallback strategy validation', () => {
     it('should map premium models to Sonnet', () => {
       const enabled = new Set<ModelProvider>(['anthropic']);
-      expect(applyFallback('gpt-5.3-codex', enabled)).toBe('claude-sonnet-4-6');
-      expect(applyFallback('o3-deep-research', enabled)).toBe('claude-sonnet-4-6');
+      expect(applyFallback('gpt-5.4', enabled)).toBe('claude-sonnet-4-6');
+      expect(applyFallback('gpt-5.5', enabled)).toBe('claude-sonnet-4-6');
       expect(applyFallback('gemini-3-pro-preview', enabled)).toBe('claude-sonnet-4-6');
     });
 
     it('should map economy models to Haiku', () => {
       const enabled = new Set<ModelProvider>(['anthropic']);
-      expect(applyFallback('gpt-4o-mini', enabled)).toBe('claude-haiku-4-5');
+      expect(applyFallback('gpt-5.4-nano', enabled)).toBe('claude-haiku-4-5');
       expect(applyFallback('gemini-3-flash-preview', enabled)).toBe('claude-haiku-4-5');
     });
 
     it('should never fallback to Opus by default', () => {
       const enabled = new Set<ModelProvider>(['anthropic']);
       const allModels: ModelId[] = [
-        'gpt-5.3-codex',
-        'o3-deep-research',
-        'gpt-4o',
-        'gpt-4o-mini',
+        'gpt-5.4',
+        'gpt-5.5',
+        'gpt-5.4-mini',
+        'gpt-5.4-nano',
         'gemini-3-pro-preview',
         'gemini-3-flash-preview',
       ];

--- a/tests/lib/router-config.test.ts
+++ b/tests/lib/router-config.test.ts
@@ -109,15 +109,11 @@ describe('router-config', () => {
       expect(openaiProvider?.baseURL).toBe('https://api.openai.com/v1');
       expect(openaiProvider?.apiKey).toBe('sk-test-key');
       expect(openaiProvider?.models).toEqual([
+        'gpt-5.4-nano',
+        'gpt-5.4-mini',
+        'gpt-5.4',
         'gpt-5.5',
         'gpt-5.5-pro',
-        'gpt-5.4',
-        'gpt-5.4-mini',
-        'gpt-5.4-pro',
-        'gpt-5.3-codex',
-        'gpt-5.2',
-        'o3',
-        'o4-mini',
       ]);
     });
 

--- a/tests/lib/settings-api.test.ts
+++ b/tests/lib/settings-api.test.ts
@@ -264,8 +264,8 @@ describe('settings-api', () => {
       const openaiIds = models.openai.map(m => m.id);
       expect(openaiIds).toContain('gpt-5.5');
       expect(openaiIds).toContain('gpt-5.4');
-      expect(openaiIds).toContain('o3');
-      expect(openaiIds).toContain('o4-mini');
+      expect(openaiIds).toContain('gpt-5.4-mini');
+      expect(openaiIds).toContain('gpt-5.4-nano');
     });
   });
 

--- a/tests/lib/settings.test.ts
+++ b/tests/lib/settings.test.ts
@@ -448,15 +448,11 @@ describe('settings', () => {
       const available = getAvailableModels(settings);
 
       expect(available.openai).toEqual([
+        'gpt-5.4-nano',
+        'gpt-5.4-mini',
+        'gpt-5.4',
         'gpt-5.5',
         'gpt-5.5-pro',
-        'gpt-5.4',
-        'gpt-5.4-mini',
-        'gpt-5.4-pro',
-        'gpt-5.3-codex',
-        'gpt-5.2',
-        'o3',
-        'o4-mini',
       ]);
     });
 


### PR DESCRIPTION
## Summary
- Trims the supported OpenAI catalog from 12 → 5 models: `gpt-5.4-nano`, `gpt-5.4-mini`, `gpt-5.4`, `gpt-5.5`, `gpt-5.5-pro`
- Purges all dropped IDs (`gpt-5.5-mini`, `gpt-5.5-nano`, `gpt-5.4-pro`, `o3`, `o4-mini`, `gpt-4o`, `gpt-4o-mini`, `o3-deep-research`, `gpt-5.3-codex`, `gpt-5.2`) from cost, fallback/priority, capabilities, settings, router-config, agent alias table, and dashboard label maps
- Adds `gpt-5.4-nano` capability entry with skills scores and nano-tier cost pricing

## Files changed
- `src/lib/model-capabilities.ts` — removed dropped entries from MODEL_CAPABILITIES & MODEL_DEPRECATIONS; added gpt-5.4-nano capability
- `src/lib/cost.ts` — removed pricing rows for dropped models; added gpt-5.4-nano pricing
- `src/lib/model-fallback.ts` — updated MODEL_PROVIDERS, FALLBACK_MAP, MODEL_TIER_RANK to 5-model catalog
- `src/lib/agents.ts` — removed dead gpt-5.4-pro alias from CLI_PROXY_MODEL_ALIASES
- `src/dashboard/server/routes/settings.ts` — updated MODEL_API_IDS and default fallback model
- `src/lib/settings-api.ts` — updated openaiOrder priority map
- `src/lib/router-config.ts` — removed dead `|| modelId === 'o3'` type guard
- `src/dashboard/frontend/src/lib/dashboard-utils.ts` — removed labels for dropped models; added gpt-5.4-nano
- All affected test files updated to reflect trimmed catalog

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (4268 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)