### PR TITLE
feat(pan-1249): verify Effect migration for src/lib/agent-runtime-mirror.ts [slot-10]

### DIFF
--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -1457,7 +1457,6 @@ export const __testInternals = { markAgentRunning, markAgentStopped };
 // every field access in one PR would have been mechanical noise.
 
 import type { AgentRuntimeSnapshot } from '@panctl/contracts';
-import { Effect } from 'effect';
 import {
   getAgentRuntimeSnapshot as fetchAgentRuntimeSnapshot,
   emitAgentEvent,


### PR DESCRIPTION
## Summary

- `src/lib/agent-runtime-mirror.ts` was already migrated to Effect-native in wave-1 prep commit (`0ff23fab4`). All four exported functions return `Effect.Effect<T, never>` using `Effect.sync()` — no Promise returns, no `execAsync`, no `fs/promises`, no try/catch.
- Fixes a duplicate `import { Effect } from 'effect'` in `src/lib/agents.ts` (a direct caller of `agent-runtime-mirror.ts`) that was introduced by the wave-1 migration. The duplicate caused `TS2300: Duplicate identifier 'Effect'` on the caller file.
- Rebased onto latest `feature/pan-1249` (808b47b58) to incorporate all merged slot PRs.

## Acceptance criteria status

- [x] All exported functions return `Effect.Effect<T, E>` with typed errors (no `Promise<T>` returns remain)
- [x] No `execAsync` / `execFileAsync` calls (not applicable — file has no subprocess calls)
- [x] No `try/catch` for expected failure modes (not applicable — no error paths)
- [x] No `fs/promises` calls (not applicable — file has no file system access)
- [x] No new `Effect.runPromise()` introduced inside `src/lib/`
- [x] Observable behavior unchanged
- [x] `npm run typecheck` and `npm run lint` pass for the touched file and its callers (`agents.ts`, `agent-state-service.ts`)

Note: remaining typecheck errors (44 in `fly-provider.ts`, `workspace-migrate.ts`, `remote-agents.ts`, `remote/index.ts`) are pre-existing in `feature/pan-1249` from the `remote/interface.ts` Effect migration — those are in scope for a separate slot.

## Test plan

- [x] `npm run typecheck` — caller errors fixed (was: TS2300 on agents.ts; now clean for agent-runtime-mirror callers)
- [x] `npm run lint` — passes
- [x] `npm test` — pre-existing failures unrelated to this slot (paths.test.ts, triage-agent.test.ts, prompts.test.ts, agent-permissions.test.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)