### PR TITLE
feat(drawer): wire Activity tab to full activity feed (PAN-1232)

### DIFF
--- a/src/dashboard/frontend/src/components/drawer/IssueDrawer.test.tsx
+++ b/src/dashboard/frontend/src/components/drawer/IssueDrawer.test.tsx
@@ -228,12 +228,14 @@ describe('IssueDrawer', () => {
     const scrollArea = screen.getByTestId('drawer-activity-rail-scroll');
 
     expect(rail).toHaveClass('w-[320px]', 'border-l', 'bg-card/70');
-    expect(screen.getByText('Merged branch')).toBeInTheDocument();
-    expect(screen.getByText('Work started')).toBeInTheDocument();
-    expect(screen.queryByText('Other issue')).not.toBeInTheDocument();
-    expect(screen.getByText('Merged branch').compareDocumentPosition(screen.getByText('Work started'))).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
-    expect(screen.getByTestId('drawer-activity-dot-done')).toHaveClass('bg-success');
-    expect(screen.getByTestId('drawer-activity-dot-work')).toHaveClass('bg-primary');
+    // Scope text + dot assertions to the rail; the Activity tab panel renders
+    // its own copy of these entries when drawer.tab === 'activity'.
+    expect(within(rail).getByText('Merged branch')).toBeInTheDocument();
+    expect(within(rail).getByText('Work started')).toBeInTheDocument();
+    expect(within(rail).queryByText('Other issue')).not.toBeInTheDocument();
+    expect(within(rail).getByText('Merged branch').compareDocumentPosition(within(rail).getByText('Work started'))).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(within(rail).getByTestId('drawer-activity-dot-done')).toHaveClass('bg-success');
+    expect(within(rail).getByTestId('drawer-activity-dot-work')).toHaveClass('bg-primary');
 
     scrollArea.scrollTop = 120;
     useDashboardStore.setState({
@@ -245,7 +247,7 @@ describe('IssueDrawer', () => {
     rerender(drawerUi(queryClient));
 
     await waitFor(() => expect(scrollArea.scrollTop).toBe(0));
-    expect(screen.getByTestId('drawer-activity-dot-review')).toHaveClass('bg-signal-review');
+    expect(within(rail).getByTestId('drawer-activity-dot-review')).toHaveClass('bg-signal-review');
   });
 
   it('matches activity rail agent events through store agent issue ownership', () => {
@@ -282,9 +284,12 @@ describe('IssueDrawer', () => {
     useDashboardStore.getState().openIssue('PAN-1', 'activity');
 
     renderDrawer();
+    const rail = screen.getByTestId('drawer-activity-rail');
 
-    expect(screen.getByText('Security reviewer active')).toBeInTheDocument();
-    expect(screen.queryByText('Other reviewer active')).not.toBeInTheDocument();
+    // Scope to the rail; the Activity tab panel also renders these entries
+    // when drawer.tab === 'activity'.
+    expect(within(rail).getByText('Security reviewer active')).toBeInTheDocument();
+    expect(within(rail).queryByText('Other reviewer active')).not.toBeInTheDocument();
   });
 
   it('renders phase timeline from drawer data with done current and upcoming states', () => {

--- a/src/dashboard/frontend/src/components/drawer/IssueDrawer.tsx
+++ b/src/dashboard/frontend/src/components/drawer/IssueDrawer.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { COMMAND_DECK_SURFACE_REGISTRY } from '../../lib/commandDeckSurfaceRegistry';
 import { useDashboardStore } from '../../lib/store';
+import { cn } from '../../lib/utils';
 import DrawerActionBar from './DrawerActionBar';
 import DrawerActiveAgent from './DrawerActiveAgent';
 import DrawerActivityRail from './DrawerActivityRail';
@@ -11,9 +12,52 @@ import DrawerReviewSpecialists from './DrawerReviewSpecialists';
 import DrawerTabs from './DrawerTabs';
 import DrawerVerificationGates from './DrawerVerificationGates';
 import PhaseTimeline from './PhaseTimeline';
-import { useDrawerData } from './useDrawerData';
+import { useDrawerData, type DrawerActivityPhase } from './useDrawerData';
 import { VBriefViewer } from '../vbrief/VBriefViewer';
 import type { VBriefDocument } from '../vbrief/types';
+
+const ACTIVITY_PHASE_DOT_CLASSES = {
+  work: 'bg-primary',
+  review: 'bg-signal-review',
+  ship: 'bg-warning',
+  done: 'bg-success',
+  info: 'bg-info',
+} satisfies Record<DrawerActivityPhase, string>;
+
+function formatActivityWhen(value: string) {
+  if (!value) return 'just now';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function DrawerActivityPanel() {
+  const { activityFull } = useDrawerData();
+  return (
+    <div data-testid="drawer-tab-panel-activity">
+      {activityFull.length === 0 ? (
+        <div className="rounded-[12px] border border-dashed border-border px-[12px] py-[18px] text-center text-[12px] text-muted-foreground">
+          No activity yet.
+        </div>
+      ) : (
+        <div className="space-y-[12px]">
+          {activityFull.map((item) => (
+            <div key={item.id} className="grid grid-cols-[14px_1fr] gap-[10px]" data-phase={item.phase}>
+              <span
+                aria-hidden="true"
+                className={cn('mt-[4px] h-[8px] w-[8px] rounded-full', ACTIVITY_PHASE_DOT_CLASSES[item.phase])}
+              />
+              <div className="min-w-0">
+                <div className="text-[12px] leading-[18px] text-foreground">{item.message}</div>
+                <div className="mt-[2px] font-mono text-[10px] leading-none text-muted-foreground">{formatActivityWhen(item.when)}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
 
 function DrawerPlanPanel({ issueId }: { issueId: string }) {
   const { data, isLoading, isError } = useQuery<VBriefDocument | null>({
@@ -167,6 +211,8 @@ export function IssueDrawer() {
               </div>
             ) : drawer.tab === 'plan' && drawer.issueId ? (
               <DrawerPlanPanel issueId={drawer.issueId} />
+            ) : drawer.tab === 'activity' ? (
+              <DrawerActivityPanel />
             ) : (
               <DrawerTabPlaceholder tab={drawer.tab} />
             )}

--- a/src/dashboard/frontend/src/components/drawer/useDrawerData.ts
+++ b/src/dashboard/frontend/src/components/drawer/useDrawerData.ts
@@ -110,7 +110,10 @@ export type DrawerData = {
   reviewSpecialists: DrawerReviewSpecialist[];
   verificationGates: DrawerVerificationGate[];
   phaseTimeline: DrawerPhaseTimelineStep[];
+  /** Capped (100 items) activity feed shown in the side rail. */
   activityRail: DrawerActivityItem[];
+  /** Full activity feed for the Activity tab — same filter, no slice cap. */
+  activityFull: DrawerActivityItem[];
 };
 
 const REVIEW_SPECIALIST_ROLES = [
@@ -377,7 +380,7 @@ export function useDrawerData(): DrawerData {
 
   return useMemo(() => {
     if (!drawerIssueId) {
-      return { issue: null, agents: [], reviewStatus: undefined, beads: [], reviewSpecialists: [], verificationGates: [], phaseTimeline: [], activityRail: [] };
+      return { issue: null, agents: [], reviewStatus: undefined, beads: [], reviewSpecialists: [], verificationGates: [], phaseTimeline: [], activityRail: [], activityFull: [] };
     }
 
     const issue = issues.find((candidate) => issueMatches(candidate, drawerIssueId)) ?? null;
@@ -388,7 +391,7 @@ export function useDrawerData(): DrawerData {
       if (activityMatchesIssue(entry, drawerIssueId, agentIssueLookup)) byId.set(activityId(entry, byId.size), entry);
     }
 
-    const activityRail = Array.from(byId.entries())
+    const activityFull = Array.from(byId.entries())
       .map(([id, entry]) => {
         const when = entry.timestamp ?? '';
         const time = when ? new Date(when).getTime() : 0;
@@ -400,8 +403,9 @@ export function useDrawerData(): DrawerData {
           time: Number.isNaN(time) ? 0 : time,
         };
       })
-      .sort((a, b) => b.time - a.time)
-      .slice(0, 100);
+      .sort((a, b) => b.time - a.time);
+
+    const activityRail = activityFull.slice(0, 100);
 
     return {
       issue,
@@ -412,6 +416,7 @@ export function useDrawerData(): DrawerData {
       verificationGates: verificationGates(reviewStatus),
       phaseTimeline: phaseTimeline(issue, reviewStatus),
       activityRail,
+      activityFull,
     };
   }, [agents, detailedActivity, drawerIssueId, issues, recentActivity, reviewStatus]);
 }


### PR DESCRIPTION
One bead under #1232 (Wire Activity tab).

Replaces the placeholder for the \`activity\` tab with an activity feed identical in row layout to \`DrawerActivityRail\` (8x8 status dot + 12px message + 10px mono muted timestamp), reading the **full** issue-scoped slice — no slice cap.

## Changes

- \`useDrawerData.ts\` — expose new \`activityFull\` field. Same filter (activityMatchesIssue + agentIssueLookup), same sort. \`activityRail\` is now derived as \`activityFull.slice(0, 100)\` so the rail keeps its 100-item ceiling.
- \`IssueDrawer.tsx\` — new \`DrawerActivityPanel\` component reuses the rail's row layout via shared phase-dot color map + \`formatActivityWhen\`. Wrapped in \`data-testid='drawer-tab-panel-activity'\`.
- \`IssueDrawer.test.tsx\` — two existing activity-rail tests opened the drawer with \`tab='activity'\`; the tab now renders its own copy of the same entries. Scoped rail assertions to \`within(rail)\` so the same matcher resolves uniquely.

## Test plan

- [x] \`IssueDrawer.test.tsx\` — 18/18 pass
- [x] typecheck/build clean
- [ ] Manual: open drawer, Activity tab, verify newest-first feed with full entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)