### PR TITLE
feat(pan-1249): migrate src/lib/tldr-daemon.ts to Effect [slot-1]

### DIFF
--- a/src/cli/commands/__tests__/status-harness.test.ts
+++ b/src/cli/commands/__tests__/status-harness.test.ts
@@ -9,10 +9,13 @@ vi.mock('../../../lib/shadow-state.js', () => ({
   isShadowed: vi.fn(async () => false),
   getShadowState: vi.fn(async () => null),
 }))
-vi.mock('../../../lib/tldr-daemon.js', () => ({
-  getTldrMetrics: vi.fn(() => ({ interceptions: 0, bypasses: 0, estimatedTokensSaved: 0 })),
-  getTldrDaemonService: vi.fn(),
-}))
+vi.mock('../../../lib/tldr-daemon.js', async () => {
+  const { Effect } = await import('effect');
+  return {
+    getTldrMetrics: vi.fn(() => Effect.succeed({ interceptions: 0, bypasses: 0, estimatedTokensSaved: 0, filesAnalyzed: [], bypassReasons: {} })),
+    getTldrDaemonService: vi.fn(),
+  };
+})
 vi.mock('../../../lib/workspace/stack-health.js', () => ({
   collectDockerContainerLifecycleSnapshot: vi.fn(async () => []),
   getWorkspaceStackHealth: vi.fn(async () => ({ healthy: true, reasons: [], lastObserved: '2026-05-17T00:00:00.000Z' })),

--- a/src/cli/commands/admin/tldr-handler.ts
+++ b/src/cli/commands/admin/tldr-handler.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { Effect } from 'effect';
 import { getTldrDaemonService, listTldrDaemonServices } from '../../../lib/tldr-daemon.js';
 import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
 import { join, basename } from 'path';
@@ -32,6 +33,7 @@ export async function tldrCommand(action: string, workspace?: string, options: T
 }
 
 async function statusCommand(options: TldrOptions): Promise<void> {
+  const { layer: NodeServicesLayer } = await import('@effect/platform-node/NodeServices');
   const projectRoot = process.cwd();
   const venvPath = join(projectRoot, '.venv');
 
@@ -47,7 +49,7 @@ async function statusCommand(options: TldrOptions): Promise<void> {
   // Check main daemon
   if (existsSync(venvPath)) {
     const service = getTldrDaemonService(projectRoot, venvPath);
-    const status = await service.getStatus();
+    const status = await Effect.runPromise(service.getStatus().pipe(Effect.provide(NodeServicesLayer)));
     const tldrPath = join(projectRoot, '.tldr');
 
     let indexAge = 'N/A';
@@ -113,7 +115,7 @@ async function statusCommand(options: TldrOptions): Promise<void> {
 
       if (existsSync(wsVenvPath)) {
         const service = getTldrDaemonService(wsPath, wsVenvPath);
-        const status = await service.getStatus();
+        const status = await Effect.runPromise(service.getStatus().pipe(Effect.provide(NodeServicesLayer)));
         const tldrPath = join(wsPath, '.tldr');
 
         let indexAge = 'N/A';
@@ -201,6 +203,7 @@ async function statusCommand(options: TldrOptions): Promise<void> {
 }
 
 async function startCommand(workspace: string | undefined, options: TldrOptions): Promise<void> {
+  const { layer: NodeServicesLayer } = await import('@effect/platform-node/NodeServices');
   const projectRoot = process.cwd();
 
   if (workspace) {
@@ -220,7 +223,7 @@ async function startCommand(workspace: string | undefined, options: TldrOptions)
     }
 
     const service = getTldrDaemonService(wsPath, venvPath);
-    await service.start();
+    await Effect.runPromise(service.start().pipe(Effect.provide(NodeServicesLayer)));
 
     if (!options.json) {
       console.log(chalk.green(`✓ Started TLDR daemon for ${workspace}`));
@@ -236,7 +239,7 @@ async function startCommand(workspace: string | undefined, options: TldrOptions)
     }
 
     const service = getTldrDaemonService(projectRoot, venvPath);
-    await service.start();
+    await Effect.runPromise(service.start().pipe(Effect.provide(NodeServicesLayer)));
 
     if (!options.json) {
       console.log(chalk.green('✓ Started TLDR daemon for main'));
@@ -245,6 +248,7 @@ async function startCommand(workspace: string | undefined, options: TldrOptions)
 }
 
 async function stopCommand(workspace: string | undefined, options: TldrOptions): Promise<void> {
+  const { layer: NodeServicesLayer } = await import('@effect/platform-node/NodeServices');
   const projectRoot = process.cwd();
 
   if (workspace) {
@@ -263,7 +267,7 @@ async function stopCommand(workspace: string | undefined, options: TldrOptions):
     }
 
     const service = getTldrDaemonService(wsPath, venvPath);
-    await service.stop();
+    await Effect.runPromise(service.stop().pipe(Effect.provide(NodeServicesLayer)));
 
     if (!options.json) {
       console.log(chalk.green(`✓ Stopped TLDR daemon for ${workspace}`));
@@ -278,7 +282,7 @@ async function stopCommand(workspace: string | undefined, options: TldrOptions):
     }
 
     const service = getTldrDaemonService(projectRoot, venvPath);
-    await service.stop();
+    await Effect.runPromise(service.stop().pipe(Effect.provide(NodeServicesLayer)));
 
     if (!options.json) {
       console.log(chalk.green('✓ Stopped TLDR daemon for main'));
@@ -287,6 +291,7 @@ async function stopCommand(workspace: string | undefined, options: TldrOptions):
 }
 
 async function warmCommand(workspace: string | undefined, options: TldrOptions): Promise<void> {
+  const { layer: NodeServicesLayer } = await import('@effect/platform-node/NodeServices');
   const projectRoot = process.cwd();
 
   if (workspace) {
@@ -311,7 +316,7 @@ async function warmCommand(workspace: string | undefined, options: TldrOptions):
       console.log(chalk.dim('This may take a few minutes for large codebases'));
     }
 
-    await service.warm(false);  // foreground mode for warming
+    await Effect.runPromise(service.warm(false).pipe(Effect.provide(NodeServicesLayer)));  // foreground mode for warming
 
     if (!options.json) {
       console.log(chalk.green(`✓ Index warming complete for ${workspace}`));
@@ -333,7 +338,7 @@ async function warmCommand(workspace: string | undefined, options: TldrOptions):
       console.log(chalk.dim('This may take a few minutes for large codebases'));
     }
 
-    await service.warm(false);  // foreground mode for warming
+    await Effect.runPromise(service.warm(false).pipe(Effect.provide(NodeServicesLayer)));  // foreground mode for warming
 
     if (!options.json) {
       console.log(chalk.green('✓ Index warming complete for main'));

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -146,13 +146,15 @@ async function startSidecars(): Promise<void> {
 
   // TLDR
   try {
+    const { Effect } = await import('effect');
+    const { layer: NodeServicesLayer } = await import('@effect/platform-node/NodeServices');
     const { getTldrDaemonService } = await import('../../lib/tldr-daemon.js');
     const projectRoot = process.cwd();
     const venvPath = join(projectRoot, '.venv');
     if (existsSync(venvPath)) {
       console.log(chalk.dim('\nStarting TLDR daemon for project root...'));
       const tldrService = getTldrDaemonService(projectRoot, venvPath);
-      await tldrService.start(true);
+      await Effect.runPromise(tldrService.start(true).pipe(Effect.provide(NodeServicesLayer)));
       console.log(chalk.green('✓ TLDR daemon started'));
     } else {
       console.log(chalk.dim('\nSkipping TLDR daemon (no .venv found)'));

--- a/src/cli/commands/restart.ts
+++ b/src/cli/commands/restart.ts
@@ -274,8 +274,10 @@ async function runFullRestart(
 
   if (tldrAvailable) {
     try {
+      const { Effect } = await import('effect');
+      const { layer: NodeServicesLayer } = await import('@effect/platform-node/NodeServices');
       const { getTldrDaemonService } = await import('../../lib/tldr-daemon.js');
-      await getTldrDaemonService(projectRoot, venvPath).stop();
+      await Effect.runPromise(getTldrDaemonService(projectRoot, venvPath).stop().pipe(Effect.provide(NodeServicesLayer)));
     } catch {
       // non-fatal — daemon may already be down
     }
@@ -311,8 +313,10 @@ async function runFullRestart(
 
   if (tldrAvailable) {
     try {
+      const { Effect } = await import('effect');
+      const { layer: NodeServicesLayer } = await import('@effect/platform-node/NodeServices');
       const { getTldrDaemonService } = await import('../../lib/tldr-daemon.js');
-      await getTldrDaemonService(projectRoot, venvPath).start(true);
+      await Effect.runPromise(getTldrDaemonService(projectRoot, venvPath).start(true).pipe(Effect.provide(NodeServicesLayer)));
     } catch {
       // non-fatal — dashboard is already healthy; TLDR just won't be available
     }

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { Effect } from 'effect';
 import { existsSync, readFileSync, statSync, readdirSync } from 'fs';
 import { join, basename } from 'path';
 import { listRunningAgents, getAgentDir, type AgentState } from '../../lib/agents.js';
@@ -200,7 +201,7 @@ export async function statusCommand(options: StatusOptions): Promise<void> {
 
     // Show TLDR session metrics if a .tldr/ dir exists in the workspace
     try {
-      const tldr = getTldrMetrics(agent.workspace);
+      const tldr = Effect.runSync(getTldrMetrics(agent.workspace));
       if (tldr.interceptions > 0 || tldr.bypasses > 0) {
         const savedK = Math.round(tldr.estimatedTokensSaved / 1000);
         const bypassStr = tldr.bypasses > 0 ? ` (${tldr.bypasses} bypassed)` : '';
@@ -309,10 +310,11 @@ export async function tldrIndexStatusCommand(projectRoot = process.cwd()): Promi
   const mainEntries: TldrIndexEntry[] = [];
   const workspaceEntries: TldrIndexEntry[] = [];
 
+  const { layer: NodeServicesLayer } = await import('@effect/platform-node/NodeServices');
   const mainVenvPath = join(projectRoot, '.venv');
   if (existsSync(mainVenvPath)) {
     const service = getTldrDaemonService(projectRoot, mainVenvPath);
-    const status = await service.getStatus();
+    const status = await Effect.runPromise(service.getStatus().pipe(Effect.provide(NodeServicesLayer)));
     const { fileCount, edgeCount, ageMs } = readTldrIndexData(projectRoot);
     mainEntries.push({ label: `Main (${projectName})`, running: status.running, fileCount, edgeCount, ageMs });
   }
@@ -326,7 +328,7 @@ export async function tldrIndexStatusCommand(projectRoot = process.cwd()): Promi
       const wsVenvPath = join(wsPath, '.venv');
       if (existsSync(wsVenvPath)) {
         const service = getTldrDaemonService(wsPath, wsVenvPath);
-        const status = await service.getStatus();
+        const status = await Effect.runPromise(service.getStatus().pipe(Effect.provide(NodeServicesLayer)));
         const { fileCount, edgeCount, ageMs } = readTldrIndexData(wsPath);
         workspaceEntries.push({ label: ws.name, running: status.running, fileCount, edgeCount, ageMs });
       }

--- a/src/dashboard/server/routes/admin.ts
+++ b/src/dashboard/server/routes/admin.ts
@@ -38,16 +38,14 @@ const getAdminTldrRoute = HttpRouter.add(
       return jsonResponse({ available: false, reason: 'No .venv found in workspace' });
     }
 
-    return yield* Effect.promise(async () => {
-      const service = getTldrDaemonService(workspacePath, venvPath);
-      const status = await service.getStatus();
-      return jsonResponse({
-        available: true,
-        running: status.running,
-        pid: status.pid,
-        healthy: status.healthy,
-        workspacePath,
-      });
+    const service = getTldrDaemonService(workspacePath, venvPath);
+    const status = yield* service.getStatus();
+    return jsonResponse({
+      available: true,
+      running: status.running,
+      pid: status.pid,
+      healthy: status.healthy,
+      workspacePath,
     });
   }))
 );

--- a/src/dashboard/server/routes/misc.ts
+++ b/src/dashboard/server/routes/misc.ts
@@ -1283,6 +1283,7 @@ const getTldrStatusRoute = HttpRouter.add(
   Effect.promise(async () => {
     try {
       const { getTldrDaemonService } = await import('../../../lib/tldr-daemon.js');
+      const { layer: NodeServicesLayer } = await import('@effect/platform-node/NodeServices');
       const projectRoot = process.cwd();
       const venvPath = join(projectRoot, '.venv');
 
@@ -1299,7 +1300,7 @@ const getTldrStatusRoute = HttpRouter.add(
 
       if (existsSync(venvPath)) {
         const service = getTldrDaemonService(projectRoot, venvPath);
-        const status = await service.getStatus();
+        const status = await Effect.runPromise(service.getStatus().pipe(Effect.provide(NodeServicesLayer)));
         const indexStats = getIndexStats(projectRoot, true);
 
         results.push({
@@ -1324,7 +1325,7 @@ const getTldrStatusRoute = HttpRouter.add(
 
           if (existsSync(wsVenvPath)) {
             const service = getTldrDaemonService(wsPath, wsVenvPath);
-            const status = await service.getStatus();
+            const status = await Effect.runPromise(service.getStatus().pipe(Effect.provide(NodeServicesLayer)));
             const indexStats = getIndexStats(wsPath, false);
 
             results.push({
@@ -1355,6 +1356,7 @@ const postTldrStartRoute = HttpRouter.add(
   Effect.promise(async () => {
     try {
       const { getTldrDaemonService } = await import('../../../lib/tldr-daemon.js');
+      const { layer: NodeServicesLayer } = await import('@effect/platform-node/NodeServices');
       const projectRoot = process.cwd();
       const venvPath = join(projectRoot, '.venv');
 
@@ -1366,7 +1368,7 @@ const postTldrStartRoute = HttpRouter.add(
       }
 
       const service = getTldrDaemonService(projectRoot, venvPath);
-      await service.start();
+      await Effect.runPromise(service.start().pipe(Effect.provide(NodeServicesLayer)));
       return jsonResponse({ success: true, message: 'TLDR daemon started' });
     }    catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
@@ -1383,6 +1385,7 @@ const postTldrStopRoute = HttpRouter.add(
   Effect.promise(async () => {
     try {
       const { getTldrDaemonService } = await import('../../../lib/tldr-daemon.js');
+      const { layer: NodeServicesLayer } = await import('@effect/platform-node/NodeServices');
       const projectRoot = process.cwd();
       const venvPath = join(projectRoot, '.venv');
 
@@ -1394,7 +1397,7 @@ const postTldrStopRoute = HttpRouter.add(
       }
 
       const service = getTldrDaemonService(projectRoot, venvPath);
-      await service.stop();
+      await Effect.runPromise(service.stop().pipe(Effect.provide(NodeServicesLayer)));
       return jsonResponse({ success: true, message: 'TLDR daemon stopped' });
     }    catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);

--- a/src/dashboard/server/routes/workspaces.ts
+++ b/src/dashboard/server/routes/workspaces.ts
@@ -5815,8 +5815,9 @@ const getWorkspaceTldrRoute = HttpRouter.add(
           });
         }
 
+        const { layer: NodeServicesLayer } = await import('@effect/platform-node/NodeServices');
         const service = getTldrDaemonService(workspacePath, venvPath);
-        const status = await service.getStatus();
+        const status = await Effect.runPromise(service.getStatus().pipe(Effect.provide(NodeServicesLayer)));
         const { fileCount, indexAge, edgeCount } = await getIndexStats(workspacePath);
 
         return jsonResponse({

--- a/src/lib/__tests__/errors.test.ts
+++ b/src/lib/__tests__/errors.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Unit tests for src/lib/errors.ts (PAN-1249 wave-0).
+ *
+ * Verifies that every exported Data.TaggedError subclass:
+ * - can be constructed with its documented fields
+ * - carries the correct `_tag` discriminant
+ * - can be caught and narrowed inside an Effect channel
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Effect } from 'effect';
+import {
+  VcsError,
+  VcsTimeoutError,
+  FsError,
+  FsNotFoundError,
+  GitError,
+  MergeConflictError,
+  TmuxError,
+  TrackerError,
+  GitHubApiError,
+  LinearApiError,
+  CheckpointError,
+  InvalidAgentIdError,
+  ConfigError,
+  ConfigParseError,
+  ProcessSpawnError,
+  ProcessTimeoutError,
+} from '../errors.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Run an Effect that is expected to fail and return the error. */
+function runFail<E>(eff: Effect.Effect<never, E, never>): E {
+  return Effect.runSync(Effect.flip(eff));
+}
+
+/** Catch a specific tag and return its message field (or tag name on miss). */
+function catchTag<E extends { _tag: string }>(
+  eff: Effect.Effect<never, E, never>,
+  tag: E['_tag'],
+): string {
+  return Effect.runSync(
+    Effect.catchTag(eff as Effect.Effect<never, any, never>, tag, (e) =>
+      Effect.succeed(`caught:${(e as { _tag: string })._tag}`),
+    ),
+  ) as string;
+}
+
+// ─── VCS ─────────────────────────────────────────────────────────────────────
+
+describe('VcsError', () => {
+  it('constructs and carries the correct _tag', () => {
+    const err = new VcsError({ operation: 'push', message: 'remote rejected' });
+    expect(err._tag).toBe('VcsError');
+    expect(err.operation).toBe('push');
+    expect(err.message).toBe('remote rejected');
+  });
+
+  it('can be caught by _tag in an Effect channel', () => {
+    const eff = Effect.fail(new VcsError({ operation: 'push', message: 'remote rejected' }));
+    expect(catchTag(eff, 'VcsError')).toBe('caught:VcsError');
+  });
+
+  it('is narrowed correctly via _tag guard', () => {
+    const err = runFail(Effect.fail(new VcsError({ operation: 'pull', message: 'auth failed' })));
+    expect(err._tag).toBe('VcsError');
+    if (err._tag === 'VcsError') {
+      expect(err.operation).toBe('pull');
+    }
+  });
+});
+
+describe('VcsTimeoutError', () => {
+  it('constructs and carries the correct _tag', () => {
+    const err = new VcsTimeoutError({ operation: 'clone', timeoutMs: 30000 });
+    expect(err._tag).toBe('VcsTimeoutError');
+    expect(err.timeoutMs).toBe(30000);
+  });
+
+  it('can be caught by _tag in an Effect channel', () => {
+    const eff = Effect.fail(new VcsTimeoutError({ operation: 'clone', timeoutMs: 30000 }));
+    expect(catchTag(eff, 'VcsTimeoutError')).toBe('caught:VcsTimeoutError');
+  });
+});
+
+// ─── Filesystem ───────────────────────────────────────────────────────────────
+
+describe('FsError', () => {
+  it('constructs and carries the correct _tag', () => {
+    const err = new FsError({ path: '/tmp/foo', operation: 'read', cause: new Error('EACCES') });
+    expect(err._tag).toBe('FsError');
+    expect(err.path).toBe('/tmp/foo');
+    expect(err.operation).toBe('read');
+  });
+
+  it('can be caught by _tag in an Effect channel', () => {
+    const eff = Effect.fail(new FsError({ path: '/tmp/foo', operation: 'write' }));
+    expect(catchTag(eff, 'FsError')).toBe('caught:FsError');
+  });
+});
+
+describe('FsNotFoundError', () => {
+  it('constructs and carries the correct _tag', () => {
+    const err = new FsNotFoundError({ path: '/missing/file' });
+    expect(err._tag).toBe('FsNotFoundError');
+    expect(err.path).toBe('/missing/file');
+  });
+
+  it('can be caught by _tag in an Effect channel', () => {
+    const eff = Effect.fail(new FsNotFoundError({ path: '/missing/file' }));
+    expect(catchTag(eff, 'FsNotFoundError')).toBe('caught:FsNotFoundError');
+  });
+});
+
+// ─── Git ──────────────────────────────────────────────────────────────────────
+
+describe('GitError', () => {
+  it('constructs and carries the correct _tag', () => {
+    const err = new GitError({ command: ['commit', '-m', 'msg'], stderr: 'nothing to commit', exitCode: 1 });
+    expect(err._tag).toBe('GitError');
+    expect(err.exitCode).toBe(1);
+    expect(err.command).toEqual(['commit', '-m', 'msg']);
+  });
+
+  it('can be caught by _tag in an Effect channel', () => {
+    const eff = Effect.fail(new GitError({ command: ['push'], stderr: 'rejected', exitCode: 128 }));
+    expect(catchTag(eff, 'GitError')).toBe('caught:GitError');
+  });
+});
+
+describe('MergeConflictError', () => {
+  it('constructs and carries the correct _tag', () => {
+    const err = new MergeConflictError({
+      branch: 'feature/x',
+      targetBranch: 'main',
+      conflictedFiles: ['src/foo.ts', 'src/bar.ts'],
+    });
+    expect(err._tag).toBe('MergeConflictError');
+    expect(err.conflictedFiles).toHaveLength(2);
+  });
+
+  it('can be caught by _tag in an Effect channel', () => {
+    const eff = Effect.fail(
+      new MergeConflictError({ branch: 'feature/x', targetBranch: 'main', conflictedFiles: [] }),
+    );
+    expect(catchTag(eff, 'MergeConflictError')).toBe('caught:MergeConflictError');
+  });
+});
+
+// ─── Tmux ─────────────────────────────────────────────────────────────────────
+
+describe('TmuxError', () => {
+  it('constructs and carries the correct _tag', () => {
+    const err = new TmuxError({ command: 'new-session -s foo', message: 'session already exists' });
+    expect(err._tag).toBe('TmuxError');
+    expect(err.command).toBe('new-session -s foo');
+  });
+
+  it('can be caught by _tag in an Effect channel', () => {
+    const eff = Effect.fail(new TmuxError({ command: 'kill-session', message: 'no such session' }));
+    expect(catchTag(eff, 'TmuxError')).toBe('caught:TmuxError');
+  });
+});
+
+// ─── Tracker / API ────────────────────────────────────────────────────────────
+
+describe('TrackerError', () => {
+  it('constructs and carries the correct _tag', () => {
+    const err = new TrackerError({ tracker: 'linear', operation: 'updateIssue', message: 'forbidden' });
+    expect(err._tag).toBe('TrackerError');
+    expect(err.tracker).toBe('linear');
+  });
+
+  it('can be caught by _tag in an Effect channel', () => {
+    const eff = Effect.fail(
+      new TrackerError({ tracker: 'github', operation: 'createIssue', message: 'rate limited' }),
+    );
+    expect(catchTag(eff, 'TrackerError')).toBe('caught:TrackerError');
+  });
+});
+
+describe('GitHubApiError', () => {
+  it('constructs and carries the correct _tag', () => {
+    const err = new GitHubApiError({ operation: 'listPRs', status: 403, message: 'forbidden' });
+    expect(err._tag).toBe('GitHubApiError');
+    expect(err.status).toBe(403);
+  });
+
+  it('can be caught by _tag in an Effect channel', () => {
+    const eff = Effect.fail(new GitHubApiError({ operation: 'mergePR', status: 422, message: 'conflict' }));
+    expect(catchTag(eff, 'GitHubApiError')).toBe('caught:GitHubApiError');
+  });
+});
+
+describe('LinearApiError', () => {
+  it('constructs and carries the correct _tag', () => {
+    const err = new LinearApiError({ operation: 'updateState', message: 'network error' });
+    expect(err._tag).toBe('LinearApiError');
+    expect(err.operation).toBe('updateState');
+  });
+
+  it('can be caught by _tag in an Effect channel', () => {
+    const eff = Effect.fail(new LinearApiError({ operation: 'getIssue', message: 'not found' }));
+    expect(catchTag(eff, 'LinearApiError')).toBe('caught:LinearApiError');
+  });
+});
+
+// ─── Agent / checkpoint ───────────────────────────────────────────────────────
+
+describe('CheckpointError', () => {
+  it('constructs and carries the correct _tag', () => {
+    const err = new CheckpointError({ agentId: 'agent-pan-123', operation: 'save', message: 'disk full' });
+    expect(err._tag).toBe('CheckpointError');
+    expect(err.agentId).toBe('agent-pan-123');
+  });
+
+  it('can be caught by _tag in an Effect channel', () => {
+    const eff = Effect.fail(
+      new CheckpointError({ agentId: 'agent-pan-123', operation: 'load', message: 'missing' }),
+    );
+    expect(catchTag(eff, 'CheckpointError')).toBe('caught:CheckpointError');
+  });
+});
+
+describe('InvalidAgentIdError', () => {
+  it('constructs and carries the correct _tag', () => {
+    const err = new InvalidAgentIdError({ agentId: 'bad-id' });
+    expect(err._tag).toBe('InvalidAgentIdError');
+    expect(err.agentId).toBe('bad-id');
+  });
+
+  it('can be caught by _tag in an Effect channel', () => {
+    const eff = Effect.fail(new InvalidAgentIdError({ agentId: '' }));
+    expect(catchTag(eff, 'InvalidAgentIdError')).toBe('caught:InvalidAgentIdError');
+  });
+});
+
+// ─── Configuration ────────────────────────────────────────────────────────────
+
+describe('ConfigError', () => {
+  it('constructs and carries the correct _tag', () => {
+    const err = new ConfigError({ message: 'PANOPTICON_HOME not set' });
+    expect(err._tag).toBe('ConfigError');
+    expect(err.message).toBe('PANOPTICON_HOME not set');
+  });
+
+  it('can be caught by _tag in an Effect channel', () => {
+    const eff = Effect.fail(new ConfigError({ message: 'missing key' }));
+    expect(catchTag(eff, 'ConfigError')).toBe('caught:ConfigError');
+  });
+});
+
+describe('ConfigParseError', () => {
+  it('constructs and carries the correct _tag', () => {
+    const err = new ConfigParseError({ path: 'projects.yaml', message: 'unexpected token' });
+    expect(err._tag).toBe('ConfigParseError');
+    expect(err.path).toBe('projects.yaml');
+  });
+
+  it('can be caught by _tag in an Effect channel', () => {
+    const eff = Effect.fail(new ConfigParseError({ path: 'settings.json', message: 'invalid JSON' }));
+    expect(catchTag(eff, 'ConfigParseError')).toBe('caught:ConfigParseError');
+  });
+});
+
+// ─── Process ──────────────────────────────────────────────────────────────────
+
+describe('ProcessSpawnError', () => {
+  it('constructs and carries the correct _tag', () => {
+    const err = new ProcessSpawnError({ command: 'git', args: ['push'], message: 'ENOENT' });
+    expect(err._tag).toBe('ProcessSpawnError');
+    expect(err.command).toBe('git');
+    expect(err.args).toEqual(['push']);
+  });
+
+  it('can be caught by _tag in an Effect channel', () => {
+    const eff = Effect.fail(new ProcessSpawnError({ command: 'bun', args: ['run', 'build'], message: 'spawn failed' }));
+    expect(catchTag(eff, 'ProcessSpawnError')).toBe('caught:ProcessSpawnError');
+  });
+});
+
+describe('ProcessTimeoutError', () => {
+  it('constructs and carries the correct _tag', () => {
+    const err = new ProcessTimeoutError({ command: 'npm', args: ['test'], timeoutMs: 60000 });
+    expect(err._tag).toBe('ProcessTimeoutError');
+    expect(err.timeoutMs).toBe(60000);
+  });
+
+  it('can be caught by _tag in an Effect channel', () => {
+    const eff = Effect.fail(new ProcessTimeoutError({ command: 'eslint', args: ['.'], timeoutMs: 30000 }));
+    expect(catchTag(eff, 'ProcessTimeoutError')).toBe('caught:ProcessTimeoutError');
+  });
+});
+
+// ─── Multi-error channel narrowing ───────────────────────────────────────────
+
+describe('multi-tag channel narrowing', () => {
+  it('catches only the matching tag in a union channel', () => {
+    type UnionErr = VcsError | FsNotFoundError;
+    const eff: Effect.Effect<never, UnionErr, never> = Effect.fail(
+      new FsNotFoundError({ path: '/lost' }),
+    );
+
+    const result = Effect.runSync(
+      Effect.gen(function* () {
+        return yield* Effect.catchTag(eff, 'FsNotFoundError', (e) =>
+          Effect.succeed(`recovered:${e.path}`),
+        );
+      }),
+    );
+
+    expect(result).toBe('recovered:/lost');
+  });
+
+  it('propagates unmatched tag through the channel', () => {
+    type UnionErr = VcsError | FsError;
+    const eff: Effect.Effect<never, UnionErr, never> = Effect.fail(
+      new VcsError({ operation: 'fetch', message: 'timeout' }),
+    );
+
+    const err = Effect.runSync(
+      Effect.flip(
+        Effect.catchTag(eff, 'FsError', () => Effect.succeed('should not reach')),
+      ),
+    );
+
+    expect(err._tag).toBe('VcsError');
+  });
+});

--- a/src/lib/__tests__/tldr-metrics.test.ts
+++ b/src/lib/__tests__/tldr-metrics.test.ts
@@ -4,7 +4,8 @@
  * Tests getTldrMetrics() accumulation and captureTldrMetrics() reset behavior.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { beforeEach, afterEach, describe, expect, it } from '@effect/vitest';
+import { Effect } from 'effect';
 import { existsSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -50,177 +51,206 @@ function writeCheckpoint(interceptionsLine: number, bypassesLine: number): void 
 // ============ getTldrMetrics ============
 
 describe('getTldrMetrics', () => {
-  it('returns zeros when workspace has no log files', () => {
-    const metrics = getTldrMetrics(TEST_WORKSPACE);
-    expect(metrics.interceptions).toBe(0);
-    expect(metrics.bypasses).toBe(0);
-    expect(metrics.estimatedTokensSaved).toBe(0);
-    expect(metrics.filesAnalyzed).toEqual([]);
-    expect(metrics.bypassReasons).toEqual({});
-  });
+  it.effect('returns zeros when workspace has no log files', () =>
+    Effect.gen(function* () {
+      const metrics = yield* getTldrMetrics(TEST_WORKSPACE);
+      expect(metrics.interceptions).toBe(0);
+      expect(metrics.bypasses).toBe(0);
+      expect(metrics.estimatedTokensSaved).toBe(0);
+      expect(metrics.filesAnalyzed).toEqual([]);
+      expect(metrics.bypassReasons).toEqual({});
+    })
+  );
 
-  it('counts interceptions from interceptions.log', () => {
-    writeInterceptions([
-      '1700000001 8000 src/lib/agents.ts',
-      '1700000002 12000 src/lib/costs/events.ts',
-      '1700000003 5000 src/lib/tldr-daemon.ts',
-    ]);
-    const metrics = getTldrMetrics(TEST_WORKSPACE);
-    expect(metrics.interceptions).toBe(3);
-  });
+  it.effect('counts interceptions from interceptions.log', () =>
+    Effect.gen(function* () {
+      writeInterceptions([
+        '1700000001 8000 src/lib/agents.ts',
+        '1700000002 12000 src/lib/costs/events.ts',
+        '1700000003 5000 src/lib/tldr-daemon.ts',
+      ]);
+      const metrics = yield* getTldrMetrics(TEST_WORKSPACE);
+      expect(metrics.interceptions).toBe(3);
+    })
+  );
 
-  it('estimates tokens saved from file sizes', () => {
-    // 8000 bytes → ~2000 tokens full; 2000 - 1000 = 1000 saved
-    writeInterceptions(['1700000001 8000 src/lib/agents.ts']);
-    const metrics = getTldrMetrics(TEST_WORKSPACE);
-    expect(metrics.estimatedTokensSaved).toBe(1000);
-  });
+  it.effect('estimates tokens saved from file sizes', () =>
+    Effect.gen(function* () {
+      // 8000 bytes → ~2000 tokens full; 2000 - 1000 = 1000 saved
+      writeInterceptions(['1700000001 8000 src/lib/agents.ts']);
+      const metrics = yield* getTldrMetrics(TEST_WORKSPACE);
+      expect(metrics.estimatedTokensSaved).toBe(1000);
+    })
+  );
 
-  it('never produces negative token savings for small files', () => {
-    // 3500 bytes → ~875 tokens full; summary (~1000) > full → savings = 0
-    writeInterceptions(['1700000001 3500 src/lib/small.ts']);
-    const metrics = getTldrMetrics(TEST_WORKSPACE);
-    expect(metrics.estimatedTokensSaved).toBe(0);
-  });
+  it.effect('never produces negative token savings for small files', () =>
+    Effect.gen(function* () {
+      // 3500 bytes → ~875 tokens full; summary (~1000) > full → savings = 0
+      writeInterceptions(['1700000001 3500 src/lib/small.ts']);
+      const metrics = yield* getTldrMetrics(TEST_WORKSPACE);
+      expect(metrics.estimatedTokensSaved).toBe(0);
+    })
+  );
 
-  it('tracks unique files in filesAnalyzed', () => {
-    writeInterceptions([
-      '1700000001 8000 src/lib/agents.ts',
-      '1700000002 8000 src/lib/agents.ts', // same file twice
-      '1700000003 8000 src/lib/costs.ts',
-    ]);
-    const metrics = getTldrMetrics(TEST_WORKSPACE);
-    expect(metrics.filesAnalyzed).toHaveLength(2);
-    expect(metrics.filesAnalyzed).toContain('src/lib/agents.ts');
-    expect(metrics.filesAnalyzed).toContain('src/lib/costs.ts');
-  });
+  it.effect('tracks unique files in filesAnalyzed', () =>
+    Effect.gen(function* () {
+      writeInterceptions([
+        '1700000001 8000 src/lib/agents.ts',
+        '1700000002 8000 src/lib/agents.ts', // same file twice
+        '1700000003 8000 src/lib/costs.ts',
+      ]);
+      const metrics = yield* getTldrMetrics(TEST_WORKSPACE);
+      expect(metrics.filesAnalyzed).toHaveLength(2);
+      expect(metrics.filesAnalyzed).toContain('src/lib/agents.ts');
+      expect(metrics.filesAnalyzed).toContain('src/lib/costs.ts');
+    })
+  );
 
-  it('counts bypasses and groups by reason', () => {
-    writeBypasses([
-      '1700000001 offset-limit src/lib/agents.ts',
-      '1700000002 offset-limit src/lib/costs.ts',
-      '1700000003 recently-edited src/lib/settings.ts',
-    ]);
-    const metrics = getTldrMetrics(TEST_WORKSPACE);
-    expect(metrics.bypasses).toBe(3);
-    expect(metrics.bypassReasons['offset-limit']).toBe(2);
-    expect(metrics.bypassReasons['recently-edited']).toBe(1);
-  });
+  it.effect('counts bypasses and groups by reason', () =>
+    Effect.gen(function* () {
+      writeBypasses([
+        '1700000001 offset-limit src/lib/agents.ts',
+        '1700000002 offset-limit src/lib/costs.ts',
+        '1700000003 recently-edited src/lib/settings.ts',
+      ]);
+      const metrics = yield* getTldrMetrics(TEST_WORKSPACE);
+      expect(metrics.bypasses).toBe(3);
+      expect(metrics.bypassReasons['offset-limit']).toBe(2);
+      expect(metrics.bypassReasons['recently-edited']).toBe(1);
+    })
+  );
 
-  it('respects sinceCheckpoint=true when checkpoint exists', () => {
-    writeInterceptions([
-      '1700000001 8000 src/lib/agents.ts',     // line 0 — before checkpoint
-      '1700000002 12000 src/lib/costs.ts',      // line 1 — before checkpoint
-      '1700000003 5000 src/lib/new-file.ts',    // line 2 — after checkpoint
-    ]);
-    writeCheckpoint(2, 0); // 2 interceptions already captured
+  it.effect('respects sinceCheckpoint=true when checkpoint exists', () =>
+    Effect.gen(function* () {
+      writeInterceptions([
+        '1700000001 8000 src/lib/agents.ts',     // line 0 — before checkpoint
+        '1700000002 12000 src/lib/costs.ts',      // line 1 — before checkpoint
+        '1700000003 5000 src/lib/new-file.ts',    // line 2 — after checkpoint
+      ]);
+      writeCheckpoint(2, 0); // 2 interceptions already captured
 
-    const metrics = getTldrMetrics(TEST_WORKSPACE, true);
-    expect(metrics.interceptions).toBe(1); // only line 2
-    expect(metrics.filesAnalyzed).toEqual(['src/lib/new-file.ts']);
-  });
+      const metrics = yield* getTldrMetrics(TEST_WORKSPACE, true);
+      expect(metrics.interceptions).toBe(1); // only line 2
+      expect(metrics.filesAnalyzed).toEqual(['src/lib/new-file.ts']);
+    })
+  );
 
-  it('returns all metrics when sinceCheckpoint=false even with checkpoint', () => {
-    writeInterceptions([
-      '1700000001 8000 src/lib/agents.ts',
-      '1700000002 8000 src/lib/costs.ts',
-    ]);
-    writeCheckpoint(1, 0); // 1 already captured
+  it.effect('returns all metrics when sinceCheckpoint=false even with checkpoint', () =>
+    Effect.gen(function* () {
+      writeInterceptions([
+        '1700000001 8000 src/lib/agents.ts',
+        '1700000002 8000 src/lib/costs.ts',
+      ]);
+      writeCheckpoint(1, 0); // 1 already captured
 
-    const metrics = getTldrMetrics(TEST_WORKSPACE, false);
-    expect(metrics.interceptions).toBe(2); // all lines
-  });
+      const metrics = yield* getTldrMetrics(TEST_WORKSPACE, false);
+      expect(metrics.interceptions).toBe(2); // all lines
+    })
+  );
 });
 
 // ============ captureTldrMetrics ============
 
 describe('captureTldrMetrics', () => {
-  it('returns null when .tldr/ does not exist', () => {
-    const noTldrWorkspace = join(tmpdir(), `no-tldr-${Date.now()}`);
-    mkdirSync(noTldrWorkspace, { recursive: true });
-    try {
-      expect(captureTldrMetrics(noTldrWorkspace)).toBeNull();
-    } finally {
-      rmSync(noTldrWorkspace, { recursive: true, force: true });
-    }
-  });
+  it.effect('returns null when .tldr/ does not exist', () =>
+    Effect.gen(function* () {
+      const noTldrWorkspace = join(tmpdir(), `no-tldr-${Date.now()}`);
+      mkdirSync(noTldrWorkspace, { recursive: true });
+      try {
+        const result = yield* captureTldrMetrics(noTldrWorkspace);
+        expect(result).toBeNull();
+      } finally {
+        rmSync(noTldrWorkspace, { recursive: true, force: true });
+      }
+    })
+  );
 
-  it('returns empty metrics and writes checkpoint when no logs exist', () => {
-    const metrics = captureTldrMetrics(TEST_WORKSPACE);
-    expect(metrics).not.toBeNull();
-    expect(metrics!.interceptions).toBe(0);
-    expect(metrics!.bypasses).toBe(0);
+  it.effect('returns empty metrics and writes checkpoint when no logs exist', () =>
+    Effect.gen(function* () {
+      const metrics = yield* captureTldrMetrics(TEST_WORKSPACE);
+      expect(metrics).not.toBeNull();
+      expect(metrics!.interceptions).toBe(0);
+      expect(metrics!.bypasses).toBe(0);
 
-    const checkpointFile = join(TEST_WORKSPACE, '.tldr', 'metrics-checkpoint.json');
-    expect(existsSync(checkpointFile)).toBe(true);
-  });
+      const checkpointFile = join(TEST_WORKSPACE, '.tldr', 'metrics-checkpoint.json');
+      expect(existsSync(checkpointFile)).toBe(true);
+    })
+  );
 
-  it('captures metrics since last checkpoint and advances checkpoint', () => {
-    writeInterceptions([
-      '1700000001 8000 src/lib/agents.ts',   // already captured
-      '1700000002 8000 src/lib/costs.ts',    // new
-    ]);
-    writeBypasses([
-      '1700000001 offset-limit src/lib/agents.ts', // new
-    ]);
-    writeCheckpoint(1, 0); // 1 interception captured, 0 bypasses captured
+  it.effect('captures metrics since last checkpoint and advances checkpoint', () =>
+    Effect.gen(function* () {
+      writeInterceptions([
+        '1700000001 8000 src/lib/agents.ts',   // already captured
+        '1700000002 8000 src/lib/costs.ts',    // new
+      ]);
+      writeBypasses([
+        '1700000001 offset-limit src/lib/agents.ts', // new
+      ]);
+      writeCheckpoint(1, 0); // 1 interception captured, 0 bypasses captured
 
-    const metrics = captureTldrMetrics(TEST_WORKSPACE)!;
-    expect(metrics.interceptions).toBe(1);  // only line 1 (index 1)
-    expect(metrics.filesAnalyzed).toEqual(['src/lib/costs.ts']);
-    expect(metrics.bypasses).toBe(1);
-    expect(metrics.bypassReasons['offset-limit']).toBe(1);
+      const metrics = (yield* captureTldrMetrics(TEST_WORKSPACE))!;
+      expect(metrics.interceptions).toBe(1);  // only line 1 (index 1)
+      expect(metrics.filesAnalyzed).toEqual(['src/lib/costs.ts']);
+      expect(metrics.bypasses).toBe(1);
+      expect(metrics.bypassReasons['offset-limit']).toBe(1);
 
-    // Checkpoint should now point to end of both logs
-    const checkpoint = JSON.parse(
-      readFileSync(join(TEST_WORKSPACE, '.tldr', 'metrics-checkpoint.json'), 'utf-8')
-    );
-    expect(checkpoint.interceptionsLine).toBe(2);
-    expect(checkpoint.bypassesLine).toBe(1);
-    expect(checkpoint.interceptionsByte).toBeGreaterThan(0);
-    expect(checkpoint.bypassesByte).toBeGreaterThan(0);
-  });
+      // Checkpoint should now point to end of both logs
+      const checkpoint = JSON.parse(
+        readFileSync(join(TEST_WORKSPACE, '.tldr', 'metrics-checkpoint.json'), 'utf-8')
+      );
+      expect(checkpoint.interceptionsLine).toBe(2);
+      expect(checkpoint.bypassesLine).toBe(1);
+      expect(checkpoint.interceptionsByte).toBeGreaterThan(0);
+      expect(checkpoint.bypassesByte).toBeGreaterThan(0);
+    })
+  );
 
-  it('uses byte checkpoints for subsequent captures', () => {
-    writeInterceptions(['1700000001 8000 src/lib/agents.ts']);
-    captureTldrMetrics(TEST_WORKSPACE);
-    writeInterceptions([
-      '1700000001 8000 src/lib/agents.ts',
-      '1700000002 8000 src/lib/new.ts',
-    ]);
+  it.effect('uses byte checkpoints for subsequent captures', () =>
+    Effect.gen(function* () {
+      writeInterceptions(['1700000001 8000 src/lib/agents.ts']);
+      yield* captureTldrMetrics(TEST_WORKSPACE);
+      writeInterceptions([
+        '1700000001 8000 src/lib/agents.ts',
+        '1700000002 8000 src/lib/new.ts',
+      ]);
 
-    const second = captureTldrMetrics(TEST_WORKSPACE)!;
-    expect(second.interceptions).toBe(1);
-    expect(second.filesAnalyzed).toEqual(['src/lib/new.ts']);
-  });
+      const second = (yield* captureTldrMetrics(TEST_WORKSPACE))!;
+      expect(second.interceptions).toBe(1);
+      expect(second.filesAnalyzed).toEqual(['src/lib/new.ts']);
+    })
+  );
 
-  it('returns zero delta on second capture with no new events', () => {
-    writeInterceptions(['1700000001 8000 src/lib/agents.ts']);
-    captureTldrMetrics(TEST_WORKSPACE); // first capture
+  it.effect('returns zero delta on second capture with no new events', () =>
+    Effect.gen(function* () {
+      writeInterceptions(['1700000001 8000 src/lib/agents.ts']);
+      yield* captureTldrMetrics(TEST_WORKSPACE); // first capture
 
-    const second = captureTldrMetrics(TEST_WORKSPACE)!;
-    expect(second.interceptions).toBe(0);
-    expect(second.bypasses).toBe(0);
-    expect(second.estimatedTokensSaved).toBe(0);
-  });
+      const second = (yield* captureTldrMetrics(TEST_WORKSPACE))!;
+      expect(second.interceptions).toBe(0);
+      expect(second.bypasses).toBe(0);
+      expect(second.estimatedTokensSaved).toBe(0);
+    })
+  );
 
-  it('accumulates correctly across multiple captures', () => {
-    // First batch: 2 interceptions
-    writeInterceptions([
-      '1700000001 8000 src/a.ts',
-      '1700000002 8000 src/b.ts',
-    ]);
-    const first = captureTldrMetrics(TEST_WORKSPACE)!;
-    expect(first.interceptions).toBe(2);
+  it.effect('accumulates correctly across multiple captures', () =>
+    Effect.gen(function* () {
+      // First batch: 2 interceptions
+      writeInterceptions([
+        '1700000001 8000 src/a.ts',
+        '1700000002 8000 src/b.ts',
+      ]);
+      const first = (yield* captureTldrMetrics(TEST_WORKSPACE))!;
+      expect(first.interceptions).toBe(2);
 
-    // Second batch: 1 more interception
-    writeInterceptions([
-      '1700000001 8000 src/a.ts',
-      '1700000002 8000 src/b.ts',
-      '1700000003 8000 src/c.ts',
-    ]);
-    const second = captureTldrMetrics(TEST_WORKSPACE)!;
-    expect(second.interceptions).toBe(1); // only the new one
-    expect(second.filesAnalyzed).toEqual(['src/c.ts']);
-  });
+      // Second batch: 1 more interception
+      writeInterceptions([
+        '1700000001 8000 src/a.ts',
+        '1700000002 8000 src/b.ts',
+        '1700000003 8000 src/c.ts',
+      ]);
+      const second = (yield* captureTldrMetrics(TEST_WORKSPACE))!;
+      expect(second.interceptions).toBe(1); // only the new one
+      expect(second.filesAnalyzed).toEqual(['src/c.ts']);
+    })
+  );
 });

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -2559,11 +2559,13 @@ export async function spawnAgent(options: SpawnOptions): Promise<AgentState> {
   try {
     const venvPath = join(options.workspace, '.venv');
     if (existsSync(venvPath)) {
+      const { Effect } = await import('effect');
+      const { layer: NodeServicesLayer } = await import('@effect/platform-node/NodeServices');
       const { getTldrDaemonService } = await import('./tldr-daemon.js');
       const tldrService = getTldrDaemonService(options.workspace, venvPath);
-      const status = await tldrService.getStatus();
+      const status = await Effect.runPromise(tldrService.getStatus().pipe(Effect.provide(NodeServicesLayer)));
       if (!status.running) {
-        await tldrService.start(true);
+        await Effect.runPromise(tldrService.start(true).pipe(Effect.provide(NodeServicesLayer)));
         console.log(`[${agentId}] Started TLDR daemon for workspace`);
       }
     }

--- a/src/lib/cloister/merge-agent.ts
+++ b/src/lib/cloister/merge-agent.ts
@@ -116,11 +116,13 @@ export async function notifyTldrDaemon(projectPath: string, sourceBranch: string
     console.log(`[merge-agent] Found ${changedFiles.length} changed source files to reindex`);
 
     // Get TLDR daemon service
+    const { Effect } = await import('effect');
+    const { layer: NodeServicesLayer } = await import('@effect/platform-node/NodeServices');
     const { getTldrDaemonService } = await import('../tldr-daemon.js');
     const tldrService = getTldrDaemonService(projectPath, venvPath);
 
     // Check if daemon is running
-    const status = await tldrService.getStatus();
+    const status = await Effect.runPromise(tldrService.getStatus().pipe(Effect.provide(NodeServicesLayer)));
     if (!status.running) {
       console.log(`[merge-agent] TLDR daemon not running, skipping notification`);
       return;
@@ -128,7 +130,7 @@ export async function notifyTldrDaemon(projectPath: string, sourceBranch: string
 
     // Trigger warm to reindex (this will update the index incrementally)
     console.log(`[merge-agent] Triggering TLDR index warm...`);
-    await tldrService.warm(true);  // background mode
+    await Effect.runPromise(tldrService.warm(true).pipe(Effect.provide(NodeServicesLayer)));
 
     console.log(`[merge-agent] ✓ TLDR daemon notified to reindex`);
     logActivity('tldr_notified', `Notified TLDR daemon to reindex ${changedFiles.length} files`);

--- a/src/lib/conversations/__tests__/system-probe.test.ts
+++ b/src/lib/conversations/__tests__/system-probe.test.ts
@@ -1,54 +1,68 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { beforeEach, expect, it } from '@effect/vitest';
+import { Effect } from 'effect';
+import { layer as NodeServicesLayer } from '@effect/platform-node/NodeServices';
 import { resetSystemCapabilitiesCache, getSystemCapabilities } from '../system-probe.js';
 
 beforeEach(() => {
   resetSystemCapabilitiesCache();
 });
 
-describe('system-probe', () => {
-  it('returns SystemCapabilities with all four fields populated', async () => {
-    const caps = await getSystemCapabilities();
-    expect(caps.cpuCores).toBeGreaterThan(0);
-    expect(['ssd', 'hdd', 'unknown']).toContain(caps.driveType);
-    expect(caps.driveReadMBps).toBeGreaterThanOrEqual(0);
-    expect(caps.availableMemoryMB).toBeGreaterThan(0);
-    expect(caps.recommendedParallelism).toBeGreaterThan(0);
-  });
+it.layer(NodeServicesLayer)('system-probe', (it) => {
+  it.effect('returns SystemCapabilities with all four fields populated', () =>
+    Effect.gen(function* () {
+      const caps = yield* getSystemCapabilities();
+      expect(caps.cpuCores).toBeGreaterThan(0);
+      expect(['ssd', 'hdd', 'unknown']).toContain(caps.driveType);
+      expect(caps.driveReadMBps).toBeGreaterThanOrEqual(0);
+      expect(caps.availableMemoryMB).toBeGreaterThan(0);
+      expect(caps.recommendedParallelism).toBeGreaterThan(0);
+    }),
+  );
 
-  it('recommendedParallelism follows spec table', async () => {
-    const caps = await getSystemCapabilities();
-    const { cpuCores, driveType, recommendedParallelism } = caps;
-    if (driveType === 'ssd') {
-      expect(recommendedParallelism).toBe(Math.min(cpuCores, 16));
-    } else if (driveType === 'hdd') {
-      expect(recommendedParallelism).toBe(2);
-    } else {
-      expect(recommendedParallelism).toBe(4);
-    }
-  });
+  it.effect('recommendedParallelism follows spec table', () =>
+    Effect.gen(function* () {
+      const caps = yield* getSystemCapabilities();
+      const { cpuCores, driveType, recommendedParallelism } = caps;
+      if (driveType === 'ssd') {
+        expect(recommendedParallelism).toBe(Math.min(cpuCores, 16));
+      } else if (driveType === 'hdd') {
+        expect(recommendedParallelism).toBe(2);
+      } else {
+        expect(recommendedParallelism).toBe(4);
+      }
+    }),
+  );
 
-  it('scanMaxParallel config override takes precedence over probe result', async () => {
-    const caps = await getSystemCapabilities(7);
-    expect(caps.recommendedParallelism).toBe(7);
-  });
+  it.effect('scanMaxParallel config override takes precedence over probe result', () =>
+    Effect.gen(function* () {
+      const caps = yield* getSystemCapabilities(7);
+      expect(caps.recommendedParallelism).toBe(7);
+    }),
+  );
 
-  it('caches result — second call returns same object', async () => {
-    const a = await getSystemCapabilities();
-    const b = await getSystemCapabilities();
-    expect(b).toBe(a); // same reference = cached
-  });
+  it.effect('caches result — second call returns same object', () =>
+    Effect.gen(function* () {
+      const a = yield* getSystemCapabilities();
+      const b = yield* getSystemCapabilities();
+      expect(b).toBe(a); // same reference = cached
+    }),
+  );
 
-  it('resetSystemCapabilitiesCache clears the cache', async () => {
-    const a = await getSystemCapabilities();
-    resetSystemCapabilitiesCache();
-    const b = await getSystemCapabilities();
-    // Should be a different object (re-probed), but same shape
-    expect(b.cpuCores).toBe(a.cpuCores);
-    expect(b).not.toBe(a);
-  });
+  it.effect('resetSystemCapabilitiesCache clears the cache', () =>
+    Effect.gen(function* () {
+      const a = yield* getSystemCapabilities();
+      resetSystemCapabilitiesCache();
+      const b = yield* getSystemCapabilities();
+      // Should be a different object (re-probed), but same shape
+      expect(b.cpuCores).toBe(a.cpuCores);
+      expect(b).not.toBe(a);
+    }),
+  );
 
-  it('does not throw on any platform', async () => {
-    // Probe should never throw even on unsupported platforms
-    await expect(getSystemCapabilities()).resolves.toBeDefined();
-  });
+  it.effect('does not throw on any platform', () =>
+    Effect.gen(function* () {
+      const caps = yield* getSystemCapabilities();
+      expect(caps).toBeDefined();
+    }),
+  );
 });

--- a/src/lib/conversations/scanner.ts
+++ b/src/lib/conversations/scanner.ts
@@ -24,6 +24,7 @@ import {
 import { parseSessionJsonl } from './jsonl-async.js';
 import { HashResolver } from './hash-resolver.js';
 import { getSystemCapabilities } from './system-probe.js';
+import { Effect } from 'effect';
 import { runWithPool } from './work-pool.js';
 import { buildCorrelationMap } from './correlator.js';
 import { getModelCapability } from '../model-capabilities.js';
@@ -188,7 +189,12 @@ export async function scan(opts: ScanOptions): Promise<ScanResult> {
   const correlationMap = buildCorrelationMap(allPaths);
 
   // 4. Determine parallelism from system-probe
-  const caps = await getSystemCapabilities(opts.maxParallel);
+  // Adapter boundary: scanner.ts is still Promise-based; provide services and bridge to Promise.
+  // This will be replaced with yield* when scanner.ts is migrated in its own wave-5 slot.
+  const { layer: NodeServicesLayer } = await import('@effect/platform-node/NodeServices');
+  const caps = await Effect.runPromise(
+    getSystemCapabilities(opts.maxParallel).pipe(Effect.provide(NodeServicesLayer)),
+  );
   const maxParallel = caps.recommendedParallelism;
 
   // 5. Track progress

--- a/src/lib/conversations/system-probe.ts
+++ b/src/lib/conversations/system-probe.ts
@@ -4,18 +4,15 @@
  * Detects CPU cores, drive type (SSD vs HDD), drive read speed, and
  * available memory. Chooses optimal scan parallelism from these stats.
  *
- * Zero sync FS or execSync calls — uses execAsync + fs/promises only.
+ * Zero sync FS or execSync calls — uses Effect FileSystem + ChildProcessSpawner.
  * Result is cached per-process (probe runs at most once).
  */
 
-import { cpus, freemem } from 'os';
-import { promises as fs } from 'fs';
+import { cpus, freemem, tmpdir } from 'os';
 import { join } from 'path';
-import { tmpdir } from 'os';
-import { exec } from 'child_process';
-import { promisify } from 'util';
-
-const execAsync = promisify(exec);
+import { Effect, FileSystem } from 'effect';
+import { ChildProcess } from 'effect/unstable/process';
+import { ChildProcessSpawner } from 'effect/unstable/process/ChildProcessSpawner';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -55,16 +52,18 @@ let cachedCapabilities: SystemCapabilities | null = null;
  *
  * @param scanMaxParallel  Optional config override. When set, overrides the probe result.
  */
-export async function getSystemCapabilities(
+export function getSystemCapabilities(
   scanMaxParallel?: number | null,
-): Promise<SystemCapabilities> {
-  if (cachedCapabilities === null) {
-    cachedCapabilities = await probe();
-  }
-  if (scanMaxParallel != null && scanMaxParallel > 0) {
-    return { ...cachedCapabilities, recommendedParallelism: scanMaxParallel };
-  }
-  return cachedCapabilities;
+): Effect.Effect<SystemCapabilities, never, FileSystem.FileSystem | ChildProcessSpawner> {
+  return Effect.gen(function* () {
+    if (cachedCapabilities === null) {
+      cachedCapabilities = yield* probe();
+    }
+    if (scanMaxParallel != null && scanMaxParallel > 0) {
+      return { ...cachedCapabilities, recommendedParallelism: scanMaxParallel };
+    }
+    return cachedCapabilities;
+  });
 }
 
 /** Reset the cache (for tests). */
@@ -74,29 +73,33 @@ export function resetSystemCapabilitiesCache(): void {
 
 // ─── Probe implementation ─────────────────────────────────────────────────────
 
-async function probe(): Promise<SystemCapabilities> {
-  const cpuCores = cpus().length;
-  const availableMemoryMB = Math.round(freemem() / 1024 / 1024);
+function probe(): Effect.Effect<SystemCapabilities, never, FileSystem.FileSystem | ChildProcessSpawner> {
+  return Effect.gen(function* () {
+    const cpuCores = cpus().length;
+    const availableMemoryMB = Math.round(freemem() / 1024 / 1024);
 
-  const driveType = await detectDriveType();
-  const driveReadMBps = await measureDriveReadSpeed();
+    const driveType = yield* detectDriveType();
+    const driveReadMBps = yield* measureDriveReadSpeed();
 
-  const partial = { cpuCores, driveType, driveReadMBps, availableMemoryMB };
-  return { ...partial, recommendedParallelism: computeParallelism(partial) };
+    const partial = { cpuCores, driveType, driveReadMBps, availableMemoryMB };
+    return { ...partial, recommendedParallelism: computeParallelism(partial) };
+  });
 }
 
 /**
  * Detect drive type using lsblk on Linux.
  * Falls back to 'unknown' on macOS/Windows or if lsblk is unavailable.
  */
-async function detectDriveType(): Promise<DriveType> {
-  if (process.platform !== 'linux') return 'unknown';
+function detectDriveType(): Effect.Effect<DriveType, never, ChildProcessSpawner> {
+  if (process.platform !== 'linux') return Effect.succeed('unknown' as DriveType);
 
-  try {
-    const { stdout } = await execAsync('lsblk -d -o name,rota --noheadings 2>/dev/null');
-    // rota=0 means non-rotational (SSD/NVMe), rota=1 means HDD
-    const lines = stdout.trim().split('\n').filter(Boolean);
-    if (lines.length === 0) return 'unknown';
+  return Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner;
+    const lines = yield* spawner
+      .lines(ChildProcess.make`lsblk -d -o name,rota --noheadings`)
+      .pipe(Effect.catch(() => Effect.succeed([] as string[])));
+
+    if (lines.length === 0) return 'unknown' as DriveType;
 
     const rotaCounts = { ssd: 0, hdd: 0 };
     for (const line of lines) {
@@ -106,37 +109,43 @@ async function detectDriveType(): Promise<DriveType> {
       else if (rota === '1') rotaCounts.hdd++;
     }
 
-    if (rotaCounts.ssd > 0 && rotaCounts.hdd === 0) return 'ssd';
-    if (rotaCounts.hdd > 0 && rotaCounts.ssd === 0) return 'hdd';
+    if (rotaCounts.ssd > 0 && rotaCounts.hdd === 0) return 'ssd' as DriveType;
+    if (rotaCounts.hdd > 0 && rotaCounts.ssd === 0) return 'hdd' as DriveType;
     // Mixed: default to ssd (common in modern systems)
-    if (rotaCounts.ssd >= rotaCounts.hdd) return 'ssd';
-    return 'hdd';
-  } catch {
-    return 'unknown';
-  }
+    if (rotaCounts.ssd >= rotaCounts.hdd) return 'ssd' as DriveType;
+    return 'hdd' as DriveType;
+  }).pipe(Effect.catch(() => Effect.succeed('unknown' as DriveType)));
 }
 
 /** Measure sequential read speed by reading a 10MB temp file. */
-async function measureDriveReadSpeed(): Promise<number> {
+function measureDriveReadSpeed(): Effect.Effect<number, never, FileSystem.FileSystem> {
   const SAMPLE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
   const tmpFile = join(tmpdir(), `pan-probe-${process.pid}.bin`);
 
-  try {
+  const measure = Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+
     // Write a 10MB buffer
-    const buf = Buffer.alloc(SAMPLE_SIZE_BYTES, 0x42);
-    await fs.writeFile(tmpFile, buf);
+    const buf = new Uint8Array(SAMPLE_SIZE_BYTES).fill(0x42);
+    yield* fs.writeFile(tmpFile, buf);
 
     // Read it back and measure elapsed time
     const start = performance.now();
-    await fs.readFile(tmpFile);
+    yield* fs.readFile(tmpFile);
     const elapsedMs = performance.now() - start;
 
     // MB/s = bytes / (elapsed / 1000) / 1024 / 1024
     const mbps = (SAMPLE_SIZE_BYTES / (elapsedMs / 1000)) / 1024 / 1024;
     return Math.round(mbps);
-  } catch {
-    return 0;
-  } finally {
-    await fs.unlink(tmpFile).catch(() => {});
-  }
+  });
+
+  const cleanup = Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    yield* fs.remove(tmpFile).pipe(Effect.catch(() => Effect.void));
+  });
+
+  return measure.pipe(
+    Effect.ensuring(cleanup),
+    Effect.catch(() => Effect.succeed(0)),
+  );
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared typed errors for src/lib Effect migration (PAN-1249, wave 0).
+ *
+ * All errors are `Data.TaggedError` subclasses so they participate in typed
+ * Effect error channels and can be narrowed with `Effect.catchTag`.
+ */
+
+import { Data } from 'effect';
+
+// ─── VCS errors ───────────────────────────────────────────────────────────────
+
+/** A version-control operation (commit, push, pull, fetch) failed. */
+export class VcsError extends Data.TaggedError('VcsError')<{
+  readonly operation: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** A version-control operation exceeded its timeout. */
+export class VcsTimeoutError extends Data.TaggedError('VcsTimeoutError')<{
+  readonly operation: string;
+  readonly timeoutMs: number;
+}> {}
+
+// ─── Filesystem errors ────────────────────────────────────────────────────────
+
+/** A filesystem operation (read, write, mkdir, unlink, stat) failed. */
+export class FsError extends Data.TaggedError('FsError')<{
+  readonly path: string;
+  readonly operation: string;
+  readonly cause?: unknown;
+}> {}
+
+/** The requested path does not exist. */
+export class FsNotFoundError extends Data.TaggedError('FsNotFoundError')<{
+  readonly path: string;
+}> {}
+
+// ─── Git errors ───────────────────────────────────────────────────────────────
+
+/** A git command exited with a non-zero code. */
+export class GitError extends Data.TaggedError('GitError')<{
+  readonly command: readonly string[];
+  readonly stderr: string;
+  readonly exitCode: number;
+  readonly cause?: unknown;
+}> {}
+
+/** A git merge or rebase produced conflicts. */
+export class MergeConflictError extends Data.TaggedError('MergeConflictError')<{
+  readonly branch: string;
+  readonly targetBranch: string;
+  readonly conflictedFiles: readonly string[];
+}> {}
+
+// ─── Tmux errors ──────────────────────────────────────────────────────────────
+
+/** A tmux command failed. */
+export class TmuxError extends Data.TaggedError('TmuxError')<{
+  readonly command: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+// ─── Tracker / API errors ─────────────────────────────────────────────────────
+
+/** A generic issue-tracker API call failed. */
+export class TrackerError extends Data.TaggedError('TrackerError')<{
+  readonly tracker: string;
+  readonly operation: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** A GitHub API call failed. */
+export class GitHubApiError extends Data.TaggedError('GitHubApiError')<{
+  readonly operation: string;
+  readonly status: number;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** A Linear API call failed. */
+export class LinearApiError extends Data.TaggedError('LinearApiError')<{
+  readonly operation: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+// ─── Agent / checkpoint errors ────────────────────────────────────────────────
+
+/** A checkpoint save, load, or delete operation failed. */
+export class CheckpointError extends Data.TaggedError('CheckpointError')<{
+  readonly agentId: string;
+  readonly operation: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** The supplied agent ID does not match the expected format. */
+export class InvalidAgentIdError extends Data.TaggedError('InvalidAgentIdError')<{
+  readonly agentId: string;
+}> {}
+
+// ─── Configuration errors ─────────────────────────────────────────────────────
+
+/** A configuration value is missing or invalid. */
+export class ConfigError extends Data.TaggedError('ConfigError')<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** A configuration file (YAML or JSON) could not be parsed. */
+export class ConfigParseError extends Data.TaggedError('ConfigParseError')<{
+  readonly path: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+// ─── Process errors ───────────────────────────────────────────────────────────
+
+/** A child process failed to spawn. */
+export class ProcessSpawnError extends Data.TaggedError('ProcessSpawnError')<{
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** A child process exceeded its allowed runtime. */
+export class ProcessTimeoutError extends Data.TaggedError('ProcessTimeoutError')<{
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly timeoutMs: number;
+}> {}

--- a/src/lib/lifecycle/teardown-workspace.ts
+++ b/src/lib/lifecycle/teardown-workspace.ts
@@ -105,9 +105,11 @@ async function stopTldrDaemon(workspacePath: string): Promise<StepResult> {
     return stepSkipped(step, ['No .venv found']);
   }
   try {
+    const { Effect } = await import('effect');
+    const { layer: NodeServicesLayer } = await import('@effect/platform-node/NodeServices');
     const { getTldrDaemonService } = await import('../tldr-daemon.js');
     const tldrService = getTldrDaemonService(workspacePath, venvPath);
-    await tldrService.stop();
+    await Effect.runPromise(tldrService.stop().pipe(Effect.provide(NodeServicesLayer)));
     return stepOk(step, ['Stopped TLDR daemon']);
   } catch {
     return stepSkipped(step, ['TLDR daemon not running or failed to stop (non-fatal)']);

--- a/src/lib/tldr-daemon.ts
+++ b/src/lib/tldr-daemon.ts
@@ -5,10 +5,27 @@
  * Provides code analysis and summarization for token-efficient agent work.
  */
 
-import { exec } from 'child_process';
-import { promisify } from 'util';
-import { existsSync, writeFileSync, readFileSync, statSync } from 'fs';
+import { existsSync, readFileSync, statSync, writeFileSync } from 'fs';
 import { join } from 'path';
+import { Data, Effect } from 'effect';
+import { ChildProcess } from 'effect/unstable/process';
+import { ChildProcessSpawner } from 'effect/unstable/process/ChildProcessSpawner';
+
+// ============================================================================
+// Typed errors
+// ============================================================================
+
+/** tldr binary not found in the venv. */
+export class TldrNotInstalledError extends Data.TaggedError('TldrNotInstalledError')<{
+  readonly venvPath: string;
+  readonly tldrBin: string;
+}> {}
+
+/** Daemon failed to write its pidfile within the startup deadline. */
+export class TldrStartError extends Data.TaggedError('TldrStartError')<{
+  readonly workspacePath: string;
+  readonly message?: string;
+}> {}
 
 // ============================================================================
 // TLDR Session Metrics (PAN-236)
@@ -23,11 +40,11 @@ import { join } from 'path';
  *   metrics-checkpoint.json — tracks byte offsets for delta (per-cost-event) reporting
  */
 export interface TldrSessionMetrics {
-  interceptions: number;                   // TLDR summaries served since last checkpoint
-  bypasses: number;                        // TLDR bypasses since last checkpoint
-  estimatedTokensSaved: number;            // Rough token savings (fullTokens - ~1000 per interception)
-  filesAnalyzed: string[];                 // Unique files summarized in this window
-  bypassReasons: Record<string, number>;   // e.g. { "offset-limit": 3, "recently-edited": 1 }
+  interceptions: number;
+  bypasses: number;
+  estimatedTokensSaved: number;
+  filesAnalyzed: string[];
+  bypassReasons: Record<string, number>;
 }
 
 /** Checkpoint persisted to .tldr/metrics-checkpoint.json */
@@ -39,25 +56,35 @@ interface TldrMetricsCheckpoint {
   capturedAt: string;
 }
 
-function readMetricsCheckpoint(checkpointFile: string): TldrMetricsCheckpoint | null {
-  if (!existsSync(checkpointFile)) return null;
-  try {
-    return JSON.parse(readFileSync(checkpointFile, 'utf-8')) as TldrMetricsCheckpoint;
-  } catch {
-    return null;
-  }
+// ─── Internal helpers (sync FS wrapped in Effect.try) ─────────────────────────
+
+function readMetricsCheckpointEffect(checkpointFile: string): Effect.Effect<TldrMetricsCheckpoint | null> {
+  if (!existsSync(checkpointFile)) return Effect.succeed(null);
+  return Effect.try({
+    try: () => JSON.parse(readFileSync(checkpointFile, 'utf-8')) as TldrMetricsCheckpoint,
+    catch: () => null as TldrMetricsCheckpoint | null,
+  }).pipe(Effect.catch(() => Effect.succeed<TldrMetricsCheckpoint | null>(null)));
 }
 
-function readLogLines(logFile: string, startByte?: number, startLine = 0): { lines: string[]; size: number } {
-  if (!existsSync(logFile)) return { lines: [], size: 0 };
-  const size = statSync(logFile).size;
-  if (startByte !== undefined) {
-    const safeStart = startByte <= size ? Math.max(0, startByte) : 0;
-    const content = readFileSync(logFile).subarray(safeStart).toString('utf-8');
-    return { lines: content.split('\n').filter(l => l.trim()), size };
-  }
-  const content = readFileSync(logFile, 'utf-8');
-  return { lines: content.split('\n').filter(l => l.trim()).slice(startLine), size };
+function readLogLinesEffect(
+  logFile: string,
+  startByte?: number,
+  startLine = 0,
+): Effect.Effect<{ lines: string[]; size: number }> {
+  if (!existsSync(logFile)) return Effect.succeed({ lines: [], size: 0 });
+  return Effect.try({
+    try: () => {
+      const size = statSync(logFile).size;
+      if (startByte !== undefined) {
+        const safeStart = startByte <= size ? Math.max(0, startByte) : 0;
+        const content = readFileSync(logFile).subarray(safeStart).toString('utf-8');
+        return { lines: content.split('\n').filter(l => l.trim()), size };
+      }
+      const content = readFileSync(logFile, 'utf-8');
+      return { lines: content.split('\n').filter(l => l.trim()).slice(startLine), size };
+    },
+    catch: () => ({ lines: [], size: 0 }),
+  }).pipe(Effect.catch(() => Effect.succeed({ lines: [], size: 0 })));
 }
 
 /**
@@ -66,65 +93,64 @@ function readLogLines(logFile: string, startByte?: number, startLine = 0): { lin
  * @param workspacePath - Workspace root (where .tldr/ lives)
  * @param sinceCheckpoint - Only return metrics since the last captured checkpoint
  */
-export function getTldrMetrics(workspacePath: string, sinceCheckpoint = false): TldrSessionMetrics {
-  const tldrDir = join(workspacePath, '.tldr');
-  const interceptionsLog = join(tldrDir, 'interceptions.log');
-  const bypassesLog = join(tldrDir, 'bypasses.log');
-  const checkpointFile = join(tldrDir, 'metrics-checkpoint.json');
+export function getTldrMetrics(workspacePath: string, sinceCheckpoint = false): Effect.Effect<TldrSessionMetrics> {
+  return Effect.gen(function* () {
+    const tldrDir = join(workspacePath, '.tldr');
+    const interceptionsLog = join(tldrDir, 'interceptions.log');
+    const bypassesLog = join(tldrDir, 'bypasses.log');
+    const checkpointFile = join(tldrDir, 'metrics-checkpoint.json');
 
-  const checkpoint = sinceCheckpoint ? readMetricsCheckpoint(checkpointFile) : null;
-  const interceptionsStartByte = checkpoint?.interceptionsByte;
-  const bypassesStartByte = checkpoint?.bypassesByte;
-  const interceptionsStartLine = checkpoint?.interceptionsLine ?? 0;
-  const bypassesStartLine = checkpoint?.bypassesLine ?? 0;
+    const checkpoint = sinceCheckpoint ? yield* readMetricsCheckpointEffect(checkpointFile) : null;
+    const interceptionsStartByte = checkpoint?.interceptionsByte;
+    const bypassesStartByte = checkpoint?.bypassesByte;
+    const interceptionsStartLine = checkpoint?.interceptionsLine ?? 0;
+    const bypassesStartLine = checkpoint?.bypassesLine ?? 0;
 
-  // Parse interceptions log: each line is "timestamp file_size rel_path"
-  const newInterceptions = readLogLines(
-    interceptionsLog,
-    sinceCheckpoint ? interceptionsStartByte : undefined,
-    sinceCheckpoint && interceptionsStartByte === undefined ? interceptionsStartLine : 0,
-  ).lines;
+    const { lines: newInterceptions } = yield* readLogLinesEffect(
+      interceptionsLog,
+      sinceCheckpoint ? interceptionsStartByte : undefined,
+      sinceCheckpoint && interceptionsStartByte === undefined ? interceptionsStartLine : 0,
+    );
 
-  let estimatedTokensSaved = 0;
-  const filesAnalyzed: string[] = [];
+    let estimatedTokensSaved = 0;
+    const filesAnalyzed: string[] = [];
 
-  for (const line of newInterceptions) {
-    const parts = line.trim().split(' ');
-    if (parts.length >= 3) {
-      const fileSizeBytes = parseInt(parts[1], 10) || 0;
-      const relPath = parts.slice(2).join(' ');
-      // Rough estimate: ~1 token per 4 bytes for code; TLDR summary is ~1000 tokens
-      const fullTokens = Math.round(fileSizeBytes / 4);
-      estimatedTokensSaved += Math.max(0, fullTokens - 1000);
-      if (relPath && !filesAnalyzed.includes(relPath)) {
-        filesAnalyzed.push(relPath);
+    for (const line of newInterceptions) {
+      const parts = line.trim().split(' ');
+      if (parts.length >= 3) {
+        const fileSizeBytes = parseInt(parts[1], 10) || 0;
+        const relPath = parts.slice(2).join(' ');
+        const fullTokens = Math.round(fileSizeBytes / 4);
+        estimatedTokensSaved += Math.max(0, fullTokens - 1000);
+        if (relPath && !filesAnalyzed.includes(relPath)) {
+          filesAnalyzed.push(relPath);
+        }
       }
     }
-  }
 
-  // Parse bypasses log: each line is "timestamp reason [rel_path]"
-  const newBypasses = readLogLines(
-    bypassesLog,
-    sinceCheckpoint ? bypassesStartByte : undefined,
-    sinceCheckpoint && bypassesStartByte === undefined ? bypassesStartLine : 0,
-  ).lines;
-  const bypassReasons: Record<string, number> = {};
+    const { lines: newBypasses } = yield* readLogLinesEffect(
+      bypassesLog,
+      sinceCheckpoint ? bypassesStartByte : undefined,
+      sinceCheckpoint && bypassesStartByte === undefined ? bypassesStartLine : 0,
+    );
+    const bypassReasons: Record<string, number> = {};
 
-  for (const line of newBypasses) {
-    const parts = line.trim().split(' ');
-    if (parts.length >= 2) {
-      const reason = parts[1];
-      bypassReasons[reason] = (bypassReasons[reason] || 0) + 1;
+    for (const line of newBypasses) {
+      const parts = line.trim().split(' ');
+      if (parts.length >= 2) {
+        const reason = parts[1];
+        bypassReasons[reason] = (bypassReasons[reason] || 0) + 1;
+      }
     }
-  }
 
-  return {
-    interceptions: newInterceptions.length,
-    bypasses: newBypasses.length,
-    estimatedTokensSaved,
-    filesAnalyzed,
-    bypassReasons,
-  };
+    return {
+      interceptions: newInterceptions.length,
+      bypasses: newBypasses.length,
+      estimatedTokensSaved,
+      filesAnalyzed,
+      bypassReasons,
+    };
+  });
 }
 
 /**
@@ -136,44 +162,59 @@ export function getTldrMetrics(workspacePath: string, sinceCheckpoint = false): 
  * @param workspacePath - Workspace root (where .tldr/ lives)
  * @returns Metrics delta since last capture, or null if no .tldr/ directory exists
  */
-export function captureTldrMetrics(workspacePath: string): TldrSessionMetrics | null {
+export function captureTldrMetrics(workspacePath: string): Effect.Effect<TldrSessionMetrics | null> {
   const tldrDir = join(workspacePath, '.tldr');
   if (!existsSync(tldrDir)) {
-    return null;
+    return Effect.succeed(null);
   }
 
-  const metrics = getTldrMetrics(workspacePath, true);
+  return Effect.gen(function* () {
+    const metrics = yield* getTldrMetrics(workspacePath, true);
 
-  // Advance checkpoint to current byte offsets without rescanning historical logs.
-  const interceptionsLog = join(tldrDir, 'interceptions.log');
-  const bypassesLog = join(tldrDir, 'bypasses.log');
-  const checkpointFile = join(tldrDir, 'metrics-checkpoint.json');
-  const previous = readMetricsCheckpoint(checkpointFile);
-  const interceptionsByte = existsSync(interceptionsLog) ? statSync(interceptionsLog).size : 0;
-  const bypassesByte = existsSync(bypassesLog) ? statSync(bypassesLog).size : 0;
-  const previousInterceptionsLine = previous?.interceptionsByte !== undefined && previous.interceptionsByte > interceptionsByte
-    ? 0
-    : previous?.interceptionsLine ?? 0;
-  const previousBypassesLine = previous?.bypassesByte !== undefined && previous.bypassesByte > bypassesByte
-    ? 0
-    : previous?.bypassesLine ?? 0;
+    const interceptionsLog = join(tldrDir, 'interceptions.log');
+    const bypassesLog = join(tldrDir, 'bypasses.log');
+    const checkpointFile = join(tldrDir, 'metrics-checkpoint.json');
 
-  const checkpoint: TldrMetricsCheckpoint = {
-    interceptionsLine: previousInterceptionsLine + metrics.interceptions,
-    bypassesLine: previousBypassesLine + metrics.bypasses,
-    interceptionsByte,
-    bypassesByte,
-    capturedAt: new Date().toISOString(),
-  };
+    const previous = yield* readMetricsCheckpointEffect(checkpointFile);
 
-  try {
-    writeFileSync(checkpointFile, JSON.stringify(checkpoint, null, 2), 'utf-8');
-  } catch { /* non-fatal — metrics still returned */ }
+    const interceptionsByte = existsSync(interceptionsLog)
+      ? yield* Effect.try({ try: () => statSync(interceptionsLog).size, catch: () => 0 })
+          .pipe(Effect.catch(n => Effect.succeed(n)))
+      : 0;
+    const bypassesByte = existsSync(bypassesLog)
+      ? yield* Effect.try({ try: () => statSync(bypassesLog).size, catch: () => 0 })
+          .pipe(Effect.catch(n => Effect.succeed(n)))
+      : 0;
 
-  return metrics;
+    const previousInterceptionsLine =
+      previous?.interceptionsByte !== undefined && previous.interceptionsByte > interceptionsByte
+        ? 0
+        : previous?.interceptionsLine ?? 0;
+    const previousBypassesLine =
+      previous?.bypassesByte !== undefined && previous.bypassesByte > bypassesByte
+        ? 0
+        : previous?.bypassesLine ?? 0;
+
+    const checkpoint: TldrMetricsCheckpoint = {
+      interceptionsLine: previousInterceptionsLine + metrics.interceptions,
+      bypassesLine: previousBypassesLine + metrics.bypasses,
+      interceptionsByte,
+      bypassesByte,
+      capturedAt: new Date().toISOString(),
+    };
+
+    yield* Effect.try({
+      try: () => writeFileSync(checkpointFile, JSON.stringify(checkpoint, null, 2), 'utf-8'),
+      catch: () => undefined,
+    }).pipe(Effect.catch(() => Effect.void));
+
+    return metrics;
+  });
 }
 
-const execAsync = promisify(exec);
+// ============================================================================
+// Daemon status / pidfile
+// ============================================================================
 
 /**
  * TLDR daemon status
@@ -192,9 +233,7 @@ export interface TldrDaemonStatus {
  *
  * The `tldr` binary writes its PID to <workspace>/.tldr/daemon.pid on start
  * and removes it on stop. That file is the single source of truth — Panopticon
- * does not maintain its own state file (PAN-1132: writing our own state with a
- * fallback to the CLI's process.pid caused the file to be reaped the moment the
- * CLI exited, making running daemons report as stopped).
+ * does not maintain its own state file (PAN-1132).
  */
 interface LiveDaemonState {
   pid: number;
@@ -211,37 +250,37 @@ function getPidFilePath(workspacePath: string): string {
  *
  * Returns null when no pidfile exists or the process is gone.
  */
-function readDaemonState(workspacePath: string): LiveDaemonState | null {
+function readDaemonStateEffect(workspacePath: string): Effect.Effect<LiveDaemonState | null> {
   const pidFile = getPidFilePath(workspacePath);
-  if (!existsSync(pidFile)) {
-    return null;
-  }
+  if (!existsSync(pidFile)) return Effect.succeed(null);
 
-  let raw: string;
-  try {
-    raw = readFileSync(pidFile, 'utf-8').trim();
-  } catch {
-    return null;
-  }
+  return Effect.gen(function* () {
+    const raw = yield* Effect.try({
+      try: () => readFileSync(pidFile, 'utf-8').trim(),
+      catch: () => '',
+    }).pipe(Effect.catch(e => Effect.succeed(e)));
 
-  const pid = parseInt(raw, 10);
-  if (!Number.isFinite(pid) || pid <= 0) {
-    return null;
-  }
+    const pid = parseInt(raw, 10);
+    if (!Number.isFinite(pid) || pid <= 0) return null as LiveDaemonState | null;
 
-  try {
-    process.kill(pid, 0);
-  } catch {
-    return null;
-  }
+    const alive = yield* Effect.try({
+      try: () => { process.kill(pid, 0); return true; },
+      catch: () => false,
+    }).pipe(Effect.catch(e => Effect.succeed(e)));
+    if (!alive) return null as LiveDaemonState | null;
 
-  let startedAt: Date | undefined;
-  try {
-    startedAt = statSync(pidFile).mtime;
-  } catch { /* informational only */ }
+    const startedAt = yield* Effect.try({
+      try: () => statSync(pidFile).mtime,
+      catch: () => undefined as Date | undefined,
+    }).pipe(Effect.catch(e => Effect.succeed(e)));
 
-  return { pid, startedAt };
+    return { pid, startedAt } as LiveDaemonState;
+  });
 }
+
+// ============================================================================
+// TldrDaemonService
+// ============================================================================
 
 /**
  * TLDR Daemon Service
@@ -252,235 +291,240 @@ export class TldrDaemonService {
   private workspacePath: string;
   private venvPath: string;
 
-  /**
-   * Create a new TLDR daemon service for a workspace
-   *
-   * @param workspacePath - Path to the workspace (project root or workspace directory)
-   * @param venvPath - Path to the Python venv containing llm-tldr
-   */
   constructor(workspacePath: string, venvPath: string) {
     this.workspacePath = workspacePath;
     this.venvPath = venvPath;
   }
 
   /**
-   * Start the TLDR daemon
+   * Start the TLDR daemon.
    *
    * @param background - Run daemon in background (default: true)
    */
-  async start(background = true): Promise<void> {
-    const currentState = readDaemonState(this.workspacePath);
-    if (currentState) {
-      console.warn(`TLDR daemon already running for ${this.workspacePath} (PID: ${currentState.pid})`);
-      return;
-    }
+  start(background = true): Effect.Effect<void, TldrNotInstalledError | TldrStartError, ChildProcessSpawner> {
+    const workspacePath = this.workspacePath;
+    const venvPath = this.venvPath;
+    return Effect.gen(function* () {
+      const currentState = yield* readDaemonStateEffect(workspacePath);
+      if (currentState !== null) {
+        return; // already running
+      }
 
-    const tldrBin = join(this.venvPath, 'bin', 'tldr');
-    if (!existsSync(tldrBin)) {
-      throw new Error(`tldr binary not found at ${tldrBin}. Ensure llm-tldr is installed in the venv.`);
-    }
+      const tldrBin = join(venvPath, 'bin', 'tldr');
+      if (!existsSync(tldrBin)) {
+        return yield* Effect.fail(new TldrNotInstalledError({ venvPath, tldrBin }));
+      }
 
-    console.log(`Starting TLDR daemon for ${this.workspacePath}...`);
-
-    try {
       const cmd = background
-        ? `cd "${this.workspacePath}" && "${tldrBin}" daemon start --project "${this.workspacePath}" >/dev/null 2>&1 &`
-        : `cd "${this.workspacePath}" && "${tldrBin}" daemon start --project "${this.workspacePath}"`;
+        ? `"${tldrBin}" daemon start --project "${workspacePath}" >/dev/null 2>&1 &`
+        : `"${tldrBin}" daemon start --project "${workspacePath}"`;
 
-      const { stderr } = await execAsync(cmd);
+      const spawner = yield* ChildProcessSpawner;
+      yield* spawner.exitCode(
+        ChildProcess.make('sh', ['-c', cmd], { cwd: workspacePath }),
+      ).pipe(
+        Effect.mapError(
+          (e) => new TldrStartError({ workspacePath, message: String(e) }),
+        ),
+      );
 
-      if (stderr && !stderr.includes('started')) {
-        console.warn(`TLDR daemon start warning: ${stderr}`);
-      }
-
-      // Poll for the tldr-owned pidfile to appear with a live process.
-      const deadline = Date.now() + 5000;
+      // Poll for the tldr-owned pidfile (both background and foreground paths).
       let state: LiveDaemonState | null = null;
-      while (Date.now() < deadline) {
-        state = readDaemonState(this.workspacePath);
-        if (state) break;
-        await new Promise(r => setTimeout(r, 100));
+      for (let i = 0; i < 50; i++) {
+        state = yield* readDaemonStateEffect(workspacePath);
+        if (state !== null) break;
+        yield* Effect.sleep('100 millis');
       }
 
-      if (!state) {
-        throw new Error(`TLDR daemon failed to write pidfile at ${getPidFilePath(this.workspacePath)} within 5s`);
+      if (state === null) {
+        return yield* Effect.fail(
+          new TldrStartError({
+            workspacePath,
+            message: `pidfile not written within 5s at ${getPidFilePath(workspacePath)}`,
+          }),
+        );
       }
-
-      console.log(`✓ TLDR daemon started for ${this.workspacePath} (PID: ${state.pid})`);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      throw new Error(`Failed to start TLDR daemon: ${errorMessage}`);
-    }
+    });
   }
 
   /**
-   * Stop the TLDR daemon
+   * Stop the TLDR daemon.
    */
-  async stop(): Promise<void> {
-    const currentState = readDaemonState(this.workspacePath);
-    if (!currentState) {
-      console.warn(`TLDR daemon not running for ${this.workspacePath}`);
-      return;
-    }
-
-    const tldrBin = join(this.venvPath, 'bin', 'tldr');
-    if (!existsSync(tldrBin)) {
-      console.warn(`tldr binary not found at ${tldrBin}, killing daemon directly`);
-      try { process.kill(currentState.pid, 'SIGTERM'); } catch { /* already gone */ }
-      return;
-    }
-
-    console.log(`Stopping TLDR daemon for ${this.workspacePath}...`);
-
-    try {
-      await execAsync(`cd "${this.workspacePath}" && "${tldrBin}" daemon stop`);
-      console.log(`✓ TLDR daemon stopped for ${this.workspacePath}`);
-    } catch (error) {
-      try {
-        process.kill(currentState.pid, 'SIGTERM');
-        console.log(`✓ Forcefully stopped TLDR daemon (PID: ${currentState.pid})`);
-      } catch (killError) {
-        console.warn(`Failed to kill TLDR daemon process: ${killError}`);
+  stop(): Effect.Effect<void, never, ChildProcessSpawner> {
+    const workspacePath = this.workspacePath;
+    const venvPath = this.venvPath;
+    return Effect.gen(function* () {
+      const currentState = yield* readDaemonStateEffect(workspacePath);
+      if (currentState === null) {
+        return; // not running
       }
-    }
+
+      const tldrBin = join(venvPath, 'bin', 'tldr');
+      if (!existsSync(tldrBin)) {
+        yield* Effect.try({
+          try: () => { process.kill(currentState.pid, 'SIGTERM'); },
+          catch: () => undefined,
+        }).pipe(Effect.catch(() => Effect.void));
+        return;
+      }
+
+      const spawner = yield* ChildProcessSpawner;
+      const stopped = yield* spawner.exitCode(
+        ChildProcess.make(tldrBin, ['daemon', 'stop'], { cwd: workspacePath }),
+      ).pipe(
+        Effect.map(code => Number(code) === 0),
+        Effect.catch(() => Effect.succeed(false)),
+      );
+
+      if (!stopped) {
+        yield* Effect.try({
+          try: () => { process.kill(currentState.pid, 'SIGTERM'); },
+          catch: () => undefined,
+        }).pipe(Effect.catch(() => Effect.void));
+      }
+    });
   }
 
   /**
-   * Get daemon status
+   * Get daemon status.
    */
-  async getStatus(): Promise<TldrDaemonStatus> {
-    const state = readDaemonState(this.workspacePath);
+  getStatus(): Effect.Effect<TldrDaemonStatus, never, ChildProcessSpawner> {
+    const workspacePath = this.workspacePath;
+    const venvPath = this.venvPath;
+    return Effect.gen(function* () {
+      const state = yield* readDaemonStateEffect(workspacePath);
 
-    if (!state) {
+      if (state === null) {
+        return { running: false, workspacePath, venvPath, healthy: false };
+      }
+
+      const svc = new TldrDaemonService(workspacePath, venvPath);
+      const healthy = yield* svc.checkHealth();
+
       return {
-        running: false,
-        workspacePath: this.workspacePath,
-        venvPath: this.venvPath,
-        healthy: false,
+        running: true,
+        pid: state.pid,
+        startedAt: state.startedAt,
+        workspacePath,
+        venvPath,
+        healthy,
       };
-    }
-
-    const healthy = await this.checkHealth();
-
-    return {
-      running: true,
-      pid: state.pid,
-      startedAt: state.startedAt,
-      workspacePath: this.workspacePath,
-      venvPath: this.venvPath,
-      healthy,
-    };
+    });
   }
 
   /**
-   * Check if daemon is healthy (can respond to status queries)
+   * Check if daemon is healthy (can respond to status queries).
    */
-  async checkHealth(): Promise<boolean> {
-    const tldrBin = join(this.venvPath, 'bin', 'tldr');
-    if (!existsSync(tldrBin)) {
-      return false;
-    }
+  checkHealth(): Effect.Effect<boolean, never, ChildProcessSpawner> {
+    const workspacePath = this.workspacePath;
+    const venvPath = this.venvPath;
+    return Effect.gen(function* () {
+      const tldrBin = join(venvPath, 'bin', 'tldr');
+      if (!existsSync(tldrBin)) return false;
 
-    try {
-      // Try to get daemon status
-      await execAsync(`cd "${this.workspacePath}" && "${tldrBin}" daemon status`, { timeout: 3000 });
-      return true;
-    } catch {
-      return false;
-    }
+      const spawner = yield* ChildProcessSpawner;
+      return yield* spawner.exitCode(
+        ChildProcess.make(tldrBin, ['daemon', 'status'], { cwd: workspacePath }),
+      ).pipe(
+        Effect.map(code => Number(code) === 0),
+        Effect.timeout('3 seconds'),
+        Effect.catchTag('TimeoutError', () => Effect.succeed(false)),
+        Effect.catch(() => Effect.succeed(false)),
+      );
+    });
   }
 
   /**
-   * Restart the daemon
+   * Restart the daemon.
    */
-  async restart(): Promise<void> {
-    console.log(`Restarting TLDR daemon for ${this.workspacePath}...`);
-    await this.stop();
-    await new Promise(r => setTimeout(r, 1000)); // Wait for cleanup
-    await this.start();
+  restart(): Effect.Effect<void, TldrNotInstalledError | TldrStartError, ChildProcessSpawner> {
+    const workspacePath = this.workspacePath;
+    const venvPath = this.venvPath;
+    const svc = new TldrDaemonService(workspacePath, venvPath);
+    return Effect.gen(function* () {
+      yield* svc.stop();
+      yield* Effect.sleep('1 second');
+      yield* svc.start();
+    });
   }
 
   /**
-   * Warm the index (trigger initial analysis)
+   * Warm the index (trigger initial analysis).
    *
    * @param background - Run in background (default: true)
    */
-  async warm(background = true): Promise<void> {
-    const tldrBin = join(this.venvPath, 'bin', 'tldr');
-    if (!existsSync(tldrBin)) {
-      throw new Error(`tldr binary not found at ${tldrBin}`);
-    }
+  warm(background = true): Effect.Effect<void, TldrNotInstalledError, ChildProcessSpawner> {
+    const workspacePath = this.workspacePath;
+    const venvPath = this.venvPath;
+    return Effect.gen(function* () {
+      const tldrBin = join(venvPath, 'bin', 'tldr');
+      if (!existsSync(tldrBin)) {
+        return yield* Effect.fail(new TldrNotInstalledError({ venvPath, tldrBin }));
+      }
 
-    console.log(`Warming TLDR index for ${this.workspacePath}...`);
-
-    try {
       const cmd = background
-        ? `cd "${this.workspacePath}" && "${tldrBin}" warm . >/dev/null 2>&1 &`
-        : `cd "${this.workspacePath}" && "${tldrBin}" warm .`;
+        ? `"${tldrBin}" warm . >/dev/null 2>&1 &`
+        : `"${tldrBin}" warm .`;
 
-      await execAsync(cmd);
-      console.log(`✓ TLDR index warming initiated for ${this.workspacePath}`);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      throw new Error(`Failed to warm TLDR index: ${errorMessage}`);
-    }
+      const spawner = yield* ChildProcessSpawner;
+      yield* spawner.exitCode(
+        ChildProcess.make('sh', ['-c', cmd], { cwd: workspacePath }),
+      ).pipe(
+        Effect.mapError(() => new TldrNotInstalledError({ venvPath, tldrBin })),
+        Effect.flatMap(code =>
+          !background && Number(code) !== 0
+            ? Effect.fail(new TldrNotInstalledError({ venvPath, tldrBin }))
+            : Effect.void,
+        ),
+      );
+    });
   }
 
   /**
-   * Check if daemon is running
+   * Check if daemon is running (sync pidfile check).
    */
-  isRunning(): boolean {
-    return readDaemonState(this.workspacePath) !== null;
+  isRunning(): Effect.Effect<boolean> {
+    return readDaemonStateEffect(this.workspacePath).pipe(
+      Effect.map(state => state !== null),
+    );
   }
 
-  /**
-   * Get workspace path
-   */
   getWorkspacePath(): string {
     return this.workspacePath;
   }
 
-  /**
-   * Get venv path
-   */
   getVenvPath(): string {
     return this.venvPath;
   }
 }
 
-/**
- * Global registry of TLDR daemon services by workspace path
- */
+// ============================================================================
+// Registry
+// ============================================================================
+
+/** Global registry of TLDR daemon services by workspace path */
 const daemonRegistry = new Map<string, TldrDaemonService>();
 
 /**
- * Get or create a TLDR daemon service for a workspace
- *
- * @param workspacePath - Path to the workspace
- * @param venvPath - Path to the Python venv
+ * Get or create a TLDR daemon service for a workspace.
  */
 export function getTldrDaemonService(workspacePath: string, venvPath: string): TldrDaemonService {
   const existing = daemonRegistry.get(workspacePath);
-  if (existing) {
-    return existing;
-  }
-
+  if (existing) return existing;
   const service = new TldrDaemonService(workspacePath, venvPath);
   daemonRegistry.set(workspacePath, service);
   return service;
 }
 
 /**
- * Remove a daemon service from the registry
- *
- * @param workspacePath - Path to the workspace
+ * Remove a daemon service from the registry.
  */
 export function removeTldrDaemonService(workspacePath: string): void {
   daemonRegistry.delete(workspacePath);
 }
 
 /**
- * List all registered daemon services
+ * List all registered daemon services.
  */
 export function listTldrDaemonServices(): TldrDaemonService[] {
   return Array.from(daemonRegistry.values());

--- a/src/lib/workspace-manager.ts
+++ b/src/lib/workspace-manager.ts
@@ -820,15 +820,17 @@ export async function createWorkspace(options: WorkspaceCreateOptions): Promise<
       }
 
       // Start TLDR daemon for this workspace
+      const { Effect } = await import('effect');
+      const { layer: NodeServicesLayer } = await import('@effect/platform-node/NodeServices');
       const { getTldrDaemonService } = await import('./tldr-daemon.js');
       const tldrService = getTldrDaemonService(workspacePath, venvPath);
-      await tldrService.start(true);
+      await Effect.runPromise(tldrService.start(true).pipe(Effect.provide(NodeServicesLayer)));
       result.steps.push('Started TLDR daemon');
 
       // Warm the index in the background — ensures workspaces always have a working index
       // even when the main branch cache was empty (nothing to copy)
       try {
-        await tldrService.warm(true);  // background=true: non-blocking
+        await Effect.runPromise(tldrService.warm(true).pipe(Effect.provide(NodeServicesLayer)));
         result.steps.push('TLDR index warm initiated (background)');
       } catch {
         // Non-fatal — daemon may not support warm yet
@@ -1436,9 +1438,11 @@ export async function removeWorkspace(options: WorkspaceRemoveOptions): Promise<
   const venvPath = join(workspacePath, '.venv');
   if (existsSync(venvPath)) {
     try {
+      const { Effect } = await import('effect');
+      const { layer: NodeServicesLayer } = await import('@effect/platform-node/NodeServices');
       const { getTldrDaemonService } = await import('./tldr-daemon.js');
       const tldrService = getTldrDaemonService(workspacePath, venvPath);
-      await tldrService.stop();
+      await Effect.runPromise(tldrService.stop().pipe(Effect.provide(NodeServicesLayer)));
       result.steps.push('Stopped TLDR daemon');
     } catch (error: any) {
       // Non-fatal - daemon may not be running

--- a/tests/lib/tldr-status.test.ts
+++ b/tests/lib/tldr-status.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Effect } from 'effect';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -15,8 +16,14 @@ vi.mock('chalk', () => ({
   },
 }));
 
+// Prevent @effect/platform-node from loading NodeRedis.js (which requires ioredis, not installed)
+vi.mock('@effect/platform-node', async () => {
+  const { Layer } = await import('effect');
+  return { NodeServices: { layer: Layer.empty } };
+});
+
 // Declare the mock function at module scope so vi.mock factory can close over it
-const mockGetStatus = vi.fn().mockResolvedValue({ running: false, healthy: false, workspacePath: '', venvPath: '' });
+const mockGetStatus = vi.fn(() => Effect.succeed({ running: false, healthy: false, workspacePath: '', venvPath: '' }));
 
 vi.mock('../../src/lib/tldr-daemon.js', () => ({
   getTldrDaemonService: () => ({ getStatus: mockGetStatus }),
@@ -35,7 +42,7 @@ describe('tldrIndexStatusCommand', () => {
     vi.spyOn(console, 'log').mockImplementation((...args) => {
       consoleLogs.push(args.join(' '));
     });
-    mockGetStatus.mockResolvedValue({ running: false, healthy: false, workspacePath: tempDir, venvPath: '' });
+    mockGetStatus.mockReturnValue(Effect.succeed({ running: false, healthy: false, workspacePath: tempDir, venvPath: '' }));
   });
 
   afterEach(() => {
@@ -61,7 +68,7 @@ describe('tldrIndexStatusCommand', () => {
     writeFileSync(join(tempDir, '.tldr', 'languages.json'), JSON.stringify({
       timestamp: Math.floor((Date.now() - 5 * 60 * 1000) / 1000),
     }));
-    mockGetStatus.mockResolvedValue({ running: true, healthy: true, workspacePath: tempDir, venvPath: '' });
+    mockGetStatus.mockReturnValue(Effect.succeed({ running: true, healthy: true, workspacePath: tempDir, venvPath: '' }));
 
     await tldrIndexStatusCommand(tempDir);
     const output = consoleLogs.join('\n');
@@ -89,7 +96,7 @@ describe('tldrIndexStatusCommand', () => {
     writeFileSync(join(tempDir, '.tldr', 'languages.json'), JSON.stringify({
       timestamp: Math.floor((Date.now() - 10 * 60 * 1000) / 1000),
     }));
-    mockGetStatus.mockResolvedValue({ running: true, healthy: true, workspacePath: tempDir, venvPath: '' });
+    mockGetStatus.mockReturnValue(Effect.succeed({ running: true, healthy: true, workspacePath: tempDir, venvPath: '' }));
 
     await tldrIndexStatusCommand(tempDir);
     const output = consoleLogs.join('\n');
@@ -105,7 +112,7 @@ describe('tldrIndexStatusCommand', () => {
     writeFileSync(join(tempDir, '.tldr', 'languages.json'), JSON.stringify({
       timestamp: Math.floor((Date.now() - 2 * 60 * 60 * 1000) / 1000),
     }));
-    mockGetStatus.mockResolvedValue({ running: true, healthy: true, workspacePath: tempDir, venvPath: '' });
+    mockGetStatus.mockReturnValue(Effect.succeed({ running: true, healthy: true, workspacePath: tempDir, venvPath: '' }));
 
     await tldrIndexStatusCommand(tempDir);
     const output = consoleLogs.join('\n');
@@ -140,7 +147,7 @@ describe('tldrIndexStatusCommand', () => {
       join(tempDir, 'workspaces', 'feature-test', '.tldr', 'languages.json'),
       JSON.stringify({ timestamp: Math.floor(Date.now() / 1000) })
     );
-    mockGetStatus.mockResolvedValue({ running: true, healthy: true, workspacePath: tempDir, venvPath: '' });
+    mockGetStatus.mockReturnValue(Effect.succeed({ running: true, healthy: true, workspacePath: tempDir, venvPath: '' }));
 
     await tldrIndexStatusCommand(tempDir);
     const output = consoleLogs.join('\n');

--- a/tests/unit/dashboard/server/routes/admin.test.ts
+++ b/tests/unit/dashboard/server/routes/admin.test.ts
@@ -7,6 +7,12 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Effect, Layer } from 'effect';
+import { layer as NodeFileSystemLayer } from '@effect/platform-node/NodeFileSystem';
+import { layer as NodePathLayer } from '@effect/platform-node/NodePath';
+import { layer as NodeChildProcessSpawnerLayer } from '@effect/platform-node/NodeChildProcessSpawner';
+
+const testLayer = Layer.provideMerge(NodeChildProcessSpawnerLayer, Layer.mergeAll(NodeFileSystemLayer, NodePathLayer));
 import { existsSync, mkdtempSync, rmSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -69,7 +75,7 @@ describe('GET /api/admin/tldr/:issueId', () => {
     // running:false, healthy:false — this is the happy path for "venv exists
     // but daemon hasn't been started yet".
     const service = getTldrDaemonService(ws, venv);
-    const status = await service.getStatus();
+    const status = await Effect.runPromise(service.getStatus().pipe(Effect.provide(testLayer)));
 
     expect(status.running).toBe(false);
     expect(status.healthy).toBe(false);


### PR DESCRIPTION
## Summary

- Migrates `src/lib/tldr-daemon.ts` to Effect as PAN-1249 wave-0 swarm slot-1
- All exports return `Effect.Effect<T, E, R>` with typed `Data.TaggedError` error channels (`TldrNotInstalledError`, `TldrStartError`)
- Replaces `execAsync`/`execFileAsync` with `ChildProcess` from `effect/unstable/process`
- Replaces `try/catch` with `Effect.try` + `Effect.catch` for typed error channels
- Migrates `tldr-metrics.test.ts` to `@effect/vitest` using `it.effect()`
- Updates all callers to use `Effect.runPromise` at adapter boundaries with dynamic `@effect/platform-node/NodeServices` imports
- Fixes ioredis test pollution: uses `@effect/platform-node/NodeServices` sub-path (avoids loading `NodeRedis.js`)
- Fixes pre-existing `scanner.ts` and `system-probe.test.ts` static `NodeServices` imports from wave-N system-probe migration

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes (skill lint passes)
- [x] `npm test` — 386 files pass, 4 skipped (0 failures)
- [x] All tldr-daemon-related tests pass (metrics, status, admin routes)
- [x] `system-probe.test.ts` migrated to `it.layer(NodeServicesLayer)` using sub-path import

🤖 Generated with [Claude Code](https://claude.com/claude-code)