### PR TITLE
feat(cli): effect-migrate src/lib/channels/permission-payload.ts

### DIFF
--- a/src/dashboard/server/routes/agent-permissions.ts
+++ b/src/dashboard/server/routes/agent-permissions.ts
@@ -1,4 +1,5 @@
 import type { ChannelPermissionRequestSnapshot } from '@panctl/contracts';
+import { Effect, Either } from 'effect';
 
 import {
   normalizeChannelPermissionRequestFields,
@@ -25,12 +26,20 @@ export function permissionResolutionVerb(behavior: 'allow' | 'deny'): 'allowed' 
 export function normalizePermissionRequestBody(body: Record<string, unknown>):
   | { ok: true; value: NormalizedChannelPermissionRequestFields }
   | { ok: false; error: string } {
-  return normalizeChannelPermissionRequestFields({
-    requestId: body['requestId'],
-    toolName: body['toolName'],
-    description: body['description'],
-    inputPreview: body['inputPreview'],
-  });
+  const either = Effect.runSync(
+    Effect.either(
+      normalizeChannelPermissionRequestFields({
+        requestId: body['requestId'],
+        toolName: body['toolName'],
+        description: body['description'],
+        inputPreview: body['inputPreview'],
+      }),
+    ),
+  );
+  if (Either.isLeft(either)) {
+    return { ok: false, error: either.left.message };
+  }
+  return { ok: true, value: either.right };
 }
 
 export function parsePermissionResponseBehavior(body: Record<string, unknown>):

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -36,6 +36,7 @@ import { BRIDGE_TOKEN_HEADER, readBridgeToken, writeBridgeToken } from './bridge
 import { canUseHarness } from './harness-policy.js';
 import type { RuntimeName } from './runtimes/types.js';
 import { createPiFifo, piFifoPaths, writePiCommand, PiNotReady } from './runtimes/pi-fifo.js';
+import { Effect } from 'effect';
 import { assertIssueHasBeads } from './beads-query.js';
 import { getWorkspaceStackHealth } from './workspace/stack-health.js';
 import { normalizeModelOverride, requireModelOverride, shellQuoteModelId } from './model-validation.js';
@@ -1456,12 +1457,10 @@ export const __testInternals = { markAgentRunning, markAgentStopped };
 // every field access in one PR would have been mechanical noise.
 
 import type { AgentRuntimeSnapshot } from '@panctl/contracts';
-import { Effect } from 'effect';
 import {
   getAgentRuntimeSnapshot as fetchAgentRuntimeSnapshot,
   emitAgentEvent,
 } from './agent-runtime.js';
-import { Effect } from 'effect';
 import { getRuntimeSnapshot, isAgentStateServiceInProcess } from './agent-runtime-mirror.js';
 
 export type AgentResolution = 'working' | 'done' | 'needs_input' | 'stuck' | 'completed' | 'unclear' | 'abandoned';

--- a/src/lib/channels/panopticon-bridge.ts
+++ b/src/lib/channels/panopticon-bridge.ts
@@ -45,6 +45,7 @@ import { chmod, mkdir, unlink, appendFile, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
+import { Effect } from 'effect';
 import { BRIDGE_TOKEN_HEADER, readBridgeToken } from '../bridge-token.js';
 import {
   normalizeChannelPermissionRequestFields,
@@ -123,23 +124,26 @@ function parsePermissionRequestNotification(payload: unknown): ChannelPermission
     throw new Error('invalid permission request notification params');
   }
 
-  const normalized = normalizeChannelPermissionRequestFields({
-    requestId: (params as { request_id?: unknown }).request_id,
-    toolName: (params as { tool_name?: unknown }).tool_name,
-    description: (params as { description?: unknown }).description,
-    inputPreview: (params as { input_preview?: unknown }).input_preview,
-  });
-  if (!normalized.ok) {
-    throw new Error(`invalid permission request notification params: ${normalized.error}`);
-  }
+  const normalized = Effect.runSync(
+    normalizeChannelPermissionRequestFields({
+      requestId: (params as { request_id?: unknown }).request_id,
+      toolName: (params as { tool_name?: unknown }).tool_name,
+      description: (params as { description?: unknown }).description,
+      inputPreview: (params as { input_preview?: unknown }).input_preview,
+    }).pipe(
+      Effect.mapError(
+        (e) => new Error(`invalid permission request notification params: ${e.message}`),
+      ),
+    ),
+  );
 
   return {
     method: 'notifications/claude/channel/permission_request',
     params: {
-      request_id: normalized.value.requestId,
-      tool_name: normalized.value.toolName,
-      description: normalized.value.description,
-      input_preview: normalized.value.inputPreview,
+      request_id: normalized.requestId,
+      tool_name: normalized.toolName,
+      description: normalized.description,
+      input_preview: normalized.inputPreview,
     },
   };
 }
@@ -147,16 +151,18 @@ function parsePermissionRequestNotification(payload: unknown): ChannelPermission
 function normalizePermissionRequest(
   notification: ChannelPermissionRequestNotification,
 ): ChannelPermissionRequest {
-  const normalized = normalizeChannelPermissionRequestFields({
-    requestId: notification.params.request_id,
-    toolName: notification.params.tool_name,
-    description: notification.params.description,
-    inputPreview: notification.params.input_preview,
-  });
-  if (!normalized.ok) {
-    throw new Error(`invalid permission request notification params: ${normalized.error}`);
-  }
-  return normalized.value;
+  return Effect.runSync(
+    normalizeChannelPermissionRequestFields({
+      requestId: notification.params.request_id,
+      toolName: notification.params.tool_name,
+      description: notification.params.description,
+      inputPreview: notification.params.input_preview,
+    }).pipe(
+      Effect.mapError(
+        (e) => new Error(`invalid permission request notification params: ${e.message}`),
+      ),
+    ),
+  );
 }
 
 export const server: Server = new Server(

--- a/src/lib/channels/permission-payload.ts
+++ b/src/lib/channels/permission-payload.ts
@@ -1,3 +1,5 @@
+import { Data, Effect } from 'effect';
+
 export const CHANNEL_PERMISSION_LIMITS = {
   requestIdBytes: 128,
   toolNameBytes: 128,
@@ -12,6 +14,14 @@ export interface NormalizedChannelPermissionRequestFields {
   inputPreview: string;
 }
 
+/** A permission request field failed validation. */
+export class PermissionPayloadValidationError extends Data.TaggedError(
+  'PermissionPayloadValidationError',
+)<{
+  readonly field: string;
+  readonly message: string;
+}> {}
+
 export function utf8ByteLength(value: string): number {
   return Buffer.byteLength(value, 'utf8');
 }
@@ -25,57 +35,66 @@ export function normalizeChannelPermissionRequestFields(input: {
   toolName: unknown;
   description: unknown;
   inputPreview?: unknown;
-}):
-  | { ok: true; value: NormalizedChannelPermissionRequestFields }
-  | { ok: false; error: string } {
-  const requestId = typeof input.requestId === 'string' ? input.requestId.trim() : '';
-  if (!requestId) {
-    return { ok: false, error: 'requestId is required' };
-  }
-  if (utf8ByteLength(requestId) > CHANNEL_PERMISSION_LIMITS.requestIdBytes) {
-    return {
-      ok: false,
-      error: `requestId exceeds ${CHANNEL_PERMISSION_LIMITS.requestIdBytes} bytes`,
-    };
-  }
+}): Effect.Effect<NormalizedChannelPermissionRequestFields, PermissionPayloadValidationError> {
+  return Effect.gen(function* () {
+    const requestId = typeof input.requestId === 'string' ? input.requestId.trim() : '';
+    if (!requestId) {
+      return yield* Effect.fail(
+        new PermissionPayloadValidationError({ field: 'requestId', message: 'requestId is required' }),
+      );
+    }
+    if (utf8ByteLength(requestId) > CHANNEL_PERMISSION_LIMITS.requestIdBytes) {
+      return yield* Effect.fail(
+        new PermissionPayloadValidationError({
+          field: 'requestId',
+          message: `requestId exceeds ${CHANNEL_PERMISSION_LIMITS.requestIdBytes} bytes`,
+        }),
+      );
+    }
 
-  const toolName = typeof input.toolName === 'string' ? input.toolName.trim() : '';
-  if (!toolName) {
-    return { ok: false, error: 'toolName is required' };
-  }
-  if (utf8ByteLength(toolName) > CHANNEL_PERMISSION_LIMITS.toolNameBytes) {
-    return {
-      ok: false,
-      error: `toolName exceeds ${CHANNEL_PERMISSION_LIMITS.toolNameBytes} bytes`,
-    };
-  }
+    const toolName = typeof input.toolName === 'string' ? input.toolName.trim() : '';
+    if (!toolName) {
+      return yield* Effect.fail(
+        new PermissionPayloadValidationError({ field: 'toolName', message: 'toolName is required' }),
+      );
+    }
+    if (utf8ByteLength(toolName) > CHANNEL_PERMISSION_LIMITS.toolNameBytes) {
+      return yield* Effect.fail(
+        new PermissionPayloadValidationError({
+          field: 'toolName',
+          message: `toolName exceeds ${CHANNEL_PERMISSION_LIMITS.toolNameBytes} bytes`,
+        }),
+      );
+    }
 
-  const description = typeof input.description === 'string' ? input.description.trim() : '';
-  if (!description) {
-    return { ok: false, error: 'description is required' };
-  }
-  if (utf8ByteLength(description) > CHANNEL_PERMISSION_LIMITS.descriptionBytes) {
-    return {
-      ok: false,
-      error: `description exceeds ${CHANNEL_PERMISSION_LIMITS.descriptionBytes} bytes`,
-    };
-  }
+    const description = typeof input.description === 'string' ? input.description.trim() : '';
+    if (!description) {
+      return yield* Effect.fail(
+        new PermissionPayloadValidationError({
+          field: 'description',
+          message: 'description is required',
+        }),
+      );
+    }
+    if (utf8ByteLength(description) > CHANNEL_PERMISSION_LIMITS.descriptionBytes) {
+      return yield* Effect.fail(
+        new PermissionPayloadValidationError({
+          field: 'description',
+          message: `description exceeds ${CHANNEL_PERMISSION_LIMITS.descriptionBytes} bytes`,
+        }),
+      );
+    }
 
-  const inputPreview = normalizePermissionInputPreview(input.inputPreview);
-  if (utf8ByteLength(inputPreview) > CHANNEL_PERMISSION_LIMITS.inputPreviewBytes) {
-    return {
-      ok: false,
-      error: `inputPreview exceeds ${CHANNEL_PERMISSION_LIMITS.inputPreviewBytes} bytes`,
-    };
-  }
+    const inputPreview = normalizePermissionInputPreview(input.inputPreview);
+    if (utf8ByteLength(inputPreview) > CHANNEL_PERMISSION_LIMITS.inputPreviewBytes) {
+      return yield* Effect.fail(
+        new PermissionPayloadValidationError({
+          field: 'inputPreview',
+          message: `inputPreview exceeds ${CHANNEL_PERMISSION_LIMITS.inputPreviewBytes} bytes`,
+        }),
+      );
+    }
 
-  return {
-    ok: true,
-    value: {
-      requestId,
-      toolName,
-      description,
-      inputPreview,
-    },
-  };
+    return { requestId, toolName, description, inputPreview };
+  });
 }


### PR DESCRIPTION
## Summary

- Converts `normalizeChannelPermissionRequestFields()` from a `{ ok, value/error }` discriminated-union to `Effect.Effect<NormalizedChannelPermissionRequestFields, PermissionPayloadValidationError>`
- Introduces `PermissionPayloadValidationError` as a `Data.TaggedError` with typed `field` + `message` fields for the Effect error channel
- Pure helpers `utf8ByteLength()` and `normalizePermissionInputPreview()` remain as simple functions (no failure channel needed)
- Updates call sites in `panopticon-bridge.ts` with `Effect.runSync + Effect.mapError` to preserve existing throw-on-failure semantics in the synchronous MCP handlers
- Updates `normalizePermissionRequestBody` in `agent-permissions.ts` with `Effect.either + Effect.runSync` to maintain the `ok/error` boundary for HTTP route callers
- Fixes pre-existing duplicate `import { Effect } from 'effect'` in `agents.ts` that was causing build failures across the parallel migration swarm

## Test plan

- [x] `npm run typecheck` passes (was failing on agents.ts duplicate before this PR)
- [x] `npm run lint` passes for all touched files
- [x] Observable behavior unchanged — same validation logic, same error messages surfaced to callers
- [x] No new `Effect.runPromise()` introduced inside `src/lib/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)