### PR TITLE
feat(pan-1249): effect migration for src/lib/browser.ts

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1264,13 +1264,17 @@ program
     // Open browser after server has had a moment to start
     setTimeout(async () => {
       console.log(`  ${chalk.cyan(url)}`);
-      try {
-        const { openBrowser } = await import('../lib/browser.js');
-        await openBrowser(browserUrl);
-      } catch {
+      const [{ openBrowser }, { Effect }, { layer: nodeServicesLayer }] = await Promise.all([
+        import('../lib/browser.js'),
+        import('effect'),
+        import('@effect/platform-node/NodeServices'),
+      ]);
+      await Effect.runPromise(
+        openBrowser(browserUrl).pipe(Effect.provide(nodeServicesLayer)),
+      ).catch(() => {
         // If openBrowser fails, show URL for manual opening
         console.log(chalk.dim(`  Open your browser to: ${browserUrl}`));
-      }
+      });
     }, 1_500);
   });
 

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -3,27 +3,37 @@
  * Used by `npx panopticon serve` to open the dashboard URL after server starts.
  */
 
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
+import { Effect } from 'effect';
+import { ChildProcess } from 'effect/unstable/process';
+import { ChildProcessSpawner } from 'effect/unstable/process/ChildProcessSpawner';
+import { ProcessSpawnError } from './errors.js';
 
-const execFileAsync = promisify(execFile);
+function runCommand(
+  command: string,
+  args: ReadonlyArray<string>,
+): Effect.Effect<void, ProcessSpawnError, ChildProcessSpawner> {
+  return Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner;
+    const code = yield* spawner
+      .exitCode(ChildProcess.make(command, args, { stdout: 'ignore', stderr: 'ignore' }))
+      .pipe(Effect.mapError((e) => new ProcessSpawnError({ command, args, message: e.message, cause: e })));
+    if (Number(code) !== 0) {
+      yield* Effect.fail(new ProcessSpawnError({ command, args, message: `exited with code ${String(code)}` }));
+    }
+  });
+}
 
-export async function openBrowser(url: string): Promise<void> {
-  if (process.platform === "darwin") {
-    await execFileAsync("open", [url]);
-  } else if (process.platform === "win32") {
+export function openBrowser(url: string): Effect.Effect<void, ProcessSpawnError, ChildProcessSpawner> {
+  if (process.platform === 'darwin') {
+    return runCommand('open', [url]);
+  } else if (process.platform === 'win32') {
     // cmd.exe /c start is the standard way; /b runs without a new window
-    await execFileAsync("cmd", ["/c", "start", "", url]);
+    return runCommand('cmd', ['/c', 'start', '', url]);
   } else {
     // Linux: try xdg-open, fall back to sensible-browser
-    try {
-      await execFileAsync("xdg-open", [url]);
-    } catch {
-      try {
-        await execFileAsync("sensible-browser", [url]);
-      } catch {
-        // Best-effort: ignore if neither is available
-      }
-    }
+    return runCommand('xdg-open', [url]).pipe(
+      Effect.catch(() => runCommand('sensible-browser', [url])),
+      Effect.catch(() => Effect.void),
+    );
   }
 }


### PR DESCRIPTION
## Summary

- Migrates `src/lib/browser.ts` from `Promise<void>` to `Effect.Effect<void, ProcessSpawnError, ChildProcessSpawner>`
- Replaces `execFileAsync` (promisify + execFile) with `ChildProcessSpawner.exitCode` from `effect/unstable/process`
- Non-zero exit codes surfaced as `ProcessSpawnError` to preserve original `execFileAsync` rejection semantics
- Linux fallback chain (`xdg-open` → `sensible-browser` → ignore) replaced with `Effect.catch` channels instead of nested `try/catch`
- Updates `src/cli/index.ts` adapter boundary: `Effect.runPromise` with `NodeServices.layer` provided

## Acceptance criteria

- [x] All exported functions return `Effect.Effect<T, E>` — `openBrowser` now returns `Effect.Effect<void, ProcessSpawnError, ChildProcessSpawner>`
- [x] All `execFileAsync` calls replaced with `ChildProcessSpawner.exitCode` via `@effect/platform-node`
- [x] All `try/catch` for expected failures replaced with `Data.TaggedError` channels (`Effect.catch`)
- [x] No `fs/promises` calls in this file
- [x] No test file exists for `browser.ts` — nothing to migrate
- [x] No new `Effect.runPromise()` inside `src/lib/` — only at the CLI adapter boundary in `src/cli/index.ts`
- [x] Observable behavior unchanged — no logic changes alongside the migration
- [x] `npm run typecheck` and `npm run lint` pass

## Test plan

- [x] `npm run typecheck` — passes clean
- [x] `npm run lint` — passes (pre-existing warnings only)
- [x] `npm test` — 386 test files pass (4303 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)