### PR TITLE
feat(dashboard): per-line color routing for active-agent stream (PAN-1232)

### DIFF
--- a/src/dashboard/frontend/src/components/drawer/DrawerActiveAgent.test.tsx
+++ b/src/dashboard/frontend/src/components/drawer/DrawerActiveAgent.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifyStreamLine } from './DrawerActiveAgent';
+
+describe('classifyStreamLine', () => {
+  it('classifies error glyphs and keywords as err', () => {
+    expect(classifyStreamLine('✗ test failed')).toBe('err');
+    expect(classifyStreamLine('something raised an ERROR')).toBe('err');
+    expect(classifyStreamLine('compilation FAIL')).toBe('err');
+  });
+
+  it('classifies warning glyphs and keywords as warn', () => {
+    expect(classifyStreamLine('! review changes requested')).toBe('warn');
+    expect(classifyStreamLine('WARN: stale cache hit')).toBe('warn');
+  });
+
+  it('classifies success glyphs and keywords as ok', () => {
+    expect(classifyStreamLine('✓ all tests pass')).toBe('ok');
+    expect(classifyStreamLine('OK now ready')).toBe('ok');
+    expect(classifyStreamLine('build PASS')).toBe('ok');
+    expect(classifyStreamLine('compile done')).toBe('ok');
+  });
+
+  it('classifies arrow/bullet glyphs as verb-line', () => {
+    expect(classifyStreamLine('→ implementing bead 4')).toBe('verb-line');
+    expect(classifyStreamLine('▸ entering review phase')).toBe('verb-line');
+    expect(classifyStreamLine('✱ thinking...')).toBe('verb-line');
+  });
+
+  it('falls back to neutral for unclassified lines', () => {
+    expect(classifyStreamLine('Reading file foo.ts')).toBe('neutral');
+    expect(classifyStreamLine('')).toBe('neutral');
+  });
+
+  it('err beats warn beats ok beats verb-line in precedence', () => {
+    expect(classifyStreamLine('→ ERROR detected')).toBe('err');
+    expect(classifyStreamLine('→ WARN cache stale')).toBe('warn');
+    expect(classifyStreamLine('→ done')).toBe('ok');
+  });
+});

--- a/src/dashboard/frontend/src/components/drawer/DrawerActiveAgent.tsx
+++ b/src/dashboard/frontend/src/components/drawer/DrawerActiveAgent.tsx
@@ -34,6 +34,28 @@ function verbBadgeForAgent(agent: Agent): VerbBadgeProps {
   return { variant: 'WORK RUNNING', className: 'text-[9px]' };
 }
 
+export type StreamLineKind = 'verb-line' | 'ok' | 'warn' | 'err' | 'neutral';
+
+const STREAM_LINE_COLOR_CLASS: Record<StreamLineKind, string> = {
+  'verb-line': 'text-signal-review-foreground',
+  ok: 'text-success-foreground',
+  warn: 'text-warning-foreground',
+  err: 'text-destructive-foreground',
+  neutral: 'text-foreground',
+};
+
+/**
+ * Classify a stream line for color routing per PRD §4.7 stream excerpt rules.
+ * Priority: err > warn > ok > verb-line > neutral.
+ */
+export function classifyStreamLine(line: string): StreamLineKind {
+  if (/^[✗❌]|\bERR\b|\bERROR\b|\bFAIL\b/i.test(line)) return 'err';
+  if (/^!|\bWARN\b|\bWARNING\b/i.test(line)) return 'warn';
+  if (/^✓|\bOK\b|\bPASS\b|\bdone\b/i.test(line)) return 'ok';
+  if (/^[→▸✱]/.test(line)) return 'verb-line';
+  return 'neutral';
+}
+
 function formatSpend(cost: number | undefined) {
   if (cost === undefined) return 'loading';
   if (cost >= 100) return `$${cost.toFixed(0)}`;
@@ -104,8 +126,10 @@ export default function DrawerActiveAgent() {
         <div className="shrink-0 text-right font-mono text-[10px] leading-none text-muted-foreground">{meta}</div>
       </div>
 
-      <div data-testid="drawer-active-agent-stream" className="mt-[12px] max-h-[180px] overflow-auto rounded-[10px] border border-border bg-[rgb(0_0_0_/_32%)] px-[12px] py-[10px] font-mono text-[11px] leading-[16px] text-muted-foreground">
-        {streamLines.length > 0 ? streamLines.map((line, index) => <div key={`${line}-${index}`} className="truncate">{line}</div>) : <div className="italic">No recent stream output</div>}
+      <div data-testid="drawer-active-agent-stream" className="mt-[12px] max-h-[180px] overflow-auto rounded-[10px] border border-border bg-[rgb(0_0_0_/_32%)] px-[12px] py-[10px] font-mono text-[11px] leading-[16px]">
+        {streamLines.length > 0 ? streamLines.map((line, index) => (
+          <div key={`${line}-${index}`} className={`truncate ${STREAM_LINE_COLOR_CLASS[classifyStreamLine(line)]}`}>{line}</div>
+        )) : <div className="italic text-muted-foreground">No recent stream output</div>}
       </div>
 
       <form className="mt-[12px] flex gap-[8px]" onSubmit={onSubmit}>


### PR DESCRIPTION
One bead under #1232 (active-agent stream excerpt: inline color helpers).

## What

Adds a pure classifier \`classifyStreamLine(line: string): 'verb-line' | 'ok' | 'warn' | 'err' | 'neutral'\` and applies the corresponding token-bound color class per line. The wrapper's blanket \`text-muted-foreground\` is removed so per-line colors win.

## Color routing (PRD §4.7)

| Kind | Match | Class |
|---|---|---|
| \`err\` | \`/^[✗❌]\|\\bERR\\b\|\\bERROR\\b\|\\bFAIL\\b/i\` | \`text-destructive-foreground\` |
| \`warn\` | \`/^!\|\\bWARN\\b\|\\bWARNING\\b/i\` | \`text-warning-foreground\` |
| \`ok\` | \`/^✓\|\\bOK\\b\|\\bPASS\\b\|\\bdone\\b/i\` | \`text-success-foreground\` |
| \`verb-line\` | \`/^[→▸✱]/\` | \`text-signal-review-foreground\` |
| \`neutral\` | default | \`text-foreground\` |

Precedence: **err > warn > ok > verb-line > neutral**, so \`→ ERROR detected\` classifies as \`err\`.

## Test plan

- [x] \`vitest DrawerActiveAgent.test.tsx\` — 6/6 (one per kind plus precedence)
- [x] typecheck / lint / build clean
- [ ] Manual: see colored lines in active-agent stream excerpt

🤖 Generated with [Claude Code](https://claude.com/claude-code)