### PR TITLE
feat(pan-1249): Effect migration: src/lib/agent-runtime.ts (wave 1, slot 3)

### DIFF
--- a/src/lib/agent-runtime.ts
+++ b/src/lib/agent-runtime.ts
@@ -9,6 +9,7 @@
  * directly (zero-roundtrip) — this module is for everything else.
  */
 
+import { Data, Effect } from 'effect'
 import type {
   AgentRuntimeSnapshot,
   Activity,
@@ -31,19 +32,28 @@ function abortSignal(ms: number): AbortSignal {
   return controller.signal
 }
 
-export async function getAgentRuntimeSnapshot(
+class AgentRuntimeFetchError extends Data.TaggedError('AgentRuntimeFetchError')<{
+  readonly url: string
+  readonly cause?: unknown
+}> {}
+
+export const getAgentRuntimeSnapshot = (
   agentId: string,
-): Promise<AgentRuntimeSnapshot | null> {
-  if (!agentId) return null
+): Effect.Effect<AgentRuntimeSnapshot | null> => {
+  if (!agentId) return Effect.succeed(null)
   const url = `${DASHBOARD_URL}/api/agents/${encodeURIComponent(agentId)}/runtime`
-  try {
-    const res = await fetch(url, { signal: abortSignal(DEFAULT_TIMEOUT_MS) })
+  return Effect.gen(function* () {
+    const res = yield* Effect.tryPromise({
+      try: () => fetch(url, { signal: abortSignal(DEFAULT_TIMEOUT_MS) }),
+      catch: (cause) => new AgentRuntimeFetchError({ url, cause }),
+    })
     if (!res.ok) return null
-    const body = (await res.json()) as { success: boolean; snapshot?: AgentRuntimeSnapshot }
+    const body = yield* Effect.tryPromise({
+      try: () => res.json() as Promise<{ success: boolean; snapshot?: AgentRuntimeSnapshot }>,
+      catch: (cause) => new AgentRuntimeFetchError({ url, cause }),
+    })
     return body.success && body.snapshot ? body.snapshot : null
-  } catch {
-    return null
-  }
+  }).pipe(Effect.orElseSucceed(() => null))
 }
 
 type HeartbeatBody =
@@ -64,20 +74,25 @@ type HeartbeatBody =
  * semantics — no retry, no buffering. The bash hooks have their own
  * pending-events.jsonl fallback; in-process callers just log and move on.
  */
-export async function emitAgentEvent(agentId: string, body: HeartbeatBody): Promise<boolean> {
-  if (!agentId) return false
+export const emitAgentEvent = (
+  agentId: string,
+  body: HeartbeatBody,
+): Effect.Effect<boolean> => {
+  if (!agentId) return Effect.succeed(false)
   const url = `${DASHBOARD_URL}/api/agents/${encodeURIComponent(agentId)}/heartbeat`
-  try {
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ...body, timestamp: new Date().toISOString() }),
-      signal: abortSignal(DEFAULT_TIMEOUT_MS),
+  return Effect.gen(function* () {
+    const res = yield* Effect.tryPromise({
+      try: () =>
+        fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...body, timestamp: new Date().toISOString() }),
+          signal: abortSignal(DEFAULT_TIMEOUT_MS),
+        }),
+      catch: (cause) => new AgentRuntimeFetchError({ url, cause }),
     })
     return res.ok
-  } catch {
-    return false
-  }
+  }).pipe(Effect.orElseSucceed(() => false))
 }
 
 // ─── Convenience wrappers mirroring the event taxonomy ────────────────────────
@@ -86,38 +101,38 @@ export const emitActivity = (
   agentId: string,
   activity: Activity,
   tool?: string,
-): Promise<boolean> => emitAgentEvent(agentId, { kind: 'activity', activity, tool })
+): Effect.Effect<boolean> => emitAgentEvent(agentId, { kind: 'activity', activity, tool })
 
 export const emitWaitingStart = (
   agentId: string,
   reason: WaitingReason,
   message?: string,
-): Promise<boolean> => emitAgentEvent(agentId, { kind: 'waiting_start', reason, message })
+): Effect.Effect<boolean> => emitAgentEvent(agentId, { kind: 'waiting_start', reason, message })
 
 export const emitWaitingClear = (
   agentId: string,
   clearedBy: 'user_response' | 'timeout' | 'stopped' | 'tool_resumed' = 'user_response',
-): Promise<boolean> => emitAgentEvent(agentId, { kind: 'waiting_clear', clearedBy })
+): Effect.Effect<boolean> => emitAgentEvent(agentId, { kind: 'waiting_clear', clearedBy })
 
 export const emitModelSet = (
   agentId: string,
   model: string,
   claudeSessionId?: string,
-): Promise<boolean> => emitAgentEvent(agentId, { kind: 'model_set', model, claudeSessionId })
+): Effect.Effect<boolean> => emitAgentEvent(agentId, { kind: 'model_set', model, claudeSessionId })
 
 export const emitMessageReceived = (
   agentId: string,
   direction: 'to_agent' | 'from_agent',
   source: 'user' | 'cloister' | 'specialist' | 'automated',
-): Promise<boolean> => emitAgentEvent(agentId, { kind: 'message_received', direction, source })
+): Effect.Effect<boolean> => emitAgentEvent(agentId, { kind: 'message_received', direction, source })
 
 export const emitChannelReply = (
   agentId: string,
   reply: { kind: ChannelReplyKind; summary: string; artifactRefs?: ChannelReplyArtifactRef[] },
-): Promise<boolean> => emitAgentEvent(agentId, { kind: 'channel_reply', reply })
+): Effect.Effect<boolean> => emitAgentEvent(agentId, { kind: 'channel_reply', reply })
 
 export const emitResolution = (
   agentId: string,
   resolution: AgentResolution,
   resolutionCount: number,
-): Promise<boolean> => emitAgentEvent(agentId, { kind: 'resolution_set', resolution, resolutionCount })
+): Effect.Effect<boolean> => emitAgentEvent(agentId, { kind: 'resolution_set', resolution, resolutionCount })

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -1456,6 +1456,7 @@ export const __testInternals = { markAgentRunning, markAgentStopped };
 // every field access in one PR would have been mechanical noise.
 
 import type { AgentRuntimeSnapshot } from '@panctl/contracts';
