### PR TITLE
feat(pan-1249): migrate src/lib/flywheel-merge-order.ts to Effect [slot-11]

### DIFF
--- a/src/cli/commands/flywheel.ts
+++ b/src/cli/commands/flywheel.ts
@@ -3,7 +3,8 @@ import { readFile, realpath, writeFile } from 'node:fs/promises';
 import { freemem, totalmem } from 'node:os';
 import { isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { promisify } from 'node:util';
-import { Schema } from 'effect';
+import { Effect, Schema } from 'effect';
+import { layer as nodeServicesLayer } from '@effect/platform-node/NodeServices';
 import { Command } from 'commander';
 import { FlywheelStatus } from '@panctl/contracts';
 import { abortFlywheelRun, clearFlywheelGate, getFlywheelRunDetail, getFlywheelRunDir, listFlywheelRuns, nextFlywheelRunId, readFlywheelLaunchMetadata, resolveLiveFlywheelRunId, writeFlywheelLaunchMetadata, writeLatestFlywheelStatus } from '../../dashboard/server/services/flywheel-run-state.js';
@@ -550,7 +551,9 @@ export async function flywheelReportCommand(options: ReportOptions = {}): Promis
     }
 
     const runNumber = runNumberFromRunId(status.runId);
-    const mergeQueue = await computeMergeQueue(status.activePipeline, cwd).catch(() => []);
+    const mergeQueue = await Effect.runPromise(
+      computeMergeQueue(status.activePipeline, cwd).pipe(Effect.provide(nodeServicesLayer)),
+    );
     const runReport = formatFlywheelStateReport(status, mergeQueue);
     await writeFile(join(getFlywheelRunDir(status.runId), 'report.md'), runReport, 'utf8');
 

--- a/src/dashboard/server/routes/flywheel.ts
+++ b/src/dashboard/server/routes/flywheel.ts
@@ -1,6 +1,7 @@
 import { lstat, mkdir, readFile, realpath, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
 import { Effect, Layer, Option, Schema } from 'effect';
+import { layer as nodeServicesLayer } from '@effect/platform-node/NodeServices';
 import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
 import { jsonResponse } from '../http-helpers.js';
 import { FlywheelRunId, FlywheelStatus } from '@panctl/contracts';
@@ -465,7 +466,11 @@ const getFlywheelMergeQueueRoute = HttpRouter.add(
       const status = await readCurrentFlywheelStatusForDashboard();
       if (!status) return jsonResponse([]);
       const { computeMergeQueue } = await import('../../../lib/flywheel-merge-order.js');
-      const queue = await computeMergeQueue(status.activePipeline, process.cwd());
+      const queue = await Effect.runPromise(
+        computeMergeQueue(status.activePipeline, process.cwd()).pipe(
+          Effect.provide(nodeServicesLayer),
+        ),
+      );
       return jsonResponse(queue);
     });
   })),

--- a/src/lib/flywheel-merge-order.ts
+++ b/src/lib/flywheel-merge-order.ts
@@ -1,8 +1,6 @@
-import { exec } from 'node:child_process';
-import { promisify } from 'node:util';
+import { Effect } from 'effect';
+import { ChildProcess, ChildProcessSpawner } from 'effect/unstable/process';
 import type { FlywheelPipelineItem } from '@panctl/contracts';
