### PR TITLE
fix(agents): tear down Docker stack on user-initiated stop (PAN-1316)

### DIFF
--- a/src/cli/commands/kill.ts
+++ b/src/cli/commands/kill.ts
@@ -4,6 +4,7 @@ import { sessionExists } from '../../lib/tmux.js';
 import { isRemoteAvailable } from '../../lib/remote/index.js';
 import { killRemoteAgent } from '../../lib/remote/remote-agents.js';
 import { resolveIssueId } from '../../lib/issue-id.js';
+import { stopWorkspaceDocker } from '../../lib/workspace-manager.js';
 
 interface KillOptions {
   force?: boolean;
@@ -56,5 +57,19 @@ export async function killCommand(id: string, options: KillOptions): Promise<voi
   } catch (error: any) {
     console.error(chalk.red('Error: ' + error.message));
     process.exit(1);
+  }
+
+  // PAN-1316: tear down the workspace Docker stack so dev-server containers
+  // don't outlive their owning agent. Restart goes through a different path
+  // that re-asserts stack health, so this is safe for user-initiated kills only.
+  if (state?.workspace && state?.issueId) {
+    try {
+      const dockerResult = await stopWorkspaceDocker(state.workspace, state.issueId.toLowerCase());
+      if (dockerResult.containersFound) {
+        console.log(chalk.gray(`Stopped Docker stack: ${dockerResult.steps.join('; ')}`));
+      }
+    } catch (err: any) {
+      console.warn(chalk.yellow(`Docker teardown warning: ${err?.message ?? err}`));
+    }
   }
 }

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -90,6 +90,7 @@ import {
   setAgentDeliveryMethod,
   normalizeAgentId,
 } from '../../../lib/agents.js';
+import { stopWorkspaceDocker } from '../../../lib/workspace-manager.js';
 import { checkCodexAuthStatus } from '../../../lib/codex-auth.js';
 import { canUseHarness } from '../../../lib/harness-policy.js';
 import { getProviderForModel } from '../../../lib/providers.js';
@@ -1068,6 +1069,24 @@ export function createAgentStopHandler(
     const stateBeforeStop = yield* Effect.promise(() => getAgentStateAsync(id));
     yield* Effect.promise(() => appendAgentLifecycleLog(id, lifecycleEvent));
     yield* Effect.promise(() => stopAgentAsync(id));
+
+    // PAN-1316: tear down the workspace Docker stack on user-initiated stop.
+    // Without this, dev-server containers (Vite/Webpack) outlive their owning
+    // agent and can degrade the host via inotify-fallback polling storms.
+    // Internal stops (restart) take a different path and don't reach here.
+    if (stateBeforeStop?.workspace && stateBeforeStop?.issueId) {
+      try {
+        const dockerResult = yield* Effect.promise(() =>
+          stopWorkspaceDocker(stateBeforeStop.workspace!, stateBeforeStop.issueId!.toLowerCase()),
+        );
+        if (dockerResult.containersFound) {
+          console.log(`[agents] ✓ Stopped Docker stack for ${id}: ${dockerResult.steps.join('; ')}`);
+        }
+      } catch (err) {
+        console.warn(`[agents] Docker teardown failed for ${id} (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
     // PAN-1048 review feedback 004 (C1): AgentStoppedEvent requires both
     // agentId AND issueId on the payload (packages/contracts/src/events.ts:36);
     // ws-rpc drops events that fail Schema validation, so emits without issueId


### PR DESCRIPTION
Closes #1316.

## Summary

Plugs a host-degrading bug where stopped agents left their workspace Docker stack running indefinitely. Specifically the frontend dev-server container (Vite) would fall back to filesystem polling across the Docker bind mount, generating a TLB-shootdown IPI storm (~57k IPIs/sec) that made the whole host crawl.

## Change

Wired `stopWorkspaceDocker(workspacePath, issueLower)` into the two user-initiated stop paths:
- **Dashboard "Stop"** — `POST /api/agents/:id/stop` in `src/dashboard/server/routes/agents.ts`
- **CLI** — `pan kill <id>` in `src/cli/commands/kill.ts`

Both already imported the agent state; just needed to call the existing `stopWorkspaceDocker` helper after stopping the tmux session.

## What's deliberately out of scope

- **`restartAgent`** asserts workspace-stack-health BEFORE stopping the tmux session, so the stop path inside restart doesn't reach either of these sites. Restart correctly keeps the stack alive.
- **Internal lifecycle stops** (flywheel orchestrator self-stop) are one-shot and don't need teardown.

This keeps the merge-flow's existing `postMergeLifecycle → stopWorkspaceDocker` symmetric with user-initiated stops; both now clean up.

## Test plan

- [x] `npm run typecheck` green
- [x] `npm run lint` green
- [ ] Manual: stop an agent via dashboard, verify `docker ps` no longer shows its stack
- [ ] Manual: `pan kill <issue>`, same verification
- [ ] Manual: `pan restart <issue>` — confirm stack stays up across the restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)