### PR TITLE
feat(beads): effect-migrate src/lib/beads-restore.ts (PAN-1249 slot-5)

### DIFF
--- a/src/lib/__tests__/beads-restore.test.ts
+++ b/src/lib/__tests__/beads-restore.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Effect } from 'effect';
 import { execSync } from 'child_process';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync, existsSync, unlinkSync } from 'fs';
 import { tmpdir } from 'os';
@@ -27,7 +28,7 @@ describe('restoreTrackedBeadsExport', () => {
     unlinkSync(join(workspace, '.beads', 'issues.jsonl'));
     expect(existsSync(join(workspace, '.beads', 'issues.jsonl'))).toBe(false);
 
-    await restoreTrackedBeadsExport(workspace);
+    await Effect.runPromise(restoreTrackedBeadsExport(workspace));
 
     expect(existsSync(join(workspace, '.beads', 'issues.jsonl'))).toBe(true);
   });
@@ -41,7 +42,7 @@ describe('restoreTrackedBeadsExport', () => {
     expect(before).toMatch(/^D\s+\.beads\/issues\.jsonl/m);
     expect(existsSync(join(workspace, '.beads', 'issues.jsonl'))).toBe(false);
 
-    await restoreTrackedBeadsExport(workspace);
+    await Effect.runPromise(restoreTrackedBeadsExport(workspace));
 
     expect(existsSync(join(workspace, '.beads', 'issues.jsonl'))).toBe(true);
     const after = execSync('git status --porcelain', { cwd: workspace, encoding: 'utf-8' });
@@ -52,7 +53,7 @@ describe('restoreTrackedBeadsExport', () => {
     const before = execSync('git status --porcelain', { cwd: workspace, encoding: 'utf-8' });
     expect(before).toBe('');
 
-    await restoreTrackedBeadsExport(workspace);
+    await Effect.runPromise(restoreTrackedBeadsExport(workspace));
 
     const after = execSync('git status --porcelain', { cwd: workspace, encoding: 'utf-8' });
     expect(after).toBe('');
@@ -61,7 +62,7 @@ describe('restoreTrackedBeadsExport', () => {
   it('is a no-op when the export was modified but not deleted', async () => {
     writeFileSync(join(workspace, '.beads', 'issues.jsonl'), '{"id":"y"}\n');
 
-    await restoreTrackedBeadsExport(workspace);
+    await Effect.runPromise(restoreTrackedBeadsExport(workspace));
 
     // The modified content should still be there — only deletions get reverted.
     const content = execSync('cat .beads/issues.jsonl', { cwd: workspace, encoding: 'utf-8' });
@@ -71,7 +72,7 @@ describe('restoreTrackedBeadsExport', () => {
   it('does not throw on a non-git directory', async () => {
     const notGit = mkdtempSync(join(tmpdir(), 'not-a-git-'));
     try {
-      await expect(restoreTrackedBeadsExport(notGit)).resolves.toBeUndefined();
+      await expect(Effect.runPromise(restoreTrackedBeadsExport(notGit))).resolves.toBeUndefined();
     } finally {
       rmSync(notGit, { recursive: true, force: true });
     }

--- a/src/lib/beads-restore.ts
+++ b/src/lib/beads-restore.ts
@@ -22,17 +22,37 @@
  * Once both PRs land, the duplicate should be removed in favour of this file.
  */
 
-import { exec } from 'child_process';
-import { promisify } from 'util';
+import { Effect, Layer, Stream } from 'effect';
+import { ChildProcess } from 'effect/unstable/process';
+import * as NodeChildProcessSpawner from '@effect/platform-node/NodeChildProcessSpawner';
+import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem';
+import * as NodePath from '@effect/platform-node/NodePath';
 
-const execAsync = promisify(exec);
+const spawnerLayer = NodeChildProcessSpawner.layer.pipe(
+  Layer.provide(Layer.mergeAll(NodeFileSystem.layer, NodePath.layer))
+);
 
-export async function restoreTrackedBeadsExport(workspacePath: string): Promise<void> {
-  try {
-    const { stdout } = await execAsync('git status --porcelain -- .beads/issues.jsonl', {
-      cwd: workspacePath,
-      encoding: 'utf-8',
-    });
+const runGit = (args: readonly string[], cwd: string): Effect.Effect<string, unknown> =>
+  Effect.gen(function* () {
+    const handle = yield* ChildProcess.make('git', [...args], { cwd });
+    const buf = yield* Stream.runFold(
+      handle.stdout,
+      () => Buffer.alloc(0),
+      (acc, chunk) => Buffer.concat([acc, Buffer.from(chunk)])
+    );
+    yield* handle.exitCode;
+    return buf.toString('utf-8');
+  }).pipe(
+    Effect.scoped,
+    Effect.provide(spawnerLayer)
+  );
+
+export const restoreTrackedBeadsExport = (workspacePath: string): Effect.Effect<void, never> =>
+  Effect.gen(function* () {
+    const stdout = yield* runGit(
+      ['status', '--porcelain', '--', '.beads/issues.jsonl'],
+      workspacePath
+    );
     // git status --porcelain shows the index column (col 0) and worktree column (col 1).
     // - "_D" = working tree deleted (file removed but still in index)
     // - "D_" = staged deletion (already removed from index — `git restore --` alone
@@ -42,11 +62,9 @@ export async function restoreTrackedBeadsExport(workspacePath: string): Promise<
     // the tracked file in every case.
     const xy = stdout.split('\n').find((line) => line.endsWith(' .beads/issues.jsonl'));
     if (xy && (xy[0] === 'D' || xy[1] === 'D')) {
-      await execAsync('git restore --source=HEAD --staged --worktree -- .beads/issues.jsonl', {
-        cwd: workspacePath,
-      });
+      yield* runGit(
+        ['restore', '--source=HEAD', '--staged', '--worktree', '--', '.beads/issues.jsonl'],
+        workspacePath
+      );
     }
-  } catch {
-    // Best effort — never throw from the safety net.
-  }
-}
+  }).pipe(Effect.catch(() => Effect.void));


### PR DESCRIPTION
## Summary

- Converts `restoreTrackedBeadsExport` from `Promise<void>` to `Effect.Effect<void, never>` (never fails externally — best-effort semantics preserved)
- Replaces `execAsync` with `ChildProcess.make` from `effect/unstable/process` backed by `@effect/platform-node` `NodeChildProcessSpawner`
- Replaces `try/catch` error swallowing with `Effect.catch(() => Effect.void)` at the outer boundary
- Provides `NodeFileSystem` and `NodePath` layers to satisfy `NodeChildProcessSpawner` dependencies
- The self-contained layer composition means callers use `yield*` (Effect) or `Effect.runPromise()` (adapter boundary) with no dependency injection required

## Test plan

- [ ] All 5 unit tests in `src/lib/__tests__/beads-restore.test.ts` pass (updated to call `Effect.runPromise()`)
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] Behavioral parity: restore works for worktree-deleted, staged-deleted, clean, modified (non-deleted), and non-git-directory cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)