-
-const execAsync = promisify(exec);
 
 export interface MergeQueueItem {
   issueId: string;
@@ -17,70 +15,75 @@ function issueNumber(issueId: string): number {
   return match ? parseInt(match[0], 10) : 0;
 }
 
-async function branchExists(branch: string, cwd: string): Promise<boolean> {
-  try {
-    await execAsync(`git rev-parse --verify ${branch}`, { cwd, encoding: 'utf8' });
-    return true;
-  } catch {
-    return false;
-  }
-}
+const branchExists = (branch: string, cwd: string) =>
+  Effect.gen(function*() {
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const cmd = ChildProcess.make('git', ['rev-parse', '--verify', branch], { cwd });
+    return yield* spawner.exitCode(cmd).pipe(
+      Effect.map((code) => code === 0),
+      Effect.orElseSucceed(() => false),
+    );
+  });
 
-async function changedFilesVsMain(branch: string, cwd: string): Promise<Set<string>> {
-  try {
-    const { stdout } = await execAsync(`git diff --name-only main...${branch}`, { cwd, encoding: 'utf8' });
-    return new Set(stdout.trim().split('\n').filter(Boolean));
-  } catch {
-    return new Set();
-  }
-}
+const changedFilesVsMain = (branch: string, cwd: string) =>
+  Effect.gen(function*() {
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const cmd = ChildProcess.make('git', ['diff', '--name-only', `main...${branch}`], { cwd });
+    return yield* spawner.string(cmd).pipe(
+      Effect.map((stdout) => new Set(stdout.trim().split('\n').filter(Boolean))),
+      Effect.orElseSucceed(() => new Set<string>()),
+    );
+  });
 
-export async function computeMergeQueue(
+export const computeMergeQueue = (
   items: ReadonlyArray<FlywheelPipelineItem>,
   projectRoot: string,
-): Promise<MergeQueueItem[]> {
-  const candidates = items.filter((item) => item.verb === 'shipping');
-  if (candidates.length === 0) return [];
+) =>
+  Effect.gen(function*() {
+    const candidates = items.filter((item) => item.verb === 'shipping');
+    if (candidates.length === 0) return [] as MergeQueueItem[];
 
-  const branches = candidates.map((item) => `feature/${item.issueId.toLowerCase()}`);
+    const branches = candidates.map((item) => `feature/${item.issueId.toLowerCase()}`);
 
-  const existsFlags = await Promise.all(
-    branches.map((branch) => branchExists(branch, projectRoot)),
-  );
+    const existsFlags = yield* Effect.all(
+      branches.map((branch) => branchExists(branch, projectRoot)),
+      { concurrency: 'unbounded' },
+    );
 
-  const existing = candidates
-    .map((item, i) => ({ item, branch: branches[i]!, exists: existsFlags[i]! }))
-    .filter(({ exists }) => exists);
+    const existing = candidates
+      .map((item, i) => ({ item, branch: branches[i]!, exists: existsFlags[i]! }))
+      .filter(({ exists }) => exists);
 
-  if (existing.length === 0) return [];
+    if (existing.length === 0) return [] as MergeQueueItem[];
 
-  const fileSets = await Promise.all(
-    existing.map(({ branch }) => changedFilesVsMain(branch, projectRoot)),
-  );
+    const fileSets = yield* Effect.all(
+      existing.map(({ branch }) => changedFilesVsMain(branch, projectRoot)),
+      { concurrency: 'unbounded' },
+    );
 
-  const conflictsMap = new Map<string, Set<string>>();
-  for (let i = 0; i < existing.length; i++) {
-    for (let j = i + 1; j < existing.length; j++) {
-      const idA = existing[i]!.item.issueId;
-      const idB = existing[j]!.item.issueId;
-      if ([...fileSets[i]!].some((f) => fileSets[j]!.has(f))) {
-        if (!conflictsMap.has(idA)) conflictsMap.set(idA, new Set());
-        if (!conflictsMap.has(idB)) conflictsMap.set(idB, new Set());
-        conflictsMap.get(idA)!.add(idB);
-        conflictsMap.get(idB)!.add(idA);
+    const conflictsMap = new Map<string, Set<string>>();
+    for (let i = 0; i < existing.length; i++) {
+      for (let j = i + 1; j < existing.length; j++) {
+        const idA = existing[i]!.item.issueId;
+        const idB = existing[j]!.item.issueId;
+        if ([...fileSets[i]!].some((f) => fileSets[j]!.has(f))) {
+          if (!conflictsMap.has(idA)) conflictsMap.set(idA, new Set());
+          if (!conflictsMap.has(idB)) conflictsMap.set(idB, new Set());
+          conflictsMap.get(idA)!.add(idB);
+          conflictsMap.get(idB)!.add(idA);
+        }
       }
     }
-  }
 
-  const sorted = [...existing].sort(
-    (a, b) => issueNumber(a.item.issueId) - issueNumber(b.item.issueId),
-  );
+    const sorted = [...existing].sort(
+      (a, b) => issueNumber(a.item.issueId) - issueNumber(b.item.issueId),
+    );
 
-  return sorted.map(({ item }, idx) => ({
-    issueId: item.issueId,
-    title: item.title,
-    pr: item.pr,
-    mergeOrder: idx + 1,
-    conflictsWith: [...(conflictsMap.get(item.issueId) ?? [])],
-  }));
-}
+    return sorted.map(({ item }, idx) => ({
+      issueId: item.issueId,
+      title: item.title,
+      pr: item.pr,
+      mergeOrder: idx + 1,
+      conflictsWith: [...(conflictsMap.get(item.issueId) ?? [])],
+    }));
+  });


### PR DESCRIPTION
## Summary

- Migrates `src/lib/flywheel-merge-order.ts` from Promise/execAsync to Effect, fulfilling task `effect-migrate-flywheel-merge-order` in the PAN-1249 swarm (wave 0, slot 11).
- `computeMergeQueue` now returns `Effect<MergeQueueItem[], never, ChildProcessSpawner>` — no Promise returns remain.
- Git subprocess calls use `@effect/platform-node` `ChildProcessSpawner` service methods (`spawner.exitCode()`, `spawner.string()`) via `ChildProcess.make()`.
- `try/catch` blocks replaced with Effect's `orElseSucceed` — all expected failure modes (branch doesn't exist, git not found) yield typed defaults with `never` error channel.
- `Promise.all` parallelism preserved via `Effect.all` with `{ concurrency: 'unbounded' }`.
- Adapter boundaries (`src/cli/commands/flywheel.ts`, `src/dashboard/server/routes/flywheel.ts`) use `Effect.runPromise` + `nodeServicesLayer` to satisfy the `ChildProcessSpawner` context requirement.
- Import uses `@effect/platform-node/NodeServices` subpath (not the barrel) to prevent `NodeRedis`/`ioredis` from being pulled into the CLI bundle.
- No logic changes — observable behavior is identical.

## Test plan

- [x] `npm run typecheck` passes (0 errors)
- [x] `npm run lint` passes (including `lint:skills` CLI startup test)
- [x] `npm test` passes (4268 tests, 50 skipped)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)