### PR TITLE
fix(dashboard): allow Conversations tab without active issue (PAN-1324)

### DIFF
--- a/src/dashboard/frontend/src/components/CommandDeck/index.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/index.tsx
@@ -387,14 +387,14 @@ function ProjectRightPaneTabs({
             onSelectFeature={openPipelineFeature}
           />
         )}
-        {activeTab !== 'pipeline' && !effectiveActiveIssueId && (
+        {activeTab !== 'pipeline' && activeTab !== 'conversations' && !effectiveActiveIssueId && (
           <div className="flex h-full items-center justify-center p-8 text-center text-sm text-muted-foreground">
             No project issue is available for {tabLabel}.
           </div>
         )}
         {activeTab === 'plans' && effectiveActiveIssueId && <VBriefTab issueId={effectiveActiveIssueId} />}
         {activeTab === 'beads' && effectiveActiveIssueId && <BeadsTab issueId={effectiveActiveIssueId} />}
-        {activeTab === 'conversations' && effectiveActiveIssueId && (
+        {activeTab === 'conversations' && (
           <div className="flex min-h-full flex-col gap-4 p-4">
             {selectedConversation ? (
               (() => {
@@ -428,7 +428,7 @@ function ProjectRightPaneTabs({
               })()
             ) : (
               <>
-                <DiscussionsTab issueId={effectiveActiveIssueId} />
+                {effectiveActiveIssueId && <DiscussionsTab issueId={effectiveActiveIssueId} />}
                 <div className="flex flex-col gap-2">
                   {conversations.length > 0 ? conversations.map((conversation) => (
                     <button


### PR DESCRIPTION
Closes #1324. Follow-up to commit \`d7a660ccf\` (PAN-1230 hot-fix for unscoped conversations).

## Problem

The Conversations tab inside \`ProjectRightPaneTabs\` was gated on \`effectiveActiveIssueId\`. A project with conversations but no active issue would fall through to \"No project issue is available for Conversations.\"

Latent today (your 4 project-scoped conversations are all in projects with active issues), but the same PAN-1230-shaped assumption (conversation ⇒ issue).

## Fix (3 line touches)

- Drop the \`effectiveActiveIssueId\` guard from the Conversations branch
- Skip the \"No project issue available\" empty state when \`activeTab\` is \`conversations\`
- Render \`<DiscussionsTab issueId={...}>\` only when \`effectiveActiveIssueId\` exists — that's the one piece that genuinely needs an issue context

The conversation viewer and the list itself depend only on the \`conversations\` array.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [ ] Manual: project with conversations + zero active issues — Conversations tab renders the list, can open a conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)