### PR TITLE
feat(migration): Effect-migrate src/lib/env-loader.ts [PAN-1249 slot-9]

### DIFF
--- a/src/dashboard/server/config.ts
+++ b/src/dashboard/server/config.ts
@@ -58,9 +58,9 @@ export class ServerConfig extends Context.Service<ServerConfig, ServerConfigShap
  */
 export const ServerConfigLayer = Layer.effect(
   ServerConfig,
-  Effect.sync((): ServerConfigShape => {
-    // Load .panopticon.env (idempotent)
-    loadPanopticonEnv();
+  Effect.gen(function* () {
+    // Load .panopticon.env (idempotent — file missing or unreadable is non-fatal)
+    yield* loadPanopticonEnv().pipe(Effect.ignore);
 
     const portStr = process.env['API_PORT'] ?? process.env['PORT'] ?? '3011';
     const port = parseInt(portStr, 10);

--- a/src/lib/env-loader.ts
+++ b/src/lib/env-loader.ts
@@ -5,9 +5,11 @@
  * This allows the settings system to access API keys configured in the .env file.
  */
 
-import { readFileSync, existsSync } from 'fs';
+import { existsSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { Effect, FileSystem } from 'effect';
+import { FsError, FsNotFoundError } from './errors.js';
 
 /**
  * Path to the Panopticon environment file
@@ -41,32 +43,39 @@ function parseEnvFile(content: string): Record<string, string> {
 }
 
 /**
- * Load environment variables from ~/.panopticon.env
+ * Load environment variables from ~/.panopticon.env.
  * Does not override existing environment variables.
  *
- * @returns Object with loaded variables and any errors
+ * Fails with `FsNotFoundError` if the env file does not exist.
+ * Fails with `FsError` if the file cannot be read.
  */
-export function loadPanopticonEnv(): {
-  loaded: string[];
-  skipped: string[];
-  error?: string;
-} {
-  const result = {
-    loaded: [] as string[],
-    skipped: [] as string[],
-  };
+export function loadPanopticonEnv(): Effect.Effect<
+  { loaded: string[]; skipped: string[] },
+  FsError | FsNotFoundError,
+  FileSystem.FileSystem
+> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
 
-  if (!existsSync(ENV_FILE_PATH)) {
-    return { ...result, error: `Env file not found: ${ENV_FILE_PATH}` };
-  }
+    const fileExists = yield* fs.exists(ENV_FILE_PATH).pipe(
+      Effect.mapError((cause) => new FsError({ path: ENV_FILE_PATH, operation: 'exists', cause })),
+    );
 
-  try {
-    const content = readFileSync(ENV_FILE_PATH, 'utf-8');
+    if (!fileExists) {
+      return yield* Effect.fail(new FsNotFoundError({ path: ENV_FILE_PATH }));
+    }
+
+    const content = yield* fs.readFileString(ENV_FILE_PATH, 'utf8').pipe(
+      Effect.mapError((cause) =>
+        new FsError({ path: ENV_FILE_PATH, operation: 'readFileString', cause }),
+      ),
+    );
+
     const envVars = parseEnvFile(content);
+    const result: { loaded: string[]; skipped: string[] } = { loaded: [], skipped: [] };
 
     for (const [key, value] of Object.entries(envVars)) {
       if (process.env[key]) {
-        // Don't override existing env vars
         result.skipped.push(key);
       } else {
         process.env[key] = value;
@@ -75,9 +84,7 @@ export function loadPanopticonEnv(): {
     }
 
     return result;
-  } catch (error: any) {
-    return { ...result, error: `Failed to load env file: ${error.message}` };
-  }
+  });
 }
 
 /**

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared typed errors for src/lib Effect migration (PAN-1249, wave 0).
+ *
+ * All errors are `Data.TaggedError` subclasses so they participate in typed
+ * Effect error channels and can be narrowed with `Effect.catchTag`.
+ */
+
+import { Data } from 'effect';
+
+// ─── VCS errors ───────────────────────────────────────────────────────────────
+
+/** A version-control operation (commit, push, pull, fetch) failed. */
+export class VcsError extends Data.TaggedError('VcsError')<{
+  readonly operation: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** A version-control operation exceeded its timeout. */
+export class VcsTimeoutError extends Data.TaggedError('VcsTimeoutError')<{
+  readonly operation: string;
+  readonly timeoutMs: number;
+}> {}
+
+// ─── Filesystem errors ────────────────────────────────────────────────────────
+
+/** A filesystem operation (read, write, mkdir, unlink, stat) failed. */
+export class FsError extends Data.TaggedError('FsError')<{
+  readonly path: string;
+  readonly operation: string;
+  readonly cause?: unknown;
+}> {}
+
+/** The requested path does not exist. */
+export class FsNotFoundError extends Data.TaggedError('FsNotFoundError')<{
+  readonly path: string;
+}> {}
+
+// ─── Git errors ───────────────────────────────────────────────────────────────
+
+/** A git command exited with a non-zero code. */
+export class GitError extends Data.TaggedError('GitError')<{
+  readonly command: readonly string[];
+  readonly stderr: string;
+  readonly exitCode: number;
+  readonly cause?: unknown;
+}> {}
+
+/** A git merge or rebase produced conflicts. */
+export class MergeConflictError extends Data.TaggedError('MergeConflictError')<{
+  readonly branch: string;
+  readonly targetBranch: string;
+  readonly conflictedFiles: readonly string[];
+}> {}
+
+// ─── Tmux errors ──────────────────────────────────────────────────────────────
+
+/** A tmux command failed. */
+export class TmuxError extends Data.TaggedError('TmuxError')<{
+  readonly command: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+// ─── Tracker / API errors ─────────────────────────────────────────────────────
+
+/** A generic issue-tracker API call failed. */
+export class TrackerError extends Data.TaggedError('TrackerError')<{
+  readonly tracker: string;
+  readonly operation: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** A GitHub API call failed. */
+export class GitHubApiError extends Data.TaggedError('GitHubApiError')<{
+  readonly operation: string;
+  readonly status: number;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** A Linear API call failed. */
+export class LinearApiError extends Data.TaggedError('LinearApiError')<{
+  readonly operation: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+// ─── Agent / checkpoint errors ────────────────────────────────────────────────
+
+/** A checkpoint save, load, or delete operation failed. */
+export class CheckpointError extends Data.TaggedError('CheckpointError')<{
+  readonly agentId: string;
+  readonly operation: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** The supplied agent ID does not match the expected format. */
+export class InvalidAgentIdError extends Data.TaggedError('InvalidAgentIdError')<{
+  readonly agentId: string;
+}> {}
+
+// ─── Configuration errors ─────────────────────────────────────────────────────
+
+/** A configuration value is missing or invalid. */
+export class ConfigError extends Data.TaggedError('ConfigError')<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** A configuration file (YAML or JSON) could not be parsed. */
+export class ConfigParseError extends Data.TaggedError('ConfigParseError')<{
+  readonly path: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+// ─── Process errors ───────────────────────────────────────────────────────────
+
+/** A child process failed to spawn. */
+export class ProcessSpawnError extends Data.TaggedError('ProcessSpawnError')<{
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** A child process exceeded its allowed runtime. */
+export class ProcessTimeoutError extends Data.TaggedError('ProcessTimeoutError')<{
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly timeoutMs: number;
+}> {}

--- a/tests/unit/dashboard/config.test.ts
+++ b/tests/unit/dashboard/config.test.ts
@@ -11,9 +11,12 @@ import { ServerConfig, ServerConfigLayer, ServerConfigError } from '../../../src
 
 // Prevent loadPanopticonEnv from loading ~/.panopticon.env during tests
 // so env var presence/absence is fully controlled by the test.
-vi.mock('../../../src/lib/env-loader.js', () => ({
-  loadPanopticonEnv: () => ({ loaded: [], skipped: [] }),
-}));
+vi.mock('../../../src/lib/env-loader.js', async () => {
+  const { Effect } = await import('effect');
+  return {
+    loadPanopticonEnv: () => Effect.succeed({ loaded: [] as string[], skipped: [] as string[] }),
+  };
+});
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `loadPanopticonEnv()` migrated from synchronous `readFileSync` to `Effect.Effect<{ loaded, skipped }, FsError | FsNotFoundError, FileSystem.FileSystem>` using `@effect/platform` `FileSystem.readFileString`
- Imports shared `FsError` / `FsNotFoundError` `Data.TaggedError` classes from `src/lib/errors.ts` (wave-0 dependency, cherry-picked from slot-1)
- `ServerConfigLayer` in `src/dashboard/server/config.ts` updated from `Effect.sync` to `Effect.gen` + `yield* loadPanopticonEnv().pipe(Effect.ignore)` — env file missing/unreadable is non-fatal
- `config.test.ts` mock updated to return `Effect.succeed({...})` so it participates correctly in the Effect machinery
- `existsSync` retained for `hasEnvFile()` (acceptable per CLAUDE.md: fast stat check, no data read)
- Pure-sync functions (`getApiKeysFromEnv`, `getShadowModeFromEnv`, `getEnvFilePath`) unchanged — no I/O, no Promise/Effect needed

## Acceptance criteria status

- [x] `loadPanopticonEnv()` returns `Effect.Effect<T, E>` with typed errors — ✅
- [x] No `execAsync`/`execFileAsync` calls — N/A (file has no child-process spawning)
- [x] `try/catch` replaced with `Data.TaggedError` channels — ✅ (`FsError`, `FsNotFoundError`)
- [x] `fs/promises` calls replaced — N/A (file used sync `readFileSync`, now replaced with Effect FileSystem)
- [x] Test file migrated — N/A (no test file exists for env-loader); mock in config.test.ts fixed
- [x] No new `Effect.runPromise()` inside `src/lib/` — ✅
- [x] Observable behavior unchanged — ✅
- [x] `npm run typecheck` and `npm run lint` pass — ✅ (4268 tests pass, 0 typecheck errors)

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm test` — 4268 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)