+import { Effect } from 'effect';
 import {
   getAgentRuntimeSnapshot as fetchAgentRuntimeSnapshot,
   emitAgentEvent,
@@ -1529,7 +1530,7 @@ export async function getAgentRuntimeStateAsync(agentId: string): Promise<AgentR
     return getAgentRuntimeState(agentId);
   }
   // Cross-process (CLI, external lib callers): sync mirror is empty, hit HTTP.
-  const snap = await fetchAgentRuntimeSnapshot(agentId);
+  const snap = await Effect.runPromise(fetchAgentRuntimeSnapshot(agentId));
   return snapshotToRuntimeState(snap);
 }
 
@@ -1539,47 +1540,47 @@ export async function getAgentRuntimeStateAsync(agentId: string): Promise<AgentR
  */
 export async function saveAgentRuntimeState(agentId: string, patch: Partial<AgentRuntimeState>): Promise<void> {
   if (patch.currentIssue !== undefined) {
-    await emitAgentEvent(agentId, {
+    await Effect.runPromise(emitAgentEvent(agentId, {
       kind: 'current_issue_set',
       currentIssue: patch.currentIssue || undefined,
-    });
+    }));
   }
 
   if (patch.resolution !== undefined && patch.resolutionCount !== undefined) {
-    await emitAgentEvent(agentId, {
+    await Effect.runPromise(emitAgentEvent(agentId, {
       kind: 'resolution_set',
       resolution: patch.resolution,
       resolutionCount: patch.resolutionCount,
-    });
+    }));
   }
 
   if (patch.state !== undefined) {
     if (patch.state === 'waiting-on-human') {
-      await emitAgentEvent(agentId, {
+      await Effect.runPromise(emitAgentEvent(agentId, {
         kind: 'waiting_start',
         reason: (patch.waitingReason as 'tool_permission' | 'user_question' | 'disambiguation' | 'other') || 'other',
         message: patch.waitingNotification,
-      });
+      }));
     } else if (patch.state === 'active') {
-      await emitAgentEvent(agentId, { kind: 'activity', activity: 'working', tool: patch.currentTool });
+      await Effect.runPromise(emitAgentEvent(agentId, { kind: 'activity', activity: 'working', tool: patch.currentTool }));
     } else if (patch.state === 'idle') {
-      await emitAgentEvent(agentId, { kind: 'activity', activity: 'idle' });
+      await Effect.runPromise(emitAgentEvent(agentId, { kind: 'activity', activity: 'idle' }));
     } else if (patch.state === 'stopped') {
-      await emitAgentEvent(agentId, { kind: 'activity', activity: 'stopped' });
+      await Effect.runPromise(emitAgentEvent(agentId, { kind: 'activity', activity: 'stopped' }));
     }
   } else if (patch.currentTool !== undefined) {
-    await emitAgentEvent(agentId, { kind: 'activity', activity: 'working', tool: patch.currentTool });
+    await Effect.runPromise(emitAgentEvent(agentId, { kind: 'activity', activity: 'working', tool: patch.currentTool }));
   }
 
   if (patch.claudeSessionId) {
     // model_set requires a model — use existing snapshot's model if present.
     const snap = getAgentRuntimeState(agentId);
     if (snap || patch.claudeSessionId) {
-      await emitAgentEvent(agentId, {
+      await Effect.runPromise(emitAgentEvent(agentId, {
         kind: 'model_set',
         model: 'unknown',
         claudeSessionId: patch.claudeSessionId,
-      });
+      }));
     }
   }
 }


### PR DESCRIPTION
## Summary

- Converts `src/lib/agent-runtime.ts` from async/Promise to `Effect.Effect` generators (PAN-1249 wave 1, swarm slot 3)
- Replaces `try/catch` blocks with `Effect.tryPromise` + module-local `AgentRuntimeFetchError extends Data.TaggedError`, absorbed via `Effect.orElseSucceed` to preserve the existing null/false fire-and-forget semantics
- All exported functions (`getAgentRuntimeSnapshot`, `emitAgentEvent`, and all 7 convenience wrappers) now return `Effect.Effect<T, never>`
- Updates `src/lib/agents.ts` call sites to `Effect.runPromise()` as the adapter boundary between the new Effect module and the still-Promise `saveAgentRuntimeState` / `getAgentRuntimeStateAsync` functions
- No `execAsync`, `fs/promises`, or test file in scope (N/A acceptance criteria)

## Acceptance criteria

- [x] All exported functions return `Effect.Effect<T, E>` with typed errors — no `Promise<T>` returns remain
- [x] No `execAsync`/`execFileAsync` — N/A (file uses `fetch` only)
- [x] `try/catch` for expected failure modes replaced with `Data.TaggedError` channels via `Effect.tryPromise`
- [x] No `fs/promises` calls — N/A
- [x] No test file — N/A
- [x] No new `Effect.runPromise()` in `agent-runtime.ts` itself
- [x] Observable behavior unchanged — null/false semantics preserved via `orElseSucceed`
- [x] `npm run typecheck` and `npm run lint` pass (4303 tests pass)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (pre-existing warnings only)
- [x] `npm test` — 4303 passed, 50 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)