### PR TITLE
feat(pan-1249): effect-migrate src/lib/planning/triage-agent.ts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
       "devDependencies": {
         "@commitlint/cli": "^20.5.0",
         "@commitlint/config-conventional": "^20.5.0",
+        "@effect/vitest": "catalog:",
         "@panctl/contracts": "workspace:*",
         "@types/better-sqlite3": "^7.6.13",
         "@types/inquirer": "^9.0.9",
@@ -324,6 +325,8 @@
     "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.45", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.45", "mime": "^4.1.0", "undici": "^7.24.0" }, "peerDependencies": { "effect": "^4.0.0-beta.45", "ioredis": "^5.7.0" } }, "sha512-P07NMG4eoy62iLX9szak0hkr7hrwgq5+XMkm7URVug/3zqfZVxEG2kxn9JzVK1lF5WbaVrEKwjt3IkEJxzSPtg=="],
 
     "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.45", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.19.0" }, "peerDependencies": { "effect": "^4.0.0-beta.45" } }, "sha512-0T4RG18o+aCVUSlmPxA7uAjHJkyE3MS/uRrR5kCNSZQNG3X71wdIbu82wE/MnV6+6YSSPDx/6TVdZWYkJF0JWw=="],
+
+    "@effect/vitest": ["@effect/vitest@4.0.0-beta.45", "", { "peerDependencies": { "effect": "^4.0.0-beta.45", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-38JA5Z6c2FoEhpVKbl7rjTrMU8Al5T30Kwtb6N3B9kOkyr2SsmvNsP9T65bh03IBh3ak9U//acrkmjS3hLQwKA=="],
 
     "@electron/asar": ["@electron/asar@3.4.1", "", { "dependencies": { "commander": "^5.0.0", "glob": "^7.1.6", "minimatch": "^3.0.4" }, "bin": { "asar": "bin/asar.js" } }, "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA=="],
 

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "@types/node": "^20.10.0",
     "@typescript-eslint/parser": "6.21.0",
     "@vitest/coverage-v8": "^4.1.6",
+    "@effect/vitest": "catalog:",
     "effect": "catalog:",
     "eslint": "^8.55.0",
     "husky": "^9.1.7",

--- a/src/lib/planning/triage-agent.ts
+++ b/src/lib/planning/triage-agent.ts
@@ -9,6 +9,8 @@
  * - Dependencies
  */
 
+import { Effect } from 'effect';
+
 export interface TriageResult {
   issueId: string;
   priority: 'P0' | 'P1' | 'P2' | 'P3' | 'P4';
@@ -34,154 +36,156 @@ export interface TriageOptions {
  *
  * This is a rule-based triage system that runs without spawning an agent.
  */
-export function analyzeIssue(options: TriageOptions): TriageResult {
-  const { issueId, title, description = '', labels = [], currentPriority } = options;
+export function analyzeIssue(options: TriageOptions): Effect.Effect<TriageResult> {
+  return Effect.sync(() => {
+    const { issueId, title, description = '', labels = [], currentPriority } = options;
 
-  const combined = `${title} ${description}`.toLowerCase();
+    const combined = `${title} ${description}`.toLowerCase();
 
-  // Determine priority
-  let priority: TriageResult['priority'] = 'P3'; // Default
+    // Determine priority
+    let priority: TriageResult['priority'] = 'P3'; // Default
 
-  // P0: Production outage, security vulnerability
-  if (
-    combined.includes('production') && combined.includes('down') ||
-    combined.includes('security vulnerability') ||
-    combined.includes('data loss')
-  ) {
-    priority = 'P0';
-  }
-  // P1: Critical bug affecting users
-  else if (
-    combined.includes('critical') ||
-    combined.includes('blocker') ||
-    combined.includes('cannot') && (combined.includes('login') || combined.includes('deploy'))
-  ) {
-    priority = 'P1';
-  }
-  // P2: Important feature or significant bug
-  else if (
-    combined.includes('important') ||
-    combined.includes('high priority') ||
-    labels.some(l => l.includes('high'))
-  ) {
-    priority = 'P2';
-  }
-  // P4: Nice to have, low impact
-  else if (
-    combined.includes('nice to have') ||
-    combined.includes('enhancement') ||
-    combined.includes('polish')
-  ) {
-    priority = 'P4';
-  }
-  // Use Linear priority if provided
-  else if (currentPriority !== undefined) {
-    priority = `P${Math.min(currentPriority, 4)}` as TriageResult['priority'];
-  }
+    // P0: Production outage, security vulnerability
+    if (
+      combined.includes('production') && combined.includes('down') ||
+      combined.includes('security vulnerability') ||
+      combined.includes('data loss')
+    ) {
+      priority = 'P0';
+    }
+    // P1: Critical bug affecting users
+    else if (
+      combined.includes('critical') ||
+      combined.includes('blocker') ||
+      combined.includes('cannot') && (combined.includes('login') || combined.includes('deploy'))
+    ) {
+      priority = 'P1';
+    }
+    // P2: Important feature or significant bug
+    else if (
+      combined.includes('important') ||
+      combined.includes('high priority') ||
+      labels.some(l => l.includes('high'))
+    ) {
+      priority = 'P2';
+    }
+    // P4: Nice to have, low impact
+    else if (
+      combined.includes('nice to have') ||
+      combined.includes('enhancement') ||
+      combined.includes('polish')
+    ) {
+      priority = 'P4';
+    }
+    // Use Linear priority if provided
+    else if (currentPriority !== undefined) {
+      priority = `P${Math.min(currentPriority, 4)}` as TriageResult['priority'];
+    }
 
-  // Determine complexity
-  let complexity: TriageResult['complexity'] = 'simple';
-  let estimatedHours = 2;
+    // Determine complexity
+    let complexity: TriageResult['complexity'] = 'simple';
+    let estimatedHours = 2;
 
-  // Trivial: typo, docs, config change
-  if (
-    combined.includes('typo') ||
-    combined.includes('documentation only') ||
-    combined.includes('update readme')
-  ) {
-    complexity = 'trivial';
-    estimatedHours = 0.5;
-  }
-  // Expert: Architecture, distributed systems, security
-  else if (
-    combined.includes('architecture') ||
-    combined.includes('distributed') ||
-    combined.includes('security model') ||
-    combined.includes('authentication system')
-  ) {
-    complexity = 'expert';
-    estimatedHours = 16;
-  }
-  // Complex: Multi-system, refactor, migration
-  else if (
-    combined.includes('refactor') ||
-    combined.includes('migration') ||
-    combined.includes('redesign') ||
-    (combined.includes('frontend') && combined.includes('backend'))
-  ) {
-    complexity = 'complex';
-    estimatedHours = 8;
-  }
-  // Medium: New feature, API endpoint, component
-  else if (
-    combined.includes('new feature') ||
-    combined.includes('implement') ||
-    combined.includes('endpoint') ||
-    combined.includes('component')
-  ) {
-    complexity = 'medium';
-    estimatedHours = 4;
-  }
+    // Trivial: typo, docs, config change
+    if (
+      combined.includes('typo') ||
+      combined.includes('documentation only') ||
+      combined.includes('update readme')
+    ) {
+      complexity = 'trivial';
+      estimatedHours = 0.5;
+    }
+    // Expert: Architecture, distributed systems, security
+    else if (
+      combined.includes('architecture') ||
+      combined.includes('distributed') ||
+      combined.includes('security model') ||
+      combined.includes('authentication system')
+    ) {
+      complexity = 'expert';
+      estimatedHours = 16;
+    }
+    // Complex: Multi-system, refactor, migration
+    else if (
+      combined.includes('refactor') ||
+      combined.includes('migration') ||
+      combined.includes('redesign') ||
+      (combined.includes('frontend') && combined.includes('backend'))
+    ) {
+      complexity = 'complex';
+      estimatedHours = 8;
+    }
+    // Medium: New feature, API endpoint, component
+    else if (
+      combined.includes('new feature') ||
+      combined.includes('implement') ||
+      combined.includes('endpoint') ||
+      combined.includes('component')
+    ) {
+      complexity = 'medium';
+      estimatedHours = 4;
+    }
 
-  // Determine required skills
-  const requiredSkills: string[] = [];
-  if (combined.includes('frontend') || combined.includes('ui') || combined.includes('react')) {
-    requiredSkills.push('frontend');
-  }
-  if (combined.includes('backend') || combined.includes('api') || combined.includes('server')) {
-    requiredSkills.push('backend');
-  }
-  if (combined.includes('database') || combined.includes('sql') || combined.includes('schema')) {
-    requiredSkills.push('database');
-  }
-  if (combined.includes('devops') || combined.includes('deploy') || combined.includes('docker')) {
-    requiredSkills.push('devops');
-  }
-  if (combined.includes('test') || combined.includes('e2e') || combined.includes('playwright')) {
-    requiredSkills.push('testing');
-  }
+    // Determine required skills
+    const requiredSkills: string[] = [];
+    if (combined.includes('frontend') || combined.includes('ui') || combined.includes('react')) {
+      requiredSkills.push('frontend');
+    }
+    if (combined.includes('backend') || combined.includes('api') || combined.includes('server')) {
+      requiredSkills.push('backend');
+    }
+    if (combined.includes('database') || combined.includes('sql') || combined.includes('schema')) {
+      requiredSkills.push('database');
+    }
+    if (combined.includes('devops') || combined.includes('deploy') || combined.includes('docker')) {
+      requiredSkills.push('devops');
+    }
+    if (combined.includes('test') || combined.includes('e2e') || combined.includes('playwright')) {
+      requiredSkills.push('testing');
+    }
 
-  // Check for dependencies
-  const dependencies: string[] = [];
-  // Pattern: "depends on #XXX" or "blocked by #XXX"
-  const depMatches = combined.match(/(?:depends on|blocked by|requires)\s+#?([a-z]+-\d+)/gi);
-  if (depMatches) {
-    dependencies.push(...depMatches.map(m => m.split(/\s+/).pop() || '').filter(Boolean));
-  }
+    // Check for dependencies
+    const dependencies: string[] = [];
+    // Pattern: "depends on #XXX" or "blocked by #XXX"
+    const depMatches = combined.match(/(?:depends on|blocked by|requires)\s+#?([a-z]+-\d+)/gi);
+    if (depMatches) {
+      dependencies.push(...depMatches.map(m => m.split(/\s+/).pop() || '').filter(Boolean));
+    }
 
-  // Determine if PRD needed
-  const needsPRD = complexity === 'complex' || complexity === 'expert' ||
-    combined.includes('unclear') ||
-    combined.includes('needs discussion') ||
-    combined.includes('tbd');
+    // Determine if PRD needed
+    const needsPRD = complexity === 'complex' || complexity === 'expert' ||
+      combined.includes('unclear') ||
+      combined.includes('needs discussion') ||
+      combined.includes('tbd');
 
-  // Determine if planning needed
-  const needsPlanning = complexity === 'complex' || complexity === 'expert' ||
-    requiredSkills.length > 2;
+    // Determine if planning needed
+    const needsPlanning = complexity === 'complex' || complexity === 'expert' ||
+      requiredSkills.length > 2;
 
-  // Generate recommendation
-  let recommendation = '';
-  if (priority === 'P0' || priority === 'P1') {
-    recommendation = 'High priority - start immediately with available resources';
-  } else if (needsPRD) {
-    recommendation = `Run 'pan prd ${issueId}' to clarify requirements before implementation`;
-  } else if (needsPlanning) {
-    recommendation = `Click 'Plan' in the dashboard for ${issueId} to create an execution plan`;
-  } else {
-    recommendation = `Ready to implement - run 'pan start ${issueId}'`;
-  }
+    // Generate recommendation
+    let recommendation = '';
+    if (priority === 'P0' || priority === 'P1') {
+      recommendation = 'High priority - start immediately with available resources';
+    } else if (needsPRD) {
+      recommendation = `Run 'pan prd ${issueId}' to clarify requirements before implementation`;
+    } else if (needsPlanning) {
+      recommendation = `Click 'Plan' in the dashboard for ${issueId} to create an execution plan`;
+    } else {
+      recommendation = `Ready to implement - run 'pan start ${issueId}'`;
+    }
 
-  return {
-    issueId,
-    priority,
-    complexity,
-    estimatedHours,
-    requiredSkills,
-    dependencies,
-    needsPRD,
-    needsPlanning,
-    recommendation,
-  };
+    return {
+      issueId,
+      priority,
+      complexity,
+      estimatedHours,
+      requiredSkills,
+      dependencies,
+      needsPRD,
+      needsPlanning,
+      recommendation,
+    };
+  });
 }
 
 /**
@@ -189,23 +193,25 @@ export function analyzeIssue(options: TriageOptions): TriageResult {
  *
  * Useful for processing a backlog of issues
  */
-export function triageMultiple(issues: TriageOptions[]): TriageResult[] {
-  return issues.map(analyzeIssue);
+export function triageMultiple(issues: TriageOptions[]): Effect.Effect<TriageResult[]> {
+  return Effect.all(issues.map(analyzeIssue));
 }
 
 /**
  * Sort issues by triage results (priority + complexity)
  */
-export function sortByPriority(results: TriageResult[]): TriageResult[] {
-  const priorityOrder = { P0: 0, P1: 1, P2: 2, P3: 3, P4: 4 };
-  const complexityOrder = { trivial: 0, simple: 1, medium: 2, complex: 3, expert: 4 };
+export function sortByPriority(results: TriageResult[]): Effect.Effect<TriageResult[]> {
+  return Effect.sync(() => {
+    const priorityOrder = { P0: 0, P1: 1, P2: 2, P3: 3, P4: 4 };
+    const complexityOrder = { trivial: 0, simple: 1, medium: 2, complex: 3, expert: 4 };
 
-  return results.sort((a, b) => {
-    // First sort by priority
-    const priorityDiff = priorityOrder[a.priority] - priorityOrder[b.priority];
-    if (priorityDiff !== 0) return priorityDiff;
+    return results.sort((a, b) => {
+      // First sort by priority
+      const priorityDiff = priorityOrder[a.priority] - priorityOrder[b.priority];
+      if (priorityDiff !== 0) return priorityDiff;
 
-    // Then by complexity (simpler first for same priority)
-    return complexityOrder[a.complexity] - complexityOrder[b.complexity];
+      // Then by complexity (simpler first for same priority)
+      return complexityOrder[a.complexity] - complexityOrder[b.complexity];
+    });
   });
 }

--- a/tests/lib/planning/triage-agent.test.ts
+++ b/tests/lib/planning/triage-agent.test.ts
@@ -1,358 +1,406 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect } from 'vitest';
+import { it } from '@effect/vitest';
+import { Effect } from 'effect';
 import { analyzeIssue, triageMultiple, sortByPriority } from '../../../src/lib/planning/triage-agent.js';
 import type { TriageOptions, TriageResult } from '../../../src/lib/planning/triage-agent.js';
 
 describe('triage-agent', () => {
   describe('analyzeIssue', () => {
-    it('should classify P0 for production outages', () => {
-      const options: TriageOptions = {
-        issueId: 'TEST-1',
-        title: 'Production is down',
-        description: 'Users cannot access the site',
-      };
+    it.effect('should classify P0 for production outages', () =>
+      Effect.gen(function* () {
+        const options: TriageOptions = {
+          issueId: 'TEST-1',
+          title: 'Production is down',
+          description: 'Users cannot access the site',
+        };
 
-      const result = analyzeIssue(options);
+        const result = yield* analyzeIssue(options);
 
-      expect(result.priority).toBe('P0');
-      expect(result.issueId).toBe('TEST-1');
-    });
+        expect(result.priority).toBe('P0');
+        expect(result.issueId).toBe('TEST-1');
+      })
+    );
 
-    it('should classify P0 for security vulnerabilities', () => {
-      const options: TriageOptions = {
-        issueId: 'TEST-2',
-        title: 'Security vulnerability in auth system',
-      };
+    it.effect('should classify P0 for security vulnerabilities', () =>
+      Effect.gen(function* () {
+        const options: TriageOptions = {
+          issueId: 'TEST-2',
+          title: 'Security vulnerability in auth system',
+        };
 
-      const result = analyzeIssue(options);
+        const result = yield* analyzeIssue(options);
 
-      expect(result.priority).toBe('P0');
-    });
+        expect(result.priority).toBe('P0');
+      })
+    );
 
-    it('should classify P1 for critical bugs', () => {
-      const options: TriageOptions = {
-        issueId: 'TEST-3',
-        title: 'Critical: Users cannot login',
-        description: 'Login form is broken',
-      };
+    it.effect('should classify P1 for critical bugs', () =>
+      Effect.gen(function* () {
+        const options: TriageOptions = {
+          issueId: 'TEST-3',
+          title: 'Critical: Users cannot login',
+          description: 'Login form is broken',
+        };
 
-      const result = analyzeIssue(options);
+        const result = yield* analyzeIssue(options);
 
-      expect(result.priority).toBe('P1');
-    });
+        expect(result.priority).toBe('P1');
+      })
+    );
 
-    it('should classify P2 for important features', () => {
-      const options: TriageOptions = {
-        issueId: 'TEST-4',
-        title: 'Important: Add user analytics',
-        labels: ['high'],
-      };
+    it.effect('should classify P2 for important features', () =>
+      Effect.gen(function* () {
+        const options: TriageOptions = {
+          issueId: 'TEST-4',
+          title: 'Important: Add user analytics',
+          labels: ['high'],
+        };
 
-      const result = analyzeIssue(options);
+        const result = yield* analyzeIssue(options);
 
-      expect(result.priority).toBe('P2');
-    });
+        expect(result.priority).toBe('P2');
+      })
+    );
 
-    it('should classify P4 for nice-to-have enhancements', () => {
-      const options: TriageOptions = {
-        issueId: 'TEST-5',
-        title: 'Nice to have: Polish the UI animations',
-      };
+    it.effect('should classify P4 for nice-to-have enhancements', () =>
+      Effect.gen(function* () {
+        const options: TriageOptions = {
+          issueId: 'TEST-5',
+          title: 'Nice to have: Polish the UI animations',
+        };
 
-      const result = analyzeIssue(options);
+        const result = yield* analyzeIssue(options);
 
-      expect(result.priority).toBe('P4');
-    });
+        expect(result.priority).toBe('P4');
+      })
+    );
 
-    it('should use Linear priority when provided', () => {
-      const options: TriageOptions = {
-        issueId: 'TEST-6',
-        title: 'Some task',
-        currentPriority: 2,
-      };
+    it.effect('should use Linear priority when provided', () =>
+      Effect.gen(function* () {
+        const options: TriageOptions = {
+          issueId: 'TEST-6',
+          title: 'Some task',
+          currentPriority: 2,
+        };
 
-      const result = analyzeIssue(options);
+        const result = yield* analyzeIssue(options);
 
-      expect(result.priority).toBe('P2');
-    });
+        expect(result.priority).toBe('P2');
+      })
+    );
 
-    it('should classify trivial complexity for typos', () => {
-      const options: TriageOptions = {
-        issueId: 'TEST-7',
-        title: 'Fix typo in README',
-      };
+    it.effect('should classify trivial complexity for typos', () =>
+      Effect.gen(function* () {
+        const options: TriageOptions = {
+          issueId: 'TEST-7',
+          title: 'Fix typo in README',
+        };
 
-      const result = analyzeIssue(options);
+        const result = yield* analyzeIssue(options);
 
-      expect(result.complexity).toBe('trivial');
-      expect(result.estimatedHours).toBe(0.5);
-    });
+        expect(result.complexity).toBe('trivial');
+        expect(result.estimatedHours).toBe(0.5);
+      })
+    );
 
-    it('should classify expert complexity for architecture work', () => {
-      const options: TriageOptions = {
-        issueId: 'TEST-8',
-        title: 'Design new authentication system',
-        description: 'Need to redesign the architecture',
-      };
+    it.effect('should classify expert complexity for architecture work', () =>
+      Effect.gen(function* () {
+        const options: TriageOptions = {
+          issueId: 'TEST-8',
+          title: 'Design new authentication system',
+          description: 'Need to redesign the architecture',
+        };
 
-      const result = analyzeIssue(options);
+        const result = yield* analyzeIssue(options);
 
-      expect(result.complexity).toBe('expert');
-      expect(result.estimatedHours).toBe(16);
-    });
+        expect(result.complexity).toBe('expert');
+        expect(result.estimatedHours).toBe(16);
+      })
+    );
 
-    it('should classify complex complexity for refactors', () => {
-      const options: TriageOptions = {
-        issueId: 'TEST-9',
-        title: 'Refactor the entire API layer',
-      };
+    it.effect('should classify complex complexity for refactors', () =>
+      Effect.gen(function* () {
+        const options: TriageOptions = {
+          issueId: 'TEST-9',
+          title: 'Refactor the entire API layer',
+        };
 
-      const result = analyzeIssue(options);
+        const result = yield* analyzeIssue(options);
 
-      expect(result.complexity).toBe('complex');
-      expect(result.estimatedHours).toBe(8);
-    });
+        expect(result.complexity).toBe('complex');
+        expect(result.estimatedHours).toBe(8);
+      })
+    );
 
-    it('should classify medium complexity for new features', () => {
-      const options: TriageOptions = {
-        issueId: 'TEST-10',
-        title: 'Implement new API endpoint for users',
-      };
+    it.effect('should classify medium complexity for new features', () =>
+      Effect.gen(function* () {
+        const options: TriageOptions = {
+          issueId: 'TEST-10',
+          title: 'Implement new API endpoint for users',
+        };
 
-      const result = analyzeIssue(options);
+        const result = yield* analyzeIssue(options);
 
-      expect(result.complexity).toBe('medium');
-      expect(result.estimatedHours).toBe(4);
-    });
+        expect(result.complexity).toBe('medium');
+        expect(result.estimatedHours).toBe(4);
+      })
+    );
 
-    it('should detect frontend skill from title', () => {
-      const options: TriageOptions = {
-        issueId: 'TEST-11',
-        title: 'Build React component for user profile',
-      };
+    it.effect('should detect frontend skill from title', () =>
+      Effect.gen(function* () {
+        const options: TriageOptions = {
+          issueId: 'TEST-11',
+          title: 'Build React component for user profile',
+        };
 
-      const result = analyzeIssue(options);
+        const result = yield* analyzeIssue(options);
 
-      expect(result.requiredSkills).toContain('frontend');
-    });
+        expect(result.requiredSkills).toContain('frontend');
+      })
+    );
 
-    it('should detect backend skill from description', () => {
-      const options: TriageOptions = {
-        issueId: 'TEST-12',
-        title: 'User feature',
-        description: 'Need to add API endpoint on the backend',
-      };
+    it.effect('should detect backend skill from description', () =>
+      Effect.gen(function* () {
+        const options: TriageOptions = {
+          issueId: 'TEST-12',
+          title: 'User feature',
+          description: 'Need to add API endpoint on the backend',
+        };
 
-      const result = analyzeIssue(options);
+        const result = yield* analyzeIssue(options);
 
-      expect(result.requiredSkills).toContain('backend');
-    });
+        expect(result.requiredSkills).toContain('backend');
+      })
+    );
 
-    it('should detect multiple skills', () => {
-      const options: TriageOptions = {
-        issueId: 'TEST-13',
-        title: 'Full-stack feature with database and tests',
-        description: 'Build UI, API, update SQL schema, and add E2E tests',
-      };
+    it.effect('should detect multiple skills', () =>
+      Effect.gen(function* () {
+        const options: TriageOptions = {
+          issueId: 'TEST-13',
+          title: 'Full-stack feature with database and tests',
+          description: 'Build UI, API, update SQL schema, and add E2E tests',
+        };
 
-      const result = analyzeIssue(options);
+        const result = yield* analyzeIssue(options);
 
-      expect(result.requiredSkills).toContain('frontend');
-      expect(result.requiredSkills).toContain('backend');
-      expect(result.requiredSkills).toContain('database');
-      expect(result.requiredSkills).toContain('testing');
-    });
+        expect(result.requiredSkills).toContain('frontend');
+        expect(result.requiredSkills).toContain('backend');
+        expect(result.requiredSkills).toContain('database');
+        expect(result.requiredSkills).toContain('testing');
+      })
+    );
 
-    it('should set needsPRD for complex work', () => {
-      const options: TriageOptions = {
-        issueId: 'TEST-15',
-        title: 'Complex refactor of entire system',
-      };
+    it.effect('should set needsPRD for complex work', () =>
+      Effect.gen(function* () {
+        const options: TriageOptions = {
+          issueId: 'TEST-15',
+          title: 'Complex refactor of entire system',
+        };
 
-      const result = analyzeIssue(options);
+        const result = yield* analyzeIssue(options);
 
-      expect(result.needsPRD).toBe(true);
-    });
+        expect(result.needsPRD).toBe(true);
+      })
+    );
 
-    it('should set needsPlanning for multi-skill work', () => {
-      const options: TriageOptions = {
-        issueId: 'TEST-16',
-        title: 'Full-stack feature',
-        description: 'Frontend, backend, database, and devops changes',
-      };
+    it.effect('should set needsPlanning for multi-skill work', () =>
+      Effect.gen(function* () {
+        const options: TriageOptions = {
+          issueId: 'TEST-16',
+          title: 'Full-stack feature',
+          description: 'Frontend, backend, database, and devops changes',
+        };
 
-      const result = analyzeIssue(options);
+        const result = yield* analyzeIssue(options);
 
-      expect(result.needsPlanning).toBe(true);
-      expect(result.requiredSkills.length).toBeGreaterThan(2);
-    });
+        expect(result.needsPlanning).toBe(true);
+        expect(result.requiredSkills.length).toBeGreaterThan(2);
+      })
+    );
 
-    it('should provide appropriate recommendation for P0', () => {
-      const options: TriageOptions = {
-        issueId: 'TEST-17',
-        title: 'Production down - data loss',
-      };
+    it.effect('should provide appropriate recommendation for P0', () =>
+      Effect.gen(function* () {
+        const options: TriageOptions = {
+          issueId: 'TEST-17',
+          title: 'Production down - data loss',
+        };
 
-      const result = analyzeIssue(options);
+        const result = yield* analyzeIssue(options);
 
-      expect(result.recommendation).toContain('immediately');
-    });
+        expect(result.recommendation).toContain('immediately');
+      })
+    );
 
-    it('should recommend PRD for unclear requirements', () => {
-      const options: TriageOptions = {
-        issueId: 'TEST-18',
-        title: 'Feature X needs discussion',
-        description: 'Requirements are unclear and TBD',
-      };
+    it.effect('should recommend PRD for unclear requirements', () =>
+      Effect.gen(function* () {
+        const options: TriageOptions = {
+          issueId: 'TEST-18',
+          title: 'Feature X needs discussion',
+          description: 'Requirements are unclear and TBD',
+        };
 
-      const result = analyzeIssue(options);
+        const result = yield* analyzeIssue(options);
 
-      expect(result.needsPRD).toBe(true);
-      expect(result.recommendation).toContain('pan prd');
-    });
+        expect(result.needsPRD).toBe(true);
+        expect(result.recommendation).toContain('pan prd');
+      })
+    );
   });
 
   describe('triageMultiple', () => {
-    it('should process multiple issues', () => {
-      const issues: TriageOptions[] = [
-        { issueId: 'TEST-1', title: 'Production down' },
-        { issueId: 'TEST-2', title: 'Fix typo in docs' },
-        { issueId: 'TEST-3', title: 'Add new feature' },
-      ];
+    it.effect('should process multiple issues', () =>
+      Effect.gen(function* () {
+        const issues: TriageOptions[] = [
+          { issueId: 'TEST-1', title: 'Production down' },
+          { issueId: 'TEST-2', title: 'Fix typo in docs' },
+          { issueId: 'TEST-3', title: 'Add new feature' },
+        ];
 
-      const results = triageMultiple(issues);
+        const results = yield* triageMultiple(issues);
 
-      expect(results).toHaveLength(3);
-      expect(results[0].issueId).toBe('TEST-1');
-      expect(results[1].issueId).toBe('TEST-2');
-      expect(results[2].issueId).toBe('TEST-3');
-    });
+        expect(results).toHaveLength(3);
+        expect(results[0].issueId).toBe('TEST-1');
+        expect(results[1].issueId).toBe('TEST-2');
+        expect(results[2].issueId).toBe('TEST-3');
+      })
+    );
 
-    it('should apply analyzeIssue to each item', () => {
-      const issues: TriageOptions[] = [
-        { issueId: 'TEST-1', title: 'Production down' },
-        { issueId: 'TEST-2', title: 'Nice to have: Polish UI' },
-      ];
+    it.effect('should apply analyzeIssue to each item', () =>
+      Effect.gen(function* () {
+        const issues: TriageOptions[] = [
+          { issueId: 'TEST-1', title: 'Production down' },
+          { issueId: 'TEST-2', title: 'Nice to have: Polish UI' },
+        ];
 
-      const results = triageMultiple(issues);
+        const results = yield* triageMultiple(issues);
 
-      expect(results[0].priority).toBe('P0');
-      expect(results[1].priority).toBe('P4');
-    });
+        expect(results[0].priority).toBe('P0');
+        expect(results[1].priority).toBe('P4');
+      })
+    );
   });
 
   describe('sortByPriority', () => {
-    it('should sort by priority first', () => {
-      const results: TriageResult[] = [
-        {
-          issueId: 'TEST-3',
-          priority: 'P3',
-          complexity: 'simple',
-          estimatedHours: 2,
-          requiredSkills: [],
-          dependencies: [],
-          needsPRD: false,
-          needsPlanning: false,
-          recommendation: '',
-        },
-        {
-          issueId: 'TEST-0',
-          priority: 'P0',
-          complexity: 'expert',
-          estimatedHours: 16,
-          requiredSkills: [],
-          dependencies: [],
-          needsPRD: false,
-          needsPlanning: false,
-          recommendation: '',
-        },
-        {
-          issueId: 'TEST-1',
-          priority: 'P1',
-          complexity: 'medium',
-          estimatedHours: 4,
-          requiredSkills: [],
-          dependencies: [],
-          needsPRD: false,
-          needsPlanning: false,
-          recommendation: '',
-        },
-      ];
+    it.effect('should sort by priority first', () =>
+      Effect.gen(function* () {
+        const results: TriageResult[] = [
+          {
+            issueId: 'TEST-3',
+            priority: 'P3',
+            complexity: 'simple',
+            estimatedHours: 2,
+            requiredSkills: [],
+            dependencies: [],
+            needsPRD: false,
+            needsPlanning: false,
+            recommendation: '',
+          },
+          {
+            issueId: 'TEST-0',
+            priority: 'P0',
+            complexity: 'expert',
+            estimatedHours: 16,
+            requiredSkills: [],
+            dependencies: [],
+            needsPRD: false,
+            needsPlanning: false,
+            recommendation: '',
+          },
+          {
+            issueId: 'TEST-1',
+            priority: 'P1',
+            complexity: 'medium',
+            estimatedHours: 4,
+            requiredSkills: [],
+            dependencies: [],
+            needsPRD: false,
+            needsPlanning: false,
+            recommendation: '',
+          },
+        ];
 
-      const sorted = sortByPriority(results);
+        const sorted = yield* sortByPriority(results);
 
-      expect(sorted[0].issueId).toBe('TEST-0'); // P0
-      expect(sorted[1].issueId).toBe('TEST-1'); // P1
-      expect(sorted[2].issueId).toBe('TEST-3'); // P3
-    });
+        expect(sorted[0].issueId).toBe('TEST-0'); // P0
+        expect(sorted[1].issueId).toBe('TEST-1'); // P1
+        expect(sorted[2].issueId).toBe('TEST-3'); // P3
+      })
+    );
 
-    it('should sort by complexity when priority is same', () => {
-      const results: TriageResult[] = [
-        {
-          issueId: 'TEST-2',
-          priority: 'P2',
-          complexity: 'complex',
-          estimatedHours: 8,
-          requiredSkills: [],
-          dependencies: [],
-          needsPRD: false,
-          needsPlanning: false,
-          recommendation: '',
-        },
-        {
-          issueId: 'TEST-1',
-          priority: 'P2',
-          complexity: 'trivial',
-          estimatedHours: 0.5,
-          requiredSkills: [],
-          dependencies: [],
-          needsPRD: false,
-          needsPlanning: false,
-          recommendation: '',
-        },
-        {
-          issueId: 'TEST-3',
-          priority: 'P2',
-          complexity: 'medium',
-          estimatedHours: 4,
-          requiredSkills: [],
-          dependencies: [],
-          needsPRD: false,
-          needsPlanning: false,
-          recommendation: '',
-        },
-      ];
+    it.effect('should sort by complexity when priority is same', () =>
+      Effect.gen(function* () {
+        const results: TriageResult[] = [
+          {
+            issueId: 'TEST-2',
+            priority: 'P2',
+            complexity: 'complex',
+            estimatedHours: 8,
+            requiredSkills: [],
+            dependencies: [],
+            needsPRD: false,
+            needsPlanning: false,
+            recommendation: '',
+          },
+          {
+            issueId: 'TEST-1',
+            priority: 'P2',
+            complexity: 'trivial',
+            estimatedHours: 0.5,
+            requiredSkills: [],
+            dependencies: [],
+            needsPRD: false,
+            needsPlanning: false,
+            recommendation: '',
+          },
+          {
+            issueId: 'TEST-3',
+            priority: 'P2',
+            complexity: 'medium',
+            estimatedHours: 4,
+            requiredSkills: [],
+            dependencies: [],
+            needsPRD: false,
+            needsPlanning: false,
+            recommendation: '',
+          },
+        ];
 
-      const sorted = sortByPriority(results);
+        const sorted = yield* sortByPriority(results);
 
-      expect(sorted[0].issueId).toBe('TEST-1'); // trivial
-      expect(sorted[1].issueId).toBe('TEST-3'); // medium
-      expect(sorted[2].issueId).toBe('TEST-2'); // complex
-    });
+        expect(sorted[0].issueId).toBe('TEST-1'); // trivial
+        expect(sorted[1].issueId).toBe('TEST-3'); // medium
+        expect(sorted[2].issueId).toBe('TEST-2'); // complex
+      })
+    );
 
-    it('should handle empty array', () => {
-      const sorted = sortByPriority([]);
-      expect(sorted).toEqual([]);
-    });
+    it.effect('should handle empty array', () =>
+      Effect.gen(function* () {
+        const sorted = yield* sortByPriority([]);
+        expect(sorted).toEqual([]);
+      })
+    );
 
-    it('should handle single item', () => {
-      const results: TriageResult[] = [
-        {
-          issueId: 'TEST-1',
-          priority: 'P1',
-          complexity: 'simple',
-          estimatedHours: 2,
-          requiredSkills: [],
-          dependencies: [],
-          needsPRD: false,
-          needsPlanning: false,
-          recommendation: '',
-        },
-      ];
+    it.effect('should handle single item', () =>
+      Effect.gen(function* () {
+        const results: TriageResult[] = [
+          {
+            issueId: 'TEST-1',
+            priority: 'P1',
+            complexity: 'simple',
+            estimatedHours: 2,
+            requiredSkills: [],
+            dependencies: [],
+            needsPRD: false,
+            needsPlanning: false,
+            recommendation: '',
+          },
+        ];
 
-      const sorted = sortByPriority(results);
+        const sorted = yield* sortByPriority(results);
 
-      expect(sorted).toHaveLength(1);
-      expect(sorted[0].issueId).toBe('TEST-1');
-    });
+        expect(sorted).toHaveLength(1);
+        expect(sorted[0].issueId).toBe('TEST-1');
+      })
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Wraps `analyzeIssue`, `triageMultiple`, and `sortByPriority` in `Effect.sync` / `Effect.all` so all exports return `Effect.Effect<T, never>` — no Promise returns remain
- No logic changes; only the return type wrapper changes
- Migrates adjacent test file `tests/lib/planning/triage-agent.test.ts` to `@effect/vitest` (`it.effect` / `Effect.gen` / `yield*`)
- Adds `@effect/vitest: catalog:` to `devDependencies` (was in catalog but missing from this package's deps)

## Acceptance criteria checklist

- [x] All exported functions return `Effect.Effect<T, E>` with typed errors (no `Promise<T>` returns remain) — functions were synchronous; wrapped with `Effect.sync`/`Effect.all`, E = `never`
- [x] No `execAsync`/`execFileAsync` calls — none existed
- [x] No `try/catch` for expected failure modes — none existed
- [x] No `fs/promises` calls — none existed
- [x] Test file migrated to `@effect/vitest` using `it.effect()` — 23 tests pass
- [x] No new `Effect.runPromise()` introduced inside `src/lib/`
- [x] Observable behavior unchanged
- [x] `npm run typecheck` and `npm run lint` pass for touched files (pre-existing `agents.ts` duplicate-identifier error unrelated to this PR)

## Test plan

- [x] `npx vitest run tests/lib/planning/triage-agent.test.ts` → 23 tests pass
- [x] `npx eslint src/lib/planning/triage-agent.ts` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)