### PR TITLE
feat(cli): effect-native agent-runtime-mirror (PAN-1249 wave 1)

### DIFF
--- a/src/dashboard/server/services/agent-state-service.ts
+++ b/src/dashboard/server/services/agent-state-service.ts
@@ -32,7 +32,7 @@ import type {
 } from '@panctl/contracts';
 import { initEventStore, getSharedDb } from '../event-store.js';
 import type { StoredEvent } from '../event-store.js';
-import { setAgentRuntimeMirror, getRuntimeSnapshotSync as getMirrorSnapshot, markAgentStateServiceInProcess } from '../../../lib/agent-runtime-mirror.js';
+import { setAgentRuntimeMirror, getRuntimeSnapshot as getMirrorSnapshot, markAgentStateServiceInProcess } from '../../../lib/agent-runtime-mirror.js';
 
 // ─── Event filtering ──────────────────────────────────────────────────────────
 
@@ -90,7 +90,7 @@ export class AgentStateService extends Context.Service<
 // ─── Live implementation ──────────────────────────────────────────────────────
 
 // Re-export the cross-process-safe mirror accessor.
-export const getRuntimeSnapshotSync = getMirrorSnapshot;
+export const getRuntimeSnapshot = getMirrorSnapshot;
 
 export const AgentStateServiceLive = Layer.effect(
   AgentStateService,
@@ -98,7 +98,7 @@ export const AgentStateServiceLive = Layer.effect(
     // Flag lib-side adapters to prefer the in-process mirror over HTTP.
     // Without this, agent-enrichment / ReadModel bootstrap would fetch() our
     // own HTTP server before it finished listening — a circular deadlock.
-    markAgentStateServiceInProcess();
+    yield* markAgentStateServiceInProcess();
     const store = yield* Effect.promise(() => initEventStore());
     const ref = yield* SubscriptionRef.make<Record<string, AgentRuntimeSnapshot>>({});
 
@@ -147,7 +147,7 @@ export const AgentStateServiceLive = Layer.effect(
         if (snap.updatedAtSequence > maxCachedSequence) maxCachedSequence = snap.updatedAtSequence;
       }
       yield* SubscriptionRef.set(ref, initial);
-      setAgentRuntimeMirror(initial);
+      yield* setAgentRuntimeMirror(initial);
       console.log(
         `[AgentStateService] Bootstrapped ${Object.keys(initial).length} runtime snapshot(s) from projection_cache (seq=${maxCachedSequence})`,
       );
@@ -228,7 +228,7 @@ function applyEventToRef(
       }
     }
 
-    setAgentRuntimeMirror(next);
+    Effect.runSync(setAgentRuntimeMirror(next));
     return next;
   });
 }

--- a/src/lib/agent-runtime-mirror.ts
+++ b/src/lib/agent-runtime-mirror.ts
@@ -2,15 +2,13 @@
  * PAN-800 — in-process mirror of AgentStateService's canonical ref.
  *
  * The dashboard server writes into this mirror on every event fold so lib code
- * running in the same process can read the latest AgentRuntimeSnapshot
- * synchronously. CLI/out-of-process callers should prefer the async HTTP path
- * in agent-runtime.ts.
+ * running in the same process can read the latest AgentRuntimeSnapshot.
+ * CLI/out-of-process callers should prefer the async HTTP path in agent-runtime.ts.
  *
- * This module intentionally has zero server-side imports so both the CLI
- * and the dashboard can pull it in without dragging in SQLite / Effect
- * layer code.
+ * All exports are Effect-native (PAN-1249 wave-1 migration).
  */
 
+import { Effect } from 'effect';
 import type { AgentRuntimeSnapshot } from '@panctl/contracts';
 
 let mirror: Record<string, AgentRuntimeSnapshot> = {};
@@ -23,18 +21,22 @@ let mirror: Record<string, AgentRuntimeSnapshot> = {};
  */
 let inProcessService = false;
 
