### PR TITLE
feat(pan-1249): Effect migration for src/lib/conversations/embeddings/providers.ts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@effect/platform-bun": "4.0.0-beta.45",
         "@effect/platform-node": "4.0.0-beta.45",
         "@effect/platform-node-shared": "4.0.0-beta.45",
+        "@effect/vitest": "4.0.0-beta.45",
         "@google-cloud/speech": "^7.3.1",
         "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1",
         "@iarna/toml": "^2.2.5",
@@ -324,6 +325,8 @@
     "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.45", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.45", "mime": "^4.1.0", "undici": "^7.24.0" }, "peerDependencies": { "effect": "^4.0.0-beta.45", "ioredis": "^5.7.0" } }, "sha512-P07NMG4eoy62iLX9szak0hkr7hrwgq5+XMkm7URVug/3zqfZVxEG2kxn9JzVK1lF5WbaVrEKwjt3IkEJxzSPtg=="],
 
     "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.45", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.19.0" }, "peerDependencies": { "effect": "^4.0.0-beta.45" } }, "sha512-0T4RG18o+aCVUSlmPxA7uAjHJkyE3MS/uRrR5kCNSZQNG3X71wdIbu82wE/MnV6+6YSSPDx/6TVdZWYkJF0JWw=="],
+
+    "@effect/vitest": ["@effect/vitest@4.0.0-beta.45", "", { "peerDependencies": { "effect": "^4.0.0-beta.45", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-38JA5Z6c2FoEhpVKbl7rjTrMU8Al5T30Kwtb6N3B9kOkyr2SsmvNsP9T65bh03IBh3ak9U//acrkmjS3hLQwKA=="],
 
     "@electron/asar": ["@electron/asar@3.4.1", "", { "dependencies": { "commander": "^5.0.0", "glob": "^7.1.6", "minimatch": "^3.0.4" }, "bin": { "asar": "bin/asar.js" } }, "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA=="],
 

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "@effect/platform-bun": "4.0.0-beta.45",
     "@effect/platform-node": "4.0.0-beta.45",
     "@effect/platform-node-shared": "4.0.0-beta.45",
+    "@effect/vitest": "4.0.0-beta.45",
     "@google-cloud/speech": "^7.3.1",
     "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1",
     "@iarna/toml": "^2.2.5",

--- a/src/cli/commands/admin/tracker-handler.ts
+++ b/src/cli/commands/admin/tracker-handler.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { Effect } from 'effect';
 import { getLinearApiKey } from '../../../lib/shadow-utils.js';
 
 interface LinearState {
@@ -127,7 +128,7 @@ interface CleanupOptions {
 }
 
 export async function listStatesCommand(options: ListOptions): Promise<void> {
-  const apiKey = getLinearApiKey();
+  const apiKey = Effect.runSync(getLinearApiKey());
   if (!apiKey) {
     console.error(chalk.red('LINEAR_API_KEY not found in ~/.panopticon.env or environment'));
     process.exit(1);
@@ -173,7 +174,7 @@ export async function listStatesCommand(options: ListOptions): Promise<void> {
 }
 
 export async function cleanupStatesCommand(options: CleanupOptions): Promise<void> {
-  const apiKey = getLinearApiKey();
+  const apiKey = Effect.runSync(getLinearApiKey());
   if (!apiKey) {
     console.error(chalk.red('LINEAR_API_KEY not found in ~/.panopticon.env or environment'));
     process.exit(1);

--- a/src/cli/commands/done.ts
+++ b/src/cli/commands/done.ts
@@ -12,6 +12,7 @@ import { runPreflightChecks } from '../../lib/work/done-preflight.js';
 import { shouldSkipTrackerUpdate } from '../../lib/shadow-mode.js';
 import { updateShadowState } from '../../lib/shadow-state.js';
 import { cleanupWorkflowLabels, getLinearStateName, findLinearStateByName } from '../../core/state-mapping.js';
+import { Effect } from 'effect';
 import { getLinearApiKey } from '../../lib/shadow-utils.js';
 import { extractNumber, resolveIssueId } from '../../lib/issue-id.js';
 import { getWorkspacePanPaths, readWorkspaceContinue, writeWorkspaceContinue } from '../../lib/pan-dir/index.js';
@@ -204,7 +205,7 @@ export async function doneCommand(id: string, options: DoneOptions = {}): Promis
         process.exit(1);
       }
     } else {
-      const linearApiKey = getLinearApiKey();
+      const linearApiKey = Effect.runSync(getLinearApiKey());
       if (linearApiKey) {
         try {
           const { LinearClient } = await import('@linear/sdk');
@@ -361,7 +362,7 @@ export async function doneCommand(id: string, options: DoneOptions = {}): Promis
         console.log(chalk.yellow(`  ⚠ Failed to update GitHub labels`));
       }
     } else {
-      const apiKey = getLinearApiKey();
+      const apiKey = Effect.runSync(getLinearApiKey());
       if (apiKey) {
         spinner.text = 'Updating Linear to In Review...';
         trackerUpdated = await updateLinearToInReview(apiKey, issueId, options.comment);

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -18,6 +18,7 @@ import {
   SOURCE_SKILLS_DIR
 } from '../../lib/paths.js';
 import { getDefaultConfig, saveConfig, loadConfig } from '../../lib/config.js';
+import { Effect } from 'effect';
 import { detectPlatform } from '../../lib/platform.js';
 import { detectDnsSyncMethod, ensureBaseDomain, syncDnsToWindows } from '../../lib/dns.js';
 import { generatePanopticonTraefikConfig, cleanupTemplateFiles, ensureProjectCerts, generateTlsConfig } from '../../lib/traefik.js';
@@ -56,7 +57,7 @@ interface PrereqResult {
   fix?: string;
 }
 
-// detectPlatform() is now in src/lib/platform.ts
+// Effect.runSync(detectPlatform()) is now in src/lib/platform.ts
 
 /**
  * Recursively copy directory contents
@@ -215,7 +216,7 @@ function printPrereqStatus(prereqs: { results: PrereqResult[]; allPassed: boolea
 async function installCommand(options: InstallOptions): Promise<void> {
   console.log(chalk.bold('\nPanopticon Installation\n'));
 
-  const plat = detectPlatform();
+  const plat = Effect.runSync(detectPlatform());
   console.log(`Platform: ${chalk.cyan(plat)}\n`);
 
   // Step 1: Check prerequisites
@@ -273,7 +274,7 @@ async function installCommand(options: InstallOptions): Promise<void> {
     if (!hasMkcert) {
       spinner.start('Installing mkcert...');
       try {
-        const plat = detectPlatform();
+        const plat = Effect.runSync(detectPlatform());
         if (plat === 'darwin') {
           execSync('brew install mkcert', { stdio: 'pipe', timeout: 120000 });
           spinner.succeed('mkcert installed via Homebrew');
@@ -343,7 +344,7 @@ async function installCommand(options: InstallOptions): Promise<void> {
       const ttydPath = join(binDir, 'ttyd');
 
       // Determine platform and download appropriate binary
-      const plat = detectPlatform();
+      const plat = Effect.runSync(detectPlatform());
       let downloadUrl = '';
       if (plat === 'darwin') {
         // macOS - try homebrew first
@@ -378,7 +379,7 @@ async function installCommand(options: InstallOptions): Promise<void> {
   if (!hasAstGrepNow) {
     spinner.start('Installing ast-grep...');
     try {
-      const plat = detectPlatform();
+      const plat = Effect.runSync(detectPlatform());
       if (plat === 'darwin') {
         try {
           execSync('brew install ast-grep', { stdio: 'pipe', timeout: 120000 });
@@ -406,7 +407,7 @@ async function installCommand(options: InstallOptions): Promise<void> {
     if (!hasBeadsNow) {
     spinner.start('Installing beads CLI (bd)...');
     try {
-      const plat = detectPlatform();
+      const plat = Effect.runSync(detectPlatform());
       if (plat === 'darwin') {
         // macOS - try homebrew
         try {
@@ -450,7 +451,7 @@ async function installCommand(options: InstallOptions): Promise<void> {
         const recommendedVersion = 1 * 10000 + 0 * 100 + 4; // v1.0.4 required for ping, doctor, prune
         if (currentVersion < recommendedVersion) {
           spinner.start(`Upgrading beads from v${major}.${minor}.${patch} to v1.0.4+...`);
-          const plat = detectPlatform();
+          const plat = Effect.runSync(detectPlatform());
           if (plat === 'darwin') {
             execSync('brew upgrade gastownhall/beads/bd', { stdio: 'pipe', timeout: 120000 });
           } else {

--- a/src/cli/commands/refresh.ts
+++ b/src/cli/commands/refresh.ts
@@ -11,6 +11,7 @@ import {
   updateTrackerStatusCache,
 } from '../../lib/shadow-state.js';
 import type { IssueState } from '../../lib/tracker/interface.js';
+import { Effect } from 'effect';
 import { getLinearApiKey, isLinearIssue, formatState } from '../../lib/shadow-utils.js';
 
 interface RefreshOptions {
@@ -81,7 +82,7 @@ export async function refreshCommand(id: string, options: RefreshOptions = {}): 
   };
 
   if (isLinearIssue(issueId)) {
-    const apiKey = getLinearApiKey();
+    const apiKey = Effect.runSync(getLinearApiKey());
     if (apiKey) {
       result = await refreshFromLinear(apiKey, issueId);
     } else {

--- a/src/cli/commands/reopen.ts
+++ b/src/cli/commands/reopen.ts
@@ -6,6 +6,7 @@ import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { LinearClient } from '@linear/sdk';
 import { reopenWorkspaceState } from '../../lib/reopen.js';
+import { Effect } from 'effect';
 import { getLinearApiKey } from '../../lib/shadow-utils.js';
 import { getTrackerContext } from '../../lib/cloister/work-agent-prompt.js';
 import { resolveProjectFromIssue } from '../../lib/projects.js';
@@ -408,7 +409,7 @@ async function reopenLinearIssueCommand(id: string, options: ReopenOptions): Pro
   const spinner = ora(`Fetching issue ${id}...`).start();
 
   try {
-    const apiKey = getLinearApiKey();
+    const apiKey = Effect.runSync(getLinearApiKey());
     if (!apiKey) {
       spinner.fail('LINEAR_API_KEY not found');
       console.log('');

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -14,6 +14,7 @@ import { syncMainIntoWorkspace } from '../../lib/cloister/merge-agent.js';
 import { resolveProjectFromIssue, hasProjects, listProjects, ProjectConfig } from '../../lib/projects.js';
 import { hasPRDDraft, getPRDDraftPath } from '../../lib/prd-draft.js';
 import { isGitHubIssue, resolveGitHubIssue } from '../../lib/tracker-utils.js';
+import { Effect } from 'effect';
 import { getLinearApiKey } from '../../lib/shadow-utils.js';
 import { getWorkspacePanPaths } from '../../lib/pan-dir/index.js';
 import { findPlan } from '../../lib/vbrief/io.js';
@@ -254,7 +255,7 @@ async function fetchIssueForAutoStart(issueId: string): Promise<AutoSynthesizeIs
   }
 
   if (isLinearIssue(issueId)) {
-    const apiKey = getLinearApiKey();
+    const apiKey = Effect.runSync(getLinearApiKey());
     if (apiKey) {
       try {
         const { LinearClient } = await import('@linear/sdk');
@@ -413,7 +414,7 @@ async function handleRemoteWorkspace(
         }
       }
     } else if (isLinearIssue(issueId)) {
-      const apiKey = getLinearApiKey();
+      const apiKey = Effect.runSync(getLinearApiKey());
       if (apiKey) {
         const updated = await updateLinearToInProgress(apiKey, issueId);
         if (updated) {

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -3,7 +3,9 @@ import chalk from 'chalk';
 import ora, { type Ora } from 'ora';
 import { existsSync, mkdirSync, writeFileSync, rmSync, readFileSync, realpathSync, symlinkSync, lstatSync, chmodSync, unlinkSync } from 'fs';
 import { join, basename, resolve } from 'path';
-import { createWorktree, removeWorktree, listWorktrees } from '../../lib/worktree.js';
+import { createWorktree, removeWorktree, listWorktrees, type WorktreeInfo } from '../../lib/worktree.js';
+import { Effect } from 'effect';
+import { layer as nodeServicesLayer } from '@effect/platform-node/NodeServices';
 import { PAN_DIRNAME, PAN_CONTINUE_FILENAME, PAN_CONTEXT_FILENAME, PAN_FEEDBACK_DIRNAME, PAN_SESSIONS_FILENAME } from '../../lib/pan-dir/index.js';
 import { generateClaudeMd, TemplateVariables } from '../../lib/template.js';
 import { mergeSkillsIntoWorkspace, applyProjectTemplateOverlay } from '../../lib/skills-merge.js';
@@ -506,7 +508,9 @@ async function createCommand(issueId: string, options: CreateOptions): Promise<v
 
     // Create worktree
     spinner.text = 'Creating git worktree...';
-    createWorktree(projectRoot, workspacePath, branchName);
+    await Effect.runPromise(
+      createWorktree(projectRoot, workspacePath, branchName).pipe(Effect.provide(nodeServicesLayer)),
+    );
 
     // Clear stale workspace-local runtime state inherited from main.
     // Keep canonical plan state (.pan/spec.vbrief.json); clear only mutable
@@ -714,20 +718,22 @@ async function listCommand(options: ListOptions): Promise<void> {
     const allWorkspaces: Array<{
       projectName: string;
       projectPath: string;
-      workspaces: ReturnType<typeof listWorktrees>;
+      workspaces: WorktreeInfo[];
     }> = [];
 
     for (const { key, config } of projects) {
       // For polyrepo projects, list worktrees from each sub-repo
       const isPolyrepo = config.workspace?.type === 'polyrepo' && config.workspace?.repos;
-      const workspaces: ReturnType<typeof listWorktrees> = [];
+      const workspaces: WorktreeInfo[] = [];
 
       if (isPolyrepo && config.workspace?.repos) {
         // Polyrepo: scan each configured repo for worktrees
         for (const repo of config.workspace.repos) {
           const repoPath = join(config.path, repo.path);
           if (!existsSync(join(repoPath, '.git'))) continue;
-          const repoWorktrees = listWorktrees(repoPath);
+          const repoWorktrees = await Effect.runPromise(
+            listWorktrees(repoPath).pipe(Effect.provide(nodeServicesLayer)),
+          );
           for (const wt of repoWorktrees) {
             if (wt.path.includes('/workspaces/') || wt.path.includes('\\workspaces\\')) {
               // Deduplicate: polyrepo workspaces share a parent dir (e.g., feature-min-697/fe, feature-min-697/api)
@@ -746,7 +752,9 @@ async function listCommand(options: ListOptions): Promise<void> {
       } else {
         // Monorepo: scan project root
         if (!existsSync(join(config.path, '.git'))) continue;
-        const worktrees = listWorktrees(config.path);
+        const worktrees = await Effect.runPromise(
+          listWorktrees(config.path).pipe(Effect.provide(nodeServicesLayer)),
+        );
         for (const wt of worktrees) {
           if (wt.path.includes('/workspaces/') || wt.path.includes('\\workspaces\\')) {
             workspaces.push(wt);
@@ -798,7 +806,9 @@ async function listCommand(options: ListOptions): Promise<void> {
     process.exit(1);
   }
 
-  const worktrees = listWorktrees(projectRoot);
+  const worktrees = await Effect.runPromise(
+    listWorktrees(projectRoot).pipe(Effect.provide(nodeServicesLayer)),
+  );
 
   // Filter to workspaces directory only
   const workspaces = worktrees.filter((w) =>
@@ -932,7 +942,9 @@ export async function destroyCommand(issueId: string, options: DestroyOptions): 
     const finalWorkspacePath = join(projectRoot, 'workspaces', folderName);
 
     spinner.text = 'Removing git worktree...';
-    removeWorktree(projectRoot, finalWorkspacePath);
+    await Effect.runPromise(
+      removeWorktree(projectRoot, finalWorkspacePath).pipe(Effect.provide(nodeServicesLayer)),
+    );
 
     spinner.succeed(`Workspace destroyed: ${folderName}`);
   } catch (error: any) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1264,13 +1264,17 @@ program
     // Open browser after server has had a moment to start
     setTimeout(async () => {
       console.log(`  ${chalk.cyan(url)}`);
-      try {
-        const { openBrowser } = await import('../lib/browser.js');
-        await openBrowser(browserUrl);
-      } catch {
+      const [{ openBrowser }, { Effect }, { layer: nodeServicesLayer }] = await Promise.all([
+        import('../lib/browser.js'),
+        import('effect'),
+        import('@effect/platform-node/NodeServices'),
+      ]);
+      await Effect.runPromise(
+        openBrowser(browserUrl).pipe(Effect.provide(nodeServicesLayer)),
+      ).catch(() => {
         // If openBrowser fails, show URL for manual opening
         console.log(chalk.dim(`  Open your browser to: ${browserUrl}`));
-      }
+      });
     }, 1_500);
   });
 

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -3,27 +3,37 @@
  * Used by `npx panopticon serve` to open the dashboard URL after server starts.
  */
 
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
+import { Effect } from 'effect';
+import { ChildProcess } from 'effect/unstable/process';
+import { ChildProcessSpawner } from 'effect/unstable/process/ChildProcessSpawner';
+import { ProcessSpawnError } from './errors.js';
 
-const execFileAsync = promisify(execFile);
+function runCommand(
+  command: string,
+  args: ReadonlyArray<string>,
+): Effect.Effect<void, ProcessSpawnError, ChildProcessSpawner> {
+  return Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner;
+    const code = yield* spawner
+      .exitCode(ChildProcess.make(command, args, { stdout: 'ignore', stderr: 'ignore' }))
+      .pipe(Effect.mapError((e) => new ProcessSpawnError({ command, args, message: e.message, cause: e })));
+    if (Number(code) !== 0) {
+      yield* Effect.fail(new ProcessSpawnError({ command, args, message: `exited with code ${String(code)}` }));
+    }
+  });
+}
 
-export async function openBrowser(url: string): Promise<void> {
-  if (process.platform === "darwin") {
-    await execFileAsync("open", [url]);
-  } else if (process.platform === "win32") {
+export function openBrowser(url: string): Effect.Effect<void, ProcessSpawnError, ChildProcessSpawner> {
+  if (process.platform === 'darwin') {
+    return runCommand('open', [url]);
+  } else if (process.platform === 'win32') {
     // cmd.exe /c start is the standard way; /b runs without a new window
-    await execFileAsync("cmd", ["/c", "start", "", url]);
+    return runCommand('cmd', ['/c', 'start', '', url]);
   } else {
     // Linux: try xdg-open, fall back to sensible-browser
-    try {
-      await execFileAsync("xdg-open", [url]);
-    } catch {
-      try {
-        await execFileAsync("sensible-browser", [url]);
-      } catch {
-        // Best-effort: ignore if neither is available
-      }
-    }
+    return runCommand('xdg-open', [url]).pipe(
+      Effect.catch(() => runCommand('sensible-browser', [url])),
+      Effect.catch(() => Effect.void),
+    );
   }
 }

--- a/src/lib/cloister/__tests__/prompts.test.ts
+++ b/src/lib/cloister/__tests__/prompts.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from '@effect/vitest';
+import { Effect } from 'effect';
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -25,9 +26,10 @@ afterEach(() => {
 
 describe('prompts loader', () => {
   describe('frontmatter parsing', () => {
-    it('parses valid frontmatter', () => {
-      writeScratch(
-        `---
+    it.effect('parses valid frontmatter', () =>
+      Effect.gen(function* () {
+        writeScratch(
+          `---
 name: scratch
 description: A scratch template for tests
 requires:
@@ -37,120 +39,144 @@ optional:
   - REMOTE
 ---
 Issue: {{ISSUE_ID}}`
-      );
-      const fm = loadPromptFrontmatter(SCRATCH);
-      expect(fm.name).toBe('scratch');
-      expect(fm.description).toBe('A scratch template for tests');
-      expect(fm.requires).toEqual(['ISSUE_ID']);
-      expect(fm.optional).toEqual(['LOCAL', 'REMOTE']);
-    });
+        );
+        const fm = yield* loadPromptFrontmatter(SCRATCH);
+        expect(fm.name).toBe('scratch');
+        expect(fm.description).toBe('A scratch template for tests');
+        expect(fm.requires).toEqual(['ISSUE_ID']);
+        expect(fm.optional).toEqual(['LOCAL', 'REMOTE']);
+      })
+    );
 
-    it('defaults requires/optional to empty arrays when omitted', () => {
-      writeScratch(
-        `---
+    it.effect('defaults requires/optional to empty arrays when omitted', () =>
+      Effect.gen(function* () {
+        writeScratch(
+          `---
 name: scratch
 description: minimal
 ---
 hello`
-      );
-      const fm = loadPromptFrontmatter(SCRATCH);
-      expect(fm.requires).toEqual([]);
-      expect(fm.optional).toEqual([]);
-    });
+        );
+        const fm = yield* loadPromptFrontmatter(SCRATCH);
+        expect(fm.requires).toEqual([]);
+        expect(fm.optional).toEqual([]);
+      })
+    );
 
-    it('throws when frontmatter is missing entirely', () => {
-      writeScratch('hello world');
-      expect(() => loadPromptFrontmatter(SCRATCH)).toThrow(PromptError);
-      expect(() => loadPromptFrontmatter(SCRATCH)).toThrow(/missing YAML frontmatter/);
-    });
+    it.effect('fails when frontmatter is missing entirely', () =>
+      Effect.gen(function* () {
+        writeScratch('hello world');
+        const err = yield* Effect.flip(loadPromptFrontmatter(SCRATCH));
+        expect(err).toBeInstanceOf(PromptError);
+        expect(err.message).toMatch(/missing YAML frontmatter/);
+      })
+    );
 
-    it('throws when name field is missing', () => {
-      writeScratch(
-        `---
+    it.effect('fails when name field is missing', () =>
+      Effect.gen(function* () {
+        writeScratch(
+          `---
 description: no name
 ---
 body`
-      );
-      expect(() => loadPromptFrontmatter(SCRATCH)).toThrow(/missing required field "name"/);
-    });
+        );
+        const err = yield* Effect.flip(loadPromptFrontmatter(SCRATCH));
+        expect(err.message).toMatch(/missing required field "name"/);
+      })
+    );
 
-    it('throws when description field is missing', () => {
-      writeScratch(
-        `---
+    it.effect('fails when description field is missing', () =>
+      Effect.gen(function* () {
+        writeScratch(
+          `---
 name: scratch
 ---
 body`
-      );
-      expect(() => loadPromptFrontmatter(SCRATCH)).toThrow(/missing required field "description"/);
-    });
+        );
+        const err = yield* Effect.flip(loadPromptFrontmatter(SCRATCH));
+        expect(err.message).toMatch(/missing required field "description"/);
+      })
+    );
 
-    it('throws when requires is not a string array', () => {
-      writeScratch(
-        `---
+    it.effect('fails when requires is not a string array', () =>
+      Effect.gen(function* () {
+        writeScratch(
+          `---
 name: scratch
 description: bad requires
 requires:
   foo: bar
 ---
 body`
-      );
-      expect(() => loadPromptFrontmatter(SCRATCH)).toThrow(/"requires" must be a list of strings/);
-    });
+        );
+        const err = yield* Effect.flip(loadPromptFrontmatter(SCRATCH));
+        expect(err.message).toMatch(/"requires" must be a list of strings/);
+      })
+    );
 
-    it('throws when YAML is malformed', () => {
-      writeScratch(
-        `---
+    it.effect('fails when YAML is malformed', () =>
+      Effect.gen(function* () {
+        writeScratch(
+          `---
 name: scratch
 description: bad
 optional: [unclosed
 ---
 body`
-      );
-      expect(() => loadPromptFrontmatter(SCRATCH)).toThrow(/invalid YAML frontmatter/);
-    });
+        );
+        const err = yield* Effect.flip(loadPromptFrontmatter(SCRATCH));
+        expect(err.message).toMatch(/invalid YAML frontmatter/);
+      })
+    );
 
-    it('throws when template file is missing', () => {
-      expect(() => loadPromptFrontmatter('definitely-not-a-real-template')).toThrow(
-        /Failed to load prompt template/
-      );
-    });
+    it.effect('fails when template file is missing', () =>
+      Effect.gen(function* () {
+        const err = yield* Effect.flip(loadPromptFrontmatter('definitely-not-a-real-template'));
+        expect(err.message).toMatch(/Failed to load prompt template/);
+      })
+    );
   });
 
   describe('rendering', () => {
-    it('substitutes a required variable', () => {
-      writeScratch(
-        `---
+    it.effect('substitutes a required variable', () =>
+      Effect.gen(function* () {
+        writeScratch(
+          `---
 name: scratch
 description: simple
 requires:
   - ISSUE_ID
 ---
 Issue {{ISSUE_ID}} is in progress.`
-      );
-      const out = renderPrompt({ name: SCRATCH, vars: { ISSUE_ID: 'PAN-123' } });
-      expect(out).toBe('Issue PAN-123 is in progress.');
-    });
+        );
+        const out = yield* renderPrompt({ name: SCRATCH, vars: { ISSUE_ID: 'PAN-123' } });
+        expect(out).toBe('Issue PAN-123 is in progress.');
+      })
+    );
 
-    it('does NOT HTML-escape values (markdown output, not HTML)', () => {
-      writeScratch(
-        `---
+    it.effect('does NOT HTML-escape values (markdown output, not HTML)', () =>
+      Effect.gen(function* () {
+        writeScratch(
+          `---
 name: scratch
 description: escape check
 requires:
   - DIFF
 ---
 {{DIFF}}`
-      );
-      const out = renderPrompt({
-        name: SCRATCH,
-        vars: { DIFF: '<script>alert("xss")</script> & "quoted"' },
-      });
-      expect(out).toBe('<script>alert("xss")</script> & "quoted"');
-    });
+        );
+        const out = yield* renderPrompt({
+          name: SCRATCH,
+          vars: { DIFF: '<script>alert("xss")</script> & "quoted"' },
+        });
+        expect(out).toBe('<script>alert("xss")</script> & "quoted"');
+      })
+    );
 
-    it('renders a section when the variable is a non-empty string and resolves the variable inside', () => {
-      writeScratch(
-        `---
+    it.effect('renders a section when the variable is a non-empty string and resolves the variable inside', () =>
+      Effect.gen(function* () {
+        writeScratch(
+          `---
 name: scratch
 description: section context
 optional:
@@ -158,16 +184,18 @@ optional:
 ---
 {{#BEADS}}Beads:
 {{BEADS}}{{/BEADS}}`
-      );
-      const out = renderPrompt({ name: SCRATCH, vars: { BEADS: '- bead-1\n- bead-2' } });
-      expect(out).toContain('Beads:');
-      expect(out).toContain('- bead-1');
-      expect(out).toContain('- bead-2');
-    });
+        );
+        const out = yield* renderPrompt({ name: SCRATCH, vars: { BEADS: '- bead-1\n- bead-2' } });
+        expect(out).toContain('Beads:');
+        expect(out).toContain('- bead-1');
+        expect(out).toContain('- bead-2');
+      })
+    );
 
-    it('hides a section when the variable is an empty string', () => {
-      writeScratch(
-        `---
+    it.effect('hides a section when the variable is an empty string', () =>
+      Effect.gen(function* () {
+        writeScratch(
+          `---
 name: scratch
 description: empty section
 optional:
@@ -176,30 +204,34 @@ optional:
 before
 {{#BEADS}}should not appear{{/BEADS}}
 after`
-      );
-      const out = renderPrompt({ name: SCRATCH, vars: { BEADS: '' } });
-      expect(out).not.toContain('should not appear');
-      expect(out).toContain('before');
-      expect(out).toContain('after');
-    });
+        );
+        const out = yield* renderPrompt({ name: SCRATCH, vars: { BEADS: '' } });
+        expect(out).not.toContain('should not appear');
+        expect(out).toContain('before');
+        expect(out).toContain('after');
+      })
+    );
 
-    it('hides a section when the variable is undefined and the field is optional', () => {
-      writeScratch(
-        `---
+    it.effect('hides a section when the variable is undefined and the field is optional', () =>
+      Effect.gen(function* () {
+        writeScratch(
+          `---
 name: scratch
 description: undefined section
 optional:
   - BEADS
 ---
 {{#BEADS}}hidden{{/BEADS}}done`
-      );
-      const out = renderPrompt({ name: SCRATCH, vars: {} });
-      expect(out).toBe('done');
-    });
+        );
+        const out = yield* renderPrompt({ name: SCRATCH, vars: {} });
+        expect(out).toBe('done');
+      })
+    );
 
-    it('switches between LOCAL and REMOTE blocks via boolean flags', () => {
-      writeScratch(
-        `---
+    it.effect('switches between LOCAL and REMOTE blocks via boolean flags', () =>
+      Effect.gen(function* () {
+        writeScratch(
+          `---
 name: scratch
 description: env switching
 optional:
@@ -207,59 +239,65 @@ optional:
   - REMOTE
 ---
 {{#LOCAL}}local-only{{/LOCAL}}{{#REMOTE}}remote-only{{/REMOTE}}`
-      );
-      const local = renderPrompt({ name: SCRATCH, vars: { LOCAL: true, REMOTE: false } });
-      const remote = renderPrompt({ name: SCRATCH, vars: { LOCAL: false, REMOTE: true } });
-      expect(local).toBe('local-only');
-      expect(remote).toBe('remote-only');
-    });
+        );
+        const local = yield* renderPrompt({ name: SCRATCH, vars: { LOCAL: true, REMOTE: false } });
+        const remote = yield* renderPrompt({ name: SCRATCH, vars: { LOCAL: false, REMOTE: true } });
+        expect(local).toBe('local-only');
+        expect(remote).toBe('remote-only');
+      })
+    );
 
-    it('renders Playwright isolation guidance in the uat-agent prompt', () => {
-      const out = renderPrompt({
-        name: 'uat-agent',
-        vars: {
-          ISSUE_ID: 'PAN-611',
-          WORKSPACE: '/workspace',
-          FRONTEND_URL: 'https://pan.localhost',
-          API_URL: 'https://pan.localhost/api',
-          TEST_TOKEN_API: 'test-key',
-        },
-      });
+    it.effect('renders Playwright isolation guidance in the uat-agent prompt', () =>
+      Effect.gen(function* () {
+        const out = yield* renderPrompt({
+          name: 'uat-agent',
+          vars: {
+            ISSUE_ID: 'PAN-611',
+            WORKSPACE: '/workspace',
+            FRONTEND_URL: 'https://pan.localhost',
+            API_URL: 'https://pan.localhost/api',
+            TEST_TOKEN_API: 'test-key',
+          },
+        });
 
-      expect(out).toContain('## Playwright Isolation');
-      expect(out).toContain('isolated Playwright browser instance/profile');
-      expect(out).toContain("Never rely on another agent's browser session");
-    });
+        expect(out).toContain('## Playwright Isolation');
+        expect(out).toContain('isolated Playwright browser instance/profile');
+        expect(out).toContain("Never rely on another agent's browser session");
+      })
+    );
 
-    it('renders Playwright isolation guidance in the work prompt', () => {
-      const out = renderPrompt({
-        name: 'work',
-        vars: {
-          ISSUE_ID: 'PAN-611',
-          ISSUE_ID_LOWER: 'pan-611',
-          WORKSPACE_PATH: '/workspace',
-          LOCAL: true,
-          REMOTE: false,
-          PROJECT_ROOT: '/project',
-          BEADS_TASKS: '',
-          STITCH_DESIGNS: '',
-          POLYREPO_CONTEXT: '',
-          PENDING_FEEDBACK: '',
-          NEW_TRACKER_CONTEXT: '',
-          TLDR_AVAILABLE: false,
-        },
-      });
+    it.effect('renders Playwright isolation guidance in the work prompt', () =>
+      Effect.gen(function* () {
+        const out = yield* renderPrompt({
+          name: 'work',
+          vars: {
+            ISSUE_ID: 'PAN-611',
+            ISSUE_ID_LOWER: 'pan-611',
+            WORKSPACE_PATH: '/workspace',
+            LOCAL: true,
+            REMOTE: false,
+            PROJECT_ROOT: '/project',
+            BEADS_TASKS: '',
+            STITCH_DESIGNS: '',
+            POLYREPO_CONTEXT: '',
+            PENDING_FEEDBACK: '',
+            NEW_TRACKER_CONTEXT: '',
+            TLDR_AVAILABLE: false,
+          },
+        });
 
-      expect(out).toContain('## Playwright Isolation');
-      expect(out).toContain('isolated browser instance/profile');
-      expect(out).toContain("Never rely on another agent's browser session");
-    });
+        expect(out).toContain('## Playwright Isolation');
+        expect(out).toContain('isolated browser instance/profile');
+        expect(out).toContain("Never rely on another agent's browser session");
+      })
+    );
   });
 
   describe('fail-loud validation', () => {
-    it('throws when a required variable is missing', () => {
-      writeScratch(
-        `---
+    it.effect('fails when a required variable is missing', () =>
+      Effect.gen(function* () {
+        writeScratch(
+          `---
 name: scratch
 description: requires test
 requires:
@@ -267,54 +305,63 @@ requires:
   - WORKSPACE_PATH
 ---
 {{ISSUE_ID}} {{WORKSPACE_PATH}}`
-      );
-      expect(() => renderPrompt({ name: SCRATCH, vars: { ISSUE_ID: 'PAN-1' } })).toThrow(
-        /requires variables that are missing: WORKSPACE_PATH/
-      );
-    });
+        );
+        const err = yield* Effect.flip(
+          renderPrompt({ name: SCRATCH, vars: { ISSUE_ID: 'PAN-1' } })
+        );
+        expect(err.message).toMatch(/requires variables that are missing: WORKSPACE_PATH/);
+      })
+    );
 
-    it('throws when an unknown variable is passed', () => {
-      writeScratch(
-        `---
+    it.effect('fails when an unknown variable is passed', () =>
+      Effect.gen(function* () {
+        writeScratch(
+          `---
 name: scratch
 description: unknown var test
 requires:
   - ISSUE_ID
 ---
 {{ISSUE_ID}}`
-      );
-      expect(() =>
-        renderPrompt({ name: SCRATCH, vars: { ISSUE_ID: 'PAN-1', WROKSPACE: '/tmp' } })
-      ).toThrow(/unknown variables: WROKSPACE/);
-    });
+        );
+        const err = yield* Effect.flip(
+          renderPrompt({ name: SCRATCH, vars: { ISSUE_ID: 'PAN-1', WROKSPACE: '/tmp' } })
+        );
+        expect(err.message).toMatch(/unknown variables: WROKSPACE/);
+      })
+    );
 
-    it('accepts an empty-string value for a required variable (treated as defined)', () => {
-      writeScratch(
-        `---
+    it.effect('accepts an empty-string value for a required variable (treated as defined)', () =>
+      Effect.gen(function* () {
+        writeScratch(
+          `---
 name: scratch
 description: empty required
 requires:
   - VALUE
 ---
 [{{VALUE}}]`
-      );
-      const out = renderPrompt({ name: SCRATCH, vars: { VALUE: '' } });
-      expect(out).toBe('[]');
-    });
+        );
+        const out = yield* renderPrompt({ name: SCRATCH, vars: { VALUE: '' } });
+        expect(out).toBe('[]');
+      })
+    );
 
-    it('accepts a boolean false value for a required variable', () => {
-      writeScratch(
-        `---
+    it.effect('accepts a boolean false value for a required variable', () =>
+      Effect.gen(function* () {
+        writeScratch(
+          `---
 name: scratch
 description: false required
 requires:
   - FLAG
 ---
 {{#FLAG}}on{{/FLAG}}{{^FLAG}}off{{/FLAG}}`
-      );
-      const out = renderPrompt({ name: SCRATCH, vars: { FLAG: false } });
-      expect(out).toBe('off');
-    });
+        );
+        const out = yield* renderPrompt({ name: SCRATCH, vars: { FLAG: false } });
+        expect(out).toBe('off');
+      })
+    );
   });
 
   describe('live review template', () => {
@@ -329,26 +376,30 @@ requires:
       API_URL: 'http://localhost:3011',
     };
 
-    it('reports stale branches through specialists/done instead of direct review status updates', () => {
-      const out = renderPrompt({
-        name: 'review',
-        vars: baseReviewVars,
-      });
-      expect(out).toContain('curl -s -X POST http://localhost:3011/api/specialists/done');
-      expect(out).toContain('"specialist":"review","issueId":"PAN-999","status":"passed"');
-      expect(out).not.toContain('/api/review/PAN-999/status');
-      expect(out).not.toContain('pan tell PAN-999');
-    });
+    it.effect('reports stale branches through specialists/done instead of direct review status updates', () =>
+      Effect.gen(function* () {
+        const out = yield* renderPrompt({
+          name: 'review',
+          vars: baseReviewVars,
+        });
+        expect(out).toContain('curl -s -X POST http://localhost:3011/api/specialists/done');
+        expect(out).toContain('"specialist":"review","issueId":"PAN-999","status":"passed"');
+        expect(out).not.toContain('/api/review/PAN-999/status');
+        expect(out).not.toContain('pan tell PAN-999');
+      })
+    );
 
-    it('reports blocked review results through specialists/done instead of pan tell', () => {
-      const out = renderPrompt({
-        name: 'review',
-        vars: baseReviewVars,
-      });
-      expect(out).toContain('"specialist":"review","issueId":"PAN-999","status":"failed"');
-      expect(out).toContain('Do NOT message the work agent directly');
-      expect(out).not.toContain('pan tell PAN-999');
-    });
+    it.effect('reports blocked review results through specialists/done instead of pan tell', () =>
+      Effect.gen(function* () {
+        const out = yield* renderPrompt({
+          name: 'review',
+          vars: baseReviewVars,
+        });
+        expect(out).toContain('"specialist":"review","issueId":"PAN-999","status":"failed"');
+        expect(out).toContain('Do NOT message the work agent directly');
+        expect(out).not.toContain('pan tell PAN-999');
+      })
+    );
   });
 
   describe('live merge template', () => {
@@ -360,56 +411,64 @@ requires:
       API_URL: 'http://localhost:3011',
     };
 
-    it('renders push+build flow when DO_PUSH and DO_BUILD are true', () => {
-      const out = renderPrompt({
-        name: 'merge',
-        vars: { ...baseVars, DO_PUSH: true, DO_BUILD: true },
-      });
-      expect(out).toContain('git push origin main');
-      expect(out).toContain('PHASE 4');
-      expect(out).toContain('Build the project');
-      expect(out).toContain('curl -s -X POST http://localhost:3011/api/specialists/done');
-      expect(out).not.toContain('Do NOT push');
-    });
+    it.effect('renders push+build flow when DO_PUSH and DO_BUILD are true', () =>
+      Effect.gen(function* () {
+        const out = yield* renderPrompt({
+          name: 'merge',
+          vars: { ...baseVars, DO_PUSH: true, DO_BUILD: true },
+        });
+        expect(out).toContain('git push origin main');
+        expect(out).toContain('PHASE 4');
+        expect(out).toContain('Build the project');
+        expect(out).toContain('curl -s -X POST http://localhost:3011/api/specialists/done');
+        expect(out).not.toContain('Do NOT push');
+      })
+    );
 
-    it('renders validation-only flow when DO_PUSH is false', () => {
-      const out = renderPrompt({
-        name: 'merge',
-        vars: { ...baseVars, DO_PUSH: false, DO_BUILD: false },
-      });
-      expect(out).toContain('Do NOT push to main');
-      expect(out).toContain('NEVER push to `main`');
-      expect(out).not.toContain('13. PUSH');
-      expect(out).not.toContain('Build the project');
-    });
+    it.effect('renders validation-only flow when DO_PUSH is false', () =>
+      Effect.gen(function* () {
+        const out = yield* renderPrompt({
+          name: 'merge',
+          vars: { ...baseVars, DO_PUSH: false, DO_BUILD: false },
+        });
+        expect(out).toContain('Do NOT push to main');
+        expect(out).toContain('NEVER push to `main`');
+        expect(out).not.toContain('13. PUSH');
+        expect(out).not.toContain('Build the project');
+      })
+    );
 
-    it('hides done-report when SKIP_DONE_REPORT is true', () => {
-      const out = renderPrompt({
-        name: 'merge',
-        vars: {
-          ...baseVars,
-          DO_PUSH: true,
-          DO_BUILD: true,
-          SKIP_DONE_REPORT: true,
-        },
-      });
-      expect(out).toContain('DO NOT call `/api/specialists/done`');
-      expect(out).not.toContain('curl -s -X POST http://localhost:3011/api/specialists/done');
-    });
+    it.effect('hides done-report when SKIP_DONE_REPORT is true', () =>
+      Effect.gen(function* () {
+        const out = yield* renderPrompt({
+          name: 'merge',
+          vars: {
+            ...baseVars,
+            DO_PUSH: true,
+            DO_BUILD: true,
+            SKIP_DONE_REPORT: true,
+          },
+        });
+        expect(out).toContain('DO NOT call `/api/specialists/done`');
+        expect(out).not.toContain('curl -s -X POST http://localhost:3011/api/specialists/done');
+      })
+    );
 
-    it('renders polyrepo header when IS_POLYREPO is true', () => {
-      const out = renderPrompt({
-        name: 'merge',
-        vars: {
-          ...baseVars,
-          DO_PUSH: false,
-          DO_BUILD: false,
-          IS_POLYREPO: true,
-          POLYREPO_DIRS: 'frontend, backend',
-        },
-      });
-      expect(out).toContain('POLYREPO project');
-      expect(out).toContain('frontend, backend');
-    });
+    it.effect('renders polyrepo header when IS_POLYREPO is true', () =>
+      Effect.gen(function* () {
+        const out = yield* renderPrompt({
+          name: 'merge',
+          vars: {
+            ...baseVars,
+            DO_PUSH: false,
+            DO_BUILD: false,
+            IS_POLYREPO: true,
+            POLYREPO_DIRS: 'frontend, backend',
+          },
+        });
+        expect(out).toContain('POLYREPO project');
+        expect(out).toContain('frontend, backend');
+      })
+    );
   });
 });

--- a/src/lib/cloister/handoff-context.ts
+++ b/src/lib/cloister/handoff-context.ts
@@ -8,6 +8,7 @@ import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { Effect } from 'effect';
 import type { TokenUsage } from '../runtimes/types.js';
 import type { ComplexityLevel } from './complexity.js';
 import type { AgentState } from '../agents.js';
@@ -335,7 +336,7 @@ export function buildHandoffPrompt(
   context: HandoffContext,
   additionalInstructions?: string
 ): string {
-  return renderPrompt({
+  return Effect.runSync(renderPrompt({
     name: 'handoff-to-work',
     vars: {
       ISSUE_ID: context.issueId,
@@ -344,5 +345,5 @@ export function buildHandoffPrompt(
       HANDOFF_CONTEXT: serializeHandoffContext(context),
       ADDITIONAL_INSTRUCTIONS_BLOCK: additionalInstructions || '',
     },
-  });
+  }));
 }

--- a/src/lib/cloister/prompts.ts
+++ b/src/lib/cloister/prompts.ts
@@ -3,6 +3,7 @@ import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import Mustache from 'mustache';
 import yaml from 'js-yaml';
+import { Data, Effect } from 'effect';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -51,79 +52,90 @@ interface ParsedPrompt {
 
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
 
-export class PromptError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'PromptError';
-  }
-}
+export class PromptError extends Data.TaggedError('PromptError')<{
+  readonly message: string;
+}> {}
 
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((v) => typeof v === 'string');
 }
 
-function parsePrompt(name: string): ParsedPrompt {
-  const path = join(resolvePromptsDir(), `${name}.md`);
-  let raw: string;
-  try {
-    raw = readFileSync(path, 'utf-8');
-  } catch (e) {
-    throw new PromptError(
-      `Failed to load prompt template "${name}" from ${path}: ${(e as Error).message}`
-    );
-  }
+function parsePrompt(name: string): Effect.Effect<ParsedPrompt, PromptError> {
+  return Effect.gen(function* () {
+    const path = join(resolvePromptsDir(), `${name}.md`);
 
-  const match = FRONTMATTER_RE.exec(raw);
-  if (!match) {
-    throw new PromptError(
-      `Prompt template "${name}" at ${path} is missing YAML frontmatter ` +
-        `(expected "---\\n<yaml>\\n---\\n<body>" header).`
-    );
-  }
+    const raw = yield* Effect.try({
+      try: () => readFileSync(path, 'utf-8'),
+      catch: (e) =>
+        new PromptError({
+          message: `Failed to load prompt template "${name}" from ${path}: ${(e as Error).message}`,
+        }),
+    });
 
-  let parsed: unknown;
-  try {
-    parsed = yaml.load(match[1]);
-  } catch (e) {
-    throw new PromptError(
-      `Prompt template "${name}" has invalid YAML frontmatter: ${(e as Error).message}`
-    );
-  }
+    const match = FRONTMATTER_RE.exec(raw);
+    if (!match) {
+      return yield* Effect.fail(
+        new PromptError({
+          message:
+            `Prompt template "${name}" at ${path} is missing YAML frontmatter ` +
+            `(expected "---\\n<yaml>\\n---\\n<body>" header).`,
+        })
+      );
+    }
 
-  if (!parsed || typeof parsed !== 'object') {
-    throw new PromptError(`Prompt template "${name}" frontmatter must be a YAML mapping.`);
-  }
-  const fm = parsed as Record<string, unknown>;
+    const parsed = yield* Effect.try({
+      try: () => yaml.load(match[1]),
+      catch: (e) =>
+        new PromptError({
+          message: `Prompt template "${name}" has invalid YAML frontmatter: ${(e as Error).message}`,
+        }),
+    });
 
-  if (typeof fm.name !== 'string' || !fm.name) {
-    throw new PromptError(
-      `Prompt template "${name}" frontmatter is missing required field "name".`
-    );
-  }
-  if (typeof fm.description !== 'string' || !fm.description) {
-    throw new PromptError(
-      `Prompt template "${name}" frontmatter is missing required field "description".`
-    );
-  }
-  if (fm.requires !== undefined && !isStringArray(fm.requires)) {
-    throw new PromptError(
-      `Prompt template "${name}" frontmatter "requires" must be a list of strings.`
-    );
-  }
-  if (fm.optional !== undefined && !isStringArray(fm.optional)) {
-    throw new PromptError(
-      `Prompt template "${name}" frontmatter "optional" must be a list of strings.`
-    );
-  }
+    if (!parsed || typeof parsed !== 'object') {
+      return yield* Effect.fail(
+        new PromptError({ message: `Prompt template "${name}" frontmatter must be a YAML mapping.` })
+      );
+    }
+    const fm = parsed as Record<string, unknown>;
 
-  const frontmatter: PromptFrontmatter = {
-    name: fm.name,
-    description: fm.description,
-    requires: (fm.requires as string[] | undefined) ?? [],
-    optional: (fm.optional as string[] | undefined) ?? [],
-  };
+    if (typeof fm.name !== 'string' || !fm.name) {
+      return yield* Effect.fail(
+        new PromptError({
+          message: `Prompt template "${name}" frontmatter is missing required field "name".`,
+        })
+      );
+    }
+    if (typeof fm.description !== 'string' || !fm.description) {
+      return yield* Effect.fail(
+        new PromptError({
+          message: `Prompt template "${name}" frontmatter is missing required field "description".`,
+        })
+      );
+    }
+    if (fm.requires !== undefined && !isStringArray(fm.requires)) {
+      return yield* Effect.fail(
+        new PromptError({
+          message: `Prompt template "${name}" frontmatter "requires" must be a list of strings.`,
+        })
+      );
+    }
+    if (fm.optional !== undefined && !isStringArray(fm.optional)) {
+      return yield* Effect.fail(
+        new PromptError({
+          message: `Prompt template "${name}" frontmatter "optional" must be a list of strings.`,
+        })
+      );
+    }
 
-  return { frontmatter, body: match[2], path };
+    const frontmatter: PromptFrontmatter = {
+      name: fm.name,
+      description: fm.description,
+      requires: (fm.requires as string[] | undefined) ?? [],
+      optional: (fm.optional as string[] | undefined) ?? [],
+    };
+
+    return { frontmatter, body: match[2], path };
+  });
 }
 
 export interface RenderPromptOptions {
@@ -131,40 +143,48 @@ export interface RenderPromptOptions {
   vars: Record<string, unknown>;
 }
 
-export function renderPrompt({ name, vars }: RenderPromptOptions): string {
-  const { frontmatter, body, path } = parsePrompt(name);
+export function renderPrompt({ name, vars }: RenderPromptOptions): Effect.Effect<string, PromptError> {
+  return Effect.gen(function* () {
+    const { frontmatter, body, path } = yield* parsePrompt(name);
 
-  const missing: string[] = [];
-  for (const key of frontmatter.requires) {
-    const value = vars[key];
-    if (value === undefined || value === null) {
-      missing.push(key);
+    const missing: string[] = [];
+    for (const key of frontmatter.requires) {
+      const value = vars[key];
+      if (value === undefined || value === null) {
+        missing.push(key);
+      }
     }
-  }
-  if (missing.length > 0) {
-    throw new PromptError(
-      `Prompt "${name}" (${path}) requires variables that are missing: ${missing.join(', ')}.\n` +
-        `Provided: ${Object.keys(vars).join(', ') || '(none)'}`
-    );
-  }
-
-  const allowed = new Set([...frontmatter.requires, ...frontmatter.optional]);
-  const unknown: string[] = [];
-  for (const key of Object.keys(vars)) {
-    if (!allowed.has(key)) {
-      unknown.push(key);
+    if (missing.length > 0) {
+      return yield* Effect.fail(
+        new PromptError({
+          message:
+            `Prompt "${name}" (${path}) requires variables that are missing: ${missing.join(', ')}.\n` +
+            `Provided: ${Object.keys(vars).join(', ') || '(none)'}`,
+        })
+      );
     }
-  }
-  if (unknown.length > 0) {
-    throw new PromptError(
-      `Prompt "${name}" (${path}) was passed unknown variables: ${unknown.join(', ')}.\n` +
-        `Declare them in the template's "requires" or "optional" frontmatter, or remove them from the call site.`
-    );
-  }
 
-  return Mustache.render(body, vars);
+    const allowed = new Set([...frontmatter.requires, ...frontmatter.optional]);
+    const unknown: string[] = [];
+    for (const key of Object.keys(vars)) {
+      if (!allowed.has(key)) {
+        unknown.push(key);
+      }
+    }
+    if (unknown.length > 0) {
+      return yield* Effect.fail(
+        new PromptError({
+          message:
+            `Prompt "${name}" (${path}) was passed unknown variables: ${unknown.join(', ')}.\n` +
+            `Declare them in the template's "requires" or "optional" frontmatter, or remove them from the call site.`,
+        })
+      );
+    }
+
+    return Mustache.render(body, vars);
+  });
 }
 
-export function loadPromptFrontmatter(name: string): PromptFrontmatter {
-  return parsePrompt(name).frontmatter;
+export function loadPromptFrontmatter(name: string): Effect.Effect<PromptFrontmatter, PromptError> {
+  return parsePrompt(name).pipe(Effect.map(({ frontmatter }) => frontmatter));
 }

--- a/src/lib/cloister/specialists.ts
+++ b/src/lib/cloister/specialists.ts
@@ -27,7 +27,6 @@ import { getSpecialistHarness } from './router.js';
 import { sendKeysAsync, capturePaneAsync, waitForClaudePrompt, confirmDelivery, createSessionAsync, killSessionAsync, buildTmuxCommandString, listPaneValuesAsync, listSessionNamesAsync, sessionExistsAsync } from '../tmux.js';
 import { notifyPipeline } from '../pipeline-notifier.js';
 import { isTaskReady } from './task-readiness.js';
-import { renderPrompt } from './prompts.js';
 
 const execAsync = promisify(exec);
 

--- a/src/lib/cloister/work-agent-prompt.ts
+++ b/src/lib/cloister/work-agent-prompt.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { join, dirname } from 'path';
+import { Effect } from 'effect';
 import { PAN_DIRNAME } from '../pan-dir/types.js';
 import { readContinueStateAsync, type ContinueFeedbackEntry } from '../vbrief/continue-state.js';
 import { renderPrompt } from './prompts.js';
@@ -58,7 +59,7 @@ export async function buildWorkAgentPrompt(ctx: WorkAgentPromptContext): Promise
     pendingFeedbackStr = readPendingFeedback(ctx.workspacePath);
   }
 
-  return renderPrompt({
+  return Effect.runSync(renderPrompt({
     name: 'work',
     vars: {
       ISSUE_ID: ctx.issueId,
@@ -75,7 +76,7 @@ export async function buildWorkAgentPrompt(ctx: WorkAgentPromptContext): Promise
       NEW_TRACKER_CONTEXT: ctx.trackerContext || '',
       TLDR_AVAILABLE: existsSync(join(ctx.workspacePath, '.venv')),
     },
-  });
+  }));
 }
 
 

--- a/src/lib/conversations/__tests__/embeddings.test.ts
+++ b/src/lib/conversations/__tests__/embeddings.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { Effect } from 'effect';
 
 import { normalizeEmbedding } from '../embeddings/providers.js';
 import { buildEmbeddingText, embedSessions } from '../embeddings/index.js';
@@ -168,14 +169,13 @@ describe('buildEmbeddingText', () => {
 
 // ─── embedSessions ────────────────────────────────────────────────────────────
 
-const mockEmbedFn = async (_provider: unknown, opts: { text: string }): Promise<EmbeddingResult> => {
-  // Return a deterministic fake embedding based on text length
+const mockEmbedFn = (_provider: unknown, opts: { text: string }): Effect.Effect<EmbeddingResult> => {
   const dim = 8;
   const values = Array.from({ length: dim }, (_, i) => (opts.text.length + i) / 1000);
-  return {
+  return Effect.succeed({
     embedding: new Float32Array(values),
     model: 'text-embedding-3-small',
-  };
+  });
 };
 
 describe('embedSessions', () => {
@@ -225,10 +225,9 @@ describe('embedSessions', () => {
 
   it('stores OpenAI text-embedding-3-small embeddings as 1536 dimensions', async () => {
     const session = seedEnrichedSession(1);
-    const embedFn = vi.fn(async (_provider: unknown, opts: { model: string }): Promise<EmbeddingResult> => ({
-      embedding: new Float32Array(1536).fill(0.1),
-      model: opts.model,
-    }));
+    const embedFn = vi.fn((_provider: unknown, opts: { model: string }): Effect.Effect<EmbeddingResult> =>
+      Effect.succeed({ embedding: new Float32Array(1536).fill(0.1), model: opts.model }),
+    );
 
     const result = await embedSessions({
       model: 'text-embedding-3-small',
@@ -244,10 +243,9 @@ describe('embedSessions', () => {
 
   it('uses nomic-embed-text as the Ollama provider default', async () => {
     const session = seedEnrichedSession(1);
-    const embedFn = vi.fn(async (_provider: unknown, opts: { model: string }): Promise<EmbeddingResult> => ({
-      embedding: new Float32Array(768).fill(0.1),
-      model: opts.model,
-    }));
+    const embedFn = vi.fn((_provider: unknown, opts: { model: string }): Effect.Effect<EmbeddingResult> =>
+      Effect.succeed({ embedding: new Float32Array(768).fill(0.1), model: opts.model }),
+    );
 
     const result = await embedSessions({
       provider: 'ollama',
@@ -275,10 +273,9 @@ describe('embedSessions', () => {
 
   it('stores Voyage voyage-code-3 embeddings as 1024 dimensions', async () => {
     const session = seedEnrichedSession(1);
-    const embedFn = vi.fn(async (_provider: unknown, opts: { model: string }): Promise<EmbeddingResult> => ({
-      embedding: new Float32Array(1024).fill(0.1),
-      model: opts.model,
-    }));
+    const embedFn = vi.fn((_provider: unknown, opts: { model: string }): Effect.Effect<EmbeddingResult> =>
+      Effect.succeed({ embedding: new Float32Array(1024).fill(0.1), model: opts.model }),
+    );
 
     const result = await embedSessions({
       provider: 'voyage',

--- a/src/lib/conversations/embeddings/index.ts
+++ b/src/lib/conversations/embeddings/index.ts
@@ -19,6 +19,7 @@ import { embed } from './providers.js';
 import { getConversationsConfig } from '../../config-yaml.js';
 import type { RuntimeConversationsConfig } from '../../config-yaml.js';
 import type { EmbeddingProviderName } from './providers.js';
+import { Effect } from 'effect';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -160,12 +161,12 @@ export async function embedSessions(opts: EmbedSessionsOptions = {}): Promise<Em
     }
 
     try {
-      const embedResult = await embedFn(provider, {
+      const embedResult = await Effect.runPromise(embedFn(provider, {
         text,
         model,
         baseUrl: opts.ollamaBaseUrl,
         apiKey: provider === 'ollama' ? undefined : config.apiKeys?.[provider],
-      });
+      }));
 
       insertEmbedding(session.id, model, embedResult.embedding);
       result.embedded++;

--- a/src/lib/conversations/embeddings/providers.ts
+++ b/src/lib/conversations/embeddings/providers.ts
@@ -9,6 +9,9 @@
  * All providers return a normalized Float32Array.
  */
 
+import { Data, Effect } from 'effect';
+import { ConfigError } from '../../errors.js';
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export type EmbeddingProviderName = 'openai' | 'voyage' | 'ollama';
@@ -25,6 +28,15 @@ export interface EmbedOptions {
   baseUrl?: string;    // Ollama only
   apiKey?: string;     // Override env var
 }
+
+// ─── Errors ───────────────────────────────────────────────────────────────────
+
+export class EmbedHttpError extends Data.TaggedError('EmbedHttpError')<{
+  readonly provider: EmbeddingProviderName;
+  readonly status: number;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
 
 // ─── Utility ──────────────────────────────────────────────────────────────────
 
@@ -46,77 +58,103 @@ export function normalizeEmbedding(values: number[]): Float32Array {
 
 const OPENAI_EMBED_URL = 'https://api.openai.com/v1/embeddings';
 
-export async function embedOpenAI(opts: EmbedOptions): Promise<EmbeddingResult> {
-  const apiKey = opts.apiKey ?? process.env.OPENAI_API_KEY;
-  if (!apiKey) throw new Error('OPENAI_API_KEY is not set');
+export function embedOpenAI(opts: EmbedOptions): Effect.Effect<EmbeddingResult, ConfigError | EmbedHttpError> {
+  return Effect.gen(function* () {
+    const apiKey = opts.apiKey ?? process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      return yield* Effect.fail(new ConfigError({ message: 'OPENAI_API_KEY is not set' }));
+    }
 
-  const resp = await fetch(OPENAI_EMBED_URL, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      model: opts.model,
-      input: opts.text,
-      encoding_format: 'float',
-    }),
+    const resp = yield* Effect.tryPromise({
+      try: () =>
+        fetch(OPENAI_EMBED_URL, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            model: opts.model,
+            input: opts.text,
+            encoding_format: 'float',
+          }),
+        }),
+      catch: (cause) =>
+        new EmbedHttpError({ provider: 'openai', status: 0, message: `Fetch failed: ${String(cause)}`, cause }),
+    });
+
+    if (!resp.ok) {
+      const body = yield* Effect.tryPromise({
+        try: () => resp.text(),
+        catch: () => new EmbedHttpError({ provider: 'openai', status: resp.status, message: 'Failed to read error body' }),
+      });
+      return yield* Effect.fail(new EmbedHttpError({ provider: 'openai', status: resp.status, message: body.slice(0, 200) }));
+    }
+
+    const data = yield* Effect.tryPromise({
+      try: () =>
+        resp.json() as Promise<{
+          data: Array<{ embedding: number[] }>;
+          usage?: { total_tokens?: number };
+        }>,
+      catch: (cause) =>
+        new EmbedHttpError({ provider: 'openai', status: resp.status, message: 'Failed to parse response JSON', cause }),
+    });
+
+    const embedding = normalizeEmbedding(data.data[0].embedding);
+    return { embedding, model: opts.model, tokenCount: data.usage?.total_tokens };
   });
-
-  if (!resp.ok) {
-    const body = await resp.text();
-    throw new Error(`OpenAI embed error ${resp.status}: ${body.slice(0, 200)}`);
-  }
-
-  const data = (await resp.json()) as {
-    data: Array<{ embedding: number[] }>;
-    usage?: { total_tokens?: number };
-  };
-
-  const embedding = normalizeEmbedding(data.data[0].embedding);
-  return {
-    embedding,
-    model: opts.model,
-    tokenCount: data.usage?.total_tokens,
-  };
 }
 
 // ─── Voyage provider ──────────────────────────────────────────────────────────
 
 const VOYAGE_EMBED_URL = 'https://api.voyageai.com/v1/embeddings';
 
-export async function embedVoyage(opts: EmbedOptions): Promise<EmbeddingResult> {
-  const apiKey = opts.apiKey ?? process.env.VOYAGE_API_KEY;
-  if (!apiKey) throw new Error('VOYAGE_API_KEY is not set');
+export function embedVoyage(opts: EmbedOptions): Effect.Effect<EmbeddingResult, ConfigError | EmbedHttpError> {
+  return Effect.gen(function* () {
+    const apiKey = opts.apiKey ?? process.env.VOYAGE_API_KEY;
+    if (!apiKey) {
+      return yield* Effect.fail(new ConfigError({ message: 'VOYAGE_API_KEY is not set' }));
+    }
 
-  const resp = await fetch(VOYAGE_EMBED_URL, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      model: opts.model,
-      input: [opts.text],
-    }),
+    const resp = yield* Effect.tryPromise({
+      try: () =>
+        fetch(VOYAGE_EMBED_URL, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            model: opts.model,
+            input: [opts.text],
+          }),
+        }),
+      catch: (cause) =>
+        new EmbedHttpError({ provider: 'voyage', status: 0, message: `Fetch failed: ${String(cause)}`, cause }),
+    });
+
+    if (!resp.ok) {
+      const body = yield* Effect.tryPromise({
+        try: () => resp.text(),
+        catch: () => new EmbedHttpError({ provider: 'voyage', status: resp.status, message: 'Failed to read error body' }),
+      });
+      return yield* Effect.fail(new EmbedHttpError({ provider: 'voyage', status: resp.status, message: body.slice(0, 200) }));
+    }
+
+    const data = yield* Effect.tryPromise({
+      try: () =>
+        resp.json() as Promise<{
+          data: Array<{ embedding: number[] }>;
+          usage?: { total_tokens?: number };
+        }>,
+      catch: (cause) =>
+        new EmbedHttpError({ provider: 'voyage', status: resp.status, message: 'Failed to parse response JSON', cause }),
+    });
+
+    const embedding = normalizeEmbedding(data.data[0].embedding);
+    return { embedding, model: opts.model, tokenCount: data.usage?.total_tokens };
   });
-
-  if (!resp.ok) {
-    const body = await resp.text();
-    throw new Error(`Voyage embed error ${resp.status}: ${body.slice(0, 200)}`);
-  }
-
-  const data = (await resp.json()) as {
-    data: Array<{ embedding: number[] }>;
-    usage?: { total_tokens?: number };
-  };
-
-  const embedding = normalizeEmbedding(data.data[0].embedding);
-  return {
-    embedding,
-    model: opts.model,
-    tokenCount: data.usage?.total_tokens,
-  };
 }
 
 // ─── Ollama provider ──────────────────────────────────────────────────────────
@@ -125,27 +163,44 @@ const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434';
 
 const SAFE_OLLAMA_HOST_RE = /^https?:\/\/(localhost|127(?:\.\d+){3}|::1)(:\d+)?\/?$/;
 
-export async function embedOllama(opts: EmbedOptions): Promise<EmbeddingResult> {
-  const baseUrl = opts.baseUrl ?? process.env.OLLAMA_BASE_URL ?? DEFAULT_OLLAMA_BASE_URL;
-  if (!SAFE_OLLAMA_HOST_RE.test(baseUrl)) {
-    throw new Error(`Ollama baseUrl must be a localhost address (got: ${baseUrl})`);
-  }
-  const url = `${baseUrl.replace(/\/$/, '')}/api/embeddings`;
+export function embedOllama(opts: EmbedOptions): Effect.Effect<EmbeddingResult, ConfigError | EmbedHttpError> {
+  return Effect.gen(function* () {
+    const baseUrl = opts.baseUrl ?? process.env.OLLAMA_BASE_URL ?? DEFAULT_OLLAMA_BASE_URL;
+    if (!SAFE_OLLAMA_HOST_RE.test(baseUrl)) {
+      return yield* Effect.fail(
+        new ConfigError({ message: `Ollama baseUrl must be a localhost address (got: ${baseUrl})` }),
+      );
+    }
+    const url = `${baseUrl.replace(/\/$/, '')}/api/embeddings`;
 
-  const resp = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ model: opts.model, prompt: opts.text }),
+    const resp = yield* Effect.tryPromise({
+      try: () =>
+        fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ model: opts.model, prompt: opts.text }),
+        }),
+      catch: (cause) =>
+        new EmbedHttpError({ provider: 'ollama', status: 0, message: `Fetch failed: ${String(cause)}`, cause }),
+    });
+
+    if (!resp.ok) {
+      const body = yield* Effect.tryPromise({
+        try: () => resp.text(),
+        catch: () => new EmbedHttpError({ provider: 'ollama', status: resp.status, message: 'Failed to read error body' }),
+      });
+      return yield* Effect.fail(new EmbedHttpError({ provider: 'ollama', status: resp.status, message: body.slice(0, 200) }));
+    }
+
+    const data = yield* Effect.tryPromise({
+      try: () => resp.json() as Promise<{ embedding: number[] }>,
+      catch: (cause) =>
+        new EmbedHttpError({ provider: 'ollama', status: resp.status, message: 'Failed to parse response JSON', cause }),
+    });
+
+    const embedding = normalizeEmbedding(data.embedding);
+    return { embedding, model: opts.model };
   });
-
-  if (!resp.ok) {
-    const body = await resp.text();
-    throw new Error(`Ollama embed error ${resp.status}: ${body.slice(0, 200)}`);
-  }
-
-  const data = (await resp.json()) as { embedding: number[] };
-  const embedding = normalizeEmbedding(data.embedding);
-  return { embedding, model: opts.model };
 }
 
 // ─── Dispatcher ───────────────────────────────────────────────────────────────
@@ -153,10 +208,10 @@ export async function embedOllama(opts: EmbedOptions): Promise<EmbeddingResult> 
 /**
  * Call the appropriate embedding provider based on provider name.
  */
-export async function embed(
+export function embed(
   provider: EmbeddingProviderName,
   opts: EmbedOptions,
-): Promise<EmbeddingResult> {
+): Effect.Effect<EmbeddingResult, ConfigError | EmbedHttpError> {
   switch (provider) {
     case 'openai': return embedOpenAI(opts);
     case 'voyage': return embedVoyage(opts);

--- a/src/lib/conversations/search.ts
+++ b/src/lib/conversations/search.ts
@@ -31,6 +31,7 @@ import { embed } from './embeddings/providers.js';
 import type { EmbeddingProviderName } from './embeddings/providers.js';
 import { getConversationsConfig } from '../config-yaml.js';
 import type { RuntimeConversationsConfig } from '../config-yaml.js';
+import { Effect } from 'effect';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -202,11 +203,11 @@ export async function searchSessions(query: SearchQuery): Promise<SearchResult> 
   // ── Semantic free-text query path ─────────────────────────────────────────
   if (query.semanticQuery?.trim()) {
     const provider = (query.semanticProvider ?? config.embeddingProvider ?? 'openai') as EmbeddingProviderName;
-    const embedResult = await embed(provider, {
+    const embedResult = await Effect.runPromise(embed(provider, {
       text: query.semanticQuery.trim(),
       model: embeddingModel,
       apiKey: provider === 'ollama' ? undefined : config.apiKeys?.[provider],
-    });
+    }));
     const queryEmbedding = embedResult.embedding;
     const filter = normalizeFilter(query.filter, undefined, undefined);
     const ranked = topKCosine(queryEmbedding, embeddingModel, filter, limit, offset);

--- a/src/lib/dns.ts
+++ b/src/lib/dns.ts
@@ -13,6 +13,7 @@ import { join } from 'path';
 import { homedir } from 'os';
 import { exec, execSync } from 'child_process';
 import { promisify } from 'util';
+import { Effect } from 'effect';
 import { detectPlatform } from './platform.js';
 
 const execAsync = promisify(exec);
@@ -25,7 +26,7 @@ export type DnsSyncMethod = 'wsl2hosts' | 'hosts_file' | 'dnsmasq';
  * Detect the best DNS sync method for the current platform.
  */
 export function detectDnsSyncMethod(): DnsSyncMethod {
-  const plat = detectPlatform();
+  const plat = Effect.runSync(detectPlatform());
   switch (plat) {
     case 'wsl':
       return 'wsl2hosts';
@@ -155,7 +156,7 @@ export function removeHostsFileEntry(hostname: string): boolean {
 // ---- dnsmasq method ----
 
 function getDnsmasqConfigDir(): string {
-  const plat = detectPlatform();
+  const plat = Effect.runSync(detectPlatform());
   if (plat === 'darwin') {
     // Homebrew Intel location; Apple Silicon uses /opt/homebrew/etc/dnsmasq.d
     const brewPrefix = existsSync('/opt/homebrew') ? '/opt/homebrew' : '/usr/local';
@@ -204,7 +205,7 @@ export function removeDnsmasqEntry(hostname: string): boolean {
 }
 
 export async function restartDnsmasq(): Promise<boolean> {
-  const plat = detectPlatform();
+  const plat = Effect.runSync(detectPlatform());
   try {
     if (plat === 'darwin') {
       await execAsync('brew services restart dnsmasq');

--- a/src/lib/planning/spawn-planning-session.ts
+++ b/src/lib/planning/spawn-planning-session.ts
@@ -16,6 +16,7 @@ import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
+import { Effect } from 'effect';
 import { extractTeamPrefix, findProjectByTeam, findProjectByPath } from '../projects.js';
 import {
   sessionExistsAsync,
@@ -277,7 +278,7 @@ The user invoked \`pan plan --auto\`. Complete planning end-to-end without askin
 - Still produce the same complete vBRIEF and beads via \`pan plan finalize\` when no contradiction exists.
 ` : '';
 
-  return renderPrompt({
+  return Effect.runSync(renderPrompt({
     name: 'planning',
     vars: {
       ISSUE_ID: issue.identifier,
@@ -295,7 +296,7 @@ The user invoked \`pan plan --auto\`. Complete planning end-to-end without askin
       AUTO_SECTION: autoSection,
       PRD_REFERENCES: prdReferences,
     },
-  });
+  }));
 }
 
 /**

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -7,20 +7,26 @@
 
 import { readFileSync } from 'fs';
 import { platform } from 'os';
+import { Effect } from 'effect';
+import { FsError } from './errors.js';
 
 export type Platform = 'linux' | 'darwin' | 'win32' | 'wsl';
 
-export function detectPlatform(): Platform {
+export function detectPlatform(): Effect.Effect<Platform> {
   const os = platform();
   if (os === 'linux') {
-    // Check for WSL
-    try {
-      const release = readFileSync('/proc/version', 'utf8').toLowerCase();
-      if (release.includes('microsoft') || release.includes('wsl')) {
-        return 'wsl';
-      }
-    } catch {}
-    return 'linux';
+    return Effect.try({
+      try: () => readFileSync('/proc/version', 'utf8').toLowerCase(),
+      catch: (cause) => new FsError({ path: '/proc/version', operation: 'read', cause }),
+    }).pipe(
+      Effect.map((release): Platform => {
+        if (release.includes('microsoft') || release.includes('wsl')) {
+          return 'wsl';
+        }
+        return 'linux';
+      }),
+      Effect.catchTag('FsError', () => Effect.succeed<Platform>('linux')),
+    );
   }
-  return os as 'darwin' | 'win32';
+  return Effect.succeed(os as 'darwin' | 'win32');
 }

--- a/src/lib/prereqs/registry.ts
+++ b/src/lib/prereqs/registry.ts
@@ -10,6 +10,7 @@ import { mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import { Effect } from "effect";
 import { detectPlatform } from "../platform.js";
 
 const execAsync = promisify(exec);
@@ -111,7 +112,7 @@ export async function installTool(tool: PrereqTool): Promise<InstallResult> {
 // ─── Per-tool installers ──────────────────────────────────────────────────────
 
 async function installTmux(): Promise<InstallResult> {
-  const plat = detectPlatform();
+  const plat = Effect.runSync(detectPlatform());
   if (plat === "darwin") {
     await execAsync("brew install tmux", { timeout: 120000 });
   } else {
@@ -123,7 +124,7 @@ async function installTmux(): Promise<InstallResult> {
 }
 
 async function installTtyd(): Promise<InstallResult> {
-  const plat = detectPlatform();
+  const plat = Effect.runSync(detectPlatform());
   const binDir = join(homedir(), "bin");
   mkdirSync(binDir, { recursive: true });
   const ttydPath = join(binDir, "ttyd");
@@ -149,7 +150,7 @@ async function installTtyd(): Promise<InstallResult> {
 }
 
 async function installMkcert(): Promise<InstallResult> {
-  const plat = detectPlatform();
+  const plat = Effect.runSync(detectPlatform());
   if (plat === "darwin") {
     await execAsync("brew install mkcert", { timeout: 120000 });
     await execAsync("mkcert -install", { timeout: 30000 });
@@ -178,7 +179,7 @@ async function installMkcert(): Promise<InstallResult> {
 }
 
 async function installBeads(): Promise<InstallResult> {
-  const plat = detectPlatform();
+  const plat = Effect.runSync(detectPlatform());
   if (plat === "darwin") {
     try {
       await execAsync("brew install gastownhall/beads/bd", {
@@ -206,7 +207,7 @@ async function installBeads(): Promise<InstallResult> {
 }
 
 async function installOx(): Promise<InstallResult> {
-  const plat = detectPlatform();
+  const plat = Effect.runSync(detectPlatform());
   const arch = process.arch === "x64" ? "amd64" : process.arch;
   const platform = plat === "darwin" ? "darwin" : "linux";
   const binDir = join(homedir(), ".local", "bin");

--- a/src/lib/shadow-utils.ts
+++ b/src/lib/shadow-utils.ts
@@ -9,18 +9,28 @@ import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import chalk from 'chalk';
+import { Effect } from 'effect';
+import { FsError } from './errors.js';
 
 /**
- * Get Linear API key from environment or config file
+ * Get Linear API key from environment or config file.
+ * Falls back to process.env.LINEAR_API_KEY if the config file is absent or unreadable.
  */
-export function getLinearApiKey(): string | null {
+export function getLinearApiKey(): Effect.Effect<string | null> {
   const envFile = join(homedir(), '.panopticon.env');
-  if (existsSync(envFile)) {
-    const content = readFileSync(envFile, 'utf-8');
-    const match = content.match(/LINEAR_API_KEY=(.+)/);
-    if (match) return match[1].trim();
+  if (!existsSync(envFile)) {
+    return Effect.succeed(process.env.LINEAR_API_KEY ?? null);
   }
-  return process.env.LINEAR_API_KEY || null;
+  return Effect.try({
+    try: () => {
+      const content = readFileSync(envFile, 'utf-8');
+      const match = content.match(/LINEAR_API_KEY=(.+)/);
+      return match ? match[1].trim() : (process.env.LINEAR_API_KEY ?? null);
+    },
+    catch: (cause) => new FsError({ path: envFile, operation: 'read', cause }),
+  }).pipe(
+    Effect.catchTag('FsError', () => Effect.succeed(process.env.LINEAR_API_KEY ?? null)),
+  );
 }
 
 /**

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -1,6 +1,9 @@
-import { execSync } from 'child_process';
 import { mkdirSync } from 'fs';
 import { dirname } from 'path';
+import { Effect, Stream } from 'effect';
+import { ChildProcess } from 'effect/unstable/process';
+import { ChildProcessSpawner } from 'effect/unstable/process/ChildProcessSpawner';
+import { FsError, GitError } from './errors.js';
 
 export interface WorktreeInfo {
   path: string;
@@ -9,71 +12,111 @@ export interface WorktreeInfo {
   prunable: boolean;
 }
 
-export function listWorktrees(repoPath: string): WorktreeInfo[] {
-  const output = execSync('git worktree list --porcelain', {
-    cwd: repoPath,
-    encoding: 'utf8',
+function gitRun(
+  args: ReadonlyArray<string>,
+  cwd: string,
+): Effect.Effect<string, GitError, ChildProcessSpawner> {
+  return Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner;
+    return yield* Effect.scoped(
+      Effect.gen(function* () {
+        const handle = yield* spawner
+          .spawn(ChildProcess.make('git', args, { cwd, stderr: 'ignore' }))
+          .pipe(
+            Effect.mapError(
+              (e) => new GitError({ command: ['git', ...args], stderr: '', exitCode: -1, cause: e }),
+            ),
+          );
+        const text = yield* Stream.runCollect(Stream.decodeText(handle.stdout)).pipe(
+          Effect.map((lines) => lines.join('')),
+          Effect.mapError(
+            (e) => new GitError({ command: ['git', ...args], stderr: '', exitCode: -1, cause: e }),
+          ),
+        );
+        const code = yield* handle.exitCode.pipe(
+          Effect.mapError(
+            (e) => new GitError({ command: ['git', ...args], stderr: '', exitCode: -1, cause: e }),
+          ),
+        );
+        if (Number(code) !== 0) {
+          return yield* Effect.fail(
+            new GitError({ command: ['git', ...args], stderr: '', exitCode: Number(code) }),
+          );
+        }
+        return text;
+      }),
+    );
   });
+}
 
-  const worktrees: WorktreeInfo[] = [];
-  let current: Partial<WorktreeInfo> = {};
+export function listWorktrees(
+  repoPath: string,
+): Effect.Effect<WorktreeInfo[], GitError, ChildProcessSpawner> {
+  return gitRun(['worktree', 'list', '--porcelain'], repoPath).pipe(
+    Effect.map((output) => {
+      const worktrees: WorktreeInfo[] = [];
+      let current: Partial<WorktreeInfo> = {};
 
-  for (const line of output.split('\n')) {
-    if (line.startsWith('worktree ')) {
+      for (const line of output.split('\n')) {
+        if (line.startsWith('worktree ')) {
+          if (current.path) worktrees.push(current as WorktreeInfo);
+          current = { path: line.slice(9), prunable: false };
+        } else if (line.startsWith('HEAD ')) {
+          current.head = line.slice(5);
+        } else if (line.startsWith('branch ')) {
+          current.branch = line.slice(7).replace('refs/heads/', '');
+        } else if (line === 'prunable') {
+          current.prunable = true;
+        }
+      }
       if (current.path) worktrees.push(current as WorktreeInfo);
-      current = { path: line.slice(9), prunable: false };
-    } else if (line.startsWith('HEAD ')) {
-      current.head = line.slice(5);
-    } else if (line.startsWith('branch ')) {
-      current.branch = line.slice(7).replace('refs/heads/', '');
-    } else if (line === 'prunable') {
-      current.prunable = true;
-    }
-  }
-  if (current.path) worktrees.push(current as WorktreeInfo);
-
-  return worktrees;
+      return worktrees;
+    }),
+  );
 }
 
 export function createWorktree(
   repoPath: string,
   targetPath: string,
-  branchName: string
-): void {
-  // Ensure parent directory exists
-  mkdirSync(dirname(targetPath), { recursive: true });
-
-  // Check if branch exists
-  try {
-    execSync(`git show-ref --verify --quiet refs/heads/${branchName}`, {
-      cwd: repoPath,
+  branchName: string,
+): Effect.Effect<void, FsError | GitError, ChildProcessSpawner> {
+  return Effect.gen(function* () {
+    yield* Effect.try({
+      try: () => mkdirSync(dirname(targetPath), { recursive: true }),
+      catch: (cause) => new FsError({ path: dirname(targetPath), operation: 'mkdir', cause }),
     });
-    // Branch exists, just add worktree
-    execSync(`git worktree add "${targetPath}" "${branchName}"`, {
-      cwd: repoPath,
-      stdio: 'pipe',
-    });
-  } catch {
-    // Branch doesn't exist, create it
-    execSync(`git worktree add -b "${branchName}" "${targetPath}"`, {
-      cwd: repoPath,
-      stdio: 'pipe',
-    });
-  }
 
-  // Configure beads role so agents don't get "beads.role not configured" warnings
-  try {
-    execSync('git config beads.role contributor', { cwd: targetPath, stdio: 'pipe' });
-  } catch { /* non-fatal */ }
-}
+    const branchExists = yield* gitRun(
+      ['show-ref', '--verify', '--quiet', `refs/heads/${branchName}`],
+      repoPath,
+    ).pipe(
+      Effect.map(() => true),
+      Effect.catchTag('GitError', () => Effect.succeed(false)),
+    );
 
-export function removeWorktree(repoPath: string, worktreePath: string): void {
-  execSync(`git worktree remove "${worktreePath}" --force`, {
-    cwd: repoPath,
-    stdio: 'pipe',
+    if (branchExists) {
+      yield* gitRun(['worktree', 'add', targetPath, branchName], repoPath);
+    } else {
+      yield* gitRun(['worktree', 'add', '-b', branchName, targetPath], repoPath);
+    }
+
+    yield* gitRun(['config', 'beads.role', 'contributor'], targetPath).pipe(
+      Effect.catch(() => Effect.void),
+    );
   });
 }
 
-export function pruneWorktrees(repoPath: string): void {
-  execSync('git worktree prune', { cwd: repoPath, stdio: 'pipe' });
+export function removeWorktree(
+  repoPath: string,
+  worktreePath: string,
+): Effect.Effect<void, GitError, ChildProcessSpawner> {
+  return gitRun(['worktree', 'remove', worktreePath, '--force'], repoPath).pipe(
+    Effect.asVoid,
+  );
+}
+
+export function pruneWorktrees(
+  repoPath: string,
+): Effect.Effect<void, GitError, ChildProcessSpawner> {
+  return gitRun(['worktree', 'prune'], repoPath).pipe(Effect.asVoid);
 }


### PR DESCRIPTION
## Summary

- Migrates `src/lib/conversations/embeddings/providers.ts` from `Promise<T>` to `Effect.Effect<T, E>` with typed error channels
- Adds `EmbedHttpError` tagged error class for HTTP-level failures (non-2xx responses, fetch errors, JSON parse failures)
- Reuses `ConfigError` from `src/lib/errors.ts` for missing API keys and invalid Ollama base URLs
- All four exported functions (`embedOpenAI`, `embedVoyage`, `embedOllama`, `embed`) now return `Effect.Effect<EmbeddingResult, ConfigError | EmbedHttpError>`
- Adds `Effect.runPromise` bridges in three callers that remain Promise-based this wave: `index.ts`, `search.ts`, and the test mocks in `embeddings.test.ts`

## Test plan

- [ ] `npm run typecheck` passes (zero errors)
- [ ] `npm run lint` passes (zero errors)
- [ ] `npm test src/lib/conversations/__tests__/embeddings.test.ts` — all 12 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)