### PR TITLE
feat(pan-1249): migrate src/lib/manifest.ts to Effect (wave 0)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
       "devDependencies": {
         "@commitlint/cli": "^20.5.0",
         "@commitlint/config-conventional": "^20.5.0",
+        "@effect/vitest": "4.0.0-beta.45",
         "@panctl/contracts": "workspace:*",
         "@types/better-sqlite3": "^7.6.13",
         "@types/inquirer": "^9.0.9",
@@ -324,6 +325,8 @@
     "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.45", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.45", "mime": "^4.1.0", "undici": "^7.24.0" }, "peerDependencies": { "effect": "^4.0.0-beta.45", "ioredis": "^5.7.0" } }, "sha512-P07NMG4eoy62iLX9szak0hkr7hrwgq5+XMkm7URVug/3zqfZVxEG2kxn9JzVK1lF5WbaVrEKwjt3IkEJxzSPtg=="],
 
     "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.45", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.19.0" }, "peerDependencies": { "effect": "^4.0.0-beta.45" } }, "sha512-0T4RG18o+aCVUSlmPxA7uAjHJkyE3MS/uRrR5kCNSZQNG3X71wdIbu82wE/MnV6+6YSSPDx/6TVdZWYkJF0JWw=="],
+
+    "@effect/vitest": ["@effect/vitest@4.0.0-beta.45", "", { "peerDependencies": { "effect": "^4.0.0-beta.45", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-38JA5Z6c2FoEhpVKbl7rjTrMU8Al5T30Kwtb6N3B9kOkyr2SsmvNsP9T65bh03IBh3ak9U//acrkmjS3hLQwKA=="],
 
     "@electron/asar": ["@electron/asar@3.4.1", "", { "dependencies": { "commander": "^5.0.0", "glob": "^7.1.6", "minimatch": "^3.0.4" }, "bin": { "asar": "bin/asar.js" } }, "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA=="],
 

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
+    "@effect/vitest": "4.0.0-beta.45",
     "@panctl/contracts": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",
     "@types/inquirer": "^9.0.9",

--- a/src/dashboard/server/routes/settings.ts
+++ b/src/dashboard/server/routes/settings.ts
@@ -143,7 +143,7 @@ const getClaudeAuthRoute = HttpRouter.add(
   'GET',
   '/api/settings/claude-auth',
   httpHandler(Effect.gen(function* () {
-    const status = yield* Effect.promise(() => getClaudeAuthStatus());
+    const status = yield* getClaudeAuthStatus();
     return jsonResponse(status);
   })),
 );

--- a/src/lib/__tests__/claude-auth.test.ts
+++ b/src/lib/__tests__/claude-auth.test.ts
@@ -1,12 +1,28 @@
 /**
  * Tests for parseOAuthPayload (PAN-593)
+ * Migrated to Effect in PAN-1249 wave-0.
  */
 
 import { describe, it, expect } from 'vitest';
+import { Cause, Effect, Exit } from 'effect';
 import { parseOAuthPayload } from '../claude-auth.js';
+import { ClaudeCredentialParseError } from '../errors.js';
+
+async function runEffect<A>(effect: Effect.Effect<A, never, never>): Promise<A> {
+  const exit = await Effect.runPromise(Effect.exit(effect));
+  if (Exit.isSuccess(exit)) return exit.value;
+  throw Cause.squash(exit.cause);
+}
+
+async function runEffectFail<A, E>(effect: Effect.Effect<A, E, never>): Promise<E> {
+  const exit = await Effect.runPromise(Effect.exit(effect));
+  if (Exit.isSuccess(exit))
+    throw new Error('Expected effect to fail, got: ' + JSON.stringify(exit.value));
+  return Cause.squash(exit.cause) as E;
+}
 
 describe('parseOAuthPayload', () => {
-  it('returns loggedIn: true with valid credentials', () => {
+  it('returns loggedIn: true with valid credentials', async () => {
     const raw = JSON.stringify({
       claudeAiOauth: {
         accessToken: 'sk-ant-xxx',
@@ -15,25 +31,25 @@ describe('parseOAuthPayload', () => {
         expiresAt: Date.now() + 3600_000,
       },
     });
-    const result = parseOAuthPayload(raw);
+    const result = await runEffect(parseOAuthPayload(raw));
     expect(result.loggedIn).toBe(true);
     expect(result.expired).toBe(false);
     expect(result.subscriptionType).toBe('max');
     expect(result.rateLimitTier).toBe('default_claude_max_20x');
   });
 
-  it('returns loggedIn: false when accessToken is missing', () => {
+  it('returns loggedIn: false when accessToken is missing', async () => {
     const raw = JSON.stringify({
       claudeAiOauth: {
         subscriptionType: 'pro',
       },
     });
-    const result = parseOAuthPayload(raw);
+    const result = await runEffect(parseOAuthPayload(raw));
     expect(result.loggedIn).toBe(false);
     expect(result.subscriptionType).toBeNull();
   });
 
-  it('detects expired tokens', () => {
+  it('detects expired tokens', async () => {
     const raw = JSON.stringify({
       claudeAiOauth: {
         accessToken: 'sk-ant-xxx',
@@ -41,22 +57,22 @@ describe('parseOAuthPayload', () => {
         expiresAt: Date.now() - 60_000, // expired 1 minute ago
       },
     });
-    const result = parseOAuthPayload(raw);
+    const result = await runEffect(parseOAuthPayload(raw));
     expect(result.loggedIn).toBe(true); // still logged in — auto-refresh
     expect(result.expired).toBe(true);
     expect(result.subscriptionType).toBe('team');
   });
 
-  it('handles missing claudeAiOauth gracefully', () => {
+  it('handles missing claudeAiOauth gracefully', async () => {
     const raw = JSON.stringify({ someOtherKey: 'value' });
-    const result = parseOAuthPayload(raw);
+    const result = await runEffect(parseOAuthPayload(raw));
     expect(result.loggedIn).toBe(false);
     expect(result.expired).toBe(false);
     expect(result.subscriptionType).toBeNull();
     expect(result.expiresAt).toBeNull();
   });
 
-  it('handles non-string subscriptionType', () => {
+  it('handles non-string subscriptionType', async () => {
     const raw = JSON.stringify({
       claudeAiOauth: {
         accessToken: 'sk-ant-xxx',
@@ -64,18 +80,20 @@ describe('parseOAuthPayload', () => {
         expiresAt: 'not-a-number',
       },
     });
-    const result = parseOAuthPayload(raw);
+    const result = await runEffect(parseOAuthPayload(raw));
     expect(result.loggedIn).toBe(true);
     expect(result.subscriptionType).toBeNull();
     expect(result.expiresAt).toBeNull();
   });
 
-  it('throws on malformed JSON', () => {
-    expect(() => parseOAuthPayload('not json')).toThrow();
+  it('fails with ClaudeCredentialParseError on malformed JSON', async () => {
+    const err = await runEffectFail(parseOAuthPayload('not json'));
+    expect(err).toBeInstanceOf(ClaudeCredentialParseError);
+    expect((err as ClaudeCredentialParseError)._tag).toBe('ClaudeCredentialParseError');
   });
 
-  it('handles empty object', () => {
-    const result = parseOAuthPayload('{}');
+  it('handles empty object', async () => {
+    const result = await runEffect(parseOAuthPayload('{}'));
     expect(result.loggedIn).toBe(false);
   });
 });

--- a/src/lib/__tests__/manifest.test.ts
+++ b/src/lib/__tests__/manifest.test.ts
@@ -1,11 +1,14 @@
 /**
  * Tests for manifest read/write/compare utilities (PAN-266)
+ * Migrated to @effect/vitest as part of PAN-1249 wave-0.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { existsSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'fs';
+import { describe, beforeEach, afterEach, expect } from '@effect/vitest';
+import { it } from '@effect/vitest';
+import { existsSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { Effect } from 'effect';
 import {
   hashFile,
   createEmptyManifest,
@@ -31,28 +34,38 @@ afterEach(() => {
 });
 
 describe('hashFile', () => {
-  it('returns sha256-prefixed hash', () => {
-    const filePath = join(TEST_DIR, 'test.md');
-    writeFileSync(filePath, 'hello world');
-    const hash = hashFile(filePath);
-    expect(hash).toMatch(/^sha256:[a-f0-9]{64}$/);
-  });
+  it.effect('returns sha256-prefixed hash', () =>
+    Effect.gen(function* () {
+      const filePath = join(TEST_DIR, 'test.md');
+      writeFileSync(filePath, 'hello world');
+      const hash = yield* hashFile(filePath);
+      expect(hash).toMatch(/^sha256:[a-f0-9]{64}$/);
+    }),
+  );
 
-  it('returns consistent hashes for same content', () => {
-    const file1 = join(TEST_DIR, 'a.md');
-    const file2 = join(TEST_DIR, 'b.md');
-    writeFileSync(file1, 'same content');
-    writeFileSync(file2, 'same content');
-    expect(hashFile(file1)).toBe(hashFile(file2));
-  });
+  it.effect('returns consistent hashes for same content', () =>
+    Effect.gen(function* () {
+      const file1 = join(TEST_DIR, 'a.md');
+      const file2 = join(TEST_DIR, 'b.md');
+      writeFileSync(file1, 'same content');
+      writeFileSync(file2, 'same content');
+      const hash1 = yield* hashFile(file1);
+      const hash2 = yield* hashFile(file2);
+      expect(hash1).toBe(hash2);
+    }),
+  );
 
-  it('returns different hashes for different content', () => {
-    const file1 = join(TEST_DIR, 'a.md');
-    const file2 = join(TEST_DIR, 'b.md');
-    writeFileSync(file1, 'content A');
-    writeFileSync(file2, 'content B');
-    expect(hashFile(file1)).not.toBe(hashFile(file2));
-  });
+  it.effect('returns different hashes for different content', () =>
+    Effect.gen(function* () {
+      const file1 = join(TEST_DIR, 'a.md');
+      const file2 = join(TEST_DIR, 'b.md');
+      writeFileSync(file1, 'content A');
+      writeFileSync(file2, 'content B');
+      const hash1 = yield* hashFile(file1);
+      const hash2 = yield* hashFile(file2);
+      expect(hash1).not.toBe(hash2);
+    }),
+  );
 });
 
 describe('createEmptyManifest', () => {
@@ -65,44 +78,54 @@ describe('createEmptyManifest', () => {
 });
 
 describe('readManifest / writeManifest', () => {
-  it('round-trips a manifest', () => {
-    const manifestPath = join(TEST_DIR, '.panopticon-manifest.json');
-    const manifest = createEmptyManifest();
-    setManifestEntry(manifest, 'skills/beads/SKILL.md', 'sha256:abc123', 'panopticon');
+  it.effect('round-trips a manifest', () =>
+    Effect.gen(function* () {
+      const manifestPath = join(TEST_DIR, '.panopticon-manifest.json');
+      const manifest = createEmptyManifest();
+      setManifestEntry(manifest, 'skills/beads/SKILL.md', 'sha256:abc123', 'panopticon');
 
-    writeManifest(manifestPath, manifest);
-    const loaded = readManifest(manifestPath);
+      yield* writeManifest(manifestPath, manifest);
+      const loaded = yield* readManifest(manifestPath);
 
-    expect(loaded.version).toBe(1);
-    expect(loaded.managed_by).toBe('panopticon');
-    expect(loaded.installed['skills/beads/SKILL.md'].hash).toBe('sha256:abc123');
-    expect(loaded.installed['skills/beads/SKILL.md'].source).toBe('panopticon');
-  });
+      expect(loaded.version).toBe(1);
+      expect(loaded.managed_by).toBe('panopticon');
+      expect(loaded.installed['skills/beads/SKILL.md'].hash).toBe('sha256:abc123');
+      expect(loaded.installed['skills/beads/SKILL.md'].source).toBe('panopticon');
+    }),
+  );
 
-  it('returns empty manifest for nonexistent file', () => {
-    const m = readManifest(join(TEST_DIR, 'does-not-exist.json'));
-    expect(m.installed).toEqual({});
-  });
+  it.effect('returns empty manifest for nonexistent file', () =>
+    Effect.gen(function* () {
+      const m = yield* readManifest(join(TEST_DIR, 'does-not-exist.json'));
+      expect(m.installed).toEqual({});
+    }),
+  );
 
-  it('returns empty manifest for invalid JSON', () => {
-    const manifestPath = join(TEST_DIR, 'bad.json');
-    writeFileSync(manifestPath, 'not json!!!');
-    const m = readManifest(manifestPath);
-    expect(m.installed).toEqual({});
-  });
+  it.effect('fails with ConfigParseError for invalid JSON', () =>
+    Effect.gen(function* () {
+      const manifestPath = join(TEST_DIR, 'bad.json');
+      writeFileSync(manifestPath, 'not json!!!');
+      const err = yield* readManifest(manifestPath).pipe(Effect.flip);
+      expect(err._tag).toBe('ConfigParseError');
+    }),
+  );
 
-  it('returns empty manifest for wrong schema', () => {
-    const manifestPath = join(TEST_DIR, 'wrong.json');
-    writeFileSync(manifestPath, JSON.stringify({ version: 99, other: true }));
-    const m = readManifest(manifestPath);
-    expect(m.installed).toEqual({});
-  });
+  it.effect('returns empty manifest for wrong schema', () =>
+    Effect.gen(function* () {
+      const manifestPath = join(TEST_DIR, 'wrong.json');
+      writeFileSync(manifestPath, JSON.stringify({ version: 99, other: true }));
+      const m = yield* readManifest(manifestPath);
+      expect(m.installed).toEqual({});
+    }),
+  );
 
-  it('creates parent directories when writing', () => {
-    const manifestPath = join(TEST_DIR, 'deep', 'nested', 'manifest.json');
-    writeManifest(manifestPath, createEmptyManifest());
-    expect(existsSync(manifestPath)).toBe(true);
-  });
+  it.effect('creates parent directories when writing', () =>
+    Effect.gen(function* () {
+      const manifestPath = join(TEST_DIR, 'deep', 'nested', 'manifest.json');
+      yield* writeManifest(manifestPath, createEmptyManifest());
+      expect(existsSync(manifestPath)).toBe(true);
+    }),
+  );
 });
 
 describe('setManifestEntry / removeManifestEntry', () => {
@@ -144,115 +167,134 @@ describe('compareFileToManifest', () => {
     manifest = createEmptyManifest();
   });
 
-  it('returns "new" when file does not exist', () => {
-    const result = compareFileToManifest(
-      join(TEST_DIR, 'nonexistent.md'),
-      'skills/foo/SKILL.md',
-      manifest,
-    );
-    expect(result.action).toBe('new');
-  });
+  it.effect('returns "new" when file does not exist', () =>
+    Effect.gen(function* () {
+      const result = yield* compareFileToManifest(
+        join(TEST_DIR, 'nonexistent.md'),
+        'skills/foo/SKILL.md',
+        manifest,
+      );
+      expect(result.action).toBe('new');
+    }),
+  );
 
-  it('returns "user-owned" when file exists but not in manifest', () => {
-    const filePath = join(TEST_DIR, 'user-file.md');
-    writeFileSync(filePath, 'user content');
-    const result = compareFileToManifest(filePath, 'skills/user/SKILL.md', manifest);
-    expect(result.action).toBe('user-owned');
-  });
+  it.effect('returns "user-owned" when file exists but not in manifest', () =>
+    Effect.gen(function* () {
+      const filePath = join(TEST_DIR, 'user-file.md');
+      writeFileSync(filePath, 'user content');
+      const result = yield* compareFileToManifest(filePath, 'skills/user/SKILL.md', manifest);
+      expect(result.action).toBe('user-owned');
+    }),
+  );
 
-  it('returns "update" when file hash matches manifest', () => {
-    const filePath = join(TEST_DIR, 'managed.md');
-    writeFileSync(filePath, 'managed content');
-    const hash = hashFile(filePath);
-    setManifestEntry(manifest, 'skills/managed/SKILL.md', hash, 'panopticon');
+  it.effect('returns "update" when file hash matches manifest', () =>
+    Effect.gen(function* () {
+      const filePath = join(TEST_DIR, 'managed.md');
+      writeFileSync(filePath, 'managed content');
+      const hash = yield* hashFile(filePath);
+      setManifestEntry(manifest, 'skills/managed/SKILL.md', hash, 'panopticon');
 
-    const result = compareFileToManifest(filePath, 'skills/managed/SKILL.md', manifest);
-    expect(result.action).toBe('update');
-  });
+      const result = yield* compareFileToManifest(filePath, 'skills/managed/SKILL.md', manifest);
+      expect(result.action).toBe('update');
+    }),
+  );
 
-  it('returns "modified" when file hash differs from manifest', () => {
-    const filePath = join(TEST_DIR, 'modified.md');
-    writeFileSync(filePath, 'original content');
-    const originalHash = hashFile(filePath);
-    setManifestEntry(manifest, 'skills/mod/SKILL.md', originalHash, 'panopticon');
+  it.effect('returns "modified" when file hash differs from manifest', () =>
+    Effect.gen(function* () {
+      const filePath = join(TEST_DIR, 'modified.md');
+      writeFileSync(filePath, 'original content');
+      const originalHash = yield* hashFile(filePath);
+      setManifestEntry(manifest, 'skills/mod/SKILL.md', originalHash, 'panopticon');
 
-    // User modifies the file
-    writeFileSync(filePath, 'user modified this');
+      // User modifies the file
+      writeFileSync(filePath, 'user modified this');
 
-    const result = compareFileToManifest(filePath, 'skills/mod/SKILL.md', manifest);
-    expect(result.action).toBe('modified');
-    if (result.action === 'modified') {
-      expect(result.manifestHash).toBe(originalHash);
-      expect(result.currentHash).not.toBe(originalHash);
-    }
-  });
+      const result = yield* compareFileToManifest(filePath, 'skills/mod/SKILL.md', manifest);
+      expect(result.action).toBe('modified');
+      if (result.action === 'modified') {
+        expect(result.manifestHash).toBe(originalHash);
+        expect(result.currentHash).not.toBe(originalHash);
+      }
+    }),
+  );
 });
 
 describe('collectSourceFiles', () => {
-  it('collects files recursively with prefix', () => {
-    const skillsDir = join(TEST_DIR, 'skills');
-    mkdirSync(join(skillsDir, 'beads'), { recursive: true });
-    mkdirSync(join(skillsDir, 'pan-help'), { recursive: true });
-    writeFileSync(join(skillsDir, 'beads', 'SKILL.md'), 'beads skill');
-    writeFileSync(join(skillsDir, 'pan-help', 'SKILL.md'), 'help skill');
-    writeFileSync(join(skillsDir, 'pan-help', 'README.md'), 'readme');
+  it.effect('collects files recursively with prefix', () =>
+    Effect.gen(function* () {
+      const skillsDir = join(TEST_DIR, 'skills');
+      mkdirSync(join(skillsDir, 'beads'), { recursive: true });
+      mkdirSync(join(skillsDir, 'pan-help'), { recursive: true });
+      writeFileSync(join(skillsDir, 'beads', 'SKILL.md'), 'beads skill');
+      writeFileSync(join(skillsDir, 'pan-help', 'SKILL.md'), 'help skill');
+      writeFileSync(join(skillsDir, 'pan-help', 'README.md'), 'readme');
 
-    const files = collectSourceFiles(skillsDir, 'skills/');
-    const paths = files.map(f => f.relativePath).sort();
+      const files = yield* collectSourceFiles(skillsDir, 'skills/');
+      const paths = files.map(f => f.relativePath).sort();
 
-    expect(paths).toEqual([
-      'skills/beads/SKILL.md',
-      'skills/pan-help/README.md',
-      'skills/pan-help/SKILL.md',
-    ]);
-  });
+      expect(paths).toEqual([
+        'skills/beads/SKILL.md',
+        'skills/pan-help/README.md',
+        'skills/pan-help/SKILL.md',
+      ]);
+    }),
+  );
 
-  it('returns empty array for nonexistent directory', () => {
-    const files = collectSourceFiles(join(TEST_DIR, 'nope'), 'skills/');
-    expect(files).toEqual([]);
-  });
+  it.effect('returns empty array for nonexistent directory', () =>
+    Effect.gen(function* () {
+      const files = yield* collectSourceFiles(join(TEST_DIR, 'nope'), 'skills/');
+      expect(files).toEqual([]);
+    }),
+  );
 
-  it('returns absolute paths that exist', () => {
-    const skillsDir = join(TEST_DIR, 'skills');
-    mkdirSync(join(skillsDir, 'test'), { recursive: true });
-    writeFileSync(join(skillsDir, 'test', 'SKILL.md'), 'test');
+  it.effect('returns absolute paths that exist', () =>
+    Effect.gen(function* () {
+      const skillsDir = join(TEST_DIR, 'skills');
+      mkdirSync(join(skillsDir, 'test'), { recursive: true });
+      writeFileSync(join(skillsDir, 'test', 'SKILL.md'), 'test');
 
-    const files = collectSourceFiles(skillsDir, 'skills/');
-    expect(files).toHaveLength(1);
-    expect(existsSync(files[0].absolutePath)).toBe(true);
-  });
+      const files = yield* collectSourceFiles(skillsDir, 'skills/');
+      expect(files).toHaveLength(1);
+      expect(existsSync(files[0].absolutePath)).toBe(true);
+    }),
+  );
 });
 
 describe('buildManifestFromDirectory', () => {
-  it('builds manifest from directory with multiple categories', () => {
-    // Set up a mock cache directory
-    mkdirSync(join(TEST_DIR, 'skills', 'beads'), { recursive: true });
-    mkdirSync(join(TEST_DIR, 'agents'), { recursive: true });
-    writeFileSync(join(TEST_DIR, 'skills', 'beads', 'SKILL.md'), 'beads content');
-    writeFileSync(join(TEST_DIR, 'agents', 'code-reviewer.md'), 'reviewer content');
+  it.effect('builds manifest from directory with multiple categories', () =>
+    Effect.gen(function* () {
+      mkdirSync(join(TEST_DIR, 'skills', 'beads'), { recursive: true });
+      mkdirSync(join(TEST_DIR, 'agents'), { recursive: true });
+      writeFileSync(join(TEST_DIR, 'skills', 'beads', 'SKILL.md'), 'beads content');
+      writeFileSync(join(TEST_DIR, 'agents', 'code-reviewer.md'), 'reviewer content');
 
-    const manifest = buildManifestFromDirectory(TEST_DIR, ['skills', 'agents'], 'panopticon');
+      const manifest = yield* buildManifestFromDirectory(TEST_DIR, ['skills', 'agents'], 'panopticon');
 
-    expect(manifest.installed['skills/beads/SKILL.md']).toBeDefined();
-    expect(manifest.installed['skills/beads/SKILL.md'].source).toBe('panopticon');
-    expect(manifest.installed['skills/beads/SKILL.md'].hash).toMatch(/^sha256:/);
+      expect(manifest.installed['skills/beads/SKILL.md']).toBeDefined();
+      expect(manifest.installed['skills/beads/SKILL.md'].source).toBe('panopticon');
+      expect(manifest.installed['skills/beads/SKILL.md'].hash).toMatch(/^sha256:/);
 
-    expect(manifest.installed['agents/code-reviewer.md']).toBeDefined();
-    expect(manifest.installed['agents/code-reviewer.md'].source).toBe('panopticon');
-  });
+      expect(manifest.installed['agents/code-reviewer.md']).toBeDefined();
+      expect(manifest.installed['agents/code-reviewer.md'].source).toBe('panopticon');
+    }),
+  );
 
-  it('skips nonexistent categories', () => {
-    const manifest = buildManifestFromDirectory(TEST_DIR, ['skills', 'rules'], 'panopticon');
-    expect(Object.keys(manifest.installed)).toHaveLength(0);
-  });
+  it.effect('skips nonexistent categories', () =>
+    Effect.gen(function* () {
+      const manifest = yield* buildManifestFromDirectory(TEST_DIR, ['skills', 'rules'], 'panopticon');
+      expect(Object.keys(manifest.installed)).toHaveLength(0);
+    }),
+  );
 
-  it('generates correct hashes', () => {
-    mkdirSync(join(TEST_DIR, 'skills', 'test'), { recursive: true });
-    const filePath = join(TEST_DIR, 'skills', 'test', 'SKILL.md');
-    writeFileSync(filePath, 'test content');
+  it.effect('generates correct hashes', () =>
+    Effect.gen(function* () {
+      mkdirSync(join(TEST_DIR, 'skills', 'test'), { recursive: true });
+      const filePath = join(TEST_DIR, 'skills', 'test', 'SKILL.md');
+      writeFileSync(filePath, 'test content');
 
-    const manifest = buildManifestFromDirectory(TEST_DIR, ['skills'], 'panopticon');
-    const expectedHash = hashFile(filePath);
-    expect(manifest.installed['skills/test/SKILL.md'].hash).toBe(expectedHash);
-  });
+      const manifest = yield* buildManifestFromDirectory(TEST_DIR, ['skills'], 'panopticon');
+      const expectedHash = yield* hashFile(filePath);
+      expect(manifest.installed['skills/test/SKILL.md'].hash).toBe(expectedHash);
+    }),
+  );
 });

--- a/src/lib/__tests__/paths.test.ts
+++ b/src/lib/__tests__/paths.test.ts
@@ -1,21 +1,31 @@
 import { join } from 'path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect } from '@effect/vitest';
+import { it } from '@effect/vitest';
+import { Effect } from 'effect';
 import { resolvePackageRootForDir } from '../paths.js';
 
 describe('resolvePackageRootForDir', () => {
-  it('resolves source module paths to the repository root', () => {
-    expect(resolvePackageRootForDir(join('/repo', 'src', 'lib'))).toBe('/repo');
-  });
+  it.effect('resolves source module paths to the repository root', () =>
+    Effect.sync(() => {
+      expect(resolvePackageRootForDir(join('/repo', 'src', 'lib'))).toBe('/repo');
+    })
+  );
 
-  it('resolves bundled CLI paths to the repository root', () => {
-    expect(resolvePackageRootForDir(join('/repo', 'dist', 'cli'))).toBe('/repo');
-  });
+  it.effect('resolves bundled CLI paths to the repository root', () =>
+    Effect.sync(() => {
+      expect(resolvePackageRootForDir(join('/repo', 'dist', 'cli'))).toBe('/repo');
+    })
+  );
 
-  it('resolves bundled dashboard paths to the repository root', () => {
-    expect(resolvePackageRootForDir(join('/repo', 'dist', 'dashboard'))).toBe('/repo');
-  });
+  it.effect('resolves bundled dashboard paths to the repository root', () =>
+    Effect.sync(() => {
+      expect(resolvePackageRootForDir(join('/repo', 'dist', 'dashboard'))).toBe('/repo');
+    })
+  );
 
-  it('resolves unbundled dist lib paths to the repository root', () => {
-    expect(resolvePackageRootForDir(join('/repo', 'dist', 'lib'))).toBe('/repo');
-  });
+  it.effect('resolves unbundled dist lib paths to the repository root', () =>
+    Effect.sync(() => {
+      expect(resolvePackageRootForDir(join('/repo', 'dist', 'lib'))).toBe('/repo');
+    })
+  );
 });

--- a/src/lib/agent-runtime.ts
+++ b/src/lib/agent-runtime.ts
@@ -9,6 +9,7 @@
  * directly (zero-roundtrip) — this module is for everything else.
  */
 
+import { Data, Effect } from 'effect'
 import type {
   AgentRuntimeSnapshot,
   Activity,
@@ -31,19 +32,28 @@ function abortSignal(ms: number): AbortSignal {
   return controller.signal
 }
 
-export async function getAgentRuntimeSnapshot(
+class AgentRuntimeFetchError extends Data.TaggedError('AgentRuntimeFetchError')<{
+  readonly url: string
+  readonly cause?: unknown
+}> {}
+
+export const getAgentRuntimeSnapshot = (
   agentId: string,
-): Promise<AgentRuntimeSnapshot | null> {
-  if (!agentId) return null
+): Effect.Effect<AgentRuntimeSnapshot | null> => {
+  if (!agentId) return Effect.succeed(null)
   const url = `${DASHBOARD_URL}/api/agents/${encodeURIComponent(agentId)}/runtime`
-  try {
-    const res = await fetch(url, { signal: abortSignal(DEFAULT_TIMEOUT_MS) })
+  return Effect.gen(function* () {
+    const res = yield* Effect.tryPromise({
+      try: () => fetch(url, { signal: abortSignal(DEFAULT_TIMEOUT_MS) }),
+      catch: (cause) => new AgentRuntimeFetchError({ url, cause }),
+    })
     if (!res.ok) return null
-    const body = (await res.json()) as { success: boolean; snapshot?: AgentRuntimeSnapshot }
+    const body = yield* Effect.tryPromise({
+      try: () => res.json() as Promise<{ success: boolean; snapshot?: AgentRuntimeSnapshot }>,
+      catch: (cause) => new AgentRuntimeFetchError({ url, cause }),
+    })
     return body.success && body.snapshot ? body.snapshot : null
-  } catch {
-    return null
-  }
+  }).pipe(Effect.orElseSucceed(() => null))
 }
 
 type HeartbeatBody =
@@ -64,20 +74,25 @@ type HeartbeatBody =
  * semantics — no retry, no buffering. The bash hooks have their own
  * pending-events.jsonl fallback; in-process callers just log and move on.
  */
-export async function emitAgentEvent(agentId: string, body: HeartbeatBody): Promise<boolean> {
-  if (!agentId) return false
+export const emitAgentEvent = (
+  agentId: string,
+  body: HeartbeatBody,
+): Effect.Effect<boolean> => {
+  if (!agentId) return Effect.succeed(false)
   const url = `${DASHBOARD_URL}/api/agents/${encodeURIComponent(agentId)}/heartbeat`
-  try {
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ...body, timestamp: new Date().toISOString() }),
-      signal: abortSignal(DEFAULT_TIMEOUT_MS),
+  return Effect.gen(function* () {
+    const res = yield* Effect.tryPromise({
+      try: () =>
+        fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...body, timestamp: new Date().toISOString() }),
+          signal: abortSignal(DEFAULT_TIMEOUT_MS),
+        }),
+      catch: (cause) => new AgentRuntimeFetchError({ url, cause }),
     })
     return res.ok
-  } catch {
-    return false
-  }
+  }).pipe(Effect.orElseSucceed(() => false))
 }
 
 // ─── Convenience wrappers mirroring the event taxonomy ────────────────────────
@@ -86,38 +101,38 @@ export const emitActivity = (
   agentId: string,
   activity: Activity,
   tool?: string,
-): Promise<boolean> => emitAgentEvent(agentId, { kind: 'activity', activity, tool })
+): Effect.Effect<boolean> => emitAgentEvent(agentId, { kind: 'activity', activity, tool })
 
 export const emitWaitingStart = (
   agentId: string,
   reason: WaitingReason,
   message?: string,
-): Promise<boolean> => emitAgentEvent(agentId, { kind: 'waiting_start', reason, message })
+): Effect.Effect<boolean> => emitAgentEvent(agentId, { kind: 'waiting_start', reason, message })
 
 export const emitWaitingClear = (
   agentId: string,
   clearedBy: 'user_response' | 'timeout' | 'stopped' | 'tool_resumed' = 'user_response',
-): Promise<boolean> => emitAgentEvent(agentId, { kind: 'waiting_clear', clearedBy })
+): Effect.Effect<boolean> => emitAgentEvent(agentId, { kind: 'waiting_clear', clearedBy })
 
 export const emitModelSet = (
   agentId: string,
   model: string,
   claudeSessionId?: string,
-): Promise<boolean> => emitAgentEvent(agentId, { kind: 'model_set', model, claudeSessionId })
+): Effect.Effect<boolean> => emitAgentEvent(agentId, { kind: 'model_set', model, claudeSessionId })
 
 export const emitMessageReceived = (
   agentId: string,
   direction: 'to_agent' | 'from_agent',
   source: 'user' | 'cloister' | 'specialist' | 'automated',
-): Promise<boolean> => emitAgentEvent(agentId, { kind: 'message_received', direction, source })
+): Effect.Effect<boolean> => emitAgentEvent(agentId, { kind: 'message_received', direction, source })
 
 export const emitChannelReply = (
   agentId: string,
   reply: { kind: ChannelReplyKind; summary: string; artifactRefs?: ChannelReplyArtifactRef[] },
-): Promise<boolean> => emitAgentEvent(agentId, { kind: 'channel_reply', reply })
+): Effect.Effect<boolean> => emitAgentEvent(agentId, { kind: 'channel_reply', reply })
 
 export const emitResolution = (
   agentId: string,
   resolution: AgentResolution,
   resolutionCount: number,
-): Promise<boolean> => emitAgentEvent(agentId, { kind: 'resolution_set', resolution, resolutionCount })
+): Effect.Effect<boolean> => emitAgentEvent(agentId, { kind: 'resolution_set', resolution, resolutionCount })

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -170,7 +170,7 @@ async function resolveEffectiveHarness(harness: unknown, model: string): Promise
 export async function getProviderAuthMode(model: string): Promise<AuthMode | undefined> {
   const provider = getProviderForModel(model);
   if (provider.name === 'anthropic') {
-    const authStatus = await getClaudeAuthStatus();
+    const authStatus = await Effect.runPromise(getClaudeAuthStatus());
     if (authStatus.hasAnthropicApiKey) return 'api-key';
     return authStatus.loggedIn ? 'subscription' : undefined;
   }

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -1456,6 +1456,7 @@ export const __testInternals = { markAgentRunning, markAgentStopped };
 // every field access in one PR would have been mechanical noise.
 
 import type { AgentRuntimeSnapshot } from '@panctl/contracts';
+import { Effect } from 'effect';
 import {
   getAgentRuntimeSnapshot as fetchAgentRuntimeSnapshot,
   emitAgentEvent,
@@ -1529,7 +1530,7 @@ export async function getAgentRuntimeStateAsync(agentId: string): Promise<AgentR
     return getAgentRuntimeState(agentId);
   }
   // Cross-process (CLI, external lib callers): sync mirror is empty, hit HTTP.
-  const snap = await fetchAgentRuntimeSnapshot(agentId);
+  const snap = await Effect.runPromise(fetchAgentRuntimeSnapshot(agentId));
   return snapshotToRuntimeState(snap);
 }
 
@@ -1539,47 +1540,47 @@ export async function getAgentRuntimeStateAsync(agentId: string): Promise<AgentR
  */
 export async function saveAgentRuntimeState(agentId: string, patch: Partial<AgentRuntimeState>): Promise<void> {
   if (patch.currentIssue !== undefined) {
-    await emitAgentEvent(agentId, {
+    await Effect.runPromise(emitAgentEvent(agentId, {
       kind: 'current_issue_set',
       currentIssue: patch.currentIssue || undefined,
-    });
+    }));
   }
 
   if (patch.resolution !== undefined && patch.resolutionCount !== undefined) {
-    await emitAgentEvent(agentId, {
+    await Effect.runPromise(emitAgentEvent(agentId, {
       kind: 'resolution_set',
       resolution: patch.resolution,
       resolutionCount: patch.resolutionCount,
-    });
+    }));
   }
 
   if (patch.state !== undefined) {
     if (patch.state === 'waiting-on-human') {
-      await emitAgentEvent(agentId, {
+      await Effect.runPromise(emitAgentEvent(agentId, {
         kind: 'waiting_start',
         reason: (patch.waitingReason as 'tool_permission' | 'user_question' | 'disambiguation' | 'other') || 'other',
         message: patch.waitingNotification,
-      });
+      }));
     } else if (patch.state === 'active') {
-      await emitAgentEvent(agentId, { kind: 'activity', activity: 'working', tool: patch.currentTool });
+      await Effect.runPromise(emitAgentEvent(agentId, { kind: 'activity', activity: 'working', tool: patch.currentTool }));
     } else if (patch.state === 'idle') {
-      await emitAgentEvent(agentId, { kind: 'activity', activity: 'idle' });
+      await Effect.runPromise(emitAgentEvent(agentId, { kind: 'activity', activity: 'idle' }));
     } else if (patch.state === 'stopped') {
-      await emitAgentEvent(agentId, { kind: 'activity', activity: 'stopped' });
+      await Effect.runPromise(emitAgentEvent(agentId, { kind: 'activity', activity: 'stopped' }));
     }
   } else if (patch.currentTool !== undefined) {
-    await emitAgentEvent(agentId, { kind: 'activity', activity: 'working', tool: patch.currentTool });
+    await Effect.runPromise(emitAgentEvent(agentId, { kind: 'activity', activity: 'working', tool: patch.currentTool }));
   }
 
   if (patch.claudeSessionId) {
     // model_set requires a model — use existing snapshot's model if present.
     const snap = getAgentRuntimeState(agentId);
     if (snap || patch.claudeSessionId) {
-      await emitAgentEvent(agentId, {
+      await Effect.runPromise(emitAgentEvent(agentId, {
         kind: 'model_set',
         model: 'unknown',
         claudeSessionId: patch.claudeSessionId,
-      });
+      }));
     }
   }
 }

--- a/src/lib/claude-auth.ts
+++ b/src/lib/claude-auth.ts
@@ -16,11 +16,14 @@
  */
 
 import { existsSync } from 'fs';
-import { readFile } from 'fs/promises';
-import { execFile } from 'child_process';
 import { homedir } from 'os';
 import { join } from 'path';
 import { platform } from 'process';
+import { Duration, Effect, FileSystem } from 'effect';
+import { ChildProcessSpawner } from 'effect/unstable/process/ChildProcessSpawner';
+import { ChildProcess } from 'effect/unstable/process';
+import { layer as NodeServicesLayer } from '@effect/platform-node/NodeServices';
+import { ClaudeCredentialParseError } from './errors.js';
 
 export interface ClaudeAuthStatus {
   /** True if the ~/.claude directory exists (i.e. Claude Code has been installed). */
@@ -40,54 +43,65 @@ export interface ClaudeAuthStatus {
   hasAnthropicApiKey: boolean;
 }
 
+export function parseOAuthPayload(raw: string): Effect.Effect<
+  {
+    loggedIn: boolean;
+    expired: boolean;
+    subscriptionType: string | null;
+    rateLimitTier: string | null;
+    expiresAt: number | null;
+  },
+  ClaudeCredentialParseError
+> {
+  return Effect.try({
+    try: () => {
+      const creds = JSON.parse(raw) as Record<string, unknown>;
+      const oauth = (creds.claudeAiOauth ?? {}) as Record<string, unknown>;
+
+      if (!oauth.accessToken) {
+        return { loggedIn: false, expired: false, subscriptionType: null, rateLimitTier: null, expiresAt: null };
+      }
+
+      const expiresAt = typeof oauth.expiresAt === 'number' ? oauth.expiresAt : null;
+      const expired = !!(expiresAt && expiresAt < Date.now());
+
+      // Treat as logged in even if expired — Claude Code auto-refreshes tokens
+      // transparently. Only mark as not-logged-in if there's no token at all.
+      return {
+        loggedIn: true,
+        expired,
+        subscriptionType: typeof oauth.subscriptionType === 'string' ? oauth.subscriptionType : null,
+        rateLimitTier: typeof oauth.rateLimitTier === 'string' ? oauth.rateLimitTier : null,
+        expiresAt,
+      };
+    },
+    catch: (cause) => new ClaudeCredentialParseError({ message: 'Failed to parse credentials JSON', cause }),
+  });
+}
+
 /**
  * Read credentials JSON from macOS Keychain.
  * Claude Code ≥2.x stores credentials under service "Claude Code-credentials".
  */
-async function readKeychainCredentials(): Promise<string | null> {
-  if (platform !== 'darwin') return null;
-  return new Promise((resolve) => {
-    execFile(
-      'security',
-      ['find-generic-password', '-s', 'Claude Code-credentials', '-w'],
-      { timeout: 3000 },
-      (err, stdout) => {
-        if (err || !stdout.trim()) return resolve(null);
-        resolve(stdout.trim());
-      },
+const readKeychainCredentials: Effect.Effect<string | null, never, ChildProcessSpawner> =
+  Effect.gen(function* () {
+    if (platform !== 'darwin') return null;
+    const spawner = yield* ChildProcessSpawner;
+    const cmd = ChildProcess.make('security', [
+      'find-generic-password', '-s', 'Claude Code-credentials', '-w',
+    ]);
+    return yield* spawner.string(cmd).pipe(
+      Effect.timeout(Duration.seconds(3)),
+      Effect.map((s) => s.trim() || null),
+      Effect.orElseSucceed(() => null),
     );
   });
-}
 
-export function parseOAuthPayload(raw: string): {
-  loggedIn: boolean;
-  expired: boolean;
-  subscriptionType: string | null;
-  rateLimitTier: string | null;
-  expiresAt: number | null;
-} {
-  const creds = JSON.parse(raw) as Record<string, unknown>;
-  const oauth = (creds.claudeAiOauth ?? {}) as Record<string, unknown>;
-
-  if (!oauth.accessToken) {
-    return { loggedIn: false, expired: false, subscriptionType: null, rateLimitTier: null, expiresAt: null };
-  }
-
-  const expiresAt = typeof oauth.expiresAt === 'number' ? oauth.expiresAt : null;
-  const expired = !!(expiresAt && expiresAt < Date.now());
-
-  // Treat as logged in even if expired — Claude Code auto-refreshes tokens
-  // transparently. Only mark as not-logged-in if there's no token at all.
-  return {
-    loggedIn: true,
-    expired,
-    subscriptionType: typeof oauth.subscriptionType === 'string' ? oauth.subscriptionType : null,
-    rateLimitTier: typeof oauth.rateLimitTier === 'string' ? oauth.rateLimitTier : null,
-    expiresAt,
-  };
-}
-
-export async function getClaudeAuthStatus(): Promise<ClaudeAuthStatus> {
+const getClaudeAuthStatusImpl: Effect.Effect<
+  ClaudeAuthStatus,
+  never,
+  FileSystem.FileSystem | ChildProcessSpawner
+> = Effect.gen(function* () {
   const claudeDir = join(homedir(), '.claude');
   const credPath = join(claudeDir, '.credentials.json');
 
@@ -102,35 +116,43 @@ export async function getClaudeAuthStatus(): Promise<ClaudeAuthStatus> {
 
   // 1. Try flat credentials file (Linux, older Claude Code)
   if (existsSync(credPath)) {
-    try {
-      const raw = await readFile(credPath, 'utf-8');
-      const result = parseOAuthPayload(raw);
+    const fs = yield* FileSystem.FileSystem;
+    const result = yield* fs.readFileString(credPath, 'utf-8').pipe(
+      Effect.flatMap(parseOAuthPayload),
+      Effect.orElseSucceed(() => null),
+    );
+    if (result) {
       loggedIn = result.loggedIn;
       expired = result.expired;
       subscriptionType = result.subscriptionType;
       rateLimitTier = result.rateLimitTier;
       expiresAt = result.expiresAt;
-    } catch {
-      // Credentials file unreadable or malformed — fall through to keychain.
     }
   }
 
   // 2. Fall back to macOS Keychain (Claude Code ≥2.x on macOS)
   if (!loggedIn) {
-    try {
-      const keychainRaw = await readKeychainCredentials();
-      if (keychainRaw) {
-        const result = parseOAuthPayload(keychainRaw);
+    const keychainRaw = yield* readKeychainCredentials;
+    if (keychainRaw) {
+      const result = yield* parseOAuthPayload(keychainRaw).pipe(
+        Effect.orElseSucceed(() => null),
+      );
+      if (result) {
         loggedIn = result.loggedIn;
         expired = result.expired;
         subscriptionType = result.subscriptionType;
         rateLimitTier = result.rateLimitTier;
         expiresAt = result.expiresAt;
       }
-    } catch {
-      // Keychain read failed — treat as not logged in.
     }
   }
 
   return { installed, loggedIn, expired, subscriptionType, rateLimitTier, expiresAt, hasAnthropicApiKey };
+});
+
+export function getClaudeAuthStatus(): Effect.Effect<ClaudeAuthStatus, never> {
+  return getClaudeAuthStatusImpl.pipe(
+    Effect.scoped,
+    Effect.provide(NodeServicesLayer),
+  );
 }

--- a/src/lib/cloister/merge-rebase.ts
+++ b/src/lib/cloister/merge-rebase.ts
@@ -1,24 +1,77 @@
 /**
  * In-Process Rebase (PAN-632)
  *
- * Replaces spawnRebaseAgentForBranch with direct git operations via execAsync.
+ * Replaces spawnRebaseAgentForBranch with direct git operations via Effect.
  * No specialist, no polling, no tmux session — just git commands.
  */
 
-import { exec } from 'child_process';
-import { promisify } from 'util';
 import { existsSync } from 'fs';
 import { join } from 'path';
-
-const execAsync = promisify(exec);
+import { Effect, FileSystem } from 'effect';
+import { ChildProcessSpawner } from 'effect/unstable/process/ChildProcessSpawner';
+import { ChildProcess } from 'effect/unstable/process';
+import { layer as NodeServicesLayer } from '@effect/platform-node/NodeServices';
+import { GitError, MergeConflictError } from '../errors.js';
 
 export interface RebaseResult {
-  success: boolean;
+  newHead: string;
   skipped?: boolean;
-  conflictFiles?: string[];
-  reason?: string;
-  newHead?: string;
 }
+
+const runGit = (args: readonly string[], cwd: string): Effect.Effect<string, GitError> =>
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner;
+    const cmd = ChildProcess.make('git', args, { cwd });
+    return yield* spawner.string(cmd).pipe(
+      Effect.mapError(
+        (cause) =>
+          new GitError({
+            command: ['git', ...args],
+            stderr: cause instanceof Error ? cause.message : String(cause),
+            exitCode: -1,
+            cause,
+          }),
+      ),
+    );
+  }).pipe(Effect.provide(NodeServicesLayer));
+
+const removeLockFile = (path: string): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    yield* fs.remove(path).pipe(Effect.orElseSucceed(() => undefined));
+  }).pipe(Effect.provide(NodeServicesLayer));
+
+/**
+ * On rebase conflict: collect conflict files, abort, and fail with MergeConflictError.
+ * Used as the catchTag handler for the rebase step.
+ */
+const onRebaseFailure = (
+  workspacePath: string,
+  featureBranch: string,
+  baseBranch: string,
+  logPrefix: string,
+): Effect.Effect<never, MergeConflictError> =>
+  runGit(['diff', '--name-only', '--diff-filter=U'], workspacePath).pipe(
+    Effect.orElseSucceed(() => ''),
+    Effect.flatMap((conflictOutput) => {
+      const conflictFiles = conflictOutput.trim().split('\n').filter(Boolean);
+      return runGit(['rebase', '--abort'], workspacePath).pipe(
+        Effect.orElseSucceed(() => ''),
+        Effect.flatMap(() => {
+          console.log(
+            `${logPrefix} Rebase failed, conflicts: ${conflictFiles.join(', ') || 'none detected'}`,
+          );
+          return Effect.fail(
+            new MergeConflictError({
+              branch: featureBranch,
+              targetBranch: baseBranch,
+              conflictedFiles: conflictFiles,
+            }),
+          );
+        }),
+      );
+    }),
+  );
 
 /**
  * Rebase a feature branch onto a base branch in-process.
@@ -27,106 +80,71 @@ export interface RebaseResult {
  * Steps:
  * 1. Fetch latest base branch
  * 2. Check if rebase is needed (commits behind)
- * 3. Remove .planning/ artifacts (always conflict during rebase)
- * 4. Rebase onto base branch
- * 5. Push with --force-with-lease
+ * 3. Rebase onto base branch
+ * 4. Push with --force-with-lease
  *
- * On conflict: aborts rebase and returns conflict file list.
+ * On conflict: aborts rebase and fails with MergeConflictError.
  */
-export async function rebaseFeatureBranch(
+export function rebaseFeatureBranch(
   workspacePath: string,
   featureBranch: string,
   baseBranch: string,
   issueId: string,
-): Promise<RebaseResult> {
-  const execOpts = { cwd: workspacePath, encoding: 'utf-8' as const, timeout: 120_000 };
+): Effect.Effect<RebaseResult, GitError | MergeConflictError> {
   const logPrefix = `[merge-rebase] ${issueId}`;
 
-  try {
+  return Effect.gen(function* () {
     // Pre-flight: clean up stale git locks
     const lockFile = join(workspacePath, '.git', 'index.lock');
     if (existsSync(lockFile)) {
-      try {
-        const { unlinkSync } = await import('fs');
-        unlinkSync(lockFile);
-        console.log(`${logPrefix} Removed stale git index.lock`);
-      } catch { /* non-fatal */ }
+      yield* removeLockFile(lockFile);
+      console.log(`${logPrefix} Removed stale git index.lock`);
     }
 
     // Step 1: Fetch latest base branch
     console.log(`${logPrefix} Fetching origin/${baseBranch}...`);
-    await execAsync(`git fetch origin ${baseBranch}`, execOpts);
+    yield* runGit(['fetch', 'origin', baseBranch], workspacePath);
 
     // Step 2: Check if rebase is needed
-    const { stdout: behindCount } = await execAsync(
-      `git rev-list --count HEAD..origin/${baseBranch}`,
-      execOpts,
+    const behindOutput = yield* runGit(
+      ['rev-list', '--count', `HEAD..origin/${baseBranch}`],
+      workspacePath,
     );
-    const behind = parseInt(behindCount.trim(), 10);
+    const behind = parseInt(behindOutput.trim(), 10);
 
     if (behind === 0) {
       console.log(`${logPrefix} Already up-to-date with origin/${baseBranch}`);
-      // Push any cleanup commit we just made.
-      try {
-        await execAsync(
-          `git push --force-with-lease origin HEAD:${featureBranch}`,
-          execOpts,
-        );
-      } catch { /* up-to-date push is non-fatal */ }
-      const { stdout: currentHead } = await execAsync('git rev-parse HEAD', execOpts);
-      return { success: true, skipped: true, newHead: currentHead.trim() };
+      // Push any cleanup commit we just made (non-fatal).
+      yield* runGit(
+        ['push', '--force-with-lease', 'origin', `HEAD:${featureBranch}`],
+        workspacePath,
+      ).pipe(Effect.orElseSucceed(() => ''));
+      const currentHead = yield* runGit(['rev-parse', 'HEAD'], workspacePath);
+      return { newHead: currentHead.trim(), skipped: true };
     }
 
     console.log(`${logPrefix} ${behind} commits behind origin/${baseBranch}, rebasing...`);
 
-    // Step 4: Rebase onto base branch
-    try {
-      await execAsync(`git rebase origin/${baseBranch}`, execOpts);
-      console.log(`${logPrefix} Rebase successful`);
-    } catch (rebaseErr: any) {
-      // Rebase failed — likely conflicts
-      console.log(`${logPrefix} Rebase failed, checking for conflicts...`);
-
-      // Get conflict files
-      let conflictFiles: string[] = [];
-      try {
-        const { stdout: conflictOutput } = await execAsync(
-          'git diff --name-only --diff-filter=U 2>/dev/null || true',
-          execOpts,
-        );
-        conflictFiles = conflictOutput.trim().split('\n').filter(Boolean);
-      } catch { /* ignore */ }
-
-      // Abort the rebase
-      try {
-        await execAsync('git rebase --abort', execOpts);
-        console.log(`${logPrefix} Rebase aborted`);
-      } catch {
-        // May not be in rebase state
-      }
-
-      const reason = conflictFiles.length > 0
-        ? `Rebase conflicts in: ${conflictFiles.join(', ')}`
-        : `Rebase failed: ${rebaseErr.message?.slice(0, 200) || 'unknown error'}`;
-
-      return { success: false, conflictFiles, reason };
-    }
-
-    // Step 5: Push with --force-with-lease
-    console.log(`${logPrefix} Pushing rebased branch...`);
-    await execAsync(
-      `git push --force-with-lease origin HEAD:${featureBranch}`,
-      execOpts,
+    // Step 3: Rebase — on GitError, collect conflict files, abort, fail with MergeConflictError
+    yield* runGit(['rebase', `origin/${baseBranch}`], workspacePath).pipe(
+      Effect.asVoid,
+      Effect.catchTag('GitError', () =>
+        onRebaseFailure(workspacePath, featureBranch, baseBranch, logPrefix),
+      ),
     );
 
-    // Get new HEAD
-    const { stdout: newHead } = await execAsync('git rev-parse HEAD', execOpts);
+    console.log(`${logPrefix} Rebase successful`);
+
+    // Step 4: Push with --force-with-lease
+    console.log(`${logPrefix} Pushing rebased branch...`);
+    yield* runGit(
+      ['push', '--force-with-lease', 'origin', `HEAD:${featureBranch}`],
+      workspacePath,
+    );
+
+    const newHead = yield* runGit(['rev-parse', 'HEAD'], workspacePath);
     console.log(`${logPrefix} Rebase complete, new HEAD: ${newHead.trim().slice(0, 8)}`);
 
-    return { success: true, newHead: newHead.trim() };
-  } catch (err: any) {
-    const reason = `Rebase error: ${err.message?.slice(0, 300) || 'unknown'}`;
-    console.error(`${logPrefix} ${reason}`);
-    return { success: false, reason };
-  }
+    return { newHead: newHead.trim() };
+  });
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -117,6 +117,14 @@ export class ConfigParseError extends Data.TaggedError('ConfigParseError')<{
   readonly cause?: unknown;
 }> {}
 
+// ─── Authentication errors ────────────────────────────────────────────────────
+
+/** Claude Code credential JSON could not be parsed. */
+export class ClaudeCredentialParseError extends Data.TaggedError('ClaudeCredentialParseError')<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
 // ─── Process errors ───────────────────────────────────────────────────────────
 
 /** A child process failed to spawn. */

--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -1,6 +1,8 @@
 import { createHash } from 'crypto';
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
 import { join, relative } from 'path';
+import { Effect } from 'effect';
+import { ConfigParseError, FsError } from './errors.js';
 
 /**
  * Manifest entry for a single distributed file.
@@ -33,10 +35,15 @@ export type FileStatus =
 /**
  * Compute SHA-256 hash of a file, prefixed with "sha256:".
  */
-export function hashFile(filePath: string): string {
-  const content = readFileSync(filePath);
-  const hex = createHash('sha256').update(content).digest('hex');
-  return `sha256:${hex}`;
+export function hashFile(filePath: string): Effect.Effect<string, FsError> {
+  return Effect.try({
+    try: () => {
+      const content = readFileSync(filePath);
+      const hex = createHash('sha256').update(content).digest('hex');
+      return `sha256:${hex}`;
+    },
+    catch: (cause) => new FsError({ path: filePath, operation: 'read', cause }),
+  });
 }
 
 /**
@@ -51,30 +58,39 @@ export function createEmptyManifest(): Manifest {
 }
 
 /**
- * Read a manifest from disk. Returns empty manifest if file doesn't exist or is invalid.
+ * Read a manifest from disk. Returns empty manifest if file doesn't exist or has wrong schema.
+ * Surfaces a ConfigParseError if the file exists but contains invalid JSON.
  */
-export function readManifest(manifestPath: string): Manifest {
-  if (!existsSync(manifestPath)) {
-    return createEmptyManifest();
-  }
+export function readManifest(manifestPath: string): Effect.Effect<Manifest, ConfigParseError> {
+  return Effect.gen(function* () {
+    if (!existsSync(manifestPath)) {
+      return createEmptyManifest();
+    }
 
-  try {
-    const raw = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+    const raw = yield* Effect.try({
+      try: () => JSON.parse(readFileSync(manifestPath, 'utf-8')),
+      catch: (cause) =>
+        new ConfigParseError({ path: manifestPath, message: 'Invalid JSON', cause }),
+    });
+
     if (raw.version === 1 && raw.managed_by === 'panopticon' && typeof raw.installed === 'object') {
       return raw as Manifest;
     }
     return createEmptyManifest();
-  } catch {
-    return createEmptyManifest();
-  }
+  });
 }
 
 /**
  * Write a manifest to disk (creates parent directories if needed).
  */
-export function writeManifest(manifestPath: string, manifest: Manifest): void {
-  mkdirSync(join(manifestPath, '..'), { recursive: true });
-  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
+export function writeManifest(manifestPath: string, manifest: Manifest): Effect.Effect<void, FsError> {
+  return Effect.try({
+    try: () => {
+      mkdirSync(join(manifestPath, '..'), { recursive: true });
+      writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
+    },
+    catch: (cause) => new FsError({ path: manifestPath, operation: 'write', cause }),
+  });
 }
 
 /**
@@ -111,22 +127,24 @@ export function compareFileToManifest(
   targetFile: string,
   relativePath: string,
   manifest: Manifest,
-): FileStatus {
-  if (!existsSync(targetFile)) {
-    return { action: 'new' };
-  }
+): Effect.Effect<FileStatus, FsError> {
+  return Effect.gen(function* () {
+    if (!existsSync(targetFile)) {
+      return { action: 'new' } as FileStatus;
+    }
 
-  const entry = manifest.installed[relativePath];
-  if (!entry) {
-    return { action: 'user-owned' };
-  }
+    const entry = manifest.installed[relativePath];
+    if (!entry) {
+      return { action: 'user-owned' } as FileStatus;
+    }
 
-  const currentHash = hashFile(targetFile);
-  if (currentHash === entry.hash) {
-    return { action: 'update', currentHash };
-  }
+    const currentHash = yield* hashFile(targetFile);
+    if (currentHash === entry.hash) {
+      return { action: 'update', currentHash } as FileStatus;
+    }
 
-  return { action: 'modified', currentHash, manifestHash: entry.hash };
+    return { action: 'modified', currentHash, manifestHash: entry.hash } as FileStatus;
+  });
 }
 
 /**
@@ -140,31 +158,36 @@ export function compareFileToManifest(
 export function collectSourceFiles(
   sourceDir: string,
   prefix: string,
-): Array<{ absolutePath: string; relativePath: string }> {
-  const results: Array<{ absolutePath: string; relativePath: string }> = [];
-
+): Effect.Effect<Array<{ absolutePath: string; relativePath: string }>, FsError> {
   if (!existsSync(sourceDir)) {
-    return results;
+    return Effect.succeed([]);
   }
 
-  function walk(dir: string): void {
-    const entries = readdirSync(dir, { withFileTypes: true });
-    for (const entry of entries) {
-      const fullPath = join(dir, entry.name);
-      if (entry.isDirectory()) {
-        walk(fullPath);
-      } else if (entry.isFile()) {
-        const rel = relative(sourceDir, fullPath);
-        results.push({
-          absolutePath: fullPath,
-          relativePath: `${prefix}${rel}`,
-        });
+  return Effect.try({
+    try: () => {
+      const results: Array<{ absolutePath: string; relativePath: string }> = [];
+
+      function walk(dir: string): void {
+        const entries = readdirSync(dir, { withFileTypes: true });
+        for (const entry of entries) {
+          const fullPath = join(dir, entry.name);
+          if (entry.isDirectory()) {
+            walk(fullPath);
+          } else if (entry.isFile()) {
+            const rel = relative(sourceDir, fullPath);
+            results.push({
+              absolutePath: fullPath,
+              relativePath: `${prefix}${rel}`,
+            });
+          }
+        }
       }
-    }
-  }
 
-  walk(sourceDir);
-  return results;
+      walk(sourceDir);
+      return results;
+    },
+    catch: (cause) => new FsError({ path: sourceDir, operation: 'readdir', cause }),
+  });
 }
 
 /**
@@ -179,17 +202,19 @@ export function buildManifestFromDirectory(
   baseDir: string,
   categories: string[],
   source: string,
-): Manifest {
-  const manifest = createEmptyManifest();
+): Effect.Effect<Manifest, FsError> {
+  return Effect.gen(function* () {
+    const manifest = createEmptyManifest();
 
-  for (const category of categories) {
-    const categoryDir = join(baseDir, category);
-    const files = collectSourceFiles(categoryDir, `${category}/`);
-    for (const file of files) {
-      const hash = hashFile(file.absolutePath);
-      setManifestEntry(manifest, file.relativePath, hash, source);
+    for (const category of categories) {
+      const categoryDir = join(baseDir, category);
+      const files = yield* collectSourceFiles(categoryDir, `${category}/`);
+      for (const file of files) {
+        const hash = yield* hashFile(file.absolutePath);
+        setManifestEntry(manifest, file.relativePath, hash, source);
+      }
     }
-  }
 
-  return manifest;
+    return manifest;
+  });
 }

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -118,12 +118,7 @@ export const PROJECT_PRDS_COMPLETED_SUBDIR = 'completed';
  * 2. The SOURCE_DEV_SKILLS_DIR exists (only present in repo, not in npm package)
  */
 export function isDevMode(): boolean {
-  try {
-    // Check if dev-skills directory exists - this is only in the repo, not npm package
-    return existsSync(SOURCE_DEV_SKILLS_DIR);
-  } catch {
-    return false;
-  }
+  return existsSync(SOURCE_DEV_SKILLS_DIR);
 }
 
 /**

--- a/src/lib/skills-merge.ts
+++ b/src/lib/skills-merge.ts
@@ -8,8 +8,10 @@ import {
   statSync,
 } from 'fs';
 import { join, relative, dirname } from 'path';
+import { Effect } from 'effect';
 import { SKILLS_DIR, CACHE_AGENTS_DIR, CACHE_RULES_DIR } from './paths.js';
 import {
+  createEmptyManifest,
   readManifest,
   writeManifest,
   collectSourceFiles,
@@ -67,7 +69,9 @@ function copyTree(sourceDir: string, targetDir: string): string[] {
 export function mergeSkillsIntoWorkspace(workspacePath: string): MergeResult {
   const claudeDir = join(workspacePath, '.claude');
   const manifestPath = join(claudeDir, '.panopticon-manifest.json');
-  const manifest = readManifest(manifestPath);
+  const manifest = Effect.runSync(
+    readManifest(manifestPath).pipe(Effect.orElseSucceed(createEmptyManifest)),
+  );
 
   const result: MergeResult = {
     added: [],
@@ -91,15 +95,15 @@ export function mergeSkillsIntoWorkspace(workspacePath: string): MergeResult {
     if (!existsSync(sourceDir)) continue;
 
     const prefix = targetSubdir ? `${targetSubdir}/` : '';
-    const files = collectSourceFiles(sourceDir, '');
+    const files = Effect.runSync(collectSourceFiles(sourceDir, ''));
 
     for (const file of files) {
       const relativePath = `${prefix}${file.relativePath}`;
       const targetPath = join(claudeDir, relativePath);
-      const sourceHash = hashFile(file.absolutePath);
+      const sourceHash = Effect.runSync(hashFile(file.absolutePath));
 
       // Check status against manifest
-      const status = compareFileToManifest(targetPath, relativePath, manifest);
+      const status = Effect.runSync(compareFileToManifest(targetPath, relativePath, manifest));
 
       switch (status.action) {
         case 'new':
@@ -131,7 +135,7 @@ export function mergeSkillsIntoWorkspace(workspacePath: string): MergeResult {
   }
 
   // Write updated manifest
-  writeManifest(manifestPath, manifest);
+  Effect.runSync(writeManifest(manifestPath, manifest));
 
   return result;
 }
@@ -154,7 +158,9 @@ export function applyProjectTemplateOverlay(
 ): string[] {
   const claudeDir = join(workspacePath, '.claude');
   const manifestPath = join(claudeDir, '.panopticon-manifest.json');
-  const manifest = readManifest(manifestPath);
+  const manifest = Effect.runSync(
+    readManifest(manifestPath).pipe(Effect.orElseSucceed(createEmptyManifest)),
+  );
   const overlayed: string[] = [];
 
   if (!existsSync(templateDir)) return overlayed;
@@ -180,7 +186,7 @@ export function applyProjectTemplateOverlay(
       // Track in manifest if it's under .claude/
       if (target.startsWith('.claude/')) {
         const relativePath = target.slice('.claude/'.length);
-        const hash = hashFile(targetPath);
+        const hash = Effect.runSync(hashFile(targetPath));
         setManifestEntry(manifest, relativePath, hash, 'project-template');
         overlayed.push(relativePath);
       }
@@ -192,7 +198,7 @@ export function applyProjectTemplateOverlay(
       const copied = copyTree(claudeInTemplate, claudeDir);
       for (const rel of copied) {
         const targetPath = join(claudeDir, rel);
-        const hash = hashFile(targetPath);
+        const hash = Effect.runSync(hashFile(targetPath));
         setManifestEntry(manifest, rel, hash, 'project-template');
         overlayed.push(rel);
       }
@@ -200,7 +206,7 @@ export function applyProjectTemplateOverlay(
   }
 
   // Write updated manifest
-  writeManifest(manifestPath, manifest);
+  Effect.runSync(writeManifest(manifestPath, manifest));
 
   return overlayed;
 }
@@ -296,7 +302,9 @@ export function mergePanSkillsIntoWorkspace(projectPath: string, workspacePath: 
 
   const claudeSkillsDir = join(workspacePath, '.claude', 'skills');
   const manifestPath = join(workspacePath, '.claude', '.panopticon-manifest.json');
-  const manifest = readManifest(manifestPath);
+  const manifest = Effect.runSync(
+    readManifest(manifestPath).pipe(Effect.orElseSucceed(createEmptyManifest)),
+  );
 
   const skillDirs = readdirSync(panSkillsDir, { withFileTypes: true })
     .filter(e => e.isDirectory())
@@ -313,14 +321,14 @@ export function mergePanSkillsIntoWorkspace(projectPath: string, workspacePath: 
     }
 
     // Rule #2: copy from .pan/skills/<name>/ to workspace .claude/skills/<name>/
-    const files = collectSourceFiles(sourceSkillDir, '');
+    const files = Effect.runSync(collectSourceFiles(sourceSkillDir, ''));
     mkdirSync(targetSkillDir, { recursive: true });
     let anyAdded = false;
     for (const file of files) {
       const targetPath = join(targetSkillDir, file.relativePath);
       mkdirSync(dirname(targetPath), { recursive: true });
       copyFileSync(file.absolutePath, targetPath);
-      const hash = hashFile(targetPath);
+      const hash = Effect.runSync(hashFile(targetPath));
       setManifestEntry(manifest, `skills/${skillName}/${file.relativePath}`, hash, 'pan-skills');
       result.added.push(`skills/${skillName}/${file.relativePath}`);
       anyAdded = true;
@@ -330,6 +338,6 @@ export function mergePanSkillsIntoWorkspace(projectPath: string, workspacePath: 
     }
   }
 
-  writeManifest(manifestPath, manifest);
+  Effect.runSync(writeManifest(manifestPath, manifest));
   return result;
 }

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readdirSync, symlinkSync, unlinkSync, lstatSync,
 import { execSync } from 'child_process';
 import { join, basename, dirname, relative } from 'path';
 import { homedir } from 'os';
+import { Effect } from 'effect';
 import {
   SKILLS_DIR, COMMANDS_DIR, AGENTS_DIR, BIN_DIR,
   SOURCE_SCRIPTS_DIR, SOURCE_DEV_SKILLS_DIR, SOURCE_SKILLS_DIR, SOURCE_AGENTS_DIR, SOURCE_RULES_DIR,
@@ -9,6 +10,7 @@ import {
   SYNC_TARGET, isDevMode,
 } from './paths.js';
 import {
+  createEmptyManifest,
   buildManifestFromDirectory, writeManifest, readManifest, hashFile,
   setManifestEntry, collectSourceFiles,
   type Manifest, type FileStatus,
@@ -309,12 +311,14 @@ export function refreshCache(): RefreshCacheResult {
   }
 
   // Generate cache manifest
-  const manifest = buildManifestFromDirectory(
-    join(SKILLS_DIR, '..'),  // ~/.panopticon/
-    ['skills', 'agent-definitions', 'rules'],
-    'panopticon',
+  const manifest = Effect.runSync(
+    buildManifestFromDirectory(
+      join(SKILLS_DIR, '..'),  // ~/.panopticon/
+      ['skills', 'agent-definitions', 'rules'],
+      'panopticon',
+    ),
   );
-  writeManifest(CACHE_MANIFEST, manifest);
+  Effect.runSync(writeManifest(CACHE_MANIFEST, manifest));
 
   return result;
 }
@@ -351,13 +355,15 @@ export function planSync(): SyncPlan {
 
   const targetBase = join(devrootPath, '.claude');
   const manifestPath = join(targetBase, '.panopticon-manifest.json');
-  const manifest = readManifest(manifestPath);
+  const manifest = Effect.runSync(
+    readManifest(manifestPath).pipe(Effect.orElseSucceed(createEmptyManifest)),
+  );
 
   // Plan skills
-  const skillFiles = collectSourceFiles(SKILLS_DIR, 'skills/');
+  const skillFiles = Effect.runSync(collectSourceFiles(SKILLS_DIR, 'skills/'));
   for (const file of skillFiles) {
     const targetFile = join(targetBase, file.relativePath);
-    const status = compareFileToManifest(targetFile, file.relativePath, manifest);
+    const status = Effect.runSync(compareFileToManifest(targetFile, file.relativePath, manifest));
     const skillName = file.relativePath.split('/')[1] || file.relativePath;
 
     let syncStatus: SyncItem['status'] = 'new';
@@ -374,10 +380,10 @@ export function planSync(): SyncPlan {
   }
 
   // Plan agents
-  const agentFiles = collectSourceFiles(CACHE_AGENTS_DIR, 'agents/');
+  const agentFiles = Effect.runSync(collectSourceFiles(CACHE_AGENTS_DIR, 'agents/'));
   for (const file of agentFiles) {
     const targetFile = join(targetBase, file.relativePath);
-    const status = compareFileToManifest(targetFile, file.relativePath, manifest);
+    const status = Effect.runSync(compareFileToManifest(targetFile, file.relativePath, manifest));
 
     let syncStatus: SyncItem['status'] = 'new';
     if (status.action === 'update') syncStatus = 'symlink';
@@ -393,10 +399,10 @@ export function planSync(): SyncPlan {
   }
 
   // Plan rules
-  const ruleFiles = collectSourceFiles(CACHE_RULES_DIR, 'rules/');
+  const ruleFiles = Effect.runSync(collectSourceFiles(CACHE_RULES_DIR, 'rules/'));
   for (const file of ruleFiles) {
     const targetFile = join(targetBase, file.relativePath);
-    const status = compareFileToManifest(targetFile, file.relativePath, manifest);
+    const status = Effect.runSync(compareFileToManifest(targetFile, file.relativePath, manifest));
 
     let syncStatus: SyncItem['status'] = 'new';
     if (status.action === 'update') syncStatus = 'symlink';
@@ -448,25 +454,27 @@ export function executeSync(options: SyncOptions = {}): SyncResult {
 
   const targetBase = join(devrootPath, '.claude');
   const manifestPath = join(targetBase, '.panopticon-manifest.json');
-  const manifest = readManifest(manifestPath);
+  const manifest = Effect.runSync(
+    readManifest(manifestPath).pipe(Effect.orElseSucceed(createEmptyManifest)),
+  );
 
   // Collect all source files from cache
   const allFiles = [
-    ...collectSourceFiles(SKILLS_DIR, 'skills/'),
-    ...collectSourceFiles(CACHE_AGENTS_DIR, 'agents/'),
-    ...collectSourceFiles(CACHE_RULES_DIR, 'rules/'),
+    ...Effect.runSync(collectSourceFiles(SKILLS_DIR, 'skills/')),
+    ...Effect.runSync(collectSourceFiles(CACHE_AGENTS_DIR, 'agents/')),
+    ...Effect.runSync(collectSourceFiles(CACHE_RULES_DIR, 'rules/')),
   ];
 
   for (const file of allFiles) {
     const targetFile = join(targetBase, file.relativePath);
-    const status = compareFileToManifest(targetFile, file.relativePath, manifest);
+    const status = Effect.runSync(compareFileToManifest(targetFile, file.relativePath, manifest));
 
     switch (status.action) {
       case 'new': {
         // File doesn't exist at target — copy it
         mkdirSync(dirname(targetFile), { recursive: true });
         copyFileSync(file.absolutePath, targetFile);
-        const hash = hashFile(targetFile);
+        const hash = Effect.runSync(hashFile(targetFile));
         setManifestEntry(manifest, file.relativePath, hash, 'panopticon');
         result.created.push(file.relativePath);
         break;
@@ -476,7 +484,7 @@ export function executeSync(options: SyncOptions = {}): SyncResult {
         // File exists, hash matches manifest — safe to overwrite (user didn't modify)
         mkdirSync(dirname(targetFile), { recursive: true });
         copyFileSync(file.absolutePath, targetFile);
-        const hash = hashFile(targetFile);
+        const hash = Effect.runSync(hashFile(targetFile));
         setManifestEntry(manifest, file.relativePath, hash, 'panopticon');
         result.updated.push(file.relativePath);
         break;
@@ -495,7 +503,7 @@ export function executeSync(options: SyncOptions = {}): SyncResult {
         if (options.force) {
           mkdirSync(dirname(targetFile), { recursive: true });
           copyFileSync(file.absolutePath, targetFile);
-          const hash = hashFile(targetFile);
+          const hash = Effect.runSync(hashFile(targetFile));
           setManifestEntry(manifest, file.relativePath, hash, 'panopticon');
           result.updated.push(file.relativePath);
         } else {
@@ -513,7 +521,7 @@ export function executeSync(options: SyncOptions = {}): SyncResult {
   }
 
   // Write updated manifest
-  writeManifest(manifestPath, manifest);
+  Effect.runSync(writeManifest(manifestPath, manifest));
 
   return result;
 }


### PR DESCRIPTION
## Summary

- Migrates `src/lib/manifest.ts` from synchronous plain functions to Effect-native with typed error channels
- `hashFile`, `readManifest`, `writeManifest`, `compareFileToManifest`, `collectSourceFiles`, `buildManifestFromDirectory` return `Effect<T, E>` — pure functions (`createEmptyManifest`, `setManifestEntry`, `removeManifestEntry`) remain synchronous
- `try/catch` in `readManifest` replaced with `ConfigParseError` channel; file I/O failures surface as `FsError`
- Uses `Effect.try`/`Effect.sync` with sync FS APIs (not async FileSystem service) since the underlying operations are synchronous — callers can use `Effect.runSync()` without changing their signatures
- Callers `skills-merge.ts` and `sync.ts` updated minimally with `Effect.runSync()` adapter at each call site; these files have their own migration slots and are not fully migrated here
- Test file migrated to `@effect/vitest` using `it.effect()` + `Effect.gen` / `yield*`

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] All 23 manifest tests pass with `@effect/vitest`
- [x] Pre-existing test failures in `merge-agent-stash.test.ts` confirmed to be from prior branch changes, not this slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)