-export function markAgentStateServiceInProcess(): void {
-  inProcessService = true;
+export function markAgentStateServiceInProcess(): Effect.Effect<void, never> {
+  return Effect.sync(() => {
+    inProcessService = true;
+  });
 }
 
-export function isAgentStateServiceInProcess(): boolean {
-  return inProcessService;
+export function isAgentStateServiceInProcess(): Effect.Effect<boolean, never> {
+  return Effect.sync(() => inProcessService);
 }
 
-export function setAgentRuntimeMirror(next: Record<string, AgentRuntimeSnapshot>): void {
-  mirror = next;
+export function setAgentRuntimeMirror(next: Record<string, AgentRuntimeSnapshot>): Effect.Effect<void, never> {
+  return Effect.sync(() => {
+    mirror = next;
+  });
 }
 
-export function getRuntimeSnapshotSync(agentId: string): AgentRuntimeSnapshot | null {
-  return mirror[agentId] ?? null;
+export function getRuntimeSnapshot(agentId: string): Effect.Effect<AgentRuntimeSnapshot | null, never> {
+  return Effect.sync(() => mirror[agentId] ?? null);
 }

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -1447,7 +1447,7 @@ export const __testInternals = { markAgentRunning, markAgentStopped };
 // SubscriptionRef → projection_cache rows keyed 'agent-runtime:<id>'.
 //
 // Writes: emitAgentEvent POSTs to /api/agents/:id/heartbeat. Reads: in-process
-// lib uses getRuntimeSnapshotSync; CLI/out-of-process uses
+// lib uses getRuntimeSnapshot (Effect-native); CLI/out-of-process uses
 // getAgentRuntimeSnapshot (HTTP).
 //
 // The functions below are adapters over AgentRuntimeSnapshot. Each caller
@@ -1460,7 +1460,8 @@ import {
   getAgentRuntimeSnapshot as fetchAgentRuntimeSnapshot,
   emitAgentEvent,
 } from './agent-runtime.js';
-import { getRuntimeSnapshotSync, isAgentStateServiceInProcess } from './agent-runtime-mirror.js';
+import { Effect } from 'effect';
+import { getRuntimeSnapshot, isAgentStateServiceInProcess } from './agent-runtime-mirror.js';
 
 export type AgentResolution = 'working' | 'done' | 'needs_input' | 'stuck' | 'completed' | 'unclear' | 'abandoned';
 
@@ -1518,14 +1519,14 @@ export function getAgentRuntimeState(agentId: string): AgentRuntimeState | null 
   // Sync path: read from the in-process mirror (empty in fresh CLI processes,
   // populated inside the dashboard server). CLI commands should prefer
   // getAgentRuntimeStateAsync so they fall through to HTTP.
-  return snapshotToRuntimeState(getRuntimeSnapshotSync(agentId));
+  return snapshotToRuntimeState(Effect.runSync(getRuntimeSnapshot(agentId)));
 }
 
 export async function getAgentRuntimeStateAsync(agentId: string): Promise<AgentRuntimeState | null> {
   // In-process (inside the dashboard): the sync mirror is authoritative. Do
   // NOT fall back to HTTP — that would fetch our own server, which may still
   // be inside Layer construction and cause a startup deadlock.
-  if (isAgentStateServiceInProcess()) {
+  if (Effect.runSync(isAgentStateServiceInProcess())) {
     return getAgentRuntimeState(agentId);
   }
   // Cross-process (CLI, external lib callers): sync mirror is empty, hit HTTP.

--- a/tests/lib/work-agent-lifecycle.test.ts
+++ b/tests/lib/work-agent-lifecycle.test.ts
@@ -8,6 +8,7 @@ import {
   saveAgentState,
   saveSessionId,
 } from '../../src/lib/agents.js';
+import { Effect } from 'effect';
 import { setAgentRuntimeMirror } from '../../src/lib/agent-runtime-mirror.js';
 import { getWorkAgentLifecycleState } from '../../src/lib/work-agent-lifecycle.js';
 import * as tmux from '../../src/lib/tmux.js';
@@ -151,14 +152,14 @@ describe('work-agent-lifecycle', () => {
     // Populate the runtime mirror directly — saveAgentRuntimeState is async and
     // relies on the dashboard event system which is not running in unit tests.
     // activity:'idle' maps to runtimeState.state === 'idle' via snapshotToRuntimeState.
-    setAgentRuntimeMirror({
+    Effect.runSync(setAgentRuntimeMirror({
       [agentId]: {
         id: agentId,
         activity: 'idle',
         lastActivity: new Date().toISOString(),
         updatedAtSequence: 1,
       },
-    });
+    }));
     saveSessionId(agentId, 'session-stuck');
 
     const sessionExistsSpy = vi.spyOn(tmux, 'sessionExists').mockReturnValue(true);
@@ -175,7 +176,7 @@ describe('work-agent-lifecycle', () => {
     expect(lifecycle.reason).toContain('runtime is idle');
 
     sessionExistsSpy.mockRestore();
-    setAgentRuntimeMirror({});
+    Effect.runSync(setAgentRuntimeMirror({}));
   });
 
   // 'suspended' is a legacy state retained for backward-compat — ensure it also
@@ -205,14 +206,14 @@ describe('work-agent-lifecycle', () => {
     // code paths that wrote state.json directly. New code uses activity:'idle'.
     // Since snapshotToRuntimeState has no 'suspended' Activity mapping, we use
     // 'idle' here as the closest real-world equivalent.
-    setAgentRuntimeMirror({
+    Effect.runSync(setAgentRuntimeMirror({
       [agentId]: {
         id: agentId,
         activity: 'idle',
         lastActivity: new Date().toISOString(),
         updatedAtSequence: 1,
       },
-    });
+    }));
     saveSessionId(agentId, 'session-suspended');
 
     const sessionExistsSpy = vi.spyOn(tmux, 'sessionExists').mockReturnValue(true);
@@ -224,7 +225,7 @@ describe('work-agent-lifecycle', () => {
     expect(lifecycle.recommendedAction).toBe('resume');
 
     sessionExistsSpy.mockRestore();
-    setAgentRuntimeMirror({});
+    Effect.runSync(setAgentRuntimeMirror({}));
   });
 
   it('allows fresh start when agent state is missing and no live session exists', () => {

--- a/tests/unit/dashboard/server/routes/resume-gate.test.ts
+++ b/tests/unit/dashboard/server/routes/resume-gate.test.ts
@@ -27,6 +27,7 @@ import {
   saveAgentState,
   saveSessionId,
 } from '../../../../../src/lib/agents.js';
+import { Effect } from 'effect';
 import { setAgentRuntimeMirror } from '../../../../../src/lib/agent-runtime-mirror.js';
 import { getWorkAgentLifecycleState } from '../../../../../src/lib/work-agent-lifecycle.js';
 import type { WorkAgentLifecycleState } from '../../../../../src/lib/work-agent-lifecycle.js';
@@ -46,7 +47,7 @@ function makeAgentId(prefix: string): string {
 }
 
 afterEach(() => {
-  setAgentRuntimeMirror({});
+  Effect.runSync(setAgentRuntimeMirror({}));
   for (const id of testAgentIds) {
     const dir = getAgentDir(id);
     if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
@@ -71,9 +72,9 @@ describe('resume route gate predicate', () => {
       status: 'running',
       startedAt: new Date().toISOString(),
     });
-    setAgentRuntimeMirror({
+    Effect.runSync(setAgentRuntimeMirror({
       [agentId]: { id: agentId, activity: 'working', lastActivity: new Date().toISOString(), updatedAtSequence: 1 },
-    });
+    }));
     saveSessionId(agentId, 'session-active');
 
     const sessionSpy = vi.spyOn(tmux, 'sessionExists').mockReturnValue(true);
@@ -106,9 +107,9 @@ describe('resume route gate predicate', () => {
       status: 'running',
       startedAt: new Date().toISOString(),
     });
-    setAgentRuntimeMirror({
+    Effect.runSync(setAgentRuntimeMirror({
       [agentId]: { id: agentId, activity: 'idle', lastActivity: new Date().toISOString(), updatedAtSequence: 1 },
-    });
+    }));
     saveSessionId(agentId, 'session-stuck');
 
     const sessionSpy = vi.spyOn(tmux, 'sessionExists').mockReturnValue(true);


### PR DESCRIPTION
## Summary

- Converts `src/lib/agent-runtime-mirror.ts` to Effect-native (PAN-1249 wave 1 swarm slot 2)
- All four exported functions now return `Effect.Effect<T, never>` via `Effect.sync()`
- Renamed `getRuntimeSnapshotSync` → `getRuntimeSnapshot` (Sync suffix redundant once callers use `yield*`)

## Changed files

- **`src/lib/agent-runtime-mirror.ts`** — migrated to Effect (all AC satisfied)
- **`src/lib/agents.ts`** — `Effect.runSync()` bridges at two non-Effect call sites; wave-6 agents.ts slot will convert these to `yield*`
- **`src/dashboard/server/services/agent-state-service.ts`** — `yield*` inside Effect.gen; `Effect.runSync()` inside synchronous `SubscriptionRef.update` callback
- **`tests/lib/work-agent-lifecycle.test.ts`** — updated `setAgentRuntimeMirror` calls to `Effect.runSync(setAgentRuntimeMirror(...))`
- **`tests/unit/dashboard/server/routes/resume-gate.test.ts`** — same fix

## Acceptance criteria

- [x] All exported functions return `Effect.Effect<T, never>` (no Promises existed, all are now Effect-wrapped)
- [x] No `execAsync`/`execFileAsync` calls (none existed)
- [x] No `try/catch` for expected failures (none existed)
- [x] No `fs/promises` calls (none existed)
- [x] No test file to migrate (none existed)
- [x] No new `Effect.runPromise()` inside `src/lib/`
- [x] Observable behavior unchanged
- [x] `npm run typecheck` and `npm run lint` pass; all 386 test files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)