### PR TITLE
refactor(dashboard): drawer title uses Space Grotesk 22px (PAN-1232)

### DIFF
--- a/src/dashboard/frontend/src/components/drawer/IssueDrawer.tsx
+++ b/src/dashboard/frontend/src/components/drawer/IssueDrawer.tsx
@@ -110,7 +110,7 @@ export function IssueDrawer() {
             <div className="truncate font-mono text-[11px] uppercase tracking-[0.08em] text-muted-foreground">
               {drawer.issueId}
             </div>
-            <h2 className="truncate text-[18px] font-semibold leading-none text-foreground">
+            <h2 className="truncate font-display text-[22px] font-semibold leading-none tracking-[-0.01em] text-foreground">
               {issue?.title ?? 'Issue details'}
             </h2>
           </div>


### PR DESCRIPTION
One bead under #1232.

Per PRD §4.7.8 the IssueDrawer title is an explicit carve-out from the §4.7 'Space Grotesk reserved for sidebar wordmark' rule.

- \`IssueDrawer.tsx:113\`: \`text-[18px] font-semibold\` → \`font-display text-[22px] font-semibold tracking-[-0.01em]\`

\`font-display\` is already wired to Space Grotesk via \`tailwind.config.js\`. No new global font-loader import — that's deferred to the sibling cross-cutting font-loader issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)