### PR TITLE
fix(agents): resolve workspace via issue, not state.workspace (PAN-1326)

### DIFF
--- a/src/cli/commands/kill.ts
+++ b/src/cli/commands/kill.ts
@@ -5,6 +5,8 @@ import { isRemoteAvailable } from '../../lib/remote/index.js';
 import { killRemoteAgent } from '../../lib/remote/remote-agents.js';
 import { resolveIssueId } from '../../lib/issue-id.js';
 import { stopWorkspaceDocker } from '../../lib/workspace-manager.js';
+import { resolveProjectFromIssue } from '../../lib/projects.js';
+import { findWorkspacePath } from '../../lib/lifecycle/archive-planning.js';
 
 interface KillOptions {
   force?: boolean;
@@ -59,14 +61,25 @@ export async function killCommand(id: string, options: KillOptions): Promise<voi
     process.exit(1);
   }
 
-  // PAN-1316: tear down the workspace Docker stack so dev-server containers
-  // don't outlive their owning agent. Restart goes through a different path
-  // that re-asserts stack health, so this is safe for user-initiated kills only.
-  if (state?.workspace && state?.issueId) {
+  // PAN-1316/PAN-1326: tear down the workspace Docker stack so dev-server
+  // containers don't outlive their owning agent. Restart goes through a
+  // different path that re-asserts stack health, so this is safe for
+  // user-initiated kills only.
+  //
+  // Resolve the workspace from the issue (not from the agent's own state) so
+  // killing a specialist (review/test/ship) — whose state.workspace may not
+  // point at the work agent's workspace — still tears down the right stack.
+  if (state?.issueId) {
     try {
-      const dockerResult = await stopWorkspaceDocker(state.workspace, state.issueId.toLowerCase());
-      if (dockerResult.containersFound) {
-        console.log(chalk.gray(`Stopped Docker stack: ${dockerResult.steps.join('; ')}`));
+      const issueLower = state.issueId.toLowerCase();
+      const project = resolveProjectFromIssue(state.issueId);
+      const projectPath = project?.projectPath ?? process.cwd();
+      const workspacePath = findWorkspacePath(projectPath, issueLower);
+      if (workspacePath) {
+        const dockerResult = await stopWorkspaceDocker(workspacePath, issueLower);
+        if (dockerResult.containersFound) {
+          console.log(chalk.gray(`Stopped Docker stack: ${dockerResult.steps.join('; ')}`));
+        }
       }
     } catch (err: any) {
       console.warn(chalk.yellow(`Docker teardown warning: ${err?.message ?? err}`));

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -1070,21 +1070,34 @@ export function createAgentStopHandler(
     yield* Effect.promise(() => appendAgentLifecycleLog(id, lifecycleEvent));
     yield* Effect.promise(() => stopAgentAsync(id));
 
-    // PAN-1316: tear down the workspace Docker stack on user-initiated stop.
+    // PAN-1316/PAN-1326: tear down the workspace Docker stack on user-initiated stop.
     // Without this, dev-server containers (Vite/Webpack) outlive their owning
     // agent and can degrade the host via inotify-fallback polling storms.
     // Internal stops (restart) take a different path and don't reach here.
-    if (stateBeforeStop?.workspace && stateBeforeStop?.issueId) {
-      try {
-        const dockerResult = yield* Effect.promise(() =>
-          stopWorkspaceDocker(stateBeforeStop.workspace!, stateBeforeStop.issueId!.toLowerCase()),
-        );
-        if (dockerResult.containersFound) {
-          console.log(`[agents] ✓ Stopped Docker stack for ${id}: ${dockerResult.steps.join('; ')}`);
+    //
+    // Resolve the workspace from the issue (not from the agent's own state) so
+    // killing a specialist (review/test/ship) — whose state.workspace may not
+    // point at the work agent's workspace — still tears down the right stack.
+    // Mirrors the postMergeLifecycle pattern in merge-agent.ts.
+    if (stateBeforeStop?.issueId) {
+      yield* Effect.promise(async () => {
+        try {
+          const { resolveProjectFromIssue } = await import('../../../lib/projects.js');
+          const { findWorkspacePath } = await import('../../../lib/lifecycle/archive-planning.js');
+          const issueLower = stateBeforeStop.issueId!.toLowerCase();
+          const project = resolveProjectFromIssue(stateBeforeStop.issueId!);
+          const projectPath = project?.projectPath ?? process.cwd();
+          const workspacePath = findWorkspacePath(projectPath, issueLower);
+          if (workspacePath) {
+            const dockerResult = await stopWorkspaceDocker(workspacePath, issueLower);
+            if (dockerResult.containersFound) {
+              console.log(`[agents] ✓ Stopped Docker stack for ${id}: ${dockerResult.steps.join('; ')}`);
+            }
+          }
+        } catch (err) {
+          console.warn(`[agents] Docker teardown failed for ${id} (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
         }
-      } catch (err) {
-        console.warn(`[agents] Docker teardown failed for ${id} (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
-      }
+      });
     }
 
     // PAN-1048 review feedback 004 (C1): AgentStoppedEvent requires both


### PR DESCRIPTION
Closes #1326. Follow-up to PR #1317 (PAN-1316).

## Problem

PR #1317 wired \`stopWorkspaceDocker\` into \`/api/agents/:id/stop\` and \`pan kill\`, but resolved the workspace via \`state.workspace\` — the agent's own state. That works for work agents (they own the workspace) but not for **specialists** (review/test/ship), whose \`state.workspace\` may be absent or point at the orchestrator's workspace.

Observed in PAN-1249/1052/1190 wind-down: killing 6 ship/test specialists via \`pan kill\` left docker stacks running:

\`\`\`
panopticon-feature-pan-1052-frontend-1   Up 3 hours
panopticon-feature-pan-1052-dev-1        Up 3 hours
panopticon-feature-pan-1190-frontend-1   Up 22 hours
panopticon-feature-pan-1190-dev-1        Up 22 hours
\`\`\`

(Cleaned up manually with \`docker compose -p panopticon-feature-XXX down\`.)

## Fix

Resolve workspace via \`resolveProjectFromIssue\` + \`findWorkspacePath(projectPath, issueLower)\` — the exact pattern \`postMergeLifecycle\` already uses in \`merge-agent.ts:540-543\`. Now killing a specialist or work agent tears down whichever workspace stack is tied to its parent \`issueId\`.

## Changes

- \`src/dashboard/server/routes/agents.ts\` — pulled the teardown into a single \`Effect.promise(async () => ...)\` wrapper so the dynamic imports + awaits are correctly scoped inside Effect.gen (no silent-await).
- \`src/cli/commands/kill.ts\` — switched to static imports of \`resolveProjectFromIssue\` and \`findWorkspacePath\`.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [ ] Manual: kill a ship specialist, verify \`docker ps\` no longer shows that issue's stack
- [ ] Manual: kill a work agent, verify same (regression check)
- [ ] Manual: \`pan restart\` still works (different code path, shouldn't tear down)

🤖 Generated with [Claude Code](https://claude.com/claude-code)