### PR TITLE
feat(pan-1249): Effect migration for src/lib/format-duration.ts

### DIFF
--- a/src/lib/format-duration.ts
+++ b/src/lib/format-duration.ts
@@ -1,38 +1,47 @@
 /**
  * Format a duration in milliseconds to a human-readable string.
- * 
+ *
  * Examples:
  *   formatDuration(500) => "< 1s"
  *   formatDuration(5000) => "5s"
  *   formatDuration(65000) => "1m 5s"
  *   formatDuration(3665000) => "1h 1m 5s"
+ *
+ * All exports are Effect-native (PAN-1249 wave-0 migration).
  */
-export function formatDuration(ms: number): string {
-  if (ms < 0) return "0s";
-  if (ms < 1000) return "< 1s";
 
-  const seconds = Math.floor(ms / 1000) % 60;
-  const minutes = Math.floor(ms / 60000) % 60;
-  const hours = Math.floor(ms / 3600000);
+import { Effect } from 'effect';
 
-  const parts: string[] = [];
-  if (hours > 0) parts.push(`${hours}h`);
-  if (minutes > 0) parts.push(`${minutes}m`);
-  if (seconds > 0 || parts.length === 0) parts.push(`${seconds}s`);
+export function formatDuration(ms: number): Effect.Effect<string, never> {
+  return Effect.sync(() => {
+    if (ms < 0) return "0s";
+    if (ms < 1000) return "< 1s";
 
-  return parts.join(" ");
+    const seconds = Math.floor(ms / 1000) % 60;
+    const minutes = Math.floor(ms / 60000) % 60;
+    const hours = Math.floor(ms / 3600000);
+
+    const parts: string[] = [];
+    if (hours > 0) parts.push(`${hours}h`);
+    if (minutes > 0) parts.push(`${minutes}m`);
+    if (seconds > 0 || parts.length === 0) parts.push(`${seconds}s`);
+
+    return parts.join(" ");
+  });
 }
 
 /**
  * Format a timestamp to relative time (e.g., "5 minutes ago").
  */
-export function timeAgo(timestamp: string | Date): string {
-  const now = Date.now();
-  const then = new Date(timestamp).getTime();
-  const diff = now - then;
+export function timeAgo(timestamp: string | Date): Effect.Effect<string, never> {
+  return Effect.sync(() => {
+    const now = Date.now();
+    const then = new Date(timestamp).getTime();
+    const diff = now - then;
 
-  if (diff < 60000) return "just now";
-  if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
-  if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`;
-  return `${Math.floor(diff / 86400000)}d ago`;
+    if (diff < 60000) return "just now";
+    if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
+    if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`;
+    return `${Math.floor(diff / 86400000)}d ago`;
+  });
 }

--- a/tests/lib/format-duration.test.ts
+++ b/tests/lib/format-duration.test.ts
@@ -1,62 +1,63 @@
 import { describe, it, expect } from "vitest";
+import { Effect } from "effect";
 import { formatDuration, timeAgo } from "../../src/lib/format-duration.js";
 
 describe("formatDuration", () => {
   it("should return '< 1s' for sub-second durations", () => {
-    expect(formatDuration(0)).toBe("< 1s");
-    expect(formatDuration(500)).toBe("< 1s");
-    expect(formatDuration(999)).toBe("< 1s");
+    expect(Effect.runSync(formatDuration(0))).toBe("< 1s");
+    expect(Effect.runSync(formatDuration(500))).toBe("< 1s");
+    expect(Effect.runSync(formatDuration(999))).toBe("< 1s");
   });
 
   it("should return '0s' for negative values", () => {
-    expect(formatDuration(-100)).toBe("0s");
-    expect(formatDuration(-1)).toBe("0s");
+    expect(Effect.runSync(formatDuration(-100))).toBe("0s");
+    expect(Effect.runSync(formatDuration(-1))).toBe("0s");
   });
 
   it("should format seconds correctly", () => {
-    expect(formatDuration(1000)).toBe("1s");
-    expect(formatDuration(5000)).toBe("5s");
-    expect(formatDuration(59000)).toBe("59s");
+    expect(Effect.runSync(formatDuration(1000))).toBe("1s");
+    expect(Effect.runSync(formatDuration(5000))).toBe("5s");
+    expect(Effect.runSync(formatDuration(59000))).toBe("59s");
   });
 
   it("should format minutes and seconds", () => {
-    expect(formatDuration(60000)).toBe("1m");
-    expect(formatDuration(65000)).toBe("1m 5s");
-    expect(formatDuration(120000)).toBe("2m");
-    expect(formatDuration(3599000)).toBe("59m 59s");
+    expect(Effect.runSync(formatDuration(60000))).toBe("1m");
+    expect(Effect.runSync(formatDuration(65000))).toBe("1m 5s");
+    expect(Effect.runSync(formatDuration(120000))).toBe("2m");
+    expect(Effect.runSync(formatDuration(3599000))).toBe("59m 59s");
   });
 
   it("should format hours, minutes, and seconds", () => {
-    expect(formatDuration(3600000)).toBe("1h");
-    expect(formatDuration(3665000)).toBe("1h 1m 5s");
-    expect(formatDuration(7200000)).toBe("2h");
-    expect(formatDuration(86400000)).toBe("24h");
+    expect(Effect.runSync(formatDuration(3600000))).toBe("1h");
+    expect(Effect.runSync(formatDuration(3665000))).toBe("1h 1m 5s");
+    expect(Effect.runSync(formatDuration(7200000))).toBe("2h");
+    expect(Effect.runSync(formatDuration(86400000))).toBe("24h");
   });
 });
 
 describe("timeAgo", () => {
   it("should return 'just now' for recent timestamps", () => {
     const now = new Date();
-    expect(timeAgo(now)).toBe("just now");
+    expect(Effect.runSync(timeAgo(now))).toBe("just now");
   });
 
   it("should return minutes ago", () => {
     const fiveMinAgo = new Date(Date.now() - 5 * 60000);
-    expect(timeAgo(fiveMinAgo)).toBe("5m ago");
+    expect(Effect.runSync(timeAgo(fiveMinAgo))).toBe("5m ago");
   });
 
   it("should return hours ago", () => {
     const twoHoursAgo = new Date(Date.now() - 2 * 3600000);
-    expect(timeAgo(twoHoursAgo)).toBe("2h ago");
+    expect(Effect.runSync(timeAgo(twoHoursAgo))).toBe("2h ago");
   });
 
   it("should return days ago", () => {
     const threeDaysAgo = new Date(Date.now() - 3 * 86400000);
-    expect(timeAgo(threeDaysAgo)).toBe("3d ago");
+    expect(Effect.runSync(timeAgo(threeDaysAgo))).toBe("3d ago");
   });
 
   it("should accept string timestamps", () => {
     const recent = new Date(Date.now() - 30000).toISOString();
-    expect(timeAgo(recent)).toBe("just now");
+    expect(Effect.runSync(timeAgo(recent))).toBe("just now");
   });
 });


### PR DESCRIPTION
## Summary

- Wraps `formatDuration` and `timeAgo` in `Effect.sync()`, returning `Effect.Effect<string, never>` — matching the wave-0 migration pattern established by `agent-runtime-mirror.ts`
- Updates `tests/lib/format-duration.test.ts` to unwrap results via `Effect.runSync()`
- No callers in `src/` import from this module, so no caller changes needed

## Acceptance Criteria

- ✅ AC1: No `Promise<T>` returns remain (functions returned `string`, now return `Effect.Effect<string, never>`)
- ✅ AC2: No `execAsync`/`execFileAsync` calls (none existed)
- ✅ AC3: No `try/catch` for failure modes (none existed)
- ✅ AC4: No `fs/promises` calls (none existed)
- ✅ AC5: Test file migrated to Effect runner pattern (`Effect.runSync`)
- ✅ AC6: No `Effect.runPromise()` introduced inside `src/lib/`
- ✅ AC7: Observable behavior unchanged (logic identical, pure computation)
- ✅ AC8: `npm run typecheck` and `npm run lint` pass; all 10 tests pass

## Test plan

- [x] `npx vitest run tests/lib/format-duration.test.ts` — 10/10 pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (pre-existing bun:sqlite warning unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)