### PR TITLE
feat(drawer): wire Beads tab to DrawerBeadsList (PAN-1232)

### DIFF
--- a/src/dashboard/frontend/src/components/drawer/IssueDrawer.tsx
+++ b/src/dashboard/frontend/src/components/drawer/IssueDrawer.tsx
@@ -134,6 +134,10 @@ export function IssueDrawer() {
                 <DrawerBeadsList />
                 <DrawerReviewSpecialists />
               </div>
+            ) : drawer.tab === 'beads' ? (
+              <div data-testid="drawer-tab-panel-beads">
+                <DrawerBeadsList />
+              </div>
             ) : (
               <DrawerTabPlaceholder tab={drawer.tab} />
             )}


### PR DESCRIPTION
One bead under #1232 (Wire Beads tab).

Replaces the \`DrawerTabPlaceholder\` for the \`beads\` tab with the existing \`DrawerBeadsList\` component, wrapped in a div carrying \`data-testid='drawer-tab-panel-beads'\` per the bead spec.

\`DrawerBeadsList\` already reads from \`useDrawerData\` and handles the empty state — trivial wiring per the bead description.

## Test plan

- [x] Existing IssueDrawer.test.tsx: 18/18 pass (close button, Esc, tab switching, URL sync — all preserved)
- [x] typecheck / build clean
- [ ] Manual: switch drawer to Beads tab, see bead list (or empty state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)