### PR TITLE
feat(pan-1249): Effect migration: src/lib/remote/workspace-metadata.ts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
       "devDependencies": {
         "@commitlint/cli": "^20.5.0",
         "@commitlint/config-conventional": "^20.5.0",
+        "@effect/vitest": "catalog:",
         "@panctl/contracts": "workspace:*",
         "@types/better-sqlite3": "^7.6.13",
         "@types/inquirer": "^9.0.9",
@@ -324,6 +325,8 @@
     "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.45", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.45", "mime": "^4.1.0", "undici": "^7.24.0" }, "peerDependencies": { "effect": "^4.0.0-beta.45", "ioredis": "^5.7.0" } }, "sha512-P07NMG4eoy62iLX9szak0hkr7hrwgq5+XMkm7URVug/3zqfZVxEG2kxn9JzVK1lF5WbaVrEKwjt3IkEJxzSPtg=="],
 
     "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.45", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.19.0" }, "peerDependencies": { "effect": "^4.0.0-beta.45" } }, "sha512-0T4RG18o+aCVUSlmPxA7uAjHJkyE3MS/uRrR5kCNSZQNG3X71wdIbu82wE/MnV6+6YSSPDx/6TVdZWYkJF0JWw=="],
+
+    "@effect/vitest": ["@effect/vitest@4.0.0-beta.45", "", { "peerDependencies": { "effect": "^4.0.0-beta.45", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-38JA5Z6c2FoEhpVKbl7rjTrMU8Al5T30Kwtb6N3B9kOkyr2SsmvNsP9T65bh03IBh3ak9U//acrkmjS3hLQwKA=="],
 
     "@electron/asar": ["@electron/asar@3.4.1", "", { "dependencies": { "commander": "^5.0.0", "glob": "^7.1.6", "minimatch": "^3.0.4" }, "bin": { "asar": "bin/asar.js" } }, "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA=="],
 

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.10.0",
     "@typescript-eslint/parser": "6.21.0",
+    "@effect/vitest": "catalog:",
     "@vitest/coverage-v8": "^4.1.6",
     "effect": "catalog:",
     "eslint": "^8.55.0",

--- a/src/cli/commands/__tests__/inspect.test.ts
+++ b/src/cli/commands/__tests__/inspect.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Effect } from 'effect';
 import { Command } from 'commander';
 
 const { mockResolveProjectFromIssue, mockSpawnInspectAgent, mockGetDiffBase, mockGetDiffStats } = vi.hoisted(() => ({
@@ -34,8 +35,8 @@ describe('inspect command', () => {
       projectKey: 'panopticon',
       projectPath: '/repo',
     });
-    mockGetDiffBase.mockResolvedValue('abcdef1234567890');
-    mockGetDiffStats.mockResolvedValue('1 file changed');
+    mockGetDiffBase.mockReturnValue(Effect.succeed('abcdef1234567890'));
+    mockGetDiffStats.mockReturnValue(Effect.succeed('1 file changed'));
     mockSpawnInspectAgent.mockResolvedValue({
       success: true,
       runId: 'run-1',

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -3,6 +3,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import chalk from 'chalk';
 import ora from 'ora';
+import { Effect } from 'effect';
 import { INIT_DIRS, CONFIG_FILE, PANOPTICON_HOME, SKILLS_DIR, AGENTS_DIR } from '../../lib/paths.js';
 import { getDefaultConfig, saveConfig } from '../../lib/config.js';
 import { detectShell, getShellRcFile, addAlias, getAliasInstructions } from '../../lib/shell.js';
@@ -110,11 +111,11 @@ export async function initCommand(): Promise<void> {
     const agentsCopied = copyBundledAgents();
 
     // Detect shell and add alias
-    const shell = detectShell();
-    const rcFile = getShellRcFile(shell);
+    const shell = Effect.runSync(detectShell());
+    const rcFile = Effect.runSync(getShellRcFile(shell));
 
     if (rcFile && existsSync(rcFile)) {
-      addAlias(rcFile);
+      Effect.runSync(addAlias(rcFile));
       spinner.succeed('Panopticon initialized!');
       console.log('');
       console.log(chalk.green('✓') + ' Created ' + chalk.cyan(PANOPTICON_HOME));
@@ -125,7 +126,7 @@ export async function initCommand(): Promise<void> {
       if (agentsCopied > 0) {
         console.log(chalk.green('✓') + ` Installed ${agentsCopied} bundled agents`);
       }
-      console.log(chalk.green('✓') + ' ' + getAliasInstructions(shell));
+      console.log(chalk.green('✓') + ' ' + Effect.runSync(getAliasInstructions(shell)));
     } else {
       spinner.succeed('Panopticon initialized!');
       console.log('');

--- a/src/cli/commands/inspect.ts
+++ b/src/cli/commands/inspect.ts
@@ -7,6 +7,7 @@
 
 import { Command } from 'commander';
 import chalk from 'chalk';
+import { Effect } from 'effect';
 import { resolveProjectFromIssue } from '../../lib/projects.js';
 import { spawnInspectAgent, type InspectContext } from '../../lib/cloister/inspect-agent.js';
 import { getDiffBase, getDiffStats } from '../../lib/cloister/inspect-checkpoints.js';
@@ -64,8 +65,8 @@ export async function inspectCommand(issueId: string, options: InspectOptions): 
   }
 
   // Show what we're inspecting
-  const diffBase = await getDiffBase(project.projectKey, normalizedIssueId, workspacePath);
-  const diffStats = await getDiffStats(workspacePath, diffBase);
+  const diffBase = await Effect.runPromise(getDiffBase(project.projectKey, normalizedIssueId, workspacePath));
+  const diffStats = await Effect.runPromise(getDiffStats(workspacePath, diffBase));
 
   console.log('');
   console.log(chalk.bold('Requesting inspection'));

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -2263,9 +2263,10 @@ const postAgentsRoute = HttpRouter.add(
     if (!existsSync(workspacePath)) {
       try {
         const nodeDir = dirname(process.execPath);
+        const wsCreateEnv = yield* buildChildEnvWithoutTmux(process.env, { PATH: `${nodeDir}:${process.env.PATH ?? ''}` });
         yield* Effect.promise(() => execAsync(
           `pan workspace create ${issueId} --local`,
-          { cwd: projectPath, encoding: 'utf-8', timeout: 60000, env: buildChildEnvWithoutTmux(process.env, { PATH: `${nodeDir}:${process.env.PATH ?? ''}` }) }
+          { cwd: projectPath, encoding: 'utf-8', timeout: 60000, env: wsCreateEnv }
         ));
       } catch (wsErr) {
         return jsonResponse({
@@ -2997,7 +2998,7 @@ const postAgentsRoute = HttpRouter.add(
                   const containerChild = spawn('./dev', ['all'], {
                     cwd: workspacePath,
                     stdio: 'ignore',
-                    env: buildChildEnvWithoutTmux(process.env, { UID: String(containerUid), GID: String(containerGid), DOCKER_USER: `${containerUid}:${containerGid}` }),
+                    env: Effect.runSync(buildChildEnvWithoutTmux(process.env, { UID: String(containerUid), GID: String(containerGid), DOCKER_USER: `${containerUid}:${containerGid}` })),
                     detached: true,
                   });
                   containerChild.unref();

--- a/src/dashboard/server/routes/command-deck.ts
+++ b/src/dashboard/server/routes/command-deck.ts
@@ -1056,7 +1056,7 @@ Be specific: reference actual file names, function names, requirement text, disc
   console.log(`[status-review] ${issueId}: generating with ${providerEnvStr}${cliCmd}${modelFlag}`);
 
   try {
-    const env = buildChildEnv(process.env, providerEnv);
+    const env = Effect.runSync(buildChildEnv(process.env, providerEnv));
     const promptContent = await readFile(promptFile, 'utf-8');
     const { stdout: aiReview } = await execAsync(
       `${cliCmd} -p${modelFlag} --no-session-persistence`,

--- a/src/dashboard/server/routes/conversations.ts
+++ b/src/dashboard/server/routes/conversations.ts
@@ -1072,7 +1072,7 @@ async function generateAiTitle(conversationName: string, firstMessage: string): 
 
   // Build provider-env for the title model (same routing as conversation sessions)
   const providerEnv = await getProviderEnvForModel(titleModel);
-  const childEnv = { ...buildChildEnv(), ...providerEnv };
+  const childEnv = { ...Effect.runSync(buildChildEnv()), ...providerEnv };
 
   const stdout = await new Promise<string>((resolve, reject) => {
     const child = spawn(

--- a/src/dashboard/server/routes/workspaces.ts
+++ b/src/dashboard/server/routes/workspaces.ts
@@ -2331,7 +2331,7 @@ const postWorkspaceContainerizeRoute = HttpRouter.add(
           cwd: workspaceDir,
           detached: true,
           stdio: ['ignore', 'pipe', 'pipe'],
-          env: buildChildEnvWithoutTmux(process.env, { UID: String(uid), GID: String(gid), DOCKER_USER: `${uid}:${gid}` }),
+          env: Effect.runSync(buildChildEnvWithoutTmux(process.env, { UID: String(uid), GID: String(gid), DOCKER_USER: `${uid}:${gid}` })),
         });
 
         devUp.stdout?.on('data', (data) => {

--- a/src/dashboard/server/services/agent-state-service.ts
+++ b/src/dashboard/server/services/agent-state-service.ts
@@ -32,7 +32,7 @@ import type {
 } from '@panctl/contracts';
 import { initEventStore, getSharedDb } from '../event-store.js';
 import type { StoredEvent } from '../event-store.js';
-import { setAgentRuntimeMirror, getRuntimeSnapshotSync as getMirrorSnapshot, markAgentStateServiceInProcess } from '../../../lib/agent-runtime-mirror.js';
+import { setAgentRuntimeMirror, getRuntimeSnapshot as getMirrorSnapshot, markAgentStateServiceInProcess } from '../../../lib/agent-runtime-mirror.js';
 
 // ─── Event filtering ──────────────────────────────────────────────────────────
 
@@ -90,7 +90,7 @@ export class AgentStateService extends Context.Service<
 // ─── Live implementation ──────────────────────────────────────────────────────
 
 // Re-export the cross-process-safe mirror accessor.
-export const getRuntimeSnapshotSync = getMirrorSnapshot;
+export const getRuntimeSnapshot = getMirrorSnapshot;
 
 export const AgentStateServiceLive = Layer.effect(
   AgentStateService,
@@ -98,7 +98,7 @@ export const AgentStateServiceLive = Layer.effect(
     // Flag lib-side adapters to prefer the in-process mirror over HTTP.
     // Without this, agent-enrichment / ReadModel bootstrap would fetch() our
     // own HTTP server before it finished listening — a circular deadlock.
-    markAgentStateServiceInProcess();
+    yield* markAgentStateServiceInProcess();
     const store = yield* Effect.promise(() => initEventStore());
     const ref = yield* SubscriptionRef.make<Record<string, AgentRuntimeSnapshot>>({});
 
@@ -147,7 +147,7 @@ export const AgentStateServiceLive = Layer.effect(
         if (snap.updatedAtSequence > maxCachedSequence) maxCachedSequence = snap.updatedAtSequence;
       }
       yield* SubscriptionRef.set(ref, initial);
-      setAgentRuntimeMirror(initial);
+      yield* setAgentRuntimeMirror(initial);
       console.log(
         `[AgentStateService] Bootstrapped ${Object.keys(initial).length} runtime snapshot(s) from projection_cache (seq=${maxCachedSequence})`,
       );
@@ -228,7 +228,7 @@ function applyEventToRef(
       }
     }
 
-    setAgentRuntimeMirror(next);
+    Effect.runSync(setAgentRuntimeMirror(next));
     return next;
   });
 }

--- a/src/dashboard/server/services/terminal-service.ts
+++ b/src/dashboard/server/services/terminal-service.ts
@@ -128,11 +128,11 @@ async function getNodePty() {
 
 /** Spawn PTY immediately — caller must ensure tmux session exists. */
 function spawnPtyImmediate(sessionName: string, cols: number, rows: number): PtyProcess {
-  const env = buildChildEnvWithoutTmux(process.env, {
+  const env = Effect.runSync(buildChildEnvWithoutTmux(process.env, {
     TERM: 'xterm-256color',
     COLORTERM: 'truecolor',
     LANG: 'en_US.UTF-8',
-  });
+  }));
   const cwd = homedir();
 
   if (isBun()) {

--- a/src/dashboard/server/ws-terminal.ts
+++ b/src/dashboard/server/ws-terminal.ts
@@ -24,6 +24,7 @@ import { buildTmuxArgs, capturePaneAsync, getWindowDimensionsAsync, listSessionN
 import { consumeReauthTerminalToken } from './routes/codex-auth.js';
 import { validateOriginHeaders } from './routes/origin-validation.js';
 import { buildChildEnvWithoutTmux } from '../../lib/child-env.js';
+import { Effect } from 'effect';
 import { isRespawnPending, waitForSessionRespawn } from './services/pending-respawn.js';
 
 // Worst-case respawn window for switch-model / resume / restart-all is
@@ -477,11 +478,11 @@ export function setupTerminalWebSocket(server: http.Server): void {
           cols: hub.cols,
           rows: hub.rows,
           cwd: homedir(),
-          env: buildChildEnvWithoutTmux(process.env, {
+          env: Effect.runSync(buildChildEnvWithoutTmux(process.env, {
             TERM: 'xterm-256color',
             COLORTERM: 'truecolor',
             LANG: 'en_US.UTF-8',
-          }) as { [key: string]: string },
+          })) as { [key: string]: string },
         });
 
         hub.pty = ptyProcess;

--- a/src/lib/agent-runtime-mirror.ts
+++ b/src/lib/agent-runtime-mirror.ts
@@ -2,15 +2,13 @@
  * PAN-800 — in-process mirror of AgentStateService's canonical ref.
  *
  * The dashboard server writes into this mirror on every event fold so lib code
- * running in the same process can read the latest AgentRuntimeSnapshot
- * synchronously. CLI/out-of-process callers should prefer the async HTTP path
- * in agent-runtime.ts.
+ * running in the same process can read the latest AgentRuntimeSnapshot.
+ * CLI/out-of-process callers should prefer the async HTTP path in agent-runtime.ts.
  *
- * This module intentionally has zero server-side imports so both the CLI
- * and the dashboard can pull it in without dragging in SQLite / Effect
- * layer code.
+ * All exports are Effect-native (PAN-1249 wave-1 migration).
  */
 
+import { Effect } from 'effect';
 import type { AgentRuntimeSnapshot } from '@panctl/contracts';
 
 let mirror: Record<string, AgentRuntimeSnapshot> = {};
@@ -23,18 +21,22 @@ let mirror: Record<string, AgentRuntimeSnapshot> = {};
  */
 let inProcessService = false;
 
-export function markAgentStateServiceInProcess(): void {
-  inProcessService = true;
+export function markAgentStateServiceInProcess(): Effect.Effect<void, never> {
+  return Effect.sync(() => {
+    inProcessService = true;
+  });
 }
 
-export function isAgentStateServiceInProcess(): boolean {
-  return inProcessService;
+export function isAgentStateServiceInProcess(): Effect.Effect<boolean, never> {
+  return Effect.sync(() => inProcessService);
 }
 
-export function setAgentRuntimeMirror(next: Record<string, AgentRuntimeSnapshot>): void {
-  mirror = next;
+export function setAgentRuntimeMirror(next: Record<string, AgentRuntimeSnapshot>): Effect.Effect<void, never> {
+  return Effect.sync(() => {
+    mirror = next;
+  });
 }
 
-export function getRuntimeSnapshotSync(agentId: string): AgentRuntimeSnapshot | null {
-  return mirror[agentId] ?? null;
+export function getRuntimeSnapshot(agentId: string): Effect.Effect<AgentRuntimeSnapshot | null, never> {
+  return Effect.sync(() => mirror[agentId] ?? null);
 }

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -1447,7 +1447,7 @@ export const __testInternals = { markAgentRunning, markAgentStopped };
 // SubscriptionRef → projection_cache rows keyed 'agent-runtime:<id>'.
 //
 // Writes: emitAgentEvent POSTs to /api/agents/:id/heartbeat. Reads: in-process
-// lib uses getRuntimeSnapshotSync; CLI/out-of-process uses
+// lib uses getRuntimeSnapshot (Effect-native); CLI/out-of-process uses
 // getAgentRuntimeSnapshot (HTTP).
 //
 // The functions below are adapters over AgentRuntimeSnapshot. Each caller
@@ -1460,7 +1460,8 @@ import {
   getAgentRuntimeSnapshot as fetchAgentRuntimeSnapshot,
   emitAgentEvent,
 } from './agent-runtime.js';
-import { getRuntimeSnapshotSync, isAgentStateServiceInProcess } from './agent-runtime-mirror.js';
+import { Effect } from 'effect';
+import { getRuntimeSnapshot, isAgentStateServiceInProcess } from './agent-runtime-mirror.js';
 
 export type AgentResolution = 'working' | 'done' | 'needs_input' | 'stuck' | 'completed' | 'unclear' | 'abandoned';
 
@@ -1518,14 +1519,14 @@ export function getAgentRuntimeState(agentId: string): AgentRuntimeState | null 
   // Sync path: read from the in-process mirror (empty in fresh CLI processes,
   // populated inside the dashboard server). CLI commands should prefer
   // getAgentRuntimeStateAsync so they fall through to HTTP.
-  return snapshotToRuntimeState(getRuntimeSnapshotSync(agentId));
+  return snapshotToRuntimeState(Effect.runSync(getRuntimeSnapshot(agentId)));
 }
 
 export async function getAgentRuntimeStateAsync(agentId: string): Promise<AgentRuntimeState | null> {
   // In-process (inside the dashboard): the sync mirror is authoritative. Do
   // NOT fall back to HTTP — that would fetch our own server, which may still
   // be inside Layer construction and cause a startup deadlock.
-  if (isAgentStateServiceInProcess()) {
+  if (Effect.runSync(isAgentStateServiceInProcess())) {
     return getAgentRuntimeState(agentId);
   }
   // Cross-process (CLI, external lib callers): sync mirror is empty, hit HTTP.

--- a/src/lib/child-env.ts
+++ b/src/lib/child-env.ts
@@ -11,6 +11,8 @@
  * Use it anywhere you would otherwise write `{ ...process.env, ...overrides }`.
  */
 
+import { Effect } from 'effect';
+
 /** Env vars that leak from a parent shell / tmux / screen and must not reach children. */
 const LEAKED_ENV_KEYS = new Set([
   'TMUX',
@@ -39,24 +41,26 @@ const STRIPPED_KEYS = new Set([...LEAKED_ENV_KEYS, ...PROVIDER_ENV_KEYS]);
  *
  * @param baseEnv  Source environment (default: process.env). Only string values are copied.
  * @param overrides  Key/value pairs to overlay AFTER stripping.
- * @returns  A plain object safe to pass to spawn, pty.spawn, etc.
+ * @returns  Effect yielding a plain object safe to pass to spawn, pty.spawn, etc.
  */
 export function buildChildEnv(
   baseEnv: NodeJS.ProcessEnv = process.env,
   overrides?: Record<string, string>,
-): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const [k, v] of Object.entries(baseEnv)) {
-    if (v === undefined) continue;
-    if (STRIPPED_KEYS.has(k)) continue;
-    out[k] = v;
-  }
-  if (overrides) {
-    for (const [k, v] of Object.entries(overrides)) {
+): Effect.Effect<Record<string, string>> {
+  return Effect.sync(() => {
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(baseEnv)) {
+      if (v === undefined) continue;
+      if (STRIPPED_KEYS.has(k)) continue;
       out[k] = v;
     }
-  }
-  return out;
+    if (overrides) {
+      for (const [k, v] of Object.entries(overrides)) {
+        out[k] = v;
+      }
+    }
+    return out;
+  });
 }
 
 /**
@@ -75,21 +79,25 @@ export const BLANKED_PROVIDER_ENV: Record<string, string> = Object.fromEntries(
 /**
  * Variant that strips ONLY tmux/screen artifacts (not provider keys).
  * Use this when the caller will handle provider env separately (e.g. launcher scripts).
+ *
+ * @returns  Effect yielding a plain object safe to pass to spawn, pty.spawn, etc.
  */
 export function buildChildEnvWithoutTmux(
   baseEnv: NodeJS.ProcessEnv = process.env,
   overrides?: Record<string, string>,
-): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const [k, v] of Object.entries(baseEnv)) {
-    if (v === undefined) continue;
-    if (LEAKED_ENV_KEYS.has(k)) continue;
-    out[k] = v;
-  }
-  if (overrides) {
-    for (const [k, v] of Object.entries(overrides)) {
+): Effect.Effect<Record<string, string>> {
+  return Effect.sync(() => {
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(baseEnv)) {
+      if (v === undefined) continue;
+      if (LEAKED_ENV_KEYS.has(k)) continue;
       out[k] = v;
     }
-  }
-  return out;
+    if (overrides) {
+      for (const [k, v] of Object.entries(overrides)) {
+        out[k] = v;
+      }
+    }
+    return out;
+  });
 }

--- a/src/lib/cloister/inspect-agent.ts
+++ b/src/lib/cloister/inspect-agent.ts
@@ -13,6 +13,7 @@ import { randomUUID } from 'crypto';
 import { fileURLToPath } from 'url';
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { Effect } from 'effect';
 import {
   getDiffBase,
   getDiffStats,
@@ -111,8 +112,8 @@ export async function buildInspectPrompt(context: InspectContext): Promise<strin
   const beadDescription = await getBeadDescription(context.beadId, context.workspace);
 
   // Get diff scope
-  const diffBase = await getDiffBase(context.projectKey, context.issueId, context.workspace);
-  const diffStats = await getDiffStats(context.workspace, diffBase);
+  const diffBase = await Effect.runPromise(getDiffBase(context.projectKey, context.issueId, context.workspace));
+  const diffStats = await Effect.runPromise(getDiffStats(context.workspace, diffBase));
 
   const apiUrl = process.env.DASHBOARD_URL || `http://localhost:${process.env.API_PORT || process.env.PORT || '3011'}`;
 
@@ -271,8 +272,8 @@ export async function onInspectComplete(
   workspacePath: string
 ): Promise<void> {
   if (status === 'passed') {
-    const commitSha = await getCurrentHead(workspacePath);
-    saveCheckpoint(projectKey, issueId, beadId, commitSha);
+    const commitSha = await Effect.runPromise(getCurrentHead(workspacePath));
+    await Effect.runPromise(saveCheckpoint(projectKey, issueId, beadId, commitSha));
     console.log(`[inspect] Checkpoint saved for ${issueId} bead ${beadId} at ${commitSha.substring(0, 8)}`);
 
   } else {

--- a/src/lib/cloister/inspect-checkpoints.ts
+++ b/src/lib/cloister/inspect-checkpoints.ts
@@ -7,11 +7,14 @@
  * First inspection: diff from branch base (main...HEAD)
  * Subsequent: diff from last checkpoint SHA to HEAD
  */
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { existsSync } from 'fs';
+import { readFile, writeFile, mkdir } from 'fs/promises';
 import { join } from 'path';
 import { homedir } from 'os';
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { Effect } from 'effect';
+import { FsError, GitError } from '../errors.js';
 
 const execAsync = promisify(exec);
 
@@ -45,24 +48,31 @@ function getCheckpointPath(projectKey: string, issueId: string): string {
 /**
  * Load checkpoints for an issue. Returns null if no checkpoints exist.
  */
-export function loadCheckpoints(projectKey: string, issueId: string): InspectCheckpointFile | null {
+export function loadCheckpoints(
+  projectKey: string,
+  issueId: string,
+): Effect.Effect<InspectCheckpointFile | null> {
   const filePath = getCheckpointPath(projectKey, issueId);
-  if (!existsSync(filePath)) return null;
+  if (!existsSync(filePath)) return Effect.succeed(null);
 
-  try {
-    return JSON.parse(readFileSync(filePath, 'utf-8'));
-  } catch {
-    return null;
-  }
+  return Effect.tryPromise({
+    try: async () => JSON.parse(await readFile(filePath, 'utf-8')) as InspectCheckpointFile,
+    catch: (e) => new FsError({ path: filePath, operation: 'read', cause: e }),
+  }).pipe(Effect.catch(() => Effect.succeed(null)));
 }
 
 /**
  * Get the last checkpoint for an issue, or null if none exist.
  */
-export function getLastCheckpoint(projectKey: string, issueId: string): InspectCheckpoint | null {
-  const data = loadCheckpoints(projectKey, issueId);
-  if (!data || data.checkpoints.length === 0) return null;
-  return data.checkpoints[data.checkpoints.length - 1];
+export function getLastCheckpoint(
+  projectKey: string,
+  issueId: string,
+): Effect.Effect<InspectCheckpoint | null> {
+  return Effect.gen(function* () {
+    const data = yield* loadCheckpoints(projectKey, issueId);
+    if (!data || data.checkpoints.length === 0) return null;
+    return data.checkpoints[data.checkpoints.length - 1] ?? null;
+  });
 }
 
 /**
@@ -72,28 +82,39 @@ export function saveCheckpoint(
   projectKey: string,
   issueId: string,
   beadId: string,
-  commitSha: string
-): InspectCheckpoint {
-  const dir = getCheckpointDir(projectKey);
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
-  }
+  commitSha: string,
+): Effect.Effect<InspectCheckpoint, FsError> {
+  return Effect.gen(function* () {
+    const dir = getCheckpointDir(projectKey);
+    if (!existsSync(dir)) {
+      yield* Effect.tryPromise({
+        try: () => mkdir(dir, { recursive: true }),
+        catch: (e) => new FsError({ path: dir, operation: 'mkdir', cause: e }),
+      });
+    }
 
-  const data = loadCheckpoints(projectKey, issueId) || {
-    issueId: issueId.toUpperCase(),
-    checkpoints: [],
-  };
+    const existing = yield* loadCheckpoints(projectKey, issueId);
+    const data: InspectCheckpointFile = existing ?? {
+      issueId: issueId.toUpperCase(),
+      checkpoints: [],
+    };
 
-  const checkpoint: InspectCheckpoint = {
-    beadId,
-    commitSha,
-    passedAt: new Date().toISOString(),
-  };
+    const checkpoint: InspectCheckpoint = {
+      beadId,
+      commitSha,
+      passedAt: new Date().toISOString(),
+    };
 
-  data.checkpoints.push(checkpoint);
-  writeFileSync(getCheckpointPath(projectKey, issueId), JSON.stringify(data, null, 2));
+    data.checkpoints.push(checkpoint);
 
-  return checkpoint;
+    const filePath = getCheckpointPath(projectKey, issueId);
+    yield* Effect.tryPromise({
+      try: () => writeFile(filePath, JSON.stringify(data, null, 2)),
+      catch: (e) => new FsError({ path: filePath, operation: 'write', cause: e }),
+    });
+
+    return checkpoint;
+  });
 }
 
 /**
@@ -104,52 +125,73 @@ export function saveCheckpoint(
  *
  * Returns the commit SHA or ref to diff from.
  */
-export async function getDiffBase(projectKey: string, issueId: string, workspacePath: string): Promise<string> {
-  const lastCheckpoint = getLastCheckpoint(projectKey, issueId);
+export function getDiffBase(
+  projectKey: string,
+  issueId: string,
+  workspacePath: string,
+): Effect.Effect<string> {
+  return Effect.gen(function* () {
+    const lastCheckpoint = yield* getLastCheckpoint(projectKey, issueId);
+    if (lastCheckpoint) {
+      return lastCheckpoint.commitSha;
+    }
 
-  if (lastCheckpoint) {
-    return lastCheckpoint.commitSha;
-  }
-
-  // No checkpoint — use the merge-base with main
-  try {
-    const { stdout } = await execAsync('git merge-base main HEAD', {
-      cwd: workspacePath,
-      encoding: 'utf-8',
-    });
-    return stdout.trim();
-  } catch {
-    // Fallback to 'main' if merge-base fails
-    return 'main';
-  }
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const { stdout } = await execAsync('git merge-base main HEAD', {
+          cwd: workspacePath,
+          encoding: 'utf-8',
+        });
+        return stdout.trim();
+      },
+      catch: (e) => new GitError({
+        command: ['git', 'merge-base', 'main', 'HEAD'],
+        stderr: String(e),
+        exitCode: 1,
+        cause: e,
+      }),
+    }).pipe(Effect.catch(() => Effect.succeed('main')));
+  });
 }
 
 /**
  * Get the diff stats (files changed, insertions, deletions) for the inspection scope.
  */
-export async function getDiffStats(workspacePath: string, diffBase: string): Promise<string> {
-  try {
-    const { stdout } = await execAsync(`git diff --stat ${diffBase}...HEAD`, {
-      cwd: workspacePath,
-      encoding: 'utf-8',
-    });
-    return stdout.trim() || 'No changes detected';
-  } catch {
-    return 'Unable to compute diff stats';
-  }
+export function getDiffStats(workspacePath: string, diffBase: string): Effect.Effect<string> {
+  return Effect.tryPromise({
+    try: async () => {
+      const { stdout } = await execAsync(`git diff --stat ${diffBase}...HEAD`, {
+        cwd: workspacePath,
+        encoding: 'utf-8',
+      });
+      return stdout.trim() || 'No changes detected';
+    },
+    catch: (e) => new GitError({
+      command: ['git', 'diff', '--stat', `${diffBase}...HEAD`],
+      stderr: String(e),
+      exitCode: 1,
+      cause: e,
+    }),
+  }).pipe(Effect.catch(() => Effect.succeed('Unable to compute diff stats')));
 }
 
 /**
  * Get the current HEAD commit SHA.
  */
-export async function getCurrentHead(workspacePath: string): Promise<string> {
-  try {
-    const { stdout } = await execAsync('git rev-parse HEAD', {
-      cwd: workspacePath,
-      encoding: 'utf-8',
-    });
-    return stdout.trim();
-  } catch {
-    return 'unknown';
-  }
+export function getCurrentHead(workspacePath: string): Effect.Effect<string> {
+  return Effect.tryPromise({
+    try: async () => {
+      const { stdout } = await execAsync('git rev-parse HEAD', {
+        cwd: workspacePath,
+        encoding: 'utf-8',
+      });
+      return stdout.trim();
+    },
+    catch: (e) => new GitError({
+      command: ['git', 'rev-parse', 'HEAD'],
+      stderr: String(e),
+      exitCode: 1,
+      cause: e,
+    }),
+  }).pipe(Effect.catch(() => Effect.succeed('unknown')));
 }

--- a/src/lib/openai-compatible-proxy.ts
+++ b/src/lib/openai-compatible-proxy.ts
@@ -1,4 +1,6 @@
 import http from 'http';
+import { Data, Effect } from 'effect';
+
 const HOST = '127.0.0.1';
 const PORT = 12436;
 
@@ -9,6 +11,11 @@ const UPSTREAMS: Record<string, string> = {
 let server: http.Server | null = null;
 let started = false;
 
+export class ProxyStartError extends Data.TaggedError('ProxyStartError')<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
 export function getOpenAICompatibleProxyBaseUrl(provider: string): string {
   return `http://${HOST}:${PORT}/${provider}`;
 }
@@ -17,44 +24,54 @@ export function getProxyPathname(url: string | undefined): string {
   return new URL(url ?? '/', `http://${HOST}:${PORT}`).pathname;
 }
 
-export async function ensureOpenAICompatibleProxyRunning(): Promise<void> {
-  if (started && server?.listening) return;
-  if (await isPortOpen()) {
-    started = true;
-    return;
-  }
+export function ensureOpenAICompatibleProxyRunning(): Effect.Effect<void, ProxyStartError> {
+  return Effect.gen(function* () {
+    if (started && server?.listening) return;
 
-  server = http.createServer((req, res) => {
-    void handleRequest(req, res).catch((err) => {
-      if (!res.headersSent) {
-        res.writeHead(500, { 'content-type': 'application/json' });
-      }
-      res.end(JSON.stringify({ error: { message: err instanceof Error ? err.message : String(err) } }));
-    });
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    server!.once('error', reject);
-    server!.listen(PORT, HOST, () => {
-      server!.off('error', reject);
+    const portOpen = yield* isPortOpen();
+    if (portOpen) {
       started = true;
-      resolve();
+      return;
+    }
+
+    yield* Effect.tryPromise({
+      try: () =>
+        new Promise<void>((resolve, reject) => {
+          server = http.createServer((req, res) => {
+            void handleRequest(req, res).catch((err) => {
+              if (!res.headersSent) {
+                res.writeHead(500, { 'content-type': 'application/json' });
+              }
+              res.end(JSON.stringify({ error: { message: err instanceof Error ? err.message : String(err) } }));
+            });
+          });
+          server.once('error', reject);
+          server.listen(PORT, HOST, () => {
+            server!.off('error', reject);
+            started = true;
+            resolve();
+          });
+        }),
+      catch: (e) => new ProxyStartError({ message: e instanceof Error ? e.message : String(e), cause: e }),
     });
   });
 }
 
-async function isPortOpen(): Promise<boolean> {
-  return new Promise((resolve) => {
-    const req = http.get({ host: HOST, port: PORT, path: '/health', timeout: 1000 }, (res) => {
-      res.resume();
-      resolve(res.statusCode === 200);
-    });
-    req.on('error', () => resolve(false));
-    req.on('timeout', () => {
-      req.destroy();
-      resolve(false);
-    });
-  });
+function isPortOpen(): Effect.Effect<boolean, never> {
+  return Effect.promise(
+    () =>
+      new Promise<boolean>((resolve) => {
+        const req = http.get({ host: HOST, port: PORT, path: '/health', timeout: 1000 }, (res) => {
+          res.resume();
+          resolve(res.statusCode === 200);
+        });
+        req.on('error', () => resolve(false));
+        req.on('timeout', () => {
+          req.destroy();
+          resolve(false);
+        });
+      }),
+  );
 }
 
 async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {

--- a/src/lib/remote/__tests__/workspace-metadata.test.ts
+++ b/src/lib/remote/__tests__/workspace-metadata.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect } from 'vitest';
+import { layer } from '@effect/vitest';
+import { Effect, FileSystem } from 'effect';
+import * as NodeFileSystem from '@effect/platform-node-shared/NodeFileSystem';
+import { writeFile } from 'fs/promises';
+import { join } from 'path';
+import { FsError } from '../../errors.js';
+import {
+  saveWorkspaceMetadata,
+  loadWorkspaceMetadata,
+  listWorkspaceMetadata,
+  deleteWorkspaceMetadata,
+  findRemoteWorkspaceMetadata,
+  WORKSPACES_DIR,
+} from '../workspace-metadata.js';
+import type { RemoteWorkspaceMetadata } from '../interface.js';
+
+const TEST_ID = 'test-pan-ws-meta-unit';
+const BAD_YAML_ID = 'test-pan-ws-meta-bad-yaml';
+
+const testMetadata: RemoteWorkspaceMetadata = {
+  id: TEST_ID,
+  issue: 'TEST-9999',
+  provider: 'test',
+  vmName: 'test-vm',
+  urls: {},
+  created: new Date('2026-01-01T00:00:00.000Z'),
+  location: 'remote',
+};
+
+layer(NodeFileSystem.layer)('workspace-metadata', (it) => {
+  describe('saveWorkspaceMetadata + loadWorkspaceMetadata round-trip', () => {
+    it.effect('persists and retrieves metadata', () =>
+      Effect.gen(function* () {
+        yield* saveWorkspaceMetadata(testMetadata);
+        const loaded = yield* loadWorkspaceMetadata(TEST_ID);
+        expect(loaded).not.toBeNull();
+        expect(loaded?.id).toBe(TEST_ID);
+        expect(loaded?.issue).toBe('TEST-9999');
+        expect(loaded?.provider).toBe('test');
+        expect(loaded?.location).toBe('remote');
+        yield* deleteWorkspaceMetadata(TEST_ID);
+      }),
+    );
+  });
+
+  describe('loadWorkspaceMetadata', () => {
+    it.effect('returns null for a non-existent issue', () =>
+      Effect.gen(function* () {
+        const result = yield* loadWorkspaceMetadata('nonexistent-issue-id-that-will-never-exist');
+        expect(result).toBeNull();
+      }),
+    );
+
+    it.effect('surfaces FsError on malformed YAML', () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const dirExists = yield* fs.exists(WORKSPACES_DIR);
+        if (!dirExists) {
+          yield* fs.makeDirectory(WORKSPACES_DIR, { recursive: true });
+        }
+        const badFile = join(WORKSPACES_DIR, `${BAD_YAML_ID}.yaml`);
+        yield* Effect.tryPromise(() => writeFile(badFile, ': invalid: yaml: {{{', 'utf-8'));
+
+        const result = yield* Effect.flip(loadWorkspaceMetadata(BAD_YAML_ID));
+        expect(result._tag).toBe('FsError');
+        expect((result as FsError).operation).toBe('parse');
+
+        yield* fs.remove(badFile);
+      }),
+    );
+  });
+
+  describe('listWorkspaceMetadata', () => {
+    it.effect('returns an array (empty when no matching files)', () =>
+      Effect.gen(function* () {
+        const workspaces = yield* listWorkspaceMetadata();
+        expect(Array.isArray(workspaces)).toBe(true);
+      }),
+    );
+
+    it.effect('includes a saved workspace in the list', () =>
+      Effect.gen(function* () {
+        yield* saveWorkspaceMetadata(testMetadata);
+        const workspaces = yield* listWorkspaceMetadata();
+        const found = workspaces.find(w => w.id === TEST_ID);
+        expect(found).toBeDefined();
+        yield* deleteWorkspaceMetadata(TEST_ID);
+      }),
+    );
+  });
+
+  describe('deleteWorkspaceMetadata', () => {
+    it.effect('returns false for a non-existent issue', () =>
+      Effect.gen(function* () {
+        const deleted = yield* deleteWorkspaceMetadata('nonexistent-issue-id-that-will-never-exist');
+        expect(deleted).toBe(false);
+      }),
+    );
+
+    it.effect('returns true and removes the file', () =>
+      Effect.gen(function* () {
+        yield* saveWorkspaceMetadata(testMetadata);
+        const deleted = yield* deleteWorkspaceMetadata(TEST_ID);
+        expect(deleted).toBe(true);
+        const loaded = yield* loadWorkspaceMetadata(TEST_ID);
+        expect(loaded).toBeNull();
+      }),
+    );
+  });
+
+  describe('findRemoteWorkspaceMetadata', () => {
+    it.effect('delegates to loadWorkspaceMetadata', () =>
+      Effect.gen(function* () {
+        yield* saveWorkspaceMetadata(testMetadata);
+        const found = yield* findRemoteWorkspaceMetadata(TEST_ID);
+        expect(found?.id).toBe(TEST_ID);
+        yield* deleteWorkspaceMetadata(TEST_ID);
+      }),
+    );
+  });
+});

--- a/src/lib/remote/workspace-metadata.ts
+++ b/src/lib/remote/workspace-metadata.ts
@@ -1,97 +1,132 @@
-/**
- * Workspace Metadata Management
- *
- * Shared module for loading, saving, and listing workspace metadata.
- * Used by both workspace.ts and work/issue.ts for remote workspace support.
- */
-
-import { existsSync, mkdirSync, writeFileSync, readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { parse, stringify } from 'yaml';
+import { Effect, FileSystem } from 'effect';
 import type { RemoteWorkspaceMetadata } from './interface.js';
+import { FsError } from '../errors.js';
 
-// Path for workspace metadata
 export const WORKSPACES_DIR = join(homedir(), '.panopticon', 'workspaces');
 
-/**
- * Save workspace metadata to ~/.panopticon/workspaces/{issueId}.yaml
- */
-export function saveWorkspaceMetadata(metadata: RemoteWorkspaceMetadata): void {
-  if (!existsSync(WORKSPACES_DIR)) {
-    mkdirSync(WORKSPACES_DIR, { recursive: true });
-  }
+function toFsError(path: string, operation: string) {
+  return (cause: unknown): FsError => new FsError({ path, operation, cause });
+}
 
-  const filename = join(WORKSPACES_DIR, `${metadata.id}.yaml`);
-  writeFileSync(filename, stringify(metadata), 'utf-8');
+/**
+ * Save workspace metadata to ~/.panopticon/workspaces/{id}.yaml
+ */
+export function saveWorkspaceMetadata(
+  metadata: RemoteWorkspaceMetadata,
+): Effect.Effect<void, FsError, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const dirExists = yield* fs.exists(WORKSPACES_DIR).pipe(
+      Effect.mapError(toFsError(WORKSPACES_DIR, 'exists')),
+    );
+    if (!dirExists) {
+      yield* fs.makeDirectory(WORKSPACES_DIR, { recursive: true }).pipe(
+        Effect.mapError(toFsError(WORKSPACES_DIR, 'mkdir')),
+      );
+    }
+    const filename = join(WORKSPACES_DIR, `${metadata.id}.yaml`);
+    yield* fs.writeFileString(filename, stringify(metadata)).pipe(
+      Effect.mapError(toFsError(filename, 'write')),
+    );
+  });
 }
 
 /**
  * Load workspace metadata from ~/.panopticon/workspaces/{issueId}.yaml
  */
-export function loadWorkspaceMetadata(issueId: string): RemoteWorkspaceMetadata | null {
-  const normalizedId = issueId.toLowerCase().replace(/[^a-z0-9-]/g, '-');
-  const filename = join(WORKSPACES_DIR, `${normalizedId}.yaml`);
+export function loadWorkspaceMetadata(
+  issueId: string,
+): Effect.Effect<RemoteWorkspaceMetadata | null, FsError, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const normalizedId = issueId.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+    const filename = join(WORKSPACES_DIR, `${normalizedId}.yaml`);
 
-  if (!existsSync(filename)) {
-    return null;
-  }
+    const exists = yield* fs.exists(filename).pipe(
+      Effect.mapError(toFsError(filename, 'exists')),
+    );
+    if (!exists) return null;
 
-  try {
-    const content = readFileSync(filename, 'utf-8');
-    return parse(content) as RemoteWorkspaceMetadata;
-  } catch {
-    return null;
-  }
+    const content = yield* fs.readFileString(filename, 'utf-8').pipe(
+      Effect.mapError(toFsError(filename, 'read')),
+    );
+    return yield* Effect.try({
+      try: () => parse(content) as RemoteWorkspaceMetadata,
+      catch: (e) => new FsError({ path: filename, operation: 'parse', cause: e }),
+    });
+  });
 }
 
 /**
  * List all workspace metadata files
  */
-export function listWorkspaceMetadata(): RemoteWorkspaceMetadata[] {
-  if (!existsSync(WORKSPACES_DIR)) {
-    return [];
-  }
+export function listWorkspaceMetadata(): Effect.Effect<
+  RemoteWorkspaceMetadata[],
+  FsError,
+  FileSystem.FileSystem
+> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
 
-  const files = readdirSync(WORKSPACES_DIR).filter(f => f.endsWith('.yaml'));
-  const workspaces: RemoteWorkspaceMetadata[] = [];
+    const dirExists = yield* fs.exists(WORKSPACES_DIR).pipe(
+      Effect.mapError(toFsError(WORKSPACES_DIR, 'exists')),
+    );
+    if (!dirExists) return [];
 
-  for (const file of files) {
-    try {
-      const content = readFileSync(join(WORKSPACES_DIR, file), 'utf-8');
-      workspaces.push(parse(content) as RemoteWorkspaceMetadata);
-    } catch {
-      // Skip invalid files
+    const files = yield* fs.readDirectory(WORKSPACES_DIR).pipe(
+      Effect.mapError(toFsError(WORKSPACES_DIR, 'readdir')),
+    );
+    const yamlFiles = files.filter(f => f.endsWith('.yaml'));
+    const workspaces: RemoteWorkspaceMetadata[] = [];
+
+    for (const file of yamlFiles) {
+      const filePath = join(WORKSPACES_DIR, file);
+      const content = yield* fs.readFileString(filePath, 'utf-8').pipe(
+        Effect.mapError(toFsError(filePath, 'read')),
+      );
+      const parsed = yield* Effect.try({
+        try: () => parse(content) as RemoteWorkspaceMetadata,
+        catch: (e) => new FsError({ path: filePath, operation: 'parse', cause: e }),
+      });
+      workspaces.push(parsed);
     }
-  }
 
-  return workspaces;
+    return workspaces;
+  });
 }
 
 /**
- * Check if a workspace exists (local or remote)
- * Returns metadata if remote workspace exists, null otherwise
+ * Check if a workspace exists (local or remote).
+ * Returns metadata if remote workspace exists, null otherwise.
  */
-export function findRemoteWorkspaceMetadata(issueId: string): RemoteWorkspaceMetadata | null {
+export function findRemoteWorkspaceMetadata(
+  issueId: string,
+): Effect.Effect<RemoteWorkspaceMetadata | null, FsError, FileSystem.FileSystem> {
   return loadWorkspaceMetadata(issueId);
 }
 
 /**
- * Delete workspace metadata
+ * Delete workspace metadata. Returns true if deleted, false if not found.
  */
-export function deleteWorkspaceMetadata(issueId: string): boolean {
-  const normalizedId = issueId.toLowerCase().replace(/[^a-z0-9-]/g, '-');
-  const filename = join(WORKSPACES_DIR, `${normalizedId}.yaml`);
+export function deleteWorkspaceMetadata(
+  issueId: string,
+): Effect.Effect<boolean, FsError, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const normalizedId = issueId.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+    const filename = join(WORKSPACES_DIR, `${normalizedId}.yaml`);
 
-  if (!existsSync(filename)) {
-    return false;
-  }
+    const exists = yield* fs.exists(filename).pipe(
+      Effect.mapError(toFsError(filename, 'exists')),
+    );
+    if (!exists) return false;
 
-  try {
-    const { unlinkSync } = require('fs');
-    unlinkSync(filename);
+    yield* fs.remove(filename).pipe(
+      Effect.mapError(toFsError(filename, 'unlink')),
+    );
     return true;
-  } catch {
-    return false;
-  }
+  });
 }

--- a/src/lib/shell.ts
+++ b/src/lib/shell.ts
@@ -1,64 +1,74 @@
 import { existsSync, readFileSync, appendFileSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
+import { Effect } from 'effect';
+import { FsError } from './errors.js';
 
 export type Shell = 'bash' | 'zsh' | 'fish' | 'unknown';
 
-export function detectShell(): Shell {
-  const shell = process.env.SHELL || '';
-
-  if (shell.includes('zsh')) return 'zsh';
-  if (shell.includes('bash')) return 'bash';
-  if (shell.includes('fish')) return 'fish';
-
-  return 'unknown';
+export function detectShell(): Effect.Effect<Shell> {
+  return Effect.sync(() => {
+    const shell = process.env.SHELL || '';
+    if (shell.includes('zsh')) return 'zsh';
+    if (shell.includes('bash')) return 'bash';
+    if (shell.includes('fish')) return 'fish';
+    return 'unknown';
+  });
 }
 
-export function getShellRcFile(shell: Shell): string | null {
-  const home = homedir();
-
-  switch (shell) {
-    case 'zsh':
-      return join(home, '.zshrc');
-    case 'bash':
-      // Prefer .bashrc, fall back to .bash_profile
-      const bashrc = join(home, '.bashrc');
-      if (existsSync(bashrc)) return bashrc;
-      return join(home, '.bash_profile');
-    case 'fish':
-      return join(home, '.config', 'fish', 'config.fish');
-    default:
-      return null;
-  }
+export function getShellRcFile(shell: Shell): Effect.Effect<string | null> {
+  return Effect.sync(() => {
+    const home = homedir();
+    switch (shell) {
+      case 'zsh':
+        return join(home, '.zshrc');
+      case 'bash': {
+        const bashrc = join(home, '.bashrc');
+        if (existsSync(bashrc)) return bashrc;
+        return join(home, '.bash_profile');
+      }
+      case 'fish':
+        return join(home, '.config', 'fish', 'config.fish');
+      default:
+        return null;
+    }
+  });
 }
 
 const ALIAS_LINE = 'alias pan="panopticon"';
 const ALIAS_MARKER = '# Panopticon CLI alias';
 
-export function hasAlias(rcFile: string): boolean {
-  if (!existsSync(rcFile)) return false;
-
-  const content = readFileSync(rcFile, 'utf8');
-  return content.includes(ALIAS_MARKER) || content.includes(ALIAS_LINE);
+export function hasAlias(rcFile: string): Effect.Effect<boolean, FsError> {
+  return Effect.try({
+    try: () => {
+      if (!existsSync(rcFile)) return false;
+      const content = readFileSync(rcFile, 'utf8');
+      return content.includes(ALIAS_MARKER) || content.includes(ALIAS_LINE);
+    },
+    catch: (e) => new FsError({ path: rcFile, operation: 'read', cause: e }),
+  });
 }
 
-export function addAlias(rcFile: string): void {
-  if (hasAlias(rcFile)) return;
+export function addAlias(rcFile: string): Effect.Effect<void, FsError> {
+  return Effect.gen(function* () {
+    const alreadyHas = yield* hasAlias(rcFile);
+    if (alreadyHas) return;
 
-  const aliasBlock = `
-${ALIAS_MARKER}
-${ALIAS_LINE}
-`;
+    const aliasBlock = `\n${ALIAS_MARKER}\n${ALIAS_LINE}\n`;
 
-  appendFileSync(rcFile, aliasBlock, 'utf8');
+    yield* Effect.try({
+      try: () => appendFileSync(rcFile, aliasBlock, 'utf8'),
+      catch: (e) => new FsError({ path: rcFile, operation: 'append', cause: e }),
+    });
+  });
 }
 
-export function getAliasInstructions(shell: Shell): string {
-  const rcFile = getShellRcFile(shell);
-
-  if (!rcFile) {
-    return `Add this to your shell config:\n  ${ALIAS_LINE}`;
-  }
-
-  return `Alias added to ${rcFile}. Run:\n  source ${rcFile}`;
+export function getAliasInstructions(shell: Shell): Effect.Effect<string> {
+  return Effect.gen(function* () {
+    const rcFile = yield* getShellRcFile(shell);
+    if (!rcFile) {
+      return `Add this to your shell config:\n  ${ALIAS_LINE}`;
+    }
+    return `Alias added to ${rcFile}. Run:\n  source ${rcFile}`;
+  });
 }

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'os';
 import { randomUUID } from 'node:crypto';
 import { getPanopticonHome } from './paths.js';
 import { loadConfig, type TmuxConfigMode } from './config-yaml.js';
+import { Effect } from 'effect';
 import { buildChildEnv } from './child-env.js';
 
 const execFileAsync = promisify(execFile);
@@ -84,7 +85,7 @@ function reloadManagedTmuxConfigSync(): void {
     // the tmux server doesn't inherit stale provider config. Without this,
     // every session spawned by the server inherits the parent's env — and tmux
     // -e can only override, not unset, so stale vars leak through.
-    const cleanEnv = buildChildEnv();
+    const cleanEnv = Effect.runSync(buildChildEnv());
     execFileSync('tmux', ['-L', getManagedTmuxSocketName(), 'start-server'], { stdio: 'ignore', env: cleanEnv });
     execFileSync('tmux', ['-L', getManagedTmuxSocketName(), 'source-file', getManagedTmuxConfigPath()], { stdio: 'ignore' });
   } catch {
@@ -95,7 +96,7 @@ function reloadManagedTmuxConfigSync(): void {
 
 async function reloadManagedTmuxConfigAsync(): Promise<void> {
   try {
-    const cleanEnv = buildChildEnv();
+    const cleanEnv = Effect.runSync(buildChildEnv());
     await execFileAsync('tmux', ['-L', getManagedTmuxSocketName(), 'start-server'], { encoding: 'utf-8', env: cleanEnv });
     await execFileAsync('tmux', ['-L', getManagedTmuxSocketName(), 'source-file', getManagedTmuxConfigPath()], { encoding: 'utf-8' });
   } catch {

--- a/tests/cloister/inspect-checkpoints.test.ts
+++ b/tests/cloister/inspect-checkpoints.test.ts
@@ -2,10 +2,11 @@
  * PAN-382: Tests for inspect checkpoint system
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, expect, vi, beforeEach, afterEach } from 'vitest';
+import { it } from '@effect/vitest';
+import { Effect } from 'effect';
 import { writeFileSync, mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
-import { tmpdir } from 'os';
 
 // Hoist mocks to avoid TDZ
 const TEST_HOME = vi.hoisted(() => {
@@ -62,126 +63,146 @@ describe('inspect-checkpoints', () => {
   });
 
   describe('loadCheckpoints', () => {
-    it('returns null when no checkpoint file exists', () => {
-      expect(loadCheckpoints(projectKey, issueId)).toBeNull();
-    });
+    it.effect('returns null when no checkpoint file exists', () =>
+      Effect.gen(function* () {
+        const result = yield* loadCheckpoints(projectKey, issueId);
+        expect(result).toBeNull();
+      })
+    );
 
-    it('loads existing checkpoints from file', () => {
-      const dir = join(TEST_HOME, '.panopticon', 'specialists', projectKey, 'inspect-agent', 'checkpoints');
-      mkdirSync(dir, { recursive: true });
-      const data = {
-        issueId: 'MIN-796',
-        checkpoints: [
-          { beadId: 'myn-80', commitSha: 'abc123', passedAt: '2026-03-22T10:00:00Z' },
-        ],
-      };
-      writeFileSync(join(dir, 'MIN-796.json'), JSON.stringify(data));
+    it.effect('loads existing checkpoints from file', () =>
+      Effect.gen(function* () {
+        const dir = join(TEST_HOME, '.panopticon', 'specialists', projectKey, 'inspect-agent', 'checkpoints');
+        mkdirSync(dir, { recursive: true });
+        const data = {
+          issueId: 'MIN-796',
+          checkpoints: [
+            { beadId: 'myn-80', commitSha: 'abc123', passedAt: '2026-03-22T10:00:00Z' },
+          ],
+        };
+        writeFileSync(join(dir, 'MIN-796.json'), JSON.stringify(data));
 
-      const result = loadCheckpoints(projectKey, issueId);
-      expect(result).not.toBeNull();
-      expect(result!.checkpoints).toHaveLength(1);
-      expect(result!.checkpoints[0].beadId).toBe('myn-80');
-    });
+        const result = yield* loadCheckpoints(projectKey, issueId);
+        expect(result).not.toBeNull();
+        expect(result!.checkpoints).toHaveLength(1);
+        expect(result!.checkpoints[0].beadId).toBe('myn-80');
+      })
+    );
   });
 
   describe('getLastCheckpoint', () => {
-    it('returns null when no checkpoints exist', () => {
-      expect(getLastCheckpoint(projectKey, issueId)).toBeNull();
-    });
+    it.effect('returns null when no checkpoints exist', () =>
+      Effect.gen(function* () {
+        const result = yield* getLastCheckpoint(projectKey, issueId);
+        expect(result).toBeNull();
+      })
+    );
 
-    it('returns the last checkpoint', () => {
-      // Save two checkpoints
-      saveCheckpoint(projectKey, issueId, 'myn-80', 'abc123');
-      saveCheckpoint(projectKey, issueId, 'myn-81', 'def456');
+    it.effect('returns the last checkpoint', () =>
+      Effect.gen(function* () {
+        yield* saveCheckpoint(projectKey, issueId, 'myn-80', 'abc123');
+        yield* saveCheckpoint(projectKey, issueId, 'myn-81', 'def456');
 
-      const last = getLastCheckpoint(projectKey, issueId);
-      expect(last).not.toBeNull();
-      expect(last!.beadId).toBe('myn-81');
-      expect(last!.commitSha).toBe('def456');
-    });
+        const last = yield* getLastCheckpoint(projectKey, issueId);
+        expect(last).not.toBeNull();
+        expect(last!.beadId).toBe('myn-81');
+        expect(last!.commitSha).toBe('def456');
+      })
+    );
   });
 
   describe('saveCheckpoint', () => {
-    it('creates checkpoint file if it does not exist', () => {
-      const checkpoint = saveCheckpoint(projectKey, issueId, 'myn-80', 'abc123');
+    it.effect('creates checkpoint file if it does not exist', () =>
+      Effect.gen(function* () {
+        const checkpoint = yield* saveCheckpoint(projectKey, issueId, 'myn-80', 'abc123');
 
-      expect(checkpoint.beadId).toBe('myn-80');
-      expect(checkpoint.commitSha).toBe('abc123');
-      expect(checkpoint.passedAt).toBeTruthy();
+        expect(checkpoint.beadId).toBe('myn-80');
+        expect(checkpoint.commitSha).toBe('abc123');
+        expect(checkpoint.passedAt).toBeTruthy();
 
-      const data = loadCheckpoints(projectKey, issueId);
-      expect(data!.checkpoints).toHaveLength(1);
-    });
+        const data = yield* loadCheckpoints(projectKey, issueId);
+        expect(data!.checkpoints).toHaveLength(1);
+      })
+    );
 
-    it('appends to existing checkpoints', () => {
-      saveCheckpoint(projectKey, issueId, 'myn-80', 'abc123');
-      saveCheckpoint(projectKey, issueId, 'myn-81', 'def456');
-      saveCheckpoint(projectKey, issueId, 'myn-82', 'ghi789');
+    it.effect('appends to existing checkpoints', () =>
+      Effect.gen(function* () {
+        yield* saveCheckpoint(projectKey, issueId, 'myn-80', 'abc123');
+        yield* saveCheckpoint(projectKey, issueId, 'myn-81', 'def456');
+        yield* saveCheckpoint(projectKey, issueId, 'myn-82', 'ghi789');
 
-      const data = loadCheckpoints(projectKey, issueId);
-      expect(data!.checkpoints).toHaveLength(3);
-      expect(data!.checkpoints[2].beadId).toBe('myn-82');
-    });
+        const data = yield* loadCheckpoints(projectKey, issueId);
+        expect(data!.checkpoints).toHaveLength(3);
+        expect(data!.checkpoints[2].beadId).toBe('myn-82');
+      })
+    );
   });
 
   describe('getDiffBase', () => {
-    it('uses merge-base when no checkpoint exists', async () => {
-      execSyncMock.mockReturnValue('abc123def456\n');
+    it.effect('uses merge-base when no checkpoint exists', () =>
+      Effect.gen(function* () {
+        execSyncMock.mockReturnValue('abc123def456\n');
+        const base = yield* getDiffBase(projectKey, issueId, '/tmp/workspace');
+        expect(base).toBe('abc123def456');
+      })
+    );
 
-      const base = await getDiffBase(projectKey, issueId, '/tmp/workspace');
-      expect(base).toBe('abc123def456');
-    });
+    it.effect('uses last checkpoint SHA when checkpoints exist', () =>
+      Effect.gen(function* () {
+        yield* saveCheckpoint(projectKey, issueId, 'myn-80', 'checkpoint-sha');
+        const base = yield* getDiffBase(projectKey, issueId, '/tmp/workspace');
+        expect(base).toBe('checkpoint-sha');
+      })
+    );
 
-    it('uses last checkpoint SHA when checkpoints exist', async () => {
-      saveCheckpoint(projectKey, issueId, 'myn-80', 'checkpoint-sha');
-
-      const base = await getDiffBase(projectKey, issueId, '/tmp/workspace');
-      expect(base).toBe('checkpoint-sha');
-    });
-
-    it('falls back to main when merge-base fails', async () => {
-      execSyncMock.mockImplementation(() => {
-        throw new Error('not a git repo');
-      });
-
-      const base = await getDiffBase(projectKey, issueId, '/tmp/workspace');
-      expect(base).toBe('main');
-    });
+    it.effect('falls back to main when merge-base fails', () =>
+      Effect.gen(function* () {
+        execSyncMock.mockImplementation(() => {
+          throw new Error('not a git repo');
+        });
+        const base = yield* getDiffBase(projectKey, issueId, '/tmp/workspace');
+        expect(base).toBe('main');
+      })
+    );
   });
 
   describe('getDiffStats', () => {
-    it('returns diff stats from git', async () => {
-      execSyncMock.mockReturnValue(' 3 files changed, 120 insertions(+), 5 deletions(-)\n');
+    it.effect('returns diff stats from git', () =>
+      Effect.gen(function* () {
+        execSyncMock.mockReturnValue(' 3 files changed, 120 insertions(+), 5 deletions(-)\n');
+        const stats = yield* getDiffStats('/tmp/workspace', 'abc123');
+        expect(stats).toContain('3 files changed');
+      })
+    );
 
-      const stats = await getDiffStats('/tmp/workspace', 'abc123');
-      expect(stats).toContain('3 files changed');
-    });
-
-    it('returns fallback message on error', async () => {
-      execSyncMock.mockImplementation(() => {
-        throw new Error('git error');
-      });
-
-      const stats = await getDiffStats('/tmp/workspace', 'abc123');
-      expect(stats).toBe('Unable to compute diff stats');
-    });
+    it.effect('returns fallback message on error', () =>
+      Effect.gen(function* () {
+        execSyncMock.mockImplementation(() => {
+          throw new Error('git error');
+        });
+        const stats = yield* getDiffStats('/tmp/workspace', 'abc123');
+        expect(stats).toBe('Unable to compute diff stats');
+      })
+    );
   });
 
   describe('getCurrentHead', () => {
-    it('returns HEAD sha', async () => {
-      execSyncMock.mockReturnValue('abc123def456\n');
+    it.effect('returns HEAD sha', () =>
+      Effect.gen(function* () {
+        execSyncMock.mockReturnValue('abc123def456\n');
+        const head = yield* getCurrentHead('/tmp/workspace');
+        expect(head).toBe('abc123def456');
+      })
+    );
 
-      const head = await getCurrentHead('/tmp/workspace');
-      expect(head).toBe('abc123def456');
-    });
-
-    it('returns unknown on error', async () => {
-      execSyncMock.mockImplementation(() => {
-        throw new Error('not a git repo');
-      });
-
-      const head = await getCurrentHead('/tmp/workspace');
-      expect(head).toBe('unknown');
-    });
+    it.effect('returns unknown on error', () =>
+      Effect.gen(function* () {
+        execSyncMock.mockImplementation(() => {
+          throw new Error('not a git repo');
+        });
+        const head = yield* getCurrentHead('/tmp/workspace');
+        expect(head).toBe('unknown');
+      })
+    );
   });
 });

--- a/tests/lib/child-env.test.ts
+++ b/tests/lib/child-env.test.ts
@@ -1,56 +1,66 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect } from 'vitest';
+import { it } from '@effect/vitest';
+import { Effect } from 'effect';
 import { buildChildEnv, buildChildEnvWithoutTmux } from '../../src/lib/child-env.js';
 
 describe('buildChildEnv', () => {
-  it('strips tmux/screen artifacts and provider keys', () => {
-    const base = {
-      PATH: '/usr/bin',
-      TMUX: '/tmp/tmux-1000/default,123,0',
-      TMUX_PANE: '%0',
-      STY: '12345.pts-0',
-      WINDOW: '0',
-      ANTHROPIC_BASE_URL: 'http://proxy',
-      ANTHROPIC_AUTH_TOKEN: 'secret',
-      OPENAI_API_KEY: 'sk-xxx',
-      HOME: '/home/test',
-    };
-    const result = buildChildEnv(base as NodeJS.ProcessEnv, { CUSTOM: 'value' });
+  it.effect('strips tmux/screen artifacts and provider keys', () =>
+    Effect.gen(function* () {
+      const base = {
+        PATH: '/usr/bin',
+        TMUX: '/tmp/tmux-1000/default,123,0',
+        TMUX_PANE: '%0',
+        STY: '12345.pts-0',
+        WINDOW: '0',
+        ANTHROPIC_BASE_URL: 'http://proxy',
+        ANTHROPIC_AUTH_TOKEN: 'secret',
+        OPENAI_API_KEY: 'sk-xxx',
+        HOME: '/home/test',
+      };
+      const result = yield* buildChildEnv(base as NodeJS.ProcessEnv, { CUSTOM: 'value' });
 
-    expect(result.PATH).toBe('/usr/bin');
-    expect(result.HOME).toBe('/home/test');
-    expect(result.CUSTOM).toBe('value');
+      expect(result.PATH).toBe('/usr/bin');
+      expect(result.HOME).toBe('/home/test');
+      expect(result.CUSTOM).toBe('value');
 
-    expect(result.TMUX).toBeUndefined();
-    expect(result.TMUX_PANE).toBeUndefined();
-    expect(result.STY).toBeUndefined();
-    expect(result.WINDOW).toBeUndefined();
-    expect(result.ANTHROPIC_BASE_URL).toBeUndefined();
-    expect(result.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
-    expect(result.OPENAI_API_KEY).toBeUndefined();
-  });
+      expect(result.TMUX).toBeUndefined();
+      expect(result.TMUX_PANE).toBeUndefined();
+      expect(result.STY).toBeUndefined();
+      expect(result.WINDOW).toBeUndefined();
+      expect(result.ANTHROPIC_BASE_URL).toBeUndefined();
+      expect(result.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+      expect(result.OPENAI_API_KEY).toBeUndefined();
+    })
+  );
 
-  it('overrides strip keys when explicitly provided', () => {
-    const base = { PATH: '/usr/bin', TMUX: 'yes' };
-    const result = buildChildEnv(base as NodeJS.ProcessEnv, { TMUX: 'allowed' });
-    expect(result.TMUX).toBe('allowed');
-  });
+  it.effect('overrides strip keys when explicitly provided', () =>
+    Effect.gen(function* () {
+      const base = { PATH: '/usr/bin', TMUX: 'yes' };
+      const result = yield* buildChildEnv(base as NodeJS.ProcessEnv, { TMUX: 'allowed' });
+      expect(result.TMUX).toBe('allowed');
+    })
+  );
 
-  it('ignores undefined values in baseEnv', () => {
-    const base = { PATH: '/usr/bin', FOO: undefined };
-    const result = buildChildEnv(base as NodeJS.ProcessEnv);
-    expect(result).not.toHaveProperty('FOO');
-  });
+  it.effect('ignores undefined values in baseEnv', () =>
+    Effect.gen(function* () {
+      const base = { PATH: '/usr/bin', FOO: undefined };
+      const result = yield* buildChildEnv(base as NodeJS.ProcessEnv);
+      expect(result).not.toHaveProperty('FOO');
+    })
+  );
 });
 
 describe('buildChildEnvWithoutTmux', () => {
-  it('only strips tmux/screen artifacts', () => {
-    const base = {
-      PATH: '/usr/bin',
-      TMUX: 'yes',
-      ANTHROPIC_BASE_URL: 'http://proxy',
-    };
-    const result = buildChildEnvWithoutTmux(base as NodeJS.ProcessEnv);
-    expect(result.TMUX).toBeUndefined();
-    expect(result.ANTHROPIC_BASE_URL).toBe('http://proxy');
-  });
+  it.effect('only strips tmux/screen artifacts', () =>
+    Effect.gen(function* () {
+      const base = {
+        PATH: '/usr/bin',
+        TMUX: 'yes',
+        ANTHROPIC_BASE_URL: 'http://proxy',
+      };
+      const result = yield* buildChildEnvWithoutTmux(base as NodeJS.ProcessEnv);
+      expect(result.TMUX).toBeUndefined();
+      expect(result.ANTHROPIC_BASE_URL).toBe('http://proxy');
+    })
+  );
 });

--- a/tests/lib/openai-compatible-proxy.test.ts
+++ b/tests/lib/openai-compatible-proxy.test.ts
@@ -1,12 +1,18 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect } from 'vitest';
+import { it } from '@effect/vitest';
+import { Effect } from 'effect';
 import { getProxyPathname } from '../../src/lib/openai-compatible-proxy.js';
 
 describe('OpenAI-compatible proxy routing', () => {
-  it('routes Claude Code messages requests with query params by pathname', () => {
-    expect(getProxyPathname('/nous/v1/messages?beta=true')).toBe('/nous/v1/messages');
-  });
+  it.effect('routes Claude Code messages requests with query params by pathname', () =>
+    Effect.sync(() => {
+      expect(getProxyPathname('/nous/v1/messages?beta=true')).toBe('/nous/v1/messages');
+    })
+  );
 
-  it('routes model list requests by pathname', () => {
-    expect(getProxyPathname('/nous/v1/models')).toBe('/nous/v1/models');
-  });
+  it.effect('routes model list requests by pathname', () =>
+    Effect.sync(() => {
+      expect(getProxyPathname('/nous/v1/models')).toBe('/nous/v1/models');
+    })
+  );
 });

--- a/tests/lib/work-agent-lifecycle.test.ts
+++ b/tests/lib/work-agent-lifecycle.test.ts
@@ -8,6 +8,7 @@ import {
   saveAgentState,
   saveSessionId,
 } from '../../src/lib/agents.js';
+import { Effect } from 'effect';
 import { setAgentRuntimeMirror } from '../../src/lib/agent-runtime-mirror.js';
 import { getWorkAgentLifecycleState } from '../../src/lib/work-agent-lifecycle.js';
 import * as tmux from '../../src/lib/tmux.js';
@@ -151,14 +152,14 @@ describe('work-agent-lifecycle', () => {
     // Populate the runtime mirror directly — saveAgentRuntimeState is async and
     // relies on the dashboard event system which is not running in unit tests.
     // activity:'idle' maps to runtimeState.state === 'idle' via snapshotToRuntimeState.
-    setAgentRuntimeMirror({
+    Effect.runSync(setAgentRuntimeMirror({
       [agentId]: {
         id: agentId,
         activity: 'idle',
         lastActivity: new Date().toISOString(),
         updatedAtSequence: 1,
       },
-    });
+    }));
     saveSessionId(agentId, 'session-stuck');
 
     const sessionExistsSpy = vi.spyOn(tmux, 'sessionExists').mockReturnValue(true);
@@ -175,7 +176,7 @@ describe('work-agent-lifecycle', () => {
     expect(lifecycle.reason).toContain('runtime is idle');
 
     sessionExistsSpy.mockRestore();
-    setAgentRuntimeMirror({});
+    Effect.runSync(setAgentRuntimeMirror({}));
   });
 
   // 'suspended' is a legacy state retained for backward-compat — ensure it also
@@ -205,14 +206,14 @@ describe('work-agent-lifecycle', () => {
     // code paths that wrote state.json directly. New code uses activity:'idle'.
     // Since snapshotToRuntimeState has no 'suspended' Activity mapping, we use
     // 'idle' here as the closest real-world equivalent.
-    setAgentRuntimeMirror({
+    Effect.runSync(setAgentRuntimeMirror({
       [agentId]: {
         id: agentId,
         activity: 'idle',
         lastActivity: new Date().toISOString(),
         updatedAtSequence: 1,
       },
-    });
+    }));
     saveSessionId(agentId, 'session-suspended');
 
     const sessionExistsSpy = vi.spyOn(tmux, 'sessionExists').mockReturnValue(true);
@@ -224,7 +225,7 @@ describe('work-agent-lifecycle', () => {
     expect(lifecycle.recommendedAction).toBe('resume');
 
     sessionExistsSpy.mockRestore();
-    setAgentRuntimeMirror({});
+    Effect.runSync(setAgentRuntimeMirror({}));
   });
 
   it('allows fresh start when agent state is missing and no live session exists', () => {

--- a/tests/unit/dashboard/server/routes/resume-gate.test.ts
+++ b/tests/unit/dashboard/server/routes/resume-gate.test.ts
@@ -27,6 +27,7 @@ import {
   saveAgentState,
   saveSessionId,
 } from '../../../../../src/lib/agents.js';
+import { Effect } from 'effect';
 import { setAgentRuntimeMirror } from '../../../../../src/lib/agent-runtime-mirror.js';
 import { getWorkAgentLifecycleState } from '../../../../../src/lib/work-agent-lifecycle.js';
 import type { WorkAgentLifecycleState } from '../../../../../src/lib/work-agent-lifecycle.js';
@@ -46,7 +47,7 @@ function makeAgentId(prefix: string): string {
 }
 
 afterEach(() => {
-  setAgentRuntimeMirror({});
+  Effect.runSync(setAgentRuntimeMirror({}));
   for (const id of testAgentIds) {
     const dir = getAgentDir(id);
     if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
@@ -71,9 +72,9 @@ describe('resume route gate predicate', () => {
       status: 'running',
       startedAt: new Date().toISOString(),
     });
-    setAgentRuntimeMirror({
+    Effect.runSync(setAgentRuntimeMirror({
       [agentId]: { id: agentId, activity: 'working', lastActivity: new Date().toISOString(), updatedAtSequence: 1 },
-    });
+    }));
     saveSessionId(agentId, 'session-active');
 
     const sessionSpy = vi.spyOn(tmux, 'sessionExists').mockReturnValue(true);
@@ -106,9 +107,9 @@ describe('resume route gate predicate', () => {
       status: 'running',
       startedAt: new Date().toISOString(),
     });
-    setAgentRuntimeMirror({
+    Effect.runSync(setAgentRuntimeMirror({
       [agentId]: { id: agentId, activity: 'idle', lastActivity: new Date().toISOString(), updatedAtSequence: 1 },
-    });
+    }));
     saveSessionId(agentId, 'session-stuck');
 
     const sessionSpy = vi.spyOn(tmux, 'sessionExists').mockReturnValue(true);


### PR DESCRIPTION
## Summary

- Migrates all 5 exported functions in `src/lib/remote/workspace-metadata.ts` to return `Effect.Effect<T, FsError, FileSystem.FileSystem>` using the `@effect/platform` FileSystem service
- Eliminates all sync FS calls: `existsSync`, `mkdirSync`, `writeFileSync`, `readdirSync`, `readFileSync`, and the `require('fs').unlinkSync` anti-pattern
- YAML parse failures now surface as `FsError` (operation: `'parse'`) instead of being silently dropped
- Creates `src/lib/remote/__tests__/workspace-metadata.test.ts` with 8 test cases using `@effect/vitest` `layer()` + `NodeFileSystem.layer`
- Expected typecheck failures in callers (`src/cli/commands/{start,workspace,workspace-migrate}.ts`) are out of scope per PAN-1249 slot scope rules

## Test plan

- [x] `npx vitest run src/lib/remote/__tests__/workspace-metadata.test.ts` — 8/8 pass
- [x] `npm run typecheck` — no errors in `src/lib/remote/workspace-metadata.ts` or `src/lib/remote/__tests__/workspace-metadata.test.ts`
- [x] `npx eslint src/lib/remote/workspace-metadata.ts src/lib/remote/__tests__/workspace-metadata.test.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)