### PR TITLE
refactor(dashboard): rename verb-badge-pulse → pulse (PAN-1234)

### DIFF
--- a/src/dashboard/frontend/src/components/primitives/VerbBadge.test.tsx
+++ b/src/dashboard/frontend/src/components/primitives/VerbBadge.test.tsx
@@ -43,7 +43,7 @@ describe('VerbBadge', () => {
         >
           <span
             aria-hidden="true"
-            class="h-[6px] w-[6px] rounded-full bg-current verb-badge-pulse"
+            class="h-[6px] w-[6px] rounded-full bg-current pulse"
           />
           <span>
             WORK RUNNING
@@ -56,7 +56,7 @@ describe('VerbBadge', () => {
         >
           <span
             aria-hidden="true"
-            class="h-[6px] w-[6px] rounded-full bg-current verb-badge-pulse"
+            class="h-[6px] w-[6px] rounded-full bg-current pulse"
           />
           <span>
             REVIEW RUNNING
@@ -69,7 +69,7 @@ describe('VerbBadge', () => {
         >
           <span
             aria-hidden="true"
-            class="h-[6px] w-[6px] rounded-full bg-current verb-badge-pulse"
+            class="h-[6px] w-[6px] rounded-full bg-current pulse"
           />
           <span>
             SHIP RUNNING
@@ -82,7 +82,7 @@ describe('VerbBadge', () => {
         >
           <span
             aria-hidden="true"
-            class="h-[6px] w-[6px] rounded-full bg-current verb-badge-pulse"
+            class="h-[6px] w-[6px] rounded-full bg-current pulse"
           />
           <span>
             PLANNING
@@ -95,7 +95,7 @@ describe('VerbBadge', () => {
         >
           <span
             aria-hidden="true"
-            class="h-[6px] w-[6px] rounded-full bg-current verb-badge-pulse"
+            class="h-[6px] w-[6px] rounded-full bg-current pulse"
           />
           <span>
             INPUT
@@ -156,7 +156,7 @@ describe('VerbBadge', () => {
       const badge = screen.getByText(variant).closest('[data-component="verb-badge"]');
 
       expect(badge).toHaveAttribute('data-variant', variant);
-      expect(container.querySelector('.verb-badge-pulse')).toBe(PULSING_VARIANTS.has(variant) ? badge?.firstChild : null);
+      expect(container.querySelector('.pulse')).toBe(PULSING_VARIANTS.has(variant) ? badge?.firstChild : null);
       unmount();
     }
   });
@@ -166,6 +166,6 @@ describe('VerbBadge', () => {
 
     expect(screen.getByText('STUCK · 12h')).toBeTruthy();
     expect(screen.getByText('STUCK · 12h').closest('[data-component="verb-badge"]')).toHaveAttribute('data-variant', 'STUCK · Nh');
-    expect(container.querySelector('.verb-badge-pulse')).toBeNull();
+    expect(container.querySelector('.pulse')).toBeNull();
   });
 });

--- a/src/dashboard/frontend/src/components/primitives/VerbBadge.tsx
+++ b/src/dashboard/frontend/src/components/primitives/VerbBadge.tsx
@@ -105,7 +105,7 @@ export default function VerbBadge(props: VerbBadgeProps) {
       {config.pulse && (
         <span
           aria-hidden="true"
-          className="h-[6px] w-[6px] rounded-full bg-current verb-badge-pulse"
+          className="h-[6px] w-[6px] rounded-full bg-current pulse"
         />
       )}
       <span>{config.label}</span>

--- a/src/dashboard/frontend/src/index.css
+++ b/src/dashboard/frontend/src/index.css
@@ -247,8 +247,8 @@ body::after {
   .drawer-gate-border-fail {
     border-color: color-mix(in srgb, var(--destructive) 32%, transparent);
   }
-  .verb-badge-pulse {
-    animation: verb-badge-pulse 1.6s ease-out infinite;
+  .pulse {
+    animation: pulse 1.6s ease-out infinite;
   }
   .drawer-bead-current-ping {
     animation: drawer-bead-current-ping 1.6s ease-out infinite;
@@ -266,7 +266,7 @@ body::after {
   }
 }
 
-@keyframes verb-badge-pulse {
+@keyframes pulse {
   0% {
     box-shadow: 0 0 0 0 currentColor;
     opacity: 1;


### PR DESCRIPTION
One bead under #1234 (PAN-1148 follow-up — cross-cutting).

## What

Renames the verb-badge pulsing-dot keyframe and utility class from \`verb-badge-pulse\` to \`pulse\` per PRD §4.7.7 token contract.

## Where

- \`src/dashboard/frontend/src/index.css\`:
  - \`@keyframes verb-badge-pulse\` → \`@keyframes pulse\`
  - \`.verb-badge-pulse { animation: verb-badge-pulse … }\` → \`.pulse { animation: pulse … }\`
- \`src/dashboard/frontend/src/components/primitives/VerbBadge.tsx\`: className \`pulse\`
- \`src/dashboard/frontend/src/components/primitives/VerbBadge.test.tsx\`: snapshots + querySelector lookups updated

## Scoping note

\`command-deck.module.css\` has its own scoped \`@keyframes pulse\` inside a CSS module. Vite hashes \`@keyframes\` names per module, so the new global \`pulse\` won't collide with the module-scoped one.

## Test plan

- [x] \`npx vitest run VerbBadge.test.tsx\` — 3/3 pass
- [x] \`grep verb-badge-pulse src/\` returns no matches
- [ ] Manual: pulsing badges still animate visibly in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)