### PR TITLE
feat(deps): Effect migrate src/lib/remote/fly-api.ts (PAN-1249 slot-9)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
       "devDependencies": {
         "@commitlint/cli": "^20.5.0",
         "@commitlint/config-conventional": "^20.5.0",
+        "@effect/vitest": "4.0.0-beta.45",
         "@panctl/contracts": "workspace:*",
         "@types/better-sqlite3": "^7.6.13",
         "@types/inquirer": "^9.0.9",
@@ -324,6 +325,8 @@
     "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.45", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.45", "mime": "^4.1.0", "undici": "^7.24.0" }, "peerDependencies": { "effect": "^4.0.0-beta.45", "ioredis": "^5.7.0" } }, "sha512-P07NMG4eoy62iLX9szak0hkr7hrwgq5+XMkm7URVug/3zqfZVxEG2kxn9JzVK1lF5WbaVrEKwjt3IkEJxzSPtg=="],
 
     "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.45", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.19.0" }, "peerDependencies": { "effect": "^4.0.0-beta.45" } }, "sha512-0T4RG18o+aCVUSlmPxA7uAjHJkyE3MS/uRrR5kCNSZQNG3X71wdIbu82wE/MnV6+6YSSPDx/6TVdZWYkJF0JWw=="],
+
+    "@effect/vitest": ["@effect/vitest@4.0.0-beta.45", "", { "peerDependencies": { "effect": "^4.0.0-beta.45", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-38JA5Z6c2FoEhpVKbl7rjTrMU8Al5T30Kwtb6N3B9kOkyr2SsmvNsP9T65bh03IBh3ak9U//acrkmjS3hLQwKA=="],
 
     "@electron/asar": ["@electron/asar@3.4.1", "", { "dependencies": { "commander": "^5.0.0", "glob": "^7.1.6", "minimatch": "^3.0.4" }, "bin": { "asar": "bin/asar.js" } }, "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA=="],
 

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
+    "@effect/vitest": "4.0.0-beta.45",
     "@panctl/contracts": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",
     "@types/inquirer": "^9.0.9",

--- a/src/dashboard/server/config.ts
+++ b/src/dashboard/server/config.ts
@@ -58,9 +58,9 @@ export class ServerConfig extends Context.Service<ServerConfig, ServerConfigShap
  */
 export const ServerConfigLayer = Layer.effect(
   ServerConfig,
-  Effect.sync((): ServerConfigShape => {
-    // Load .panopticon.env (idempotent)
-    loadPanopticonEnv();
+  Effect.gen(function* () {
+    // Load .panopticon.env (idempotent — file missing or unreadable is non-fatal)
+    yield* loadPanopticonEnv().pipe(Effect.ignore);
 
     const portStr = process.env['API_PORT'] ?? process.env['PORT'] ?? '3011';
     const port = parseInt(portStr, 10);

--- a/src/lib/env-loader.ts
+++ b/src/lib/env-loader.ts
@@ -5,9 +5,11 @@
  * This allows the settings system to access API keys configured in the .env file.
  */
 
-import { readFileSync, existsSync } from 'fs';
+import { existsSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { Effect, FileSystem } from 'effect';
+import { FsError, FsNotFoundError } from './errors.js';
 
 /**
  * Path to the Panopticon environment file
@@ -41,32 +43,39 @@ function parseEnvFile(content: string): Record<string, string> {
 }
 
 /**
- * Load environment variables from ~/.panopticon.env
+ * Load environment variables from ~/.panopticon.env.
  * Does not override existing environment variables.
  *
- * @returns Object with loaded variables and any errors
+ * Fails with `FsNotFoundError` if the env file does not exist.
+ * Fails with `FsError` if the file cannot be read.
  */
-export function loadPanopticonEnv(): {
-  loaded: string[];
-  skipped: string[];
-  error?: string;
-} {
-  const result = {
-    loaded: [] as string[],
-    skipped: [] as string[],
-  };
+export function loadPanopticonEnv(): Effect.Effect<
+  { loaded: string[]; skipped: string[] },
+  FsError | FsNotFoundError,
+  FileSystem.FileSystem
+> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
 
-  if (!existsSync(ENV_FILE_PATH)) {
-    return { ...result, error: `Env file not found: ${ENV_FILE_PATH}` };
-  }
+    const fileExists = yield* fs.exists(ENV_FILE_PATH).pipe(
+      Effect.mapError((cause) => new FsError({ path: ENV_FILE_PATH, operation: 'exists', cause })),
+    );
 
-  try {
-    const content = readFileSync(ENV_FILE_PATH, 'utf-8');
+    if (!fileExists) {
+      return yield* Effect.fail(new FsNotFoundError({ path: ENV_FILE_PATH }));
+    }
+
+    const content = yield* fs.readFileString(ENV_FILE_PATH, 'utf8').pipe(
+      Effect.mapError((cause) =>
+        new FsError({ path: ENV_FILE_PATH, operation: 'readFileString', cause }),
+      ),
+    );
+
     const envVars = parseEnvFile(content);
+    const result: { loaded: string[]; skipped: string[] } = { loaded: [], skipped: [] };
 
     for (const [key, value] of Object.entries(envVars)) {
       if (process.env[key]) {
-        // Don't override existing env vars
         result.skipped.push(key);
       } else {
         process.env[key] = value;
@@ -75,9 +84,7 @@ export function loadPanopticonEnv(): {
     }
 
     return result;
-  } catch (error: any) {
-    return { ...result, error: `Failed to load env file: ${error.message}` };
-  }
+  });
 }
 
 /**

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared typed errors for src/lib Effect migration (PAN-1249, wave 0).
+ *
+ * All errors are `Data.TaggedError` subclasses so they participate in typed
+ * Effect error channels and can be narrowed with `Effect.catchTag`.
+ */
+
+import { Data } from 'effect';
+
+// ─── VCS errors ───────────────────────────────────────────────────────────────
+
+/** A version-control operation (commit, push, pull, fetch) failed. */
+export class VcsError extends Data.TaggedError('VcsError')<{
+  readonly operation: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** A version-control operation exceeded its timeout. */
+export class VcsTimeoutError extends Data.TaggedError('VcsTimeoutError')<{
+  readonly operation: string;
+  readonly timeoutMs: number;
+}> {}
+
+// ─── Filesystem errors ────────────────────────────────────────────────────────
+
+/** A filesystem operation (read, write, mkdir, unlink, stat) failed. */
+export class FsError extends Data.TaggedError('FsError')<{
+  readonly path: string;
+  readonly operation: string;
+  readonly cause?: unknown;
+}> {}
+
+/** The requested path does not exist. */
+export class FsNotFoundError extends Data.TaggedError('FsNotFoundError')<{
+  readonly path: string;
+}> {}
+
+// ─── Git errors ───────────────────────────────────────────────────────────────
+
+/** A git command exited with a non-zero code. */
+export class GitError extends Data.TaggedError('GitError')<{
+  readonly command: readonly string[];
+  readonly stderr: string;
+  readonly exitCode: number;
+  readonly cause?: unknown;
+}> {}
+
+/** A git merge or rebase produced conflicts. */
+export class MergeConflictError extends Data.TaggedError('MergeConflictError')<{
+  readonly branch: string;
+  readonly targetBranch: string;
+  readonly conflictedFiles: readonly string[];
+}> {}
+
+// ─── Tmux errors ──────────────────────────────────────────────────────────────
+
+/** A tmux command failed. */
+export class TmuxError extends Data.TaggedError('TmuxError')<{
+  readonly command: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+// ─── Tracker / API errors ─────────────────────────────────────────────────────
+
+/** A generic issue-tracker API call failed. */
+export class TrackerError extends Data.TaggedError('TrackerError')<{
+  readonly tracker: string;
+  readonly operation: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** A GitHub API call failed. */
+export class GitHubApiError extends Data.TaggedError('GitHubApiError')<{
+  readonly operation: string;
+  readonly status: number;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** A Linear API call failed. */
+export class LinearApiError extends Data.TaggedError('LinearApiError')<{
+  readonly operation: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+// ─── Agent / checkpoint errors ────────────────────────────────────────────────
+
+/** A checkpoint save, load, or delete operation failed. */
+export class CheckpointError extends Data.TaggedError('CheckpointError')<{
+  readonly agentId: string;
+  readonly operation: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** The supplied agent ID does not match the expected format. */
+export class InvalidAgentIdError extends Data.TaggedError('InvalidAgentIdError')<{
+  readonly agentId: string;
+}> {}
+
+// ─── Configuration errors ─────────────────────────────────────────────────────
+
+/** A configuration value is missing or invalid. */
+export class ConfigError extends Data.TaggedError('ConfigError')<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** A configuration file (YAML or JSON) could not be parsed. */
+export class ConfigParseError extends Data.TaggedError('ConfigParseError')<{
+  readonly path: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+// ─── Process errors ───────────────────────────────────────────────────────────
+
+/** A child process failed to spawn. */
+export class ProcessSpawnError extends Data.TaggedError('ProcessSpawnError')<{
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** A child process exceeded its allowed runtime. */
+export class ProcessTimeoutError extends Data.TaggedError('ProcessTimeoutError')<{
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly timeoutMs: number;
+}> {}

--- a/src/lib/remote/fly-api.ts
+++ b/src/lib/remote/fly-api.ts
@@ -6,6 +6,9 @@
  * Auth: FLY_API_TOKEN environment variable
  */
 
+import { Data, Effect } from 'effect';
+import { ConfigError } from '../errors.js';
+
 export interface FlyMachineConfig {
   image: string;
   env?: Record<string, string>;
@@ -39,16 +42,12 @@ export interface FlyExecResult {
   exit_code: number;
 }
 
-export class FlyApiError extends Error {
-  constructor(
-    message: string,
-    public readonly statusCode: number,
-    public readonly body: string
-  ) {
-    super(message);
-    this.name = 'FlyApiError';
-  }
-}
+export class FlyApiError extends Data.TaggedError('FlyApiError')<{
+  readonly operation: string;
+  readonly statusCode: number;
+  readonly body: string;
+  readonly message: string;
+}> {}
 
 const BASE_URL = 'https://api.machines.dev/v1';
 
@@ -59,48 +58,72 @@ export class FlyApiClient {
     this.token = token;
   }
 
-  private async request<T>(
+  private request<T>(
     method: string,
     path: string,
     body?: unknown
-  ): Promise<T> {
+  ): Effect.Effect<T, FlyApiError> {
     const url = `${BASE_URL}${path}`;
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.token}`,
       'Content-Type': 'application/json',
     };
 
-    const response = await fetch(url, {
-      method,
-      headers,
-      body: body !== undefined ? JSON.stringify(body) : undefined,
-    });
-
-    const text = await response.text();
-
-    if (!response.ok) {
-      throw new FlyApiError(
-        `Fly API error ${response.status} for ${method} ${path}: ${text}`,
-        response.status,
-        text
-      );
-    }
-
-    if (!text) return undefined as T;
-
-    try {
-      return JSON.parse(text) as T;
-    } catch {
-      return text as unknown as T;
-    }
+    return Effect.tryPromise({
+      try: () =>
+        fetch(url, {
+          method,
+          headers,
+          body: body !== undefined ? JSON.stringify(body) : undefined,
+        }),
+      catch: (cause) =>
+        new FlyApiError({
+          operation: `${method} ${path}`,
+          statusCode: 0,
+          body: '',
+          message: `Network error: ${String(cause)}`,
+        }),
+    }).pipe(
+      Effect.flatMap((response) =>
+        Effect.tryPromise({
+          try: () => response.text(),
+          catch: (cause) =>
+            new FlyApiError({
+              operation: `${method} ${path}`,
+              statusCode: 0,
+              body: '',
+              message: `Failed to read response: ${String(cause)}`,
+            }),
+        }).pipe(
+          Effect.flatMap((text) => {
+            if (!response.ok) {
+              return Effect.fail(
+                new FlyApiError({
+                  operation: `${method} ${path}`,
+                  statusCode: response.status,
+                  body: text,
+                  message: `Fly API error ${response.status} for ${method} ${path}: ${text}`,
+                })
+              );
+            }
+            if (!text) return Effect.succeed(undefined as T);
+            try {
+              return Effect.succeed(JSON.parse(text) as T);
+            } catch {
+              return Effect.succeed(text as unknown as T);
+            }
+          })
+        )
+      )
+    );
   }
 
   /** Create a machine in an app */
-  async createMachine(
+  createMachine(
     appName: string,
     name: string,
     config: FlyMachineConfig
-  ): Promise<FlyMachine> {
+  ): Effect.Effect<FlyMachine, FlyApiError> {
     return this.request<FlyMachine>('POST', `/apps/${appName}/machines`, {
       name,
       config: {
@@ -118,29 +141,29 @@ export class FlyApiClient {
   }
 
   /** Destroy a machine (force=true for immediate) */
-  async destroyMachine(appName: string, machineId: string): Promise<void> {
-    await this.request<void>(
+  destroyMachine(appName: string, machineId: string): Effect.Effect<void, FlyApiError> {
+    return this.request<void>(
       'DELETE',
       `/apps/${appName}/machines/${machineId}?force=true`
     );
   }
 
   /** Start a stopped machine */
-  async startMachine(appName: string, machineId: string): Promise<void> {
-    await this.request<void>(
+  startMachine(appName: string, machineId: string): Effect.Effect<void, FlyApiError> {
+    return this.request<void>(
       'POST',
       `/apps/${appName}/machines/${machineId}/start`
     );
   }
 
   /** Stop a running machine */
-  async stopMachine(
+  stopMachine(
     appName: string,
     machineId: string,
     signal?: string,
     timeout?: number
-  ): Promise<void> {
-    await this.request<void>(
+  ): Effect.Effect<void, FlyApiError> {
+    return this.request<void>(
       'POST',
       `/apps/${appName}/machines/${machineId}/stop`,
       signal || timeout ? { signal, timeout } : undefined
@@ -148,7 +171,7 @@ export class FlyApiClient {
   }
 
   /** Get a machine by ID */
-  async getMachine(appName: string, machineId: string): Promise<FlyMachine> {
+  getMachine(appName: string, machineId: string): Effect.Effect<FlyMachine, FlyApiError> {
     return this.request<FlyMachine>(
       'GET',
       `/apps/${appName}/machines/${machineId}`
@@ -156,21 +179,20 @@ export class FlyApiClient {
   }
 
   /** List all machines in an app */
-  async listMachines(appName: string): Promise<FlyMachine[]> {
-    const result = await this.request<FlyMachine[] | null>(
+  listMachines(appName: string): Effect.Effect<FlyMachine[], FlyApiError> {
+    return this.request<FlyMachine[] | null>(
       'GET',
       `/apps/${appName}/machines`
-    );
-    return result ?? [];
+    ).pipe(Effect.map((result) => result ?? []));
   }
 
   /** Execute a command inside a running machine */
-  async execCommand(
+  execCommand(
     appName: string,
     machineId: string,
     command: string[],
     timeout: number = 30
-  ): Promise<FlyExecResult> {
+  ): Effect.Effect<FlyExecResult, FlyApiError> {
     return this.request<FlyExecResult>(
       'POST',
       `/apps/${appName}/machines/${machineId}/exec`,
@@ -179,43 +201,45 @@ export class FlyApiClient {
   }
 
   /** Wait for a machine to reach a target state */
-  async waitForState(
+  waitForState(
     appName: string,
     machineId: string,
     state: string,
     timeout: number = 60
-  ): Promise<void> {
-    await this.request<void>(
+  ): Effect.Effect<void, FlyApiError> {
+    return this.request<void>(
       'GET',
       `/apps/${appName}/machines/${machineId}/wait?state=${state}&timeout=${timeout}`
     );
   }
 
   /** Create a Fly app if it doesn't exist */
-  async ensureApp(appName: string, orgSlug: string): Promise<void> {
-    try {
-      await this.request<unknown>('GET', `/apps/${appName}`);
-    } catch (err) {
-      if (err instanceof FlyApiError && err.statusCode === 404) {
-        await this.request<unknown>('POST', '/apps', {
-          app_name: appName,
-          org_slug: orgSlug,
-          network: 'default',
-        });
-      } else {
-        throw err;
-      }
-    }
+  ensureApp(appName: string, orgSlug: string): Effect.Effect<void, FlyApiError> {
+    return this.request<unknown>('GET', `/apps/${appName}`).pipe(
+      Effect.catchTag('FlyApiError', (err) =>
+        err.statusCode === 404
+          ? this.request<unknown>('POST', '/apps', {
+              app_name: appName,
+              org_slug: orgSlug,
+              network: 'default',
+            })
+          : Effect.fail(err)
+      ),
+      Effect.asVoid
+    );
   }
 }
 
 /** Create a FlyApiClient from env or explicit token */
-export function createFlyApiClient(token?: string): FlyApiClient {
+export function createFlyApiClient(token?: string): Effect.Effect<FlyApiClient, ConfigError> {
   const tok = token ?? process.env.FLY_API_TOKEN;
   if (!tok) {
-    throw new Error(
-      'Fly API token not found. Set FLY_API_TOKEN environment variable or run: fly auth login'
+    return Effect.fail(
+      new ConfigError({
+        message:
+          'Fly API token not found. Set FLY_API_TOKEN environment variable or run: fly auth login',
+      })
     );
   }
-  return new FlyApiClient(tok);
+  return Effect.succeed(new FlyApiClient(tok));
 }

--- a/tests/lib/remote/fly-api.test.ts
+++ b/tests/lib/remote/fly-api.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from '@effect/vitest';
+import { Effect } from 'effect';
+import { ConfigError } from '../../../src/lib/errors.js';
 import { FlyApiClient, FlyApiError, createFlyApiClient } from '../../../src/lib/remote/fly-api.js';
 
 // Mock global fetch
@@ -29,151 +31,183 @@ describe('FlyApiClient', () => {
     client = new FlyApiClient('test-token');
   });
 
-  it('sets Authorization header on all requests', async () => {
-    mockOk([]);
-    await client.listMachines('my-app');
-    expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining('/apps/my-app/machines'),
-      expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer test-token' }) })
+  it.effect('sets Authorization header on all requests', () =>
+    Effect.gen(function* () {
+      mockOk([]);
+      yield* client.listMachines('my-app');
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/apps/my-app/machines'),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer test-token' }),
+        })
+      );
+    })
+  );
+
+  describe('createMachine', () => {
+    it.effect('POSTs to /apps/{app}/machines with name and config', () =>
+      Effect.gen(function* () {
+        const machine = { id: 'm1', name: 'ws-123', state: 'started', region: 'iad' };
+        mockOk(machine);
+        const result = yield* client.createMachine('my-app', 'ws-123', {
+          image: 'registry.fly.io/pan-workspace:latest',
+        });
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.machines.dev/v1/apps/my-app/machines',
+          expect.objectContaining({ method: 'POST' })
+        );
+        expect(result.id).toBe('m1');
+      })
     );
   });
 
-  describe('createMachine', () => {
-    it('POSTs to /apps/{app}/machines with name and config', async () => {
-      const machine = { id: 'm1', name: 'ws-123', state: 'started', region: 'iad' };
-      mockOk(machine);
-      const result = await client.createMachine('my-app', 'ws-123', { image: 'registry.fly.io/pan-workspace:latest' });
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://api.machines.dev/v1/apps/my-app/machines',
-        expect.objectContaining({ method: 'POST' })
-      );
-      expect(result.id).toBe('m1');
-    });
-  });
-
   describe('destroyMachine', () => {
-    it('DELETEs with force=true', async () => {
-      mockOk('');
-      await client.destroyMachine('my-app', 'm1');
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://api.machines.dev/v1/apps/my-app/machines/m1?force=true',
-        expect.objectContaining({ method: 'DELETE' })
-      );
-    });
+    it.effect('DELETEs with force=true', () =>
+      Effect.gen(function* () {
+        mockOk('');
+        yield* client.destroyMachine('my-app', 'm1');
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.machines.dev/v1/apps/my-app/machines/m1?force=true',
+          expect.objectContaining({ method: 'DELETE' })
+        );
+      })
+    );
   });
 
   describe('startMachine', () => {
-    it('POSTs to /start', async () => {
-      mockOk({ id: 'm1', name: 'ws-123', state: 'started', region: 'iad' });
-      await client.startMachine('my-app', 'm1');
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://api.machines.dev/v1/apps/my-app/machines/m1/start',
-        expect.objectContaining({ method: 'POST' })
-      );
-    });
+    it.effect('POSTs to /start', () =>
+      Effect.gen(function* () {
+        mockOk({ id: 'm1', name: 'ws-123', state: 'started', region: 'iad' });
+        yield* client.startMachine('my-app', 'm1');
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.machines.dev/v1/apps/my-app/machines/m1/start',
+          expect.objectContaining({ method: 'POST' })
+        );
+      })
+    );
   });
 
   describe('stopMachine', () => {
-    it('POSTs to /stop', async () => {
-      mockOk({ id: 'm1', name: 'ws-123', state: 'stopped', region: 'iad' });
-      await client.stopMachine('my-app', 'm1');
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://api.machines.dev/v1/apps/my-app/machines/m1/stop',
-        expect.objectContaining({ method: 'POST' })
-      );
-    });
+    it.effect('POSTs to /stop', () =>
+      Effect.gen(function* () {
+        mockOk({ id: 'm1', name: 'ws-123', state: 'stopped', region: 'iad' });
+        yield* client.stopMachine('my-app', 'm1');
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.machines.dev/v1/apps/my-app/machines/m1/stop',
+          expect.objectContaining({ method: 'POST' })
+        );
+      })
+    );
   });
 
   describe('getMachine', () => {
-    it('makes GET and returns machine', async () => {
-      const machine = { id: 'm1', name: 'ws-123', state: 'started', region: 'iad' };
-      mockOk(machine);
-      const result = await client.getMachine('my-app', 'm1');
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://api.machines.dev/v1/apps/my-app/machines/m1',
-        expect.objectContaining({ method: 'GET' })
-      );
-      expect(result.id).toBe('m1');
-    });
+    it.effect('makes GET and returns machine', () =>
+      Effect.gen(function* () {
+        const machine = { id: 'm1', name: 'ws-123', state: 'started', region: 'iad' };
+        mockOk(machine);
+        const result = yield* client.getMachine('my-app', 'm1');
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.machines.dev/v1/apps/my-app/machines/m1',
+          expect.objectContaining({ method: 'GET' })
+        );
+        expect(result.id).toBe('m1');
+      })
+    );
   });
 
   describe('listMachines', () => {
-    it('returns empty array when API returns null', async () => {
-      mockOk(null);
-      const result = await client.listMachines('my-app');
-      expect(result).toEqual([]);
-    });
+    it.effect('returns empty array when API returns null', () =>
+      Effect.gen(function* () {
+        mockOk(null);
+        const result = yield* client.listMachines('my-app');
+        expect(result).toEqual([]);
+      })
+    );
 
-    it('returns machines array', async () => {
-      const machines = [{ id: 'm1', name: 'ws-1', state: 'started', region: 'iad' }];
-      mockOk(machines);
-      const result = await client.listMachines('my-app');
-      expect(result).toHaveLength(1);
-    });
+    it.effect('returns machines array', () =>
+      Effect.gen(function* () {
+        const machines = [{ id: 'm1', name: 'ws-1', state: 'started', region: 'iad' }];
+        mockOk(machines);
+        const result = yield* client.listMachines('my-app');
+        expect(result).toHaveLength(1);
+      })
+    );
   });
 
   describe('execCommand', () => {
-    it('POSTs command array to exec endpoint', async () => {
-      mockOk({ stdout: 'hello', stderr: '', exit_code: 0 });
-      await client.execCommand('my-app', 'm1', ['/bin/sh', '-c', 'echo hello']);
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://api.machines.dev/v1/apps/my-app/machines/m1/exec',
-        expect.objectContaining({
-          method: 'POST',
-          body: expect.stringContaining('"command"'),
-        })
-      );
-    });
+    it.effect('POSTs command array to exec endpoint', () =>
+      Effect.gen(function* () {
+        mockOk({ stdout: 'hello', stderr: '', exit_code: 0 });
+        yield* client.execCommand('my-app', 'm1', ['/bin/sh', '-c', 'echo hello']);
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.machines.dev/v1/apps/my-app/machines/m1/exec',
+          expect.objectContaining({
+            method: 'POST',
+            body: expect.stringContaining('"command"'),
+          })
+        );
+      })
+    );
   });
 
   describe('waitForState', () => {
-    it('makes GET with state and timeout params', async () => {
-      mockOk({ id: 'm1', name: 'ws-123', state: 'started', region: 'iad' });
-      await client.waitForState('my-app', 'm1', 'started', 30);
-      expect(fetchMock).toHaveBeenCalledWith(
-        expect.stringContaining('/apps/my-app/machines/m1/wait'),
-        expect.objectContaining({ method: 'GET' })
-      );
-      const url: string = fetchMock.mock.calls[0][0];
-      expect(url).toContain('state=started');
-      expect(url).toContain('timeout=30');
-    });
+    it.effect('makes GET with state and timeout params', () =>
+      Effect.gen(function* () {
+        mockOk({ id: 'm1', name: 'ws-123', state: 'started', region: 'iad' });
+        yield* client.waitForState('my-app', 'm1', 'started', 30);
+        expect(fetchMock).toHaveBeenCalledWith(
+          expect.stringContaining('/apps/my-app/machines/m1/wait'),
+          expect.objectContaining({ method: 'GET' })
+        );
+        const url: string = fetchMock.mock.calls[0][0];
+        expect(url).toContain('state=started');
+        expect(url).toContain('timeout=30');
+      })
+    );
   });
 
   describe('ensureApp', () => {
-    it('does nothing if app already exists', async () => {
-      mockOk({ name: 'my-app' });
-      await client.ensureApp('my-app', 'personal');
-      expect(fetchMock).toHaveBeenCalledTimes(1);
-    });
+    it.effect('does nothing if app already exists', () =>
+      Effect.gen(function* () {
+        mockOk({ name: 'my-app' });
+        yield* client.ensureApp('my-app', 'personal');
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      })
+    );
 
-    it('creates app if 404', async () => {
-      mockError(404);
-      mockOk({ name: 'my-app' });
-      await client.ensureApp('my-app', 'personal');
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-      expect(fetchMock).toHaveBeenLastCalledWith(
-        'https://api.machines.dev/v1/apps',
-        expect.objectContaining({ method: 'POST' })
-      );
-    });
+    it.effect('creates app if 404', () =>
+      Effect.gen(function* () {
+        mockError(404);
+        mockOk({ name: 'my-app' });
+        yield* client.ensureApp('my-app', 'personal');
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(fetchMock).toHaveBeenLastCalledWith(
+          'https://api.machines.dev/v1/apps',
+          expect.objectContaining({ method: 'POST' })
+        );
+      })
+    );
 
-    it('rethrows non-404 errors', async () => {
-      mockError(500, 'internal error');
-      await expect(client.ensureApp('my-app', 'personal')).rejects.toThrow(FlyApiError);
-    });
+    it.effect('rethrows non-404 errors', () =>
+      Effect.gen(function* () {
+        mockError(500, 'internal error');
+        const err = yield* Effect.flip(client.ensureApp('my-app', 'personal'));
+        expect(err._tag).toBe('FlyApiError');
+        expect((err as FlyApiError).statusCode).toBe(500);
+      })
+    );
   });
 
   describe('error handling', () => {
-    it('throws FlyApiError with statusCode and body on non-ok response', async () => {
-      mockError(403, 'forbidden');
-      await expect(client.listMachines('my-app')).rejects.toThrow(FlyApiError);
-      mockError(403, 'forbidden');
-      await expect(client.listMachines('my-app').catch(e => e)).resolves.toMatchObject({
-        statusCode: 403,
-        body: 'forbidden',
-      });
-    });
+    it.effect('surfaces FlyApiError with statusCode and body on non-ok response', () =>
+      Effect.gen(function* () {
+        mockError(403, 'forbidden');
+        const err = yield* Effect.flip(client.listMachines('my-app'));
+        expect(err._tag).toBe('FlyApiError');
+        expect((err as FlyApiError).statusCode).toBe(403);
+        expect((err as FlyApiError).body).toBe('forbidden');
+      })
+    );
   });
 });
 
@@ -188,20 +222,28 @@ describe('createFlyApiClient', () => {
     }
   });
 
-  it('reads token from FLY_API_TOKEN env var', () => {
-    process.env.FLY_API_TOKEN = 'env-token';
-    const client = createFlyApiClient();
-    expect(client).toBeInstanceOf(FlyApiClient);
-  });
+  it.effect('reads token from FLY_API_TOKEN env var', () =>
+    Effect.gen(function* () {
+      process.env.FLY_API_TOKEN = 'env-token';
+      const client = yield* createFlyApiClient();
+      expect(client).toBeInstanceOf(FlyApiClient);
+    })
+  );
 
-  it('uses explicit token over env var', () => {
-    process.env.FLY_API_TOKEN = 'env-token';
-    const client = createFlyApiClient('explicit-token');
-    expect(client).toBeInstanceOf(FlyApiClient);
-  });
+  it.effect('uses explicit token over env var', () =>
+    Effect.gen(function* () {
+      process.env.FLY_API_TOKEN = 'env-token';
+      const client = yield* createFlyApiClient('explicit-token');
+      expect(client).toBeInstanceOf(FlyApiClient);
+    })
+  );
 
-  it('throws if no token available', () => {
-    delete process.env.FLY_API_TOKEN;
-    expect(() => createFlyApiClient()).toThrow('Fly API token not found');
-  });
+  it.effect('fails with ConfigError if no token available', () =>
+    Effect.gen(function* () {
+      delete process.env.FLY_API_TOKEN;
+      const err = yield* Effect.flip(createFlyApiClient());
+      expect(err._tag).toBe('ConfigError');
+      expect((err as ConfigError).message).toContain('Fly API token not found');
+    })
+  );
 });

--- a/tests/unit/dashboard/config.test.ts
+++ b/tests/unit/dashboard/config.test.ts
@@ -11,9 +11,12 @@ import { ServerConfig, ServerConfigLayer, ServerConfigError } from '../../../src
 
 // Prevent loadPanopticonEnv from loading ~/.panopticon.env during tests
 // so env var presence/absence is fully controlled by the test.
-vi.mock('../../../src/lib/env-loader.js', () => ({
-  loadPanopticonEnv: () => ({ loaded: [], skipped: [] }),
-}));
+vi.mock('../../../src/lib/env-loader.js', async () => {
+  const { Effect } = await import('effect');
+  return {
+    loadPanopticonEnv: () => Effect.succeed({ loaded: [] as string[], skipped: [] as string[] }),
+  };
+});
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Migrates `src/lib/remote/fly-api.ts` from Promise-based to Effect-native API
- `FlyApiError` converted from `extends Error` to `Data.TaggedError('FlyApiError')` with typed fields (`operation`, `statusCode`, `body`, `message`)
- All `FlyApiClient` methods now return `Effect.Effect<T, FlyApiError>` instead of `Promise<T>`
- `createFlyApiClient()` returns `Effect.Effect<FlyApiClient, ConfigError>` instead of throwing
- Test suite migrated to `@effect/vitest` with `it.effect()` throughout (17 tests, all green)
- Installs `@effect/vitest@4.0.0-beta.45` which was missing from node_modules

## Notes

`fly-provider.ts` callers have temporary typecheck errors — this is expected and will be fixed by the SCC migration task (`effect-migrate-cycle-activity-logger-and-13-more`) which explicitly includes `fly-provider.ts` in its scope and runs at a later wave.

## Test plan

- [x] All 17 tests in `tests/lib/remote/fly-api.test.ts` pass with `@effect/vitest`
- [x] `npm run typecheck` clean for `fly-api.ts` and test file
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)