### PR TITLE
Add agents Effect siblings

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
-# Graph Report - feature-pan-1189  (2026-05-19)
+# Graph Report - feature-pan-1312-slot-1  (2026-05-21)
 
 ## Corpus Check
-- 1777 files · ~2,358,067 words
+- 1878 files · ~2,476,433 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 24396 nodes · 37552 edges · 1223 communities (1175 shown, 48 thin omitted)
-- Extraction: 99% EXTRACTED · 1% INFERRED · 0% AMBIGUOUS · INFERRED: 546 edges (avg confidence: 0.8)
+- 26647 nodes · 41375 edges · 1272 communities (1222 shown, 50 thin omitted)
+- Extraction: 99% EXTRACTED · 1% INFERRED · 0% AMBIGUOUS · INFERRED: 502 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `5b3d036e`
+- Built from commit: `4772308c`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -1176,15 +1176,20 @@
 - [[_COMMUNITY_Community 1158|Community 1158]]
 - [[_COMMUNITY_Community 1159|Community 1159]]
 - [[_COMMUNITY_Community 1160|Community 1160]]
+- [[_COMMUNITY_Community 1161|Community 1161]]
+- [[_COMMUNITY_Community 1162|Community 1162]]
 - [[_COMMUNITY_Community 1163|Community 1163]]
 - [[_COMMUNITY_Community 1164|Community 1164]]
 - [[_COMMUNITY_Community 1165|Community 1165]]
+- [[_COMMUNITY_Community 1166|Community 1166]]
 - [[_COMMUNITY_Community 1167|Community 1167]]
 - [[_COMMUNITY_Community 1168|Community 1168]]
 - [[_COMMUNITY_Community 1169|Community 1169]]
 - [[_COMMUNITY_Community 1170|Community 1170]]
 - [[_COMMUNITY_Community 1171|Community 1171]]
+- [[_COMMUNITY_Community 1172|Community 1172]]
 - [[_COMMUNITY_Community 1173|Community 1173]]
+- [[_COMMUNITY_Community 1174|Community 1174]]
 - [[_COMMUNITY_Community 1175|Community 1175]]
 - [[_COMMUNITY_Community 1176|Community 1176]]
 - [[_COMMUNITY_Community 1177|Community 1177]]
@@ -1196,4586 +1201,4821 @@
 - [[_COMMUNITY_Community 1183|Community 1183]]
 - [[_COMMUNITY_Community 1184|Community 1184]]
 - [[_COMMUNITY_Community 1185|Community 1185]]
+- [[_COMMUNITY_Community 1186|Community 1186]]
+- [[_COMMUNITY_Community 1187|Community 1187]]
+- [[_COMMUNITY_Community 1188|Community 1188]]
+- [[_COMMUNITY_Community 1189|Community 1189]]
+- [[_COMMUNITY_Community 1190|Community 1190]]
+- [[_COMMUNITY_Community 1191|Community 1191]]
+- [[_COMMUNITY_Community 1192|Community 1192]]
+- [[_COMMUNITY_Community 1193|Community 1193]]
+- [[_COMMUNITY_Community 1194|Community 1194]]
+- [[_COMMUNITY_Community 1195|Community 1195]]
+- [[_COMMUNITY_Community 1196|Community 1196]]
+- [[_COMMUNITY_Community 1197|Community 1197]]
+- [[_COMMUNITY_Community 1198|Community 1198]]
+- [[_COMMUNITY_Community 1199|Community 1199]]
+- [[_COMMUNITY_Community 1200|Community 1200]]
+- [[_COMMUNITY_Community 1201|Community 1201]]
+- [[_COMMUNITY_Community 1202|Community 1202]]
+- [[_COMMUNITY_Community 1203|Community 1203]]
+- [[_COMMUNITY_Community 1204|Community 1204]]
+- [[_COMMUNITY_Community 1205|Community 1205]]
+- [[_COMMUNITY_Community 1206|Community 1206]]
+- [[_COMMUNITY_Community 1209|Community 1209]]
+- [[_COMMUNITY_Community 1210|Community 1210]]
+- [[_COMMUNITY_Community 1212|Community 1212]]
+- [[_COMMUNITY_Community 1213|Community 1213]]
+- [[_COMMUNITY_Community 1214|Community 1214]]
+- [[_COMMUNITY_Community 1215|Community 1215]]
+- [[_COMMUNITY_Community 1216|Community 1216]]
+- [[_COMMUNITY_Community 1218|Community 1218]]
+- [[_COMMUNITY_Community 1220|Community 1220]]
+- [[_COMMUNITY_Community 1221|Community 1221]]
+- [[_COMMUNITY_Community 1222|Community 1222]]
+- [[_COMMUNITY_Community 1223|Community 1223]]
+- [[_COMMUNITY_Community 1224|Community 1224]]
+- [[_COMMUNITY_Community 1225|Community 1225]]
+- [[_COMMUNITY_Community 1226|Community 1226]]
+- [[_COMMUNITY_Community 1227|Community 1227]]
+- [[_COMMUNITY_Community 1228|Community 1228]]
+- [[_COMMUNITY_Community 1229|Community 1229]]
+- [[_COMMUNITY_Community 1230|Community 1230]]
+- [[_COMMUNITY_Community 1231|Community 1231]]
+- [[_COMMUNITY_Community 1232|Community 1232]]
+- [[_COMMUNITY_Community 1233|Community 1233]]
+- [[_COMMUNITY_Community 1234|Community 1234]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `fetch` - 207 edges
-2. `getDatabase()` - 126 edges
-3. `resolveProjectFromIssue()` - 119 edges
-4. `sessionExistsAsync()` - 65 edges
-5. `useDashboardStore` - 65 edges
-6. `spawnRun()` - 52 edges
-7. `jsonResponse()` - 51 edges
-8. `spawnAgent()` - 50 edges
-9. `messageAgent()` - 48 edges
-10. `runPatrol()` - 48 edges
+1. `fetch` - 199 edges
+2. `resolveProjectFromIssue()` - 126 edges
+3. `getDatabase()` - 121 edges
+4. `useDashboardStore` - 87 edges
+5. `FsError` - 80 edges
+6. `sessionExistsAsync()` - 68 edges
+7. `cn()` - 64 edges
+8. `jsonResponse()` - 56 edges
+9. `spawnRun()` - 53 edges
+10. `spawnAgent()` - 52 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `pathExists()` --calls--> `Access`  [INFERRED]
   src/lib/tts-daemon.ts → docs/god-view.md
-- `pathExistsAsync()` --calls--> `Access`  [INFERRED]
-  src/lib/work-agent-lifecycle.ts → docs/god-view.md
+- `fileExists()` --calls--> `Access`  [INFERRED]
+  src/lib/cloister/config.ts → docs/god-view.md
 - `pathExists()` --calls--> `Access`  [INFERRED]
   src/dashboard/server/routes/command-deck.ts → docs/god-view.md
+- `getIndexStats()` --calls--> `Access`  [INFERRED]
+  src/dashboard/server/routes/misc.ts → docs/god-view.md
 - `pathExists()` --calls--> `Access`  [INFERRED]
   src/dashboard/server/routes/projects.ts → docs/god-view.md
-- `pathExists()` --calls--> `Access`  [INFERRED]
-  src/dashboard/server/routes/jsonl-resolver.ts → docs/god-view.md
 
-## Communities (1223 total, 48 thin omitted)
+## Communities (1272 total, 50 thin omitted)
 
 ### Community 0 - "Community 0"
 Cohesion: 0.03
-Nodes (173): checkCompletedButUnsignaledReviews(), isAgentIdleForNudge(), monitorReviewConvoySignals(), nudgeIdleWorkAgentsWithOpenBeads(), detectHandoffMethod(), HandoffMethod, HandoffOptions, performHandoff() (+165 more)
+Nodes (192): detectHandoffMethod(), HandoffError, HandoffMethod, HandoffOptions, HandoffResult, performHandoff(), performKillAndSpawn(), sleep() (+184 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.02
-Nodes (145): backup, bundledFrontendIndex, bundledServer, child, composeFile, config, configContent, configFile (+137 more)
+Nodes (159): AutoResumeConfig, normalizeAutoResumeConfig(), positiveNumber(), resolveAutoResumeConfigForIssue(), validBackoffSchedule(), cleanupAbandonedFeedback(), clearStaleCiFeedback(), clearFeedbackFiles() (+151 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.03
-Nodes (125): forkCommand(), ForkOptions, normalize(), unarchiveConversationCommand(), copySessionFromCompactBoundary(), createSummaryFork(), findLastCompactBoundaryOffset(), generateFallbackSummary() (+117 more)
+Cohesion: 0.02
+Nodes (147): ACTIVE_STATUS_PATTERNS, addLog(), API_ERROR_PATTERNS, apiErrorRecoveryState, autoCloseOut(), autoCloseOutCache, autoResumeStoppedWorkAgents(), checkAndSuspendIdleAgents() (+139 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.03
-Nodes (103): formatCost(), formatTokens(), InspectorPanel(), InspectorPanelProps, INSPECTOR_PANEL_SOURCE, state, IssueCard(), PanOpenInPicker() (+95 more)
+Cohesion: 0.02
+Nodes (123): BASE_TIME, exitSpy, loadDeaconWithResumeMock(), loadStartCommand(), mailDir, mailFiles, state, stderrSpy (+115 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.03
-Nodes (127): ACTIVE_STATUS_PATTERNS, addLog(), API_ERROR_PATTERNS, apiErrorRecoveryState, checkAndSuspendIdleAgents(), checkFailedMergeRetry(), checkFirstCompletionAgents(), checkHeartbeat() (+119 more)
+Cohesion: 0.02
+Nodes (90): githubTracker, linearTracker, longBody, mockCreateTrackerFromConfig, mockExistsSync, mockLoadConfig, mockStatSync, STATE_MTIME (+82 more)
 
 ### Community 5 - "Community 5"
-Cohesion: 0.03
-Nodes (116): setAgentStatusChangedNotifier(), setAgentStoppedNotifier(), pendingCommand(), after, before, blockers, result, statuses (+108 more)
+Cohesion: 0.02
+Nodes (118): getUnblockedItems(), getUnblockedItemsEffect(), isTaskReady(), isTaskReadyEffect(), TERMINAL_STATUSES, writeStoryFeatureContext(), findWorkspaceRoot(), planFinalizeCommand() (+110 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.03
-Nodes (124): autoResumeStoppedWorkAgents(), checkMissingReviewStatuses(), buildConvoyPrompt(), buildReviewRolePrompt(), cleanupReviewTempStash(), ensureReviewTempStash(), execAsync, isReviewSessionForIssue() (+116 more)
+Nodes (122): forkCommand(), ForkOptions, normalize(), unarchiveConversationCommand(), buildCorrelationMap(), CorrelationResult, copySessionFromCompactBoundary(), createSummaryFork() (+114 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.02
-Nodes (112): getCavemanExperimentData(), adminRouteLayer, getAdminTldrRoute, agentsRouteLayer, autopresoRouteLayer, backToStagingRoute, readJsonBody, requireTrustedOrigin() (+104 more)
+Nodes (116): buildSyncFailureFeedback(), execAsync, getSyncTargetBranch(), resolveGitDirs(), runVerificationForIssue(), SyncResult, syncSingleRepo(), commands (+108 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.02
-Nodes (113): AutoActions, AutoRestartConfig, CLOISTER_CONFIG_FILE, CloisterConfig, CostTrackingConfig, deepMerge(), DEFAULT_CLOISTER_CONFIG, HandoffConfig (+105 more)
+Nodes (115): checkMissingReviewStatuses(), monitorReviewConvoySignals(), dropLingeringPreMergeStashes(), buildConvoyPrompt(), buildReviewRolePrompt(), cleanupReviewTempStash(), ensureReviewTempStash(), execAsync (+107 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.04
-Nodes (113): embedAction(), confirmCost(), enrichAction(), formatCost(), ScanOptions, normalizeFilter(), SearchMode, SearchQuery (+105 more)
+Cohesion: 0.02
+Nodes (111): cn(), Button, ButtonLink, SharedButtonBaseProps, SharedButtonLinkProps, SharedButtonProps, SharedButtonSize, SharedButtonVariant (+103 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.03
-Nodes (106): announceMerge(), buildShipPreparationPrompt(), buildShipSyncMainPrompt(), _closeIssueFailures, closeIssueWithCircuitBreaker(), _completedPostMerge, defaultWorkspaceForIssue(), __dirname (+98 more)
+Nodes (119): buildHostOverrideConfirmation(), confirmDropRecovery(), confirmHostOverride(), DASHBOARD_URL, difficultyColor(), dryRun(), isSwarmRecoverAction(), parseFiniteInteger() (+111 more)
 
 ### Community 11 - "Community 11"
 Cohesion: 0.02
-Nodes (94): EventRouter(), EDITOR_LABELS, PanOpenInPickerProps, buildFilterParams(), ConversationRpcFilter, ConversationsPage(), CostResponse, countCostFacets() (+86 more)
+Nodes (91): ActivitySection, ActivityView(), ActivityViewProps, CostByStage, fetchActivity(), AgentOutputPanel(), AgentOutputPanelProps, deriveAgentIssueId() (+83 more)
 
 ### Community 12 - "Community 12"
-Cohesion: 0.03
-Nodes (105): buildHostOverrideConfirmation(), confirmHostOverride(), DASHBOARD_URL, difficultyColor(), dryRun(), parseFiniteInteger(), printActiveSliceForIssue(), printWavePlan() (+97 more)
+Cohesion: 0.02
+Nodes (104): ActivitySparkline(), ActivitySparklineProps, CATEGORY_COLORS, SparklineCategory, SparklineEvent, ALL_TABS, OverviewTabSpec, ZoneCOverview() (+96 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.02
-Nodes (90): ArtifactLinks(), ArtifactLinksProps, BulkActionBar(), BulkActionBarProps, BulkCloseOutProgress(), BulkCloseOutProgressProps, BulkCloseResult, BulkCloseStatus (+82 more)
+Nodes (111): assertIssueHasBeadsEffect(), BeadEntry, BeadsMissingError, execFileAsync, queryBeadById(), queryBeadsForIssue(), queryBeadsForIssueEffect(), readBeadsFromJsonl() (+103 more)
 
 ### Community 14 - "Community 14"
 Cohesion: 0.02
-Nodes (97): computeAgentEnrichment(), execAsync, getActiveSessionPath(), getAgentJsonlMtime(), getAgentJsonlPath(), getAgentPendingQuestions(), getAgentWorkspace(), getClaudeProjectDir() (+89 more)
+Nodes (75): DrawerTabPlaceholder(), tabLabel(), criteria, doc, projectDoc, projectRoot, workspaceDoc, workspacePath (+67 more)
 
 ### Community 15 - "Community 15"
-Cohesion: 0.03
-Nodes (98): checkApiErrorAgents(), captureTmuxOutput(), agentStatusCommand(), AgentStatusOptions, analyzeSession(), detectStatus(), extractCost(), extractModel() (+90 more)
+Cohesion: 0.04
+Nodes (103): approveCommand(), cancelCommand(), collectInFlightRows(), collectLifecycleRows(), completeCommand(), dedupeRows(), formatTransition(), getProjectPath() (+95 more)
 
 ### Community 16 - "Community 16"
 Cohesion: 0.02
-Nodes (88): ActivitySparkline(), ActivitySparklineProps, CATEGORY_COLORS, SparklineCategory, SparklineEvent, CostEvent, CostStreamResponse, fetchCostStream() (+80 more)
+Nodes (96): BulkActionBar(), BulkActionBarProps, BulkAgentWarningDialog(), BulkAgentWarningDialogProps, BulkCloseOutProgress(), BulkCloseOutProgressProps, BulkCloseResult, BulkCloseStatus (+88 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.05
-Nodes (89): deriveProjectRoot(), queueAutoCommit(), deleteContinueFile(), getContinueFilePath(), getContinuesDir(), hasContinueFile(), listContinueFiles(), readContinueFile() (+81 more)
+Cohesion: 0.03
+Nodes (85): createHumeConfig(), deleteHumeConfig(), HumeApiError, humeFetch(), HumeResult, content, d, existingDir (+77 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.04
-Nodes (86): readCavemanVariant(), checkStuckReviewing(), buildMergeAgentMemory(), checkAndRotateIfNeeded(), DEFAULT_MEMORY_TIERS, execAsync, MemoryTiers, MergeRecord (+78 more)
+Cohesion: 0.02
+Nodes (98): setAgentStatusChangedNotifier(), setAgentStoppedNotifier(), setMergeReadyNotifier(), announceMerge(), DEACON_DIR, DEACON_STATE_PATH, _deaconState, mockNotifier (+90 more)
 
 ### Community 19 - "Community 19"
-Cohesion: 0.03
-Nodes (79): AgentSpawner, AgentSpawnerLive, AgentSpawnerShape, DeepWipeOptions, SpawnedAgent, StartPlanningOptions, StartWorkOptions, getGitHubClient() (+71 more)
+Cohesion: 0.04
+Nodes (99): embedAction(), ScanOptions, normalizeFilter(), SearchMode, SearchQuery, searchSessions(), semanticCandidateWindow(), semanticRerankCandidateLimit() (+91 more)
 
 ### Community 20 - "Community 20"
 Cohesion: 0.03
-Nodes (73): ActivitySection, ActivityView(), ActivityViewProps, CostByStage, fetchActivity(), AgentOutputPanel(), AgentOutputPanelProps, deriveAgentIssueId() (+65 more)
+Nodes (81): ActivityFeedSidebar(), ActivityFeedSidebarProps, BUCKET_LABELS, BUCKET_ORDER, createActionStatusObservationSelector(), EMPTY_OBSERVATIONS, bucket, first (+73 more)
 
 ### Community 21 - "Community 21"
 Cohesion: 0.03
-Nodes (92): updateTtsConfig(), agentDir, body, dir, launcher, LEGACY_FIELDS, legacyFields, options (+84 more)
+Nodes (88): readCavemanVariant(), buildMergeAgentMemory(), checkAndRotateIfNeeded(), DEFAULT_MEMORY_TIERS, execAsync, MemoryTiers, MergeRecord, needsSessionRotation() (+80 more)
 
 ### Community 22 - "Community 22"
 Cohesion: 0.03
-Nodes (77): fetchConversations(), GeneralConversation, GeneralSectionProps, ActivityEntry, AgentList(), AgentListProps, CloisterStatus, fetchActivity() (+69 more)
+Nodes (82): EDITOR_LABELS, PanOpenInPickerProps, buildFilterParams(), ConversationRpcFilter, ConversationsPage(), CostResponse, countCostFacets(), countFacetValues() (+74 more)
 
 ### Community 23 - "Community 23"
 Cohesion: 0.04
-Nodes (83): NormalizedTtsDaemonConfig, getTtsDaemonAuthHeaders(), buildDirectTtsSpeakPayload(), buildTtsSpeakPayload(), FetchLike, postSpeakPayload(), renderTemplate(), resolveAndSpeak() (+75 more)
+Nodes (66): useZoneAActions(), ZoneActionStrip(), ZoneActionStripProps, ZoneBActionStrip(), ZoneBActionStripProps, ArtifactLinksProps, CloseOutIssueButton(), CloseOutIssueButtonProps (+58 more)
 
 ### Community 24 - "Community 24"
 Cohesion: 0.03
-Nodes (69): ComposerFooter(), ComposerFooterProps, deleteConversationImage(), PendingImage, sendConversationMessage(), switchModel(), uploadConversationImage(), ensureDefaultConversationModel() (+61 more)
+Nodes (76): ChannelPermissionDialog(), ChannelPermissionDialogProps, { container }, onAllow, onDeny, request, ConfirmationDialog(), ConfirmationDialogProps (+68 more)
 
 ### Community 25 - "Community 25"
 Cohesion: 0.03
-Nodes (65): ChatMessage, CompactBoundary, ConversationEvent, ProposedPlan, TurnDiffSummary, WorkLogEntry, ConversationPanelProps, ConversationView() (+57 more)
+Nodes (72): captureTmuxOutput(), agentStatusCommand(), AgentStatusOptions, analyzeSession(), detectStatus(), extractCost(), extractModel(), MODEL_PATTERNS (+64 more)
 
 ### Community 26 - "Community 26"
 Cohesion: 0.03
-Nodes (71): DetailPanelLayout(), DetailPanelLayoutProps, loadPanelState(), PanelMode, PanelState, savePanelState(), formatCost(), formatTimestamp() (+63 more)
+Nodes (78): backup, bundledFrontendIndex, bundledServer, child, composeFile, config, configContent, configFile (+70 more)
 
 ### Community 27 - "Community 27"
 Cohesion: 0.03
-Nodes (78): dequeueMerge(), ActivityEntry, activityLog, ApprovePushResult, checkProjectGitSafeState(), ContainerPortBinding, ContainerServiceHealth, deleteWorkspacePendingRoute (+70 more)
+Nodes (75): detectMergedSwarmSlots(), buildShipPreparationPrompt(), buildShipSyncMainPrompt(), _completedPostMerge, defaultWorkspaceForIssue(), __dirname, execAsync, __filename (+67 more)
 
 ### Community 28 - "Community 28"
-Cohesion: 0.04
-Nodes (61): criteria, doc, result, { projectPath, workspacePath }, promoted, specFiles, fsHooks, ACCompletionResult (+53 more)
+Cohesion: 0.03
+Nodes (74): loadCloisterConfig(), checkPendingTestDispatch(), checkUndispatchedShip(), cleanupStaleAgentState(), DeaconLogEntry, getDeaconLogs(), getLastPatrolResult(), PatrolResult (+66 more)
 
 ### Community 29 - "Community 29"
 Cohesion: 0.04
-Nodes (78): defaults, first, { models }, second, MODEL_DEPRECATIONS, deprecatedIds, resolved, result (+70 more)
+Nodes (72): transitionIssueToVerifyingOnMain(), HttpServerResponse, getShowHealthRoute, getShowRoute, getShowShadowRoute, AgentSpawner, AgentSpawnerLive, AgentSpawnerShape (+64 more)
 
 ### Community 30 - "Community 30"
-Cohesion: 0.05
-Nodes (55): useZoneAActions(), ZoneActionStrip(), ZoneActionStripProps, ZoneBActionStrip(), ZoneBActionStripProps, AlertOptions, ConfirmOptions, DialogContext (+47 more)
+Cohesion: 0.03
+Nodes (69): ActivityFeed(), ActivityFeedProps, EVENT_COLORS, EVENT_ICONS, fetchActivityREST(), selectIssueActivityFeed(), ConnectionLinesProps, CostDonut() (+61 more)
 
 ### Community 31 - "Community 31"
-Cohesion: 0.03
-Nodes (60): IssueComposer(), IssueWorkbench(), IssueWorkbenchProps, ZoneA(), ZoneAProps, ALL_TABS, OverviewTab, OverviewTabSpec (+52 more)
+Cohesion: 0.04
+Nodes (78): activeSwarmIssueIds, assertPathInside(), autoAdvanceInFlight, buildSlotPrompt(), buildStructuredSlotTaskInput(), canonicalIssueId(), clearAutoAdvanceFailureFields(), continueDirForWorkspace() (+70 more)
 
 ### Community 32 - "Community 32"
-Cohesion: 0.03
-Nodes (73): agentDir, dir1, dir2, marker, missing, nested, invalidateAgentsCache(), cb (+65 more)
+Cohesion: 0.04
+Nodes (64): buildACLookupByTitle(), buildActiveSliceContext(), buildWorkAgentPrompt(), extractStitchDesigns(), inferIssueIdFromWorkspace(), matchBeadToAC(), readBeadsTasks(), readFeatureContext() (+56 more)
 
 ### Community 33 - "Community 33"
-Cohesion: 0.04
-Nodes (67): BUNDLED_GIT_HOOKS_DIR, checkCommand(), __dirname, __filename, syncCommand(), SyncOptions, getCurrentVersion(), getLatestVersion() (+59 more)
+Cohesion: 0.03
+Nodes (75): agentDir, dir1, dir2, marker, missing, nested, cb, cmdArgs (+67 more)
 
 ### Community 34 - "Community 34"
-Cohesion: 0.04
-Nodes (71): constantTimeTokenEqual(), cookieValue(), dashboardSessionCookieHeader(), getDashboardSessionToken(), getHeader(), hasDashboardAuth(), hasDashboardAuthHeaders(), hasDashboardInternalToken() (+63 more)
+Cohesion: 0.05
+Nodes (72): claimTranscriptRangeAsync(), commitTranscriptRangeAsync(), getTranscriptCheckpointAsync(), listTranscriptCheckpointsAsync(), pendingRequests, postWorkerRequest(), releaseTranscriptRangeAsync(), runInline() (+64 more)
 
 ### Community 35 - "Community 35"
 Cohesion: 0.04
-Nodes (59): adaptFlywheelAgent(), AGENT_STATUS_MAP, AgentRole, AgentStatus, BUG_STATUS_CLASS, FlywheelStatusDetails(), FlywheelStatusDetailsProps, formatMemory() (+51 more)
+Nodes (73): { config }, Role, applyEnvironmentFallbacks(), applyMigrations(), backupGlobalConfig(), CavemanConfig, CavemanMode, cloneRoles() (+65 more)
 
 ### Community 36 - "Community 36"
 Cohesion: 0.04
-Nodes (55): ActivityFeed(), ActivityFeedProps, EVENT_COLORS, EVENT_ICONS, fetchActivityREST(), selectIssueActivityFeed(), AgentCard(), AgentCardProps (+47 more)
+Nodes (57): BUNDLED_GIT_HOOKS_DIR, checkCommand(), __dirname, __filename, syncCommand(), SyncOptions, ensureExcalidrawMcp(), ensurePlaywrightIsolation() (+49 more)
 
 ### Community 37 - "Community 37"
-Cohesion: 0.04
-Nodes (55): fmtCost(), fmtDuration(), RoundCard(), RoundCardProps, RoundData, RoundVerdict, VERDICT_COLOR, VERDICT_LABEL (+47 more)
+Cohesion: 0.02
+Nodes (80): ActivityDetailedEvent, ActivityEntryEvent, ActivityTtsEvent, ActivityUpdatedEvent, AgentActivityChangedEvent, AgentChannelReplyEvent, AgentCompletedEvent, AgentCreatedEvent (+72 more)
 
 ### Community 38 - "Community 38"
 Cohesion: 0.04
-Nodes (59): ChannelPermissionDialog(), ChannelPermissionDialogProps, { container }, onAllow, onDeny, request, ConfirmationDialog(), ConfirmationDialogProps (+51 more)
+Nodes (71): updateTtsConfig(), defaults, first, { models }, second, clearConfigCache(), getGlobalConfigPath(), ModelRef (+63 more)
 
 ### Community 39 - "Community 39"
 Cohesion: 0.03
-Nodes (74): ActivityDetailedEvent, ActivityEntryEvent, ActivityTtsEvent, ActivityUpdatedEvent, AgentActivityChangedEvent, AgentChannelReplyEvent, AgentCompletedEvent, AgentCreatedEvent (+66 more)
+Nodes (56): DrawerActivityRail(), DrawerBeadsList(), DrawerReviewSpecialists(), DRAWER_TABS, DrawerTabs(), DrawerVerificationGates(), IssueDrawer(), createQueryClient() (+48 more)
 
 ### Community 40 - "Community 40"
-Cohesion: 0.05
-Nodes (63): createHumeConfig(), deleteHumeConfig(), humeFetch(), HumeResult, addTunnelIngress(), cfFetch(), CloudflareCredentials, CloudflareIngressRule (+55 more)
+Cohesion: 0.03
+Nodes (69): resetDb(), resetDb(), closeDatabase(), getDatabasePath(), isBunRuntime(), _require, resetDatabase(), ExtractedPayload (+61 more)
 
 ### Community 41 - "Community 41"
-Cohesion: 0.04
-Nodes (62): resetDb(), resetDb(), closeDatabase(), getDatabasePath(), isBunRuntime(), _require, resetDatabase(), conv (+54 more)
+Cohesion: 0.05
+Nodes (64): addRepoCommand(), AddRepoOptions, convertToSshUrl(), createCommand(), CreateOptions, createRemoteWorkspace(), DestroyOptions, destroyRemoteWorkspace() (+56 more)
 
 ### Community 42 - "Community 42"
-Cohesion: 0.04
-Nodes (62): ContainerDetailPanel(), ContainerDetailPanelProps, ContainerDetails, DetailTab, fetchContainerDetails(), formatBytes(), getBarColor(), ResourceBar() (+54 more)
+Cohesion: 0.05
+Nodes (57): ComposerMode, IssueComposer(), IssueComposerProps, PlanningState, ZoneAActionsState, RestartResult, SwitchModelModal(), SwitchModelModalProps (+49 more)
 
 ### Community 43 - "Community 43"
-Cohesion: 0.05
-Nodes (58): writeStoryFeatureContext(), findWorkspaceRoot(), planFinalizeCommand(), PlanFinalizeOptions, stampPlanForFinalization(), completePlanningArtifacts(), badPath, doc (+50 more)
+Cohesion: 0.04
+Nodes (65): ContainerDetailPanel(), ContainerDetailPanelProps, ContainerDetails, DetailTab, fetchContainerDetails(), formatBytes(), DeepWipeDialogProps, DeepWipeProgress (+57 more)
 
 ### Community 44 - "Community 44"
 Cohesion: 0.03
-Nodes (50): AC_STATUS_ICONS, BeadsResponse, BeadsTasksPanel(), BeadsTasksPanelProps, BeadTask, PlanItemDetailProps, AC_STATUS_COLORS, AC_STATUS_SYMBOL (+42 more)
+Nodes (55): agentPhase(), AgentPhaseFilter, agentRole(), AgentsFilterState, AgentsViewMode, DropdownFilter(), FilterOption, filterSummary() (+47 more)
 
 ### Community 45 - "Community 45"
-Cohesion: 0.06
-Nodes (59): buildActiveSliceContext(), buildPolyrepoContext(), buildWorkAgentPrompt(), extractStitchDesigns(), inferIssueIdFromWorkspace(), matchBeadToAC(), readBeadsTasks(), readPendingFeedback() (+51 more)
+Cohesion: 0.04
+Nodes (50): ChangedFilesTree, EMPTY_DIRECTORY_OVERRIDES, CompactBoundary, ConversationEvent, ProposedPlan, TurnDiffFileChange, TurnDiffSummary, DiffStatLabel (+42 more)
 
 ### Community 46 - "Community 46"
+Cohesion: 0.05
+Nodes (53): acquireStartLock(), buildManagedProcessIdentity(), buildTtsDaemonEnv(), clearState(), clearTtsDaemonManualStopGate(), defaultAllowedOrigins(), execFileAsync, fetchDaemonHealth() (+45 more)
+
+### Community 47 - "Community 47"
+Cohesion: 0.04
+Nodes (56): CodexAuthBanner(), SensitiveText(), SensitiveTextProps, CodexAuthStatus, fetchCodexAuthStatus(), useCodexAuthStatus(), DEFAULTS, UIPreferences (+48 more)
+
+### Community 48 - "Community 48"
 Cohesion: 0.04
 Nodes (52): buildContextMenu(), buildMenuTemplate(), buildTooltip(), callServerApi(), configureApplicationMenu(), createTerminalWindow(), createTray(), createTrayIcon() (+44 more)
 
-### Community 47 - "Community 47"
-Cohesion: 0.06
-Nodes (58): acquireStartLock(), buildManagedProcessIdentity(), buildTtsDaemonEnv(), clearState(), clearTtsDaemonManualStopGate(), defaultAllowedOrigins(), execFileAsync, fetchDaemonHealth() (+50 more)
-
-### Community 48 - "Community 48"
-Cohesion: 0.05
-Nodes (53): getReviewerSessionName(), parseReviewerSessionName(), REVIEWER_ROLES, ReviewerRole, result, ActivityContext, awaitingInputFromProjection(), buildIssueTitleMap() (+45 more)
-
 ### Community 49 - "Community 49"
 Cohesion: 0.04
-Nodes (56): DEFAULTS, UIPreferences, useUIPreferences(), DesktopSettings, DesktopSettingsSection(), isDesktopApp(), NOTIFICATION_LABELS, NotificationEventType (+48 more)
+Nodes (50): useAvailableModels(), AggregateActivityState, AggregateBadge, buildActivitySummary(), computeDominantStatus(), FeatureContextMenu(), FeatureContextMenuProps, FeatureItem() (+42 more)
 
 ### Community 50 - "Community 50"
-Cohesion: 0.03
-Nodes (55): { activeSessions }, agentDir, fortyMinutesAgo, twentyMinutesAgo, result, checkAgentHealthAsync(), determineHealthStatusAsync(), clearCacheRoute (+47 more)
+Cohesion: 0.05
+Nodes (62): BudgetKey, buildContext(), CandidateContext, countHits(), emptyAllocations(), emptyHitCounts(), escapeJsonForPrompt(), estimateTokens() (+54 more)
 
 ### Community 51 - "Community 51"
 Cohesion: 0.04
-Nodes (49): AggregateActivityState, AggregateBadge, buildActivitySummary(), computeDominantStatus(), FeatureContextMenu(), FeatureContextMenuProps, FeatureItem(), FeatureItemProps (+41 more)
+Nodes (52): REVIEWER_STYLE, ReviewerRole, RoleBadge(), RoleBadgeProps, RoleBadgeSize, RoleStyle, SESSION_STYLE, SIZE_PX (+44 more)
 
 ### Community 52 - "Community 52"
-Cohesion: 0.05
-Nodes (55): buildCorrelationMap(), CorrelationResult, ClaudeMessageWithCwd, ClaudeUsage, ContentBlock, extractFilePath(), FILE_TOOLS, parseSessionJsonl() (+47 more)
+Cohesion: 0.07
+Nodes (58): updateMemoryHealth(), writeStatus(), assertMemorySafeSegment(), assertUnderMemoryBase(), ensureDir(), ensureParentDir(), resolveArchiveDir(), resolveCheckpointFile() (+50 more)
 
 ### Community 53 - "Community 53"
-Cohesion: 0.07
-Nodes (42): parsePiSession(), waitForPiAgentReady(), CLAUDE_PROJECTS_DIR, SessionIndexEntry, agentDirFor(), agentsDir(), cleanupPiTransientFiles(), execAsync (+34 more)
+Cohesion: 0.05
+Nodes (48): format(), LiveCounter(), LiveCounterProps, ACTIVE_AGENT_STATUSES, agentForFeature(), BucketedFeature, bucketFeaturePhase(), classifierAgent() (+40 more)
 
 ### Community 54 - "Community 54"
-Cohesion: 0.05
-Nodes (48): buildInspectPrompt(), detectCompileCommand(), __dirname, execAsync, __filename, getBeadDescription(), InspectContext, InspectResult (+40 more)
+Cohesion: 0.07
+Nodes (53): dashboardBundleMtimeMs(), parseHealthTimeout(), recordReloadStatus(), reloadCommand(), ReloadOptions, runBuild(), UsageError, DashboardBundleCandidate (+45 more)
 
 ### Community 55 - "Community 55"
-Cohesion: 0.04
-Nodes (49): makeTestService(), sentinel, eightDaysAgo, events, payload, r1, r2, received (+41 more)
+Cohesion: 0.05
+Nodes (41): archiveCustomState(), CleanupOptions, cleanupStatesCommand(), LinearState, ListOptions, listStatesCommand(), listTeamStates(), refreshCommand() (+33 more)
 
 ### Community 56 - "Community 56"
 Cohesion: 0.04
-Nodes (50): cosineSimilarity(), getFtsRow(), insertEmbedding(), replaceDiscoveredSessionArrayIndexes(), replaceFtsRow(), replaceSessionArrayIndex(), updateEnrichment(), upsertDiscoveredSession() (+42 more)
+Nodes (54): fetchConversations(), GeneralConversation, GeneralSectionProps, archiveConversation(), ConversationMutations, favoriteConversation(), stopConversation(), summaryForkConversation() (+46 more)
 
 ### Community 57 - "Community 57"
-Cohesion: 0.07
-Nodes (53): activeSwarmIssueIds, assertPathInside(), autoAdvanceInFlight, buildSlotPrompt(), buildStructuredSlotTaskInput(), canonicalIssueId(), continueDirForWorkspace(), createSlotWorktree() (+45 more)
+Cohesion: 0.04
+Nodes (53): executeHandoff(), HandoffPanel(), HandoffPanelProps, MODEL_COLORS, ActivityEntry, AgentPauseFields, clearTroubledAgent(), CloisterHealth (+45 more)
 
 ### Community 58 - "Community 58"
-Cohesion: 0.05
-Nodes (50): applyTierAwareFallback(), detectEnabledProviders(), ENRICHMENT_TIER_MAX_MESSAGES, EnrichmentTier, EnrichmentTierConfig, FALLBACK_MAP, filterAvailableModels(), getAvailableModels() (+42 more)
+Cohesion: 0.04
+Nodes (52): ClaudeMessageWithCwd, ClaudeUsage, ContentBlock, FILE_TOOLS, parseSessionJsonl(), SessionMetadata, scanAction(), collectJsonlFiles() (+44 more)
 
 ### Community 59 - "Community 59"
-Cohesion: 0.06
-Nodes (52): isEligibleForCleanup(), PrdLocation, getIssueDataService(), ActivityContext, awaitingInputFromProjection(), closedIssuesCache, commandDeckRouteLayer, costCache (+44 more)
+Cohesion: 0.04
+Nodes (54): db, makeTestLayer(), makeTestService(), received, runWithService(), store, svc, unsubscribe (+46 more)
 
 ### Community 60 - "Community 60"
-Cohesion: 0.05
-Nodes (33): DiffPanel(), DiffPanelProps, DiffThemeType, getRenderablePatch(), readDiffParamsFromUrl(), RenderablePatch, ToggleButton(), DiffPanelLoadingState() (+25 more)
+Cohesion: 0.04
+Nodes (48): ComposerFooter(), ComposerFooterProps, deleteConversationImage(), PendingImage, sendConversationMessage(), switchModel(), uploadConversationImage(), EFFORT_LEVELS (+40 more)
 
 ### Community 61 - "Community 61"
-Cohesion: 0.05
-Nodes (45): changedFiles, errOutput, fetchMock, output, abortReviewCommand(), DASHBOARD_URL, configShadowCommand(), ShadowOptions (+37 more)
+Cohesion: 0.04
+Nodes (46): getDefaultConversationModel(), VoiceMode, VoiceWidget(), Conversation, ConversationListProps, fetchConversations(), getSortKey(), ListTab (+38 more)
 
 ### Community 62 - "Community 62"
 Cohesion: 0.06
-Nodes (51): buildDefaultTtsTestVoice(), buildTtsSpeakPayload(), deleteTtsVoiceByName(), findVoiceByNameOrReport(), formatMegabytes(), formatSeconds(), formatTtsDaemonStatus(), formatVoiceDetails() (+43 more)
+Nodes (45): addEventToCache(), CostCache, createEmptyCache(), getCacheFile(), getCacheStatus(), getCostsByIssue(), getCostsDir(), getCostsForIssue() (+37 more)
 
 ### Community 63 - "Community 63"
-Cohesion: 0.06
-Nodes (43): InlineSparkline(), InlineSparklineProps, listeners, useSharedTick(), ContainerNode(), containerStatusColor(), containerStatusToDot(), formatMemory() (+35 more)
+Cohesion: 0.08
+Nodes (46): getReviewStatusFromDbAsync(), BlockerReason, getReviewStatusAsync(), setReviewStatusAsync(), addFailingSource(), getFailingChecksBlocker(), getRepoFromPrUrl(), getTrackedRepos() (+38 more)
 
 ### Community 64 - "Community 64"
-Cohesion: 0.07
-Nodes (52): assertExistingPathInsideRoot(), commitFlywheelReport(), createInitialFlywheelStatus(), dashboardBaseUrl(), decodeFlywheelStatus, emitStatusCommand(), EmitStatusOptions, execAsync (+44 more)
+Cohesion: 0.04
+Nodes (51): buildClaudeUserSettings(), ClaudeUserSettings, getClaudePermissionFlags(), readYoloEnv(), resolvePermissionMode(), YOLO_FALSE, YOLO_TRUE, ClaudePermissionMode (+43 more)
 
 ### Community 65 - "Community 65"
-Cohesion: 0.07
-Nodes (22): importTrackerConfig(), getCachedPlanningState(), IssueDataService, issuesChanged(), mapRallyStateToCanonical(), PLANNING_FINISHED_STATUSES, planningStateCache, PlanningStateCacheEntry (+14 more)
+Cohesion: 0.06
+Nodes (53): assertExistingPathInsideRoot(), clearFlywheelRunGate(), commitFlywheelStateChanges(), createInitialFlywheelStatus(), dashboardBaseUrl(), decodeFlywheelStatus, emitStatusCommand(), EmitStatusOptions (+45 more)
 
 ### Community 66 - "Community 66"
-Cohesion: 0.06
-Nodes (49): Access, buildConversationResponse(), getCachedMessages(), isPiSessionFile(), validateCwdContainment(), getIndexStats(), getIndexStats(), analyze_session() (+41 more)
+Cohesion: 0.05
+Nodes (39): getCurrentVersion(), getLatestVersion(), isNewer(), updateCommand(), ConversationsConfig, ConversationsEnrichmentConfig, deepMerge(), DEFAULT_CONFIG (+31 more)
 
 ### Community 67 - "Community 67"
-Cohesion: 0.05
-Nodes (40): VoiceMode, VoiceWidget(), Conversation, ConversationListProps, fetchConversations(), getSortKey(), ListTab, SORT_LABELS (+32 more)
+Cohesion: 0.04
+Nodes (50): cosineSimilarity(), getFtsRow(), insertEmbedding(), replaceDiscoveredSessionArrayIndexes(), replaceFtsRow(), replaceSessionArrayIndex(), updateEnrichment(), upsertDiscoveredSession() (+42 more)
 
 ### Community 68 - "Community 68"
-Cohesion: 0.08
-Nodes (48): devCommand(), __dirname, ensureDashboardBundle(), killPort(), readConfig(), resolveNode22(), sleep(), waitForHealth() (+40 more)
+Cohesion: 0.05
+Nodes (57): postAgentMessageLikeRoute(), validateAgentMessageOrigin(), constantTimeTokenEqual(), cookieValue(), dashboardCsrfToken(), dashboardSessionCookieHeader(), getDashboardSessionToken(), getHeader() (+49 more)
 
 ### Community 69 - "Community 69"
-Cohesion: 0.07
-Nodes (45): checkCommand(), checkComposeLabelDrift(), checkDirectory(), checkPi(), CheckResult, compareSemver(), ComposeDriftEntry, countItems() (+37 more)
+Cohesion: 0.06
+Nodes (50): BYTE_UNITS, cachedContainerLifecycleSnapshot, ContainerHistory, ContainerStats, DockerContainerLifecycle, DockerNetwork, DockerPsRaw, DockerStatsCollector (+42 more)
 
 ### Community 70 - "Community 70"
-Cohesion: 0.06
-Nodes (44): parseContainerServiceName(), parseIssueIdFromText(), fetchProjectTree(), isBenchmarkMode, startedAt, computeResourceAllocatedIssues(), discoverResourceAllocatedIssues(), discoverResourceAllocatedIssuesFresh() (+36 more)
+Cohesion: 0.05
+Nodes (51): AgentRollup, CavemanExperimentRow, dailySpendCache, dailySpendCacheKey(), DailyTrend, DatabaseError, DbCostRow, DbIssueSummaryRow (+43 more)
 
 ### Community 71 - "Community 71"
-Cohesion: 0.1
-Nodes (45): BlockerReason, getReviewStatusAsync(), setReviewStatusAsync(), addFailingSource(), getFailingChecksBlocker(), getRepoFromPrUrl(), getTrackedRepos(), handleCheckRun() (+37 more)
+Cohesion: 0.06
+Nodes (29): buildObservation(), buildObservationPrompt(), ExtractedObservationPayload, ExtractedResultMetadata, ExtractObservationCall, extractObservationFromTurn(), ExtractObservationInput, ExtractObservationResult (+21 more)
 
 ### Community 72 - "Community 72"
-Cohesion: 0.04
-Nodes (47): AIProvider, calculateCost(), CostEntry, DEFAULT_PRICING, getPricing(), logUsage(), ModelPricing, anthropicModels (+39 more)
+Cohesion: 0.06
+Nodes (40): createMemoryCommand(), queryCostEvents(), buildDailySummaryMarkdown(), createResetMarker(), DailySummaryResult, DailySummaryStatus, dedupeResetMarkers(), generateDailySummary() (+32 more)
 
 ### Community 73 - "Community 73"
-Cohesion: 0.12
-Nodes (46): applyClosedOutLabel(), applyLabelGitHub(), applyLabelLinear(), applyLabelViaTracker(), closeGitHubDirect(), closeGitHubPr(), CloseIssueOptions, closeLinearDirect() (+38 more)
+Cohesion: 0.04
+Nodes (40): isRunningAgent(), isActiveAgent(), CostEvent, CostStreamResponse, fetchCostStream(), useCostStream(), UseCostStreamOptions, UseCostStreamResult (+32 more)
 
 ### Community 74 - "Community 74"
-Cohesion: 0.07
-Nodes (43): appendBridgeLog(), BunGlobal, ChannelPermissionRequest, ChannelPermissionRequestNotification, ChannelPushPayload, ChannelPushResult, constantTimeHeaderMatch(), forwardPermissionRequestToDashboard() (+35 more)
+Cohesion: 0.04
+Nodes (49): adminRouteLayer, getAdminTldrRoute, agentsRouteLayer, cliproxyRouteLayer, conversationsRouteLayer, deleteDockerContainerRoute, deleteDockerNetworkRoute, deleteDockerVolumeRoute (+41 more)
 
 ### Community 75 - "Community 75"
 Cohesion: 0.04
-Nodes (48): DomainEvent, AgentOutput, ChatMessage, CompactBoundary, ConversationCostTotals, ConversationEvent, ConversationResponse, DeepWipeRpc (+40 more)
+Nodes (51): result, isDeaconGloballyPaused(), clearCacheRoute, ConfirmationRequest, deletePlanningSessionRoute, execAsync, getCacheStatusRoute, getConfirmationsRoute (+43 more)
 
 ### Community 76 - "Community 76"
-Cohesion: 0.04
-Nodes (48): 10. UX Requirements, 11. Implementation Notes, 12. Acceptance Criteria, 13. Success Criteria, 1. New Dashboard Surface, 2.1 By Issue, 2.2 By Workspace, 2.3 By Agent Type (+40 more)
+Cohesion: 0.05
+Nodes (37): categorizeToolUse(), CompressedTranscriptDelta, compressEntry(), compressJsonlBuffer(), compressTranscriptDelta(), CompressTranscriptDeltaInput, extractBashCommand(), extractText() (+29 more)
 
 ### Community 77 - "Community 77"
-Cohesion: 0.04
-Nodes (48): 1.1 What We Have Today, 1.2 Tool-by-Tool Analysis, 1.3 Comparative Matrix, 2.1 Design Principles, 2.2 Proposed Enhancements (Prioritized), 2.3 Implementation Roadmap, 2.4 What We're NOT Adopting (and Why), 2.5 Success Metrics (+40 more)
+Cohesion: 0.05
+Nodes (33): DiffPanel(), DiffPanelProps, DiffThemeType, getRenderablePatch(), readDiffParamsFromUrl(), RenderablePatch, ToggleButton(), DiffPanelLoadingState() (+25 more)
 
 ### Community 78 - "Community 78"
-Cohesion: 0.04
-Nodes (48): 10. God View: Keep But Integrate, 1. Rename: Mission Control → Command Deck, 2. Navigation: Horizontal Bar → Grouped Sidebar, 3. Color System: Semantic Token Architecture, 4. Typography Update, 5. Fractal Noise Texture Overlay, 6. Component Unification, 7. Scrollbar Styling (+40 more)
+Cohesion: 0.06
+Nodes (52): buildDefaultTtsTestVoice(), buildTtsSpeakPayload(), deleteTtsVoiceByName(), findVoiceByNameOrReport(), formatMegabytes(), formatSeconds(), formatTtsDaemonStatus(), formatVoiceDetails() (+44 more)
 
 ### Community 79 - "Community 79"
 Cohesion: 0.07
-Nodes (42): AnthropicContentBlock, AnthropicInputBlock, AnthropicMessage, AnthropicMessageResponse, AnthropicMessagesRequest, emptyBlock(), ensureOpenAICompatibleProxyRunning(), getOpenAICompatibleProxyBaseUrl() (+34 more)
+Nodes (46): devCommand(), __dirname, ensureDashboardBundle(), killPort(), readConfig(), resolveNode22(), sleep(), waitForHealth() (+38 more)
 
 ### Community 80 - "Community 80"
 Cohesion: 0.05
-Nodes (34): ActivitySection, AgentSection(), AgentSectionProps, formatCost(), formatDuration(), formatModel(), formatTime(), getPreviewLine() (+26 more)
+Nodes (44): WorkLogEntry, ConversationPanel(), ConversationPanelProps, ConversationView(), ConversationViewProps, FailedMessage, fetchMessages(), FORK_STEPS (+36 more)
 
 ### Community 81 - "Community 81"
-Cohesion: 0.04
-Nodes (47): 1. **work-agent**, 2. **planning-agent**, 3. **review-agent**, 4. **test-agent**, 5. **merge-agent**, 6. **inspect-agent** ⚠️ PARTIAL CONFIGURATION, 7. **uat-agent** ⚠️ CRITICAL GAPS, Action Items (Prioritized) (+39 more)
+Cohesion: 0.07
+Nodes (42): buildManifestFromDirectory(), collectSourceFiles(), compareFileToManifest(), createEmptyManifest(), FileStatus, hashFile(), Manifest, ManifestEntry (+34 more)
 
 ### Community 82 - "Community 82"
 Cohesion: 0.04
-Nodes (46): 1. Dashboard UI Integration (from PAN-225), 2. FTS5 as Phase 1 Search (from PAN-225, PAN-179), 3. Session-Oriented Learning Types (from PAN-225, PAN-184), 4. Specific Thinking-Block Perception Signals (from PAN-184), 5. Explicit Deduplication Threshold (from PAN-225), Acceptance Criteria, Architecture, code:block1 (Source of truth (git-tracked):) (+38 more)
+Nodes (52): EDITOR_IDS, EditorEntry, EditorId, EditorIdSchema, EDITORS, OpenInEditorInput, AgentOutput, ChatMessage (+44 more)
 
 ### Community 83 - "Community 83"
-Cohesion: 0.04
-Nodes (47): 1. Agent Discovery, 1. Monitor Regularly, 2. Activity Detection, 2. Establish Baselines, 3. Automate Alerts, 3. Log Analysis, 4. Log Everything, 4. Resource Usage (+39 more)
+Cohesion: 0.1
+Nodes (44): bridgeCodexAuthToCliproxy(), bridgeCodexAuthToCliproxyAsync(), bridgeGeminiAuthToCliproxyAsync(), buildCliproxyConfig(), checkCliproxyPortAsync(), cliproxyCatch(), CliproxyCodexCredentials, CliproxyError (+36 more)
 
 ### Community 84 - "Community 84"
-Cohesion: 0.04
-Nodes (47): 1. Start Traefik, 2. Add DNS Entry, 3. Verify, "502 Bad Gateway", Add a New Route, Architecture, "Certificate Error", Certificate Management (+39 more)
+Cohesion: 0.05
+Nodes (38): ActivitySection, AgentSection(), AgentSectionProps, formatCost(), formatDuration(), formatModel(), formatTime(), getPreviewLine() (+30 more)
 
 ### Community 85 - "Community 85"
-Cohesion: 0.06
-Nodes (43): migrateConfigCommand(), MigrateConfigOptions, BACKUP_SETTINGS_PATH, convertToYamlConfig(), detectEnabledProviders(), getMigrationStatus(), hasLegacySettings(), LEGACY_SETTINGS_PATH (+35 more)
+Cohesion: 0.05
+Nodes (42): fetchFlywheelState(), FlywheelStatePane(), FlywheelStatePayload, formatLastModified(), adaptFlywheelAgent(), AGENT_STATUS_MAP, AgentRole, AgentStatus (+34 more)
 
 ### Community 86 - "Community 86"
-Cohesion: 0.08
-Nodes (40): wipeCommand(), calls, { mockExecAsync }, opts, closeIssue(), compactBeads(), CompactBeadsOptions, execAsync (+32 more)
+Cohesion: 0.07
+Nodes (42): AutoPresoAgentSettings, createModel(), createTools(), DEFAULT_SETTINGS, readCodexBearerToken(), runWhiteboardAgent(), runWhiteboardWarmupOnce(), systemPrompt() (+34 more)
 
 ### Community 87 - "Community 87"
-Cohesion: 0.09
-Nodes (43): addEventToCache(), CostCache, createEmptyCache(), getCacheFile(), getCacheStatus(), getCostsByIssue(), getCostsDir(), getCostsForIssue() (+35 more)
+Cohesion: 0.08
+Nodes (44): checkCommand(), checkComposeLabelDrift(), checkDirectory(), checkPi(), CheckResult, compareSemver(), ComposeDriftEntry, countItems() (+36 more)
 
 ### Community 88 - "Community 88"
-Cohesion: 0.06
-Nodes (41): AvailableModel, AvailableModelsResponse, DEFAULT_FLYWHEEL_CONFIG, DEFAULT_WORKHORSES, displayModelRef(), Effort, fetchAvailableModels(), fetchSettings() (+33 more)
+Cohesion: 0.05
+Nodes (43): AvailableModel, AvailableModelsResponse, ClaudeAuthStatus, DEFAULT_FLYWHEEL_CONFIG, DEFAULT_WORKHORSES, displayModelRef(), Effort, fetchAvailableModels() (+35 more)
 
 ### Community 89 - "Community 89"
-Cohesion: 0.13
-Nodes (44): bridgeCodexAuthToCliproxy(), bridgeCodexAuthToCliproxyAsync(), bridgeGeminiAuthToCliproxyAsync(), buildCliproxyConfig(), checkCliproxyPortAsync(), CliproxyCodexCredentials, CliproxyGeminiCredentials, CodexAuthFile (+36 more)
+Cohesion: 0.05
+Nodes (41): entry, { issueId }, { limit }, old, op, ops, recent, result (+33 more)
 
 ### Community 90 - "Community 90"
-Cohesion: 0.04
-Nodes (46): 1. Issue lifecycle, 2. Observation, 3. Things you manage, 4. System / daemon, 5. Releases, 6. First-run & maintenance, 7. `pan admin` — plumbing, code:bash (pan issues                       # what can I work on?) (+38 more)
+Cohesion: 0.09
+Nodes (47): confirmHostOverride(), countBeadsTasks(), determineWorkspaceLocation(), ensureRemoteWorkspace(), execAsync, execFileAsync, failPostCreateValidation(), fetchIssueForAutoStart() (+39 more)
 
 ### Community 91 - "Community 91"
-Cohesion: 0.04
-Nodes (46): 1.1 Kanban Card Cost Badge, 1.2 Issue Detail Panel Cost Section, 1. Per-Issue Cost Display, 2.1 Session File Location, 2.2 JSONL Message Format, 2.3 Parser Implementation, 2. Claude Code JSONL Parsing, 3.1 Linking Mechanism (+38 more)
+Cohesion: 0.09
+Nodes (34): parsePiSession(), ProcessSpawnError, TmuxError, CLAUDE_PROJECTS_DIR, SessionIndexEntry, agentDirFor(), agentsDir(), cleanupPiTransientFiles() (+26 more)
 
 ### Community 92 - "Community 92"
-Cohesion: 0.04
-Nodes (46): 10. Compose right pane for project-selected mode, 11. CSS for session tree, issue header, session panel, 1. Add `SessionNode`, `FeatureNode`, `ProjectSessionTree` types to contracts, 2. Extend `fetchActivityData` to include reviewer sub-agents, presence, and JSONL paths, 3. New endpoint `GET /api/projects/:projectKey/session-tree`, 4. RPC subscription `subscribeProjectSessionTree`, 5. `SessionNode.tsx` component, 6. Extend `FeatureItem.tsx` to be expandable (+38 more)
+Cohesion: 0.06
+Nodes (45): buildConversationResponse(), getCachedMessages(), isPiSessionFile(), analyze_session(), find_sessions(), main(), Analyze a single session file for health issues., Find all session files. (+37 more)
 
 ### Community 93 - "Community 93"
-Cohesion: 0.07
-Nodes (38): cont, doc, projectRoot, specsDir, workspace, runtime, state, next (+30 more)
+Cohesion: 0.05
+Nodes (44): CappedBodyReadResult, CheckTtsHealthOptions, clearTtsVoices(), createTtsVoice(), CreateTtsVoiceInput, deleteTtsVoiceRoute, deleteTtsVoicesRoute, ExtractEmbeddingDeps (+36 more)
 
 ### Community 94 - "Community 94"
-Cohesion: 0.09
-Nodes (42): updateCommand(), buildManifestFromDirectory(), collectSourceFiles(), compareFileToManifest(), createEmptyManifest(), hashFile(), Manifest, ManifestEntry (+34 more)
+Cohesion: 0.04
+Nodes (48): 10. UX Requirements, 11. Implementation Notes, 12. Acceptance Criteria, 13. Success Criteria, 1. New Dashboard Surface, 2.1 By Issue, 2.2 By Workspace, 2.3 By Agent Type (+40 more)
 
 ### Community 95 - "Community 95"
 Cohesion: 0.04
-Nodes (45): 1. Overview, 2.1 What It Is, 2.2 Implementation, 2. Ralph Wiggum Self-Assessment Loop, 3.1 What It Is, 3.2 Current State, 3.3 Proposed State, 3.4 Implementation (+37 more)
+Nodes (48): 1.1 What We Have Today, 1.2 Tool-by-Tool Analysis, 1.3 Comparative Matrix, 2.1 Design Principles, 2.2 Proposed Enhancements (Prioritized), 2.3 Implementation Roadmap, 2.4 What We're NOT Adopting (and Why), 2.5 Success Metrics (+40 more)
 
 ### Community 96 - "Community 96"
 Cohesion: 0.04
-Nodes (45): Automated Installation, code:bash (pan doctor), code:bash (# Option 1: Install globally), code:bash (# Add user to docker group), code:bash (# Using nvm (recommended)), code:bash (# Ubuntu/Debian), code:bash (# Ubuntu/Debian (Docker Compose v2)), code:bash (# Clear npm cache) (+37 more)
+Nodes (48): 10. God View: Keep But Integrate, 1. Rename: Mission Control → Command Deck, 2. Navigation: Horizontal Bar → Grouped Sidebar, 3. Color System: Semantic Token Architecture, 4. Typography Update, 5. Fractal Noise Texture Overlay, 6. Component Unification, 7. Scrollbar Styling (+40 more)
 
 ### Community 97 - "Community 97"
-Cohesion: 0.04
-Nodes (45): 1. Creation, 2. Usage, 3. Cleanup, Architecture, Best Practices, code:block1 (project/), code:bash (pan workspace create MIN-123), code:bash (pan workspace create MIN-123 --docker) (+37 more)
+Cohesion: 0.09
+Nodes (44): flywheelAbortCommand(), loadReportFlywheelStatus(), getFlywheelActiveRunId(), getFlywheelRunPayload(), getFlywheelRunsPayload(), abortFlywheelRun(), decodeFlywheelRunId, decodeFlywheelStatus (+36 more)
 
 ### Community 98 - "Community 98"
-Cohesion: 0.06
-Nodes (29): format(), LiveCounter(), LiveCounterProps, ACTIVE_AGENT_STATUSES, BUCKET_STAGES, BucketedFeature, bucketFeature(), CostBadge() (+21 more)
+Cohesion: 0.05
+Nodes (27): estimateCost(), getModelCapability(), MODEL_CAPABILITIES, ModelCapability, SkillDimension, calculateSkillScore(), formatSelectionResults(), getSimpleModelMapping() (+19 more)
 
 ### Community 99 - "Community 99"
-Cohesion: 0.05
-Nodes (30): StandaloneTerminal(), StandaloneTerminalProps, ContextMenuState, isMac, TERMINAL_PROFILE_ENABLED, TerminalSizeMessage, TerminalSnapshotMessage, checkbox (+22 more)
+Cohesion: 0.06
+Nodes (27): configShadowCommand(), ShadowOptions, ENV_KEYS, EnvSnapshot, PanopticonConfig, ENV_FILE_PATH, getShadowModeFromEnv(), loadPanopticonEnv() (+19 more)
 
 ### Community 100 - "Community 100"
-Cohesion: 0.04
-Nodes (44): After Frontend Code Changes, After Server Code Changes, Architecture, code:block1 (Browser → https://pan.localhost (Traefik)), code:bash (cd /home/eltmon/Projects/panopticon-cli && npm run build:das), code:bash (cd /home/eltmon/Projects/panopticon-cli && \), code:bash (for i in $(seq 1 15); do), code:bash (cd /home/eltmon/Projects/panopticon-cli/src/dashboard/fronte) (+36 more)
+Cohesion: 0.07
+Nodes (26): createCostCommand(), formatIssueCostAggregate(), aggregate, output, IssueAggregate, BUDGETS_FILE, checkBudget(), CostBudget (+18 more)
 
 ### Community 101 - "Community 101"
-Cohesion: 0.05
-Nodes (43): 1. Concise is Key, 1. Source Locations, 2. Degrees of Freedom, 2. Installation Flow, 3. Progressive Disclosure, Bundled Resources, code:block1 (pan install (first time)), code:bash (# For public skills) (+35 more)
+Cohesion: 0.04
+Nodes (47): 1. **work-agent**, 2. **planning-agent**, 3. **review-agent**, 4. **test-agent**, 5. **merge-agent**, 6. **inspect-agent** ⚠️ PARTIAL CONFIGURATION, 7. **uat-agent** ⚠️ CRITICAL GAPS, Action Items (Prioritized) (+39 more)
 
 ### Community 102 - "Community 102"
-Cohesion: 0.08
-Nodes (32): getUnblockedItems(), isTaskReady(), TERMINAL_STATUSES, buildACLookupByTitle(), beadsDir, doc, result, AcceptanceCriterion (+24 more)
+Cohesion: 0.04
+Nodes (46): 1. Dashboard UI Integration (from PAN-225), 2. FTS5 as Phase 1 Search (from PAN-225, PAN-179), 3. Session-Oriented Learning Types (from PAN-225, PAN-184), 4. Specific Thinking-Block Perception Signals (from PAN-184), 5. Explicit Deduplication Threshold (from PAN-225), Acceptance Criteria, Architecture, code:block1 (Source of truth (git-tracked):) (+38 more)
 
 ### Community 103 - "Community 103"
-Cohesion: 0.05
-Nodes (34): ViewMode, firstSessionPanel, firstWorkbench, overview, workbench, ConversationList(), DeaconLogEntry, DeaconStatus() (+26 more)
+Cohesion: 0.04
+Nodes (47): 1. Agent Discovery, 1. Monitor Regularly, 2. Activity Detection, 2. Establish Baselines, 3. Automate Alerts, 3. Log Analysis, 4. Log Everything, 4. Resource Usage (+39 more)
 
 ### Community 104 - "Community 104"
-Cohesion: 0.05
-Nodes (43): Activity, AgentChannelReply, AgentId, AgentResolution, AgentRuntimeSnapshot, AgentSnapshot, CHANNEL_REPLY_KIND_VALUES, ChannelPermissionRequestSnapshot (+35 more)
+Cohesion: 0.04
+Nodes (47): 1. Start Traefik, 2. Add DNS Entry, 3. Verify, "502 Bad Gateway", Add a New Route, Architecture, "Certificate Error", Certificate Management (+39 more)
 
 ### Community 105 - "Community 105"
-Cohesion: 0.05
-Nodes (42): execAsync, execFileAsync, firePostMergeLifecycle(), getModelsResolveRoute, getProjectPathForIssue(), getProjectSpecialistContextRoute, getProjectSpecialistGraceRoute, getProjectSpecialistLatestLogRoute (+34 more)
+Cohesion: 0.08
+Nodes (29): hookCommand(), HookOptions, generateRecoveryPrompt(), checkHook(), clearHook(), collectMail(), generateFixedPointPrompt(), getHook() (+21 more)
 
 ### Community 106 - "Community 106"
 Cohesion: 0.07
-Nodes (40): computeRestartDelay(), getSmeeBinaryPath(), getSmeeUrl(), getWebhookTarget(), isProcessAlive(), isSmeeProcessRunning(), isSmeeRunning(), errorSpy (+32 more)
+Nodes (41): evaluateAgentStartGate(), evaluateSpawnGuardrails(), formatLeakedSpecialistSummary(), hasActiveAgentGateOrRetry(), resolveAgentCountEnv(), buildLeakedSpecialists(), buildTopConsumers(), bytesToGb() (+33 more)
 
 ### Community 107 - "Community 107"
-Cohesion: 0.05
-Nodes (43): After Adding Custom Skills, After Updating Panopticon, Auto-Sync, Available Targets, Backup Location, Backup Only, Backups, code:block1 (~/.panopticon/skills/          (Panopticon skills - source)) (+35 more)
+Cohesion: 0.04
+Nodes (46): 1. Issue lifecycle, 2. Observation, 3. Things you manage, 4. System / daemon, 5. Releases, 6. First-run & maintenance, 7. `pan admin` — plumbing, code:bash (pan issues                       # what can I work on?) (+38 more)
 
 ### Community 108 - "Community 108"
-Cohesion: 0.05
-Nodes (43): Anatomy of a Resumable Issue, Anti-Patterns, code:markdown (Description: What needs to be built and why), code:block10, code:block11, code:block12, code:markdown (Title: Fix typo in README), code:markdown (Acceptance:) (+35 more)
+Cohesion: 0.04
+Nodes (46): 1.1 Kanban Card Cost Badge, 1.2 Issue Detail Panel Cost Section, 1. Per-Issue Cost Display, 2.1 Session File Location, 2.2 JSONL Message Format, 2.3 Parser Implementation, 2. Claude Code JSONL Parsing, 3.1 Linking Mechanism (+38 more)
 
 ### Community 109 - "Community 109"
-Cohesion: 0.05
-Nodes (43): Boundaries: When to Use bd vs TodoWrite, code:block1 (bd issue: "Implement user authentication" (epic)), code:block2 (Session start:), code:block3 (1. Create bd issue with current TodoWrite content), code:block4 (1. Keep bd issue for historical record), code:block5 (db-epic: "Migrate production database to PostgreSQL"), code:block6 (- [ ] Import logging library), code:block7 (- [ ] Reproduce bug) (+35 more)
+Cohesion: 0.04
+Nodes (46): 10. Compose right pane for project-selected mode, 11. CSS for session tree, issue header, session panel, 1. Add `SessionNode`, `FeatureNode`, `ProjectSessionTree` types to contracts, 2. Extend `fetchActivityData` to include reviewer sub-agents, presence, and JSONL paths, 3. New endpoint `GET /api/projects/:projectKey/session-tree`, 4. RPC subscription `subscribeProjectSessionTree`, 5. `SessionNode.tsx` component, 6. Extend `FeatureItem.tsx` to be expandable (+38 more)
 
 ### Community 110 - "Community 110"
 Cohesion: 0.05
-Nodes (43): Architectural Smells (High Confidence), Available Categories, code:bash (# If project has override skill, this skill is permanently d), code:bash (# AI will add this section if it doesn't exist, or append to), code:bash (# Edit directly), code:bash (# Remove the AI Suggestion Preferences section), code:bash (rm -rf .claude/skills/refactor-radar/), code:markdown (## Refactoring Proposal: Standardize User Entity Naming) (+35 more)
+Nodes (41): assertExistingPathInsideRoot(), assertWritePathInsideRoot(), BriefRequestBody, decodeFlywheelRunId, FlywheelActionDeps, flywheelRouteLayer, FlywheelStatusResponse, getFlywheelBriefRoute (+33 more)
 
 ### Community 111 - "Community 111"
-Cohesion: 0.06
-Nodes (38): mockLoadProjectsConfig, mockRunQualityGates, PASSING_GATE_RESULT, runProjectQualityGates(), autoRevertMerge(), DEFAULT_GATES, execAsync, parseValidationOutput() (+30 more)
+Cohesion: 0.1
+Nodes (37): killCommand(), KillOptions, getManagedTmuxSocketName(), createFlyProvider(), FlyProviderConfig, { execAsyncMock, spawnMock, mockApi }, fly, p (+29 more)
 
 ### Community 112 - "Community 112"
-Cohesion: 0.07
-Nodes (36): createSpecialistHandoff(), ensureLogDir(), getLiveQueueDepth(), getSpecialistHandoffLogFile(), getSpecialistHandoffStats(), getTodaySpecialistHandoffs(), logSpecialistHandoff(), readIssueSpecialistHandoffs() (+28 more)
+Cohesion: 0.06
+Nodes (41): DEFAULT_AUTO_RESUME_CONFIG, applyEnvironmentOverrides(), AutoActions, AutoRestartConfig, CLOISTER_CONFIG_FILE, CloisterConfig, CloseOutConfig, CostLimitsConfig (+33 more)
 
 ### Community 113 - "Community 113"
-Cohesion: 0.05
-Nodes (42): code:bash (# Create test settings), code:bash (pan start PAN-999 --model claude-sonnet-4-5), code:bash (# Configure settings.json with Kimi API key), code:bash (# Configure settings.json with GLM API key), code:bash (# Configure settings.json with OpenAI API key), code:bash (# Check if router is running), code:block15 ([ ] API key configured in settings.json), code:block16 ([ ] claude-code-router installed) (+34 more)
+Cohesion: 0.06
+Nodes (37): createSpecialistHandoff(), ensureLogDir(), getLiveQueueDepth(), getSpecialistHandoffLogFile(), getSpecialistHandoffStats(), getTodaySpecialistHandoffs(), logSpecialistHandoff(), readIssueSpecialistHandoffs() (+29 more)
 
 ### Community 114 - "Community 114"
-Cohesion: 0.05
-Nodes (42): Backward Compatibility, code:block1 (.pan/), code:block2 (.pan/), code:block3 (draft ──► proposed ──► active ──► completed), code:json ({), code:json ({), code:json (// WRONG — missing vBRIEFInfo, plan wrapper), code:json (// WRONG — use plan.id, not these) (+34 more)
+Cohesion: 0.04
+Nodes (45): 1. Overview, 2.1 What It Is, 2.2 Implementation, 2. Ralph Wiggum Self-Assessment Loop, 3.1 What It Is, 3.2 Current State, 3.3 Proposed State, 3.4 Implementation (+37 more)
 
 ### Community 115 - "Community 115"
-Cohesion: 0.05
-Nodes (42): 1. Make the frontend typography contract explicit and centralized, 2. Remove the Mission Control / conversation typography island, 3. Normalize conversations end-to-end, 4. Restrict display-font usage to the exact approved boundary, 5. Preserve SF Mono only for semantically technical surfaces, 6. Sweep the rest of the non–God View dashboard for drift, 7. Update documentation so the codebase does not drift again, 8. Verification plan (+34 more)
+Cohesion: 0.04
+Nodes (45): Automated Installation, code:bash (pan doctor), code:bash (# Option 1: Install globally), code:bash (# Add user to docker group), code:bash (# Using nvm (recommended)), code:bash (# Ubuntu/Debian), code:bash (# Ubuntu/Debian (Docker Compose v2)), code:bash (# Clear npm cache) (+37 more)
 
 ### Community 116 - "Community 116"
-Cohesion: 0.05
-Nodes (42): 1. Navigation & Routing, 2. Planning Artifacts Scope, 3. Shadow Engineering Implementation, 4. UI/UX Design, 5. Data Architecture, 6. Out of Scope (Explicitly Deferred), Architecture, Backend APIs (+34 more)
+Cohesion: 0.04
+Nodes (45): 1. Creation, 2. Usage, 3. Cleanup, Architecture, Best Practices, code:block1 (project/), code:bash (pan workspace create MIN-123), code:bash (pan workspace create MIN-123 --docker) (+37 more)
 
 ### Community 117 - "Community 117"
-Cohesion: 0.05
-Nodes (42): 0.1 The breaking change, 0.2 Files affected in Panopticon, 0.3 Execution, 0.4 Risk, 0. Prerequisite: Effect beta.43 → beta.48 bump, 1.1 What t3code does, 1.2 What Panopticon does today, 1.3 Recommendation: migrate to single `/ws` with structured `TerminalEvent` (+34 more)
+Cohesion: 0.06
+Nodes (26): SETTINGS_FILE, getKimiAnthropicBaseUrl(), getProviderEnv(), ProviderAuthType, ProviderName, PROVIDERS, AnthropicModel, ApiKeysConfig (+18 more)
 
 ### Community 118 - "Community 118"
-Cohesion: 0.1
-Nodes (30): build_voice_clone_prompt(), _close_player(), _ensure_player(), _extract_audio(), extract_embedding(), _get_default_sink_state(), Handler, load_base_model() (+22 more)
+Cohesion: 0.06
+Nodes (35): CLAUDE_PROJECTS_DIR, ClaudeMessage, getRecentSessions(), importSessionToCostLog(), normalizeModelName(), parseAllSessions(), AIProvider, calculateCost() (+27 more)
 
 ### Community 119 - "Community 119"
-Cohesion: 0.08
-Nodes (34): getHealthThresholdsMs(), evaluateHealthState(), formatDuration(), generateHealthSummary(), getAgentHealth(), getAgentsNeedingAttention(), getAgentsToKill(), getAgentsToPoke() (+26 more)
+Cohesion: 0.04
+Nodes (44): After Frontend Code Changes, After Server Code Changes, Architecture, code:block1 (Browser → https://pan.localhost (Traefik)), code:bash (cd /home/eltmon/Projects/panopticon-cli && npm run build:das), code:bash (cd /home/eltmon/Projects/panopticon-cli && \), code:bash (for i in $(seq 1 15); do), code:bash (cd /home/eltmon/Projects/panopticon-cli/src/dashboard/fronte) (+36 more)
 
 ### Community 120 - "Community 120"
-Cohesion: 0.09
-Nodes (37): getTrackerContext(), addGitHubComment(), fetchGitHubIssue(), fetchIssueWithComments(), findLocalWorkspace(), formatComments(), getGitHubToken(), GitHubIssueResult (+29 more)
+Cohesion: 0.05
+Nodes (43): 1. Concise is Key, 1. Source Locations, 2. Degrees of Freedom, 2. Installation Flow, 3. Progressive Disclosure, Bundled Resources, code:block1 (pan install (first time)), code:bash (# For public skills) (+35 more)
 
 ### Community 121 - "Community 121"
-Cohesion: 0.06
-Nodes (38): executeHandoff(), HandoffPanel(), HandoffPanelProps, MODEL_COLORS, ActivityEntry, AgentPauseFields, clearTroubledAgent(), CloisterHealth (+30 more)
+Cohesion: 0.08
+Nodes (41): isRecord(), isSubagentHookPayload(), SubagentHookPayload, enqueuePipeline, getTranscriptSize, registerTranscript, response, statTranscript (+33 more)
 
 ### Community 122 - "Community 122"
 Cohesion: 0.08
-Nodes (31): ComposerMode, IssueComposerProps, PlanningState, ZoneAActionsState, CodexAuthBanner(), SensitiveText(), SensitiveTextProps, RestartResult (+23 more)
+Nodes (34): useLiveFlash(), resolveWorkTypeKey(), useResolvedModels(), activityToStatus(), capitalize(), deriveDotStatus(), deriveSessionLabel(), deriveSessionModel() (+26 more)
 
 ### Community 123 - "Community 123"
-Cohesion: 0.06
-Nodes (37): SearchFilters, SearchResult, useSearch(), UseSearchOptions, fetchIssues(), SearchModal(), SearchModalProps, mockPrefetchQuery (+29 more)
+Cohesion: 0.07
+Nodes (37): boundedAutoPresoElements(), jsonByteLength(), readElementLikes(), validateAutoPresoCanvasElements(), AutoPresoSession, ExcalidrawElementLike, autopresoRouteLayer, backToStagingRoute (+29 more)
 
 ### Community 124 - "Community 124"
-Cohesion: 0.05
-Nodes (41): Agentic, All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, Coding, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer` (+33 more)
+Cohesion: 0.07
+Nodes (39): isBenchmarkMode, startedAt, computeResourceAllocatedIssues(), discoverResourceAllocatedIssues(), discoverResourceAllocatedIssuesFresh(), execFileAsync, getCachedResourceAllocatedIssues(), getResourceDetailIdentifiers() (+31 more)
 
 ### Community 125 - "Community 125"
-Cohesion: 0.05
-Nodes (41): 1. Run Diagnostics, 2. Check Configuration, 3. Check Running Services, 4. Check Skills, 5. Check Dependencies, Agents, Clean Up Old Workspaces, code:bash (pan doctor) (+33 more)
+Cohesion: 0.08
+Nodes (34): buildInspectPrompt(), __dirname, execAsync, __filename, getBeadDescription(), InspectContext, InspectResult, onInspectComplete() (+26 more)
 
 ### Community 126 - "Community 126"
-Cohesion: 0.06
-Nodes (32): BeadsTask, buildHandoffPrompt(), captureBeadsTasks(), captureFiles(), captureGitState(), captureHandoffContext(), execAsync, HandoffContext (+24 more)
+Cohesion: 0.05
+Nodes (43): After Adding Custom Skills, After Updating Panopticon, Auto-Sync, Available Targets, Backup Location, Backup Only, Backups, code:block1 (~/.panopticon/skills/          (Panopticon skills - source)) (+35 more)
 
 ### Community 127 - "Community 127"
-Cohesion: 0.06
-Nodes (35): ActivityEntry, ActivityItem(), ActivityPanel(), ActivityPanelProps, ActivityStream, applyPinWarnings(), CategoryFilter, fetchActivityREST() (+27 more)
+Cohesion: 0.05
+Nodes (43): Anatomy of a Resumable Issue, Anti-Patterns, code:markdown (Description: What needs to be built and why), code:block10, code:block11, code:block12, code:markdown (Title: Fix typo in README), code:markdown (Acceptance:) (+35 more)
 
 ### Community 128 - "Community 128"
 Cohesion: 0.05
-Nodes (40): Automatic Setup (Recommended), Certificate Errors in Browser, code:bash (pan install), code:bash (# Install dnsmasq), code:bash (# Install dnsmasq), code:bash (cat /etc/hosts | grep pan.localhost), code:bash (# macOS), code:bash (curl -k https://pan.localhost) (+32 more)
+Nodes (43): Boundaries: When to Use bd vs TodoWrite, code:block1 (bd issue: "Implement user authentication" (epic)), code:block2 (Session start:), code:block3 (1. Create bd issue with current TodoWrite content), code:block4 (1. Keep bd issue for historical record), code:block5 (db-epic: "Migrate production database to PostgreSQL"), code:block6 (- [ ] Import logging library), code:block7 (- [ ] Reproduce bug) (+35 more)
 
 ### Community 129 - "Community 129"
 Cohesion: 0.05
-Nodes (40): 10. References, 1. Problem, 2. Goal, 3. Non-Goals, 4.1 Information Architecture, 4.2 Five Surfaces (canonical mockups), 4.3 Shared Primitives, 4.4 Verb Badges (+32 more)
+Nodes (43): Architectural Smells (High Confidence), Available Categories, code:bash (# If project has override skill, this skill is permanently d), code:bash (# AI will add this section if it doesn't exist, or append to), code:bash (# Edit directly), code:bash (# Remove the AI Suggestion Preferences section), code:bash (rm -rf .claude/skills/refactor-radar/), code:markdown (## Refactoring Proposal: Standardize User Entity Naming) (+35 more)
 
 ### Community 130 - "Community 130"
-Cohesion: 0.05
-Nodes (40): 1. Copy Template Files, 2. Create Environment File, 3. Start Containers, 4. Verify, Add a Service, Add Environment Variables, Available Templates, By Database Needs (+32 more)
+Cohesion: 0.1
+Nodes (32): insertCostEvent(), AnthropicExtractionProvider, AnthropicCompatibleResponse, CliproxyExtractionProvider, FetchFn, extractWithProviderPolicy(), getTodayMemoryExtractionSpendUsd(), MemoryExtractionPolicyDeps (+24 more)
 
 ### Community 131 - "Community 131"
-Cohesion: 0.08
-Nodes (36): CLAUDE_DIR, createClaudeAdapter(), createRuntimeRegistry(), getInstalledRuntimes(), getRuntimeAdapter(), getSupportedRuntimes(), isRuntimeInstalled(), AgentMessage (+28 more)
+Cohesion: 0.07
+Nodes (22): chunks, emitter, googleMocks, stream, emitter, onTurn, queue, setupVoiceWebSocket() (+14 more)
 
 ### Community 132 - "Community 132"
-Cohesion: 0.09
-Nodes (32): DbMergeSetRepoRow, DbMergeSetRow, deleteMergeSet(), getAllMergeSetsFromDb(), getMergeSetFromDb(), getReposFromDb(), rowToMergeSet(), repos (+24 more)
+Cohesion: 0.07
+Nodes (32): resizeWindowAsync(), activePtyHubs, addClientToHub(), broadcastToHub(), hubFlushTimer, hubOutputBuffer, PtyHub, removeClientFromHub() (+24 more)
 
 ### Community 133 - "Community 133"
 Cohesion: 0.05
-Nodes (39): AC-Driven Specialist Pipeline, Artifact Lifecycle, Automatic Beads Conversion, Can agents produce valid vBRIEF JSON reliably?, code:block1 (PRD (human, markdown)              ← requirements & intent), code:block2 (docs/prds/), code:json ({), code:json ({) (+31 more)
+Nodes (42): code:bash (# Create test settings), code:bash (pan start PAN-999 --model claude-sonnet-4-5), code:bash (# Configure settings.json with Kimi API key), code:bash (# Configure settings.json with GLM API key), code:bash (# Configure settings.json with OpenAI API key), code:bash (# Check if router is running), code:block15 ([ ] API key configured in settings.json), code:block16 ([ ] claude-code-router installed) (+34 more)
 
 ### Community 134 - "Community 134"
 Cohesion: 0.05
-Nodes (37): 1. record-cost-event.js esbuild bundle broken, 2. Deacon patrolWorkAgentResolutions — getEnabledSpecialists not defined, 3. Issue ID regex missing prefixes, Bugs Found and Fixed (2026-03-20), Build Requirements, code:block1 (~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl), code:block2 (cwd: /home/eltmon/Projects/krux/workspaces/feature-krux-4), code:block5 (Claude Code Agent (tmux session)) (+29 more)
+Nodes (42): Backward Compatibility, code:block1 (.pan/), code:block2 (.pan/), code:block3 (draft ──► proposed ──► active ──► completed), code:json ({), code:json ({), code:json (// WRONG — missing vBRIEFInfo, plan wrapper), code:json (// WRONG — use plan.id, not these) (+34 more)
 
 ### Community 135 - "Community 135"
 Cohesion: 0.05
-Nodes (39): Acceptance Criteria, API Changes, API Server, Architecture, Beads Tasks, CLI, code:block1 (~/.panopticon/specialists/), code:block2 (~/.panopticon/specialists/) (+31 more)
+Nodes (42): 1. Make the frontend typography contract explicit and centralized, 2. Remove the Mission Control / conversation typography island, 3. Normalize conversations end-to-end, 4. Restrict display-font usage to the exact approved boundary, 5. Preserve SF Mono only for semantically technical surfaces, 6. Sweep the rest of the non–God View dashboard for drift, 7. Update documentation so the codebase does not drift again, 8. Verification plan (+34 more)
 
 ### Community 136 - "Community 136"
 Cohesion: 0.05
-Nodes (39): Action Items, Agentic, All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, Coding, Community Reception `[K2.6]`, Confirmed Improvements `[K2.6]`, `convoy:correctness-reviewer` (+31 more)
+Nodes (42): 1. Navigation & Routing, 2. Planning Artifacts Scope, 3. Shadow Engineering Implementation, 4. UI/UX Design, 5. Data Architecture, 6. Out of Scope (Explicitly Deferred), Architecture, Backend APIs (+34 more)
 
 ### Community 137 - "Community 137"
 Cohesion: 0.05
-Nodes (39): 1. Create a `dev` Script, 1. Register the Project, 2. Create CLAUDE.md (Recommended), 2. Create docker-compose.yml, 3. Panopticon Integration, 3. Set Up Tracker Mapping, 4. Verify Setup, Add a Project (+31 more)
+Nodes (42): 0.1 The breaking change, 0.2 Files affected in Panopticon, 0.3 Execution, 0.4 Risk, 0. Prerequisite: Effect beta.43 → beta.48 bump, 1.1 What t3code does, 1.2 What Panopticon does today, 1.3 Recommendation: migrate to single `/ws` with structured `TerminalEvent` (+34 more)
 
 ### Community 138 - "Community 138"
-Cohesion: 0.05
-Nodes (39): 1. Isolate High-Volume Operations, 2. Parallel Research, 3. Cost Optimization, 4. Security Boundaries, Built-in Subagents, CLI-Defined Subagents, code:markdown (---), code:markdown (---) (+31 more)
+Cohesion: 0.1
+Nodes (30): build_voice_clone_prompt(), _close_player(), _ensure_player(), _extract_audio(), extract_embedding(), _get_default_sink_state(), Handler, load_base_model() (+22 more)
 
 ### Community 139 - "Community 139"
-Cohesion: 0.09
-Nodes (32): getDefaultTtsDaemonConfig(), getGlobalConfigPath(), mergeTtsConfig(), mergeTtsDaemonConfigs(), startTtsDaemonFromDashboard(), StoredEvent, ActivityTtsPayload, drainQueue() (+24 more)
+Cohesion: 0.07
+Nodes (29): applyTierAwareFallback(), detectEnabledProviders(), ENRICHMENT_TIER_MAX_MESSAGES, FALLBACK_MAP, filterAvailableModels(), getAvailableModels(), getBestAnthropicAtTier(), getFallbackModel() (+21 more)
 
 ### Community 140 - "Community 140"
 Cohesion: 0.07
-Nodes (27): createClaudeCodeRuntime(), getGlobalRegistry(), getRuntime(), getRuntimeForAgent(), RuntimeRegistry, setGlobalRegistry(), createPiRuntime(), PiSpawnTimeout (+19 more)
+Nodes (30): execAsync, gatherArtifacts(), generateBasicInference(), generateMonitoringPrompt(), InferenceDocument, MonitoringAgentConfig, MonitoringAgentError, readInferenceDocument() (+22 more)
 
 ### Community 141 - "Community 141"
-Cohesion: 0.1
-Nodes (37): appendToRunLog(), checkLogSizeLimit(), cleanupAllLogs(), cleanupOldLogs(), createRunLog(), ensureRunsDirectory(), finalizeRunLog(), generateRunId() (+29 more)
+Cohesion: 0.06
+Nodes (33): ensureDefaultConversationModel(), fetchSettings(), isIssueTtsMuted(), normalizeIssueId(), putSettings(), setIssueTtsMuted(), fetchMock, muted (+25 more)
 
 ### Community 142 - "Community 142"
-Cohesion: 0.07
-Nodes (30): markEnrichmentFailed(), buildConversationExcerpt(), buildL1Prompt(), buildL2Prompt(), buildL3Prompt(), callClaudeApi(), callClaudeApiWithConfig(), EnrichmentApiConfig (+22 more)
+Cohesion: 0.06
+Nodes (37): SearchFilters, SearchResult, useSearch(), UseSearchOptions, fetchIssues(), SearchModal(), SearchModalProps, mockPrefetchQuery (+29 more)
 
 ### Community 143 - "Community 143"
 Cohesion: 0.05
-Nodes (38): 1. Read Enforcer (`PreToolUse` on `Read`), 2. Post-Edit Notify (`PostToolUse` on `Edit|Write`), 3. MCP Server, Architecture, Build Triggers, CLI Commands, code:block1 (PROJECT ROOT (main branch)), code:block2 (┌─────────────────────────┐) (+30 more)
+Nodes (32): AC_STATUS_ICONS, BeadsResponse, BeadsTasksPanel(), BeadsTasksPanelProps, BeadTask, PlanItemDetailProps, AC_STATUS_COLORS, AC_STATUS_SYMBOL (+24 more)
 
 ### Community 144 - "Community 144"
 Cohesion: 0.05
-Nodes (38): Before Production, code:typescript (cache.lastEventLine += events.length;), code:block2 (events.jsonl has lines 0-104 (105 total lines)), code:javascript (const agentId = process.env.PANOPTICON_AGENT_ID ||), code:typescript (const content = events.map(e => JSON.stringify(e)).join('\n'), code:typescript (const content = events.length > 0), code:block6 (Process A writes: {"ts":"2026...), Critical Bugs Found in PAN-81 Implementation (+30 more)
+Nodes (41): Agentic, All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, Coding, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer` (+33 more)
 
 ### Community 145 - "Community 145"
 Cohesion: 0.05
-Nodes (38): 10. JSONL Session File Format & Access, #10 — JSONL Session File Format & Access, 11. Specialist Event File Protocol, #11 — Specialist Event File Protocol, 12. Heartbeat File Deprecation Plan, #12 — Heartbeat File Deprecation Plan, 13. Backwards Compatibility During Migration, #13 — Backwards Compatibility During Migration (+30 more)
+Nodes (41): 1. Run Diagnostics, 2. Check Configuration, 3. Check Running Services, 4. Check Skills, 5. Check Dependencies, Agents, Clean Up Old Workspaces, code:bash (pan doctor) (+33 more)
 
 ### Community 146 - "Community 146"
-Cohesion: 0.05
-Nodes (38): Agentic, All subagents (`explore`, `plan`, `bash`, `general-purpose`), Benchmark Credibility Note, `cli:interactive` and `cli:quick-command`, Coding, Composite, `convoy:correctness-reviewer`, `convoy:performance-reviewer` (+30 more)
+Cohesion: 0.08
+Nodes (38): EnqueueStatusRollup, findExistingPendingTurn(), inFlightRollups, loadThreshold(), maybeTriggerStatusRollup(), pendingTurnRangeKey(), readPendingTurns(), safeFileSegment() (+30 more)
 
 ### Community 147 - "Community 147"
-Cohesion: 0.05
-Nodes (38): code:block1 ([completed] Implement login endpoint), code:bash (bd update oauth-5 --notes "COMPLETED: Token refresh endpoint), code:bash (bd create "Q4 strategic planning document" -t task -p 0), code:bash (bd update strat-1 --notes "COMPLETED: Research phase (review), code:block13 (- [ ] Draft recommendation 1: Market expansion), code:bash (bd create "Refactor auth system to use JWT" -t epic -p 0), code:block15 (Current: login-1), code:bash (bd close login-1 --reason "Updated to JWT. Tests passing. Ba) (+30 more)
+Cohesion: 0.06
+Nodes (35): ActivityEntry, ActivityItem(), ActivityPanel(), ActivityPanelProps, ActivityStream, applyPinWarnings(), CategoryFilter, fetchActivityREST() (+27 more)
 
 ### Community 148 - "Community 148"
-Cohesion: 0.07
-Nodes (27): estimateCost(), getModelCapability(), MODEL_CAPABILITIES, ModelCapability, SkillDimension, calculateSkillScore(), formatSelectionResults(), getSimpleModelMapping() (+19 more)
+Cohesion: 0.08
+Nodes (36): doCommit(), flushAutoCommits(), flushInner(), flushPromise(), FlushResult, GitResult, pending, queueAutoCommit() (+28 more)
 
 ### Community 149 - "Community 149"
-Cohesion: 0.11
-Nodes (30): refreshCommand(), refreshFromLinear(), RefreshOptions, shadowCommand(), CanonicalState, createShadowState(), ensureShadowStateDir(), getDisplayStatus() (+22 more)
+Cohesion: 0.07
+Nodes (32): markEnrichmentFailed(), buildConversationExcerpt(), buildL1Prompt(), buildL2Prompt(), buildL3Prompt(), callClaudeApi(), callClaudeApiWithConfig(), EnrichmentApiConfig (+24 more)
 
 ### Community 150 - "Community 150"
-Cohesion: 0.09
-Nodes (34): getFlywheelRunPayload(), getFlywheelRunsPayload(), decodeFlywheelRunId, decodeFlywheelStatus, decodeLaunchMetadata(), deriveRunStatus(), fileExists(), FlywheelCurrentStatusOptions (+26 more)
+Cohesion: 0.05
+Nodes (40): Automatic Setup (Recommended), Certificate Errors in Browser, code:bash (pan install), code:bash (# Install dnsmasq), code:bash (# Install dnsmasq), code:bash (cat /etc/hosts | grep pan.localhost), code:bash (# macOS), code:bash (curl -k https://pan.localhost) (+32 more)
 
 ### Community 151 - "Community 151"
-Cohesion: 0.13
-Nodes (33): assertSafeAgentId(), captureCheckpoint(), checkpointRef(), deleteAllCheckpoints(), deleteCheckpoint(), deleteLegacyCheckpointRefs(), diffAgainstMain(), diffAgainstMainFiles() (+25 more)
+Cohesion: 0.05
+Nodes (40): 10. References, 1. Problem, 2. Goal, 3. Non-Goals, 4.1 Information Architecture, 4.2 Five Surfaces (canonical mockups), 4.3 Shared Primitives, 4.4 Verb Badges (+32 more)
 
 ### Community 152 - "Community 152"
 Cohesion: 0.05
-Nodes (37): 1. ChatMarkdown, 2. MessagesTimeline, 3. JSONL Parser (server-side), 4. ComposerPromptEditor, 5. ModelPicker, 6. EffortPicker, 7. SendButton + Message Submission, 8. ConversationPanel (wrapper) (+29 more)
+Nodes (40): 1. Copy Template Files, 2. Create Environment File, 3. Start Containers, 4. Verify, Add a Service, Add Environment Variables, Available Templates, By Database Needs (+32 more)
 
 ### Community 153 - "Community 153"
-Cohesion: 0.05
-Nodes (36): 1. CommentMediator Service, 2. Author Filtering, 3. Content Classifier, 4. Summarizer, 5. Retrofit `getTrackerContext()`, 6. Quarantine Storage & Dashboard, 7. Gated Full-Text Tool, 8. Configuration (+28 more)
+Cohesion: 0.07
+Nodes (30): migrateConfigCommand(), MigrateConfigOptions, BACKUP_SETTINGS_PATH, convertToYamlConfig(), detectEnabledProviders(), getMigrationStatus(), hasLegacySettings(), LEGACY_SETTINGS_PATH (+22 more)
 
 ### Community 154 - "Community 154"
-Cohesion: 0.05
-Nodes (37): Audit Completeness, Category: Agent Lifecycle, Category: Delivery Confirmation, Category: Git Pattern Scanning (Merge Agent), Category: Health Checks (No Pattern Scanning), Category: Health & Stuck Detection (Deacon), Category: Model & Metadata Extraction, Category: Readiness Detection (+29 more)
+Cohesion: 0.09
+Nodes (33): getHealthThresholdsMs(), AgentHealth, evaluateHealthState(), formatDuration(), generateHealthSummary(), getAgentHealth(), getAgentsNeedingAttention(), getAgentsToKill() (+25 more)
 
 ### Community 155 - "Community 155"
-Cohesion: 0.05
-Nodes (37): 1. Triggered After Test Pass, 2. UAT Specialist Receives Context, 3. UAT Specialist Runs Verification, 4. UAT Specialist Reports, Auth Flow, code:block1 (Agent → Inspect (per-bead) → Review (full MR) → Test (suite)), code:typescript (// After test passes, queue UAT), code:block11 (Agent finishes bead → Inspect (bead diff)    → PASS → next b) (+29 more)
+Cohesion: 0.07
+Nodes (26): appendCostEvent(), CostEvent, deduplicateEvents(), ensureEventsFile(), EventMetadata, getCostsDir(), getEventsFile(), ReadEventsOptions (+18 more)
 
 ### Community 156 - "Community 156"
-Cohesion: 0.05
-Nodes (37): Advanced Features, bd vs TodoWrite, Beads - Persistent Task Memory for AI Agents, CLI Reference, Close & Reopen, code:bash (# Link beads issue to GitHub issue PAN-84), code:bash (bd label add <id> <label> --json), code:bash (bd show <id> --json              # Full issue details) (+29 more)
+Cohesion: 0.08
+Nodes (33): findVendoredDir(), getCavemanHooksDir(), getCavemanSkillsDir(), setupCavemanCompressScripts(), setupCavemanHooks(), CavemanVariant, determineCavemanVariant(), HookEntry (+25 more)
 
 ### Community 157 - "Community 157"
-Cohesion: 0.05
-Nodes (37): Arguments, Auto-Detection (when no wrapper config), code:block1 (1. Check: Does ~/.panopticon/skills/spec-readiness-*/config.), code:block10 (## Bug Analysis), code:block11 (Read spec-readiness-{identifier}.json), code:block12 (spec readiness MIN-704), code:yaml (# ~/.panopticon/skills/spec-readiness-mycompany/config.yaml), code:block3 (get_issue         → mcp__linear__get_issue(id, includeRelati) (+29 more)
+Cohesion: 0.07
+Nodes (33): autoRevertMerge(), DEFAULT_GATES, execAsync, parseValidationOutput(), QualityGateResult, QualityGateRunOptions, runHttpHealthGate(), runMergeValidation() (+25 more)
 
 ### Community 158 - "Community 158"
-Cohesion: 0.09
-Nodes (25): BeadsTask, COMPLEXITY_KEYWORDS, COMPLEXITY_LABELS, ComplexityDetectionResult, ComplexityLevel, complexityToModel(), detectComplexity(), detectComplexityFromEstimate() (+17 more)
+Cohesion: 0.05
+Nodes (39): AC-Driven Specialist Pipeline, Artifact Lifecycle, Automatic Beads Conversion, Can agents produce valid vBRIEF JSON reliably?, code:block1 (PRD (human, markdown)              ← requirements & intent), code:block2 (docs/prds/), code:json ({), code:json ({) (+31 more)
 
 ### Community 159 - "Community 159"
-Cohesion: 0.09
-Nodes (32): addRepoCommand(), AddRepoOptions, convertToSshUrl(), createCommand(), CreateOptions, createRemoteWorkspace(), DestroyOptions, encodeBeadsVersion() (+24 more)
+Cohesion: 0.05
+Nodes (37): 1. record-cost-event.js esbuild bundle broken, 2. Deacon patrolWorkAgentResolutions — getEnabledSpecialists not defined, 3. Issue ID regex missing prefixes, Bugs Found and Fixed (2026-03-20), Build Requirements, code:block1 (~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl), code:block2 (cwd: /home/eltmon/Projects/krux/workspaces/feature-krux-4), code:block5 (Claude Code Agent (tmux session)) (+29 more)
 
 ### Community 160 - "Community 160"
-Cohesion: 0.07
-Nodes (33): registerFlywheelCommands(), getFlywheelConversationPayload(), postFlywheelPausePayload(), postFlywheelResumePayload(), postFlywheelStartPayload(), subscribeLatestFlywheelStatus(), briefPath, completed (+25 more)
+Cohesion: 0.05
+Nodes (39): Acceptance Criteria, API Changes, API Server, Architecture, Beads Tasks, CLI, code:block1 (~/.panopticon/specialists/), code:block2 (~/.panopticon/specialists/) (+31 more)
 
 ### Community 161 - "Community 161"
-Cohesion: 0.11
-Nodes (35): listActiveConversations(), markConversationEnded(), handleConversationImageUpload(), safeUploadExtension(), validateImageMagicBytes(), assertSafeName(), cleanupConversationAttachments(), cleanupOrphanedConversationAttachments() (+27 more)
+Cohesion: 0.05
+Nodes (39): Action Items, Agentic, All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, Coding, Community Reception `[K2.6]`, Confirmed Improvements `[K2.6]`, `convoy:correctness-reviewer` (+31 more)
 
 ### Community 162 - "Community 162"
-Cohesion: 0.11
-Nodes (32): DashboardBundleCandidate, dashboardBundleCandidates(), resolveNode22(), RestartOptions, runFullRestart(), searchedBundlePaths(), spawnDashboardDetached(), uniqueBundleCandidates() (+24 more)
+Cohesion: 0.05
+Nodes (39): 1. Create a `dev` Script, 1. Register the Project, 2. Create CLAUDE.md (Recommended), 2. Create docker-compose.yml, 3. Panopticon Integration, 3. Set Up Tracker Mapping, 4. Verify Setup, Add a Project (+31 more)
 
 ### Community 163 - "Community 163"
 Cohesion: 0.05
-Nodes (36): 1. All-Up Skill, 2. Awaiting Merge Page, 3. Workflow Orchestration Visibility, Acceptance Criteria, Architecture, Awaiting Merge Page Spec, Behavior, Benefits (+28 more)
+Nodes (39): 1. Isolate High-Volume Operations, 2. Parallel Research, 3. Cost Optimization, 4. Security Boundaries, Built-in Subagents, CLI-Defined Subagents, code:markdown (---), code:markdown (---) (+31 more)
 
 ### Community 164 - "Community 164"
-Cohesion: 0.05
-Nodes (35): 1. Identity key and registry shape, 1. Per-project singleton baked in at three places, 2. Inverted model priority — hidden Sonnet default, 2. Model resolution — authoritative chain + resolution trace, 3. PAN-540 convoy reviewers in the registry, 3. PAN-540 convoy reviewers invisible, 4. Duplicate-tab risk on shared worktree, 4. Single-writer-per-worktree enforcement (+27 more)
+Cohesion: 0.07
+Nodes (27): createClaudeCodeRuntime(), getGlobalRegistry(), getRuntime(), getRuntimeForAgent(), RuntimeRegistry, setGlobalRegistry(), createPiRuntime(), PiSpawnTimeout (+19 more)
 
 ### Community 165 - "Community 165"
 Cohesion: 0.05
-Nodes (36): Closure Checklist, Closure Pattern, code:bash ($ bd ready), code:bash (bd list --status in_progress), code:bash (bd show issue-id), code:block12 ("From bd notes: [summary of COMPLETED]. Currently [IN PROGRE), code:block13 (Issue: bd-42 "OAuth refresh token implementation"), code:block14 (- [ ] Implement rate limiting on refresh endpoint) (+28 more)
+Nodes (30): defect, defectQuery, feature, featureQuery, featureWithEmptyState, featureWithObjectState, featureWithPartialState, mockCreate (+22 more)
 
 ### Community 166 - "Community 166"
-Cohesion: 0.05
-Nodes (35): API Commands, code:bash (gh issue list --state open --limit 50), code:bash (gh pr merge 456 --squash --delete-branch), code:bash (gh pr close 456), code:bash (gh pr checkout 456), code:bash (# Get PR comments), code:bash (gh issue list -R eltmon/panopticon-cli), code:bash (gh issue view 123) (+27 more)
+Cohesion: 0.08
+Nodes (24): showHelp(), startCommand(), statusCommand(), stopCommand(), tldrCommand(), TldrOptions, warmCommand(), captureTldrMetrics() (+16 more)
 
 ### Community 167 - "Community 167"
-Cohesion: 0.12
-Nodes (35): buildReleaseNotesMarkdown(), contractsPackageJsonPath, desktopPackageJsonPath, __dirname, ensureCleanTree(), ensureMainBranch(), ensureTagDoesNotExist(), __filename (+27 more)
+Cohesion: 0.05
+Nodes (38): 1. Read Enforcer (`PreToolUse` on `Read`), 2. Post-Edit Notify (`PostToolUse` on `Edit|Write`), 3. MCP Server, Architecture, Build Triggers, CLI Commands, code:block1 (PROJECT ROOT (main branch)), code:block2 (┌─────────────────────────┐) (+30 more)
 
 ### Community 168 - "Community 168"
-Cohesion: 0.06
-Nodes (35): Adding Repos Mid-Work, Agent Skill: `/workspace-add-repo`, Architecture, code:typescript (export interface WorkspaceConfig {), code:block10, code:block11 (## Readonly Repos), code:typescript (// CURRENT: create worktree for every repo), code:typescript (// NEW: respect progressive mode) (+27 more)
+Cohesion: 0.05
+Nodes (38): Before Production, code:typescript (cache.lastEventLine += events.length;), code:block2 (events.jsonl has lines 0-104 (105 total lines)), code:javascript (const agentId = process.env.PANOPTICON_AGENT_ID ||), code:typescript (const content = events.map(e => JSON.stringify(e)).join('\n'), code:typescript (const content = events.length > 0), code:block6 (Process A writes: {"ts":"2026...), Critical Bugs Found in PAN-81 Implementation (+30 more)
 
 ### Community 169 - "Community 169"
-Cohesion: 0.06
-Nodes (35): Bug Tracking During Oversight, code:block1 (/pan-oversee PAN-129), code:bash (# Manually trigger review), code:bash (# Check specialist status), code:bash (# Wake it manually), code:bash (# Check if work agent received feedback), code:bash (# Check test status), code:bash (# Final status check) (+27 more)
+Cohesion: 0.05
+Nodes (38): 10. JSONL Session File Format & Access, #10 — JSONL Session File Format & Access, 11. Specialist Event File Protocol, #11 — Specialist Event File Protocol, 12. Heartbeat File Deprecation Plan, #12 — Heartbeat File Deprecation Plan, 13. Backwards Compatibility During Migration, #13 — Backwards Compatibility During Migration (+30 more)
 
 ### Community 170 - "Community 170"
-Cohesion: 0.1
-Nodes (28): CloseOutContext, CloseOutResult, CloseOutStep, execAsync, executeCloseOut(), findWorkspacePath(), isBranchMerged(), ARCHIVES_DIR (+20 more)
+Cohesion: 0.05
+Nodes (38): Agentic, All subagents (`explore`, `plan`, `bash`, `general-purpose`), Benchmark Credibility Note, `cli:interactive` and `cli:quick-command`, Coding, Composite, `convoy:correctness-reviewer`, `convoy:performance-reviewer` (+30 more)
 
 ### Community 171 - "Community 171"
-Cohesion: 0.09
-Nodes (33): eventsFileExists(), AgentContext, findSessionDirsByIssue(), getAgentsDir(), getClaudeProjectsDir(), getProjectPaths(), getProjectsYamlPath(), getSessionDir() (+25 more)
+Cohesion: 0.05
+Nodes (38): code:block1 ([completed] Implement login endpoint), code:bash (bd update oauth-5 --notes "COMPLETED: Token refresh endpoint), code:bash (bd create "Q4 strategic planning document" -t task -p 0), code:bash (bd update strat-1 --notes "COMPLETED: Research phase (review), code:block13 (- [ ] Draft recommendation 1: Market expansion), code:bash (bd create "Refactor auth system to use JWT" -t epic -p 0), code:block15 (Current: login-1), code:bash (bd close login-1 --reason "Updated to JWT. Tests passing. Ba) (+30 more)
 
 ### Community 172 - "Community 172"
-Cohesion: 0.09
-Nodes (29): appendCostEvent(), CostEvent, deduplicateEvents(), ensureEventsFile(), EventMetadata, getCostsDir(), getEventsFile(), getEventsFilePath() (+21 more)
+Cohesion: 0.08
+Nodes (33): eventsFileExists(), AgentContext, findSessionDirsByIssue(), getAgentsDir(), getClaudeProjectsDir(), getProjectPaths(), getProjectsYamlPath(), getSessionDir() (+25 more)
 
 ### Community 173 - "Community 173"
 Cohesion: 0.07
-Nodes (31): AgentRollup, CavemanExperimentRow, DailyTrend, DbCostRow, DbIssueSummaryRow, getAgentRollup(), getCostForIssueFromDb(), getCostsByIssueFromDb() (+23 more)
+Nodes (23): countCompleteLines(), defaultTranscriptPoller, isSuccessfulExtractionResult(), readTranscriptSlice(), RegisteredTranscript, registerTranscriptForPolling(), startTranscriptPoller(), syncTranscriptPollerRegistry() (+15 more)
 
 ### Community 174 - "Community 174"
-Cohesion: 0.13
-Nodes (29): hookCommand(), HookOptions, generateRecoveryPrompt(), checkHook(), clearHook(), collectMail(), generateFixedPointPrompt(), getHook() (+21 more)
+Cohesion: 0.06
+Nodes (25): ChatMessage, MessagesTimeline, derivePlanningIssueId(), fetchOutput(), TerminalPanel(), TerminalPanelProps, agent, queryClient (+17 more)
 
 ### Community 175 - "Community 175"
 Cohesion: 0.07
-Nodes (29): AgentDetailView(), AgentDetailViewProps, AgentHealthHistory, fetchHealthHistory(), fetchSpecialists(), formatDuration(), formatTokens(), HEALTH_STATE_EMOJI (+21 more)
+Nodes (27): EventRouter(), error, replayPromise, request, snapshot, unsubscribe, createRecoveryCoordinator(), EventClassification (+19 more)
 
 ### Community 176 - "Community 176"
-Cohesion: 0.06
-Nodes (34): Authentication failure, Build and push, Building the pan-workspace Image, code:bash (curl -L https://fly.io/install.sh | sh), code:bash (pan workspace delete PAN-42), code:bash (# Tunnel remote port 4173 to local port 4173), code:bash (pan workspace sync-auth PAN-42), code:bash (# Via the dashboard UI (Costs tab)) (+26 more)
+Cohesion: 0.08
+Nodes (32): after, backupPath, backups, calls, errSpy, exitSpy, original, out (+24 more)
 
 ### Community 177 - "Community 177"
-Cohesion: 0.06
-Nodes (34): 1. Filesystem: `.claude/agents/<name>.md`, 2. CLI JSON: `--agents '{"name":{...}}'`, 3. Hybrid: Filesystem base + CLI `--model` override, Agent Definition Format (Full Spec), Agent Teams: Out of Scope, Architecture: Three Injection Paths, `claude agents` Has No JSON Output, code:yaml (---) (+26 more)
+Cohesion: 0.05
+Nodes (37): 1. ChatMarkdown, 2. MessagesTimeline, 3. JSONL Parser (server-side), 4. ComposerPromptEditor, 5. ModelPicker, 6. EffortPicker, 7. SendButton + Message Submission, 8. ConversationPanel (wrapper) (+29 more)
 
 ### Community 178 - "Community 178"
-Cohesion: 0.06
-Nodes (34): 1. Agent Triggers Inspection (Only When Flagged), 2. Inspect Specialist Runs, 3. Inspect Specialist Reports, 4. Checkpoint System, Agent Workflow Integration, Check 1: Spec Fidelity, Check 2: Constraint Compliance, Check 3: Compile + Smoke (+26 more)
+Cohesion: 0.05
+Nodes (36): 1. CommentMediator Service, 2. Author Filtering, 3. Content Classifier, 4. Summarizer, 5. Retrofit `getTrackerContext()`, 6. Quarantine Storage & Dashboard, 7. Gated Full-Text Tool, 8. Configuration (+28 more)
 
 ### Community 179 - "Community 179"
-Cohesion: 0.06
-Nodes (34): 1. Configuration Ownership, 2. Implementation Scope, 3. API Key Storage, 4. Complexity Routing, Acceptance Criteria Checklist, Agent Spawning Changes, Architecture, code:block1 (~/.panopticon/) (+26 more)
+Cohesion: 0.05
+Nodes (37): Audit Completeness, Category: Agent Lifecycle, Category: Delivery Confirmation, Category: Git Pattern Scanning (Merge Agent), Category: Health Checks (No Pattern Scanning), Category: Health & Stuck Detection (Deacon), Category: Model & Metadata Extraction, Category: Readiness Detection (+29 more)
 
 ### Community 180 - "Community 180"
-Cohesion: 0.06
-Nodes (34): `cli:interactive` and `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit, Gemini 3 Flash Preview Work Type Fit Analysis (+26 more)
+Cohesion: 0.05
+Nodes (37): 1. Triggered After Test Pass, 2. UAT Specialist Receives Context, 3. UAT Specialist Runs Verification, 4. UAT Specialist Reports, Auth Flow, code:block1 (Agent → Inspect (per-bead) → Review (full MR) → Test (suite)), code:typescript (// After test passes, queue UAT), code:block11 (Agent finishes bead → Inspect (bead diff)    → PASS → next b) (+29 more)
 
 ### Community 181 - "Community 181"
-Cohesion: 0.06
-Nodes (34): `cli:interactive`, `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit (+26 more)
+Cohesion: 0.05
+Nodes (37): Advanced Features, bd vs TodoWrite, Beads - Persistent Task Memory for AI Agents, CLI Reference, Close & Reopen, code:bash (# Link beads issue to GitHub issue PAN-84), code:bash (bd label add <id> <label> --json), code:bash (bd show <id> --json              # Full issue details) (+29 more)
 
 ### Community 182 - "Community 182"
-Cohesion: 0.06
-Nodes (34): Agent States, code:bash (# List recent boots — the previous boot (-1) is the crashed ), code:bash (# Check .pan/continue.json for each workspace), code:bash (# Current memory usage), code:markdown (## Crash Summary), code:typescript (pool: 'forks',), code:bash (# All OOM events from the crashed boot), code:bash (# Find the process table dump from the first OOM event) (+26 more)
+Cohesion: 0.05
+Nodes (37): Arguments, Auto-Detection (when no wrapper config), code:block1 (1. Check: Does ~/.panopticon/skills/spec-readiness-*/config.), code:block10 (## Bug Analysis), code:block11 (Read spec-readiness-{identifier}.json), code:block12 (spec readiness MIN-704), code:yaml (# ~/.panopticon/skills/spec-readiness-mycompany/config.yaml), code:block3 (get_issue         → mcp__linear__get_issue(id, includeRelati) (+29 more)
 
 ### Community 183 - "Community 183"
-Cohesion: 0.11
-Nodes (3): stopDeacon(), CloisterService, writeStateFile()
+Cohesion: 0.09
+Nodes (25): BeadsTask, COMPLEXITY_KEYWORDS, COMPLEXITY_LABELS, ComplexityDetectionResult, ComplexityLevel, complexityToModel(), detectComplexity(), detectComplexityFromEstimate() (+17 more)
 
 ### Community 184 - "Community 184"
-Cohesion: 0.12
-Nodes (31): cloneReposOnVm(), collectPanWorkspaceFiles(), convertToSshUrl(), copyPlanningStateFromRemote(), copyPlanningStateToRemote(), copyWorkspacePanStateFromRemote(), copyWorkspacePanStateToRemote(), detectWorkspaceLocation() (+23 more)
+Cohesion: 0.09
+Nodes (35): getIssueDataService(), ActivityContext, awaitingInputFromProjection(), closedIssuesCache, commandDeckRouteLayer, costCache, execAsync, execFileAsync (+27 more)
 
 ### Community 185 - "Community 185"
-Cohesion: 0.07
-Nodes (32): assertExistingPathInsideRoot(), assertWritePathInsideRoot(), BriefRequestBody, decodeFlywheelRunId, decodeFlywheelStatus, FlywheelActionDeps, flywheelRouteLayer, FlywheelStatusResponse (+24 more)
+Cohesion: 0.05
+Nodes (36): 1. All-Up Skill, 2. Awaiting Merge Page, 3. Workflow Orchestration Visibility, Acceptance Criteria, Architecture, Awaiting Merge Page Spec, Behavior, Benefits (+28 more)
 
 ### Community 186 - "Community 186"
-Cohesion: 0.08
-Nodes (32): cleanupOldHealthEvents(), deleteAgentHealthHistory(), getAgentsWithHistory(), getAllHealthHistory(), getHealthHistory(), getLatestHealthEvent(), getRecentHealthHistory(), HealthEvent (+24 more)
+Cohesion: 0.05
+Nodes (35): 1. Identity key and registry shape, 1. Per-project singleton baked in at three places, 2. Inverted model priority — hidden Sonnet default, 2. Model resolution — authoritative chain + resolution trace, 3. PAN-540 convoy reviewers in the registry, 3. PAN-540 convoy reviewers invisible, 4. Duplicate-tab risk on shared worktree, 4. Single-writer-per-worktree enforcement (+27 more)
 
 ### Community 187 - "Community 187"
-Cohesion: 0.1
-Nodes (28): readFeatureContext(), readWorkspaceContext(), writeWorkspaceContext(), ensureWorkspacePanDir(), getWorkspacePanPaths(), readWorkspaceContinue(), readWorkspaceContinueAsync(), uniqueTmpPath() (+20 more)
+Cohesion: 0.05
+Nodes (36): Closure Checklist, Closure Pattern, code:bash ($ bd ready), code:bash (bd list --status in_progress), code:bash (bd show issue-id), code:block12 ("From bd notes: [summary of COMPLETED]. Currently [IN PROGRE), code:block13 (Issue: bd-42 "OAuth refresh token implementation"), code:block14 (- [ ] Implement rate limiting on refresh endpoint) (+28 more)
 
 ### Community 188 - "Community 188"
-Cohesion: 0.09
-Nodes (26): ConversationPanel(), ConversationRow(), ConversationRowProps, PHASE_ICONS, WorkingSpinner(), PersistedState, useConversationUiState(), useNow() (+18 more)
+Cohesion: 0.05
+Nodes (35): API Commands, code:bash (gh issue list --state open --limit 50), code:bash (gh pr merge 456 --squash --delete-branch), code:bash (gh pr close 456), code:bash (gh pr checkout 456), code:bash (# Get PR comments), code:bash (gh issue list -R eltmon/panopticon-cli), code:bash (gh issue view 123) (+27 more)
 
 ### Community 189 - "Community 189"
-Cohesion: 0.07
-Nodes (30): entry, { issueId }, { limit }, old, op, ops, recent, result (+22 more)
-
-### Community 190 - "Community 190"
-Cohesion: 0.09
-Nodes (24): showHelp(), startCommand(), statusCommand(), stopCommand(), tldrCommand(), TldrOptions, warmCommand(), captureTldrMetrics() (+16 more)
+Cohesion: 0.06
+Nodes (9): FlyApiClient, FlyApiError, FlyExecResult, FlyMachine, FlyMachineConfig, client, fetchMock, machine (+1 more)
 
 ### Community 191 - "Community 191"
-Cohesion: 0.11
-Nodes (31): getCachedDockerContainerLifecycleObservedAt(), getCachedDockerContainerLifecycleSnapshot(), recordDockerContainerLifecycleSnapshot(), resetCachedDockerContainerLifecycleSnapshotForTests(), dockerProject, health, now, projectRoot (+23 more)
+Cohesion: 0.09
+Nodes (31): createDatabase(), databases, deferSqliteWork(), getMemoryFtsDatabase(), getMemoryFtsWorker(), initializeMemoryFtsSchema(), isBunRuntime(), MemoryFtsStatement (+23 more)
 
 ### Community 192 - "Community 192"
-Cohesion: 0.1
-Nodes (30): buildLeakedSpecialists(), buildTopConsumers(), bytesToGb(), collectAgentProcesses(), CpuSample, DEFAULT_RESOURCE_CONFIG, defaultThresholds(), ensureResourceConfigLoaded() (+22 more)
+Cohesion: 0.09
+Nodes (30): ActionKey, ActionLayout, derivePipelineState(), flattenActions(), getZoneAActions(), getZoneBActions(), normalizeCanonicalState(), PipelineState (+22 more)
 
 ### Community 193 - "Community 193"
-Cohesion: 0.06
-Nodes (33): 1. Upgrade CanonicalState to 9-State vBRIEF Lifecycle, 2. vBRIEF Lifecycle Folders, 3. `pan install` Bootstraps Deft, 4. Layered Rule Hierarchy for Agent Prompts, 5. Deterministic Gates in Cloister Pipeline, 6. Structured Planning Strategies, 7. Swarm Integration, 8. Issue Ingestion and Reconciliation (+25 more)
+Cohesion: 0.07
+Nodes (33): cleanupOldHealthEvents(), DatabaseError, deleteAgentHealthHistory(), getAgentsWithHistory(), getAllHealthHistory(), getHealthHistory(), getLatestHealthEvent(), getRecentHealthHistory() (+25 more)
 
 ### Community 194 - "Community 194"
-Cohesion: 0.06
-Nodes (31): `AgentStateService` — the single interface, Architectural principle, Backpressure, code:block1 (writers                          canonical state            ), code:typescript (// in AgentSnapshot Schema.Struct, add:), code:typescript (export const AgentActivityChanged = Schema.Struct({), code:typescript (export const AgentStateRestored = Schema.Struct({), code:typescript (// inside applyEvent switch, representative case:) (+23 more)
+Cohesion: 0.1
+Nodes (28): acquireRestartLock(), acquireStaleBreaker(), isErrnoException(), isProcessAlive(), isStale(), readHolderFromPath(), readRestartLockHolder(), RestartLockError (+20 more)
 
 ### Community 195 - "Community 195"
 Cohesion: 0.06
-Nodes (33): 10. Preserve power-user trust, 1. Replace the current page shell with a coherent settings shell, 2. Introduce reusable settings primitives, 3. Reorganize the settings information architecture, 4. Add explicit local settings navigation, 5. Redesign Providers into summary-first expandable management panels, 6. Redesign Model Routing around presets + overrides, not a wall of tiles, 7. Normalize Conversations, Terminal, Tracker Keys, Appearance, Maintenance, and Desktop sections into the shared system (+25 more)
+Nodes (35): Activity, AgentChannelReply, AgentId, AgentResolution, AgentStatus, CHANNEL_REPLY_KIND_VALUES, ChannelReplyArtifactRef, ChannelReplyKind (+27 more)
 
 ### Community 196 - "Community 196"
 Cohesion: 0.06
-Nodes (32): 1. mem0 Overview, 2. Architecture, 3. Key Technical Details, 4. Managed Platform vs Open Source, 5. Performance Claims, 6. Panopticon Adoption Analysis, 7. References, AI Memory Layer Research: mem0 and Adoption Strategy for Panopticon (+24 more)
+Nodes (35): Adding Repos Mid-Work, Agent Skill: `/workspace-add-repo`, Architecture, code:typescript (export interface WorkspaceConfig {), code:block10, code:block11 (## Readonly Repos), code:typescript (// CURRENT: create worktree for every repo), code:typescript (// NEW: respect progressive mode) (+27 more)
 
 ### Community 197 - "Community 197"
 Cohesion: 0.06
-Nodes (33): 1. Public bootstrap/health/config endpoints, 2. Inspect the deployed frontend bundle, 3. SSH and inspect runtime directly, code:bash (pan remote setup), code:bash (fly auth whoami), code:bash (pan remote status), code:bash (fly proxy 4173:4173 -a <app>), code:bash (fly status -a <app>) (+25 more)
+Nodes (35): Bug Tracking During Oversight, code:block1 (/pan-oversee PAN-129), code:bash (# Manually trigger review), code:bash (# Check specialist status), code:bash (# Wake it manually), code:bash (# Check if work agent received feedback), code:bash (# Check test status), code:bash (# Final status check) (+27 more)
 
 ### Community 198 - "Community 198"
-Cohesion: 0.06
-Nodes (33): 1. Find the Agent Session, 2. Check Current Agent Status, 3. Send Your Message, 4. Verify Message Was Received, Change Priorities, code:bash (# ALWAYS use pan tell - it handles Enter correctly), code:bash (pan tell ISSUE-123 "Looks good! Please commit your changes a), code:bash (# List all sessions to find the correct name) (+25 more)
+Cohesion: 0.07
+Nodes (31): decodeFlywheelStatus, postFlywheelStatusPayload(), subscribeLatestFlywheelStatus(), writeLatestFlywheelStatus(), abort, aborted, briefPath, completed (+23 more)
 
 ### Community 199 - "Community 199"
-Cohesion: 0.06
-Nodes (33): Backend Frameworks, code:yaml (projects:), code:bash (# Rebuild one workspace Docker stack from the configured com), code:bash (# Create workspace (uses configuration from projects.yaml)), code:yaml (services:), code:yaml (projects:), code:yaml (projects:), code:yaml (projects:) (+25 more)
+Cohesion: 0.11
+Nodes (32): sshCommand(), CHUNK_BUDGET_CHARS_BY_MODEL, chunkEntriesByBudget(), CompactionOptions, CompactionResult, computeFileLists(), createFileOps(), CutPointResult (+24 more)
 
 ### Community 200 - "Community 200"
-Cohesion: 0.06
-Nodes (33): code:block1 (myproject/), code:block10 (your-project/), code:yaml (# ~/.panopticon/projects.yaml), code:yaml (# WRONG - causes Maven startup failure), code:yaml (projects:), code:yaml (projects:), code:yaml (services:), code:block4 (your-project/) (+25 more)
+Cohesion: 0.13
+Nodes (34): buildReleaseNotesMarkdown(), contractsPackageJsonPath, desktopPackageJsonPath, __dirname, ensureCleanTree(), ensureMainBranch(), ensureTagDoesNotExist(), __filename (+26 more)
 
 ### Community 201 - "Community 201"
-Cohesion: 0.06
-Nodes (33): Agent Self-Requeue (Circuit Breaker), Automatic Handoffs, Cloister: AI Lifecycle Manager, code:block1 (┌───────────────────────────────────────────────────────────), code:json ({), code:javascript ({), code:json ({), code:bash (# Via dashboard - click "Start" in the Cloister status bar) (+25 more)
+Cohesion: 0.09
+Nodes (31): activeViolations, checkAgentForViolations(), clearOldViolations(), clearOldViolationsEffect(), DEFAULT_FPP_CONFIG, FPPViolation, FPPViolationConfig, FPPViolationType (+23 more)
 
 ### Community 202 - "Community 202"
-Cohesion: 0.12
-Nodes (32): sshCommand(), CHUNK_BUDGET_CHARS_BY_MODEL, chunkEntriesByBudget(), CompactionOptions, CompactionResult, computeFileLists(), createFileOps(), CutPointResult (+24 more)
+Cohesion: 0.07
+Nodes (29): AgentDetailView(), AgentDetailViewProps, AgentHealthHistory, fetchHealthHistory(), fetchSpecialists(), formatDuration(), formatTokens(), HEALTH_STATE_EMOJI (+21 more)
 
 ### Community 203 - "Community 203"
 Cohesion: 0.07
-Nodes (24): isAgentStateServiceInProcess(), markAgentStateServiceInProcess(), mirror, setAgentRuntimeMirror(), saveSessionId(), agentId, dir, lifecycle (+16 more)
+Nodes (22): ActivitySection, formatModel(), IsolationMode(), IsolationModeProps, TYPE_STYLES, ALLOWED_CSS_PROPERTIES, ALLOWED_SHIKI_ATTRS, ALLOWED_SHIKI_TAGS (+14 more)
 
 ### Community 204 - "Community 204"
-Cohesion: 0.08
-Nodes (23): SearchResult, sessionFilePath(), buildContinuation(), convertConversationTranscript(), ConvertOptions, ConvertResult, extractClaudeTranscript(), extractContentText() (+15 more)
+Cohesion: 0.06
+Nodes (32): cb, completedState, dispatched, featureWorkspace, ghArgs, ghExecFileMock, { handler, dispose }, implSlot (+24 more)
 
 ### Community 205 - "Community 205"
-Cohesion: 0.09
-Nodes (26): clearFeedbackFiles(), getNextSequenceNumber(), resolveWorkspacePath(), writeFeedbackFile(), WriteFeedbackOptions, WriteFeedbackResult, formatFeedbackForAgent(), sendFeedbackToAgent() (+18 more)
+Cohesion: 0.1
+Nodes (28): isNoResumeValueEnabled(), NO_RESUME_MODE_ACTIVE, TRUTHY_NO_RESUME_VALUES, formatGatingReason(), formatRestartAge(), formatRestartDuration(), formatTldrAge(), formatTldrRow() (+20 more)
 
 ### Community 206 - "Community 206"
-Cohesion: 0.12
-Nodes (27): acquireRestartLock(), acquireStaleBreaker(), isErrnoException(), isProcessAlive(), isStale(), readHolderFromPath(), readRestartLockHolder(), RestartLockHandle (+19 more)
+Cohesion: 0.06
+Nodes (34): Authentication failure, Build and push, Building the pan-workspace Image, code:bash (curl -L https://fly.io/install.sh | sh), code:bash (pan workspace delete PAN-42), code:bash (# Tunnel remote port 4173 to local port 4173), code:bash (pan workspace sync-auth PAN-42), code:bash (# Via the dashboard UI (Costs tab)) (+26 more)
 
 ### Community 207 - "Community 207"
-Cohesion: 0.08
-Nodes (22): FetchFn, InternalState, LogFn, parsePositiveIntEnv(), readWatchdogConfig(), readWatchdogPersistentState(), SpawnRestart, SpawnRestartResult (+14 more)
+Cohesion: 0.06
+Nodes (34): 1. Filesystem: `.claude/agents/<name>.md`, 2. CLI JSON: `--agents '{"name":{...}}'`, 3. Hybrid: Filesystem base + CLI `--model` override, Agent Definition Format (Full Spec), Agent Teams: Out of Scope, Architecture: Three Injection Paths, `claude agents` Has No JSON Output, code:yaml (---) (+26 more)
 
 ### Community 208 - "Community 208"
-Cohesion: 0.11
-Nodes (28): drainPendingEvents(), envFor(), getDashboardUrl(), handlePanDone(), handleSessionStart(), handleToolExecutionEnd(), handleTurnEnd(), HookEnv (+20 more)
+Cohesion: 0.06
+Nodes (34): 1. Agent Triggers Inspection (Only When Flagged), 2. Inspect Specialist Runs, 3. Inspect Specialist Reports, 4. Checkpoint System, Agent Workflow Integration, Check 1: Spec Fidelity, Check 2: Constraint Compliance, Check 3: Compile + Smoke (+26 more)
 
 ### Community 209 - "Community 209"
 Cohesion: 0.06
-Nodes (32): 1. Installation Test, 2. DNS Setup Test, 3. Startup Test (pan up), 4. Port-based Fallback Test, 5. Traefik Routing Test, 6. Shutdown Test (pan down), 7. Minimal Mode Test, Automated Test Script (+24 more)
+Nodes (34): 1. Configuration Ownership, 2. Implementation Scope, 3. API Key Storage, 4. Complexity Routing, Acceptance Criteria Checklist, Agent Spawning Changes, Architecture, code:block1 (~/.panopticon/) (+26 more)
 
 ### Community 210 - "Community 210"
 Cohesion: 0.06
-Nodes (32): 1.1 vBRIEF (Adopted), 1.2 Deft, 1.3 Superpowers, 1.4 Spec Kit (GitHub), 1.5 Taskmaster (eyaltoledano/claude-task-master), 1.6 OpenAI Agents SDK ("Agent OS" candidate), 1.7 Not Found / Need Clarification, 1. The Frameworks (+24 more)
+Nodes (34): `cli:interactive` and `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit, Gemini 3 Flash Preview Work Type Fit Analysis (+26 more)
 
 ### Community 211 - "Community 211"
 Cohesion: 0.06
-Nodes (31): 1. FizzyApiClient (`src/lib/tracker/fizzy-client.ts`), 2. FizzyCardMapping (SQLite), 3. FizzySyncService (`src/lib/fizzy/sync-service.ts`), 4. FizzyWebhookReceiver (`src/dashboard/server/routes/fizzy-webhooks.ts`), 5. FizzyColumnResolver (`src/lib/fizzy/column-resolver.ts`), Architecture, code:block1 (GitHub Issues (source of truth)), code:yaml (fizzy:) (+23 more)
+Nodes (34): `cli:interactive`, `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit (+26 more)
 
 ### Community 212 - "Community 212"
 Cohesion: 0.06
-Nodes (32): Automated Synthesis, Best Practices, Code Conflicts, code:bash (# Get convoy status and results), code:typescript (// Agent 1 added field:), code:bash (# Generate synthesis prompt), code:bash (# Convoy management), code:bash (# Check each workspace for changes) (+24 more)
+Nodes (34): Agent States, code:bash (# List recent boots — the previous boot (-1) is the crashed ), code:bash (# Check .pan/continue.json for each workspace), code:bash (# Current memory usage), code:markdown (## Crash Summary), code:typescript (pool: 'forks',), code:bash (# All OOM events from the crashed boot), code:bash (# Find the process table dump from the first OOM event) (+26 more)
 
 ### Community 213 - "Community 213"
-Cohesion: 0.06
-Nodes (32): code:bash (pan setup), code:yaml (# template.yaml), code:block11 (team-meta/), code:bash (# Setup Agent prompt includes:), code:block2 ($ pan setup), code:block3 (Step 2: Project Type Detection), code:block4 (Step 3: Template Selection), code:block5 (Step 4: Repository Configuration) (+24 more)
+Cohesion: 0.09
+Nodes (26): computeRestartDelay(), getSmeeBinaryPath(), getSmeeUrl(), getWebhookTarget(), isProcessAlive(), isSmeeProcessRunning(), errorSpy, killSpy (+18 more)
 
 ### Community 214 - "Community 214"
 Cohesion: 0.1
-Nodes (28): activeViolations, checkAgentForViolations(), clearOldViolations(), DEFAULT_FPP_CONFIG, FPPViolation, FPPViolationConfig, FPPViolationType, getActiveViolations() (+20 more)
+Nodes (31): doneCommand(), DoneOptions, execAsync, getGitHubConfig(), isMergeSetMergedIntoTargets(), updateGitHubToInReview(), updateLinearToInReview(), AutoCreateStateConfig (+23 more)
 
 ### Community 215 - "Community 215"
 Cohesion: 0.07
-Nodes (30): defect, defectQuery, feature, featureQuery, featureWithEmptyState, featureWithObjectState, featureWithPartialState, mockCreate (+22 more)
+Nodes (28): getAvailableModelsRoute, getClaudeAuthRoute, getHarnessPolicyRoute, getMiniMaxDefaultsRoute, getOpenAIAuthRoute, getOpenRouterModelsRoute, getOptimalDefaultsRoute, getProviderEnvConflictsRoute (+20 more)
 
 ### Community 216 - "Community 216"
 Cohesion: 0.09
-Nodes (28): execAsync, gatherArtifacts(), generateBasicInference(), generateMonitoringPrompt(), InferenceDocument, MonitoringAgentConfig, readInferenceDocument(), updateInferenceDocument() (+20 more)
+Nodes (23): execAsync, rebaseFeatureBranch(), RebaseResult, openBrowser(), runCommand(), ClaudeAuthStatus, getClaudeAuthStatusImpl, parseOAuthPayload() (+15 more)
 
 ### Community 217 - "Community 217"
-Cohesion: 0.08
-Nodes (28): CategoryFilter, formatContextLength(), formatCost(), ModelCard(), OpenRouterModel, OpenRouterModelBrowser(), OpenRouterModelBrowserProps, fetchOpenRouterModels() (+20 more)
+Cohesion: 0.07
+Nodes (23): SearchResult, RuntimeConversationsConfig, ReadModelServiceShape, AgentIssueLookup, AgentIssueRecord, buildAgentIssueLookup(), buildEnrichSessionsJobPayload(), EnrichSessionsRpcInput (+15 more)
 
 ### Community 218 - "Community 218"
-Cohesion: 0.06
-Nodes (30): 1. JWT Expiry (Primary), 2. CLIProxy Log Tailing (Secondary), Automatic Retry, Bridging to CLIProxy, code:block1 (~/.panopticon/cliproxy/auth/codex-primary.json), code:bash (curl http://localhost:3000/api/settings/codex-auth), code:bash (pan config get issue-agent:implementation), code:block2 (~/.codex/) (+22 more)
+Cohesion: 0.13
+Nodes (5): findProjectsByRallyProject(), IssueDataService, issuesChanged(), mapRallyStateToCanonical(), validateRallyConfig()
 
 ### Community 219 - "Community 219"
 Cohesion: 0.06
-Nodes (31): All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Critical Issue: Tool Behavior Bug (+23 more)
+Nodes (33): 1. Upgrade CanonicalState to 9-State vBRIEF Lifecycle, 2. vBRIEF Lifecycle Folders, 3. `pan install` Bootstraps Deft, 4. Layered Rule Hierarchy for Agent Prompts, 5. Deterministic Gates in Cloister Pipeline, 6. Structured Planning Strategies, 7. Swarm Integration, 8. Issue Ingestion and Reconciliation (+25 more)
 
 ### Community 220 - "Community 220"
 Cohesion: 0.06
-Nodes (31): All subagents (except general-purpose), Claude Sonnet 4.6 Work Type Fit Analysis, `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent` (+23 more)
+Nodes (31): `AgentStateService` — the single interface, Architectural principle, Backpressure, code:block1 (writers                          canonical state            ), code:typescript (// in AgentSnapshot Schema.Struct, add:), code:typescript (export const AgentActivityChanged = Schema.Struct({), code:typescript (export const AgentStateRestored = Schema.Struct({), code:typescript (// inside applyEvent switch, representative case:) (+23 more)
 
 ### Community 221 - "Community 221"
 Cohesion: 0.06
-Nodes (31): 1. Be Specific, 2. Explain Why, 3. Order Steps Logically, 4. Consider Edge Cases, 5. Be Realistic, code:typescript (// Find authentication code), code:typescript (AskUserQuestion({), code:markdown (# [ISSUE-ID]: [Issue Title]) (+23 more)
+Nodes (33): 10. Preserve power-user trust, 1. Replace the current page shell with a coherent settings shell, 2. Introduce reusable settings primitives, 3. Reorganize the settings information architecture, 4. Add explicit local settings navigation, 5. Redesign Providers into summary-first expandable management panels, 6. Redesign Model Routing around presets + overrides, not a wall of tiles, 7. Normalize Conversations, Terminal, Tracker Keys, Appearance, Maintenance, and Desktop sections into the shared system (+25 more)
 
 ### Community 222 - "Community 222"
 Cohesion: 0.06
-Nodes (31): Available Commands, Available Skills, Code Review, code:bash (# 1. Initialize Panopticon), code:bash (# 1. Optionally create a plan first), code:bash (# List all workspaces), Configuration, Configuration Files (+23 more)
+Nodes (32): 1. mem0 Overview, 2. Architecture, 3. Key Technical Details, 4. Managed Platform vs Open Source, 5. Performance Claims, 6. Panopticon Adoption Analysis, 7. References, AI Memory Layer Research: mem0 and Adoption Strategy for Panopticon (+24 more)
 
 ### Community 223 - "Community 223"
 Cohesion: 0.06
-Nodes (31): Best Practices, Built-in Convoy Templates, code-review Template, code:bash (# Run a parallel code review), code:block10 (1. Start command received), code:bash (# Watch convoy progress), code:bash (# Check individual agent status), code:block2 (pan convoy start code-review --files "src/**/*.ts") (+23 more)
+Nodes (33): 1. Public bootstrap/health/config endpoints, 2. Inspect the deployed frontend bundle, 3. SSH and inspect runtime directly, code:bash (pan remote setup), code:bash (fly auth whoami), code:bash (pan remote status), code:bash (fly proxy 4173:4173 -a <app>), code:bash (fly status -a <app>) (+25 more)
 
 ### Community 224 - "Community 224"
 Cohesion: 0.06
-Nodes (31): Available TLDR Tools, Beads Tasks, code:block1 (1. Agent needs to understand auth.ts), code:bash (node -e "const fs=require('fs'); const p='.pan/spec.vbrief.j), code:bash (git fetch origin main && git rebase origin/main), code:bash (pan done {{ISSUE_ID}} -c "Work already complete from previou), code:json ({), code:bash (npm test                                         # Run tests) (+23 more)
+Nodes (33): 1. Find the Agent Session, 2. Check Current Agent Status, 3. Send Your Message, 4. Verify Message Was Received, Change Priorities, code:bash (# ALWAYS use pan tell - it handles Enter correctly), code:bash (pan tell ISSUE-123 "Looks good! Please commit your changes a), code:bash (# List all sessions to find the correct name) (+25 more)
 
 ### Community 225 - "Community 225"
-Cohesion: 0.15
-Nodes (28): createCostCommand(), formatIssueCostAggregate(), aggregate, output, IssueAggregate, BUDGETS_FILE, checkBudget(), CostBudget (+20 more)
+Cohesion: 0.06
+Nodes (33): Backend Frameworks, code:yaml (projects:), code:bash (# Rebuild one workspace Docker stack from the configured com), code:bash (# Create workspace (uses configuration from projects.yaml)), code:yaml (services:), code:yaml (projects:), code:yaml (projects:), code:yaml (projects:) (+25 more)
 
 ### Community 226 - "Community 226"
-Cohesion: 0.14
-Nodes (3): execAsync, FlyProvider, mapFlyStateToVmStatus()
+Cohesion: 0.06
+Nodes (33): code:block1 (myproject/), code:block10 (your-project/), code:yaml (# ~/.panopticon/projects.yaml), code:yaml (# WRONG - causes Maven startup failure), code:yaml (projects:), code:yaml (projects:), code:yaml (services:), code:block4 (your-project/) (+25 more)
 
 ### Community 227 - "Community 227"
-Cohesion: 0.14
-Nodes (30): reconcileClosedPrReadyForMerge(), reconcileFalseMerged(), APP_DIR, configureWorkspaceForBot(), execAsync, generateInstallationToken(), generateJWT(), getAppStatus() (+22 more)
+Cohesion: 0.06
+Nodes (33): Agent Self-Requeue (Circuit Breaker), Automatic Handoffs, Cloister: AI Lifecycle Manager, code:block1 (┌───────────────────────────────────────────────────────────), code:json ({), code:javascript ({), code:json ({), code:bash (# Via dashboard - click "Start" in the Cloister status bar) (+25 more)
 
 ### Community 228 - "Community 228"
-Cohesion: 0.1
-Nodes (28): AlsoSyncTool, collectSkillDirs(), extractSkillName(), MultiToolSyncResult, readSkillContent(), resolveAlsoSyncTools(), runMultiToolSync(), stripFrontmatter() (+20 more)
+Cohesion: 0.09
+Nodes (20): DbMergeSetRepoRow, DbMergeSetRow, deleteMergeSet(), getAllMergeSetsFromDb(), getMergeSetFromDb(), getReposFromDb(), rowToMergeSet(), repos (+12 more)
 
 ### Community 229 - "Community 229"
-Cohesion: 0.06
-Nodes (31): code:yaml (# Your original docker-compose.yml), code:bash (pan workspace create my-feature --template node-fullstack), code:block102 (~/.panopticon/templates/), code:toml ([template]), code:block109 (~/.panopticon/), code:yaml (# ~/.panopticon/traefik/dynamic/feature-min-648.yml), code:toml ([panopticon]), code:toml ([project]) (+23 more)
+Cohesion: 0.16
+Nodes (32): extractNumber(), extractPrefix(), applyLabelGitHubImpl(), applyLabelLinearImpl(), closeGitHubDirectImpl(), closeGitHubPrImpl(), closeLinearDirectImpl(), closeRallyDirectImpl() (+24 more)
 
 ### Community 230 - "Community 230"
-Cohesion: 0.06
-Nodes (30): 2026-04-12 — Run 1, 2026-04-12 — Run 2, 2026-04-12 — Run 3, 2026-04-13 — Run 4, 2026-04-13 — Run 8, 2026-04-14 — Run 9, Bug Log Template, code:block1 (### BUG: [Short description]) (+22 more)
+Cohesion: 0.07
+Nodes (25): DeaconLogEntry, DeaconStatus(), DeaconStatusData, fetchDeaconLogs(), fetchDeaconStatus(), LOG_LEVEL_COLORS, LOG_LEVEL_LABELS, SpecialistHealthState (+17 more)
 
 ### Community 231 - "Community 231"
-Cohesion: 0.06
-Nodes (30): 1. Template File Resolution, 2. Config File Integration, 3. Docker Compose Integration, 4. Certificate Integration, code:bash (pan install), code:bash (node -e "import('./dist/chunk-*.js').then(m => console.log(m), code:bash (ls -la templates/traefik/), code:bash (ls -la ~/.panopticon/traefik/) (+22 more)
+Cohesion: 0.08
+Nodes (23): sentinel, emitReactiveLifecycleEvent(), emitResetMarkerCreated(), emitMemoryHealthChanged(), emitMemoryObservationCreated(), emitStatusUpdatedEvent(), EventRow, EventStore (+15 more)
 
 ### Community 232 - "Community 232"
-Cohesion: 0.06
-Nodes (30): 1. Review Artifact Creation at `pan done`, 1. The work agent owns all code-changing git operations, 2. Merge-Set Data Model, 2. Review artifacts are created at work completion, 3. Merge agent is the coordinator for merge sets, 3. Work-Agent-Owned Rebase Flow, 4. Non-Mutating Post-Rebase Verification, 4. Verification runs twice (+22 more)
+Cohesion: 0.09
+Nodes (27): getReviewerSessionName(), parseReviewerSessionName(), REVIEWER_ROLES, ReviewerRole, result, API_ERROR_PATTERNS, buildReviewerNodes(), BuildReviewerNodesOptions (+19 more)
 
 ### Community 233 - "Community 233"
-Cohesion: 0.06
-Nodes (30): 1. Extend XTerminal Component, 3. Smart Ctrl+C Logic, 4. Context Menu (Embedded in XTerminal), 5. Auto-Copy on Selection, 6. Configuration UI, Breakdown into Sub-Tasks, code:typescript (interface XTerminalProps {), code:typescript (// Pseudo-code) (+22 more)
+Cohesion: 0.11
+Nodes (28): drainPendingEvents(), envFor(), getDashboardUrl(), handlePanDone(), handleSessionStart(), handleToolExecutionEnd(), handleTurnEnd(), HookEnv (+20 more)
 
 ### Community 234 - "Community 234"
 Cohesion: 0.06
-Nodes (30): All subagents, `cli:interactive` and `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit (+22 more)
+Nodes (32): 1. Installation Test, 2. DNS Setup Test, 3. Startup Test (pan up), 4. Port-based Fallback Test, 5. Traefik Routing Test, 6. Shutdown Test (pan down), 7. Minimal Mode Test, Automated Test Script (+24 more)
 
 ### Community 235 - "Community 235"
 Cohesion: 0.06
-Nodes (30): Agent State Management, Architecture, code:block1 (┌───────────────────────────────────────────────────────────), code:bash (# Check what will be synced (including dev-skills)), code:block2 (~/.panopticon/), code:json ({), code:bash (pan remote init        # Initialize Fly.io provider), code:bash (pan work wipe MIN-123           # Basic cleanup) (+22 more)
+Nodes (32): 1.1 vBRIEF (Adopted), 1.2 Deft, 1.3 Superpowers, 1.4 Spec Kit (GitHub), 1.5 Taskmaster (eyaltoledano/claude-task-master), 1.6 OpenAI Agents SDK ("Agent OS" candidate), 1.7 Not Found / Need Clarification, 1. The Frameworks (+24 more)
 
 ### Community 236 - "Community 236"
 Cohesion: 0.06
-Nodes (30): 1. Planning Phase, 2. Implementation Phase, 3. Iteration, "API not enabled" errors, Available MCP Tools, Best Practices, Bidirectional Sync, Code Quality (+22 more)
+Nodes (31): 1. FizzyApiClient (`src/lib/tracker/fizzy-client.ts`), 2. FizzyCardMapping (SQLite), 3. FizzySyncService (`src/lib/fizzy/sync-service.ts`), 4. FizzyWebhookReceiver (`src/dashboard/server/routes/fizzy-webhooks.ts`), 5. FizzyColumnResolver (`src/lib/fizzy/column-resolver.ts`), Architecture, code:block1 (GitHub Issues (source of truth)), code:yaml (fizzy:) (+23 more)
 
 ### Community 237 - "Community 237"
 Cohesion: 0.06
-Nodes (30): Agent Commands, code:bash (# Spawn an agent for a Linear issue), code:bash (pan work request-review min-123 -m "Fixed: added tests and r), code:bash (# Clean up agents, state, Linear status), code:bash (# Recover a specific agent), code:bash (# Check status of all specialists), code:bash (# Initialize Fly.io provider), code:bash (pan work status) (+22 more)
+Nodes (32): Automated Synthesis, Best Practices, Code Conflicts, code:bash (# Get convoy status and results), code:typescript (// Agent 1 added field:), code:bash (# Generate synthesis prompt), code:bash (# Convoy management), code:bash (# Check each workspace for changes) (+24 more)
 
 ### Community 238 - "Community 238"
-Cohesion: 0.1
-Nodes (22): buildMenuTemplate(), configureApplicationMenu(), fetchActiveWorkspaces(), rebuildMenu(), WorkspaceSummary, checkForUpdates(), currentStatus, downloadUpdate() (+14 more)
+Cohesion: 0.06
+Nodes (32): code:bash (pan setup), code:yaml (# template.yaml), code:block11 (team-meta/), code:bash (# Setup Agent prompt includes:), code:block2 ($ pan setup), code:block3 (Step 2: Project Type Detection), code:block4 (Step 3: Template Selection), code:block5 (Step 4: Repository Configuration) (+24 more)
 
 ### Community 239 - "Community 239"
-Cohesion: 0.17
-Nodes (21): Comment, Issue, IssueFilters, IssueNotFoundError, IssueState, IssueTracker, IssueUpdate, NewIssue (+13 more)
+Cohesion: 0.06
+Nodes (32): Available TLDR Tools, Beads Tasks, code:block1 (1. Agent needs to understand auth.ts), code:bash (node -e "const fs=require('fs'); const p='.pan/spec.vbrief.j), code:bash (git fetch origin main && git rebase origin/main), code:bash (pan done {{ISSUE_ID}} -c "Work already complete from previou), code:json ({), code:bash (npm test                                         # Run tests) (+24 more)
 
 ### Community 240 - "Community 240"
-Cohesion: 0.11
-Nodes (23): addCandidateRoot(), collectCandidatePaths(), extractHashFromJsonlPath(), HashResolver, projectCandidateRoots(), ResolvedWorkspace, ReverseMapCache, encodeClaudeProjectDir() (+15 more)
+Cohesion: 0.12
+Nodes (31): FlywheelScope, RoleEffort, runDashboardDbJob(), abortFlywheelRunForDashboard(), assertExistingPathInsideRoot(), createInitialFlywheelStatus(), dashboardSetting(), execAsync (+23 more)
 
 ### Community 241 - "Community 241"
+Cohesion: 0.09
+Nodes (23): ARCHIVES_DIR, canonicalPrdSubdir(), findDraftPrd(), findPrdAnywhere(), findPrdAtStatus(), PrdFormat, PrdLocation, PrdStatus (+15 more)
+
+### Community 242 - "Community 242"
+Cohesion: 0.11
+Nodes (4): createFlyApiClient(), effFromPromise(), execAsync, FlyProvider
+
+### Community 243 - "Community 243"
+Cohesion: 0.09
+Nodes (26): AlsoSyncTool, collectSkillDirs(), extractSkillName(), MultiToolSyncResult, readSkillContent(), stripFrontmatter(), syncSkillsToTools(), syncToAider() (+18 more)
+
+### Community 244 - "Community 244"
+Cohesion: 0.06
+Nodes (30): 1. JWT Expiry (Primary), 2. CLIProxy Log Tailing (Secondary), Automatic Retry, Bridging to CLIProxy, code:block1 (~/.panopticon/cliproxy/auth/codex-primary.json), code:bash (curl http://localhost:3000/api/settings/codex-auth), code:bash (pan config get issue-agent:implementation), code:block2 (~/.codex/) (+22 more)
+
+### Community 245 - "Community 245"
+Cohesion: 0.06
+Nodes (31): All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Critical Issue: Tool Behavior Bug (+23 more)
+
+### Community 246 - "Community 246"
+Cohesion: 0.06
+Nodes (31): All subagents (except general-purpose), Claude Sonnet 4.6 Work Type Fit Analysis, `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent` (+23 more)
+
+### Community 247 - "Community 247"
+Cohesion: 0.06
+Nodes (31): 1. Be Specific, 2. Explain Why, 3. Order Steps Logically, 4. Consider Edge Cases, 5. Be Realistic, code:typescript (// Find authentication code), code:typescript (AskUserQuestion({), code:markdown (# [ISSUE-ID]: [Issue Title]) (+23 more)
+
+### Community 248 - "Community 248"
+Cohesion: 0.06
+Nodes (31): Available Commands, Available Skills, Code Review, code:bash (# 1. Initialize Panopticon), code:bash (# 1. Optionally create a plan first), code:bash (# List all workspaces), Configuration, Configuration Files (+23 more)
+
+### Community 249 - "Community 249"
+Cohesion: 0.06
+Nodes (31): Best Practices, Built-in Convoy Templates, code-review Template, code:bash (# Run a parallel code review), code:block10 (1. Start command received), code:bash (# Watch convoy progress), code:bash (# Check individual agent status), code:block2 (pan convoy start code-review --files "src/**/*.ts") (+23 more)
+
+### Community 250 - "Community 250"
+Cohesion: 0.09
+Nodes (29): ACCEPTANCE_CRITERIA_TEMPLATE, ALREADY_MIGRATED, AnalysisGraph, AnalysisOutput, assignWaves(), buildGraph(), buildPerFileItem(), buildSharedErrorsItem() (+21 more)
+
+### Community 251 - "Community 251"
+Cohesion: 0.12
+Nodes (21): cvCommand(), CVOptions, relativeTime(), showCommand(), ShowOptions, calls, logSpy, now (+13 more)
+
+### Community 252 - "Community 252"
+Cohesion: 0.1
+Nodes (27): snapshot, status, Jsonish, ReviewStatusSnapshotInput, SpecialistAgentName, SpecialistLifecycleState, toAgentResolution(), toAgentStatus() (+19 more)
+
+### Community 253 - "Community 253"
+Cohesion: 0.1
+Nodes (6): getActiveSessionModel(), getProjectDirs(), getSessionFiles(), parseClaudeSession(), ClaudeCodeRuntime, ClaudeCodeRuntimeEffect
+
+### Community 254 - "Community 254"
+Cohesion: 0.1
+Nodes (26): BeadsTask, buildHandoffPrompt(), captureBeadsTasks(), captureFiles(), captureGitState(), captureHandoffContext(), execAsync, HandoffContextError (+18 more)
+
+### Community 255 - "Community 255"
+Cohesion: 0.09
+Nodes (20): FetchFn, InternalState, LogFn, readWatchdogPersistentState(), SpawnRestart, SpawnRestartResult, SupervisorWatchdog, SupervisorWatchdogConfig (+12 more)
+
+### Community 256 - "Community 256"
+Cohesion: 0.06
+Nodes (30): 1. Template File Resolution, 2. Config File Integration, 3. Docker Compose Integration, 4. Certificate Integration, code:bash (pan install), code:bash (node -e "import('./dist/chunk-*.js').then(m => console.log(m), code:bash (ls -la templates/traefik/), code:bash (ls -la ~/.panopticon/traefik/) (+22 more)
+
+### Community 257 - "Community 257"
+Cohesion: 0.06
+Nodes (30): 1. Review Artifact Creation at `pan done`, 1. The work agent owns all code-changing git operations, 2. Merge-Set Data Model, 2. Review artifacts are created at work completion, 3. Merge agent is the coordinator for merge sets, 3. Work-Agent-Owned Rebase Flow, 4. Non-Mutating Post-Rebase Verification, 4. Verification runs twice (+22 more)
+
+### Community 258 - "Community 258"
+Cohesion: 0.06
+Nodes (30): 1. Extend XTerminal Component, 3. Smart Ctrl+C Logic, 4. Context Menu (Embedded in XTerminal), 5. Auto-Copy on Selection, 6. Configuration UI, Breakdown into Sub-Tasks, code:typescript (interface XTerminalProps {), code:typescript (// Pseudo-code) (+22 more)
+
+### Community 259 - "Community 259"
+Cohesion: 0.06
+Nodes (30): All subagents, `cli:interactive` and `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit (+22 more)
+
+### Community 260 - "Community 260"
+Cohesion: 0.06
+Nodes (30): Agent State Management, Architecture, code:block1 (┌───────────────────────────────────────────────────────────), code:bash (# Check what will be synced (including dev-skills)), code:block2 (~/.panopticon/), code:json ({), code:bash (pan remote init        # Initialize Fly.io provider), code:bash (pan work wipe MIN-123           # Basic cleanup) (+22 more)
+
+### Community 261 - "Community 261"
+Cohesion: 0.06
+Nodes (30): 1. Planning Phase, 2. Implementation Phase, 3. Iteration, "API not enabled" errors, Available MCP Tools, Best Practices, Bidirectional Sync, Code Quality (+22 more)
+
+### Community 262 - "Community 262"
+Cohesion: 0.06
+Nodes (30): Agent Commands, code:bash (# Spawn an agent for a Linear issue), code:bash (pan work request-review min-123 -m "Fixed: added tests and r), code:bash (# Clean up agents, state, Linear status), code:bash (# Recover a specific agent), code:bash (# Check status of all specialists), code:bash (# Initialize Fly.io provider), code:bash (pan work status) (+22 more)
+
+### Community 263 - "Community 263"
+Cohesion: 0.12
+Nodes (17): contextCommand(), ContextOptions, appendSummary(), checkContextBudget(), ContextBudget, estimateTokens(), generateSummaryEntry(), getHistoryDir() (+9 more)
+
+### Community 264 - "Community 264"
+Cohesion: 0.09
+Nodes (20): CapabilityStats, clearMetrics(), DailyStats, DEFAULT_METRICS, getAggregatedMetrics(), getAllRuntimeMetrics(), getIssueTasks(), getRecentTasks() (+12 more)
+
+### Community 265 - "Community 265"
+Cohesion: 0.13
+Nodes (19): workspaceDeepCleanCommand(), WorkspaceDeepCleanOptions, dangerBanner(), DangerousGitOpError, DangerousOp, DangerousOpBlockedError, dryRunGitClean(), execAsync (+11 more)
+
+### Community 266 - "Community 266"
 Cohesion: 0.11
 Nodes (25): main(), print_usage(), build_compress_prompt(), build_fix_prompt(), call_claude(), compress_file(), Strip outer ```markdown ... ``` fence when it wraps the entire output., strip_llm_wrapper() (+17 more)
 
-### Community 242 - "Community 242"
-Cohesion: 0.08
-Nodes (18): clearTtsVoices(), deleteTtsVoice(), fetchTtsVoices(), playTtsVoice(), requireTtsSpoken(), SavedVoicesTab(), TtsVoiceListItem, playVoice() (+10 more)
-
-### Community 243 - "Community 243"
-Cohesion: 0.1
-Nodes (11): issues, result, CACHE_DB_PATH, CacheEntry, CacheService, DEFAULT_TTLS, L1Entry, openSqliteDb() (+3 more)
-
-### Community 244 - "Community 244"
-Cohesion: 0.07
-Nodes (29): Agent Enrichment Service, API, Auto-Resume Gates, Bulk apply, code:yaml (cloister:), code:yaml (autoResume:), code:bash (tsx scripts/deacon-ignore-bulk.ts --prefix MIN --states "in ), Configuration (+21 more)
-
-### Community 245 - "Community 245"
-Cohesion: 0.07
-Nodes (29): code:typescript (interface VBriefReference {), code:typescript (export interface VBriefInfo {), code:json ({), code:block4 (## vBRIEF Plan Format), code:markdown (| **vBRIEF Plan Format** | Machine-readable work plans using), code:typescript (// Scan for PRDs matching this issue), code:block7 (VBriefViewer), code:block8 (tests/vbrief/full-spec.test.ts) (+21 more)
-
-### Community 246 - "Community 246"
-Cohesion: 0.07
-Nodes (29): 1. Be Realistic, 2. Verify with Code, 3. Consider Context, 4. Communicate Uncertainty, 5. Update Estimates, Best Practices, Bug Triage, code:bash (# Find related code) (+21 more)
-
-### Community 247 - "Community 247"
-Cohesion: 0.07
-Nodes (29): Access Points, Alternative Backend Frameworks, API Communication, Backend CORS, Backend Development, code:block1 (project/), code:javascript (const cors = require('cors')), code:bash (docker compose exec backend npx prisma migrate dev) (+21 more)
-
-### Community 248 - "Community 248"
-Cohesion: 0.1
-Nodes (25): snapshot, status, Jsonish, ReadModelServiceShape, SpecialistAgentName, SpecialistLifecycleState, toAgentResolution(), toAgentStatus() (+17 more)
-
-### Community 249 - "Community 249"
-Cohesion: 0.14
-Nodes (28): assertExistingPathInsideRoot(), createInitialFlywheelStatus(), dashboardSetting(), execAsync, FlywheelGateSnapshot, getActiveRunId(), getPlatformOpenCommand(), gitOutput() (+20 more)
-
-### Community 250 - "Community 250"
-Cohesion: 0.13
-Nodes (27): buildDigestPrompt(), deleteContextDigest(), ensureContextDirectory(), execAsync(), generateContextDigest(), getContextDigestPath(), getContextDirectory(), getContextRunsCount() (+19 more)
-
-### Community 251 - "Community 251"
-Cohesion: 0.11
-Nodes (25): AwaitingInputDetection, AwaitingInputReason, compactPrompt(), detectAwaitingInputForAgent(), detectAwaitingInputFromPane(), findPermissionMenuEndIndex(), getPaneDetectionCacheKey(), isCurrentPromptIndex() (+17 more)
-
-### Community 252 - "Community 252"
-Cohesion: 0.13
-Nodes (25): isNoResumeValueEnabled(), formatGatingReason(), formatRestartAge(), formatRestartDuration(), formatTldrAge(), formatTldrRow(), isBootNoResumeModeActive(), issueKey() (+17 more)
-
-### Community 253 - "Community 253"
-Cohesion: 0.07
-Nodes (28): API Endpoints, Architecture Overview, Backoff Strategy, CacheService (`src/dashboard/server/services/cache-service.ts`), code:block1 (Frontend (TanStack Query)), code:typescript (await issueDataService.invalidateTracker('github'); // or 'l), code:json ({), Dashboard API Caching & Real-Time Push Architecture (+20 more)
-
-### Community 254 - "Community 254"
-Cohesion: 0.07
-Nodes (28): 1. Interactive CLI Wizard (`pan setup`), 2. Project Templates, 3. Setup Agent, Architecture, code:block1 ($ pan setup), code:typescript (interface SetupState {), code:typescript (async function detectRepos(projectPath: string): Promise<Det), code:block4 (templates/project-types/) (+20 more)
-
-### Community 255 - "Community 255"
-Cohesion: 0.07
-Nodes (28): 1. `ensureManagedTmuxConfig*` thrash on every tmux invocation, 2. 5000-line escape-coded snapshot on every attach, 3. `sendKeysAsync` per-line buffer + 50 ms sleep, Acceptance Criteria, Add, Code Changes Summary, code:typescript (// Lines 84-88 (sync) and 90-94 (async):), code:typescript (async function captureSnapshot(sessionName: string, cols: nu) (+20 more)
-
-### Community 256 - "Community 256"
-Cohesion: 0.07
-Nodes (28): 1. Keep or Remove Runtime Parameter?, 1. Remove Sync Targets and Runtime Adapters, 2. Config Migration Strategy, 2. Consolidate Cloister Runtime System, 3. Remove CLI Runtime Selection, 3. Symlink Cleanup Approach, 4. Cloister Runtime Consolidation, 4. Config Migration (+20 more)
-
-### Community 257 - "Community 257"
-Cohesion: 0.07
-Nodes (28): 1. Cleanup Strategy: **Delete Permanently**, 2. Age Threshold: **7 Days (Configurable)**, 3. Directory Types to Clean, 4. Cleanup Triggers: **Both Auto + Manual**, 5. Status Marking: **Add 'completed' Status**, 6. Cost Endpoint Migration: **Yes, Include It**, Acceptance Criteria, Blocker Status: RESOLVED ✓ (+20 more)
-
-### Community 258 - "Community 258"
-Cohesion: 0.07
-Nodes (28): All subagents, inspect agent, merge agent, CLI modes, API Migration from Opus 4.6, Breaking Changes, Claude Opus 4.7 Work Type Fit Analysis, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer` (+20 more)
-
-### Community 259 - "Community 259"
-Cohesion: 0.07
-Nodes (28): All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, `convoy:performance-reviewer` and `convoy:correctness-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit, GLM-5.1 Work Type Fit Analysis (+20 more)
-
-### Community 260 - "Community 260"
-Cohesion: 0.07
-Nodes (28): code:bash (# PAN-XXX -> /home/eltmon/projects/panopticon (GitHub)), code:block10 (Items:), code:block11 (Items:), code:json ({), code:json ({), code:bash (# Materialize beads and mark the workspace spec proposed), code:bash (# Load Stitch tools), code:bash (gh label create "planned" --color "0E8A16" 2>/dev/null || tr) (+20 more)
-
-### Community 261 - "Community 261"
-Cohesion: 0.07
-Nodes (28): code:bash (# Check dashboard is running), code:bash (# Check for uncommitted changes), code:bash (# Create GitHub issue), code:bash (# Create test fixture), code:bash (# Trigger the approval - this kicks off review-agent), code:bash (# Watch review-agent (should complete review and hand off)), code:bash (# Check if branch was merged to main), code:bash (# Close the GitHub issue) (+20 more)
-
-### Community 262 - "Community 262"
-Cohesion: 0.09
-Nodes (22): boundedAutoPresoElements(), jsonByteLength(), readElementLikes(), validateAutoPresoCanvasElements(), AutoPresoAgentMessage, AutoPresoListener, AutoPresoMode, AutoPresoSession (+14 more)
-
-### Community 263 - "Community 263"
-Cohesion: 0.11
-Nodes (19): FlyProviderConfig, { execAsyncMock, spawnMock, mockApi }, fly, p, getRemoteProvider(), ProviderType, execAsync, initCommand() (+11 more)
-
-### Community 264 - "Community 264"
-Cohesion: 0.16
-Nodes (25): decodeFlywheelRunId, defaultFlywheelPrompt(), defaultFlywheelRunId(), FlywheelLifecycleOptions, FlywheelPauseResult, FlywheelResumeResult, isFlywheelDevcontainerRuntime(), parseRunId() (+17 more)
-
-### Community 265 - "Community 265"
-Cohesion: 0.11
-Nodes (25): buildReviewContext(), BuildReviewContextOpts, ChangedFile, execAsync, extractAcceptanceCriteria(), flattenAC(), getChangedFiles(), getCurrentBranch() (+17 more)
-
-### Community 266 - "Community 266"
-Cohesion: 0.09
-Nodes (23): ProviderCard(), ProviderCardProps, PROVIDER_INFO, ProviderPanelProps, THINKING_LEVEL_LABELS, THINKING_LEVELS, ThinkingLevelSlider(), ThinkingLevelSliderProps (+15 more)
-
 ### Community 267 - "Community 267"
-Cohesion: 0.08
-Nodes (18): ActionBar(), ActionBarProps, AgentTimeline(), AgentTimelineProps, TimelineEvent, TYPE_COLORS, BeadsKanban(), BeadsKanbanProps (+10 more)
+Cohesion: 0.1
+Nodes (22): buildMenuTemplate(), configureApplicationMenu(), fetchActiveWorkspaces(), rebuildMenu(), WorkspaceSummary, checkForUpdates(), currentStatus, downloadUpdate() (+14 more)
 
 ### Community 268 - "Community 268"
 Cohesion: 0.09
-Nodes (23): ComposerPlugin(), ComposerPromptEditor(), ComposerPromptEditorProps, EditorRefPluginProps, filterCommands(), getDraftKey(), InnerPluginProps, loadDraft() (+15 more)
+Nodes (21): backfillDiscoveredSessionArrayIndexes(), initDiscoveredSessionsSchema(), initSchema(), initWorkspaceDiscoveredSessionsSchema(), base, cols, colsAfter, colsBefore (+13 more)
 
 ### Community 269 - "Community 269"
-Cohesion: 0.07
-Nodes (27): 1.1 vBRIEF (Adopted), 1.2 Deft, 1.3 Superpowers, 1.4 Spec Kit (GitHub), 1.5 Not Found / Unavailable, 1. The Frameworks, 2.1 Ralph Wiggum Self-Assessment Loop, 2.2 Two-Stage Specialist Review Gate (+19 more)
+Cohesion: 0.1
+Nodes (18): cleanupOldEvents(), CLOISTER_DB_PATH, CloisterDatabaseError, deleteAgentHistory(), getAgentsWithHistory(), getAllHealthHistory(), getDatabaseStats(), getHealthDatabase() (+10 more)
 
 ### Community 270 - "Community 270"
-Cohesion: 0.07
-Nodes (28): Auto-Sync, `ccr` Utility Script, code:bash (# Direct execution (recommended)), code:bash (# Make executable (if needed)), code:block61 (~/.panopticon/skills/*     →  ~/.claude/skills/           # ), code:toml ([sync]), code:typescript (type SyncTargetState =), code:bash ($ pan sync) (+20 more)
+Cohesion: 0.09
+Nodes (25): getTtsDaemonAuthHeaders(), buildDirectTtsSpeakPayload(), buildTtsSpeakPayload(), FetchLike, postSpeakPayload(), renderTemplate(), resolveAndSpeak(), ResolveAndSpeakDeps (+17 more)
 
 ### Community 271 - "Community 271"
-Cohesion: 0.07
-Nodes (27): 1. State of LLM Evals in 2026, 2.1 Compaction (`src/lib/conversations/smart-compaction.ts`), 2.2 Observability / Activity Feed (PAN-1052), 2.3 Other Panopticon surfaces (out of scope now, in scope soon), 2. What to evaluate in Panopticon, 3.1 Choice of base library: **`evalite` + `autoevals`** (both MIT, TS-native), in-tree under `evals/`., 3.2 Repo layout, 3.3 The `pan evals` CLI surface (+19 more)
+Cohesion: 0.1
+Nodes (24): AwaitingInputReason, compactPrompt(), detectAwaitingInputForAgent(), detectAwaitingInputFromPane(), findPermissionMenuEndIndex(), getPaneDetectionCacheKey(), isCurrentPromptIndex(), isRecentPromptIndex() (+16 more)
 
 ### Community 272 - "Community 272"
-Cohesion: 0.07
-Nodes (27): Async Gates for Workflow Coordination, Best Practices, Can't find gate ID, CI run ID detection fails, code:bash (bd config set types.custom '["gate"]'), code:bash (bd gate list | grep "spec-myfeature"), code:bash (# Check gate details), code:bash (# List all gates (including closed)) (+19 more)
+Cohesion: 0.11
+Nodes (23): ActivityContext, awaitingInputFromProjection(), buildIssueTitleMap(), collectSessionTreeNodes(), compareSessionTreeSessionIds(), escapeRegExp(), fetchProjectSessionTree(), getAllSessionTreesRoute (+15 more)
 
 ### Community 273 - "Community 273"
-Cohesion: 0.07
-Nodes (27): code:block1 (User invokes /pan-code-review), code:typescript (// Read the synthesis report), code:bash (# Review all uncommitted changes (git diff)), code:bash (# Review specific files), code:bash (# Review all changes in current branch vs main), code:bash (# Focus on security only), code:typescript (// Default: review uncommitted changes), code:typescript (// Create reviews directory) (+19 more)
+Cohesion: 0.1
+Nodes (11): issues, result, CACHE_DB_PATH, CacheEntry, CacheService, DEFAULT_TTLS, L1Entry, openSqliteDb() (+3 more)
 
 ### Community 274 - "Community 274"
 Cohesion: 0.07
-Nodes (27): Case 1 — Expected Score: ~42 (Partial / Risky), Case 2 — Expected Score: ~35 (Not Ready), code:json ({), Deduction Examples, Deduction Examples, Deduction Examples, Deduction Examples, Deduction Examples (+19 more)
+Nodes (29): Agent Enrichment Service, API, Auto-Resume Gates, Bulk apply, code:yaml (cloister:), code:yaml (autoResume:), code:bash (tsx scripts/deacon-ignore-bulk.ts --prefix MIN --states "in ), Configuration (+21 more)
 
 ### Community 275 - "Community 275"
 Cohesion: 0.07
-Nodes (27): code:bash (pan project add <path> --name <name>), code:block10 (## New Project Setup Complete: <NAME>), code:yaml (<project-key>:), code:yaml (<project-key>:), code:bash (# Format: owner/repo:PREFIX (comma-separated)), code:bash (cd <project-path>), code:bash (mkdir -p <project-path>/workspaces), code:bash (grep -q '^workspaces/' <project-path>/.gitignore 2>/dev/null) (+19 more)
+Nodes (29): code:typescript (interface VBriefReference {), code:typescript (export interface VBriefInfo {), code:json ({), code:block4 (## vBRIEF Plan Format), code:markdown (| **vBRIEF Plan Format** | Machine-readable work plans using), code:typescript (// Scan for PRDs matching this issue), code:block7 (VBriefViewer), code:block8 (tests/vbrief/full-spec.test.ts) (+21 more)
 
 ### Community 276 - "Community 276"
 Cohesion: 0.07
-Nodes (27): `.agent-template/`, code:block1 (team-meta/), code:bash (#!/bin/bash), code:yaml (groups:), code:block3 (Step 6: Meta Repo), code:bash (mkdir -p team-meta/{.agent-template/.claude,panopticon,docs/), code:bash (git clone git@github.com:yourorg/team-meta.git), code:bash (cd team-meta/docs/onboarding) (+19 more)
+Nodes (29): 1. Be Realistic, 2. Verify with Code, 3. Consider Context, 4. Communicate Uncertainty, 5. Update Estimates, Best Practices, Bug Triage, code:bash (# Find related code) (+21 more)
 
 ### Community 277 - "Community 277"
-Cohesion: 0.12
-Nodes (18): emitter, onTurn, queue, subscribeVoiceSettings(), isTrustedWebSocketOrigin(), setupVoiceWebSocket(), createGoogleCloudTranscription(), GoogleStreamingRecognizeResponse (+10 more)
+Cohesion: 0.07
+Nodes (29): Access Points, Alternative Backend Frameworks, API Communication, Backend CORS, Backend Development, code:block1 (project/), code:javascript (const cors = require('cors')), code:bash (docker compose exec backend npx prisma migrate dev) (+21 more)
 
 ### Community 278 - "Community 278"
-Cohesion: 0.16
-Nodes (22): doneCommand(), DoneOptions, execAsync, getGitHubConfig(), isMergeSetMergedIntoTargets(), updateGitHubToInReview(), updateLinearToInReview(), WipeOptions (+14 more)
+Cohesion: 0.14
+Nodes (26): decodeFlywheelRunId, defaultFlywheelPrompt(), defaultFlywheelRunId(), FlywheelLifecycleOptions, FlywheelPauseResult, FlywheelResumeResult, getLocalFlywheelRunDir(), isFlywheelDevcontainerRuntime() (+18 more)
 
 ### Community 279 - "Community 279"
-Cohesion: 0.15
-Nodes (12): CLAUDE_PROJECTS_DIR, ClaudeMessage, getActiveSessionModel(), getAllSessionFiles(), getProjectDirs(), getRecentSessions(), getSessionFiles(), importSessionToCostLog() (+4 more)
+Cohesion: 0.14
+Nodes (28): reconcileClosedPrReadyForMerge(), reconcileFalseMerged(), apiCatch(), APP_DIR, configureWorkspaceForBot(), execAsync, generateInstallationToken(), generateInstallationTokenEffect() (+20 more)
 
 ### Community 280 - "Community 280"
-Cohesion: 0.07
-Nodes (21): createCall, createCalls, dbError, deleteCalls, doc, doctorCalls, existingBeads, expectedPrefix (+13 more)
+Cohesion: 0.1
+Nodes (25): AnthropicContentBlock, AnthropicInputBlock, AnthropicMessage, AnthropicMessageResponse, AnthropicMessagesRequest, emptyBlock(), ensureOpenAICompatibleProxyRunning(), getOpenAICompatibleProxyBaseUrl() (+17 more)
 
 ### Community 281 - "Community 281"
-Cohesion: 0.07
-Nodes (26): A. Provider Billing & Observability → #730, Already Fixed / Shipped (14), B. Metrics Page v2 → #750, Biggest backlog themes, C. Documentation Overhaul → #634, Critical (5 issues) — 1.0 blockers or active pipeline corruption, D. Cost Display Polish → new umbrella or #77, Duplicates (10) (+18 more)
+Cohesion: 0.1
+Nodes (26): writeObservationRecord(), runMemoryFtsTransaction(), appendJsonl(), appendLocks, findIndexedObservationByteOffset(), findObservationByteOffset(), indexObservation(), inline() (+18 more)
 
 ### Community 282 - "Community 282"
-Cohesion: 0.07
-Nodes (26): 1. Check release readiness, 2. Create the release commit and tag, 3. Push intentionally, Branch and channel policy, Build or tests fail during preflight, Canary, Canary tags, code:bash (pan release check) (+18 more)
+Cohesion: 0.11
+Nodes (25): buildReviewContext(), BuildReviewContextOpts, ChangedFile, execAsync, extractAcceptanceCriteria(), flattenAC(), getChangedFiles(), getCurrentBranch() (+17 more)
 
 ### Community 283 - "Community 283"
-Cohesion: 0.07
-Nodes (26): Advanced: Work Type Table, Available Providers, Bulk Reset, Canonical Sources, Changing a Model Assignment, code:yaml (models:), code:yaml (openrouter:), Configuration File (+18 more)
+Cohesion: 0.13
+Nodes (25): buildDigestPrompt(), deleteContextDigest(), ensureContextDirectory(), execAsync(), generateContextDigest(), getContextDigestPath(), getContextDirectory(), getContextRunsCount() (+17 more)
 
 ### Community 284 - "Community 284"
 Cohesion: 0.07
-Nodes (26): Anthropic-heavy reviews, cheaper helpers, Choosing What to Override, CLI Modes, code:yaml (models:), code:yaml (models:), code:yaml (models:), code:yaml (models:), code:yaml (models:) (+18 more)
+Nodes (28): API Endpoints, Architecture Overview, Backoff Strategy, CacheService (`src/dashboard/server/services/cache-service.ts`), code:block1 (Frontend (TanStack Query)), code:typescript (await issueDataService.invalidateTracker('github'); // or 'l), code:json ({), Dashboard API Caching & Real-Time Push Architecture (+20 more)
 
 ### Community 285 - "Community 285"
 Cohesion: 0.07
-Nodes (25): 1. The breaker logic and the reset logic do not match, 2. `manual_retry` does not fit the current history type, 3. The `markWorkspaceStuck()` sample call is type-wrong, 4. The new retry endpoint overlaps heavily with the existing unstick flow, 5. `checkStuckReviewing()` may become too aggressive if tmux output pauses, 6. The PRD should call out interaction with stale-session cleanup in `runParallelReview()`, 7. The frontend copy and state model are good, but the PRD under-specifies how `stuckReason` should drive copy, 8. Minor path/documentation mismatch (+17 more)
+Nodes (28): 1. Interactive CLI Wizard (`pan setup`), 2. Project Templates, 3. Setup Agent, Architecture, code:block1 ($ pan setup), code:typescript (interface SetupState {), code:typescript (async function detectRepos(projectPath: string): Promise<Det), code:block4 (templates/project-types/) (+20 more)
 
 ### Community 286 - "Community 286"
 Cohesion: 0.07
-Nodes (26): Acceptance Criteria, Architecture, Claude Code, CLI Surface, code:markdown (# Project Rules), code:block2 ([WARN] sync.devroot is deprecated. Run `pan context migrate`), code:block3 (pan context list                    # Show all three layers'), code:bash (claude --append-system-prompt-file "$WORKSPACE/.panopticon/c) (+18 more)
+Nodes (28): 1. `ensureManagedTmuxConfig*` thrash on every tmux invocation, 2. 5000-line escape-coded snapshot on every attach, 3. `sendKeysAsync` per-line buffer + 50 ms sleep, Acceptance Criteria, Add, Code Changes Summary, code:typescript (// Lines 84-88 (sync) and 90-94 (async):), code:typescript (async function captureSnapshot(sessionName: string, cols: nu) (+20 more)
 
 ### Community 287 - "Community 287"
 Cohesion: 0.07
-Nodes (26): A/B Infrastructure, code:markdown (## Simplicity First), code:markdown ({{#KARPATHY_GUIDELINES}}), code:markdown ({{#KARPATHY_GUIDELINES}}), code:markdown ({{#KARPATHY_GUIDELINES}}), code:yaml (# ~/.panopticon/config.yaml), Config Schema, Design (+18 more)
+Nodes (28): 1. Keep or Remove Runtime Parameter?, 1. Remove Sync Targets and Runtime Adapters, 2. Config Migration Strategy, 2. Consolidate Cloister Runtime System, 3. Remove CLI Runtime Selection, 3. Symlink Cleanup Approach, 4. Cloister Runtime Consolidation, 4. Config Migration (+20 more)
 
 ### Community 288 - "Community 288"
 Cohesion: 0.07
-Nodes (26): 1. Infrastructure Model: Self-Contained Machines, 2. Command Execution: Hybrid Approach, 3. Exe Provider: Delete and Reimplement, 4. Docker Image: Full Pipeline, 5. Workspace Flow: Full Parity (minus shared infra), 6. Cost Tracking: Existing JSONL System, 7. Agent Management: Fly Machine Exec API, Architecture (+18 more)
+Nodes (28): 1. Cleanup Strategy: **Delete Permanently**, 2. Age Threshold: **7 Days (Configurable)**, 3. Directory Types to Clean, 4. Cleanup Triggers: **Both Auto + Manual**, 5. Status Marking: **Add 'completed' Status**, 6. Cost Endpoint Migration: **Yes, Include It**, Acceptance Criteria, Blocker Status: RESOLVED ✓ (+20 more)
 
 ### Community 289 - "Community 289"
 Cohesion: 0.07
-Nodes (26): All implementation work types, All specialist agents (except review), All subagents, Claude Opus 4.6 Work Type Fit Analysis, CLI modes, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer` (+18 more)
+Nodes (28): All subagents, inspect agent, merge agent, CLI modes, API Migration from Opus 4.6, Breaking Changes, Claude Opus 4.7 Work Type Fit Analysis, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer` (+20 more)
 
 ### Community 290 - "Community 290"
 Cohesion: 0.07
-Nodes (26): All convoy reviewers, All implementation work types, All specialist agents (except inspect), `cli:interactive`, `cli:quick-command`, Excellent Fit, Good Fit — Worth Benchmarking, GPT-5.4 Nano Work Type Fit Analysis (+18 more)
+Nodes (28): All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, `convoy:performance-reviewer` and `convoy:correctness-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit, GLM-5.1 Work Type Fit Analysis (+20 more)
 
 ### Community 291 - "Community 291"
 Cohesion: 0.07
-Nodes (26): 1. Check Agent Status First, 2. Graceful Shutdown (Recommended), 3. Immediate Stop (If Needed), 4. Verify Stopped, 5. Clean Up (Optional), After Killing, code:bash (# Using pan CLI), code:bash (# List all matching sessions) (+18 more)
+Nodes (28): code:bash (# PAN-XXX -> /home/eltmon/projects/panopticon (GitHub)), code:block10 (Items:), code:block11 (Items:), code:json ({), code:json ({), code:bash (# Materialize beads and mark the workspace spec proposed), code:bash (# Load Stitch tools), code:bash (gh label create "planned" --color "0E8A16" 2>/dev/null || tr) (+20 more)
 
 ### Community 292 - "Community 292"
 Cohesion: 0.07
-Nodes (26): code:bash (python3 scripts/conv-find.py <id>), code:text (Conversation #108), code:bash (python3 scripts/conv-find.py --jsonl 108), code:bash (python3 scripts/conv-find.py --summary 108), code:bash (python3 scripts/conv-find.py --json 108), code:bash (python3 scripts/conv-find.py --recent 20   # default 20), code:bash (python3 scripts/conv-find.py --search lexerra), code:python (import json, pathlib) (+18 more)
+Nodes (28): code:bash (# Check dashboard is running), code:bash (# Check for uncommitted changes), code:bash (# Create GitHub issue), code:bash (# Create test fixture), code:bash (# Trigger the approval - this kicks off review-agent), code:bash (# Watch review-agent (should complete review and hand off)), code:bash (# Check if branch was merged to main), code:bash (# Close the GitHub issue) (+20 more)
 
 ### Community 293 - "Community 293"
-Cohesion: 0.07
-Nodes (26): 1. Visual Theme & Atmosphere, 2. Color Palette & Roles, 3. Typography Rules, 4. Component Stylings, 5. Layout Principles, 6. Design System Notes for Stitch Generation, Accent & Interactive, Alignment & Visual Balance (+18 more)
+Cohesion: 0.1
+Nodes (22): approveReviewArtifactEffect(), ApproveReviewArtifactInput, buildRepositoryFlag(), commentOnArtifactEffect(), CommentOnArtifactInput, createReviewArtifactEffect(), CreateReviewArtifactInput, CreateReviewArtifactResult (+14 more)
 
 ### Community 294 - "Community 294"
-Cohesion: 0.07
-Nodes (26): Adding Repos Mid-Work, CLI Command, code:yaml (# ~/.panopticon/projects.yaml), code:yaml (# Old config — still works, all repos checked out), code:yaml (# team-meta/panopticon/repo-groups.yaml), code:bash (# Add specific repos), code:bash (# Add specific repos), code:block5 (/workspace-add-repo) (+18 more)
+Cohesion: 0.13
+Nodes (19): execFileAsync, gitFetch(), gitForcePush(), gitMerge(), gitPush(), gitRevParse(), MainDivergedError, appendGitOperation() (+11 more)
 
 ### Community 295 - "Community 295"
-Cohesion: 0.07
-Nodes (26): Agent Self-Requeue (Circuit Breaker), code:block1 (Human clicks "Review"), code:bash (# All specialists with their current state), code:bash (# Via dashboard: click "Review" on an issue card), code:yaml (projects:), code:yaml (projects:), code:yaml (projects:), code:bash (# Via dashboard: click "Approve & Merge" on an issue card) (+18 more)
+Cohesion: 0.09
+Nodes (20): err, exec(), execFile(), execMock, kCustom, prompt, spawnRunMock, tmuxCapturePaneAsyncMock (+12 more)
 
 ### Community 296 - "Community 296"
-Cohesion: 0.07
-Nodes (26): 1. Test Coverage, 2. No Blocking Operations, 3. No Dead Code, 4. Error Handling, 5. Type Safety, 6. Temporal Dead Zone (TDZ), Acceptance Criteria (from vBRIEF plan) — MANDATORY GATE, APPROVED (rare — only for PERFECT code) (+18 more)
+Cohesion: 0.1
+Nodes (16): assertSafeAgentIdEffect(), captureCheckpointEffect(), CheckpointGitResult, checkpointSpawnerLayer, deleteAllCheckpointsEffect(), deleteCheckpointEffect(), diffCheckpointFilesEffect(), diffCheckpointsEffect() (+8 more)
 
 ### Community 297 - "Community 297"
-Cohesion: 0.11
-Nodes (19): childEnv, expectedExits, killChildTree(), port, requiredFiles, restartQueue, shutdown(), startApp() (+11 more)
+Cohesion: 0.09
+Nodes (23): ComposerPlugin(), ComposerPromptEditor(), ComposerPromptEditorProps, EditorRefPluginProps, filterCommands(), getDraftKey(), InnerPluginProps, loadDraft() (+15 more)
 
 ### Community 298 - "Community 298"
 Cohesion: 0.1
-Nodes (24): AutoCreateStateConfig, CANONICAL_STATES, CanonicalState, CanonicalStateDefinition, canonicalToTrackerState(), cleanupWorkflowLabels(), DEFAULT_STATE_MAPPINGS, getLinearStateName() (+16 more)
+Nodes (27): applyEvent(), bumpRuntimeSnapshotSequence(), DashboardLifecycleState, defaultRuntimeSnapshot(), getMaxMemoryObservationsPerIssue(), getMaxTurnDiffSummariesPerAgent(), MemoryHealthSnapshot, MemoryReadModelState (+19 more)
 
 ### Community 299 - "Community 299"
-Cohesion: 0.1
-Nodes (10): createFlyApiClient(), FlyApiClient, FlyApiError, FlyExecResult, FlyMachine, FlyMachineConfig, client, fetchMock (+2 more)
+Cohesion: 0.07
+Nodes (27): 1.1 vBRIEF (Adopted), 1.2 Deft, 1.3 Superpowers, 1.4 Spec Kit (GitHub), 1.5 Not Found / Unavailable, 1. The Frameworks, 2.1 Ralph Wiggum Self-Assessment Loop, 2.2 Two-Stage Specialist Review Gate (+19 more)
 
 ### Community 300 - "Community 300"
-Cohesion: 0.09
-Nodes (19): extractEmbedding(), ExtractEmbeddingInput, previewDesignVoice(), PreviewDesignVoiceInput, saveCloneVoice(), SaveCloneVoiceInput, saveDesignVoice(), SaveDesignVoiceInput (+11 more)
+Cohesion: 0.07
+Nodes (28): Auto-Sync, `ccr` Utility Script, code:bash (# Direct execution (recommended)), code:bash (# Make executable (if needed)), code:block61 (~/.panopticon/skills/*     →  ~/.claude/skills/           # ), code:toml ([sync]), code:typescript (type SyncTargetState =), code:bash ($ pan sync) (+20 more)
 
 ### Community 301 - "Community 301"
-Cohesion: 0.08
-Nodes (22): db, makeTestLayer(), received, runWithService(), store, svc, unsubscribe, deleteDockerContainerRoute (+14 more)
+Cohesion: 0.07
+Nodes (27): 1. State of LLM Evals in 2026, 2.1 Compaction (`src/lib/conversations/smart-compaction.ts`), 2.2 Observability / Activity Feed (PAN-1052), 2.3 Other Panopticon surfaces (out of scope now, in scope soon), 2. What to evaluate in Panopticon, 3.1 Choice of base library: **`evalite` + `autoevals`** (both MIT, TS-native), in-tree under `evals/`., 3.2 Repo layout, 3.3 The `pan evals` CLI surface (+19 more)
 
 ### Community 302 - "Community 302"
-Cohesion: 0.09
-Nodes (18): ApproveReviewArtifactInput, buildRepositoryFlag(), CommentOnArtifactInput, CreateReviewArtifactInput, CreateReviewArtifactResult, DiscoverArtifactInput, execAsync, ForgeAdapter (+10 more)
+Cohesion: 0.07
+Nodes (27): Async Gates for Workflow Coordination, Best Practices, Can't find gate ID, CI run ID detection fails, code:bash (bd config set types.custom '["gate"]'), code:bash (bd gate list | grep "spec-myfeature"), code:bash (# Check gate details), code:bash (# List all gates (including closed)) (+19 more)
 
 ### Community 303 - "Community 303"
-Cohesion: 0.08
-Nodes (22): body, bytes, claudeProjectDir, conv, created, deliverMock, encodedCwd, getTrustedOrigins() (+14 more)
+Cohesion: 0.07
+Nodes (27): code:block1 (User invokes /pan-code-review), code:typescript (// Read the synthesis report), code:bash (# Review all uncommitted changes (git diff)), code:bash (# Review specific files), code:bash (# Review all changes in current branch vs main), code:bash (# Focus on security only), code:typescript (// Default: review uncommitted changes), code:typescript (// Create reviews directory) (+19 more)
 
 ### Community 304 - "Community 304"
-Cohesion: 0.08
-Nodes (25): cb, completedState, dispatched, featureWorkspace, implSlot, initial, initialState, jsonBlock (+17 more)
+Cohesion: 0.07
+Nodes (27): Case 1 — Expected Score: ~42 (Partial / Risky), Case 2 — Expected Score: ~35 (Not Ready), code:json ({), Deduction Examples, Deduction Examples, Deduction Examples, Deduction Examples, Deduction Examples (+19 more)
 
 ### Community 305 - "Community 305"
-Cohesion: 0.08
-Nodes (25): BRANCH_NOT_FOUND, Check Merged, code:bash (# Standard naming convention), code:bash (# Get repo list from project config), code:bash (# Check local branches), code:bash (# Check for unmerged commits), code:bash (git -C "$PROJECT_PATH" fetch origin "$BRANCH" 2>/dev/null), code:bash (# Check if any commit in main references the issue ID) (+17 more)
+Cohesion: 0.07
+Nodes (27): code:bash (pan project add <path> --name <name>), code:block10 (## New Project Setup Complete: <NAME>), code:yaml (<project-key>:), code:yaml (<project-key>:), code:bash (# Format: owner/repo:PREFIX (comma-separated)), code:bash (cd <project-path>), code:bash (mkdir -p <project-path>/workspaces), code:bash (grep -q '^workspaces/' <project-path>/.gitignore 2>/dev/null) (+19 more)
 
 ### Community 306 - "Community 306"
-Cohesion: 0.08
-Nodes (25): 10. Footer, 1. Brand Stripe (4px), 2. Header Block (primary_color background), 3. Issue Info Row (Light Gray background, #F5F5F5), 4. Score Dashboard — 5 metric cards in a row/grid, 5. Overall Score Bar, 6. Top Blockers (Amber/warning callout box), 7. Dimension Details — One section per dimension (+17 more)
+Cohesion: 0.07
+Nodes (27): `.agent-template/`, code:block1 (team-meta/), code:bash (#!/bin/bash), code:yaml (groups:), code:block3 (Step 6: Meta Repo), code:bash (mkdir -p team-meta/{.agent-template/.claude,panopticon,docs/), code:bash (git clone git@github.com:yourorg/team-meta.git), code:bash (cd team-meta/docs/onboarding) (+19 more)
 
 ### Community 307 - "Community 307"
-Cohesion: 0.08
-Nodes (20): assistantIssues, assistantText, CLAUDE_PROJECTS, contextIssues, cost, db, DB_PATH, entries (+12 more)
+Cohesion: 0.07
+Nodes (27): 1. Test Coverage, 2. No Blocking Operations, 3. No Dead Code, 4. Error Handling, 5. Type Safety, 6. Temporal Dead Zone (TDZ), Acceptance Criteria (from vBRIEF plan) — MANDATORY GATE, APPROVED (rare — only for PERFECT code) (+19 more)
 
 ### Community 308 - "Community 308"
-Cohesion: 0.08
-Nodes (23): content, createTestDb(), db, event, goodLine, history, ids, latest (+15 more)
+Cohesion: 0.07
+Nodes (17): archiveIdx, beadsDir, branchStep, clearStep, closeIdx, commands, content, ctx (+9 more)
 
 ### Community 309 - "Community 309"
-Cohesion: 0.17
-Nodes (18): workspaceDeepCleanCommand(), WorkspaceDeepCleanOptions, dangerBanner(), DangerousOp, DangerousOpBlockedError, dryRunGitClean(), execAsync, pathLeaf() (+10 more)
+Cohesion: 0.13
+Nodes (20): CLAUDE_DIR, createClaudeAdapter(), createClaudeAdapterEffect(), createRuntimeRegistry(), getInstalledRuntimes(), getRuntimeAdapter(), getSupportedRuntimes(), isRuntimeInstalled() (+12 more)
 
 ### Community 310 - "Community 310"
 Cohesion: 0.08
-Nodes (24): Agent Auto-Resume Gates, Beads Enforcement, Claude Code Channels (experimental), Commit and Push When Working on Main, CRITICAL: Deep-Wipe Destroys Everything — NEVER Run Without Explicit User Confirmation, CRITICAL: Deliver Complete Features — No Partial Implementations, CRITICAL: JSONL Session Files Are Sacred — NEVER Delete, CRITICAL: Never Do Agent Work — Fix the System (+16 more)
+Nodes (20): EMPTY_HEALTH, MemoryHealthChangedPayload, MemoryHealthSnapshot, MemoryHealthStatus, MemoryHealthUpdate, MemoryHealthUpdateOptions, readMemoryHealth(), readMemoryHealthSnapshot() (+12 more)
 
 ### Community 311 - "Community 311"
-Cohesion: 0.08
-Nodes (24): Architecture, Auto-Start, Auto-Updater Channels, Available Actions, Building the Desktop App, Cmd+K Command Palette, code:bash (chmod +x Panopticon-*.AppImage), code:bash (npx panopticon serve) (+16 more)
+Cohesion: 0.16
+Nodes (20): costAction(), CostRow, formatTokens(), GroupBy, resolveGroupKey(), confirmCost(), enrichAction(), formatCost() (+12 more)
 
 ### Community 312 - "Community 312"
-Cohesion: 0.08
-Nodes (24): Backlog (hidden), Canonical States (Internal), Classification Labels (all trackers), Close-Out Ceremony, code:block1 (┌─────────────────────────────────────────┐), code:block2 (docs/prds/), code:block3 (backlog      -- Hidden from board, separate view), Columns (+16 more)
+Cohesion: 0.16
+Nodes (26): handleConversationImageUpload(), safeUploadExtension(), validateCwdContainment(), validateImageMagicBytes(), assertSafeName(), cleanupConversationAttachments(), cleanupOrphanedConversationAttachments(), cleanupUnreferencedConversationAttachments() (+18 more)
 
 ### Community 313 - "Community 313"
-Cohesion: 0.08
-Nodes (24): code:block1 (project-repo/), code:block2 (project-repo/), code:yaml (models:), code:yaml (# ~/.panopticon/config.yaml), code:yaml (# .pan.yaml (per-project, merges with global — never replace), code:block6 (project-repo/  (main branch)), code:block7 (project-repo/  (feature branch workspace)), code:block8 (.pan/events/) (+16 more)
+Cohesion: 0.07
+Nodes (26): A. Provider Billing & Observability → #730, Already Fixed / Shipped (14), B. Metrics Page v2 → #750, Biggest backlog themes, C. Documentation Overhaul → #634, Critical (5 issues) — 1.0 blockers or active pipeline corruption, D. Cost Display Polish → new umbrella or #77, Duplicates (10) (+18 more)
 
 ### Community 314 - "Community 314"
-Cohesion: 0.08
-Nodes (24): Authentication & Network Exposure, Backpressure, Bash / curl, code:block1 (GET /events/stream), code:block2 (event: activity.entry), code:bash (curl -N -H "Accept: text/event-stream" \), code:python (import sseclient, requests, json), code:ts (import { EventSource } from 'eventsource';) (+16 more)
+Cohesion: 0.07
+Nodes (26): 1. Check release readiness, 2. Create the release commit and tag, 3. Push intentionally, Branch and channel policy, Build or tests fail during preflight, Canary, Canary tags, code:bash (pan release check) (+18 more)
 
 ### Community 315 - "Community 315"
-Cohesion: 0.08
-Nodes (25): Automatic Complexity Detection, Beads Integration, code:block10 (┌───────────────────────────────────────────────────────────), code:typescript (// Example: Task completion triggers handoff), code:yaml (# ~/.panopticon/cloister.yaml), code:typescript (interface HandoffContext {), code:block18 (┌───────────────────────────────────────────────────────────), code:typescript (interface HandoffEvent {) (+17 more)
+Cohesion: 0.07
+Nodes (26): Advanced: Work Type Table, Available Providers, Bulk Reset, Canonical Sources, Changing a Model Assignment, code:yaml (models:), code:yaml (openrouter:), Configuration File (+18 more)
 
 ### Community 316 - "Community 316"
-Cohesion: 0.08
-Nodes (24): Adding New Assets, Build Commands, Build Commands, Build Pipeline, Build Tools, code:javascript (// Injected by tsdown shims), code:typescript (import { renderPrompt } from './prompts.js';), code:block3 (src/lib/cloister/prompts/*.md → dist/dashboard/prompts/) (+16 more)
+Cohesion: 0.07
+Nodes (26): Anthropic-heavy reviews, cheaper helpers, Choosing What to Override, CLI Modes, code:yaml (models:), code:yaml (models:), code:yaml (models:), code:yaml (models:), code:yaml (models:) (+18 more)
 
 ### Community 317 - "Community 317"
-Cohesion: 0.08
-Nodes (23): Acceptance Criteria, Architecture, Budget Controls, Build Pipeline, CLI, code:bash (# scripts/build-docs-index.ts), code:block3 (pan docs query "<text>" [--top 5] [--kind docs|skill|rule|pr), code:markdown (## docs/HARNESSES.md → Installing Pi) (+15 more)
+Cohesion: 0.07
+Nodes (25): 1. The breaker logic and the reset logic do not match, 2. `manual_retry` does not fit the current history type, 3. The `markWorkspaceStuck()` sample call is type-wrong, 4. The new retry endpoint overlaps heavily with the existing unstick flow, 5. `checkStuckReviewing()` may become too aggressive if tmux output pauses, 6. The PRD should call out interaction with stale-session cleanup in `runParallelReview()`, 7. The frontend copy and state model are good, but the PRD under-specifies how `stuckReason` should drive copy, 8. Minor path/documentation mismatch (+17 more)
 
 ### Community 318 - "Community 318"
-Cohesion: 0.08
-Nodes (24): Acceptance Criteria, Architecture, code:block1 (┌─────────────────────────────────────────────────────┐), code:typescript (// packages/contracts/src/editor.ts), code:typescript (// In WS_METHODS:), code:typescript ([WS_METHODS.shellOpenInEditor]: (input) => panOpen.openInEdi), code:block5 (┌─ Inspector: MIN-846 ─────────────────────────────────┐), Design Goals (+16 more)
+Cohesion: 0.07
+Nodes (26): Acceptance Criteria, Architecture, Claude Code, CLI Surface, code:markdown (# Project Rules), code:block2 ([WARN] sync.devroot is deprecated. Run `pan context migrate`), code:block3 (pan context list                    # Show all three layers'), code:bash (claude --append-system-prompt-file "$WORKSPACE/.panopticon/c) (+18 more)
 
 ### Community 319 - "Community 319"
-Cohesion: 0.08
-Nodes (24): Architecture, code:block1 (MissionControl (index.tsx)), code:block2 (JSONL file (append-only)), code:block3 (@pierre/diffs, react-markdown, remark-gfm, lexical, @lexical), Data Flow, Decisions, Frontend Changes, Full Lexical Editor (+16 more)
+Cohesion: 0.07
+Nodes (26): A/B Infrastructure, code:markdown (## Simplicity First), code:markdown ({{#KARPATHY_GUIDELINES}}), code:markdown ({{#KARPATHY_GUIDELINES}}), code:markdown ({{#KARPATHY_GUIDELINES}}), code:yaml (# ~/.panopticon/config.yaml), Config Schema, Design (+18 more)
 
 ### Community 320 - "Community 320"
-Cohesion: 0.08
-Nodes (24): code:yaml (projects:), code:bash (# Run all tests for a workspace), code:yaml (tests:), code:yaml (tests:), code:yaml (tests:), code:yaml (tests:), code:block7 (reports/), code:markdown (# Test Run Report - feature-min-123) (+16 more)
+Cohesion: 0.07
+Nodes (26): 1. Infrastructure Model: Self-Contained Machines, 2. Command Execution: Hybrid Approach, 3. Exe Provider: Delete and Reimplement, 4. Docker Image: Full Pipeline, 5. Workspace Flow: Full Parity (minus shared infra), 6. Cost Tracking: Existing JSONL System, 7. Agent Management: Fly Machine Exec API, Architecture (+18 more)
 
 ### Community 321 - "Community 321"
-Cohesion: 0.08
-Nodes (24): Adding DNS Entries, Automatic (Recommended), Checking Status, code:bash (pan doctor --fix), code:powershell (powershell -ExecutionPolicy Bypass -File "$env:USERPROFILE\.), code:powershell (cd \\wsl$\Ubuntu-20.04\home\eltmon\projects\panopticon\infra), code:powershell (# Copy sync script), code:bash (echo "myapp.localhost" >> ~/.wsl2hosts) (+16 more)
+Cohesion: 0.07
+Nodes (26): All implementation work types, All specialist agents (except review), All subagents, Claude Opus 4.6 Work Type Fit Analysis, CLI modes, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer` (+18 more)
 
 ### Community 322 - "Community 322"
-Cohesion: 0.08
-Nodes (24): 1. Provider Configuration, 2. Cost Tracking, 3. Model Routing, 4. Dashboard Visibility, 5. CLI Visibility, API Contract, Chat Completions, code:block1 (POST /v1/chat/completions) (+16 more)
+Cohesion: 0.07
+Nodes (26): All convoy reviewers, All implementation work types, All specialist agents (except inspect), `cli:interactive`, `cli:quick-command`, Excellent Fit, Good Fit — Worth Benchmarking, GPT-5.4 Nano Work Type Fit Analysis (+18 more)
 
 ### Community 323 - "Community 323"
-Cohesion: 0.14
-Nodes (20): setupCavemanCompressScripts(), addPanopticonHookIfMissing(), checkJqInstalled(), ClaudeSettings, HookConfig, installJq(), isHookConfigured(), McpServer (+12 more)
+Cohesion: 0.07
+Nodes (26): 1. Check Agent Status First, 2. Graceful Shutdown (Recommended), 3. Immediate Stop (If Needed), 4. Verify Stopped, 5. Clean Up (Optional), After Killing, code:bash (# Using pan CLI), code:bash (# List all matching sessions) (+18 more)
 
 ### Community 324 - "Community 324"
-Cohesion: 0.12
-Nodes (17): createTerminalWindow(), createWindow(), iconPath, IPC, isDevelopment, resolveResourcePath(), resolveServerStaticDir(), resolveWindowUrl() (+9 more)
+Cohesion: 0.07
+Nodes (26): code:bash (python3 scripts/conv-find.py <id>), code:text (Conversation #108), code:bash (python3 scripts/conv-find.py --jsonl 108), code:bash (python3 scripts/conv-find.py --summary 108), code:bash (python3 scripts/conv-find.py --json 108), code:bash (python3 scripts/conv-find.py --recent 20   # default 20), code:bash (python3 scripts/conv-find.py --search lexerra), code:python (import json, pathlib) (+18 more)
 
 ### Community 325 - "Community 325"
-Cohesion: 0.11
-Nodes (21): DEFAULT_FLYWHEEL_CONFIG, fetchFlywheelConversation(), fetchJson(), findFlywheelConversation(), FlywheelConversationPane(), FlywheelConversationPaneProps, FlywheelRoleConfig, FlywheelRunDetail (+13 more)
+Cohesion: 0.07
+Nodes (26): 1. Visual Theme & Atmosphere, 2. Color Palette & Roles, 3. Typography Rules, 4. Component Stylings, 5. Layout Principles, 6. Design System Notes for Stitch Generation, Accent & Interactive, Alignment & Visual Balance (+18 more)
 
 ### Community 326 - "Community 326"
-Cohesion: 0.09
-Nodes (20): existingSkillDir, existsInTarget, mockClaudeSkills, mockPanopticonSkills, nonSkillDir, skillDir, skills, skillsToSync (+12 more)
+Cohesion: 0.07
+Nodes (26): Adding Repos Mid-Work, CLI Command, code:yaml (# ~/.panopticon/projects.yaml), code:yaml (# Old config — still works, all repos checked out), code:yaml (# team-meta/panopticon/repo-groups.yaml), code:bash (# Add specific repos), code:bash (# Add specific repos), code:block5 (/workspace-add-repo) (+18 more)
 
 ### Community 327 - "Community 327"
-Cohesion: 0.08
-Nodes (23): Activity View, Adding Projects, Badge Bar, code:block1 (feature-pan-XXX/.planning/), Concept, Configuration, Conversation List, Conversations (+15 more)
+Cohesion: 0.07
+Nodes (26): Agent Self-Requeue (Circuit Breaker), code:block1 (Human clicks "Review"), code:bash (# All specialists with their current state), code:bash (# Via dashboard: click "Review" on an issue card), code:yaml (projects:), code:yaml (projects:), code:yaml (projects:), code:bash (# Via dashboard: click "Approve & Merge" on an issue card) (+18 more)
 
 ### Community 328 - "Community 328"
-Cohesion: 0.08
-Nodes (23): Agent Guidance, Agent System, Architecture & Design, Build & Development, Configuration, Configuration & Models, Development, Documentation Maintenance (+15 more)
+Cohesion: 0.11
+Nodes (19): childEnv, expectedExits, killChildTree(), port, requiredFiles, restartQueue, shutdown(), startApp() (+11 more)
 
 ### Community 329 - "Community 329"
 Cohesion: 0.08
-Nodes (23): code:block1 (Session 1: AI queries users.created_at → Error (column is "c), code:block2 (myproject/), code:markdown (# In ~/.claude/CLAUDE.md (developer's personal config)), code:bash (pan start MIN-123 --shadow), code:yaml (# In <project>/.panopticon.yaml), code:yaml (# In ~/.panopticon/config.yaml), code:bash (SHADOW_MODE=true pan start MIN-123), code:yaml (# In .panopticon.yaml — only shadow Linear, not GitHub) (+15 more)
+Nodes (19): generateRouterConfigFromWorkTypes(), Provider, ROUTER_CONFIG_DIR, ROUTER_CONFIG_FILE, RouterConfig, RouterRule, config, config1 (+11 more)
 
 ### Community 330 - "Community 330"
 Cohesion: 0.08
-Nodes (23): Auth: Internal Token, CLI, code:bash (pan swarm <id>                       # Spawn dispatchable it), code:bash (pan swarm <id> --task next                        # List dis), code:ts (interface SwarmRuntime {), code:block4 (plan dispatch), `continue-state.ts` — async helpers, Continue vBRIEF (Runtime State) (+15 more)
+Nodes (23): CloisterEvent, setCloisterService(), capturedEvents, consoleSpy, customService, emergencyEvent, health, healths (+15 more)
 
 ### Community 331 - "Community 331"
 Cohesion: 0.08
-Nodes (23): Architecture, code:block1 (Main repo (host)), code:yaml (projects:), code:yaml (volumes:), code:yaml (# ✗ WRONG — causes two hard failures:), code:sh (bun install &&), code:json ("overrides": {), Container Image (+15 more)
+Nodes (22): body, bytes, claudeProjectDir, conv, created, deliverMock, encodedCwd, getTrustedOrigins() (+14 more)
 
 ### Community 332 - "Community 332"
-Cohesion: 0.08
-Nodes (23): Architecture Decisions, Build Verification, code:bash (pan install), code:bash (pan up), code:bash (pan down), code:bash (pan install --minimal), Documentation, Files Created/Modified (+15 more)
+Cohesion: 0.13
+Nodes (21): runCostSync(), buildSessionIndex(), decodeClaudeDirName(), extractCostEvents(), extractSessionId(), getAgentsDir(), getClaudeProjectsDir(), getSessionOffset() (+13 more)
 
 ### Community 333 - "Community 333"
-Cohesion: 0.08
-Nodes (22): Acceptance Criteria, Architecture, CLI Surface, code:markdown (# Working Inside Panopticon), code:bash (claude --append-system-prompt-file "$HOME/.panopticon/sessio), code:bash (# dist/hooks/briefing-refresh.sh), code:markdown (## Knowledge Registry), code:typescript (// src/lib/hooks/compliance-audit.ts) (+14 more)
+Cohesion: 0.12
+Nodes (19): createTerminalWindow(), createWindow(), iconPath, IPC, isDevelopment, resolveResourcePath(), resolveServerEntry(), resolveWindowUrl() (+11 more)
 
 ### Community 334 - "Community 334"
-Cohesion: 0.08
-Nodes (23): Click Behavior Split on ProjectNode, code:block1 (selectedConversation → ConversationView), code:typescript (export type PipelineStage =), code:typescript (interface ProjectOverviewProps {), Command Deck — Project Overview Panel (PAN-1044), Component Design, Data Sources, Files (+15 more)
+Cohesion: 0.09
+Nodes (19): extractEmbedding(), ExtractEmbeddingInput, previewDesignVoice(), PreviewDesignVoiceInput, saveCloneVoice(), SaveCloneVoiceInput, saveDesignVoice(), SaveDesignVoiceInput (+11 more)
 
 ### Community 335 - "Community 335"
-Cohesion: 0.08
-Nodes (22): Acceptance Criteria, Architecture, CLI, CLI Examples, code:block1 (pan artifacts validate <file>              # validate, no pu), code:yaml (http:), code:bash (# Agent writes the file), Dashboard Integration (+14 more)
+Cohesion: 0.1
+Nodes (17): RoundMarker, ZoneCConversation(), ZoneCConversationProps, deriveRoundMarkers(), TimestampedItem, getViewKey(), PanelView, readView() (+9 more)
 
 ### Community 336 - "Community 336"
-Cohesion: 0.08
-Nodes (23): Agent Slots, AgentSnapshot extensions, Architecture (3 sentences), CLI Command, Cloister as Monitor, code:block1 (Wave 1: [items with no unmet blocks dependencies]  → spawn N), code:block2 (PAN-970), code:bash (pan swarm <issueId>          # Analyze DAG, show wave plan, ) (+15 more)
+Cohesion: 0.11
+Nodes (14): CloseOutContext, CloseOutError, CloseOutResult, CloseOutStep, execAsync, executeCloseOut(), findWorkspacePath(), isBranchMerged() (+6 more)
 
 ### Community 337 - "Community 337"
 Cohesion: 0.08
-Nodes (23): Acceptance Criteria, code:block1 (click + → DraftConversationPanel mounts → user types first m), code:block2 (click + → POST /api/conversations { model, effort }), Compact-boundary offset, Design, Duplicate-id audit (#696), Goals, Implementation Notes (+15 more)
+Nodes (25): BRANCH_NOT_FOUND, Check Merged, code:bash (# Standard naming convention), code:bash (# Get repo list from project config), code:bash (# Check local branches), code:bash (# Check for unmerged commits), code:bash (git -C "$PROJECT_PATH" fetch origin "$BRANCH" 2>/dev/null), code:bash (# Check if any commit in main references the issue ID) (+17 more)
 
 ### Community 338 - "Community 338"
 Cohesion: 0.08
-Nodes (23): A/B Testing, caveman-compress (manual only), caveman-review for Review Agent, code:json ({), code:yaml (# ~/.panopticon/config.yaml), code:block3 (## Panopticon Overrides (non-negotiable)), code:block4 (Format: L<line>: <problem>. <fix>.), Config Schema (+15 more)
+Nodes (25): 10. Footer, 1. Brand Stripe (4px), 2. Header Block (primary_color background), 3. Issue Info Row (Light Gray background, #F5F5F5), 4. Score Dashboard — 5 metric cards in a row/grid, 5. Overall Score Bar, 6. Top Blockers (Amber/warning callout box), 7. Dimension Details — One section per dimension (+17 more)
 
 ### Community 339 - "Community 339"
 Cohesion: 0.08
-Nodes (23): Animations, Architecture, Charts (visx), code:block1 (GodViewPage (new tab component)), code:block2 (Server:), Data Flow, Decisions Made, Design System (God View scope) (+15 more)
+Nodes (20): assistantIssues, assistantText, CLAUDE_PROJECTS, contextIssues, cost, db, DB_PATH, entries (+12 more)
 
 ### Community 340 - "Community 340"
-Cohesion: 0.08
-Nodes (23): 1a. Verification Gate Enhancement, 1b. Review Convoy Enhancement, Architecture, Attribution, code:typescript (async function checkForStubs(workspacePath: string): Promise), code:block2 (## Stub Detection), code:markdown (## Locked Decisions), code:block4 (## Decision Protocol) (+15 more)
+Cohesion: 0.12
+Nodes (16): ForgeType, buildMergeSetForIssue(), getRepoForge(), inferProjectForge(), normalizeForge(), resolveConfiguredRepos(), ResolvedProjectRepo, resolveProjectReposForIssue() (+8 more)
 
 ### Community 341 - "Community 341"
-Cohesion: 0.08
-Nodes (23): Architecture Decisions, D1: Extend existing command, not create new, D2: Transition to "In Progress", not Backlog, D3: Keep .planning-complete marker, D4: Reset specialist states to pending (preserve history), D5: Append-only STATE.md updates, D6: Core reopen logic in a shared function, D7: Remove issue from specialist queues on reopen (+15 more)
+Cohesion: 0.12
+Nodes (15): completeSession(), DEFAULT_DATA, findSessionById(), getAllIssuesWithCosts(), getIssueCostSummary(), getIssueSessions(), IssueSessionMap, linkSessionToIssue() (+7 more)
 
 ### Community 342 - "Community 342"
-Cohesion: 0.08
-Nodes (22): Architecture, code:block1 (main.ts: await startSharedIssueService()     ← BLOCKS until ), code:block2 (main.ts: startSharedIssueService()           ← NO await, fir), Current Flow (Slow), Decisions, Edge Cases, EventRouter Changes, Files Changed (Summary) (+14 more)
+Cohesion: 0.1
+Nodes (15): clearTtsVoices(), deleteTtsVoice(), fetchTtsVoices(), playTtsVoice(), requireTtsSpoken(), TtsVoiceListItem, playVoice(), requireTtsSpoken() (+7 more)
 
 ### Community 343 - "Community 343"
-Cohesion: 0.08
-Nodes (23): 1. God View: Token foundation only, 2. API rename: Full rename, 3. Chat components: Included in rebrand, 4. Sidebar: Custom component, Architecture Overview, Decisions Made, Design References, In Scope (+15 more)
+Cohesion: 0.12
+Nodes (10): defectQuery, hrQuery, mockCreate, mockQuery, mockUpdate, tracker, escapeQueryValue(), RallyTracker (+2 more)
 
 ### Community 344 - "Community 344"
-Cohesion: 0.08
-Nodes (23): By Gemini 3 Flash (for subagent:explore), By GPT-5.4 Nano (for subagent/CLI work), Claude Haiku 4.5 Work Type Fit Analysis, `cli:interactive`, `cli:quick-command`, Good Fit (Current Defaults), Integration Notes, Keep Haiku for: (+15 more)
+Cohesion: 0.12
+Nodes (19): extractHashFromJsonlPath(), HashResolver, encodeClaudeProjectDir(), pathExists(), pickFreshestSessionId(), readOptional(), resolveClaudeSessionId(), resolveJsonlPath() (+11 more)
 
 ### Community 345 - "Community 345"
 Cohesion: 0.08
-Nodes (23): Anti-Patterns, Chemistry Patterns, code:block1 (┌───────────────────────────────────────────────────────────), code:block2 (Will this work be referenced later?), code:bash (# Start grooming), code:bash (# Start review), code:bash (# Start spike (2 hour timebox)), code:bash (# Persistent mol (solid → liquid)) (+15 more)
+Nodes (18): AgentState, __testInternals, createSessionAsync, dir, emitActivityEntry, legacyDir, rawState, state (+10 more)
 
 ### Community 346 - "Community 346"
 Cohesion: 0.08
-Nodes (23): code:block1 (~/.panopticon/skills/spec-readiness-{name}/), code:bash (mkdir -p ~/.panopticon/skills/spec-readiness-{name}), code:block11 (Created spec-readiness wrapper: spec-readiness-{name}), code:block12 (User: setup spec readiness), code:yaml (tracker:), code:yaml (tracker:), code:yaml (tracker:), code:yaml (tracker:) (+15 more)
+Nodes (24): Agent Auto-Resume Gates, Beads Enforcement, Claude Code Channels (experimental), Commit and Push When Working on Main, CRITICAL: Deep-Wipe Destroys Everything — NEVER Run Without Explicit User Confirmation, CRITICAL: Deliver Complete Features — No Partial Implementations, CRITICAL: JSONL Session Files Are Sacred — NEVER Delete, CRITICAL: Never Do Agent Work — Fix the System (+16 more)
 
 ### Community 347 - "Community 347"
 Cohesion: 0.08
-Nodes (23): Bead Description (What Was Asked), BLOCKED — Any check fails, Check 1: Spec Fidelity, Check 2: Constraint Compliance, Check 3: Compile + Smoke, code:bash (cd {{workspacePath}}), code:bash (# Check workspace CLAUDE.md), code:bash (# Example: check for prohibited imports) (+15 more)
+Nodes (24): Architecture, Auto-Start, Auto-Updater Channels, Available Actions, Building the Desktop App, Cmd+K Command Palette, code:bash (chmod +x Panopticon-*.AppImage), code:bash (npx panopticon serve) (+16 more)
 
 ### Community 348 - "Community 348"
-Cohesion: 0.15
-Nodes (21): runCostSync(), buildSessionIndex(), decodeClaudeDirName(), extractCostEvents(), extractSessionId(), getAgentsDir(), getClaudeProjectsDir(), getSessionOffset() (+13 more)
+Cohesion: 0.08
+Nodes (24): Backlog (hidden), Canonical States (Internal), Classification Labels (all trackers), Close-Out Ceremony, code:block1 (┌─────────────────────────────────────────┐), code:block2 (docs/prds/), code:block3 (backlog      -- Hidden from board, separate view), Columns (+16 more)
 
 ### Community 349 - "Community 349"
-Cohesion: 0.11
-Nodes (19): __dirname, __filename, isStringArray(), loadPromptFrontmatter(), ParsedPrompt, parsePrompt(), PromptError, PromptFrontmatter (+11 more)
+Cohesion: 0.08
+Nodes (25): code:yaml (# Your original docker-compose.yml), code:block109 (~/.panopticon/), code:yaml (# ~/.panopticon/traefik/dynamic/feature-min-648.yml), code:toml ([panopticon]), code:toml ([project]), code:bash (npx panopticon install), code:bash (npx panopticon install --minimal), code:bash (# User has an existing project with docker-compose) (+17 more)
 
 ### Community 350 - "Community 350"
-Cohesion: 0.09
-Nodes (22): all, backing, cheap, enriched, expensive, fetched, inserted, malformed (+14 more)
+Cohesion: 0.08
+Nodes (24): code:block1 (project-repo/), code:block2 (project-repo/), code:yaml (models:), code:yaml (# ~/.panopticon/config.yaml), code:yaml (# .pan.yaml (per-project, merges with global — never replace), code:block6 (project-repo/  (main branch)), code:block7 (project-repo/  (feature branch workspace)), code:block8 (.pan/events/) (+16 more)
 
 ### Community 351 - "Community 351"
-Cohesion: 0.17
-Nodes (19): execFileAsync, gitFetch(), gitForcePush(), gitMerge(), gitPush(), gitRevParse(), MainDivergedError, appendGitOperation() (+11 more)
+Cohesion: 0.08
+Nodes (24): Authentication & Network Exposure, Backpressure, Bash / curl, code:block1 (GET /events/stream), code:block2 (event: activity.entry), code:bash (curl -N -H "Accept: text/event-stream" \), code:python (import sseclient, requests, json), code:ts (import { EventSource } from 'eventsource';) (+16 more)
 
 ### Community 352 - "Community 352"
-Cohesion: 0.13
-Nodes (19): displayIssues(), getConfiguredTrackers(), getTrackerConfig(), listCommand(), ListOptions, PRIORITY_LABELS, { loadConfigMock, isShadowedMock, getPendingSyncCountMock, createTrackerMock, loadProjectsConfigMock }, mockIssues (+11 more)
+Cohesion: 0.08
+Nodes (25): Automatic Complexity Detection, Beads Integration, code:block10 (┌───────────────────────────────────────────────────────────), code:typescript (// Example: Task completion triggers handoff), code:yaml (# ~/.panopticon/cloister.yaml), code:typescript (interface HandoffContext {), code:block18 (┌───────────────────────────────────────────────────────────), code:typescript (interface HandoffEvent {) (+17 more)
 
 ### Community 353 - "Community 353"
-Cohesion: 0.16
-Nodes (21): ACTIVE_AGENT_STATUSES, CandidateGroup, collectActiveAgentIssueIds(), collectWorkspaceReapCandidatesFromInspect(), composeDown(), confirmApply(), DockerInspectContainer, execFileAsync (+13 more)
+Cohesion: 0.08
+Nodes (24): Adding New Assets, Build Commands, Build Commands, Build Pipeline, Build Tools, code:javascript (// Injected by tsdown shims), code:typescript (import { renderPrompt } from './prompts.js';), code:block3 (src/lib/cloister/prompts/*.md → dist/dashboard/prompts/) (+16 more)
 
 ### Community 354 - "Community 354"
-Cohesion: 0.12
-Nodes (17): BYTE_UNITS, cachedContainerLifecycleSnapshot, ContainerHistory, ContainerStats, DockerContainerLifecycle, DockerNetwork, DockerPsRaw, DockerStatsCollector (+9 more)
+Cohesion: 0.08
+Nodes (23): Acceptance Criteria, Architecture, Budget Controls, Build Pipeline, CLI, code:bash (# scripts/build-docs-index.ts), code:block3 (pan docs query "<text>" [--top 5] [--kind docs|skill|rule|pr), code:markdown (## docs/HARNESSES.md → Installing Pi) (+15 more)
 
 ### Community 355 - "Community 355"
-Cohesion: 0.09
-Nodes (22): Architecture, Best Practices, CLI Commands, code:bash (# 1. Implement feature), code:bash (# List all specialists with status), code:toml ([specialists.review_agent]), code:typescript (type Priority = 'urgent' | 'high' | 'normal' | 'low';), Configuration (+14 more)
+Cohesion: 0.08
+Nodes (24): Acceptance Criteria, Architecture, code:block1 (┌─────────────────────────────────────────────────────┐), code:typescript (// packages/contracts/src/editor.ts), code:typescript (// In WS_METHODS:), code:typescript ([WS_METHODS.shellOpenInEditor]: (input) => panOpen.openInEdi), code:block5 (┌─ Inspector: MIN-846 ─────────────────────────────────┐), Design Goals (+16 more)
 
 ### Community 356 - "Community 356"
-Cohesion: 0.09
-Nodes (23): code:block126 (┌─────────────────┐    ┌─────────────────┐    ┌─────────────), code:block127 (┌──────────────────────────────────────────────────────────┐), code:yaml (permissions:), code:json ({), code:bash (# 1. Login to npm (one-time)), code:bash (# Bump version (follows semver)), code:bash (# One-shot (no global install needed)), code:bash (# Tag beta releases) (+15 more)
+Cohesion: 0.08
+Nodes (24): Architecture, code:block1 (MissionControl (index.tsx)), code:block2 (JSONL file (append-only)), code:block3 (@pierre/diffs, react-markdown, remark-gfm, lexical, @lexical), Data Flow, Decisions, Frontend Changes, Full Lexical Editor (+16 more)
 
 ### Community 357 - "Community 357"
-Cohesion: 0.09
-Nodes (23): code:typescript (interface IssueTracker {), code:block78 (┌───────────────────────────────────────────────────────────), code:toml (# ~/.panopticon/projects.toml), code:block80 (┌──────────┐    ┌──────────┐    ┌──────────┐    ┌───────────), code:yaml (# ~/.panopticon/state-mappings.yaml), code:typescript (// ~/.panopticon/issue-states.json), code:typescript (interface StateManager {), code:block84 ($ pan project add ~/projects/myn --tracker linear --team MIN) (+15 more)
+Cohesion: 0.08
+Nodes (24): code:yaml (projects:), code:bash (# Run all tests for a workspace), code:yaml (tests:), code:yaml (tests:), code:yaml (tests:), code:yaml (tests:), code:block7 (reports/), code:markdown (# Test Run Report - feature-min-123) (+16 more)
 
 ### Community 358 - "Community 358"
-Cohesion: 0.09
-Nodes (23): 10. `onboard-codebase` - Understanding New Code, All Questions Resolved ✅, Appendix A: Key Concepts Reference, Appendix C: References, Appendix D: Open Questions, code:block141 (workspaces/feature-min-648/), code:bash (# 1. Mayor spawns convoy), code:block37 (+15 more)
+Cohesion: 0.08
+Nodes (24): Adding DNS Entries, Automatic (Recommended), Checking Status, code:bash (pan doctor --fix), code:powershell (powershell -ExecutionPolicy Bypass -File "$env:USERPROFILE\.), code:powershell (cd \\wsl$\Ubuntu-20.04\home\eltmon\projects\panopticon\infra), code:powershell (# Copy sync script), code:bash (echo "myapp.localhost" >> ~/.wsl2hosts) (+16 more)
 
 ### Community 359 - "Community 359"
-Cohesion: 0.09
-Nodes (23): 6. Agreed End-State, Agent Startup Context, code:block10 (pan sync), code:block11 (pan sync), code:yaml (devroot: ~/Projects        # where you launch Claude Code fr), code:json ({), code:json ({), code:bash (pan workspace update MIN-678    # explicit command, only whe) (+15 more)
+Cohesion: 0.08
+Nodes (24): 1. Provider Configuration, 2. Cost Tracking, 3. Model Routing, 4. Dashboard Visibility, 5. CLI Visibility, API Contract, Chat Completions, code:block1 (POST /v1/chat/completions) (+16 more)
 
 ### Community 360 - "Community 360"
-Cohesion: 0.09
-Nodes (22): A. Per-issue allow-list at plan time, Acceptance Criteria, Approach (Option 5 — combination), Architecture, Awaiting-input extension, Awaiting-input indicator (Section C), B. Outbound-write suppression during prompt display, C. Awaiting-input indicator + inspector deep link (+14 more)
+Cohesion: 0.13
+Nodes (18): buildAnthropicMessagesUrl(), cache, CacheEntry, cacheKey(), classifyError(), classifyFetchError(), doProbe(), formatProbeError() (+10 more)
 
 ### Community 361 - "Community 361"
 Cohesion: 0.09
-Nodes (22): 1. Root policy: what stays at root, 2. Root artifacts to relocate, 3. Destination policy, 4. Reference update pass, 5. Professionalism rule for future additions, Audits / investigations / findings, Constraints, Design (+14 more)
+Nodes (17): ALLOWED, AuthMode, AvailableModelsState, FALLBACK_GROUPS, getProviderForPickerModel(), Harness, HARNESS_OPTIONS, HarnessDecision (+9 more)
 
 ### Community 362 - "Community 362"
-Cohesion: 0.09
-Nodes (22): 1. Viewer in scope, 2. Model injection for plan.author, 3. vBRIEFInfo.author from package.json, 4. Artifact copy: skip if exists, 5. Testing approach, Architecture, Artifact auto-copy (issues.ts — complete-planning), Beads sync (beads.ts) (+14 more)
+Cohesion: 0.13
+Nodes (18): InlineSparkline(), InlineSparklineProps, BranchNode(), BranchNodeProps, ContainerNode(), ContainerNodeProps, containerStatusColor(), containerStatusToDot() (+10 more)
 
 ### Community 363 - "Community 363"
-Cohesion: 0.09
-Nodes (21): 1. KanbanBoard.tsx — `CycleFilter` type (line 678), 2. KanbanBoard.tsx — `groupByStatus()` (lines 191-193), 3. KanbanBoard.tsx — Filter bar UI (around line 1042), 4. KanbanBoard.tsx — Canceled list view, 5. issue-data-service.ts — `getIssues()` (around line 223), Acceptance Criteria, Architecture, code:typescript (// Before:) (+13 more)
+Cohesion: 0.12
+Nodes (20): DatabaseError, cleanupOldEntries(), dequeueMerge(), enqueueMerge(), getAllActiveQueues(), getCurrentMerge(), getQueueForProject(), markMergeProcessing() (+12 more)
 
 ### Community 364 - "Community 364"
-Cohesion: 0.09
-Nodes (22): 1. Scope — all 5 phases in this issue, 2. Table model — new `discovered_sessions` table, separate from `conversations`, 3. Hash→path resolution — JSONL cwd primary, reverse-map fallback, 4. Adaptive parallelism — full probe as spec'd, 5. Embeddings — all three providers (OpenAI, Voyage, Ollama), 6. Enrichment execution — reuse `model-fallback.ts` routing, 7. Re-scanning — manual only in v1, 8. Blocking FS calls — must use async everywhere in server code (+14 more)
+Cohesion: 0.13
+Nodes (15): appendToRunLog(), checkLogSizeLimit(), createRunLog(), ensureRunsDirectory(), finalizeRunLog(), generateRunId(), getRunLog(), getRunLogPath() (+7 more)
 
 ### Community 365 - "Community 365"
-Cohesion: 0.09
-Nodes (22): Acceptance criteria, Command Taxonomy Reorganization, Decision, Design principles, Implementation plan, Out of scope, Phase 1 — Scaffolding (non-breaking), Phase 2 — Collapse commands (+14 more)
+Cohesion: 0.08
+Nodes (23): Activity View, Adding Projects, Badge Bar, code:block1 (feature-pan-XXX/.planning/), Concept, Configuration, Conversation List, Conversations (+15 more)
 
 ### Community 366 - "Community 366"
-Cohesion: 0.09
-Nodes (22): 1. Auth Configuration, 2. CCR Command, 3. claudish Installation, 4. Model Prefixes, 5. Dashboard Model Display, 6. OpenAI Model Registry, 7. Token Usage Tracking, Architecture (+14 more)
+Cohesion: 0.08
+Nodes (23): Agent Guidance, Agent System, Architecture & Design, Build & Development, Configuration, Configuration & Models, Development, Documentation Maintenance (+15 more)
 
 ### Community 367 - "Community 367"
-Cohesion: 0.09
-Nodes (22): 10. Not yet decided, 1.1 PAN-722 (queue removal) left a per-project singleton, 1.2 Inverted model priority — Sonnet lurking under every config, 1.3 PAN-540 parallel review — invisible sibling tmux sessions, 1.4 Cross-cutting: duplicate-tab failure mode, 1. Problem inventory, 2. Root cause, 3. The DAG reframe (+14 more)
+Cohesion: 0.08
+Nodes (23): code:block1 (Session 1: AI queries users.created_at → Error (column is "c), code:block2 (myproject/), code:markdown (# In ~/.claude/CLAUDE.md (developer's personal config)), code:bash (pan start MIN-123 --shadow), code:yaml (# In <project>/.panopticon.yaml), code:yaml (# In ~/.panopticon/config.yaml), code:bash (SHADOW_MODE=true pan start MIN-123), code:yaml (# In .panopticon.yaml — only shadow Linear, not GitHub) (+15 more)
 
 ### Community 368 - "Community 368"
-Cohesion: 0.09
-Nodes (22): ACCEPTANCE CRITERIA (WHAT SUCCESS LOOKS LIKE):, Ask the user before creating when:, code:markdown (bd update issue-9 --notes "IMPLEMENTATION GUIDE:), code:block2 (Two-phase Docs API approach:), code:block3 (- [ ] Markdown formatting renders in Doc (bold, italic, head), code:block4 (- [ ] Use two-phase batchUpdate approach), Contents, Create directly when: (+14 more)
+Cohesion: 0.08
+Nodes (23): Auth: Internal Token, CLI, code:bash (pan swarm <id>                       # Spawn dispatchable it), code:bash (pan swarm <id> --task next                        # List dis), code:ts (interface SwarmRuntime {), code:block4 (plan dispatch), `continue-state.ts` — async helpers, Continue vBRIEF (Runtime State) (+15 more)
 
 ### Community 369 - "Community 369"
-Cohesion: 0.09
-Nodes (22): 1. Confirm scope before destroying anything, 2. Kill work agents via the CLI (preferred), 3. Kill review coordinators and test specialists, 4. Verify only conversations and the server remain, 5. (Optional) Stop the dashboard, 6. Verify, code:bash (# List live tmux sessions, classified), code:bash (# Loop over agent sessions and kill each via pan) (+14 more)
+Cohesion: 0.08
+Nodes (23): Architecture, code:block1 (Main repo (host)), code:yaml (projects:), code:yaml (volumes:), code:yaml (# ✗ WRONG — causes two hard failures:), code:sh (bun install &&), code:json ("overrides": {), Container Image (+15 more)
 
 ### Community 370 - "Community 370"
-Cohesion: 0.09
-Nodes (22): Bead ID vs Issue ID, Beads Quick Reference for Panopticon Agents, code:bash (bd list --issue PAN-116), code:bash (# Option 1: Search in title (most common)), code:bash (# Find ALL beads for PAN-116 (including closed)), code:bash (# By status), code:bash (# Start work on a bead), code:bash (# ❌ WRONG) (+14 more)
+Cohesion: 0.08
+Nodes (23): Architecture Decisions, Build Verification, code:bash (pan install), code:bash (pan up), code:bash (pan down), code:bash (pan install --minimal), Documentation, Files Created/Modified (+15 more)
 
 ### Community 371 - "Community 371"
-Cohesion: 0.09
-Nodes (23): 7. Components, Alerts, Badges, Buttons, Cards, code:block11 (Container:), code:block12 (Base:), code:block13 (Base:) (+15 more)
+Cohesion: 0.08
+Nodes (22): Acceptance Criteria, Architecture, CLI Surface, code:markdown (# Working Inside Panopticon), code:bash (claude --append-system-prompt-file "$HOME/.panopticon/sessio), code:bash (# dist/hooks/briefing-refresh.sh), code:markdown (## Knowledge Registry), code:typescript (// src/lib/hooks/compliance-audit.ts) (+14 more)
 
 ### Community 372 - "Community 372"
-Cohesion: 0.09
-Nodes (22): AI Self-Monitoring, Best Practices, Built-In Skills, Code Review Subagents, code:block1 (# In Claude Code, Cursor, Windsurf, etc:), code:bash (# Use the guided skill creator), code:markdown (# Skill Title), code:bash (# Sync all skills to AI tools (Claude Code, Cursor, etc.)) (+14 more)
+Cohesion: 0.08
+Nodes (23): Click Behavior Split on ProjectNode, code:block1 (selectedConversation → ConversationView), code:typescript (export type PipelineStage =), code:typescript (interface ProjectOverviewProps {), Command Deck — Project Overview Panel (PAN-1044), Component Design, Data Sources, Files (+15 more)
 
 ### Community 373 - "Community 373"
-Cohesion: 0.09
-Nodes (22): Anthropic, Benchmark Leaderboards, code:json ({), Coding Benchmarks, Community Sources, Deliverables, Google, Important Notes (+14 more)
+Cohesion: 0.08
+Nodes (22): Acceptance Criteria, Architecture, CLI, CLI Examples, code:block1 (pan artifacts validate <file>              # validate, no pu), code:yaml (http:), code:bash (# Agent writes the file), Dashboard Integration (+14 more)
 
 ### Community 374 - "Community 374"
-Cohesion: 0.09
-Nodes (18): agent2, baseAgent, bigOutput, events, existing, issues, next, planningAgent (+10 more)
+Cohesion: 0.08
+Nodes (23): Agent Slots, AgentSnapshot extensions, Architecture (3 sentences), CLI Command, Cloister as Monitor, code:block1 (Wave 1: [items with no unmet blocks dependencies]  → spawn N), code:block2 (PAN-970), code:bash (pan swarm <issueId>          # Analyze DAG, show wave plan, ) (+15 more)
 
 ### Community 375 - "Community 375"
-Cohesion: 0.09
-Nodes (21): consoleSpy, mirrorLog, mockCleanupLegacyRuntimeSymlinks, mockCreateBackup, mockEnsurePlaywrightIsolation, mockExecuteSync, mockGetDevrootPath, mockListProjects (+13 more)
+Cohesion: 0.08
+Nodes (23): Acceptance Criteria, code:block1 (click + → DraftConversationPanel mounts → user types first m), code:block2 (click + → POST /api/conversations { model, effort }), Compact-boundary offset, Design, Duplicate-id audit (#696), Goals, Implementation Notes (+15 more)
 
 ### Community 376 - "Community 376"
-Cohesion: 0.09
-Nodes (16): CLAUDE_PROJECTS, cost, db, DB_PATH, entry, insert, issueStats, lines (+8 more)
+Cohesion: 0.08
+Nodes (23): A/B Testing, caveman-compress (manual only), caveman-review for Review Agent, code:json ({), code:yaml (# ~/.panopticon/config.yaml), code:block3 (## Panopticon Overrides (non-negotiable)), code:block4 (Format: L<line>: <problem>. <fix>.), Config Schema (+15 more)
 
 ### Community 377 - "Community 377"
-Cohesion: 0.14
-Nodes (16): handleAutoStartNag(), showFirstLaunchDialog(), deepClone(), DEFAULTS, DesktopSettings, getDesktopSettings(), loadDesktopSettings(), saveDesktopSettings() (+8 more)
+Cohesion: 0.08
+Nodes (23): Animations, Architecture, Charts (visx), code:block1 (GodViewPage (new tab component)), code:block2 (Server:), Data Flow, Decisions Made, Design System (God View scope) (+15 more)
 
 ### Community 378 - "Community 378"
-Cohesion: 0.15
-Nodes (17): createWarmupUserMessage(), ExcalidrawElement, finiteNumber(), normalizeElements(), normalizeExcalidrawElement(), randomId(), randomNonce(), extractKeywords() (+9 more)
+Cohesion: 0.08
+Nodes (23): 1a. Verification Gate Enhancement, 1b. Review Convoy Enhancement, Architecture, Attribution, code:typescript (async function checkForStubs(workspacePath: string): Promise), code:block2 (## Stub Detection), code:markdown (## Locked Decisions), code:block4 (## Decision Protocol) (+15 more)
 
 ### Community 379 - "Community 379"
-Cohesion: 0.12
-Nodes (10): formatIssueRef(), LinkDirection, LinkManager, LinkStore, parseIssueRef(), link, links, newManager (+2 more)
+Cohesion: 0.08
+Nodes (23): Architecture Decisions, D1: Extend existing command, not create new, D2: Transition to "In Progress", not Backlog, D3: Keep .planning-complete marker, D4: Reset specialist states to pending (preserve history), D5: Append-only STATE.md updates, D6: Core reopen logic in a shared function, D7: Remove issue from specialist queues on reopen (+15 more)
 
 ### Community 380 - "Community 380"
-Cohesion: 0.23
-Nodes (21): destroyRemoteWorkspace(), createFlyProvider(), AGENTS_DIR, buildRemoteTmuxCommand(), ensureRemoteTmuxContext(), getRemoteAgentOutput(), getRemoteAgentStateFile(), getRemoteTmuxBaseArgs() (+13 more)
+Cohesion: 0.08
+Nodes (22): Architecture, code:block1 (main.ts: await startSharedIssueService()     ← BLOCKS until ), code:block2 (main.ts: startSharedIssueService()           ← NO await, fir), Current Flow (Slow), Decisions, Edge Cases, EventRouter Changes, Files Changed (Summary) (+14 more)
 
 ### Community 381 - "Community 381"
-Cohesion: 0.2
-Nodes (16): costAction(), CostRow, formatTokens(), GroupBy, resolveGroupKey(), formatBrief(), formatDate(), formatIds() (+8 more)
+Cohesion: 0.08
+Nodes (23): 1. God View: Token foundation only, 2. API rename: Full rename, 3. Chat components: Included in rebrand, 4. Sidebar: Custom component, Architecture Overview, Decisions Made, Design References, In Scope (+15 more)
 
 ### Community 382 - "Community 382"
-Cohesion: 0.17
-Nodes (20): checkCommand(), execAsync, getMissingToolsForFeature(), INSTALLABLE_TOOLS, installBeads(), installMkcert(), installOx(), InstallResult (+12 more)
+Cohesion: 0.08
+Nodes (23): By Gemini 3 Flash (for subagent:explore), By GPT-5.4 Nano (for subagent/CLI work), Claude Haiku 4.5 Work Type Fit Analysis, `cli:interactive`, `cli:quick-command`, Good Fit (Current Defaults), Integration Notes, Keep Haiku for: (+15 more)
 
 ### Community 383 - "Community 383"
-Cohesion: 0.09
-Nodes (19): assistantLine, content, existingFiles, firstLine, fixture, fixturePath, ids, lines (+11 more)
+Cohesion: 0.08
+Nodes (23): Anti-Patterns, Chemistry Patterns, code:block1 (┌───────────────────────────────────────────────────────────), code:block2 (Will this work be referenced later?), code:bash (# Start grooming), code:bash (# Start review), code:bash (# Start spike (2 hour timebox)), code:bash (# Persistent mol (solid → liquid)) (+15 more)
 
 ### Community 384 - "Community 384"
-Cohesion: 0.09
-Nodes (20): companionInTarget, contentAfterFirst, dstScript, gitCwd, gitManifestDir, manifest, manifestAfterFirst, result (+12 more)
+Cohesion: 0.08
+Nodes (23): code:block1 (~/.panopticon/skills/spec-readiness-{name}/), code:bash (mkdir -p ~/.panopticon/skills/spec-readiness-{name}), code:block11 (Created spec-readiness wrapper: spec-readiness-{name}), code:block12 (User: setup spec readiness), code:yaml (tracker:), code:yaml (tracker:), code:yaml (tracker:), code:yaml (tracker:) (+15 more)
 
 ### Community 385 - "Community 385"
-Cohesion: 0.09
-Nodes (21): 13 Dashboard Views, Agent Auto-Resume Controls, Architecture at a Glance, code:bash (npx @panctl/cli), code:block2 (Issue         PRD           Agent         Review        Test), Command Deck, Contributing, Documentation (+13 more)
+Cohesion: 0.13
+Nodes (18): workspaceRebuildCommand(), StepResult, tempDirs, workspace, DevcontainerRenderResult, ensureDevcontainer(), EnsureDevcontainerInput, EnsureDevcontainerResult (+10 more)
 
 ### Community 386 - "Community 386"
-Cohesion: 0.09
-Nodes (21): 1. Batch Processing, 2. Cascade Approach, 3. Parallel Processing, Alternative Models, Claude Family (USD per million tokens), Cost Analysis, Detailed Recommendations, For Cost-Sensitive Deployments (+13 more)
+Cohesion: 0.17
+Nodes (19): archivePlanning(), ApproveOptions, ArchiveOptions, DeepWipeOptions, DeepWipeProgress, getLinearApiKey(), TeardownOptions, WorkflowResult (+11 more)
 
 ### Community 387 - "Community 387"
-Cohesion: 0.09
-Nodes (21): 1. Supported harnesses, 2. Installing Pi, 3. Where you pick the harness, 4. ToS rules, 5. Troubleshooting, 6. Tradeoffs, Auth mode is exclusive, Claude Code (default) (+13 more)
+Cohesion: 0.17
+Nodes (17): FsError, readWorkspaceContext(), writeWorkspaceContext(), ensureWorkspacePanDir(), getWorkspacePanPaths(), readWorkspaceContinue(), uniqueTmpPath(), workspacePanPaths() (+9 more)
 
 ### Community 388 - "Community 388"
-Cohesion: 0.09
-Nodes (20): Architecture, Backward Compatibility, code:typescript (/**), code:typescript (export interface ProjectConfig {), code:typescript (export function resolveTrackerType(issueId: string): Tracker), code:yaml (# Rally-tracked project with multiple artifact type prefixes), Configuration Example, Decision (+12 more)
+Cohesion: 0.13
+Nodes (9): DEFAULT_STORE, formatIssueRef(), LinkDirection, LinkManager, LinkStore, parseIssueRef(), pathExists(), newManager (+1 more)
 
 ### Community 389 - "Community 389"
-Cohesion: 0.09
-Nodes (21): 1. Event Bus & Real-Time Broadcast, 2. Webhook System, 3. Claude Session Introspection, 4. Alert Rules Engine, 5. Standup / Daily Reports, 6. Workflow Templates & Pipelines, 7. Quality Review Gate Improvements, 8. RBAC & Authentication (+13 more)
+Cohesion: 0.17
+Nodes (20): checkCostLimits(), checkDailyReset(), COST_DATA_FILE, CostAlert, CostAlertLevel, CostData, CostDataPersisted, getAgentCost() (+12 more)
 
 ### Community 390 - "Community 390"
-Cohesion: 0.09
-Nodes (21): 1. Extract Project Identity (JSON), 2. Define the Atmosphere (Image/HTML), 3. Map the Color Palette (Tailwind Config/JSON), 4. Translate Geometry & Shape (CSS/Tailwind), 5. Describe Depth & Elevation, Analysis & Synthesis Instructions, Best Practices, code:markdown (# Design System: [Project Title]) (+13 more)
+Cohesion: 0.1
+Nodes (19): AvailableModel, AvailableModelsResponse, ClaudeAuthStatus, fetchAvailableModels(), fetchClaudeAuth(), fetchSettings(), PROVIDER_LABELS, providerForModel() (+11 more)
 
 ### Community 391 - "Community 391"
 Cohesion: 0.09
-Nodes (21): Claude Code subagents (NOT Panopticon roles), code:block1 (pan plan finalize), code:json ({), code:json ({), continue.vbrief.json Format, CRITICAL: PLANNING ONLY - NO IMPLEMENTATION, Description, Difficulty Estimation (+13 more)
+Nodes (21): content, db, event, goodLine, history, ids, latest, lines (+13 more)
 
 ### Community 392 - "Community 392"
 Cohesion: 0.09
-Nodes (21): code:bash (pan workspace create MIN-123), code:bash (pan workspace create MIN-123 --docker), code:javascript (// Disable Docker by default), code:bash (# From dashboard: click "Start Planning" (Docker enabled by ), code:bash (pan workspace list), code:bash (pan workspace destroy MIN-123), code:bash (export PANOPTICON_AUTO_REVERT_CHECKOUT=1  # Add to .bashrc/.), code:bash (./scripts/install-git-hooks.sh /path/to/your/project) (+13 more)
+Nodes (22): all, backing, cheap, enriched, expensive, fetched, inserted, malformed (+14 more)
 
 ### Community 393 - "Community 393"
-Cohesion: 0.1
-Nodes (16): CLAUDE_PROJECTS, cost, db, DB_PATH, entry, insert, issueId, issueStats (+8 more)
+Cohesion: 0.19
+Nodes (20): healthCommand(), HealthOptions, AgentHealth, formatHealthStatus(), getAgentHealth(), getAgentOutput(), getHealthFile(), handleStuckAgent() (+12 more)
 
 ### Community 394 - "Community 394"
-Cohesion: 0.17
-Nodes (18): CostLimitsConfig, checkCostLimits(), checkDailyReset(), COST_DATA_FILE, CostAlert, CostAlertLevel, CostData, CostDataPersisted (+10 more)
+Cohesion: 0.16
+Nodes (21): ACTIVE_AGENT_STATUSES, CandidateGroup, collectActiveAgentIssueIds(), collectWorkspaceReapCandidatesFromInspect(), composeDown(), confirmApply(), DockerInspectContainer, execFileAsync (+13 more)
 
 ### Community 395 - "Community 395"
-Cohesion: 0.13
-Nodes (19): parseLogMetadata(), execAsync, listLogsCommand(), logsCommand(), LogsOptions, tailLogCommand(), actual, allLogs (+11 more)
+Cohesion: 0.09
+Nodes (23): 10. `onboard-codebase` - Understanding New Code, All Questions Resolved ✅, Appendix A: Key Concepts Reference, Appendix C: References, Appendix D: Open Questions, code:block141 (workspaces/feature-min-648/), code:bash (# 1. Mayor spawns convoy), code:block37 (+15 more)
 
 ### Community 396 - "Community 396"
-Cohesion: 0.19
-Nodes (20): approveCommand(), cancelCommand(), collectInFlightRows(), collectLifecycleRows(), completeCommand(), dedupeRows(), formatTransition(), getProjectPath() (+12 more)
+Cohesion: 0.09
+Nodes (23): code:typescript (interface IssueTracker {), code:block78 (┌───────────────────────────────────────────────────────────), code:toml (# ~/.panopticon/projects.toml), code:block80 (┌──────────┐    ┌──────────┐    ┌──────────┐    ┌───────────), code:yaml (# ~/.panopticon/state-mappings.yaml), code:typescript (// ~/.panopticon/issue-states.json), code:typescript (interface StateManager {), code:block84 ($ pan project add ~/projects/myn --tracker linear --team MIN) (+15 more)
 
 ### Community 397 - "Community 397"
-Cohesion: 0.14
-Nodes (16): DEACON_PAUSE_QUERY_KEY, DeaconPauseBanner(), DeaconPauseToggle(), useDeaconPause(), useDeaconPauseMutation(), Tab, FlywheelRunSummary, NAV_GROUPS (+8 more)
+Cohesion: 0.09
+Nodes (23): code:block126 (┌─────────────────┐    ┌─────────────────┐    ┌─────────────), code:block127 (┌──────────────────────────────────────────────────────────┐), code:yaml (permissions:), code:json ({), code:bash (# 1. Login to npm (one-time)), code:bash (# Bump version (follows semver)), code:bash (# One-shot (no global install needed)), code:bash (# Tag beta releases) (+15 more)
 
 ### Community 398 - "Community 398"
-Cohesion: 0.13
-Nodes (15): ChangedFilesTree, EMPTY_DIRECTORY_OVERRIDES, TurnDiffFileChange, DiffStatLabel, hasNonZeroStat(), buildTurnDiffTree(), MutableDirectoryNode, normalizePathSegments() (+7 more)
+Cohesion: 0.09
+Nodes (22): A. Per-issue allow-list at plan time, Acceptance Criteria, Approach (Option 5 — combination), Architecture, Awaiting-input extension, Awaiting-input indicator (Section C), B. Outbound-write suppression during prompt display, C. Awaiting-input indicator + inspector deep link (+14 more)
 
 ### Community 399 - "Community 399"
-Cohesion: 0.1
-Nodes (19): FlywheelAgent, FlywheelAgentStatus, FlywheelEffort, FlywheelHarness, FlywheelHeadline, FlywheelHttpUrl, FlywheelOrchestrator, FlywheelParkedItem (+11 more)
+Cohesion: 0.09
+Nodes (22): 1. Root policy: what stays at root, 2. Root artifacts to relocate, 3. Destination policy, 4. Reference update pass, 5. Professionalism rule for future additions, Audits / investigations / findings, Constraints, Design (+14 more)
 
 ### Community 400 - "Community 400"
-Cohesion: 0.1
-Nodes (17): fail, failLayer, githubLayer, layer, mockGitHubAddLabel, mockGitHubCloseIssue, mockGitHubRemoveLabel, mockGitHubReopenIssue (+9 more)
+Cohesion: 0.09
+Nodes (22): 1. Viewer in scope, 2. Model injection for plan.author, 3. vBRIEFInfo.author from package.json, 4. Artifact copy: skip if exists, 5. Testing approach, Architecture, Artifact auto-copy (issues.ts — complete-planning), Beads sync (beads.ts) (+14 more)
 
 ### Community 401 - "Community 401"
-Cohesion: 0.12
-Nodes (17): activePtyHubs, addClientToHub(), broadcastToHub(), hubFlushTimer, hubOutputBuffer, PtyHub, removeClientFromHub(), setClientReady() (+9 more)
+Cohesion: 0.09
+Nodes (21): 1. KanbanBoard.tsx — `CycleFilter` type (line 678), 2. KanbanBoard.tsx — `groupByStatus()` (lines 191-193), 3. KanbanBoard.tsx — Filter bar UI (around line 1042), 4. KanbanBoard.tsx — Canceled list view, 5. issue-data-service.ts — `getIssues()` (around line 223), Acceptance Criteria, Architecture, code:typescript (// Before:) (+13 more)
 
 ### Community 402 - "Community 402"
-Cohesion: 0.1
-Nodes (20): 10. B20 does not fully account for the current terminal surface area, 11. The resources event model is too narrow for the current resources UI, 12. The dependency DAG has one sequencing problem, 1. The current dashboard already has a real data layer; the problem is inconsistency, not total absence, 2. "Wrap existing libs in Effect" does not fix the blocking-call problem, 3. The storage plan should not introduce a third SQLite story without justification, 4. The toolchain/runtime section is not fully aligned with the repo as it exists today, 5. The dist/output migration has more blast radius than the PRD currently captures (+12 more)
+Cohesion: 0.09
+Nodes (22): 1. Scope — all 5 phases in this issue, 2. Table model — new `discovered_sessions` table, separate from `conversations`, 3. Hash→path resolution — JSONL cwd primary, reverse-map fallback, 4. Adaptive parallelism — full probe as spec'd, 5. Embeddings — all three providers (OpenAI, Voyage, Ollama), 6. Enrichment execution — reuse `model-fallback.ts` routing, 7. Re-scanning — manual only in v1, 8. Blocking FS calls — must use async everywhere in server code (+14 more)
 
 ### Community 403 - "Community 403"
-Cohesion: 0.1
-Nodes (20): Code Changes Required in Panopticon, code:block1 (┌─────────────────────────────────────────────────────────┐), code:yaml (myn:), Critical Constraint: exe.dev Single Port, Current State, Goals, Implementation Checklist, Manual Fixes Still Required Per-Project (+12 more)
+Cohesion: 0.09
+Nodes (22): Acceptance criteria, Command Taxonomy Reorganization, Decision, Design principles, Implementation plan, Out of scope, Phase 1 — Scaffolding (non-breaking), Phase 2 — Collapse commands (+14 more)
 
 ### Community 404 - "Community 404"
-Cohesion: 0.1
-Nodes (20): Agent Navigation, Architecture, Backend (Server), code:block1 (docker stats (5s poll)), Container Detail View, Data Flow, Decisions, Files to Create/Modify (+12 more)
+Cohesion: 0.09
+Nodes (22): 1. Auth Configuration, 2. CCR Command, 3. claudish Installation, 4. Model Prefixes, 5. Dashboard Model Display, 6. OpenAI Model Registry, 7. Token Usage Tracking, Architecture (+14 more)
 
 ### Community 405 - "Community 405"
-Cohesion: 0.1
-Nodes (20): Architecture, btca CLI Skill, code:block1 (Browser (React + Vite)), code:json ({ "key": "mod+j", "command": "terminal.toggle" },), code:bash (btca ask -r codex -q "What is the return format for Codex Ap), Comparison to Panopticon, Feature Inventory, High priority (+12 more)
+Cohesion: 0.09
+Nodes (22): 10. Not yet decided, 1.1 PAN-722 (queue removal) left a per-project singleton, 1.2 Inverted model priority — Sonnet lurking under every config, 1.3 PAN-540 parallel review — invisible sibling tmux sessions, 1.4 Cross-cutting: duplicate-tab failure mode, 1. Problem inventory, 2. Root cause, 3. The DAG reframe (+14 more)
 
 ### Community 406 - "Community 406"
-Cohesion: 0.1
-Nodes (21): 10. Configuration, 1. High-Level Structure, 2. Entry Points, 3. Architecture Patterns, 4. Code Organization, 5. Feature Location, 6. Dependencies Analysis, 7. Data Models (+13 more)
+Cohesion: 0.09
+Nodes (22): ACCEPTANCE CRITERIA (WHAT SUCCESS LOOKS LIKE):, Ask the user before creating when:, code:markdown (bd update issue-9 --notes "IMPLEMENTATION GUIDE:), code:block2 (Two-phase Docs API approach:), code:block3 (- [ ] Markdown formatting renders in Doc (bold, italic, head), code:block4 (- [ ] Use two-phase batchUpdate approach), Contents, Create directly when: (+14 more)
 
 ### Community 407 - "Community 407"
-Cohesion: 0.1
-Nodes (20): Ad-Hoc Speak and CLI Smoke Test, Architecture, code:block1 (pan dashboard                  qwen-tts daemon            au), code:bash (pan install                # creates packages/qwen-tts-linux), code:yaml (endpoint: http://127.0.0.1:3000/events/stream), code:bash (# one-shot foreground run (smoke test)), code:bash (pan tts test), code:bash (./scripts/say.sh "Build is green, ready for review.") (+12 more)
+Cohesion: 0.09
+Nodes (22): 1. Confirm scope before destroying anything, 2. Kill work agents via the CLI (preferred), 3. Kill review coordinators and test specialists, 4. Verify only conversations and the server remain, 5. (Optional) Stop the dashboard, 6. Verify, code:bash (# List live tmux sessions, classified), code:bash (# Loop over agent sessions and kill each via pan) (+14 more)
 
 ### Community 408 - "Community 408"
-Cohesion: 0.1
-Nodes (20): code:block1 (skill-name/), code:yaml (---), code:bash (python scripts/init_skill.py <skill-name> --path <output-dir), code:bash (python scripts/package_skill.py <path/to/skill-folder> [outp), Concise is Key, Core Principles, Creation Process, Degrees of Freedom (+12 more)
+Cohesion: 0.09
+Nodes (22): Bead ID vs Issue ID, Beads Quick Reference for Panopticon Agents, code:bash (bd list --issue PAN-116), code:bash (# Option 1: Search in title (most common)), code:bash (# Find ALL beads for PAN-116 (including closed)), code:bash (# By status), code:bash (# Start work on a bead), code:bash (# ❌ WRONG) (+14 more)
 
 ### Community 409 - "Community 409"
-Cohesion: 0.1
-Nodes (20): Activity View, Adding Projects, Badge Bar, code:block1 (feature-pan-XXX/.planning/), Concept, Configuration, How It Works, Layout (+12 more)
+Cohesion: 0.09
+Nodes (23): 7. Components, Alerts, Badges, Buttons, Cards, code:block11 (Container:), code:block12 (Base:), code:block13 (Base:) (+15 more)
 
 ### Community 410 - "Community 410"
-Cohesion: 0.11
-Nodes (19): activeIssues, date1, date2, expectedOrder, filtered, filteredIds, filterRecentCompletedIssues(), getOneDayAgo() (+11 more)
+Cohesion: 0.09
+Nodes (22): AI Self-Monitoring, Best Practices, Built-In Skills, Code Review Subagents, code:block1 (# In Claude Code, Cursor, Windsurf, etc:), code:bash (# Use the guided skill creator), code:markdown (# Skill Title), code:bash (# Sync all skills to AI tools (Claude Code, Cursor, etc.)) (+14 more)
 
 ### Community 411 - "Community 411"
-Cohesion: 0.22
-Nodes (17): contextCommand(), ContextOptions, appendSummary(), checkContextBudget(), ContextBudget, estimateTokens(), generateSummaryEntry(), getHistoryDir() (+9 more)
+Cohesion: 0.09
+Nodes (22): Claude Code subagents (NOT Panopticon roles), code:block1 (pan plan finalize), code:json ({), code:json ({), continue.vbrief.json Format, CRITICAL: PLANNING ONLY - NO IMPLEMENTATION, Description, Difficulty Estimation (+14 more)
 
 ### Community 412 - "Community 412"
-Cohesion: 0.22
-Nodes (3): escapeQueryValue(), RallyTracker, validateRallyId()
+Cohesion: 0.09
+Nodes (22): Anthropic, Benchmark Leaderboards, code:json ({), Coding Benchmarks, Community Sources, Deliverables, Google, Important Notes (+14 more)
 
 ### Community 413 - "Community 413"
-Cohesion: 0.16
-Nodes (16): ForgeType, buildMergeSetForIssue(), getRepoForge(), inferProjectForge(), normalizeForge(), resolveConfiguredRepos(), ResolvedProjectRepo, resolveProjectReposForIssue() (+8 more)
+Cohesion: 0.09
+Nodes (21): consoleSpy, mirrorLog, mockCleanupLegacyRuntimeSymlinks, mockCreateBackup, mockEnsurePlaywrightIsolation, mockExecuteSync, mockGetDevrootPath, mockListProjects (+13 more)
 
 ### Community 414 - "Community 414"
-Cohesion: 0.1
-Nodes (20): 10 High-Value Skills, 1. `feature-work` - Standard Feature Development, 2. `bug-fix` - Bug Investigation and Fix, 3. `code-review` - Code Review Focus Areas, 4. `code-review-security` - Security-Focused Review, 5. `code-review-performance` - Performance-Focused Review, 6. `refactor` - Safe Refactoring, 7. `release` - Release Process (+12 more)
+Cohesion: 0.09
+Nodes (16): CLAUDE_PROJECTS, cost, db, DB_PATH, entry, insert, issueStats, lines (+8 more)
 
 ### Community 415 - "Community 415"
-Cohesion: 0.1
-Nodes (19): Appendix: exe.dev CLI Reference, CLI Reference, code:bash (# Authentication), Documentation Updates, Future Enhancements, Goals, Modified Commands, New Commands (+11 more)
+Cohesion: 0.13
+Nodes (15): getForgeAdapter(), {
+  execMock,
+  getPullRequestStateMock,
+  isGitHubAppConfiguredMock,
+  mergePullRequestWithAppMock,
+  parsePullRequestRefMock,
+}, kCustom, mergePromise, withRepoArtifactUrl(), withRepoState(), buildRichReviewArtifactBody(), createReviewArtifactsForIssue() (+7 more)
 
 ### Community 416 - "Community 416"
-Cohesion: 0.1
-Nodes (19): Canonical reviewer naming, code:block2 (┌───────────────────────────────────────────────────────────), code:typescript (// src/lib/cloister/specialists.ts), code:block3 (╔═══════════════════════════════════════════════════════════), code:typescript (// pseudocode for review-agent.ts after PAN-830), code:block31 (┌───────────────────────────────────────────────────────────), code:typescript (async function resolveJsonlPath(session: SessionDescriptor):), Goal (+11 more)
+Cohesion: 0.14
+Nodes (19): applyClosedOutLabel(), applyLabelGitHub(), applyLabelLinear(), applyLabelViaTracker(), closeGitHubDirect(), closeGitHubPr(), closeIssue(), CloseIssueOptions (+11 more)
 
 ### Community 417 - "Community 417"
-Cohesion: 0.1
-Nodes (19): Architecture (3 sentences), code:block1 ([work items DAG] ──→ VERIFY ──→ REVIEW ──→ TEST ──→ MERGE ──), Data Sources, Depends On, Design, Escape State Overlays, Inline Diff Toggle, Motivation (+11 more)
+Cohesion: 0.17
+Nodes (21): buildPlaceholders(), clearLegacyPlanningDir(), clearProjectBeads(), clearShadowState(), deleteBranches(), deleteBranchesImpl(), execAsync, isDockerContainerProcess() (+13 more)
 
 ### Community 418 - "Community 418"
-Cohesion: 0.1
-Nodes (19): 10. Cleanup, 1. `.panopticon/` → `.pan/` (project-level only), 2. `.panopticon.yaml` → `.pan.yaml`, 3. Archive structure: flat → per-issue subdirectory, 4. `findWorkspacePath` numeric suffix fix, 5. `.pan/skills/` as sync source, 6. Multi-tool sync (all 6 tools), 7. `.gitignore` injection (+11 more)
+Cohesion: 0.09
+Nodes (21): TldrSessionMetrics, branch, branchMatch, buffer, cavemanVariant, cost, entry, input (+13 more)
 
 ### Community 419 - "Community 419"
-Cohesion: 0.1
-Nodes (19): 9 items flagged for Epic D recovery review, Bug locations (as of HEAD), code:block1 (feature/pan-698@{2026-04-22 15:30:09}: reset: moving to e0ce), code:block2 (Epic D  →  Epic A  →  Epic B  →  Epic C), Context, Decisions (resolved 2026-04-23), Epic A — Labels as display, internal state as source of truth, Epic B — Work agent doesn't touch git (+11 more)
+Cohesion: 0.14
+Nodes (16): handleAutoStartNag(), showFirstLaunchDialog(), deepClone(), DEFAULTS, DesktopSettings, getDesktopSettings(), loadDesktopSettings(), saveDesktopSettings() (+8 more)
 
 ### Community 420 - "Community 420"
-Cohesion: 0.1
-Nodes (19): 10. Cleanup, 1. `.panopticon/` → `.pan/` (project-level only), 2. `.panopticon.yaml` → `.pan.yaml`, 3. Archive structure: flat → per-issue subdirectory, 4. `findWorkspacePath` numeric suffix fix, 5. `.pan/skills/` as sync source, 6. Multi-tool sync (all 6 tools), 7. `.gitignore` injection (+11 more)
+Cohesion: 0.13
+Nodes (19): buildEmbeddingText(), embed(), EmbeddingProviderName, EmbeddingResult, EmbedHttpError, embedOllama(), embedOpenAI(), EmbedOptions (+11 more)
 
 ### Community 421 - "Community 421"
-Cohesion: 0.1
-Nodes (19): API Endpoints, Auth Token Refresh, Check Recent Logs, CLIProxy — Check and Restart, code:bash (# Is it running?), code:bash (# Kill any existing instance), code:bash (# Last 30 lines of cliproxy log), code:yaml (host: "127.0.0.1") (+11 more)
+Cohesion: 0.09
+Nodes (18): fail, failLayer, githubLayer, layer, mockGitHubAddLabel, mockGitHubCloseIssue, mockGitHubEnsureLabel, mockGitHubRemoveLabel (+10 more)
 
 ### Community 422 - "Community 422"
-Cohesion: 0.1
-Nodes (19): CLI Overview, code:bash (# Install Panopticon globally), code:bash (pan work issue MIN-123      # Spawn agent), code:bash (pan workspace create MIN-123         # Create workspace), code:bash (pan up    # Start dashboard at localhost:3011), code:bash (# General help), Command Structure, Common Options (+11 more)
+Cohesion: 0.17
+Nodes (20): checkCommand(), execAsync, getMissingToolsForFeature(), INSTALLABLE_TOOLS, installBeads(), installMkcert(), installOx(), InstallResult (+12 more)
 
 ### Community 423 - "Community 423"
 Cohesion: 0.13
-Nodes (9): ENV_KEYS, EnvSnapshot, ENV_FILE_PATH, loadPanopticonEnv(), parseEnvFile(), ServerConfig, ServerConfigError, ServerConfigLayer (+1 more)
+Nodes (12): NormalizedTtsDaemonConfig, isTtsDaemonManuallyStopped(), parseTtsWatchdogIntEnv(), readTtsWatchdogConfig(), TtsWatchdog, TtsWatchdogConfig, TtsWatchdogStatus, parsePositiveIntEnv() (+4 more)
 
 ### Community 424 - "Community 424"
-Cohesion: 0.18
-Nodes (17): cleanupOldEvents(), CLOISTER_DB_PATH, deleteAgentHistory(), getAgentsWithHistory(), getAllHealthHistory(), getDatabaseStats(), getHealthDatabase(), getHealthHistory() (+9 more)
+Cohesion: 0.09
+Nodes (19): assistantLine, content, existingFiles, firstLine, fixture, fixturePath, ids, lines (+11 more)
 
 ### Community 425 - "Community 425"
-Cohesion: 0.16
-Nodes (16): mockCreateTracker, mockCreateTrackerFromConfig, mockFindProjectByPath, mockGetIssuePrefix, mockTracker, warnSpy, createTracker(), createTrackerFromConfig() (+8 more)
+Cohesion: 0.09
+Nodes (20): companionInTarget, contentAfterFirst, dstScript, gitCwd, gitManifestDir, manifest, manifestAfterFirst, result (+12 more)
 
 ### Community 426 - "Community 426"
-Cohesion: 0.19
-Nodes (17): buildChannelsArgs(), buildCommand(), buildNonConversationCommand(), buildPiCommand(), buildReviewSubRoleCommand(), generateLauncherWrapper(), LauncherConfig, LauncherHarness (+9 more)
+Cohesion: 0.09
+Nodes (18): agent2, baseAgent, bigOutput, events, existing, issues, next, planningAgent (+10 more)
 
 ### Community 427 - "Community 427"
-Cohesion: 0.23
-Nodes (17): deletePRDDraft(), getPRDDraftInfo(), getPRDDraftPath(), hasPRDDraft(), listPRDDrafts(), readPRDDraft(), resolveDraftProjectRoot(), writePRDDraft() (+9 more)
+Cohesion: 0.09
+Nodes (21): 13 Dashboard Views, Agent Auto-Resume Controls, Architecture at a Glance, code:bash (npx @panctl/cli), code:block2 (Issue         PRD           Agent         Review        Test), Command Deck, Contributing, Documentation (+13 more)
 
 ### Community 428 - "Community 428"
-Cohesion: 0.11
-Nodes (14): CavemanExperimentRow, CostsPage(), CostsResponse, DailyTrend, ExperimentsResponse, fetchCosts(), fetchExperiments(), fetchIssueDetail() (+6 more)
+Cohesion: 0.09
+Nodes (21): 1. Batch Processing, 2. Cascade Approach, 3. Parallel Processing, Alternative Models, Claude Family (USD per million tokens), Cost Analysis, Detailed Recommendations, For Cost-Sensitive Deployments (+13 more)
 
 ### Community 429 - "Community 429"
-Cohesion: 0.12
-Nodes (16): AvailableModel, AvailableModelsResponse, fetchAvailableModels(), fetchSettings(), PROVIDER_LABELS, providerForModel(), providerWarning(), saveWorkhorse() (+8 more)
+Cohesion: 0.09
+Nodes (21): 1. Supported harnesses, 2. Installing Pi, 3. Where you pick the harness, 4. ToS rules, 5. Troubleshooting, 6. Tradeoffs, Auth mode is exclusive, Claude Code (default) (+13 more)
 
 ### Community 430 - "Community 430"
-Cohesion: 0.11
-Nodes (16): formatRelativeTime(), date, fiftyNineMin, fiftyNineS, isoString, lastYear, NOW, oneHour (+8 more)
+Cohesion: 0.09
+Nodes (20): Architecture, Backward Compatibility, code:typescript (/**), code:typescript (export interface ProjectConfig {), code:typescript (export function resolveTrackerType(issueId: string): Tracker), code:yaml (# Rally-tracked project with multiple artifact type prefixes), Configuration Example, Decision (+12 more)
 
 ### Community 431 - "Community 431"
-Cohesion: 0.18
-Nodes (16): deliverQueuedFeedback(), enqueuePendingFeedbackDelivery(), FeedbackKind, isDeliveryStillRelevant(), markPendingFeedbackDelivered(), PENDING_FEEDBACK_FILE, PendingFeedbackDelivery, PendingFeedbackStore (+8 more)
+Cohesion: 0.09
+Nodes (21): 1. Event Bus & Real-Time Broadcast, 2. Webhook System, 3. Claude Session Introspection, 4. Alert Rules Engine, 5. Standup / Daily Reports, 6. Workflow Templates & Pipelines, 7. Quality Review Gate Improvements, 8. RBAC & Authentication (+13 more)
 
 ### Community 432 - "Community 432"
-Cohesion: 0.11
-Nodes (18): Agents, Beads, Cloister, Command Deck, Convoys, Core Concepts, Cost Tracking, Docker Integration (+10 more)
+Cohesion: 0.09
+Nodes (21): 1. Extract Project Identity (JSON), 2. Define the Atmosphere (Image/HTML), 3. Map the Color Palette (Tailwind Config/JSON), 4. Translate Geometry & Shape (CSS/Tailwind), 5. Describe Depth & Elevation, Analysis & Synthesis Instructions, Best Practices, code:markdown (# Design System: [Project Title]) (+13 more)
 
 ### Community 433 - "Community 433"
-Cohesion: 0.11
-Nodes (19): code:yaml (---), code:block20 (┌───────────────────────────────────────────────────────────), code:bash (# Skills tell the agent HOW to work), code:block22 (┌───────────────────────────────────────────────────────────), code:bash (# Update all agent workspaces with latest skills), code:bash (# Edit a skill in the canonical location), code:block25 (┌───────────────────────────────────────────────────────────), code:bash (# Parallel code review - spawn 4 agents with different focus) (+11 more)
+Cohesion: 0.09
+Nodes (21): Bead Description (What Was Asked), BLOCKED — Any check fails, Check 1: Spec Fidelity, Check 2: Constraint Compliance, code:bash (cd {{workspacePath}}), code:bash (# Check workspace CLAUDE.md), code:bash (# Example: check for prohibited imports), code:bash (pan tell {{issueId}} "INSPECTION PASSED for bead {{beadId}}.) (+13 more)
 
 ### Community 434 - "Community 434"
-Cohesion: 0.11
-Nodes (18): Architecture, Backend Changes (`src/dashboard/server/index.ts`), code:block1 (socketIo.emit('planning:started', { issueId: issue.identifie), code:block2 (socketIo.emit('planning:failed', { issueId: issue.identifier), code:block3 (Background async task fails), Data Flow, Decision: Full Recovery Controls, Decision: Kanban Card Failure Indicator (+10 more)
+Cohesion: 0.09
+Nodes (21): code:bash (pan workspace create MIN-123), code:bash (pan workspace create MIN-123 --docker), code:javascript (// Disable Docker by default), code:bash (# From dashboard: click "Start Planning" (Docker enabled by ), code:bash (pan workspace list), code:bash (pan workspace destroy MIN-123), code:bash (export PANOPTICON_AUTO_REVERT_CHECKOUT=1  # Add to .bashrc/.), code:bash (./scripts/install-git-hooks.sh /path/to/your/project) (+13 more)
 
 ### Community 435 - "Community 435"
-Cohesion: 0.11
-Nodes (18): Acceptance Criteria, Architecture, code:block1 (Cannot find module 'close-issue-BVnGI6Mw.js'), code:block2 (OLD SERVER PROCESS), Decision: Detached deploy script + pending lifecycle file, Difficulty, Edge Cases, Files to Modify (+10 more)
+Cohesion: 0.1
+Nodes (16): CLAUDE_PROJECTS, cost, db, DB_PATH, entry, insert, issueId, issueStats (+8 more)
 
 ### Community 436 - "Community 436"
-Cohesion: 0.11
-Nodes (18): `cli:quick-command`, Flash-Lite's Niche in Panopticon, Gemini 3.1 Flash-Lite Preview Work Type Fit Analysis, Good Fit, Integration Notes, Key Benchmarks, Known Weaknesses, Model Profile (+10 more)
+Cohesion: 0.14
+Nodes (17): displayIssues(), getConfiguredTrackers(), getTrackerConfig(), listCommand(), ListOptions, PRIORITY_LABELS, { loadConfigMock, isShadowedMock, getPendingSyncCountMock, createTrackerMock, loadProjectsConfigMock }, mockIssues (+9 more)
 
 ### Community 437 - "Community 437"
-Cohesion: 0.11
-Nodes (16): code:bash (grep -E "FAIL|✗|Error|failed|BUILD FAILURE" /tmp/test-featur), code:bash (curl -s -X POST {{API_URL}}/api/review/{{ISSUE_ID}}/status \), code:bash (curl -s -X POST {{API_URL}}/api/review/{{ISSUE_ID}}/status \), code:bash (# Check if containers are running for this workspace), CRITICAL: Bash Timeout for Test Commands, CRITICAL: Context Management — Output Redirection, Never Close GitHub Issues, REQUIRED: Container Smoke Test (+8 more)
+Cohesion: 0.15
+Nodes (14): BUNDLED_AGENTS_DIR, BUNDLED_SKILLS_DIR, copyBundledAgents(), copyBundledSkills(), __dirname, __filename, initCommand(), PACKAGE_ROOT (+6 more)
 
 ### Community 438 - "Community 438"
-Cohesion: 0.11
-Nodes (18): Built-in Convoy Templates, code-review Template, code:bash (# Run a parallel code review), code:bash (# Show most recent convoy status), code:bash (# List all convoys), code:bash (pan convoy stop <convoy-id>), code:json ({), code:bash (pan convoy start lightweight-review --files "src/**/*.ts") (+10 more)
+Cohesion: 0.17
+Nodes (17): buildChannelsArgs(), buildCommand(), buildNonConversationCommand(), buildPiCommand(), buildReviewSubRoleCommand(), generateLauncherWrapper(), LauncherConfig, LauncherHarness (+9 more)
 
 ### Community 439 - "Community 439"
-Cohesion: 0.11
-Nodes (16): capturedCmds, mockCreateReviewArtifactsForIssue, mockEnsureMergeSetForIssue, mockExecFileFn, mockExecFn, mockGetAgentState, mockGetDashboardApiUrl, mockGetReviewStatus (+8 more)
+Cohesion: 0.13
+Nodes (19): parseLogMetadata(), execAsync, listLogsCommand(), logsCommand(), LogsOptions, tailLogCommand(), actual, allLogs (+11 more)
 
 ### Community 440 - "Community 440"
-Cohesion: 0.16
-Nodes (14): atomicWrite(), backupIfNeeded(), detectProviderEnvConflicts(), findNewestBackup(), injectPanopticonInfraDeny(), injectProviderEnvOverlay(), INVALID_LEGACY_PATTERNS, OverlayResult (+6 more)
+Cohesion: 0.1
+Nodes (19): FlywheelAgent, FlywheelAgentStatus, FlywheelEffort, FlywheelHarness, FlywheelHeadline, FlywheelHttpUrl, FlywheelOrchestrator, FlywheelParkedItem (+11 more)
 
 ### Community 441 - "Community 441"
-Cohesion: 0.14
-Nodes (16): SessionUsage, emptyUsage(), isAssistantMessage(), isMessage(), KNOWN_TYPES, parsePiSessionContent(), ParseResult, PiEntry (+8 more)
+Cohesion: 0.1
+Nodes (20): 10. B20 does not fully account for the current terminal surface area, 11. The resources event model is too narrow for the current resources UI, 12. The dependency DAG has one sequencing problem, 1. The current dashboard already has a real data layer; the problem is inconsistency, not total absence, 2. "Wrap existing libs in Effect" does not fix the blocking-call problem, 3. The storage plan should not introduce a third SQLite story without justification, 4. The toolchain/runtime section is not fully aligned with the repo as it exists today, 5. The dist/output migration has more blast radius than the PRD currently captures (+12 more)
 
 ### Community 442 - "Community 442"
-Cohesion: 0.26
-Nodes (15): cvCommand(), CVOptions, relativeTime(), showCommand(), ShowOptions, AgentCV, completeWork(), formatCV() (+7 more)
+Cohesion: 0.1
+Nodes (20): Code Changes Required in Panopticon, code:block1 (┌─────────────────────────────────────────────────────────┐), code:yaml (myn:), Critical Constraint: exe.dev Single Port, Current State, Goals, Implementation Checklist, Manual Fixes Still Required Per-Project (+12 more)
 
 ### Community 443 - "Community 443"
-Cohesion: 0.11
-Nodes (15): agentState, callOrder, checkFn, killed, mockGetAgentState, mockGetRuntimeForAgent, mockKillAgent, mockKillSession (+7 more)
+Cohesion: 0.1
+Nodes (20): Agent Navigation, Architecture, Backend (Server), code:block1 (docker stats (5s poll)), Container Detail View, Data Flow, Decisions, Files to Create/Modify (+12 more)
 
 ### Community 444 - "Community 444"
-Cohesion: 0.18
-Nodes (16): buildReport(), categorizeProcesses(), ClaudeProcess, detectRole(), formatGb(), formatMb(), getClaudeProcesses(), getHeavyProcesses() (+8 more)
+Cohesion: 0.1
+Nodes (20): Architecture, btca CLI Skill, code:block1 (Browser (React + Vite)), code:json ({ "key": "mod+j", "command": "terminal.toggle" },), code:bash (btca ask -r codex -q "What is the return format for Codex Ap), Comparison to Panopticon, Feature Inventory, High priority (+12 more)
 
 ### Community 445 - "Community 445"
-Cohesion: 0.11
-Nodes (17): firstSelect, openaiKeyInput, openaiProvider, PANOPTICON_HOME, reviewAgentLabel, reviewAgentSelect, ROUTER_CONFIG, routerConfig (+9 more)
+Cohesion: 0.1
+Nodes (21): 10. Configuration, 1. High-Level Structure, 2. Entry Points, 3. Architecture Patterns, 4. Code Organization, 5. Feature Location, 6. Dependencies Analysis, 7. Data Models (+13 more)
 
 ### Community 446 - "Community 446"
-Cohesion: 0.12
-Nodes (13): button, { container }, defaultProps, makeMutation(), makeSyncMutation(), onDismissPending, onKillSuccess, onPlan (+5 more)
+Cohesion: 0.1
+Nodes (20): Ad-Hoc Speak and CLI Smoke Test, Architecture, code:block1 (pan dashboard                  qwen-tts daemon            au), code:bash (pan install                # creates packages/qwen-tts-linux), code:yaml (endpoint: http://127.0.0.1:3000/events/stream), code:bash (# one-shot foreground run (smoke test)), code:bash (pan tts test), code:bash (./scripts/say.sh "Build is green, ready for review.") (+12 more)
 
 ### Community 447 - "Community 447"
-Cohesion: 0.18
-Nodes (13): AutoPresoControls(), warmupIcon(), AutoPresoView(), Excalidraw, ExcalidrawApiLike, TranscriptPanel(), AutoPresoMessage, AutoPresoMode (+5 more)
+Cohesion: 0.1
+Nodes (20): code:block1 (skill-name/), code:yaml (---), code:bash (python scripts/init_skill.py <skill-name> --path <output-dir), code:bash (python scripts/package_skill.py <path/to/skill-folder> [outp), Concise is Key, Core Principles, Creation Process, Degrees of Freedom (+12 more)
 
 ### Community 448 - "Community 448"
-Cohesion: 0.11
-Nodes (17): cb, cmdArgs, cmdStr, inline, issueCommentsJson, linearGetComments, linearGetIssueId, mockExec (+9 more)
+Cohesion: 0.1
+Nodes (20): Activity View, Adding Projects, Badge Bar, code:block1 (feature-pan-XXX/.planning/), Concept, Configuration, How It Works, Layout (+12 more)
 
 ### Community 449 - "Community 449"
-Cohesion: 0.22
-Nodes (17): startPostLaunchSidecars(), startSidecars(), recordRestartStatus(), reportHeldRestartLock(), resolveScope(), restartCommand(), readPlatformConfig(), getSupervisorPort() (+9 more)
+Cohesion: 0.1
+Nodes (19): agentDir, body, commit, dir, files, launcher, LEGACY_FIELDS, legacyFields (+11 more)
 
 ### Community 450 - "Community 450"
-Cohesion: 0.11
-Nodes (18): Approach 1: Passive Detection (MVP), Approach 2: Active Heartbeats (via Claude Code Hooks), Approach 3: Hybrid (Recommended), code:typescript (interface PassiveHeartbeat {), code:json ({), code:bash (#!/bin/bash), code:json ({), code:typescript (function getHeartbeat(agentId: string): Heartbeat {) (+10 more)
+Cohesion: 0.17
+Nodes (19): HandoffContext, createHandoffEvent(), ensureLogDir(), ensureLogDirAsync(), getHandoffStats(), getPendingVerificationHandoffs(), getPendingVerificationHandoffsEffect(), HANDOFF_LOG_FILE (+11 more)
 
 ### Community 451 - "Community 451"
-Cohesion: 0.11
-Nodes (18): `<ActivitySparkline events={Event[]} windowMinutes={60} buckets={12} />`, Animation-timing reference, code:typescript (// Renders a 6×6 (small) or 8×8 (medium) circle with the rig), code:typescript (// Animates the number on change (vertical scroll fade, 250m), code:typescript (// Inline SVG, ~120×16px.), code:typescript (// 140-wide mini card with verdict, finding count, duration,), code:typescript (// Cross-fades the tool name on change (200ms each, with → b), code:typescript (// Wraps a lucide icon with the right ring color and avatar ) (+10 more)
+Cohesion: 0.12
+Nodes (18): NormalizedChannelPermissionRequestFields, buildPermissionActivityDetails(), buildPermissionWaitingMessage(), normalizePermissionRequestBody(), parsePermissionResponseBehavior(), permissionResolutionVerb(), processPermissionResponse(), ProcessPermissionResponseDeps (+10 more)
 
 ### Community 452 - "Community 452"
-Cohesion: 0.11
-Nodes (17): Architecture Decisions, code:block1 (wire-converter ──blocks──> remove-bd-prompts), Decisions, Dependency Graph (text), Key Files to Modify, Out of Scope, PAN-388: vBRIEF Integration — Structured Plans, Programmatic Beads, DAG Visualization, Phase 2 (+9 more)
+Cohesion: 0.19
+Nodes (20): assertSafeAgentId(), captureCheckpoint(), checkpointRef(), deleteAllCheckpoints(), deleteCheckpoint(), deleteLegacyCheckpointRefs(), diffCheckpointFiles(), diffCheckpoints() (+12 more)
 
 ### Community 453 - "Community 453"
 Cohesion: 0.11
-Nodes (17): Access Points, Add Dependencies, Add Services, Change Java Version, code:bash (# Copy template to your project), code:bash (# Application), code:bash (# Connect to PostgreSQL), code:bash (docker compose restart app) (+9 more)
+Nodes (19): activeIssues, date1, date2, expectedOrder, filtered, filteredIds, filterRecentCompletedIssues(), getOneDayAgo() (+11 more)
 
 ### Community 454 - "Community 454"
-Cohesion: 0.11
-Nodes (17): Access Points, Adding Dependencies, Alembic Migrations, code:bash (# Copy template to your project), code:bash (APP_PORT=8000), code:python (# database.py), code:bash (# Install alembic), code:bash (# Connect to PostgreSQL) (+9 more)
+Cohesion: 0.1
+Nodes (17): agentStateDir, closeIssueMock, commands, execMock, fixtureRoot, movePrdMock, planningStateDir, projectPath (+9 more)
 
 ### Community 455 - "Community 455"
 Cohesion: 0.11
-Nodes (17): Adding Workspace Routes, code:block1 (~/.panopticon/traefik/), code:bash (mkcert "*.pan.localhost" "*.localhost" localhost 127.0.0.1 :), code:bash (cd ~/.panopticon/traefik), code:bash (cd ~/.panopticon/traefik), code:bash (docker logs -f panopticon-traefik), code:yaml (# dynamic/feature-pan-4.yml), Directory Structure (+9 more)
+Nodes (19): getRecentRunLogs(), listRunLogs(), content, deleted, { filePath }, largeContent, metadata, oldDate (+11 more)
 
 ### Community 456 - "Community 456"
+Cohesion: 0.1
+Nodes (20): 10 High-Value Skills, 1. `feature-work` - Standard Feature Development, 2. `bug-fix` - Bug Investigation and Fix, 3. `code-review` - Code Review Focus Areas, 4. `code-review-security` - Security-Focused Review, 5. `code-review-performance` - Performance-Focused Review, 6. `refactor` - Safe Refactoring, 7. `release` - Release Process (+12 more)
+
+### Community 457 - "Community 457"
+Cohesion: 0.1
+Nodes (19): Appendix: exe.dev CLI Reference, CLI Reference, code:bash (# Authentication), Documentation Updates, Future Enhancements, Goals, Modified Commands, New Commands (+11 more)
+
+### Community 458 - "Community 458"
+Cohesion: 0.1
+Nodes (19): Canonical reviewer naming, code:block2 (┌───────────────────────────────────────────────────────────), code:typescript (// src/lib/cloister/specialists.ts), code:block3 (╔═══════════════════════════════════════════════════════════), code:typescript (// pseudocode for review-agent.ts after PAN-830), code:block31 (┌───────────────────────────────────────────────────────────), code:typescript (async function resolveJsonlPath(session: SessionDescriptor):), Goal (+11 more)
+
+### Community 459 - "Community 459"
+Cohesion: 0.1
+Nodes (19): Architecture (3 sentences), code:block1 ([work items DAG] ──→ VERIFY ──→ REVIEW ──→ TEST ──→ MERGE ──), Data Sources, Depends On, Design, Escape State Overlays, Inline Diff Toggle, Motivation (+11 more)
+
+### Community 460 - "Community 460"
+Cohesion: 0.1
+Nodes (19): 10. Cleanup, 1. `.panopticon/` → `.pan/` (project-level only), 2. `.panopticon.yaml` → `.pan.yaml`, 3. Archive structure: flat → per-issue subdirectory, 4. `findWorkspacePath` numeric suffix fix, 5. `.pan/skills/` as sync source, 6. Multi-tool sync (all 6 tools), 7. `.gitignore` injection (+11 more)
+
+### Community 461 - "Community 461"
+Cohesion: 0.1
+Nodes (19): 9 items flagged for Epic D recovery review, Bug locations (as of HEAD), code:block1 (feature/pan-698@{2026-04-22 15:30:09}: reset: moving to e0ce), code:block2 (Epic D  →  Epic A  →  Epic B  →  Epic C), Context, Decisions (resolved 2026-04-23), Epic A — Labels as display, internal state as source of truth, Epic B — Work agent doesn't touch git (+11 more)
+
+### Community 462 - "Community 462"
+Cohesion: 0.1
+Nodes (19): 10. Cleanup, 1. `.panopticon/` → `.pan/` (project-level only), 2. `.panopticon.yaml` → `.pan.yaml`, 3. Archive structure: flat → per-issue subdirectory, 4. `findWorkspacePath` numeric suffix fix, 5. `.pan/skills/` as sync source, 6. Multi-tool sync (all 6 tools), 7. `.gitignore` injection (+11 more)
+
+### Community 463 - "Community 463"
+Cohesion: 0.1
+Nodes (19): API Endpoints, Auth Token Refresh, Check Recent Logs, CLIProxy — Check and Restart, code:bash (# Is it running?), code:bash (# Kill any existing instance), code:bash (# Last 30 lines of cliproxy log), code:yaml (host: "127.0.0.1") (+11 more)
+
+### Community 464 - "Community 464"
+Cohesion: 0.1
+Nodes (17): code:bash (grep -E "FAIL|✗|Error|failed|BUILD FAILURE" /tmp/test-featur), code:bash (curl -s -X POST {{API_URL}}/api/review/{{ISSUE_ID}}/status \), code:bash (curl -s -X POST {{API_URL}}/api/review/{{ISSUE_ID}}/status \), code:bash (# Check if containers are running for this workspace), CRITICAL: Bash Timeout for Test Commands, CRITICAL: Context Management — Output Redirection, Memory Context, Never Close GitHub Issues (+9 more)
+
+### Community 465 - "Community 465"
+Cohesion: 0.1
+Nodes (19): CLI Overview, code:bash (# Install Panopticon globally), code:bash (pan work issue MIN-123      # Spawn agent), code:bash (pan workspace create MIN-123         # Create workspace), code:bash (pan up    # Start dashboard at localhost:3011), code:bash (# General help), Command Structure, Common Options (+11 more)
+
+### Community 466 - "Community 466"
+Cohesion: 0.13
+Nodes (17): getCliproxyAuthDir(), getCliproxyGeminiCredPath(), parseBridgedGeminiApiKey(), readBridgedGeminiApiKey(), readBridgedGeminiApiKeyAsync(), applyBurnedTokenOverride(), CheckCodexAuthOptions, checkCodexAuthStatus() (+9 more)
+
+### Community 467 - "Community 467"
+Cohesion: 0.13
+Nodes (16): SessionUsage, emptyUsage(), isAssistantMessage(), isMessage(), KNOWN_TYPES, parsePiSessionContent(), ParseResult, PiEntry (+8 more)
+
+### Community 468 - "Community 468"
+Cohesion: 0.13
+Nodes (10): createPiFifo(), execAsync, PiFifoError, PiNotReady, shellQuote(), chunks, paths, reader (+2 more)
+
+### Community 469 - "Community 469"
+Cohesion: 0.13
+Nodes (17): BunGlobal, ChannelPermissionRequest, ChannelPermissionRequestNotification, ChannelPushPayload, ChannelPushResult, constantTimeHeaderMatch(), forwardPermissionRequestToDashboard(), getDashboardBaseUrl() (+9 more)
+
+### Community 470 - "Community 470"
+Cohesion: 0.11
+Nodes (14): CavemanExperimentRow, CostsPage(), CostsResponse, DailyTrend, ExperimentsResponse, fetchCosts(), fetchExperiments(), fetchIssueDetail() (+6 more)
+
+### Community 471 - "Community 471"
+Cohesion: 0.11
+Nodes (14): exitGracePeriod(), GraceCountdown(), GraceCountdownProps, GracePeriodState, pauseGracePeriod(), resumeGracePeriod(), fetchContextDigest(), fetchGracePeriod() (+6 more)
+
+### Community 472 - "Community 472"
+Cohesion: 0.19
+Nodes (13): getVBriefACStatus(), BeadRecord, checkOpenBeads(), checkUncommittedChanges(), checkVBriefACStatus(), errorCode(), execAsync, execFileAsync (+5 more)
+
+### Community 473 - "Community 473"
+Cohesion: 0.11
+Nodes (16): eightDaysAgo, events, payload, r1, r2, received, recent, remaining (+8 more)
+
+### Community 474 - "Community 474"
+Cohesion: 0.14
+Nodes (16): validateAgentDeliveryMethodOrigin(), _resetDashboardSessionTokenForTests(), issuesRouteLayer, _resetTrustedOriginsForTests(), IssueLifecycle, LinearClient, result, cachedIssue (+8 more)
+
+### Community 475 - "Community 475"
+Cohesion: 0.11
+Nodes (18): Agents, Beads, Cloister, Command Deck, Convoys, Core Concepts, Cost Tracking, Docker Integration (+10 more)
+
+### Community 476 - "Community 476"
+Cohesion: 0.11
+Nodes (18): Architecture, Best Practices, CLI Commands, code:bash (# 1. Implement feature), code:bash (# List all specialists with status), code:toml ([specialists.review_agent]), code:typescript (type Priority = 'urgent' | 'high' | 'normal' | 'low';), Configuration (+10 more)
+
+### Community 477 - "Community 477"
+Cohesion: 0.11
+Nodes (19): code:yaml (---), code:block20 (┌───────────────────────────────────────────────────────────), code:bash (# Skills tell the agent HOW to work), code:block22 (┌───────────────────────────────────────────────────────────), code:bash (# Update all agent workspaces with latest skills), code:bash (# Edit a skill in the canonical location), code:block25 (┌───────────────────────────────────────────────────────────), code:bash (# Parallel code review - spawn 4 agents with different focus) (+11 more)
+
+### Community 478 - "Community 478"
+Cohesion: 0.11
+Nodes (18): Architecture, Backend Changes (`src/dashboard/server/index.ts`), code:block1 (socketIo.emit('planning:started', { issueId: issue.identifie), code:block2 (socketIo.emit('planning:failed', { issueId: issue.identifier), code:block3 (Background async task fails), Data Flow, Decision: Full Recovery Controls, Decision: Kanban Card Failure Indicator (+10 more)
+
+### Community 479 - "Community 479"
+Cohesion: 0.11
+Nodes (18): Acceptance Criteria, Architecture, code:block1 (Cannot find module 'close-issue-BVnGI6Mw.js'), code:block2 (OLD SERVER PROCESS), Decision: Detached deploy script + pending lifecycle file, Difficulty, Edge Cases, Files to Modify (+10 more)
+
+### Community 480 - "Community 480"
+Cohesion: 0.11
+Nodes (18): `cli:quick-command`, Flash-Lite's Niche in Panopticon, Gemini 3.1 Flash-Lite Preview Work Type Fit Analysis, Good Fit, Integration Notes, Key Benchmarks, Known Weaknesses, Model Profile (+10 more)
+
+### Community 481 - "Community 481"
+Cohesion: 0.11
+Nodes (18): Abort, code:bash (pan flywheel start), code:bash (pan flywheel start), code:bash (pan flywheel status), code:bash (pan flywheel pause), code:bash (pan flywheel abort), code:bash (pan flywheel emit-status --file latest.json), code:bash (pan flywheel report) (+10 more)
+
+### Community 482 - "Community 482"
+Cohesion: 0.11
+Nodes (18): Built-in Convoy Templates, code-review Template, code:bash (# Run a parallel code review), code:bash (# Show most recent convoy status), code:bash (# List all convoys), code:bash (pan convoy stop <convoy-id>), code:json ({), code:bash (pan convoy start lightweight-review --files "src/**/*.ts") (+10 more)
+
+### Community 483 - "Community 483"
+Cohesion: 0.11
+Nodes (16): capturedCmds, mockCreateReviewArtifactsForIssue, mockEnsureMergeSetForIssue, mockExecFileFn, mockExecFn, mockGetAgentState, mockGetDashboardApiUrl, mockGetReviewStatus (+8 more)
+
+### Community 484 - "Community 484"
+Cohesion: 0.16
+Nodes (14): atomicWrite(), backupIfNeeded(), detectProviderEnvConflicts(), findNewestBackup(), injectPanopticonInfraDeny(), injectProviderEnvOverlay(), INVALID_LEGACY_PATTERNS, OverlayResult (+6 more)
+
+### Community 485 - "Community 485"
+Cohesion: 0.23
+Nodes (16): registerAdminCommands(), registerCloisterCommands(), compactCommand(), CompactOptions, detectPlatform(), doctorCommand(), execAsync, getOldClosedCount() (+8 more)
+
+### Community 486 - "Community 486"
+Cohesion: 0.11
+Nodes (17): firstSelect, openaiKeyInput, openaiProvider, PANOPTICON_HOME, reviewAgentLabel, reviewAgentSelect, ROUTER_CONFIG, routerConfig (+9 more)
+
+### Community 487 - "Community 487"
+Cohesion: 0.18
+Nodes (13): AutoPresoControls(), warmupIcon(), AutoPresoView(), Excalidraw, ExcalidrawApiLike, TranscriptPanel(), AutoPresoMessage, AutoPresoMode (+5 more)
+
+### Community 488 - "Community 488"
+Cohesion: 0.18
+Nodes (16): buildReport(), categorizeProcesses(), ClaudeProcess, detectRole(), formatGb(), formatMb(), getClaudeProcesses(), getHeavyProcesses() (+8 more)
+
+### Community 489 - "Community 489"
+Cohesion: 0.11
+Nodes (14): ensuredLabels, makeTestLayer(), mockGitHubAddLabel, mockGitHubCloseIssue, mockGitHubEnsureLabel, mockGitHubRemoveLabel, mockGitHubReopenIssue, mockLinearGetIssue (+6 more)
+
+### Community 490 - "Community 490"
+Cohesion: 0.11
+Nodes (17): cb, cmdArgs, cmdStr, inline, issueCommentsJson, linearGetComments, linearGetIssueId, mockExec (+9 more)
+
+### Community 491 - "Community 491"
+Cohesion: 0.23
+Nodes (9): addVoice(), clearVoices(), deleteVoice(), findVoiceById(), findVoiceByName(), getTtsVoicesPath(), loadVoices(), saveVoices() (+1 more)
+
+### Community 492 - "Community 492"
+Cohesion: 0.19
+Nodes (12): startPostLaunchSidecars(), startSidecars(), getSupervisorPort(), getSupervisorUrl(), isProcessAlive(), isSupervisorRunning(), readSupervisorPid(), resolveSupervisorBundle() (+4 more)
+
+### Community 493 - "Community 493"
+Cohesion: 0.11
+Nodes (18): Approach 1: Passive Detection (MVP), Approach 2: Active Heartbeats (via Claude Code Hooks), Approach 3: Hybrid (Recommended), code:typescript (interface PassiveHeartbeat {), code:json ({), code:bash (#!/bin/bash), code:json ({), code:typescript (function getHeartbeat(agentId: string): Heartbeat {) (+10 more)
+
+### Community 494 - "Community 494"
+Cohesion: 0.11
+Nodes (18): `<ActivitySparkline events={Event[]} windowMinutes={60} buckets={12} />`, Animation-timing reference, code:typescript (// Renders a 6×6 (small) or 8×8 (medium) circle with the rig), code:typescript (// Animates the number on change (vertical scroll fade, 250m), code:typescript (// Inline SVG, ~120×16px.), code:typescript (// 140-wide mini card with verdict, finding count, duration,), code:typescript (// Cross-fades the tool name on change (200ms each, with → b), code:typescript (// Wraps a lucide icon with the right ring color and avatar ) (+10 more)
+
+### Community 495 - "Community 495"
+Cohesion: 0.11
+Nodes (17): Architecture Decisions, code:block1 (wire-converter ──blocks──> remove-bd-prompts), Decisions, Dependency Graph (text), Key Files to Modify, Out of Scope, PAN-388: vBRIEF Integration — Structured Plans, Programmatic Beads, DAG Visualization, Phase 2 (+9 more)
+
+### Community 496 - "Community 496"
+Cohesion: 0.11
+Nodes (17): Access Points, Add Dependencies, Add Services, Change Java Version, code:bash (# Copy template to your project), code:bash (# Application), code:bash (# Connect to PostgreSQL), code:bash (docker compose restart app) (+9 more)
+
+### Community 497 - "Community 497"
+Cohesion: 0.11
+Nodes (17): Access Points, Adding Dependencies, Alembic Migrations, code:bash (# Copy template to your project), code:bash (APP_PORT=8000), code:python (# database.py), code:bash (# Install alembic), code:bash (# Connect to PostgreSQL) (+9 more)
+
+### Community 498 - "Community 498"
+Cohesion: 0.11
+Nodes (17): Adding Workspace Routes, code:block1 (~/.panopticon/traefik/), code:bash (mkcert "*.pan.localhost" "*.localhost" localhost 127.0.0.1 :), code:bash (cd ~/.panopticon/traefik), code:bash (cd ~/.panopticon/traefik), code:bash (docker logs -f panopticon-traefik), code:yaml (# dynamic/feature-pan-4.yml), Directory Structure (+9 more)
+
+### Community 499 - "Community 499"
 Cohesion: 0.11
 Nodes (17): bd vs TodoWrite, Beads Skill for Claude Code, code:bash (# Global installation), code:block2 (beads/), code:bash (# Want: "Setup must complete before Implementation"), code:bash (bd update issue-123 --notes "COMPLETED: JWT auth with RS256), Contributing, File Structure (+9 more)
 
-### Community 457 - "Community 457"
-Cohesion: 0.11
-Nodes (17): code:block1 (Session Start (when bd is available):), code:block15 (Resume Workflow:), code:block23 (Unblocking Workflow:), code:block24 (Situation: bd ready shows nothing), code:block25 (Hybrid Workflow:), code:block5 (Discovery Workflow:), code:block6 (Issue Lifecycle:), Contents (+9 more)
-
-### Community 458 - "Community 458"
+### Community 500 - "Community 500"
 Cohesion: 0.11
 Nodes (17): Benchmark: QuantumLlama Provider Integration, code:block1 (/benchmark <scenario description>), code:bash (cat /home/eltmon/Projects/panopticon-cli/benchmarks/template), code:bash (cd /home/eltmon/Projects/panopticon-cli && gh label create b), code:bash (cd /home/eltmon/Projects/panopticon-cli && gh issue create \), code:block5 (Created PAN-XXX: Benchmark: QuantumLlama — <scenario>), Execution Steps, Important Notes (+9 more)
 
-### Community 459 - "Community 459"
+### Community 501 - "Community 501"
 Cohesion: 0.11
 Nodes (17): API Documentation, Checklist Output, Code Generation, code:markdown (## Analysis Report), code:markdown (## Review Checklist), code:markdown (## Generated Code), code:markdown (## Changes Made), code:markdown (## Option Analysis) (+9 more)
 
-### Community 460 - "Community 460"
+### Community 502 - "Community 502"
 Cohesion: 0.11
 Nodes (17): code:bash (# Register a project), code:yaml (projects:), code:json ([), code:yaml (projects:), code:bash (#!/bin/bash), code:yaml (projects:), Configuration Fields, Custom Workspace Commands (Legacy) (+9 more)
 
-### Community 461 - "Community 461"
-Cohesion: 0.12
-Nodes (15): CI_FAILED_STATUS, ciBlockedStatus, feedbackDir, mockGetAgentRuntimeState, mockLoadReviewStatuses, mockResolveProjectFromIssue, mockSendKeysAsync, mockSessionExists (+7 more)
-
-### Community 462 - "Community 462"
-Cohesion: 0.29
-Nodes (16): display_title(), extract_text_fragments(), extract_tool_names(), find_by_id(), format_cost(), get_db(), get_session_summary(), iter_session_messages() (+8 more)
-
-### Community 463 - "Community 463"
-Cohesion: 0.18
-Nodes (14): COMPOSE_FILES, composeProjectNameForWorkspace(), declaredComposeProjectName(), dockerCompose(), execFileAsync, findDevcontainerComposeFile(), workspaceRebuildCommand(), tempDirs (+6 more)
-
-### Community 464 - "Community 464"
-Cohesion: 0.29
-Nodes (15): healthCommand(), HealthOptions, AgentHealth, formatHealthStatus(), getAgentHealth(), getAgentOutput(), getHealthFile(), handleStuckAgent() (+7 more)
-
-### Community 465 - "Community 465"
-Cohesion: 0.15
-Nodes (14): doCommit(), execAsync, flush(), flushAutoCommits(), FlushResult, pending, QueuedCommit, serializer (+6 more)
-
-### Community 467 - "Community 467"
-Cohesion: 0.14
-Nodes (14): cleanupExpiredReauthSessions(), codexAuthRouteLayer, consumeReauthTerminalToken(), getCodexAuthRoute, getExistingLiveReauthSession(), getLiveReauthSession(), postCodexReauthRoute, postCodexReauthStatusRoute (+6 more)
-
-### Community 468 - "Community 468"
-Cohesion: 0.21
-Nodes (15): BUNDLED_AGENTS_DIR, BUNDLED_SKILLS_DIR, copyBundledAgents(), copyBundledSkills(), __dirname, __filename, initCommand(), PACKAGE_ROOT (+7 more)
-
-### Community 469 - "Community 469"
-Cohesion: 0.12
-Nodes (17): Agent Sessions Not Appearing, code:bash (# Check if ports are in use), code:bash (# Regenerate certificates), code:bash (# Check tmux sessions), code:bash (# List worktrees), code:bash (# Install build tools (macOS)), code:bash (# Verify API key), code:bash (# Check Traefik status) (+9 more)
-
-### Community 470 - "Community 470"
-Cohesion: 0.12
-Nodes (17): API Compatibility Levels, code:bash (# Option 1: Kimi coding endpoint), code:bash (# GLM/Z.AI endpoint (Anthropic-compatible)), code:bash (export ANTHROPIC_BASE_URL=https://open.bigmodel.cn/api/anthr), code:bash (# Kimi API configuration for Claude Code), code:bash (source ~/.bashrc  # or source ~/.zshrc), code:bash (claude /status), code:bash (# Install router) (+9 more)
-
-### Community 471 - "Community 471"
-Cohesion: 0.12
-Nodes (16): code:block1 (work role completes beads and signals done), code:block2 (roles/), code:markdown (# Verdict: APPROVED | CHANGES_REQUESTED | FAILED), code:yaml (workhorses:), Cost attribution, Dashboard restart invariant, Instruction layout, Invariants (+8 more)
-
-### Community 472 - "Community 472"
-Cohesion: 0.12
-Nodes (16): Acceptance Criteria, code:block1 (┌───────────────────────────────────────────┐), Docs are part of every fix, Exit Criteria for a Single Run, Goals, Main must always be clean, Non-goals, PRD: Fix-All Flywheel (+8 more)
-
-### Community 473 - "Community 473"
-Cohesion: 0.12
-Nodes (17): ActivitySource — After, ActivitySource — Before, AgentState interface — After, AgentState interface — Before (`src/lib/agents.ts:388-433`), code:yaml (# ~/.panopticon/config.yaml), code:typescript (export type ActivitySource = 'merge-agent' | 'cloister' | 'r), code:typescript (// In activity-logger.ts, the source is computed:), code:json ({) (+9 more)
-
-### Community 474 - "Community 474"
-Cohesion: 0.12
-Nodes (16): Architecture, CLI Interface (full surface), code:block1 (┌──────────────────────────────────────────┐), code:bash (pan conversations embed                      # all enriched,), code:yaml (# config.yaml), code:bash (# Discovery), code:block20 (GET  /api/archived-conversations), Dependencies (+8 more)
-
-### Community 475 - "Community 475"
-Cohesion: 0.12
-Nodes (17): code:block21 (- discovers all sessions in target dir), code:block22 (- detects SSD vs HDD via lsblk rotational flag), code:block23 (- structured filters compose with AND), code:block24 (- L1 selects cheapest available model), code:block25 (- correct dimensions stored per provider/model), code:block26 (- nav entry routes to /conversations), code:block27 (- all fields render), code:block28 (- scan → enrich → embed → search across all three tiers) (+9 more)
-
-### Community 476 - "Community 476"
-Cohesion: 0.12
-Nodes (17): Action cluster, code:block10 ($0.04/min currently · projecting $1.20 for this session at t), code:block11 (+47 lines), code:block12 (○ idle for 4m 12s — needs nudge?    [Send Message] [Stop]), code:block6 (phase: review-response · tool: Grep), code:block7 (🧠 thinking · since 14:32:42 · last tool was Grep 8s ago), code:block8 (⏸ waiting · {reason} — {message}                    [Resolve), code:block9 (┌──────────────┐  ┌──────────────┐  ┌──────────────┐) (+9 more)
-
-### Community 477 - "Community 477"
-Cohesion: 0.12
-Nodes (16): Additional Gaps, code:json ({), code:block2 (For each running work agent:), code:typescript ({), Files to Change, Non-Goals, PAN-309: Evidence-Based Completion Detection & Lifecycle Badges, Phase 1: Evidence-Based Completion Detection (stop-hook) (+8 more)
-
-### Community 478 - "Community 478"
-Cohesion: 0.12
-Nodes (15): Approach: Pre-fetch in callers, pass to prompt builder, Architecture, code:block1 ([issueCommand() / server endpoint]), Data Flow, Data to include, Decisions, Error handling: Warn in prompt, Files to Modify (+7 more)
-
-### Community 479 - "Community 479"
-Cohesion: 0.12
-Nodes (16): Constraints, Design, Draft-mode parity, Explicit reconciliation, Local outbox model, Must Have, Open Questions, Out of Scope (+8 more)
-
-### Community 480 - "Community 480"
-Cohesion: 0.12
-Nodes (16): Architecture, Bootstrap, code:block1 (AgentEnrichmentService (3s poll)), Contracts Package (`packages/contracts/src/`), Data Flow, Decisions, Files to Modify, Frontend (verify only) (+8 more)
-
-### Community 481 - "Community 481"
-Cohesion: 0.12
-Nodes (16): Access Points, code:bash (# Copy template to your project), code:bash (APP_PORT=5000), code:block3 (Server=sqlserver;Database=${DB_NAME};User Id=sa;Password=${D), code:json ({), code:bash (# Run migrations), code:bash (# Connect via sqlcmd), Connection String (+8 more)
-
-### Community 482 - "Community 482"
-Cohesion: 0.12
-Nodes (16): Authentication Issues, code:bash (npx @_davideast/stitch-mcp init), code:json ({), code:bash (npx @_davideast/stitch-mcp doctor), code:bash (export STITCH_USE_SYSTEM_GCLOUD=1), Environment Detection, Manual Configuration, Prerequisites (+8 more)
-
-### Community 483 - "Community 483"
-Cohesion: 0.12
-Nodes (16): 1. Generate the table, 2. Add an Awaiting Merge summary line, 3. (Optional) Defer to other status skills if user wants more detail, Cell semantics, code:block1 (ISSUE      TITLE                                            ), code:bash (python3 - <<'PY'), code:bash (curl -s http://localhost:3011/api/issues | python3 -c "), code:block4 (For deeper detail beyond the pipeline view:) (+8 more)
-
-### Community 484 - "Community 484"
-Cohesion: 0.12
-Nodes (16): code:bash (pan flywheel start), code:bash (pan flywheel start), code:bash (pan flywheel status), code:bash (pan flywheel pause), code:bash (pan flywheel emit-status --file latest.json), code:bash (pan flywheel report), Commands, Emit Status (+8 more)
-
-### Community 485 - "Community 485"
-Cohesion: 0.12
-Nodes (16): Cleanup After Shutdown, code:bash (# Clean up log files), code:bash (# Monitor in one terminal), code:bash (# Clean up stale resources), code:env (# Graceful shutdown timeout (seconds)), Configuration Options, Monitoring Shutdown, More Information (+8 more)
-
-### Community 486 - "Community 486"
-Cohesion: 0.12
-Nodes (16): 10. Scrollbars, 16. File Organization, 17. Quick Reference Card, 1. Design Philosophy, 5. Border Radius Scale, 6. Spacing & Sizing, 9. Fractal Noise Texture, code:css (--radius: 0.625rem;  /* 10px */) (+8 more)
-
-### Community 487 - "Community 487"
-Cohesion: 0.12
-Nodes (16): code:bash (curl {{API_URL}}/api/health), code:bash (# Get test token (server-side, before opening browser)), code:javascript (// Launch browser), code:block4 (## UAT Results), Context, Critical Notes, Examples of BLOCKED vs PASS, Handling Playwright (Browser Automation) (+8 more)
-
-### Community 488 - "Community 488"
-Cohesion: 0.12
-Nodes (16): Best Value by Tier, Budget Tasks, Changes from Baseline, Code Review & Security, Conclusion, Cost-Effectiveness Analysis, Debugging, Executive Summary (+8 more)
-
-### Community 489 - "Community 489"
-Cohesion: 0.12
-Nodes (16): code:bash (# Full install (includes Traefik + mkcert for HTTPS)), code:bash (pan sync), code:bash (pan doctor), code:bash (# Start with default settings), code:bash (pan down), code:bash (pan restart), code:bash (pan health), Core Commands (+8 more)
-
-### Community 490 - "Community 490"
-Cohesion: 0.15
-Nodes (6): MockRallyArtifact, RallyApiMock, compoundQueries, mock, sampleArtifacts, typeQueries
-
-### Community 491 - "Community 491"
-Cohesion: 0.21
-Nodes (14): registerAdminCommands(), archiveCustomState(), CleanupOptions, cleanupStatesCommand(), LinearState, ListOptions, listStatesCommand(), listTeamStates() (+6 more)
-
-### Community 492 - "Community 492"
-Cohesion: 0.23
-Nodes (15): completeSession(), DEFAULT_DATA, findSessionById(), getAllIssuesWithCosts(), getIssueCostSummary(), getIssueSessions(), IssueSessionMap, linkSessionToIssue() (+7 more)
-
-### Community 494 - "Community 494"
-Cohesion: 0.19
-Nodes (12): getAllSpecialistStatus(), LegacySpecialistRuntimeStatus, displaySpecialist(), getRelativeTime(), getStatusColor(), getStatusIcon(), listCommand(), ListOptions (+4 more)
-
-### Community 495 - "Community 495"
-Cohesion: 0.17
-Nodes (13): assertIssueHasBeads(), BeadEntry, execFileAsync, queryBeadById(), queryBeadsForIssue(), readBeadsFromJsonl(), buildRichPRBody(), readBeadsFromJsonl() (+5 more)
-
-### Community 496 - "Community 496"
-Cohesion: 0.12
-Nodes (15): agentDir, agentResult, beadsDir, branchResult, clearResult, content, legacyDir, legacyResult (+7 more)
-
-### Community 497 - "Community 497"
-Cohesion: 0.12
-Nodes (16): Baseline-Aware Test Validation, code:block1 (┌───────────────────────────────────────────────────────────), code:bash (# In validate-merge.sh), code:typescript (// validation.ts — autoRevertMerge always uses ORIG_HEAD), code:typescript (const { stdout: statusOut } = await execAsync('git status --), code:typescript (if (stashCreated) {), code:block6 (┌──────────┐     ┌──────────┐     ┌──────────┐     ┌────────), code:typescript (POST /api/specialists/done) (+8 more)
-
-### Community 498 - "Community 498"
-Cohesion: 0.12
-Nodes (15): code:block1 (tests/), code:typescript (// Mock execAsync for git command tests), code:typescript (// Preferred: testid), Conventions, Dashboard UI Testing, `data-testid` Convention, Mocking, Playwright MCP (+7 more)
-
-### Community 499 - "Community 499"
-Cohesion: 0.12
-Nodes (15): API Integration, Component Structure, Core Layout, Design 1: Collapsed State, Design 2: Expanded State, Next Steps, Overrides (6 components), Overview (+7 more)
-
-### Community 500 - "Community 500"
-Cohesion: 0.12
-Nodes (16): 10. Autonomous flywheel daemon, 11. Public flywheel dashboard page, 12. Updated `all-up` skill, 13. Updated `CLAUDE.md` (repo-level), 1. `retro-agent` — New agent type, 2. Retro storage, 3. Synthesis step — new Step 8 in `all-up` skill, 4. `docs/FLYWHEEL-REPORT.md` — user-facing living doc (+8 more)
-
-### Community 501 - "Community 501"
-Cohesion: 0.12
-Nodes (15): Acceptance Criteria, Code to Preserve (Merge Queue), code:block1 (if (specialist busy) → submitToSpecialistQueue()), code:block2 (if (workspace already has running specialist) → no-op (dupli), Current Architecture, Goal, Key Files to Remove/Modify, New Dispatch Pattern (+7 more)
-
-### Community 502 - "Community 502"
-Cohesion: 0.12
-Nodes (15): Approach, D1: Full scope — all 6 problem areas, D2: Typed error-to-HTTP mapping via `httpHandler` wrapper, D3: Convert ALL sync FS calls including `existsSync`, D4: Keep existing route composition pattern, Decisions, Out of Scope, PAN-470: Rewrite route handlers to idiomatic Effect (+7 more)
-
 ### Community 503 - "Community 503"
-Cohesion: 0.12
-Nodes (15): 1. Eliminating Waterfalls (CRITICAL), 2. Bundle Size Optimization (CRITICAL), 3. Server-Side Performance (HIGH), 4. Client-Side Data Fetching (MEDIUM-HIGH), 5. Re-render Optimization (MEDIUM), 6. Rendering Performance (MEDIUM), 7. JavaScript Performance (LOW-MEDIUM), 8. Advanced Patterns (LOW) (+7 more)
+Cohesion: 0.11
+Nodes (17): 1. Review the shared context first, 2. Wait for convoy signals, 3. Read available reviewer reports, 4. Determine the cycle number and the diff scope to evaluate, 5. Synthesize the verdict, 6. Write the synthesis report, 7. Signal review status, Boundaries (+9 more)
 
 ### Community 504 - "Community 504"
 Cohesion: 0.12
-Nodes (15): Auto-Fix Critical Issues, Check Specific Workspace, code:bash (python ~/.claude/skills/session-health/scripts/check_session), code:bash (python ~/.claude/skills/session-health/scripts/check_session), code:bash (# Replace with your actual project path), code:bash (tmux kill-session -t agent-proj-123), code:python (import os, glob), code:bash (pan start PROJ-123) (+7 more)
+Nodes (15): activeAgent, address, agent, feature, frontendRoot, issue, newContext(), openRoute() (+7 more)
 
 ### Community 505 - "Community 505"
 Cohesion: 0.12
-Nodes (15): Beads Completion Check, BLOCKED - Open Beads Found, code:bash (# Check for open beads), code:block2 (BEADS CHECK: PASS), code:block3 (BEADS CHECK: BLOCKED), code:block4 (Task(subagent_type='beads-completion-check', prompt='Check i), code:json ({), Error Handling (+7 more)
+Nodes (15): CI_FAILED_STATUS, ciBlockedStatus, feedbackDir, mockGetAgentRuntimeState, mockLoadReviewStatuses, mockResolveProjectFromIssue, mockSendKeysAsync, mockSessionExists (+7 more)
 
 ### Community 506 - "Community 506"
-Cohesion: 0.12
-Nodes (15): Code Review Agent, code:markdown (---), code:markdown (---), code:markdown (---), code:markdown (---), code:markdown (---), code:markdown (---), code:markdown (---) (+7 more)
+Cohesion: 0.29
+Nodes (16): display_title(), extract_text_fragments(), extract_tool_names(), find_by_id(), format_cost(), get_db(), get_session_summary(), iter_session_messages() (+8 more)
 
 ### Community 507 - "Community 507"
-Cohesion: 0.12
-Nodes (15): code:markdown (## Process), code:markdown (## Decision Tree), code:markdown (## Data Transformation), code:markdown (## Investigation Flow), code:markdown (## Setup Wizard), code:markdown (## Multi-Source Research), code:markdown (## Robust Execution), Conditional Branching (+7 more)
+Cohesion: 0.13
+Nodes (14): checkNodeVersion(), checkServerBundle(), __dirname, launch(), packageDir, resolveElectron(), CONFIG, hadPackageDir (+6 more)
 
 ### Community 508 - "Community 508"
 Cohesion: 0.12
-Nodes (15): 1. Inspect commit context, 2. Choose the narrowest fitting scope, 3. Draft the commit message, 4. Commit safely, 5. If commitlint rejects the message, code:bash (git status --short --branch), code:text (feat(cli): add pan-commit skill), code:text (fix(dashboard): rehydrate snapshot after reconnect) (+7 more)
+Nodes (15): agentDir, agentResult, beadsDir, branchResult, clearResult, content, legacyDir, legacyResult (+7 more)
 
 ### Community 509 - "Community 509"
-Cohesion: 0.12
-Nodes (15): 1. Review the shared context first, 2. Wait for convoy signals, 3. Read available reviewer reports, 4. Synthesize the verdict, 5. Write the synthesis report, 6. Signal review status, Boundaries, code:markdown (# Review Synthesis — <issueId> — <timestamp>) (+7 more)
+Cohesion: 0.15
+Nodes (12): GPT_5_5_API_KEY_BLOCK, HarnessPolicyDecision, PI_ANTHROPIC_SUBSCRIPTION_BLOCK, SUBSCRIPTION_ONLY_OPENAI_MODELS, AuthMode, RuntimeName, AUTH_MODES, cells (+4 more)
 
 ### Community 510 - "Community 510"
 Cohesion: 0.12
-Nodes (15): code:bash (cd {{projectPath}}), code:bash (git diff --check), code:bash (git commit --no-edit), code:block4 (MERGE_RESULT: SUCCESS), code:block5 (MERGE_RESULT: FAILURE), code:bash (git merge --abort), Conflict Files, Critical Rules (+7 more)
+Nodes (15): existingSkillDir, existsInTarget, mockClaudeSkills, mockPanopticonSkills, nonSkillDir, skillDir, skills, skillsToSync (+7 more)
 
 ### Community 511 - "Community 511"
+Cohesion: 0.14
+Nodes (12): cache, db, loaded, row, rows, savedRow, snapshot, DbAdapter (+4 more)
+
+### Community 512 - "Community 512"
+Cohesion: 0.14
+Nodes (14): cleanupExpiredReauthSessions(), codexAuthRouteLayer, consumeReauthTerminalToken(), getCodexAuthRoute, getExistingLiveReauthSession(), getLiveReauthSession(), postCodexReauthRoute, postCodexReauthStatusRoute (+6 more)
+
+### Community 513 - "Community 513"
+Cohesion: 0.19
+Nodes (10): backupCleanCommand(), backupListCommand(), restoreCommand(), BackupInfo, cleanOldBackups(), createBackup(), createBackupTimestamp(), listBackups() (+2 more)
+
+### Community 514 - "Community 514"
+Cohesion: 0.12
+Nodes (17): Agent Sessions Not Appearing, code:bash (# Check if ports are in use), code:bash (# Regenerate certificates), code:bash (# Check tmux sessions), code:bash (# List worktrees), code:bash (# Install build tools (macOS)), code:bash (# Verify API key), code:bash (# Check Traefik status) (+9 more)
+
+### Community 515 - "Community 515"
+Cohesion: 0.12
+Nodes (17): 6. Agreed End-State, Agent Startup Context, code:yaml (devroot: ~/Projects        # where you launch Claude Code fr), code:bash (pan workspace update MIN-678    # explicit command, only whe), code:block16 (pan workspace create MIN-678), code:block17 (Agent starts on MIN-678 workspace), code:block18 (~/.panopticon/                          PANOPTICON'S PRIVATE), code:block9 (DEVROOT (~/Projects/)                    Not a git repo) (+9 more)
+
+### Community 516 - "Community 516"
+Cohesion: 0.12
+Nodes (17): API Compatibility Levels, code:bash (# Option 1: Kimi coding endpoint), code:bash (# GLM/Z.AI endpoint (Anthropic-compatible)), code:bash (export ANTHROPIC_BASE_URL=https://open.bigmodel.cn/api/anthr), code:bash (# Kimi API configuration for Claude Code), code:bash (source ~/.bashrc  # or source ~/.zshrc), code:bash (claude /status), code:bash (# Install router) (+9 more)
+
+### Community 517 - "Community 517"
+Cohesion: 0.12
+Nodes (16): code:block1 (work role completes beads and signals done), code:block2 (roles/), code:markdown (# Verdict: APPROVED | CHANGES_REQUESTED | FAILED), code:yaml (workhorses:), Cost attribution, Dashboard restart invariant, Instruction layout, Invariants (+8 more)
+
+### Community 518 - "Community 518"
+Cohesion: 0.12
+Nodes (17): ActivitySource — After, ActivitySource — Before, AgentState interface — After, AgentState interface — Before (`src/lib/agents.ts:388-433`), code:yaml (# ~/.panopticon/config.yaml), code:typescript (export type ActivitySource = 'merge-agent' | 'cloister' | 'r), code:typescript (// In activity-logger.ts, the source is computed:), code:json ({) (+9 more)
+
+### Community 519 - "Community 519"
+Cohesion: 0.12
+Nodes (17): code:block21 (- discovers all sessions in target dir), code:block22 (- detects SSD vs HDD via lsblk rotational flag), code:block23 (- structured filters compose with AND), code:block24 (- L1 selects cheapest available model), code:block25 (- correct dimensions stored per provider/model), code:block26 (- nav entry routes to /conversations), code:block27 (- all fields render), code:block28 (- scan → enrich → embed → search across all three tiers) (+9 more)
+
+### Community 520 - "Community 520"
+Cohesion: 0.12
+Nodes (16): Architecture, CLI Interface (full surface), code:block1 (┌──────────────────────────────────────────┐), code:bash (pan conversations embed                      # all enriched,), code:yaml (# config.yaml), code:bash (# Discovery), code:block20 (GET  /api/archived-conversations), Dependencies (+8 more)
+
+### Community 521 - "Community 521"
+Cohesion: 0.12
+Nodes (17): Action cluster, code:block10 ($0.04/min currently · projecting $1.20 for this session at t), code:block11 (+47 lines), code:block12 (○ idle for 4m 12s — needs nudge?    [Send Message] [Stop]), code:block6 (phase: review-response · tool: Grep), code:block7 (🧠 thinking · since 14:32:42 · last tool was Grep 8s ago), code:block8 (⏸ waiting · {reason} — {message}                    [Resolve), code:block9 (┌──────────────┐  ┌──────────────┐  ┌──────────────┐) (+9 more)
+
+### Community 522 - "Community 522"
+Cohesion: 0.12
+Nodes (16): Additional Gaps, code:json ({), code:block2 (For each running work agent:), code:typescript ({), Files to Change, Non-Goals, PAN-309: Evidence-Based Completion Detection & Lifecycle Badges, Phase 1: Evidence-Based Completion Detection (stop-hook) (+8 more)
+
+### Community 523 - "Community 523"
+Cohesion: 0.12
+Nodes (15): Approach: Pre-fetch in callers, pass to prompt builder, Architecture, code:block1 ([issueCommand() / server endpoint]), Data Flow, Data to include, Decisions, Error handling: Warn in prompt, Files to Modify (+7 more)
+
+### Community 524 - "Community 524"
+Cohesion: 0.12
+Nodes (16): Constraints, Design, Draft-mode parity, Explicit reconciliation, Local outbox model, Must Have, Open Questions, Out of Scope (+8 more)
+
+### Community 525 - "Community 525"
+Cohesion: 0.12
+Nodes (16): Architecture, Bootstrap, code:block1 (AgentEnrichmentService (3s poll)), Contracts Package (`packages/contracts/src/`), Data Flow, Decisions, Files to Modify, Frontend (verify only) (+8 more)
+
+### Community 526 - "Community 526"
+Cohesion: 0.12
+Nodes (16): Access Points, code:bash (# Copy template to your project), code:bash (APP_PORT=5000), code:block3 (Server=sqlserver;Database=${DB_NAME};User Id=sa;Password=${D), code:json ({), code:bash (# Run migrations), code:bash (# Connect via sqlcmd), Connection String (+8 more)
+
+### Community 527 - "Community 527"
+Cohesion: 0.12
+Nodes (16): Authentication Issues, code:bash (npx @_davideast/stitch-mcp init), code:json ({), code:bash (npx @_davideast/stitch-mcp doctor), code:bash (export STITCH_USE_SYSTEM_GCLOUD=1), Environment Detection, Manual Configuration, Prerequisites (+8 more)
+
+### Community 528 - "Community 528"
+Cohesion: 0.12
+Nodes (16): 1. Generate the table, 2. Add an Awaiting Merge summary line, 3. (Optional) Defer to other status skills if user wants more detail, Cell semantics, code:block1 (ISSUE      TITLE                                            ), code:bash (python3 - <<'PY'), code:bash (curl -s http://localhost:3011/api/issues | python3 -c "), code:block4 (For deeper detail beyond the pipeline view:) (+8 more)
+
+### Community 529 - "Community 529"
+Cohesion: 0.12
+Nodes (16): Cleanup After Shutdown, code:bash (# Clean up log files), code:bash (# Monitor in one terminal), code:bash (# Clean up stale resources), code:env (# Graceful shutdown timeout (seconds)), Configuration Options, Monitoring Shutdown, More Information (+8 more)
+
+### Community 530 - "Community 530"
+Cohesion: 0.12
+Nodes (16): 10. Scrollbars, 16. File Organization, 17. Quick Reference Card, 1. Design Philosophy, 5. Border Radius Scale, 6. Spacing & Sizing, 9. Fractal Noise Texture, code:css (--radius: 0.625rem;  /* 10px */) (+8 more)
+
+### Community 531 - "Community 531"
+Cohesion: 0.12
+Nodes (16): code:bash (curl {{API_URL}}/api/health), code:bash (# Get test token (server-side, before opening browser)), code:javascript (// Launch browser), code:block4 (## UAT Results), Context, Critical Notes, Examples of BLOCKED vs PASS, Handling Playwright (Browser Automation) (+8 more)
+
+### Community 532 - "Community 532"
+Cohesion: 0.12
+Nodes (16): Best Value by Tier, Budget Tasks, Changes from Baseline, Code Review & Security, Conclusion, Cost-Effectiveness Analysis, Debugging, Executive Summary (+8 more)
+
+### Community 533 - "Community 533"
+Cohesion: 0.12
+Nodes (16): code:bash (# Full install (includes Traefik + mkcert for HTTPS)), code:bash (pan sync), code:bash (pan doctor), code:bash (# Start with default settings), code:bash (pan down), code:bash (pan restart), code:bash (pan health), Core Commands (+8 more)
+
+### Community 534 - "Community 534"
+Cohesion: 0.15
+Nodes (6): MockRallyArtifact, RallyApiMock, compoundQueries, mock, sampleArtifacts, typeQueries
+
+### Community 535 - "Community 535"
+Cohesion: 0.14
+Nodes (14): isSmeeRunning(), stopSmeeClient(), delay, errorSpy, logSpy, mockExistsSync, mockLoadConfig, mockReadFileSync (+6 more)
+
+### Community 536 - "Community 536"
+Cohesion: 0.23
+Nodes (14): getDefaultTtsDaemonConfig(), mergeTtsConfig(), mergeTtsDaemonConfigs(), YamlConfig, cloneTtsConfig(), currentConfig, findProjectRootAsync(), pathExists() (+6 more)
+
+### Community 537 - "Community 537"
+Cohesion: 0.13
+Nodes (13): getBridgeLogPath(), getPanopticonHome(), BRIDGE_ENTRY, entry, exitPromise, lines, logPath, params (+5 more)
+
+### Community 538 - "Community 538"
+Cohesion: 0.14
+Nodes (14): fetchOpenRouterModels(), KeyStatus, OpenRouterModelsResponse, OpenRouterPage(), OpenRouterPageProps, saveApiKey(), saveFavorites(), SaveOpenRouterKeyResponse (+6 more)
+
+### Community 539 - "Community 539"
+Cohesion: 0.23
+Nodes (14): startTtsDaemonFromDashboard(), ActivityTtsPayload, drainQueue(), dropIndexForFullQueue(), enqueueActivityTts(), eventPriority(), onEvent(), optionalString() (+6 more)
+
+### Community 540 - "Community 540"
+Cohesion: 0.12
+Nodes (16): Baseline-Aware Test Validation, code:block1 (┌───────────────────────────────────────────────────────────), code:bash (# In validate-merge.sh), code:typescript (// validation.ts — autoRevertMerge always uses ORIG_HEAD), code:typescript (const { stdout: statusOut } = await execAsync('git status --), code:typescript (if (stashCreated) {), code:block6 (┌──────────┐     ┌──────────┐     ┌──────────┐     ┌────────), code:typescript (POST /api/specialists/done) (+8 more)
+
+### Community 541 - "Community 541"
+Cohesion: 0.12
+Nodes (15): code:block1 (tests/), code:typescript (// Mock execAsync for git command tests), code:typescript (// Preferred: testid), Conventions, Dashboard UI Testing, `data-testid` Convention, Mocking, Playwright MCP (+7 more)
+
+### Community 542 - "Community 542"
+Cohesion: 0.12
+Nodes (15): API Integration, Component Structure, Core Layout, Design 1: Collapsed State, Design 2: Expanded State, Next Steps, Overrides (6 components), Overview (+7 more)
+
+### Community 543 - "Community 543"
+Cohesion: 0.12
+Nodes (16): 10. Autonomous flywheel daemon, 11. Public flywheel dashboard page, 12. Updated `all-up` skill, 13. Updated `CLAUDE.md` (repo-level), 1. `retro-agent` — New agent type, 2. Retro storage, 3. Synthesis step — new Step 8 in `all-up` skill, 4. `docs/FLYWHEEL-REPORT.md` — user-facing living doc (+8 more)
+
+### Community 544 - "Community 544"
+Cohesion: 0.12
+Nodes (15): Acceptance Criteria, Code to Preserve (Merge Queue), code:block1 (if (specialist busy) → submitToSpecialistQueue()), code:block2 (if (workspace already has running specialist) → no-op (dupli), Current Architecture, Goal, Key Files to Remove/Modify, New Dispatch Pattern (+7 more)
+
+### Community 545 - "Community 545"
+Cohesion: 0.12
+Nodes (15): Approach, D1: Full scope — all 6 problem areas, D2: Typed error-to-HTTP mapping via `httpHandler` wrapper, D3: Convert ALL sync FS calls including `existsSync`, D4: Keep existing route composition pattern, Decisions, Out of Scope, PAN-470: Rewrite route handlers to idiomatic Effect (+7 more)
+
+### Community 546 - "Community 546"
+Cohesion: 0.12
+Nodes (15): 1. Eliminating Waterfalls (CRITICAL), 2. Bundle Size Optimization (CRITICAL), 3. Server-Side Performance (HIGH), 4. Client-Side Data Fetching (MEDIUM-HIGH), 5. Re-render Optimization (MEDIUM), 6. Rendering Performance (MEDIUM), 7. JavaScript Performance (LOW-MEDIUM), 8. Advanced Patterns (LOW) (+7 more)
+
+### Community 547 - "Community 547"
+Cohesion: 0.12
+Nodes (15): Auto-Fix Critical Issues, Check Specific Workspace, code:bash (python ~/.claude/skills/session-health/scripts/check_session), code:bash (python ~/.claude/skills/session-health/scripts/check_session), code:bash (# Replace with your actual project path), code:bash (tmux kill-session -t agent-proj-123), code:python (import os, glob), code:bash (pan start PROJ-123) (+7 more)
+
+### Community 548 - "Community 548"
+Cohesion: 0.12
+Nodes (15): Beads Completion Check, BLOCKED - Open Beads Found, code:bash (# Check for open beads), code:block2 (BEADS CHECK: PASS), code:block3 (BEADS CHECK: BLOCKED), code:block4 (Task(subagent_type='beads-completion-check', prompt='Check i), code:json ({), Error Handling (+7 more)
+
+### Community 549 - "Community 549"
+Cohesion: 0.12
+Nodes (15): Code Review Agent, code:markdown (---), code:markdown (---), code:markdown (---), code:markdown (---), code:markdown (---), code:markdown (---), code:markdown (---) (+7 more)
+
+### Community 550 - "Community 550"
+Cohesion: 0.12
+Nodes (15): code:markdown (## Process), code:markdown (## Decision Tree), code:markdown (## Data Transformation), code:markdown (## Investigation Flow), code:markdown (## Setup Wizard), code:markdown (## Multi-Source Research), code:markdown (## Robust Execution), Conditional Branching (+7 more)
+
+### Community 551 - "Community 551"
+Cohesion: 0.12
+Nodes (15): 1. Inspect commit context, 2. Choose the narrowest fitting scope, 3. Draft the commit message, 4. Commit safely, 5. If commitlint rejects the message, code:bash (git status --short --branch), code:text (feat(cli): add pan-commit skill), code:text (fix(dashboard): rehydrate snapshot after reconnect) (+7 more)
+
+### Community 552 - "Community 552"
+Cohesion: 0.12
+Nodes (15): code:bash (cd {{projectPath}}), code:bash (git diff --check), code:bash (git commit --no-edit), code:block4 (MERGE_RESULT: SUCCESS), code:block5 (MERGE_RESULT: FAILURE), code:bash (git merge --abort), Conflict Files, Critical Rules (+7 more)
+
+### Community 553 - "Community 553"
 Cohesion: 0.13
 Nodes (14): backup, backup1, backup2, backupDir, backups, dir1, dir2, removed (+6 more)
 
-### Community 512 - "Community 512"
-Cohesion: 0.2
-Nodes (14): applyEvent(), bumpRuntimeSnapshotSequence(), DashboardLifecycleState, defaultRuntimeSnapshot(), EmbedProgressSnapshot, EnrichProgressSnapshot, EnrichStatsSnapshot, getMaxTurnDiffSummariesPerAgent() (+6 more)
-
-### Community 513 - "Community 513"
-Cohesion: 0.23
-Nodes (12): findVendoredDir(), getCavemanHooksDir(), getCavemanSkillsDir(), setupCavemanHooks(), CavemanVariant, determineCavemanVariant(), injectCavemanSettings(), NormalizedCavemanConfig (+4 more)
-
-### Community 514 - "Community 514"
-Cohesion: 0.13
-Nodes (13): after, backupPath, backups, calls, errSpy, exitSpy, original, out (+5 more)
-
-### Community 515 - "Community 515"
-Cohesion: 0.17
-Nodes (10): ApiKeyValidationResult, classifyModel(), detectThinkingSupport(), ModelCache, OpenRouterModel, OpenRouterService, OpenRouterServiceLive, OpenRouterServiceShape (+2 more)
-
-### Community 516 - "Community 516"
+### Community 554 - "Community 554"
 Cohesion: 0.13
 Nodes (12): claudeProjectDir, content, lines, newContent, newSessionFile, oldContent, oldSessionFile, projectDirName (+4 more)
 
-### Community 517 - "Community 517"
-Cohesion: 0.21
-Nodes (11): getShadowModeStatus(), getShadowModeSummary(), hasProjectShadowConfig(), isShadowModeEnabled(), resolveShadowMode(), ShadowModeOptions, ShadowModeResult, id (+3 more)
+### Community 555 - "Community 555"
+Cohesion: 0.16
+Nodes (11): isStale(), PHASE_CONFIG, recentActionObservations(), issue, list, onOpenWorkspaceHome, status, summary (+3 more)
 
-### Community 518 - "Community 518"
+### Community 556 - "Community 556"
+Cohesion: 0.18
+Nodes (13): bucketByTime(), classifyTimeBucket(), isSameLocalDay(), TimeBucketed, TimeBucketKey, toDate(), buckets, Item (+5 more)
+
+### Community 557 - "Community 557"
 Cohesion: 0.13
 Nodes (12): mockDeepWipe, mockExistsSync, mockGetAgentState, mockGetAgentStateAsync, mockMessageAgent, mockMkdir, mockSpawnAgent, mockSpawnPlanningSession (+4 more)
 
-### Community 519 - "Community 519"
+### Community 558 - "Community 558"
+Cohesion: 0.13
+Nodes (14): ExtractionProviderConfig, ExtractionProviderTarget, MemoryIdentity, MemoryObservation, MemoryStatus, MemoryStatusPhase, MemoryTokenUsage, PendingTurn (+6 more)
+
+### Community 559 - "Community 559"
 Cohesion: 0.13
 Nodes (15): Agent Commands, code:bash (# Start dashboard (prefers Electron desktop app if installed), code:bash (# Create workspace for an issue), code:bash (# Check agent status), code:bash (# Start work agent for an issue), code:bash (# Add project), code:bash (# Sync skills to Claude Code), code:bash (# Verify that main is releasable) (+7 more)
 
-### Community 520 - "Community 520"
+### Community 560 - "Community 560"
 Cohesion: 0.13
 Nodes (15): code:block111 (┌───────────────────────────────────────────────────────────), code:bash (# Key configuration (written to /etc/dnsmasq.d/panopticon.co), code:bash (# 1. Install dnsmasq), code:powershell (# Reads ~/.wsl2hosts from WSL2), code:powershell (# Run sync every 5 minutes (or on-demand when workspaces cha), code:bash (# Creates a helper command that can be run with sudo without), code:bash (# 1. Create workspace directories, containers, etc.), Component 1: dnsmasq Wildcard DNS (WSL2 Side) (+7 more)
 
-### Community 521 - "Community 521"
+### Community 561 - "Community 561"
+Cohesion: 0.13
+Nodes (14): 10. Tracked Issues, 11. Implementation Scope, 3. Real-World Conflict: Mind Your Now, 4. Enterprise / Managed Policy, 5. Path Portability (Completed), 7. Rules: Planned Content, 9. Decisions Log, code:block7 (pan workspace create MIN-678) (+6 more)
+
+### Community 562 - "Community 562"
 Cohesion: 0.13
 Nodes (15): Artifact Lifecycle, code:block46 (docs/prds/), code:block47 (.planning/), code:block48 (.beads/), code:bash (# Before moving (on source machine)), code:bash (bd sync                              # Export beads DB → JSO), code:bash (git checkout feature/min-667), code:bash (pan workspace migrate MIN-667 --to remote) (+7 more)
 
-### Community 522 - "Community 522"
+### Community 563 - "Community 563"
 Cohesion: 0.13
 Nodes (15): code:yaml (models:), code:env (ANTHROPIC_API_KEY=sk-ant-api03-...), code:yaml (models:), code:env (ANTHROPIC_API_KEY=sk-ant-...), code:yaml (models:), code:env (ANTHROPIC_API_KEY=sk-ant-...), code:yaml (models:), code:yaml (models:) (+7 more)
 
-### Community 523 - "Community 523"
+### Community 564 - "Community 564"
 Cohesion: 0.13
 Nodes (15): Activity logger (`src/lib/activity-logger.ts`), API routes (`src/dashboard/server/routes/`), Backend Changes, Cloister service (`src/lib/cloister/service.ts`), code:typescript (type Workhorse = 'expensive' | 'mid' | 'cheap';), code:typescript (async function onIssueStateChange(issueId: string, newState:), code:yaml (workhorses:), Config schema (`~/.panopticon/config.yaml`) (+7 more)
 
-### Community 524 - "Community 524"
-Cohesion: 0.13
-Nodes (14): A.1 Add `isInfrastructureFailure` helper, A.2 Enhance `checkStuckReviewing` to detect dead parallel sessions, A.3 Add infrastructure-failure circuit breaker, A.4 Honor `stuck` flag in re-dispatch path, A.5 ~~Detect verification/review contradiction~~ — REMOVED, A.6 Partial results from incomplete parallel reviews, A. `src/lib/cloister/deacon.ts`, code:typescript (function isInfrastructureFailure(notes?: string): boolean {) (+6 more)
-
-### Community 525 - "Community 525"
+### Community 565 - "Community 565"
 Cohesion: 0.13
 Nodes (14): Acceptance Criteria, Bead 1: HarnessPicker Component, Bead 2: API harness params, Bead 3: PlanDialog picker, Bead 4: Start-agent picker, Bead 5: ConversationPanel picker, Bead 6: SettingsPage defaults, Design Goals (+6 more)
 
-### Community 526 - "Community 526"
+### Community 566 - "Community 566"
 Cohesion: 0.13
 Nodes (14): code:bash (# Migrate local → remote), Command Design, Current Architecture, Edge Cases, File: `src/cli/commands/workspace-migrate.ts`, Files to Create/Modify, Implementation, Local Workspaces (+6 more)
 
-### Community 527 - "Community 527"
+### Community 567 - "Community 567"
 Cohesion: 0.13
 Nodes (14): Decision, Difficulty Estimates, Implementation Complete, In Scope, Key Architectural Choices, Out of Scope, PAN-428: Dashboard Data Layer — Consolidate Polling, Push-First Architecture, Parallelization Strategy (+6 more)
 
-### Community 528 - "Community 528"
+### Community 568 - "Community 568"
 Cohesion: 0.13
 Nodes (14): Architecture Overview, Auto-Selection Logic, code:block1 (Command Deck (project selected)), Core Design: Conversation-First with Contextual Chrome, Data Flow, Decision Summary, Key Decisions Made, Key Patterns to Follow (+6 more)
 
-### Community 529 - "Community 529"
+### Community 569 - "Community 569"
 Cohesion: 0.13
 Nodes (14): Access Points, Adding Dependencies, App Router vs Pages Router, code:bash (# Copy template to your project), code:bash (APP_PORT=3000), code:javascript (/** @type {import('next').NextConfig} */), code:bash (# Install inside container), Development Workflow (+6 more)
 
-### Community 530 - "Community 530"
+### Community 570 - "Community 570"
 Cohesion: 0.13
 Nodes (14): Batch Operations, code:bash (# From a pipe), code:block2 (close <id> [reason...]), code:bash (# Close all open beads for PAN-116), code:bash (# Deprioritize multiple beads), Error Handling, Example: Bulk Close, Example: Bulk Update (+6 more)
 
-### Community 531 - "Community 531"
+### Community 571 - "Community 571"
 Cohesion: 0.13
 Nodes (15): Automatic Unblocking, blocks - Hard Blocker, code:block1 (db-schema-1: "Create users table"), code:block2 (migrate-1: "Backup production database"), code:block3 (setup-1: "Install JWT library"), code:bash (bd dep add prerequisite-issue blocked-issue), code:block5 (foundation-1: "Set up authentication system"), code:block6 (step-1 blocks step-2 blocks step-3 blocks step-4) (+7 more)
 
-### Community 532 - "Community 532"
+### Community 572 - "Community 572"
 Cohesion: 0.13
 Nodes (15): code:block22 (feature-10: "Add user profiles"), code:block23 (research-5: "Investigate caching options"), code:block24 (refactor-20: "Extract validation logic"), code:bash (bd dep add original-work-id discovered-issue-id --type disco), code:block26 (spike-1: "Investigate API redesign"), code:block27 (bug-1: "Login fails intermittently"), code:block28 (feature-main: "Add shopping cart"), code:block29 (feature-10: "Add user profiles") (+7 more)
 
-### Community 533 - "Community 533"
+### Community 573 - "Community 573"
 Cohesion: 0.13
 Nodes (15): Basic Filters, code:bash (# Labels (AND: must have ALL)), code:bash (# Title search (substring)), code:bash (# Date range filters (YYYY-MM-DD or RFC3339)), code:bash (# Empty/null checks), code:bash (# Priority ranges), code:bash (# Combine multiple filters), code:bash (# Filter by status, priority, type) (+7 more)
 
-### Community 534 - "Community 534"
+### Community 574 - "Community 574"
+Cohesion: 0.13
+Nodes (14): code:block1 (Session Start (when bd is available):), code:block15 (Resume Workflow:), code:block25 (Hybrid Workflow:), code:block5 (Discovery Workflow:), code:block6 (Issue Lifecycle:), Contents, Decision Points, Discovery and Issue Creation {#discovery} (+6 more)
+
+### Community 575 - "Community 575"
 Cohesion: 0.13
 Nodes (14): Architecture, code:bash (bd worktree create .worktrees/{name} --branch feature/{name}), code:block2 (main-repo/), code:bash (# Create worktree with beads support), code:bash (bd where              # Shows actual .beads location (follow), code:bash (bd init --branch beads-metadata    # Use separate branch for), Commands, Debugging (+6 more)
 
-### Community 535 - "Community 535"
+### Community 576 - "Community 576"
 Cohesion: 0.13
 Nodes (14): 1. Find the right document, 2. Decide the document type before editing, 3. Update the target document, 4. Update the index, 5. Verify the docs surface, Add or update documentation, Answer a docs question, Clean up confusing docs (+6 more)
 
-### Community 536 - "Community 536"
+### Community 577 - "Community 577"
 Cohesion: 0.14
 Nodes (11): cache, capped, cpuList, events, lines, memFree, memTotal, result (+3 more)
 
-### Community 537 - "Community 537"
-Cohesion: 0.14
-Nodes (12): compressSrc, destDir, dir, hookFiles, hooksDir, keys, mockFileURLToPath, mockHomedir (+4 more)
+### Community 578 - "Community 578"
+Cohesion: 0.19
+Nodes (9): calls, { mockExecAsync }, opts, compactBeads(), compactBeadsImpl(), CompactBeadsOptions, execAsync, { mockExecAsync } (+1 more)
 
-### Community 539 - "Community 539"
+### Community 579 - "Community 579"
+Cohesion: 0.19
+Nodes (11): checkAllTriggers(), checkStuckEscalation(), checkTaskCompletion(), checkTestFailure(), detectTestFailure(), execAsync, taskCompletionCache, TaskCompletionCacheEntry (+3 more)
+
+### Community 580 - "Community 580"
+Cohesion: 0.14
+Nodes (13): shouldSkipCheckpointReconciliation(), isTerminalTurnDiffSummaryStatus(), agentIds, baseTimestamp, checkpoints, deleteLegacyCheckpointRefs, diffCheckpointFiles, encoder (+5 more)
+
+### Community 581 - "Community 581"
+Cohesion: 0.14
+Nodes (10): calls, claimRange, commitRange, emitObservationCreated, extract, maybeTriggerRollup, releaseRange, updateHealth (+2 more)
+
+### Community 582 - "Community 582"
 Cohesion: 0.14
 Nodes (12): closedWorkspaceIcon, issueId, pan777Row, pan862Row, ProjectData, projectHeader, RESOURCE_DETAIL_IDENTIFIERS, RESOURCE_ISSUES (+4 more)
 
-### Community 540 - "Community 540"
-Cohesion: 0.15
-Nodes (11): fetchProjectSpecialists(), fetchRunLogs(), formatDate(), ProjectSpecialist, ProjectSpecialistCard(), ProjectSpecialistCardProps, ProjectSpecialistMetadata, RunLogEntry (+3 more)
-
-### Community 541 - "Community 541"
-Cohesion: 0.19
-Nodes (11): fetchSettings(), isIssueTtsMuted(), normalizeIssueId(), putSettings(), setIssueTtsMuted(), fetchMock, muted, putCall (+3 more)
-
-### Community 542 - "Community 542"
-Cohesion: 0.21
-Nodes (10): BranchNode(), BranchNodeProps, ContainerNodeProps, PrNode(), PrNodeProps, getStorageKey(), readExpanded(), ResourcesGroup() (+2 more)
-
-### Community 544 - "Community 544"
+### Community 583 - "Community 583"
 Cohesion: 0.14
-Nodes (11): mockDeepWipe, mockExistsSync, mockGetAgentState, mockGetAgentStateAsync, mockMessageAgent, mockMkdir, mockSpawnAgent, mockSpawnPlanningSession (+3 more)
-
-### Community 545 - "Community 545"
-Cohesion: 0.14
-Nodes (10): mockGetLinearApiKey, mockSdkCreateComment, mockSdkCreateIssueLabel, mockSdkIssue, mockSdkIssueLabels, mockSdkSearchIssues, mockSdkTeam, mockSdkUpdateIssue (+2 more)
-
-### Community 546 - "Community 546"
-Cohesion: 0.23
-Nodes (10): dashboardBundleMtimeMs(), parseHealthTimeout(), recordReloadStatus(), reloadCommand(), ReloadOptions, runBuild(), UsageError, resolveBundledServerPath() (+2 more)
-
-### Community 547 - "Community 547"
-Cohesion: 0.25
-Nodes (4): execAsync, getPidFilePath(), readDaemonState(), TldrDaemonService
-
-### Community 548 - "Community 548"
-Cohesion: 0.14
-Nodes (13): code:bash (npx @panctl/cli), code:mermaid (flowchart LR), code:bash (npx @panctl/cli), Command Deck, Dashboard Views, How It Works, Key Features, Learn More (+5 more)
-
-### Community 549 - "Community 549"
-Cohesion: 0.14
-Nodes (13): code:block1 (Claude Code fires hook), Global `~/.claude/settings.json`, Hook Execution Flow, Hook Scripts Inventory, Migration Pruning, Panopticon Hook System, Per-Agent Frontmatter (`agents/pan-*.md`), Pi Event Channel (PAN-1134) (+5 more)
-
-### Community 550 - "Community 550"
-Cohesion: 0.14
-Nodes (13): 1. Browser / app shell, 2. Panopticon terminal wrapper (`XTerminal.tsx`), 3. xterm.js, 4. Remote PTY app (`tmux` + attached TUI), Debugging checklist, Managed tmux policy, Ownership rules, Right-click / context menu (+5 more)
-
-### Community 551 - "Community 551"
-Cohesion: 0.14
-Nodes (13): code:bash (pan up), code:bash (pan dev), code:bash (npm run build), code:bash (pan reload), code:bash (pan status), code:bash (less ~/.panopticon/logs/supervisor.log), code:bash (less ~/.panopticon/logs/dashboard.log), Failure triage (+5 more)
-
-### Community 552 - "Community 552"
-Cohesion: 0.14
-Nodes (14): Agent Attribution, Agent CVs (Work History), Beads Flow with Panopticon, Beyond Issue Tracking, code:block13 (┌───────────────────────────────────────────────────────────), code:bash (# Hook structure), code:json ({), code:bash (bd stats --actor=panopticon/agent-min-648) (+6 more)
-
-### Community 553 - "Community 553"
-Cohesion: 0.14
-Nodes (14): Available Hook Points, code:toml (# .panopticon/project.toml), code:toml ([hooks.pre_commit]), code:block122 (workspace_aware = false (default):), code:toml (# /home/eltmon/projects/myn/.panopticon/project.toml), code:toml ([hooks.post_agent_complete]), code:toml ([hooks.pre_commit]), Hook Configuration (+6 more)
-
-### Community 554 - "Community 554"
-Cohesion: 0.14
-Nodes (14): Built-in Variables, CLAUDE.md Templating System, code:block104 (┌───────────────────────────────────────────────────────────), code:toml (# .panopticon/project.toml), code:markdown (<!-- ~/.panopticon/templates/claude-md/sections/workspace-in), code:markdown (<!-- .panopticon/claude-md/sections/principles.md -->), code:bash (pan workspace create min-648), Example: Panopticon-Provided Section (+6 more)
-
-### Community 555 - "Community 555"
-Cohesion: 0.14
-Nodes (13): code:block1 (skills/pan-<verb>/SKILL.md            (canonical, committed)), Creating a new wrapper skill, For CLI-wrapper skills, For workflow / reference / topical skills, How skills are distributed, Linting, Panopticon Skills ↔ CLI Convention, Related (+5 more)
-
-### Community 556 - "Community 556"
-Cohesion: 0.14
-Nodes (14): 1.1 Add exe.dev Provider, 1.2 New Commands, 2.2 Modified docker-compose for Remote, 5.1 Workspace List View, 5.2 Agent Terminal View, code:yaml (# .devcontainer/docker-compose.remote.yml), code:block21 (┌───────────────────────────────────────────────────────────), code:typescript (// Server-side: bridge WebSocket to SSH) (+6 more)
-
-### Community 557 - "Community 557"
-Cohesion: 0.14
-Nodes (14): Claude Code Bypass Permissions (Automatic), code:block26 (https://github.com/owner/repo.git  → git@github.com:owner/re), code:bash (mkdir -p ~/.panopticon/ssh), code:bash (cat ~/.panopticon/ssh/exe-dev-key.pub | pbcopy  # Copy to cl), code:bash (# For GitHub:), code:bash (ssh exe.dev help), code:json ({), code:bash (ssh <vm-name>.exe.xyz 'echo "{\"bypassPermissionsModeAccepte) (+6 more)
-
-### Community 558 - "Community 558"
-Cohesion: 0.14
-Nodes (13): Agent Grid, code:block1 (┌────────────────────────────────────────────────────┐), code:css (--gv-bg: #0a0e1a          /* Dark navy background */), Components, Dependencies, Design System, Focus View, God View — Real-time Agent Activity Command Center (+5 more)
-
-### Community 559 - "Community 559"
-Cohesion: 0.14
-Nodes (13): 12. Responsive Behavior, 14. File Structure, 15. Acceptance Criteria, 16. Risks & Mitigations, 17. Open Questions, 1. Problem Statement, 2. Design Philosophy, 6. Cloister Banner (+5 more)
-
-### Community 560 - "Community 560"
-Cohesion: 0.14
-Nodes (14): A.1 Add `isInfrastructureFailure` helper, A.2 Enhance `checkStuckReviewing` to detect dead parallel sessions, A.3 Add infrastructure-failure circuit breaker, A.4 Honor `stuck` flag in re-dispatch path, A.5 Detect verification/review contradiction, A.6 Partial results from incomplete parallel reviews, A. `src/lib/cloister/deacon.ts`, code:typescript (function isInfrastructureFailure(notes?: string): boolean {) (+6 more)
-
-### Community 561 - "Community 561"
-Cohesion: 0.14
-Nodes (14): B0: Toolchain Setup, B18: Integration + Build, B19: Frontend Component Migration, B1: Contracts Package, B20: Terminal Streaming RPC (Dual-Runtime), B21: Cleanup + Verification, B2: Event Store, B3: ServerConfig Service (+6 more)
-
-### Community 562 - "Community 562"
-Cohesion: 0.14
-Nodes (13): Acceptance Criteria, code:typescript (export async function buildAgentLaunchConfig(opts: {), code:block2 (POST /api/agents/:id/restart), code:typescript (export async function resumeAgent(agentId: string, message?:), Design, Files to Modify, Motivation, PAN-980: Agent Restart Refactor — Shared Launch Config, Model Override, Graceful Shutdown (+5 more)
-
-### Community 563 - "Community 563"
-Cohesion: 0.14
-Nodes (13): Acceptance Criteria for the Epic, Architecture Overview, Children, code:block1 (┌───────────────────────────────────────────────────────────), Differentiation vs Prior Art, Files Likely Touched, Open Questions, PAN-1200 — Universal Context System (Epic) (+5 more)
-
-### Community 564 - "Community 564"
-Cohesion: 0.14
-Nodes (13): 1. PAN-685 model-override frontend (`stash@{34}` + `d81260d0e`), 2. Material Symbols (`stash@{38}`), 3. PAN-TTS + model-routing README (`stash@{35}`), 4. Model-override work (`stash@{39}` + `df0982bcb`), 5. "Other changes to restore later" (`7b12b85990`), 6. Inspector panel (`stash@{18}`) — **NEEDS USER DECISION**, Flagged items — 9 total, 6 unique (3 duplicates), Follow-up tickets to file (if user agrees with recommendation) (+5 more)
-
-### Community 565 - "Community 565"
-Cohesion: 0.14
-Nodes (13): Decisions, Files Modified, Implementation Plan, Out of Scope, PAN-290: Fix 9 Pre-existing Test Failures, Problem, Root Cause Analysis, Session-rotation (3 failures) (+5 more)
-
-### Community 566 - "Community 566"
-Cohesion: 0.14
-Nodes (13): 1. Programmatic cleanup in `postMergeLifecycle()`, 2. Belt-and-suspenders: .gitignore, 3. Update planning code to use `git add -f`, 4. Ordering in postMergeLifecycle(), code:block1 (.planning/STATE.md), code:block2 (1. Move PRD (existing)), Decisions, Files to Modify (+5 more)
-
-### Community 567 - "Community 567"
-Cohesion: 0.14
-Nodes (13): Approach, Architecture Notes, Endpoint location: conversations.ts, NOT agents.ts, Files Changed, Image storage: OS temp dir, Key Decisions, PAN-539: Image Paste Support in Activity View Conversation, Paste interception: wrapper div, not Lexical plugin (+5 more)
-
-### Community 568 - "Community 568"
-Cohesion: 0.14
-Nodes (13): Do Not Route, Exception: One-Shot High-Stakes Analysis, GPT-5.4 Pro Work Type Fit Analysis, Integration Notes, Key Benchmarks, Known Weaknesses, Model Profile, Sources (+5 more)
-
-### Community 569 - "Community 569"
-Cohesion: 0.14
-Nodes (13): Access Points, Adding Dependencies, code:bash (# Copy template to your project), code:bash (APP_PORT=5173), code:typescript (export default defineConfig({), code:bash (# Install inside container), Development Workflow, Environment Variables (+5 more)
-
-### Community 570 - "Community 570"
-Cohesion: 0.14
-Nodes (13): After Reopening, code:bash (pan reopen PAN-123), code:bash (curl -X POST http://localhost:3011/api/issues/PAN-123/reopen), Do NOT Use `pan done` Until Re-Work Is Complete, How to Reopen, Preflight Guard, Reopen a Closed/Completed Issue for Re-Work, Via CLI (recommended for agents/supervisors) (+5 more)
-
-### Community 571 - "Community 571"
-Cohesion: 0.14
-Nodes (14): code:block15 (oauth-epic: "Implement OAuth integration" (epic)), code:block16 (research-epic: "Investigate caching strategies" (epic)), code:bash (bd dep add child-task-id parent-epic-id --type parent-child), code:block18 (auth-epic (parent of all)), code:block19 (Epic with no ordering between children:), code:block20 (Epic with blocks dependencies between children:), code:block21 (major-epic), Combining with blocks (+6 more)
-
-### Community 572 - "Community 572"
-Cohesion: 0.14
-Nodes (13): Basic Usage, code:bash (# Start all services), code:env (# Dashboard port (default: 3001)), code:bash (# Overall health check), Configuration Options, Health Checks, More Information, Next Steps (+5 more)
-
-### Community 573 - "Community 573"
-Cohesion: 0.14
-Nodes (14): code:bash (# Check if pan command exists), code:bash (# Check for running services), code:bash (pan down), code:bash (pan up), code:block6 (✓ API server started on port 3002), code:bash (# Check all services are running), code:block8 (http://localhost:3001), code:bash (# View dashboard logs) (+6 more)
-
-### Community 574 - "Community 574"
-Cohesion: 0.14
-Nodes (13): Auto-planning, Available commands, code:bash (pan plan <id> [--auto] [--model <model>] [--harness claude-c), code:bash (pan plan PAN-1071), code:bash (pan plan PAN-1071 --auto), code:bash (pan plan finalize), code:bash (pan plan done PAN-1071), Completing planning (`pan plan done`) (+5 more)
-
-### Community 575 - "Community 575"
-Cohesion: 0.14
-Nodes (13): 1. Identify the Issue, 2. Gather Context, 3. Research (Interactive), 4. Write the Spec, 5. Confirm File Location, code:markdown (# {Issue ID}: {Title}), code:block2 (Spec written: docs/prds/active/{filename}-spec.md), Execution Steps (+5 more)
-
-### Community 576 - "Community 576"
-Cohesion: 0.14
-Nodes (13): code:block1 (Session 1: AI queries users.created_at → Error (column is "c), code:block2 (myproject/), code:markdown (# In ~/.claude/CLAUDE.md (developer's personal config)), Configurable Per Team and Per Developer, For Executives, For Technical Leaders, How It Works, Legacy Codebase Support (+5 more)
-
-### Community 577 - "Community 577"
-Cohesion: 0.14
-Nodes (14): 2. Typography, code:html (<!-- index.html -->), code:js (fontFamily: {), code:css (body {), Conversation Typography, CRITICAL: The Four Canonical Typography Rules (PAN-698), CSS Default, Deprecated Patterns (DO NOT USE) (+6 more)
-
-### Community 578 - "Community 578"
-Cohesion: 0.14
-Nodes (13): CLI, code:bash (pan swarm <id>                       # Spawn dispatchable it), code:bash (pan swarm <id> --task next                              # Li), code:ts (interface SwarmRuntime {), HTTP Surface, Inspect and Mutate Items, Mental Model, Plan Authoring: `files_scope` and Synthesis (+5 more)
-
-### Community 579 - "Community 579"
-Cohesion: 0.15
-Nodes (12): shouldSkipCheckpointReconciliation(), agentIds, baseTimestamp, checkpoints, deleteLegacyCheckpointRefs, diffCheckpointFiles, encoder, getCheckpointTimestamp (+4 more)
-
-### Community 580 - "Community 580"
-Cohesion: 0.28
-Nodes (11): cleanFile(), configCommand(), execAsync, ExtendedProjectConfig, findFullProjectByTeam(), loadFullProjects(), seedCommand(), snapshotCommand() (+3 more)
-
-### Community 581 - "Community 581"
-Cohesion: 0.18
-Nodes (11): build, cliPromptsDir, copyCavemanAssets(), copyCloisterPrompts(), copyMatching(), dashboardDir, distDir, preservedDashboardDir (+3 more)
-
-### Community 582 - "Community 582"
-Cohesion: 0.24
-Nodes (12): AutoPresoAgentSettings, createModel(), createTools(), DEFAULT_SETTINGS, readCodexBearerToken(), runWhiteboardAgent(), runWhiteboardWarmupOnce(), systemPrompt() (+4 more)
+Nodes (13): conversationButton, CONVERSATIONS_RESPONSE, conversationsTab, COSTS_RESPONSE, featureRow, ISSUES_RESPONSE, pipelineTab, projectHeader (+5 more)
 
 ### Community 584 - "Community 584"
 Cohesion: 0.15
-Nodes (11): dir, event, eventsDir1, eventsDir2, line, lines, parsed, repo1 (+3 more)
+Nodes (11): fetchProjectSpecialists(), fetchRunLogs(), formatDate(), ProjectSpecialist, ProjectSpecialistCard(), ProjectSpecialistCardProps, ProjectSpecialistMetadata, RunLogEntry (+3 more)
 
 ### Community 586 - "Community 586"
-Cohesion: 0.15
-Nodes (9): githubTracker, linearTracker, longBody, mockCreateTrackerFromConfig, mockExistsSync, mockLoadConfig, mockStatSync, STATE_MTIME (+1 more)
+Cohesion: 0.14
+Nodes (11): mockDeepWipe, mockExistsSync, mockGetAgentState, mockGetAgentStateAsync, mockMessageAgent, mockMkdir, mockSpawnAgent, mockSpawnPlanningSession (+3 more)
 
 ### Community 587 - "Community 587"
-Cohesion: 0.17
-Nodes (10): future, id, rows, rows1, rows2, GitOperation, GitOperationFilter, GitOperationStatus (+2 more)
+Cohesion: 0.14
+Nodes (10): mockGetLinearApiKey, mockSdkCreateComment, mockSdkCreateIssueLabel, mockSdkIssue, mockSdkIssueLabels, mockSdkSearchIssues, mockSdkTeam, mockSdkUpdateIssue (+2 more)
 
 ### Community 588 - "Community 588"
+Cohesion: 0.25
+Nodes (4): execAsync, getPidFilePath(), readDaemonState(), TldrDaemonService
+
+### Community 589 - "Community 589"
+Cohesion: 0.14
+Nodes (13): code:bash (npx @panctl/cli), code:mermaid (flowchart LR), code:bash (npx @panctl/cli), Command Deck, Dashboard Views, How It Works, Key Features, Learn More (+5 more)
+
+### Community 590 - "Community 590"
+Cohesion: 0.14
+Nodes (13): code:block1 (Claude Code fires hook), Global `~/.claude/settings.json`, Hook Execution Flow, Hook Scripts Inventory, Migration Pruning, Panopticon Hook System, Per-Agent Frontmatter (`agents/pan-*.md`), Pi Event Channel (PAN-1134) (+5 more)
+
+### Community 591 - "Community 591"
+Cohesion: 0.14
+Nodes (13): 1. Browser / app shell, 2. Panopticon terminal wrapper (`XTerminal.tsx`), 3. xterm.js, 4. Remote PTY app (`tmux` + attached TUI), Debugging checklist, Managed tmux policy, Ownership rules, Right-click / context menu (+5 more)
+
+### Community 592 - "Community 592"
+Cohesion: 0.14
+Nodes (13): code:bash (pan up), code:bash (pan dev), code:bash (npm run build), code:bash (pan reload), code:bash (pan status), code:bash (less ~/.panopticon/logs/supervisor.log), code:bash (less ~/.panopticon/logs/dashboard.log), Failure triage (+5 more)
+
+### Community 593 - "Community 593"
+Cohesion: 0.14
+Nodes (14): Agent Attribution, Agent CVs (Work History), Beads Flow with Panopticon, Beyond Issue Tracking, code:block13 (┌───────────────────────────────────────────────────────────), code:bash (# Hook structure), code:json ({), code:bash (bd stats --actor=panopticon/agent-min-648) (+6 more)
+
+### Community 594 - "Community 594"
+Cohesion: 0.14
+Nodes (14): Available Hook Points, code:toml (# .panopticon/project.toml), code:toml ([hooks.pre_commit]), code:block122 (workspace_aware = false (default):), code:toml (# /home/eltmon/projects/myn/.panopticon/project.toml), code:toml ([hooks.post_agent_complete]), code:toml ([hooks.pre_commit]), Hook Configuration (+6 more)
+
+### Community 595 - "Community 595"
+Cohesion: 0.14
+Nodes (14): Built-in Variables, CLAUDE.md Templating System, code:block104 (┌───────────────────────────────────────────────────────────), code:toml (# .panopticon/project.toml), code:markdown (<!-- ~/.panopticon/templates/claude-md/sections/workspace-in), code:markdown (<!-- .panopticon/claude-md/sections/principles.md -->), code:bash (pan workspace create min-648), Example: Panopticon-Provided Section (+6 more)
+
+### Community 596 - "Community 596"
+Cohesion: 0.14
+Nodes (13): code:block1 (skills/pan-<verb>/SKILL.md            (canonical, committed)), Creating a new wrapper skill, For CLI-wrapper skills, For workflow / reference / topical skills, How skills are distributed, Linting, Panopticon Skills ↔ CLI Convention, Related (+5 more)
+
+### Community 597 - "Community 597"
+Cohesion: 0.14
+Nodes (14): Claude Code Bypass Permissions (Automatic), code:block26 (https://github.com/owner/repo.git  → git@github.com:owner/re), code:bash (mkdir -p ~/.panopticon/ssh), code:bash (cat ~/.panopticon/ssh/exe-dev-key.pub | pbcopy  # Copy to cl), code:bash (# For GitHub:), code:bash (ssh exe.dev help), code:json ({), code:bash (ssh <vm-name>.exe.xyz 'echo "{\"bypassPermissionsModeAccepte) (+6 more)
+
+### Community 598 - "Community 598"
+Cohesion: 0.14
+Nodes (14): 1.1 Add exe.dev Provider, 1.2 New Commands, 2.2 Modified docker-compose for Remote, 5.1 Workspace List View, 5.2 Agent Terminal View, code:yaml (# .devcontainer/docker-compose.remote.yml), code:block21 (┌───────────────────────────────────────────────────────────), code:typescript (// Server-side: bridge WebSocket to SSH) (+6 more)
+
+### Community 599 - "Community 599"
+Cohesion: 0.14
+Nodes (13): Agent Grid, code:block1 (┌────────────────────────────────────────────────────┐), code:css (--gv-bg: #0a0e1a          /* Dark navy background */), Components, Dependencies, Design System, Focus View, God View — Real-time Agent Activity Command Center (+5 more)
+
+### Community 600 - "Community 600"
+Cohesion: 0.14
+Nodes (13): 12. Responsive Behavior, 14. File Structure, 15. Acceptance Criteria, 16. Risks & Mitigations, 17. Open Questions, 1. Problem Statement, 2. Design Philosophy, 6. Cloister Banner (+5 more)
+
+### Community 601 - "Community 601"
+Cohesion: 0.14
+Nodes (13): Acceptance Criteria, Design Goals, Files Likely Touched, Goal, Host Role & Handoff, Implementation Phases (sequencing within PAN-658), Input Model, Open question — concurrent direct-submit ordering (+5 more)
+
+### Community 602 - "Community 602"
+Cohesion: 0.14
+Nodes (14): A.1 Add `isInfrastructureFailure` helper, A.2 Enhance `checkStuckReviewing` to detect dead parallel sessions, A.3 Add infrastructure-failure circuit breaker, A.4 Honor `stuck` flag in re-dispatch path, A.5 Detect verification/review contradiction, A.6 Partial results from incomplete parallel reviews, A. `src/lib/cloister/deacon.ts`, code:typescript (function isInfrastructureFailure(notes?: string): boolean {) (+6 more)
+
+### Community 603 - "Community 603"
+Cohesion: 0.14
+Nodes (14): B0: Toolchain Setup, B18: Integration + Build, B19: Frontend Component Migration, B1: Contracts Package, B20: Terminal Streaming RPC (Dual-Runtime), B21: Cleanup + Verification, B2: Event Store, B3: ServerConfig Service (+6 more)
+
+### Community 604 - "Community 604"
+Cohesion: 0.14
+Nodes (13): Acceptance Criteria, code:typescript (export async function buildAgentLaunchConfig(opts: {), code:block2 (POST /api/agents/:id/restart), code:typescript (export async function resumeAgent(agentId: string, message?:), Design, Files to Modify, Motivation, PAN-980: Agent Restart Refactor — Shared Launch Config, Model Override, Graceful Shutdown (+5 more)
+
+### Community 605 - "Community 605"
+Cohesion: 0.14
+Nodes (13): Acceptance Criteria for the Epic, Architecture Overview, Children, code:block1 (┌───────────────────────────────────────────────────────────), Differentiation vs Prior Art, Files Likely Touched, Open Questions, PAN-1200 — Universal Context System (Epic) (+5 more)
+
+### Community 606 - "Community 606"
+Cohesion: 0.14
+Nodes (13): 1. PAN-685 model-override frontend (`stash@{34}` + `d81260d0e`), 2. Material Symbols (`stash@{38}`), 3. PAN-TTS + model-routing README (`stash@{35}`), 4. Model-override work (`stash@{39}` + `df0982bcb`), 5. "Other changes to restore later" (`7b12b85990`), 6. Inspector panel (`stash@{18}`) — **NEEDS USER DECISION**, Flagged items — 9 total, 6 unique (3 duplicates), Follow-up tickets to file (if user agrees with recommendation) (+5 more)
+
+### Community 607 - "Community 607"
+Cohesion: 0.14
+Nodes (13): Decisions, Files Modified, Implementation Plan, Out of Scope, PAN-290: Fix 9 Pre-existing Test Failures, Problem, Root Cause Analysis, Session-rotation (3 failures) (+5 more)
+
+### Community 608 - "Community 608"
+Cohesion: 0.14
+Nodes (13): 1. Programmatic cleanup in `postMergeLifecycle()`, 2. Belt-and-suspenders: .gitignore, 3. Update planning code to use `git add -f`, 4. Ordering in postMergeLifecycle(), code:block1 (.planning/STATE.md), code:block2 (1. Move PRD (existing)), Decisions, Files to Modify (+5 more)
+
+### Community 609 - "Community 609"
+Cohesion: 0.14
+Nodes (13): Approach, Architecture Notes, Endpoint location: conversations.ts, NOT agents.ts, Files Changed, Image storage: OS temp dir, Key Decisions, PAN-539: Image Paste Support in Activity View Conversation, Paste interception: wrapper div, not Lexical plugin (+5 more)
+
+### Community 610 - "Community 610"
+Cohesion: 0.14
+Nodes (13): Do Not Route, Exception: One-Shot High-Stakes Analysis, GPT-5.4 Pro Work Type Fit Analysis, Integration Notes, Key Benchmarks, Known Weaknesses, Model Profile, Sources (+5 more)
+
+### Community 611 - "Community 611"
+Cohesion: 0.14
+Nodes (13): Access Points, Adding Dependencies, code:bash (# Copy template to your project), code:bash (APP_PORT=5173), code:typescript (export default defineConfig({), code:bash (# Install inside container), Development Workflow, Environment Variables (+5 more)
+
+### Community 612 - "Community 612"
+Cohesion: 0.14
+Nodes (13): After Reopening, code:bash (pan reopen PAN-123), code:bash (curl -X POST http://localhost:3011/api/issues/PAN-123/reopen), Do NOT Use `pan done` Until Re-Work Is Complete, How to Reopen, Preflight Guard, Reopen a Closed/Completed Issue for Re-Work, Via CLI (recommended for agents/supervisors) (+5 more)
+
+### Community 613 - "Community 613"
+Cohesion: 0.14
+Nodes (14): code:block15 (oauth-epic: "Implement OAuth integration" (epic)), code:block16 (research-epic: "Investigate caching strategies" (epic)), code:bash (bd dep add child-task-id parent-epic-id --type parent-child), code:block18 (auth-epic (parent of all)), code:block19 (Epic with no ordering between children:), code:block20 (Epic with blocks dependencies between children:), code:block21 (major-epic), Combining with blocks (+6 more)
+
+### Community 614 - "Community 614"
+Cohesion: 0.14
+Nodes (13): Basic Usage, code:bash (# Start all services), code:env (# Dashboard port (default: 3001)), code:bash (# Overall health check), Configuration Options, Health Checks, More Information, Next Steps (+5 more)
+
+### Community 615 - "Community 615"
+Cohesion: 0.14
+Nodes (14): code:bash (# Check if pan command exists), code:bash (# Check for running services), code:bash (pan down), code:bash (pan up), code:block6 (✓ API server started on port 3002), code:bash (# Check all services are running), code:block8 (http://localhost:3001), code:bash (# View dashboard logs) (+6 more)
+
+### Community 616 - "Community 616"
+Cohesion: 0.14
+Nodes (13): Auto-planning, Available commands, code:bash (pan plan <id> [--auto] [--model <model>] [--harness claude-c), code:bash (pan plan PAN-1071), code:bash (pan plan PAN-1071 --auto), code:bash (pan plan finalize), code:bash (pan plan done PAN-1071), Completing planning (`pan plan done`) (+5 more)
+
+### Community 617 - "Community 617"
+Cohesion: 0.14
+Nodes (13): 1. Identify the Issue, 2. Gather Context, 3. Research (Interactive), 4. Write the Spec, 5. Confirm File Location, code:markdown (# {Issue ID}: {Title}), code:block2 (Spec written: docs/prds/active/{filename}-spec.md), Execution Steps (+5 more)
+
+### Community 618 - "Community 618"
+Cohesion: 0.14
+Nodes (13): code:block1 (Session 1: AI queries users.created_at → Error (column is "c), code:block2 (myproject/), code:markdown (# In ~/.claude/CLAUDE.md (developer's personal config)), Configurable Per Team and Per Developer, For Executives, For Technical Leaders, How It Works, Legacy Codebase Support (+5 more)
+
+### Community 619 - "Community 619"
+Cohesion: 0.14
+Nodes (14): 2. Typography, code:html (<!-- index.html -->), code:js (fontFamily: {), code:css (body {), Conversation Typography, CRITICAL: The Four Canonical Typography Rules (PAN-698), CSS Default, Deprecated Patterns (DO NOT USE) (+6 more)
+
+### Community 620 - "Community 620"
+Cohesion: 0.14
+Nodes (13): CLI, code:bash (pan swarm <id>                       # Spawn dispatchable it), code:bash (pan swarm <id> --task next                              # Li), code:ts (interface SwarmRuntime {), HTTP Surface, Inspect and Mutate Items, Mental Model, Plan Authoring: `files_scope` and Synthesis (+5 more)
+
+### Community 621 - "Community 621"
+Cohesion: 0.15
+Nodes (12): agentDir, mockGetAgentRuntimeState, mockGetAgentState, mockGetTmuxSessionName, mockGetWorkspaceStackHealth, mockLoadReviewStatuses, mockRebuildWorkspaceStack, mockResolveProjectFromIssue (+4 more)
+
+### Community 622 - "Community 622"
+Cohesion: 0.18
+Nodes (11): build, cliPromptsDir, copyCavemanAssets(), copyCloisterPrompts(), copyMatching(), dashboardDir, distDir, preservedDashboardDir (+3 more)
+
+### Community 623 - "Community 623"
+Cohesion: 0.24
+Nodes (11): buildStatus(), decodeBase64Url(), decodeJwtPayload(), getCodexAuthPath(), getJwtExpiry(), getOpenAIAuthStatusSync(), hasApiKey(), OpenAIAuthStatus (+3 more)
+
+### Community 624 - "Community 624"
+Cohesion: 0.15
+Nodes (10): cleanupMergedLabels(), calls, ctx, mockClientCreateIssueLabel, mockClientIssueLabels, mockClientIssues, { mockExecAsync, mockGetLinearApiKey }, mockIssueLabels (+2 more)
+
+### Community 625 - "Community 625"
+Cohesion: 0.24
+Nodes (11): AgentRuntimeFetchError, emitActivity(), emitAgentEvent(), emitChannelReply(), emitMessageReceived(), emitModelSet(), emitResolution(), emitWaitingClear() (+3 more)
+
+### Community 627 - "Community 627"
+Cohesion: 0.15
+Nodes (8): PendingCompletion, _pendingCompletions, ResumeCallback, SpecialistCancelledError, SpecialistCompletionError, SpecialistCompletionResult, SpecialistCompletionTimeoutError, SpecialistSupersededError
+
+### Community 628 - "Community 628"
+Cohesion: 0.15
+Nodes (11): dir, event, eventsDir1, eventsDir2, line, lines, parsed, repo1 (+3 more)
+
+### Community 629 - "Community 629"
 Cohesion: 0.15
 Nodes (12): ACTIVITY_RESPONSE, AGENTS_RESPONSE, COSTS_RESPONSE, DISCUSSIONS_RESPONSE, ISSUES_RESPONSE, PLANNING_RESPONSE, PR_DIFF_RESPONSE, PR_RESPONSE (+4 more)
 
-### Community 589 - "Community 589"
+### Community 630 - "Community 630"
 Cohesion: 0.21
 Nodes (10): CapabilityStats, DailyStats, fetchRuntimeMetrics(), formatCost(), formatDuration(), formatPercent(), getSuccessColor(), MetricsResponse (+2 more)
 
-### Community 590 - "Community 590"
-Cohesion: 0.17
-Nodes (11): REVIEWER_STYLE, ReviewerRole, RoleBadge(), RoleBadgeProps, RoleBadgeSize, RoleStyle, SESSION_STYLE, SIZE_PX (+3 more)
+### Community 631 - "Community 631"
+Cohesion: 0.24
+Nodes (11): buildContinuation(), convertConversationTranscript(), ConvertOptions, ConvertResult, extractClaudeTranscript(), extractContentText(), extractPiTranscript(), renderTranscript() (+3 more)
 
-### Community 591 - "Community 591"
+### Community 632 - "Community 632"
 Cohesion: 0.28
-Nodes (12): buildStatus(), decodeBase64Url(), decodeJwtPayload(), getCodexAuthPath(), getJwtExpiry(), getOpenAIAuthStatus(), getOpenAIAuthStatusSync(), hasApiKey() (+4 more)
+Nodes (11): cleanFile(), configCommand(), execAsync, ExtendedProjectConfig, findFullProjectByTeam(), loadFullProjects(), seedCommand(), snapshotCommand() (+3 more)
 
-### Community 592 - "Community 592"
+### Community 633 - "Community 633"
 Cohesion: 0.15
 Nodes (13): code:block53 (~/.panopticon/), code:block54 (~/projects/myn/.panopticon/), code:toml ([panopticon]), code:toml ([[projects]]), code:toml ([project]), code:toml (# panopticon/.panopticon/project.toml), Example: Open Source Project Config, Global Config (`~/.panopticon/config.toml`) (+5 more)
 
-### Community 593 - "Community 593"
+### Community 634 - "Community 634"
+Cohesion: 0.15
+Nodes (12): 1. Role file — `roles/*.md`, 2. Panopticon pipeline agent — `agents/pan-*-agent.md`, 3. Claude Code subagent — `.claude/agents/*.md`, Adding a new role or sub-role, code:block1 (Cloister decides to spawn (role, subRole?)), File shapes you will see, How a run actually gets the right instructions, Roles: Panopticon's Agent Definition Primitive (+4 more)
+
+### Community 635 - "Community 635"
 Cohesion: 0.15
 Nodes (12): Agent Taxonomy, Architecture, CLI Commands, Cloister: Agent Watchdog Framework, code:block23 (┌───────────────────────────────────────────────────────────), code:bash (# Cloister control), Goals, Issue Agents (Ephemeral) (+4 more)
 
-### Community 594 - "Community 594"
+### Community 636 - "Community 636"
 Cohesion: 0.15
 Nodes (12): Dependencies, Design Principles, Implementation Notes, Key files, Non-goals, Phase 1: Interactive FeatureCard (Dashboard UI), Phase 2: Feature Planning Pipeline (Backend), Phase 3: Integration Testing (+4 more)
 
-### Community 595 - "Community 595"
+### Community 637 - "Community 637"
 Cohesion: 0.15
 Nodes (13): Actions vs Roles, code:block1 (User Action          Cloister spawns       Role (.md)       ), code:block2 (Run = (role, model, harness)), code:block3 (Tracker (GitHub Issue)          Cloister (Scheduler)        ), code:yaml (# ~/.panopticon/config.yaml — defaults), code:block5 (model), Convoy Reviewers, Eval Grid (+5 more)
 
-### Community 596 - "Community 596"
+### Community 638 - "Community 638"
 Cohesion: 0.15
 Nodes (12): code:typescript (export function isReviewPipelineStuck(status?: PipelineState), code:typescript (// PAN-794: Recovery state indicators), code:typescript (const recoveryBorderClass = isReviewRecoveryInProgress), code:typescript (className={`relative ... bg-gradient-to-br ${cardTone} ${rec), code:typescript (const phaseLabel =), E.1 Update `isReviewPipelineStuck` in `src/dashboard/frontend/src/lib/pipeline-state.ts`, E.2 Add recovery indicator helpers to `KanbanBoard.tsx`, E.3 Add recovery border and badges to the card (+4 more)
 
-### Community 597 - "Community 597"
+### Community 639 - "Community 639"
 Cohesion: 0.15
-Nodes (12): C.1 Update `isReviewPipelineStuck` in `src/dashboard/frontend/src/lib/pipeline-state.ts`, C.2 Add recovery indicator helpers to `KanbanBoard.tsx`, C.3 Add pulsing border and recovery badge to the card, C.4 Add recovery badge in the card header, C.6 Style compliance, C. Frontend: Kanban Card Recovery Indicators, code:typescript (export function isReviewPipelineStuck(status?: PipelineState), code:typescript (export function isReviewPipelineStuck(status?: PipelineState) (+4 more)
+Nodes (12): C.2 Add recovery indicator helpers to `KanbanBoard.tsx`, C.3 Add pulsing border and recovery badge to the card, C.4 Add recovery badge in the card header, C.5 Update `phaseLabel` to show recovery state, C.6 Style compliance, C. Frontend: Kanban Card Recovery Indicators, code:typescript (// PAN-794: Recovery state indicators), code:typescript (<div) (+4 more)
 
-### Community 598 - "Community 598"
+### Community 640 - "Community 640"
 Cohesion: 0.15
 Nodes (12): Affected Components, Architecture, code:block1 (App.tsx), Decision, Difficulty: medium, Files to Create, Files to Modify, Key Decisions (+4 more)
 
-### Community 599 - "Community 599"
+### Community 641 - "Community 641"
 Cohesion: 0.15
 Nodes (12): Acceptance (feature-level), Approach, Decisions, Destination directories (none exist yet), Discovery Findings, Goal, PAN-697 Planning — Root Artifact Cleanup, Problem (+4 more)
 
-### Community 600 - "Community 600"
+### Community 642 - "Community 642"
 Cohesion: 0.15
 Nodes (12): Architecture, Difficulty Estimates, Discovery Summary, Files to Modify, Items NOT in scope for v1, Menu Integration, npx latest version, Package Distribution (+4 more)
 
-### Community 601 - "Community 601"
+### Community 643 - "Community 643"
 Cohesion: 0.15
 Nodes (12): Approach, Conversation list titles → DM Sans prose, Decomposition, Documentation, Out of scope, PAN-698: Dashboard Typography Cleanup — Planning State, Playwright isolation, Policy (final, to be encoded everywhere) (+4 more)
 
-### Community 602 - "Community 602"
+### Community 644 - "Community 644"
 Cohesion: 0.15
-Nodes (13): code:bash (bd dep add issue-2 issue-1 --type blocks), code:bash (bd version), code:bash (# Via Homebrew (macOS/Linux)), code:bash (pkill -f "bd daemon"  # Kill old daemon), code:bash (bd create "Test A" -t task), code:bash (ps aux | grep "bd daemon"), code:bash (# Instead of: bd --no-daemon dep add ...), code:bash (cat .beads/issues.jsonl | jq '.dependencies') (+5 more)
+Nodes (13): code:bash (# If project has override skill, this skill is permanently d), code:bash (cat .panopticon/knowledge-capture.json 2>/dev/null || echo "), code:json ({), code:javascript (// Pseudocode for decision), code:bash (mkdir -p .claude/skills/knowledge-capture), code:bash (# Ensure directory exists), Invocation Protocol, Step 0: Check for Permanent Override (+5 more)
 
-### Community 603 - "Community 603"
+### Community 645 - "Community 645"
 Cohesion: 0.15
 Nodes (12): `bd rules audit`, `bd rules compact`, Best Practices, code:bash (bd rules audit                    # Default scan), code:bash (bd rules compact --dry-run        # Preview merges without a), code:bash ($ bd rules audit), code:bash (# In pan sync workflow), Commands (+4 more)
 
-### Community 604 - "Community 604"
+### Community 646 - "Community 646"
 Cohesion: 0.15
 Nodes (13): code:block10 (Start: "What's the final deliverable?"), code:block11 (Ready Front 1:  gt-buffer (foundation)), code:bash (# Create epic (the goal)), code:block7 (Ready Front = Issues where all dependencies are closed), code:block8 (⚠️ COGNITIVE TRAP:), code:block9 (Epic Planning with Ready Fronts:), Epic Planning {#epic-planning}, Epic Planning Workflow (+5 more)
 
-### Community 605 - "Community 605"
+### Community 647 - "Community 647"
 Cohesion: 0.15
 Nodes (13): At Session End (Claude prompts user), At Session Start (Claude's responsibility), code:block16 (Session Start with in_progress issues:), code:block17 (Session End Handoff:), code:block18 (Good handoff note (current state):), code:block19 (Session End Checklist:), code:block20 (User Tips:), code:bash (bd update workspace-mcp-server-2 --notes "COMPLETED: Set up ) (+5 more)
 
-### Community 606 - "Community 606"
+### Community 648 - "Community 648"
 Cohesion: 0.15
 Nodes (12): API Function, Categories, code:bash (pan tell ISSUE-123 "Your feedback message here"), code:block2 (Sending feedback to agent-pan-45:), code:block3 (Sending feedback to agent-pan-45:), Example: Merge Success, Example: Test Failure, Feedback Types (+4 more)
 
-### Community 607 - "Community 607"
+### Community 649 - "Community 649"
 Cohesion: 0.15
 Nodes (12): code:bash (#!/bin/bash), code:bash (# Check system health), Complete Quick Start Script, Feedback and Support, Overview, Panopticon Quick Start, Related Skills, Success Checklist (+4 more)
 
-### Community 608 - "Community 608"
+### Community 650 - "Community 650"
 Cohesion: 0.15
 Nodes (13): "Certificate not trusted" warnings, code:bash (docker ps | grep traefik), code:bash (docker logs panopticon-traefik), code:bash (ls ~/.panopticon/traefik/certs/), code:bash (mkcert -install), code:bash (docker network inspect panopticon), code:bash (docker inspect <container> | grep -A 20 Labels), code:bash (# Find what's using the ports) (+5 more)
 
-### Community 609 - "Community 609"
+### Community 651 - "Community 651"
 Cohesion: 0.17
 Nodes (11): available, content, defaults, defaults1, defaults2, error, invalidSettings, loaded (+3 more)
 
-### Community 610 - "Community 610"
+### Community 652 - "Community 652"
 Cohesion: 0.17
 Nodes (10): bin, binPath, content, desktopDir, devDeps, engines, files, p (+2 more)
 
-### Community 612 - "Community 612"
+### Community 653 - "Community 653"
 Cohesion: 0.17
 Nodes (10): mockClearConfigCache, mockLoadConfig, mockMergeConfigs, mockReadFile, mockResolveModelId, mockWriteFile, result, settings (+2 more)
 
-### Community 613 - "Community 613"
-Cohesion: 0.27
-Nodes (11): execAsync, formatDuration(), generateReport(), parseTestOutput(), runTests(), RunTestsOptions, runTestSuite(), sendNotification() (+3 more)
-
-### Community 614 - "Community 614"
-Cohesion: 0.24
-Nodes (10): analyzeIssue(), sortByPriority(), issues, options, result, results, sorted, triageMultiple() (+2 more)
-
-### Community 615 - "Community 615"
+### Community 655 - "Community 655"
 Cohesion: 0.17
 Nodes (10): allOps, divergedOp, execAsync, execFileMock, execMock, ops, opTypes, status (+2 more)
 
-### Community 616 - "Community 616"
-Cohesion: 0.18
-Nodes (9): CostMetrics, fetchCostMetrics(), fetchMetricsSummary(), MetricsPage(), MetricsSummary, fetchTldrStatus(), TldrDaemonStatus, TldrServiceStatus() (+1 more)
+### Community 656 - "Community 656"
+Cohesion: 0.21
+Nodes (8): detectDriveType, DriveType, getSystemCapabilities(), measureDriveReadSpeed, probe(), probeImpl, resetSystemCapabilitiesCache(), SystemCapabilities
 
-### Community 617 - "Community 617"
-Cohesion: 0.3
-Nodes (11): abortSignal(), emitActivity(), emitAgentEvent(), emitChannelReply(), emitMessageReceived(), emitModelSet(), emitResolution(), emitWaitingClear() (+3 more)
-
-### Community 618 - "Community 618"
-Cohesion: 0.23
-Nodes (9): CacheEntry, clearSnapshotCache(), loadSnapshotFromCache(), saveSnapshotToCache(), serialize(), bigSnapshot, err, loaded (+1 more)
-
-### Community 619 - "Community 619"
+### Community 658 - "Community 658"
 Cohesion: 0.2
-Nodes (11): applyBurnedTokenOverride(), CheckCodexAuthOptions, checkCodexAuthStatus(), CliproxyCodexCredentials, CodexAuthBurned, CodexAuthExpired, CodexAuthMissing, CodexAuthStatus (+3 more)
+Nodes (9): authorized(), eventsRouteLayer, getEventStreamRoute, getEventVersionRoute, getHeader(), isPublicEventType(), matchesFilter(), PUBLIC_CATALOG (+1 more)
 
-### Community 620 - "Community 620"
-Cohesion: 0.32
-Nodes (9): backupCleanCommand(), backupListCommand(), restoreCommand(), BackupInfo, cleanOldBackups(), createBackup(), createBackupTimestamp(), listBackups() (+1 more)
+### Community 659 - "Community 659"
+Cohesion: 0.23
+Nodes (10): clearRunningAgentsCache(), getCachedRunningAgents(), runningAgentsCache, sweepExpired(), firstAgents, firstPromise, listAgents, ListAgentsFn (+2 more)
 
-### Community 621 - "Community 621"
-Cohesion: 0.17
-Nodes (12): Before starting any work, Build before deploy, code:bash (# 1. Rebase onto latest main (always — even if STATE.md alre), code:bash (npm run build), code:bash (# WRONG — may stage .beads/, dist/, secrets), code:bash (bd ready -l pan-xxx          # Next unblocked bead for THIS ), code:bash (npm test                                         # Must pass), Completing work (+4 more)
+### Community 660 - "Community 660"
+Cohesion: 0.29
+Nodes (8): cleanupAgentDirectories(), CleanupResult, findOrphanedAgentDirs(), getPlanningIssueId(), isLegacyConversationDirectory(), isValidAgentDirectoryName(), OrphanedAgentDir, names
 
-### Community 622 - "Community 622"
+### Community 661 - "Community 661"
 Cohesion: 0.17
 Nodes (12): Always pre-trust directories before spawning agents, Architecture Rules, code:typescript (// WRONG), code:bash (# CORRECT), code:typescript (// WRONG), code:typescript (let running = false;), code:typescript (import { preTrustDirectory } from '../workspace-manager.js';), Idempotency guards on background services (+4 more)
 
-### Community 623 - "Community 623"
+### Community 662 - "Community 662"
+Cohesion: 0.17
+Nodes (12): Before starting any work, Build before deploy, code:bash (# 1. Rebase onto latest main (always — even if STATE.md alre), code:bash (npm run build), code:bash (# WRONG — may stage .beads/, dist/, secrets), code:bash (bd ready -l pan-xxx          # Next unblocked bead for THIS ), code:bash (npm test                                         # Must pass), Completing work (+4 more)
+
+### Community 663 - "Community 663"
 Cohesion: 0.17
 Nodes (11): Agent Instructions, Beads Issue Tracker, code:bash (bd ready              # Find available work), code:bash (git pull --rebase), code:bash (bd ready              # Find available work), code:bash (git pull --rebase), Landing the Plane (Session Completion), Quick Reference (+3 more)
 
-### Community 624 - "Community 624"
+### Community 664 - "Community 664"
 Cohesion: 0.17
 Nodes (11): Architecture at a Glance, code:bash (npx @panctl/cli), code:bash (npm install -g @panctl/cli), code:bash (npm install -g @panctl/cli), Direct Desktop Downloads, Headless / CI, One Command, Power-User Path: Install Everything Up Front (+3 more)
 
-### Community 625 - "Community 625"
+### Community 665 - "Community 665"
 Cohesion: 0.17
 Nodes (11): code:typescript (interface ContextBudget {), Context Budget Manager, ⚠️ DECOUPLING FROM MYN (CRITICAL), DO NOT rely on MYN infrastructure:, If tests pass, commit, Migration checklist (from MYN):, Panopticon: Multi-Agent Orchestration for Claude Code, Panopticon MUST be self-contained: (+3 more)
 
-### Community 626 - "Community 626"
+### Community 666 - "Community 666"
 Cohesion: 0.17
 Nodes (12): Agent Integration, Canonical PRD Sections, CLI Commands, code:block143 ({project}/), code:block144 (┌───────────────────────────────────────────────────────────), code:bash (# Initialize/regenerate canonical PRD), Feature PRDs Live in Workspaces, Naming Convention (+4 more)
 
-### Community 627 - "Community 627"
+### Community 667 - "Community 667"
 Cohesion: 0.17
 Nodes (12): code:bash (# 1. Install Panopticon), code:bash (# Start the day), code:bash (# Create detailed plan before spawning agent), code:bash (# Update Panopticon itself), code:toml (# In projects.toml), code:bash (pan sync), Daily Development, Initial Setup (+4 more)
 
-### Community 628 - "Community 628"
+### Community 668 - "Community 668"
 Cohesion: 0.17
 Nodes (12): code:bash (pan workspace create MIN-667 --remote    # Create on exe.dev), code:toml (# ~/.panopticon/config.toml), code:block38 ($ pan workspace create MIN-667), code:block39 (┌───────────────────────────────────────────────────────────), code:block40 (┌─────────────────────┐), code:block41 (┌─────────────────────────────┐), code:block42 (┌────────────────────────────────────────────────────────┐), code:block43 (┌────────────────────────────────────────────────────────┐) (+4 more)
 
-### Community 629 - "Community 629"
+### Community 669 - "Community 669"
 Cohesion: 0.17
 Nodes (11): code:yaml (models:), code:yaml (models:), code:env (ANTHROPIC_API_KEY=sk-ant-...), code:yaml (models:), Configuration Guide, Getting Help, Provider Configuration, Provider Management (+3 more)
 
-### Community 630 - "Community 630"
+### Community 670 - "Community 670"
 Cohesion: 0.17
 Nodes (12): code:yaml (# Deprecated → Current), code:yaml (models:), code:yaml (models:), code:block24 (✓ Backed up config.yaml → config.yaml.bak), code:bash (cp ~/.panopticon/config.yaml.bak ~/.panopticon/config.yaml), Current Deprecations, Dashboard Behavior, Example Migration (+4 more)
 
-### Community 631 - "Community 631"
-Cohesion: 0.17
-Nodes (11): 1. Role file — `roles/*.md`, 2. Panopticon pipeline agent — `agents/pan-*-agent.md`, 3. Claude Code subagent — `.claude/agents/*.md`, Adding a new role or sub-role, code:block1 (Cloister decides to spawn (role, subRole?)), File shapes you will see, How a run actually gets the right instructions, Roles: Panopticon's Agent Definition Primitive (+3 more)
-
-### Community 632 - "Community 632"
+### Community 671 - "Community 671"
 Cohesion: 0.17
 Nodes (11): code:typescript (// In src/dashboard/server/routes/resources.ts), code:typescript (HttpRouter.post('/api/resources/docker/container/:id/start',), code:typescript (// In src/dashboard/server/services/resource-discovery.ts (o), code:typescript (// New field on the response), Container name parsing utility (new), Extend `ResourceDetailIdentifiers` response, `GET /api/resources/docker/container/:id/logs`, New API endpoints (+3 more)
 
-### Community 633 - "Community 633"
+### Community 672 - "Community 672"
 Cohesion: 0.17
 Nodes (12): Branch node layout, code:block2 (├── MIN-846  [$12.40]  In Review  [📁 🔀 📻 📋 🐛 🔀 🐳]     ← reso), code:block3 (┌──────────────────────────────────────────────────────────┐), code:block4 (┌──────────────────────────────────────────────────────────┐), code:block5 (┌──────────────────────────────────────────────────────────┐), code:block6 (┌──────────────────────────────────────────────────────────┐), Container node context menu (right-click), Container node layout (single row) (+4 more)
 
-### Community 634 - "Community 634"
+### Community 673 - "Community 673"
 Cohesion: 0.17
 Nodes (12): 1. Status billboard, 2. Reviewer summary (when in review), 3. Test summary (when test has run), 4. PR summary (when PR exists), 5. Cost breakdown sparkline, 6. Recent activity feed (combined across all sessions), 7. Quick links, code:block17 (┌───────────────────────────────────────────────────────────) (+4 more)
 
-### Community 635 - "Community 635"
+### Community 674 - "Community 674"
 Cohesion: 0.17
 Nodes (11): Architecture Notes, code:typescript (const confirmed = await confirm({), code:typescript (catch (labelErr) {), Decisions, Implementation Plan, Out of Scope, PAN-445: Planning Abort button uses native JS confirm() instead of styled dialog, Problem (+3 more)
 
-### Community 636 - "Community 636"
+### Community 675 - "Community 675"
 Cohesion: 0.17
 Nodes (11): Architecture, Backend Changes, code:block1 (Backend /api/agents → includes planning-* agents with agentP), Data Flow, Decisions, Edge Cases, Files to Modify, Frontend Changes (+3 more)
 
-### Community 637 - "Community 637"
+### Community 676 - "Community 676"
 Cohesion: 0.17
 Nodes (12): code:typescript (export function validateRallyConfig(config: RallyConfig): {), code:typescript (private async pollRally(): Promise<void> {), code:typescript (// POST /api/rally/validate - Test Rally connection and conf), code:typescript (describe('Rally Integration', () => {), code:typescript (const mock = new RallyApiMock();), Task 1: Fix Query String Builder (CRITICAL), Task 2: Add Comprehensive Unit Tests, Task 3: Create Mock Rally API Server (+4 more)
 
-### Community 638 - "Community 638"
+### Community 677 - "Community 677"
 Cohesion: 0.17
 Nodes (11): code:json ({ "HEAD": "abc1234", "branch": "feature/PAN-333" }), Decision: Implement the missing function, Difficulty: simple, Files to modify, Implementation approach, No changes needed, PAN-342: getWorkspaceCommitHashes is not a function, Problem (+3 more)
 
-### Community 639 - "Community 639"
+### Community 678 - "Community 678"
 Cohesion: 0.17
 Nodes (11): Affected Files, code:typescript (const inInput = ['INPUT', 'TEXTAREA'].includes(target.tagNam), code:typescript (const inInput = target.tagName === 'INPUT' || target.tagName), Complexity, Out of Scope, Part 1: Fix global search hotkey (App.tsx), Part 2: Add slash command menu (ComposerPromptEditor.tsx), Problem (+3 more)
 
-### Community 640 - "Community 640"
+### Community 679 - "Community 679"
 Cohesion: 0.17
 Nodes (11): 1. Eliminate Extended Token Layer, 2. Replace `text-white` with Semantic Foreground Tokens, 3. Rename Mission Control → Command Deck, 4. Delete Isolated Codex Theme, 5. Upgrade DialogProvider, 6. Align `index.css` with T3Code Formulas, Acceptance Criteria, Objective (+3 more)
 
-### Community 641 - "Community 641"
+### Community 680 - "Community 680"
 Cohesion: 0.17
 Nodes (11): Approach, Backend status: already done, Difficulty, Edit state, Empty/whitespace, Files touched, Out of scope, PAN-596: Allow editing a conversation title (+3 more)
 
-### Community 642 - "Community 642"
+### Community 681 - "Community 681"
 Cohesion: 0.17
 Nodes (11): Current architecture (observed), Decision summary, Difficulty, Files to change, Goal, Out of scope (explicit), PAN-509 — Inspector: Phase-Aware Terminal, Phase → session mapping (+3 more)
 
-### Community 643 - "Community 643"
+### Community 682 - "Community 682"
 Cohesion: 0.17
 Nodes (11): Approach, Decisions, Files to Modify, Layer 1: Frontend (toast + better messaging), Layer 2: Backend — complete-planning, Layer 3: Backend — POST /api/agents, Layer 4: beads.ts — robust initialization, Out of Scope (+3 more)
 
-### Community 644 - "Community 644"
+### Community 683 - "Community 683"
 Cohesion: 0.17
 Nodes (12): code:block10 (feature-1: "Add OAuth login"), code:block11 (perf-1: "Investigate Redis caching"), code:bash (bd dep add issue-1 issue-2 --type related), code:block13 (api-redesign related to:), code:block14 (security-audit related to:), code:block9 (refactor-1: "Extract validation logic"), Common Patterns, Creating related Dependencies (+4 more)
 
-### Community 645 - "Community 645"
-Cohesion: 0.17
-Nodes (11): CLI Command Reference, code:bash (# Single issue), code:bash (bd ready), Dependency Types, Human-Readable Output, Issue Types, JSON Output (Recommended for Agents), Output Formats (+3 more)
-
-### Community 646 - "Community 646"
+### Community 684 - "Community 684"
 Cohesion: 0.17
 Nodes (12): Agent shows as crashed, code:bash (# Check tmux sessions directly), code:bash (# Check agent logs), code:bash (# Check Docker containers directly), code:bash (nvm install 18), code:bash (sudo systemctl start docker  # Linux), code:bash (pan up), code:bash (# Check API key in config) (+4 more)
 
-### Community 647 - "Community 647"
+### Community 685 - "Community 685"
 Cohesion: 0.17
 Nodes (11): Basic Usage, code:block1 (Invoke first: pipeline-status), code:bash (# Check all running agents (shorthand for work status)), Lead with the pipeline-status table, More Information, Next Steps, Overview, Panopticon Status Overview (+3 more)
 
-### Community 648 - "Community 648"
+### Community 686 - "Community 686"
 Cohesion: 0.17
 Nodes (11): Canary, code:bash (pan release check), code:bash (pan release stable --version 0.7.1), code:bash (git push origin main), Core policy, Notes, Panopticon Release Workflow, Preferred operator flow (+3 more)
 
-### Community 649 - "Community 649"
+### Community 687 - "Community 687"
 Cohesion: 0.17
 Nodes (12): 3. Color System, Architecture, code:css (:root {), code:css (@variant dark {), code:block6 (NEVER: bg-gray-800, bg-gray-900, bg-gray-700), Color Restraint (Data-Dense Views), Column Semantic Colors (Kanban Pipeline), Dark Mode Tokens (+4 more)
 
-### Community 650 - "Community 650"
+### Community 688 - "Community 688"
 Cohesion: 0.17
 Nodes (11): Boundaries, code:bash (npm test), Completion, Deep depth: `inspect-deep`, Fast depth: `inspect`, Hardcoding it here would override the user's config and force everyone onto a, Jidoka Inspection Gates, No `model:` pin — Cloister resolves the model from config.yaml (roles.work.model). (+3 more)
 
-### Community 651 - "Community 651"
+### Community 689 - "Community 689"
 Cohesion: 0.17
 Nodes (11): Boundaries, code:bash (npm run typecheck), Hardcoding it here would override the user's config and force everyone onto a, Human-Merge Invariant, Inputs, No `model:` pin — Cloister resolves the model from config.yaml (roles.ship.model)., Panopticon Ship Role, Shipping Workflow (+3 more)
 
-### Community 652 - "Community 652"
-Cohesion: 0.18
-Nodes (6): configFixture, __dirname, issueFixture, mockGitHubResponses, mockLinearResponses, skillFixture
-
-### Community 653 - "Community 653"
-Cohesion: 0.25
-Nodes (9): create_skill(), init_skill(), main(), Validate skill name follows conventions., Convert skill-name to Skill Name., Create a new skill directory structure., Initialize a new skill directory structure., to_title() (+1 more)
-
-### Community 654 - "Community 654"
-Cohesion: 0.18
-Nodes (10): desktopDir, __dirname, pkg, pkgPath, publicDest, publicSrc, repoRoot, serverDest (+2 more)
-
-### Community 655 - "Community 655"
-Cohesion: 0.29
-Nodes (10): callServerApi(), AgentStatus, buildContextMenu(), buildTooltip(), createTray(), createTrayIcon(), destroyTray(), HealthResponse (+2 more)
-
-### Community 656 - "Community 656"
-Cohesion: 0.18
-Nodes (9): calls, ctx, mockClientCreateIssueLabel, mockClientIssueLabels, mockClientIssues, { mockExecAsync, mockGetLinearApiKey }, mockIssueLabels, mockIssueUpdate (+1 more)
-
-### Community 658 - "Community 658"
-Cohesion: 0.31
-Nodes (9): buildClaudeUserSettings(), ClaudeUserSettings, getClaudePermissionFlags(), readYoloEnv(), resolvePermissionMode(), YOLO_FALSE, YOLO_TRUE, ClaudePermissionMode (+1 more)
-
-### Community 659 - "Community 659"
-Cohesion: 0.18
-Nodes (9): BASE_TIME, exitSpy, loadDeaconWithResumeMock(), loadStartCommand(), mailDir, mailFiles, state, stderrSpy (+1 more)
-
-### Community 660 - "Community 660"
-Cohesion: 0.18
-Nodes (10): base, cols, colsAfter, colsBefore, correctedPath, index, names, row (+2 more)
-
-### Community 661 - "Community 661"
-Cohesion: 0.18
-Nodes (8): first, found, path, paths, read, second, sessions, updated
-
-### Community 662 - "Community 662"
-Cohesion: 0.22
-Nodes (7): BadgeBarProps, fetchPlanning(), PlanningData, MarkdownModal(), MarkdownModalProps, TranscriptUpload(), TranscriptUploadProps
-
-### Community 663 - "Community 663"
-Cohesion: 0.22
-Nodes (9): EditorLaunch, execAsync, getFileManagerCommand(), isCommandAvailable(), launchDetached(), PanOpen, PanOpenLive, PanOpenShape (+1 more)
-
-### Community 664 - "Community 664"
-Cohesion: 0.18
-Nodes (7): mockAddComment, mockGetChildIssues, mockGetIssue, mockGetRallyConfig, mockTransitionIssue, program, RALLY_CONFIG
-
-### Community 665 - "Community 665"
-Cohesion: 0.18
-Nodes (8): MOCK_PROJECT, mockCreateWorkspace, mockExistsSync, mockLoadProjectsConfig, mockRemoveWorkspace, mockResolveProjectFromIssue, mockStopWorkspaceDocker, program
-
-### Community 666 - "Community 666"
-Cohesion: 0.18
-Nodes (8): MOCK_PROJECT, mockCreateWorkspace, mockExistsSync, mockLoadProjectsConfig, mockRemoveWorkspace, mockResolveProjectFromIssue, mockStopWorkspaceDocker, program
-
-### Community 667 - "Community 667"
-Cohesion: 0.18
-Nodes (11): Acceptance Criteria Pipeline, Agent Environment Variables, Beads Prerequisite, code:block4 (1. Planning agent writes:), DAG-Aware Task Scheduling, Handling Pre-Existing PRDs, Lifecycle, Planning → Implementation Transition (+3 more)
-
-### Community 668 - "Community 668"
-Cohesion: 0.18
-Nodes (11): 1. Tool Response Materialization, 2. Chat History as Queryable Files, 3. Skills as Discoverable Definitions, 4. MCP Tool Discovery, 5. Terminal Output Integration, code:block10 (~/.panopticon/mcp/), code:block11 (~/.panopticon/terminals/), code:typescript (// Before) (+3 more)
-
-### Community 669 - "Community 669"
-Cohesion: 0.18
-Nodes (11): code:typescript (interface Runtime {), code:toml (# ~/.panopticon/runtimes/claude.toml), code:toml (# ~/.panopticon/runtimes/codex.toml), code:bash (# Default: use project runtime), code:typescript (interface RuntimeMetrics {), Part 6: Multi-Runtime Architecture, Per-Agent Runtime Selection, Runtime Abstraction Layer (+3 more)
-
-### Community 670 - "Community 670"
-Cohesion: 0.18
-Nodes (11): Adopting GSD Patterns for Panopticon, code:markdown (# Workspace Context: MIN-648), code:markdown (# Agent State: MIN-648), code:markdown (# Work Summary: Research Phase), code:block43 (┌───────────────────────────────────────────────────────────), Context File Lifecycle, Part 5: Context Engineering from GSD-Plus, PROJECT.md → Workspace Context (+3 more)
-
-### Community 671 - "Community 671"
-Cohesion: 0.18
-Nodes (11): code:json ({), code:bash (# Cost for a specific issue), code:bash (bd show MIN-123), Cost Calculation, Data Sources, Implementation Notes, Part 15: Per-Feature Cost Tracking, Related Tools (+3 more)
-
-### Community 672 - "Community 672"
-Cohesion: 0.18
-Nodes (10): Conversation Forks, Developer Notes, Fork Modes, Fork Options, Model Switching, Plain Fork, Summary Fork (Default), Thinking Block Behavior (+2 more)
-
-### Community 673 - "Community 673"
-Cohesion: 0.18
-Nodes (11): 1. Claude Code's Native Hierarchy, Additional Loading Behavior, CLAUDE.md Precedence (team wins over personal), code:block1 (HIGHEST PRIORITY), code:block2 (HIGHEST PRIORITY), code:yaml (---), code:bash (export CLAUDE_CODE_DISABLE_AUTO_MEMORY=0  # Force ON), Rules vs. Skills vs. Agents (+3 more)
-
-### Community 674 - "Community 674"
-Cohesion: 0.18
-Nodes (10): Acceptance criteria, Architecture Overview, code:block1 (┌───────────────────────────────────────────────────────────), Decision, Implementation notes, Non-goals, Open questions, PAN-709: Self-Improving Flywheel — Retro Agent, Skill-Change Pipeline, and Autonomous Daemon (+2 more)
-
-### Community 675 - "Community 675"
-Cohesion: 0.18
-Nodes (11): code:typescript (const isPlanningAgent = agent?.agentPhase === 'planning' || ), code:typescript (const isPlanningAgent = agent?.role === 'plan';), code:typescript (const label = specialist), code:typescript (const label = agent?.role), Dashboard Component Changes, Issue card phase label (`KanbanBoard.tsx`), PlanDialog (`PlanDialog.tsx:94-104`), Planning detection (`AgentOutputPanel.tsx:88`) (+3 more)
-
-### Community 676 - "Community 676"
-Cohesion: 0.18
-Nodes (10): 1. `InlineSparkline.tsx`, 2. `ContainerNode.tsx`, 3. `ResourcesGroup.tsx`, 4. `FeatureItem.tsx` modifications, 5. Container stats polling in `CommandDeck/index.tsx`, code:typescript (interface InlineSparklineProps {), code:typescript (interface ContainerNodeProps {), code:typescript (interface ResourcesGroupProps {) (+2 more)
-
-### Community 677 - "Community 677"
-Cohesion: 0.18
-Nodes (10): Acceptance criteria, code:css (.resourcesGroup {), CSS additions, Goal, Non-goals, PAN-965: Command Deck — Hierarchical Resource Tree Under Issues, Relationship to existing work, Status (+2 more)
-
-### Community 678 - "Community 678"
-Cohesion: 0.18
-Nodes (10): Acceptance Criteria, code:typescript (import { HttpRouter, HttpServer, HttpServerRequest, HttpServ), code:block8 (┌──────────────────┐), Decision, PAN-428: Full Effect.js Migration — Dashboard Server + Data Layer, Problem, Reference Implementation, Risk Assessment (Post-Investigation) (+2 more)
-
-### Community 679 - "Community 679"
-Cohesion: 0.18
-Nodes (11): Activity sparkline (NEW, Zone A enrichment), code:block4 (⚠ Stuck — {reason}              [View details] [Mark unstuck), code:block5 (⚠ Salvageable user work in stash — recover before destructiv), Contextual actions row, Identity row (visual spec), Live cost ticker, Quality gates rollup (right side of stage row), Salvageable stash warning (+3 more)
-
-### Community 680 - "Community 680"
-Cohesion: 0.18
-Nodes (11): P0 — Remove the worst offenders, P3 — Dashboard transcripts (stream from JSONL), P4 — WebSocket terminal (in-memory buffer), Per-Consumer Migration Plan, `src/dashboard/server/routes/agents.ts:526` — agent output endpoint, `src/dashboard/server/routes/mission-control.ts:161` — ActivityView agent transcript, `src/dashboard/server/routes/mission-control.ts:297` — specialist live output filter, `src/dashboard/server/routes/workspaces.ts:931` — model extraction (+3 more)
-
-### Community 681 - "Community 681"
-Cohesion: 0.18
-Nodes (10): Approach, Constraints, Decisions, PAN-410: DAG Visualization — Match vBRIEF Studio Quality, Problem, Risks, Status: Planning Complete, Task 1: Node Enhancements (PlanDAG.tsx) (+2 more)
-
-### Community 682 - "Community 682"
-Cohesion: 0.18
-Nodes (10): Approach, Decisions Made, Files Modified, Investigation: `scrollback: 0` History, Out of Scope, PAN-209: Mouse scroll in planning dialog scrolls chat input instead of agent output, Problem, Risk Assessment (+2 more)
-
-### Community 683 - "Community 683"
-Cohesion: 0.18
-Nodes (10): code:block1 (specialists.review_agent = 'claude-opus-4-6'), Decisions, Failure Group 1: settings.test.ts (4 failures), Failure Group 2: tracker/factory.test.ts (2 failures), Files to Modify, PAN-136: Fix Pre-existing Test Failures, Problem, Root Cause Analysis (+2 more)
-
-### Community 684 - "Community 684"
-Cohesion: 0.18
-Nodes (10): Architecture — new parallel-review runner, code:ts (async function runParallelReview(ctx: ReviewContext, agents:), Decisions, Out of scope, PAN-540: Remove convoy abstraction, inline parallel review into review-agent, Problem, Proposal, Quality gates (per bead, enforced by pipeline) (+2 more)
-
-### Community 685 - "Community 685"
-Cohesion: 0.18
-Nodes (10): 1. `.claude/skills/test-specialist-workflow/SKILL.md` (4 refs), 2. `.claude/skills/update-panopticon-docs/resources/EXAMPLES.md` (1 ref), Approach, Audit findings, Current taxonomy (verified against `pan --help` on feature/pan-712), Decomposition, Out of scope, PAN-712: Fix stale pan work/cloister/specialists refs in .claude/skills/ (+2 more)
-
-### Community 686 - "Community 686"
-Cohesion: 0.18
-Nodes (10): Architecture outline, Data flow (divergence case), Decisions, Modified files, New files, Out of scope, PAN-653 — Hotfix commits on main get silently lost, Problem (+2 more)
-
-### Community 687 - "Community 687"
-Cohesion: 0.18
-Nodes (10): Architecture Decisions, Decision Summary, Feature Decisions, Framework: Electron, Out of Scope, PAN-442: Electron Desktop App for Panopticon Dashboard, Reference Architecture, Status: Planning Complete (+2 more)
-
-### Community 688 - "Community 688"
-Cohesion: 0.18
-Nodes (9): Acceptance Criteria, Affected File, code:typescript (return yield* RallyClient.pipe(Effect.provide(RallyClientLiv), code:block2 (Error: Fiber.runLoop: Not a valid effect: { "_id": "Service"), Difficulty: Simple, Fix, Issue, Root Cause (+1 more)
-
-### Community 689 - "Community 689"
-Cohesion: 0.18
-Nodes (11): A Mustache section renders when it shouldn't, A template renders the literal `{{VAR}}` instead of a value, code:block13 (Prompt "merge" (.../prompts/merge.md) requires variables tha), code:block14 (Prompt "review" (.../prompts/review.md) was passed unknown v), code:block15 (Prompt template "<name>" at .../<name>.md is missing YAML fr), code:block16 (Failed to load prompt template "work" from .../prompts/work.), "Failed to load prompt template", "missing YAML frontmatter" (+3 more)
-
 ### Community 690 - "Community 690"
-Cohesion: 0.18
-Nodes (10): ADR-0001: Use bd prime as CLI Reference Source of Truth, Consequences, Context, Date, Decision, Implementation, Negative, Positive (+2 more)
+Cohesion: 0.17
+Nodes (11): code:bash (curl -s -X POST {{API_URL}}/api/specialists/done \), code:bash (curl -s -X POST {{API_URL}}/api/specialists/done \), Hard Rules, Memory Context, Merge Task — {{ISSUE_ID}}, PHASE 1 — SYNC & BASELINE (before merge), PHASE 2 — MERGE, PHASE 3 — VERIFY (+3 more)
 
 ### Community 691 - "Community 691"
 Cohesion: 0.18
-Nodes (10): CLI Quick Reference, code:bash (bd mol distill bd-o5xe --as "Release Workflow"), code:bash (--var branch=feature-auth      # variable=value (recommended), Distilling Protos, Molecules and Wisps Reference, The Chemistry Metaphor, Troubleshooting, Use Protos/Mols When: (+2 more)
+Nodes (6): configFixture, __dirname, issueFixture, mockGitHubResponses, mockLinearResponses, skillFixture
 
 ### Community 692 - "Community 692"
 Cohesion: 0.18
-Nodes (11): code:block31 (docs-1: "Update documentation"), code:block32 (epic-1: "OAuth integration"), code:block33 (Everything blocks everything else in strict sequential order), code:bash (bd dep add api-endpoint database-schema), code:bash (bd dep add database-schema api-endpoint), Common Mistakes, Mistake 1: Using blocks for Preferences, Mistake 2: Using discovered-from for Planning (+3 more)
+Nodes (9): decode, events, identity, marker, next, observation, observationEvents, pendingTurn (+1 more)
 
 ### Community 693 - "Community 693"
 Cohesion: 0.18
-Nodes (10): code:block30 (Does Issue A prevent Issue B from starting?), code:block40 (Issue: feature-10), Contents, Decision Guide, Decision Tree, Dependency Types Guide, Overview, Quick Reference by Situation (+2 more)
+Nodes (6): ACTIVE_STATUS_PATTERNS, agentDir, LAZY_PATTERNS, lazySamples, oldTime, stateFile
 
 ### Community 694 - "Community 694"
-Cohesion: 0.18
-Nodes (11): Add Your First Project, code:bash (pan init), code:bash (# Edit ~/.panopticon.env and add:), code:bash (# Edit ~/.panopticon.env and add:), code:bash (# Edit ~/.panopticon.env and add:), code:bash (# Add the project you want to work on), code:bash (# Check system health), Configure Issue Tracker (+3 more)
+Cohesion: 0.25
+Nodes (9): create_skill(), init_skill(), main(), Validate skill name follows conventions., Convert skill-name to Skill Name., Create a new skill directory structure., Initialize a new skill directory structure., to_title() (+1 more)
 
 ### Community 695 - "Community 695"
 Cohesion: 0.18
-Nodes (10): code:bash (# CLI command), code:bash (# Sync PAN-123 workspace with latest main), Dashboard, Design Decisions, Examples, Outcomes, Related Commands, Sync with Main (+2 more)
+Nodes (10): desktopDir, __dirname, pkg, pkgPath, publicDest, publicSrc, repoRoot, serverDest (+2 more)
 
 ### Community 696 - "Community 696"
 Cohesion: 0.18
-Nodes (11): code:bash (# Find what's using the port), code:bash (# Check if frontend built correctly), code:bash (# Check what's using port 80/443), code:bash (# Check browser console for errors), code:bash (# Run in foreground to see errors), Dashboard shows blank page, Port already in use, Services don't stay running (+3 more)
+Nodes (9): diffAgainstMain(), diffAgainstMainFiles(), diffsRouteLayer, getDiffsRoute, getFullDiffRoute, getTurnDiffRoute, getVsMainDiffRoute, postTestCheckpointRoute (+1 more)
 
 ### Community 697 - "Community 697"
-Cohesion: 0.18
-Nodes (11): Buttons, Cards, code:tsx (// Blue gradient background), code:tsx (// Variants: default, destructive, success, error, warning, ), code:tsx (// Input), code:tsx (// Primary), code:tsx (// Main card (primary, higher elevation)), Component Patterns (+3 more)
+Cohesion: 0.29
+Nodes (10): callServerApi(), AgentStatus, buildContextMenu(), buildTooltip(), createTray(), createTrayIcon(), destroyTray(), HealthResponse (+2 more)
 
 ### Community 698 - "Community 698"
-Cohesion: 0.18
-Nodes (11): Agent sessions remain after shutdown, Can't stop Traefik, code:bash (# Check for orphaned processes), code:bash (# Find what's using the port), code:bash (# Check Traefik status), code:bash (# List tmux sessions), code:bash (# Remove stale PID files), PID file exists but process doesn't (+3 more)
+Cohesion: 0.22
+Nodes (7): BadgeBarProps, fetchPlanning(), PlanningData, MarkdownModal(), MarkdownModalProps, TranscriptUpload(), TranscriptUploadProps
 
 ### Community 699 - "Community 699"
-Cohesion: 0.18
-Nodes (10): code:bash (curl -s -X POST {{API_URL}}/api/specialists/done \), code:bash (curl -s -X POST {{API_URL}}/api/specialists/done \), Hard Rules, Merge Task — {{ISSUE_ID}}, PHASE 1 — SYNC & BASELINE (before merge), PHASE 2 — MERGE, PHASE 3 — VERIFY, PHASE 4 — DECIDE (+2 more)
+Cohesion: 0.2
+Nodes (10): client, input, input1, input2, makeClient(), mockConversation, patchCalls, pendingResponses (+2 more)
 
 ### Community 700 - "Community 700"
 Cohesion: 0.18
-Nodes (10): Claude Code Channels — Manual Smoke Test (PAN-985), code:block1 ([agent-pan-XXX] channels:eligible), code:block2 ({"ts":"2026-05-07T...","agentId":"agent-pan-XXX","contentLen), code:block3 ({"ts":"2026-...","agentId":"agent-pan-XXX","path":"channel",), code:block4 ({"ts":"2026-...","agentId":"agent-pan-XXX","path":"tmux","re), Expected log signatures, Failure modes & where to look, Prerequisites (+2 more)
+Nodes (10): ghCliIssue, githubApiIssue, githubOpenIssue, issueWithCompletedAt, issueWithoutCompletedAt, linearIssue, linearOpenIssue, mappedIssue (+2 more)
 
 ### Community 701 - "Community 701"
-Cohesion: 0.44
-Nodes (9): compactCommand(), CompactOptions, detectPlatform(), doctorCommand(), execAsync, getOldClosedCount(), isBdAvailable(), statsCommand() (+1 more)
+Cohesion: 0.18
+Nodes (10): columns, db, divergedRows, id, indexes, indexNames, names, pushRows (+2 more)
 
 ### Community 702 - "Community 702"
-Cohesion: 0.2
-Nodes (8): content, d, existingDir, lines, oldDir, result, skillDir, ensurePanGitignore()
+Cohesion: 0.18
+Nodes (7): mockAddComment, mockGetChildIssues, mockGetIssue, mockGetRallyConfig, mockTransitionIssue, program, RALLY_CONFIG
 
 ### Community 703 - "Community 703"
-Cohesion: 0.2
-Nodes (9): createdIssue, mockAssignee, mockClient, mockComment, mockIssue, mockLabels, mockState, stateTests (+1 more)
+Cohesion: 0.18
+Nodes (8): MOCK_PROJECT, mockCreateWorkspace, mockExistsSync, mockLoadProjectsConfig, mockRemoveWorkspace, mockResolveProjectFromIssue, mockStopWorkspaceDocker, program
 
 ### Community 704 - "Community 704"
-Cohesion: 0.2
-Nodes (8): CONFIG, hadPackageDir, hadPython, hadVenvDir, killSpy, packageDir, python, scriptPath
+Cohesion: 0.18
+Nodes (8): MOCK_PROJECT, mockCreateWorkspace, mockExistsSync, mockLoadProjectsConfig, mockRemoveWorkspace, mockResolveProjectFromIssue, mockStopWorkspaceDocker, program
 
 ### Community 705 - "Community 705"
-Cohesion: 0.31
-Nodes (9): buildReviewFeedbackBody(), deliverReviewVerdictFeedback(), DeliverReviewVerdictFeedbackOptions, DeliverReviewVerdictFeedbackResult, execFileAsync, findLatestSynthesis(), parseGitHubPrUrl(), postPrComment() (+1 more)
+Cohesion: 0.18
+Nodes (11): Acceptance Criteria Pipeline, Agent Environment Variables, Beads Prerequisite, code:block4 (1. Planning agent writes:), DAG-Aware Task Scheduling, Handling Pre-Existing PRDs, Lifecycle, Planning → Implementation Transition (+3 more)
 
 ### Community 706 - "Community 706"
-Cohesion: 0.2
-Nodes (5): activeContinuePath, continuePath, projectRoot, updated, wsDir
+Cohesion: 0.18
+Nodes (11): 1. Tool Response Materialization, 2. Chat History as Queryable Files, 3. Skills as Discoverable Definitions, 4. MCP Tool Discovery, 5. Terminal Output Integration, code:block10 (~/.panopticon/mcp/), code:block11 (~/.panopticon/terminals/), code:typescript (// Before) (+3 more)
 
 ### Community 707 - "Community 707"
-Cohesion: 0.2
-Nodes (8): merge, mergeAgent, pollSpecialistApiStatus(), review, reviewAgent, SpecialistApiStatus, test, testAgent
+Cohesion: 0.18
+Nodes (11): Adopting GSD Patterns for Panopticon, code:markdown (# Workspace Context: MIN-648), code:markdown (# Agent State: MIN-648), code:markdown (# Work Summary: Research Phase), code:block43 (┌───────────────────────────────────────────────────────────), Context File Lifecycle, Part 5: Context Engineering from GSD-Plus, PROJECT.md → Workspace Context (+3 more)
 
 ### Community 708 - "Community 708"
-Cohesion: 0.2
-Nodes (9): ArcProps, GroupProps, HTMLMotionProps, MotionComponent, PanopticonBridge, PanopticonBridgeDesktopSettings, Transition, Variants (+1 more)
+Cohesion: 0.18
+Nodes (11): code:json ({), code:bash (# Cost for a specific issue), code:bash (bd show MIN-123), Cost Calculation, Data Sources, Implementation Notes, Part 15: Per-Feature Cost Tracking, Related Tools (+3 more)
 
 ### Community 709 - "Community 709"
-Cohesion: 0.2
-Nodes (6): ACTIVE_STATUS_PATTERNS, agentDir, LAZY_PATTERNS, lazySamples, oldTime, stateFile
+Cohesion: 0.18
+Nodes (11): code:typescript (interface Runtime {), code:toml (# ~/.panopticon/runtimes/claude.toml), code:toml (# ~/.panopticon/runtimes/codex.toml), code:bash (# Default: use project runtime), code:typescript (interface RuntimeMetrics {), Part 6: Multi-Runtime Architecture, Per-Agent Runtime Selection, Runtime Abstraction Layer (+3 more)
 
 ### Community 710 - "Community 710"
+Cohesion: 0.18
+Nodes (10): Conversation Forks, Developer Notes, Fork Modes, Fork Options, Model Switching, Plain Fork, Summary Fork (Default), Thinking Block Behavior (+2 more)
+
+### Community 711 - "Community 711"
+Cohesion: 0.18
+Nodes (11): 1. Claude Code's Native Hierarchy, Additional Loading Behavior, CLAUDE.md Precedence (team wins over personal), code:block1 (HIGHEST PRIORITY), code:block2 (HIGHEST PRIORITY), code:yaml (---), code:bash (export CLAUDE_CODE_DISABLE_AUTO_MEMORY=0  # Force ON), Rules vs. Skills vs. Agents (+3 more)
+
+### Community 712 - "Community 712"
+Cohesion: 0.18
+Nodes (10): Autonomous planning auto-promote (commit 861cf8baa, 2026-05-20, RUN-1), Deacon orphan-detection races new agent spawn (observed RUN-1 tick 2), Flywheel State, GitHub App credential config fails ENOTDIR in worktrees (observed RUN-3), Open questions for the human, Orphan-test recovery loops on an unhealthy docker stack (commit ebb7f1387, 2026-05-20, RUN-3), Parked items, Recurring patterns to watch (+2 more)
+
+### Community 713 - "Community 713"
+Cohesion: 0.18
+Nodes (10): Author allowlist (hard filter), End of run, Flywheel Brief, Human input invariant, Parked labels, Read first, Scope, Status vs State (+2 more)
+
+### Community 714 - "Community 714"
+Cohesion: 0.18
+Nodes (10): Acceptance criteria, Architecture Overview, code:block1 (┌───────────────────────────────────────────────────────────), Decision, Implementation notes, Non-goals, Open questions, PAN-709: Self-Improving Flywheel — Retro Agent, Skill-Change Pipeline, and Autonomous Daemon (+2 more)
+
+### Community 715 - "Community 715"
+Cohesion: 0.18
+Nodes (11): code:typescript (const isPlanningAgent = agent?.agentPhase === 'planning' || ), code:typescript (const isPlanningAgent = agent?.role === 'plan';), code:typescript (const label = specialist), code:typescript (const label = agent?.role), Dashboard Component Changes, Issue card phase label (`KanbanBoard.tsx`), PlanDialog (`PlanDialog.tsx:94-104`), Planning detection (`AgentOutputPanel.tsx:88`) (+3 more)
+
+### Community 716 - "Community 716"
+Cohesion: 0.18
+Nodes (11): A.1 Add `isInfrastructureFailure` helper, A.2 Enhance `checkStuckReviewing` to detect dead parallel sessions, A.3 Add infrastructure-failure circuit breaker, A.4 Honor `stuck` flag in re-dispatch path, A.5 ~~Detect verification/review contradiction~~ — REMOVED, A. `src/lib/cloister/deacon.ts`, code:typescript (function isInfrastructureFailure(notes?: string): boolean {), code:typescript (// After building activeReviewIssues from specialist statuse) (+3 more)
+
+### Community 717 - "Community 717"
+Cohesion: 0.18
+Nodes (10): Acceptance criteria, code:css (.resourcesGroup {), CSS additions, Goal, Non-goals, PAN-965: Command Deck — Hierarchical Resource Tree Under Issues, Relationship to existing work, Status (+2 more)
+
+### Community 718 - "Community 718"
+Cohesion: 0.18
+Nodes (10): 1. `InlineSparkline.tsx`, 2. `ContainerNode.tsx`, 3. `ResourcesGroup.tsx`, 4. `FeatureItem.tsx` modifications, 5. Container stats polling in `CommandDeck/index.tsx`, code:typescript (interface InlineSparklineProps {), code:typescript (interface ContainerNodeProps {), code:typescript (interface ResourcesGroupProps {) (+2 more)
+
+### Community 719 - "Community 719"
+Cohesion: 0.18
+Nodes (10): Acceptance Criteria, code:typescript (import { HttpRouter, HttpServer, HttpServerRequest, HttpServ), code:block8 (┌──────────────────┐), Decision, PAN-428: Full Effect.js Migration — Dashboard Server + Data Layer, Problem, Reference Implementation, Risk Assessment (Post-Investigation) (+2 more)
+
+### Community 720 - "Community 720"
+Cohesion: 0.18
+Nodes (11): Activity sparkline (NEW, Zone A enrichment), code:block4 (⚠ Stuck — {reason}              [View details] [Mark unstuck), code:block5 (⚠ Salvageable user work in stash — recover before destructiv), Contextual actions row, Identity row (visual spec), Live cost ticker, Quality gates rollup (right side of stage row), Salvageable stash warning (+3 more)
+
+### Community 721 - "Community 721"
+Cohesion: 0.18
+Nodes (11): P0 — Remove the worst offenders, P3 — Dashboard transcripts (stream from JSONL), P4 — WebSocket terminal (in-memory buffer), Per-Consumer Migration Plan, `src/dashboard/server/routes/agents.ts:526` — agent output endpoint, `src/dashboard/server/routes/mission-control.ts:161` — ActivityView agent transcript, `src/dashboard/server/routes/mission-control.ts:297` — specialist live output filter, `src/dashboard/server/routes/workspaces.ts:931` — model extraction (+3 more)
+
+### Community 722 - "Community 722"
+Cohesion: 0.18
+Nodes (10): Approach, Constraints, Decisions, PAN-410: DAG Visualization — Match vBRIEF Studio Quality, Problem, Risks, Status: Planning Complete, Task 1: Node Enhancements (PlanDAG.tsx) (+2 more)
+
+### Community 723 - "Community 723"
+Cohesion: 0.18
+Nodes (10): Approach, Decisions Made, Files Modified, Investigation: `scrollback: 0` History, Out of Scope, PAN-209: Mouse scroll in planning dialog scrolls chat input instead of agent output, Problem, Risk Assessment (+2 more)
+
+### Community 724 - "Community 724"
+Cohesion: 0.18
+Nodes (10): code:block1 (specialists.review_agent = 'claude-opus-4-6'), Decisions, Failure Group 1: settings.test.ts (4 failures), Failure Group 2: tracker/factory.test.ts (2 failures), Files to Modify, PAN-136: Fix Pre-existing Test Failures, Problem, Root Cause Analysis (+2 more)
+
+### Community 725 - "Community 725"
+Cohesion: 0.18
+Nodes (10): Architecture — new parallel-review runner, code:ts (async function runParallelReview(ctx: ReviewContext, agents:), Decisions, Out of scope, PAN-540: Remove convoy abstraction, inline parallel review into review-agent, Problem, Proposal, Quality gates (per bead, enforced by pipeline) (+2 more)
+
+### Community 726 - "Community 726"
+Cohesion: 0.18
+Nodes (10): 1. `.claude/skills/test-specialist-workflow/SKILL.md` (4 refs), 2. `.claude/skills/update-panopticon-docs/resources/EXAMPLES.md` (1 ref), Approach, Audit findings, Current taxonomy (verified against `pan --help` on feature/pan-712), Decomposition, Out of scope, PAN-712: Fix stale pan work/cloister/specialists refs in .claude/skills/ (+2 more)
+
+### Community 727 - "Community 727"
+Cohesion: 0.18
+Nodes (10): Architecture outline, Data flow (divergence case), Decisions, Modified files, New files, Out of scope, PAN-653 — Hotfix commits on main get silently lost, Problem (+2 more)
+
+### Community 728 - "Community 728"
+Cohesion: 0.18
+Nodes (10): Architecture Decisions, Decision Summary, Feature Decisions, Framework: Electron, Out of Scope, PAN-442: Electron Desktop App for Panopticon Dashboard, Reference Architecture, Status: Planning Complete (+2 more)
+
+### Community 729 - "Community 729"
+Cohesion: 0.18
+Nodes (9): Acceptance Criteria, Affected File, code:typescript (return yield* RallyClient.pipe(Effect.provide(RallyClientLiv), code:block2 (Error: Fiber.runLoop: Not a valid effect: { "_id": "Service"), Difficulty: Simple, Fix, Issue, Root Cause (+1 more)
+
+### Community 730 - "Community 730"
+Cohesion: 0.18
+Nodes (11): A Mustache section renders when it shouldn't, A template renders the literal `{{VAR}}` instead of a value, code:block13 (Prompt "merge" (.../prompts/merge.md) requires variables tha), code:block14 (Prompt "review" (.../prompts/review.md) was passed unknown v), code:block15 (Prompt template "<name>" at .../<name>.md is missing YAML fr), code:block16 (Failed to load prompt template "work" from .../prompts/work.), "Failed to load prompt template", "missing YAML frontmatter" (+3 more)
+
+### Community 731 - "Community 731"
+Cohesion: 0.18
+Nodes (10): ADR-0001: Use bd prime as CLI Reference Source of Truth, Consequences, Context, Date, Decision, Implementation, Negative, Positive (+2 more)
+
+### Community 732 - "Community 732"
+Cohesion: 0.18
+Nodes (10): CLI Quick Reference, code:bash (bd mol distill bd-o5xe --as "Release Workflow"), code:bash (--var branch=feature-auth      # variable=value (recommended), Distilling Protos, Molecules and Wisps Reference, The Chemistry Metaphor, Troubleshooting, Use Protos/Mols When: (+2 more)
+
+### Community 733 - "Community 733"
+Cohesion: 0.18
+Nodes (10): code:block30 (Does Issue A prevent Issue B from starting?), code:block40 (Issue: feature-10), Contents, Decision Guide, Decision Tree, Dependency Types Guide, Overview, Quick Reference by Situation (+2 more)
+
+### Community 734 - "Community 734"
+Cohesion: 0.18
+Nodes (11): code:block31 (docs-1: "Update documentation"), code:block32 (epic-1: "OAuth integration"), code:block33 (Everything blocks everything else in strict sequential order), code:bash (bd dep add api-endpoint database-schema), code:bash (bd dep add database-schema api-endpoint), Common Mistakes, Mistake 1: Using blocks for Preferences, Mistake 2: Using discovered-from for Planning (+3 more)
+
+### Community 735 - "Community 735"
+Cohesion: 0.18
+Nodes (11): Add Your First Project, code:bash (pan init), code:bash (# Edit ~/.panopticon.env and add:), code:bash (# Edit ~/.panopticon.env and add:), code:bash (# Edit ~/.panopticon.env and add:), code:bash (# Add the project you want to work on), code:bash (# Check system health), Configure Issue Tracker (+3 more)
+
+### Community 736 - "Community 736"
+Cohesion: 0.18
+Nodes (10): code:bash (# CLI command), code:bash (# Sync PAN-123 workspace with latest main), Dashboard, Design Decisions, Examples, Outcomes, Related Commands, Sync with Main (+2 more)
+
+### Community 737 - "Community 737"
+Cohesion: 0.18
+Nodes (11): code:bash (# Find what's using the port), code:bash (# Check if frontend built correctly), code:bash (# Check what's using port 80/443), code:bash (# Check browser console for errors), code:bash (# Run in foreground to see errors), Dashboard shows blank page, Port already in use, Services don't stay running (+3 more)
+
+### Community 738 - "Community 738"
+Cohesion: 0.18
+Nodes (11): Buttons, Cards, code:tsx (// Blue gradient background), code:tsx (// Variants: default, destructive, success, error, warning, ), code:tsx (// Input), code:tsx (// Primary), code:tsx (// Main card (primary, higher elevation)), Component Patterns (+3 more)
+
+### Community 739 - "Community 739"
+Cohesion: 0.18
+Nodes (11): Agent sessions remain after shutdown, Can't stop Traefik, code:bash (# Check for orphaned processes), code:bash (# Find what's using the port), code:bash (# Check Traefik status), code:bash (# List tmux sessions), code:bash (# Remove stale PID files), PID file exists but process doesn't (+3 more)
+
+### Community 740 - "Community 740"
+Cohesion: 0.18
+Nodes (10): Code Review: Requirements Coverage, code:markdown (# Requirements Coverage Review - <timestamp>), Inputs from your spawn prompt, Method, Output format, Per-AC scope classification (REQUIRED), Scope, Severity and evidence (+2 more)
+
+### Community 741 - "Community 741"
+Cohesion: 0.18
+Nodes (10): Claude Code Channels — Manual Smoke Test (PAN-985), code:block1 ([agent-pan-XXX] channels:eligible), code:block2 ({"ts":"2026-05-07T...","agentId":"agent-pan-XXX","contentLen), code:block3 ({"ts":"2026-...","agentId":"agent-pan-XXX","path":"channel",), code:block4 ({"ts":"2026-...","agentId":"agent-pan-XXX","path":"tmux","re), Expected log signatures, Failure modes & where to look, Prerequisites (+2 more)
+
+### Community 742 - "Community 742"
+Cohesion: 0.29
+Nodes (9): AGENTS_DIR, AgentState, APPLY, dirExists(), execFileAsync, issueIsClosed(), loadState(), main() (+1 more)
+
+### Community 743 - "Community 743"
 Cohesion: 0.22
 Nodes (8): HealthCheck, systemHealthCommand(), mockExistsSync, mockFetch, mockGetDashboardApiUrl, mockIsCliproxyRunning, mockIsSmeeProcessRunning, output
 
-### Community 711 - "Community 711"
-Cohesion: 0.38
-Nodes (8): cleanupAgentDirectories(), CleanupResult, findOrphanedAgentDirs(), getPlanningIssueId(), isLegacyConversationDirectory(), isValidAgentDirectoryName(), OrphanedAgentDir, names
+### Community 744 - "Community 744"
+Cohesion: 0.29
+Nodes (8): MergeSet, execAsync, RebaseAllResult, rebaseAndPushRepos(), RebaseError, rebaseOneRepo(), RebaseResult, tryResolvePlanningConflicts()
 
-### Community 712 - "Community 712"
+### Community 745 - "Community 745"
+Cohesion: 0.31
+Nodes (8): analyzeIssue(), sortByPriority(), issues, options, results, triageMultiple(), TriageOptions, TriageResult
+
+### Community 746 - "Community 746"
+Cohesion: 0.27
+Nodes (9): handlePermissionRequestNotification(), normalizePermissionRequest(), parsePermissionRequestNotification(), CHANNEL_PERMISSION_LIMITS, normalizeChannelPermissionRequestFields(), normalizePermissionInputPreview(), PermissionPayloadValidationError, utf8ByteLength() (+1 more)
+
+### Community 747 - "Community 747"
+Cohesion: 0.2
+Nodes (8): merge, mergeAgent, pollSpecialistApiStatus(), review, reviewAgent, SpecialistApiStatus, test, testAgent
+
+### Community 748 - "Community 748"
+Cohesion: 0.2
+Nodes (9): ArcProps, GroupProps, HTMLMotionProps, MotionComponent, PanopticonBridge, PanopticonBridgeDesktopSettings, Transition, Variants (+1 more)
+
+### Community 749 - "Community 749"
 Cohesion: 0.2
 Nodes (10): 1. TypeScript typecheck, 2. Lint, 3. Tests, 4. No ephemeral files staged, code:bash (npm run typecheck    # npx tsc --noEmit), code:bash (npm run lint), code:bash (npm test), code:typescript (// vitest.config.ts) (+2 more)
 
-### Community 713 - "Community 713"
+### Community 750 - "Community 750"
 Cohesion: 0.2
 Nodes (10): code:bash (npx @panctl/cli), code:bash (npm install -g @panctl/cli && pan install && pan up), code:bash (npm install -g @panctl/cli), code:bash (pan install), code:bash (pan sync), code:bash (cd /path/to/your-project), code:bash (pan up), Installation (+2 more)
 
-### Community 714 - "Community 714"
+### Community 751 - "Community 751"
 Cohesion: 0.2
 Nodes (9): Agent Types Index, code:ts (export type Role = 'plan' | 'work' | 'review' | 'test' | 'sh), Important distinction: roles vs helper subagents, Related docs, Runtime role inventory, Sub-roles, The big picture, Typical workflow (+1 more)
 
-### Community 715 - "Community 715"
+### Community 752 - "Community 752"
 Cohesion: 0.2
 Nodes (10): Caveats, code:json ({), code:yaml (claude:), code:bash (pan up                     # uses config (default: auto)), code:bash (pan --yolo=false up        # before subcommand), Permission Mode, Precedence, Prereq for `auto` mode (+2 more)
 
-### Community 716 - "Community 716"
+### Community 753 - "Community 753"
 Cohesion: 0.2
 Nodes (10): code:yaml (fpp_violation:), code:typescript (interface FPPViolation {), FPP (Fixed Point Principle) Violation Detection, Implementation Phases, Phase 1: Core Watchdog (MVP), Phase 2: Agent Management UI, Phase 3: Active Heartbeats & Hooks, Phase 4: Model Routing & Handoffs (+2 more)
 
-### Community 717 - "Community 717"
-Cohesion: 0.2
-Nodes (9): Default Flywheel Brief, End-of-run report, Human input invariant, Operating loop, Role taxonomy, Scope, Source material, Status contract (+1 more)
-
-### Community 718 - "Community 718"
+### Community 754 - "Community 754"
 Cohesion: 0.2
 Nodes (10): Agent state — new `waiting-on-human` state, code:yaml (---), code:yaml (---), code:yaml (flywheel:), Dashboard schema — new kanban badge + Awaiting Merge sub-tab, Data model changes, `docs/FLYWHEEL-REPORT.md` (new), `docs/flywheel/retros/<issue-id>-<timestamp>.md` (new) (+2 more)
 
-### Community 719 - "Community 719"
+### Community 755 - "Community 755"
 Cohesion: 0.2
 Nodes (10): code:bash (pan conversations enrich), code:bash (pan conversations enrich --deep), code:bash (pan conversations enrich --with claude-opus-4-6 <session-id>), code:block15 (Session abc123 — 847 messages, ~125K tokens), L1 — Quick enrich (cheap, batch), L2 — Deep enrich (mid-tier model), L3 — Custom enrich (user-selected model), Re-enrichment rules (+2 more)
 
-### Community 720 - "Community 720"
+### Community 756 - "Community 756"
 Cohesion: 0.2
 Nodes (7): code:sql (CREATE VIEW archived_conversations_v AS), Data Model, Existing — `conversations` table, New — `discovered_sessions` table, New — FTS5 mirror, New — vector embeddings (optional), Unified view — `archived_conversations_v`
 
-### Community 721 - "Community 721"
+### Community 757 - "Community 757"
 Cohesion: 0.2
 Nodes (10): Architecture, Backend extraction, code:block1 (┌──────────────────────────┐         ┌──────────────────────), code:block2 (src/lib/setup/), code:typescript (// src/dashboard/frontend/src/stores/wizardStore.ts), Dashboard surfaces, High-level shape, Setup Agent as a first-class agent (+2 more)
 
-### Community 722 - "Community 722"
+### Community 758 - "Community 758"
 Cohesion: 0.2
 Nodes (9): Files to Create, Files to Modify, Goals, Non-goals, Open Questions, Problem, Project Setup Wizard — Dashboard UI, Risks (+1 more)
 
-### Community 723 - "Community 723"
+### Community 759 - "Community 759"
 Cohesion: 0.2
 Nodes (10): code:typescript (export interface ReviewStatusSnapshot {), code:typescript (describe('isInfrastructureFailure', () => {), D.1 Add new fields to `ReviewStatusSnapshot`, D. `packages/contracts/src/types.ts`, Detailed Changes, E.1 Unit test: `isInfrastructureFailure`, E.2 Unit test: circuit breaker in `checkOrphanedReviewStatuses`, E.3 Unit test: `checkStuckReviewing` with dead parallel sessions (+2 more)
 
-### Community 724 - "Community 724"
+### Community 760 - "Community 760"
 Cohesion: 0.2
 Nodes (9): 1. Do NOT rewrite `src/lib/*` modules, 2. Do NOT modify `server.ts` from route modules, 3. Preserve exact API contracts, 4. Socket.io → EventStore mapping, 5. Background processes become Effect fibers, 6. Effect service pattern for existing modules, code:typescript (// services/agent-manager.ts), code:typescript (// CORRECT — wrap existing async code in Effect) (+1 more)
 
-### Community 725 - "Community 725"
+### Community 761 - "Community 761"
 Cohesion: 0.2
 Nodes (9): Architecture, code:typescript ({), Data Flow, Decisions, Files to Modify, Key Implementation Details, PAN-426: Tasks Panel and DAG — AC Subtask Toggle, Scope (+1 more)
 
-### Community 726 - "Community 726"
+### Community 762 - "Community 762"
 Cohesion: 0.2
 Nodes (9): Approach, Architecture, code:block1 (DetailPanelLayout), Decision Record, Files Modified, Key Decisions, PAN-406: Workspace detail — replace polling logs with live interactive terminal, Problem (+1 more)
 
-### Community 727 - "Community 727"
+### Community 763 - "Community 763"
 Cohesion: 0.2
 Nodes (9): Architecture, Decisions, Edge Cases, Files to Modify, Flow After Fix, Out of Scope, PAN-208: Stale planning state causes premature 'Planning Complete' on restart, Problem (+1 more)
 
-### Community 728 - "Community 728"
+### Community 764 - "Community 764"
 Cohesion: 0.2
 Nodes (9): 1. Deep Link URL Format, 2. Deep Link Navigation Behavior, 3. Copy Button Feedback, Affected Files, Context, Decisions, Implementation Plan, Out of Scope (+1 more)
 
-### Community 729 - "Community 729"
+### Community 765 - "Community 765"
 Cohesion: 0.2
 Nodes (9): Context, Decision: Add unit tests for createBeadsFromVBrief, Difficulty, Files affected, PAN-507: beads db not initialized on fresh install, Status: Planning Complete, Test approach, What NOT to test (+1 more)
 
-### Community 730 - "Community 730"
+### Community 766 - "Community 766"
 Cohesion: 0.2
 Nodes (10): Boolean flags, code:mustache (Issue: {{ISSUE_ID}}), code:mustache ({{#USER_MESSAGE}}), code:mustache ({{^DO_PUSH}}), code:typescript (renderPrompt({), Inverted sections, Mustache syntax reference, No partials, no lambdas, no custom helpers (+2 more)
 
-### Community 731 - "Community 731"
+### Community 767 - "Community 767"
 Cohesion: 0.2
 Nodes (9): Codebase Explorer, Deliverables, Exploration Strategies, For Architecture Understanding, For New Codebases, For Specific Questions, Performance Tips, Remember (+1 more)
 
-### Community 732 - "Community 732"
+### Community 768 - "Community 768"
 Cohesion: 0.2
 Nodes (9): code:bash (tmux -L panopticon list-sessions), code:block2 ({{WORKSPACE_PATH}}), code:bash (# 1. Run tests), Completion Requirements (CRITICAL), CRITICAL: Workspace Isolation, Investigation First — NEVER Fix Inline, NEVER Defer Work (CRITICAL), tmux Socket — CRITICAL (+1 more)
 
-### Community 733 - "Community 733"
-Cohesion: 0.2
-Nodes (10): code:bash (# If project has override skill, this skill is permanently d), code:javascript (// Pseudocode for decision), code:bash (mkdir -p .claude/skills/knowledge-capture), code:bash (# Ensure directory exists), Invocation Protocol, Step 0: Check for Permanent Override, Step 2: Respect Cooldowns and Dismissals, Step 3: Present to User (+2 more)
-
-### Community 734 - "Community 734"
+### Community 769 - "Community 769"
 Cohesion: 0.2
 Nodes (9): AI Writing Patterns to Avoid, Bottom Line, Clear Writing, Composition Rules, Limited Context Strategy, Overview, Reference Files, Rules (+1 more)
 
-### Community 735 - "Community 735"
+### Community 770 - "Community 770"
 Cohesion: 0.2
 Nodes (10): code:bash (# In directory: /Users/name/Google Drive/...), code:bash (# Wrong location (cloud sync)), code:bash (mv ~/Google\ Drive/project ~/Repos/project), code:bash (bd init myproject), code:bash (bd import < issues-backup.jsonl), code:bash (# Don't initialize bd in cloud-synced directory), Database Errors on Cloud Storage, Resolution (+2 more)
 
-### Community 736 - "Community 736"
+### Community 771 - "Community 771"
 Cohesion: 0.2
 Nodes (10): code:bash (bd mol wisp mol-patrol                       # From proto), code:bash (bd mol wisp list                     # List all wisps), code:bash (bd mol squash wisp-abc123                              # Aut), code:bash (bd mol burn wisp-abc123                    # Delete wisp, no), code:bash (bd mol wisp gc                       # Clean up orphaned wis), Creating Wisps, Ending Wisps, Garbage Collection (+2 more)
 
-### Community 737 - "Community 737"
+### Community 772 - "Community 772"
 Cohesion: 0.2
 Nodes (9): 1. Verify Implementation, 2. Self-Review Your Changes, 3. Commit Your Work (BLOCKING - DO THIS FIRST), 4. Signal Completion, 5. Wait for User Response, code:bash (git diff origin/main...HEAD), code:bash (# Check for uncommitted changes), code:block3 (✅ WORK COMPLETE - Ready for Review) (+1 more)
 
-### Community 738 - "Community 738"
+### Community 773 - "Community 773"
 Cohesion: 0.2
 Nodes (10): Approve and Merge, Check Pending Work, code:bash (# Start dashboard and services), code:bash (# See completed work awaiting review), code:bash (# Approve work, merge MR, update tracker), Quick Start Workflow, Review in Dashboard, Step 1: Prerequisites Check (+2 more)
 
-### Community 739 - "Community 739"
+### Community 774 - "Community 774"
 Cohesion: 0.2
 Nodes (10): Agent Status, code:bash (pan status), code:block4 (Running Agents (3):), code:bash (pan workspace list), code:block6 (Workspaces (5):), code:bash (pan doctor), code:block8 (Panopticon System Health), System Health (+2 more)
 
-### Community 740 - "Community 740"
+### Community 775 - "Community 775"
 Cohesion: 0.2
 Nodes (10): code:bash (# Check Panopticon status), code:bash (# Check for agents), code:bash (pan down), code:block5 (✓ Stopping API server (PID 12345)), code:bash (# Check nothing is listening on ports), Step 1: Check What's Running, Step 2: Save Any Pending Work, Step 3: Stop Services (+2 more)
 
-### Community 741 - "Community 741"
+### Community 776 - "Community 776"
 Cohesion: 0.2
 Nodes (9): Code Review: Performance, code:markdown (# Performance Review - <timestamp>), Inputs from your spawn prompt, Method, Output format, Scope, Severity and evidence, TLDR: prefer code summaries over full reads (+1 more)
 
-### Community 742 - "Community 742"
+### Community 777 - "Community 777"
 Cohesion: 0.2
 Nodes (9): Code Review: Security, code:markdown (# Security Review - <timestamp>), Inputs from your spawn prompt, Method, Output format, Scope, Severity and evidence, TLDR: prefer code summaries over full reads (+1 more)
 
-### Community 743 - "Community 743"
+### Community 778 - "Community 778"
 Cohesion: 0.2
 Nodes (9): Code Review: Correctness, code:markdown (# Correctness Review - <timestamp>), Inputs from your spawn prompt, Method, Output format, Scope, Severity and evidence, TLDR: prefer code summaries over full reads (+1 more)
 
-### Community 744 - "Community 744"
-Cohesion: 0.2
-Nodes (9): Code Review: Requirements Coverage, code:markdown (# Requirements Coverage Review - <timestamp>), Inputs from your spawn prompt, Method, Output format, Scope, Severity and evidence, TLDR: prefer code summaries over full reads (+1 more)
-
-### Community 745 - "Community 745"
+### Community 779 - "Community 779"
 Cohesion: 0.2
 Nodes (9): Boundaries, Browser UAT Contract, Hardcoding it here would override the user's config and force everyone onto a, Inputs, No `model:` pin — Cloister resolves the model from config.yaml (roles.test.model)., Panopticon Test Role, single model, defeating the per-role model configurability the dashboard exposes., TLDR: prefer code summaries over full reads (+1 more)
 
-### Community 746 - "Community 746"
+### Community 780 - "Community 780"
 Cohesion: 0.2
 Nodes (9): Boundaries, Hardcoding it here would override the user's config and force everyone onto a, No `model:` pin — Cloister resolves the model from config.yaml (roles.plan.model)., Outputs, Panopticon Planning Agent, Process, single model, defeating the per-role model configurability the dashboard exposes., State model (+1 more)
 
-### Community 747 - "Community 747"
+### Community 781 - "Community 781"
 Cohesion: 0.22
 Nodes (7): activeBeadsIgnore, activePlanningBeadsIgnore, content, gitignorePath, lines, ROOT, tracked
 
-### Community 748 - "Community 748"
-Cohesion: 0.31
-Nodes (8): continuesDir, ensureContinuesDir(), legacyLifecycles, lifecycleDir, log(), migrateFile(), parseIssueId(), projectRoot
-
-### Community 749 - "Community 749"
-Cohesion: 0.22
-Nodes (5): dispatchMenuAction(), consoleErrors, flywheelStatus, MockWebSocket, statusPane
-
-### Community 750 - "Community 750"
-Cohesion: 0.31
-Nodes (6): resolveServerEntry(), randomHex(), resolvePort(), spawnServer(), startServer(), stopServer()
-
-### Community 751 - "Community 751"
-Cohesion: 0.22
-Nodes (6): { getRuntimeForAgentMock, getAgentHealthMock }, issueId, MOCK_HEALTH, MOCK_RUNTIME, runtime, SHADOW_STATE_DIR
-
-### Community 752 - "Community 752"
+### Community 782 - "Community 782"
 Cohesion: 0.28
 Nodes (7): formatDuration(), fiveMinAgo, now, recent, threeDaysAgo, twoHoursAgo, timeAgo()
 
-### Community 753 - "Community 753"
-Cohesion: 0.22
-Nodes (8): error, mockComment, mockComments, mockIssue, mockIssues, mockOctokit, stateTests, tracker
+### Community 783 - "Community 783"
+Cohesion: 0.31
+Nodes (8): continuesDir, ensureContinuesDir(), legacyLifecycles, lifecycleDir, log(), migrateFile(), parseIssueId(), projectRoot
 
-### Community 754 - "Community 754"
-Cohesion: 0.22
-Nodes (8): listener(), electron, IPC, result, wrapped(), notifyVoiceSettings(), publishFlywheelStatusCleared(), publishLatestFlywheelStatus()
-
-### Community 755 - "Community 755"
-Cohesion: 0.28
-Nodes (6): BYTE_UNITS, hist, parseBytes(), parseMemUsage(), parseNetIO(), result
-
-### Community 756 - "Community 756"
-Cohesion: 0.22
-Nodes (8): MOCK_HEALTH_RESPONSE, MOCK_PROJECT_SPECIALISTS_RESPONSE, MOCK_SPECIALISTS_RESPONSE, panBadge, perProjectHeader, sectionHeader, sessionCard, statusBar
-
-### Community 757 - "Community 757"
+### Community 784 - "Community 784"
 Cohesion: 0.36
 Nodes (7): consolidateSpeakerCues(), decodeHtmlEntities(), formatTimestamp(), ParsedCue, parseTimestamp(), result, vttToMarkdown()
 
-### Community 758 - "Community 758"
-Cohesion: 0.28
-Nodes (7): decode, decodeCandidate(), ev, bodyToEvent(), decodeDomainEvent, isChannelReplyKind(), normalizeChannelReplyPayload()
-
-### Community 759 - "Community 759"
+### Community 785 - "Community 785"
 Cohesion: 0.22
 Nodes (8): cb, cmdArgs, { MainDivergedErrorClass }, mockExec, mockGitPush, mockMarkWorkspaceStuck, result, pushApproveMain()
 
-### Community 760 - "Community 760"
-Cohesion: 0.22
-Nodes (9): After making changes, Building and Running, code:bash (npm run build           # Compiles TypeScript to dist/ via t), code:bash (npm run dev             # Dashboard with hot reload (Vite fr), code:bash (# ALWAYS use the explicit Node 22 path), code:bash (npm run build && npm link   # Rebuild + re-link `pan` global), Development mode, Full build (+1 more)
-
-### Community 761 - "Community 761"
-Cohesion: 0.22
-Nodes (8): code:markdown (## Summary), code:block5 (panopticon-cli/), Contributing to Panopticon CLI, Filing Bugs, Issue Tracking, Key Invariants, Repository Layout, Table of Contents
-
-### Community 762 - "Community 762"
-Cohesion: 0.22
-Nodes (9): code:bash (# Activate Node 22 (always required)), code:bash (cp .env.example ~/.panopticon.env), code:bash (cd /path/to/panopticon-cli), code:bash (pan status          # Should show "Panopticon is running" or), Development Setup, Environment, Initialize beads (once per project), Prerequisites (+1 more)
-
-### Community 763 - "Community 763"
-Cohesion: 0.22
-Nodes (8): [0.7.0] — Command Taxonomy Reorganization, Breaking Changes, Changed, Changelog, Changes, Deprecations Removed, New Commands, Unreleased
-
-### Community 764 - "Community 764"
-Cohesion: 0.22
-Nodes (9): 1. Reviewer canonical sessions (PAN-830) — persistent across rounds, 2. Other specialist dispatches (test-agent, merge-agent, etc.) — fresh per dispatch, code:block14 (specialist-<projectKey>-<issueId>-review-<role>), code:block15 (IMPORTANT: This is a NEW task dispatch. You may have context), code:bash (# Reset via CLI — clears session state and context digest), Context Digest (cross-dispatch memory), Event-driven status (PAN-915), Resetting a Specialist (+1 more)
-
-### Community 765 - "Community 765"
-Cohesion: 0.22
-Nodes (8): Current State (2026), Decision Log, Guiding Principle, Panopticon Product Vision, Phase 1 — Shared Instance, Phase 2 — Multi-Tenant SaaS, Vision Roadmap, Why local-first?
-
-### Community 766 - "Community 766"
-Cohesion: 0.22
-Nodes (9): code:bash (# Register a project), code:json ([), code:bash (LINEAR_API_KEY=lin_api_xxxxx), Configuration, Environment File, Issue Trackers, Map Linear Projects to Local Directories, Rally Features and Derived Status (+1 more)
-
-### Community 767 - "Community 767"
-Cohesion: 0.22
-Nodes (9): code:block3 (┌───────────────────────────────────────────────────────────), code:block4 (┌───────────────────────────────────────────────────────────), code:block5 (~/.panopticon/), code:bash (# CLI equivalent of /work-issue MIN-648), Panopticon Ships Batteries-Included, The Mayor Architecture: Dual-Interface Design, The Mayor Concept (from Gastown), What `pan sync` Syncs (+1 more)
-
-### Community 768 - "Community 768"
-Cohesion: 0.22
-Nodes (8): Automatic Recovery, code:block50 (┌───────────────────────────────────────────────────────────), code:typescript (interface AgentHealth {), code:typescript (async function handleStuckAgent(agentId: string) {), Health Check Flow, Panopticon Health Dashboard, Part 7: Stuck Detection and Health Monitoring, The Deacon Pattern
-
-### Community 769 - "Community 769"
-Cohesion: 0.22
-Nodes (8): 10. Tracked Issues, 11. Implementation Scope, 4. Enterprise / Managed Policy, 5. Path Portability (Completed), 7. Rules: Planned Content, 9. Decisions Log, References, Skill Distribution Architecture: Analysis & Findings
-
-### Community 770 - "Community 770"
-Cohesion: 0.22
-Nodes (9): 2.1 Workspace Creation Flow, code:bash (exe ssh min-667 "cd /workspace && docker compose up -d fe ap), code:bash (# exe.dev's HTTPS proxy handles this automatically), code:yaml (# ~/.panopticon/workspaces/min-667.yaml), code:bash (pan workspace create MIN-667 --remote), code:bash (exe vm create min-667), code:bash (exe ssh min-667 "git clone git@github.com:org/repo.git /work), code:bash (exe ssh min-667 "cat > /workspace/.env << 'EOF') (+1 more)
-
-### Community 771 - "Community 771"
-Cohesion: 0.22
-Nodes (8): Acceptance Criteria, code:block24 (Foundation), Implementation — Single Branch, Hard Cut, Open Questions, PAN-1048: Unify Agent Type System — Role Primitive with Reactive Cloister, Problem, Related Issues, Vision
-
-### Community 772 - "Community 772"
-Cohesion: 0.22
-Nodes (8): Acceptance Criteria, Backend: Deacon stuck detection, Background, Files Modified, Frontend: Recovery UI indicators, PRD: Stuck Parallel Review Detection, Recovery, and UI Indicators (PAN-794), Risks and Mitigations, Solution Overview
-
-### Community 773 - "Community 773"
-Cohesion: 0.22
-Nodes (9): C.1 Add migration in `schema.ts`, C.2 Update `upsertReviewStatus` in `review-status-db.ts`, C.3 Update `rowToReviewStatus` in `review-status-db.ts`, C. Database schema changes (`src/lib/database/schema.ts` + `src/lib/database/review-status-db.ts`), code:typescript (// v24 → v25: add review_retry_count and recovery_started_at), code:typescript (export const ReviewStatusSnapshot = Schema.Struct({), D.1 Add new fields to `ReviewStatusSnapshot`, D. `packages/contracts/src/types.ts` (+1 more)
-
-### Community 774 - "Community 774"
-Cohesion: 0.22
-Nodes (9): code:typescript (describe('isInfrastructureFailure', () => {), F.1 Unit test: `isInfrastructureFailure`, F.2 Unit test: circuit breaker in `checkOrphanedReviewStatuses`, F.3 Unit test: `checkStuckReviewing` with dead parallel sessions, F.4 Unit test: `isProcessActive` etime parsing, F.5 Frontend test: recovery and infra-stuck badges, F.6 Unit test: breaker honors recovery window boundary, F.7 Unit test: unstick route resets recovery window (+1 more)
-
-### Community 775 - "Community 775"
-Cohesion: 0.22
-Nodes (9): Problem 1: Dead/stuck parallel review sessions are invisible to deacon, Problem 2: No circuit breaker for infrastructure-failure cycling, Problem 3: Verification passed but review blocks the pipeline forever, Problem 4: Incomplete parallel reviews waste completed findings, Problem 5: `stuck` flag is never checked in re-dispatch path, Problem 6: No cycle boundary for the circuit breaker, Problem 7: No UI indication that recovery is happening, Problem 8: Multiple actors can manipulate the same review tmux sessions (+1 more)
-
-### Community 776 - "Community 776"
-Cohesion: 0.22
-Nodes (9): code:block4 (┌───────────────────────────────────────────────────────────), code:block5 (┌──────────────────────────────────────────────────────────┐), First-run welcome, Project detail page (`/projects/:projectKey`), Project list page (`/projects`), Setup Agent in the agent list, Steps, UX Specification (+1 more)
-
-### Community 777 - "Community 777"
-Cohesion: 0.22
-Nodes (9): US-1 — First project (zero state), US-2 — Second project (existing user), US-3 — Watch the Setup Agent work, US-4 — Review generated docs, US-5 — Edit an existing project's config, US-6 — Re-run setup after adding repos, US-7 — Remove a project, US-8 — Dogfood through the dashboard (+1 more)
-
-### Community 778 - "Community 778"
-Cohesion: 0.22
-Nodes (8): Acceptance Criteria, Backend: Deacon stuck detection, Background, Files Modified, Frontend: Recovery UI indicators, PRD: Stuck Parallel Review Detection, Recovery, and UI Indicators (PAN-794), Risks and Mitigations, Solution Overview
-
-### Community 779 - "Community 779"
-Cohesion: 0.22
-Nodes (9): Agent Events, Cost / Bead Events, Domain Events Catalog, Issue Events, Pipeline Events, Planning Events, Resource Events, Specialist Events (+1 more)
-
-### Community 780 - "Community 780"
-Cohesion: 0.22
-Nodes (9): Build System: esbuild → tsdown + Vite, code:typescript (// Auto-detect runtime for HTTP server), code:typescript (// T3Code pattern: apps/server/src/terminal/Layers/BunPTY.ts), Effect Version: `4.0.0-beta.43` (pinned), Package Manager: npm → Bun, PTY: Dual-Runtime Terminal, Runtime: Dual-Mode (Bun + Node), SQLite: Dual-Runtime (+1 more)
-
-### Community 781 - "Community 781"
-Cohesion: 0.22
-Nodes (9): Acceptance criteria, Action parity, Density, Issue-selected mode, JSONL resolution, Liveness, Reviewer canonical naming + resumption, Three-zone Command Deck (+1 more)
-
-### Community 782 - "Community 782"
-Cohesion: 0.22
-Nodes (9): Implementation plan, Phase 0 — Reading, Phase 1 — Reviewer canonical naming + resumption (server-side), Phase 2 — Three-zone Command Deck shell (frontend), Phase 3 — Liveness building blocks, Phase 4 — Issue-selected mode, Phase 5 — Action surface parity (additive only), Phase 6 — Tree node redesign + dividers (+1 more)
-
-### Community 783 - "Community 783"
-Cohesion: 0.22
-Nodes (8): Critical Discovery: PAN-759 Root Cause, Documents, Files to Modify, Guiding Principle, Open Questions / Research Needed, PAN-798: Eliminate All tmux capture-pane Usage, Problem Statement, Success Criteria
-
-### Community 784 - "Community 784"
-Cohesion: 0.22
-Nodes (8): Current Status, Decisions, PAN-408: Wire vBRIEF Acceptance Criteria into Specialist Pipeline, Part 1: Wire AC into Specialist Pipeline, Part 2: Documentation Alignment, Remaining Work, Specialist Feedback, What Was Done
-
-### Community 785 - "Community 785"
-Cohesion: 0.22
-Nodes (8): Not In Scope Here, PAN-632 Implementation Plan, Principles, Slice 1: Foundation, Slice 2: Review Artifact Creation, Slice 3: Readiness and Verification, Slice 4: Merge Orchestration, Slice 5: Recovery and Validation
-
 ### Community 786 - "Community 786"
-Cohesion: 0.22
-Nodes (8): Acceptance summary, Approach (chosen), Changes, Files touched, Out of scope, PAN-699 — Conversation view renders tool calls out of terminal order, Problem, Testing
+Cohesion: 0.28
+Nodes (7): detectTestCommand(), detectTestCommandEffect(), fileExists(), command, jestConfig, packageJson, testDir
 
 ### Community 787 - "Community 787"
-Cohesion: 0.22
-Nodes (8): Approach, code:block1 (vitest --run --no-file-parallelism && cd src/dashboard/front), code:block2 (vitest --run --no-file-parallelism), Convention, Decision, PAN-645: Tests: root Vitest config does not discover ActionsSection.test.tsx, Problem, Scope
+Cohesion: 0.28
+Nodes (6): BYTE_UNITS, hist, parseBytes(), parseMemUsage(), parseNetIO(), result
 
 ### Community 788 - "Community 788"
 Cohesion: 0.22
-Nodes (8): Acceptance Criteria, Approach, Difficulty, Goal, Out of Scope, PAN-655: PRD Pipeline Test Marker, Risks, Scope
+Nodes (8): MOCK_HEALTH_RESPONSE, MOCK_PROJECT_SPECIALISTS_RESPONSE, MOCK_SPECIALISTS_RESPONSE, panBadge, perProjectHeader, sectionHeader, sessionCard, statusBar
 
 ### Community 789 - "Community 789"
 Cohesion: 0.22
-Nodes (8): Approach, Decision, Difficulty, Files Modified, PAN-494: pan start fails if workspace doesn't exist, Problem, Root Cause, Scope
+Nodes (5): dispatchMenuAction(), consoleErrors, flywheelStatus, MockWebSocket, statusPane
 
 ### Community 790 - "Community 790"
-Cohesion: 0.22
-Nodes (9): Cache invalidation, code:typescript (import { renderPrompt } from './prompts.js';), code:typescript (export function renderPrompt(options: RenderPromptOptions): ), code:block3 (Prompt "work" (.../prompts/work.md) requires variables that ), Error handling, Prompts directory resolution, Signature, The `renderPrompt` API (+1 more)
+Cohesion: 0.25
+Nodes (7): ActivityItem, callSummarizer(), flush(), OpenAIChatCompletion, startTtsSummarizer(), state, SummarizerState
 
 ### Community 791 - "Community 791"
 Cohesion: 0.22
-Nodes (9): 1. Start Broad, Then Narrow, 2. Follow the Imports, 3. Read Tests to Understand Usage, 4. Look for README and Docs, 5. Use Multiple Techniques, Best Practices, code:typescript (Read file_path="src/index.ts"  // See what it imports), code:bash (Glob pattern="**/*.test.ts") (+1 more)
+Nodes (6): chalk, exitSpy, logs, MockCostThresholdError, mockEnrichSessions, output
 
 ### Community 792 - "Community 792"
-Cohesion: 0.22
-Nodes (9): code:bash (Grep pattern="try.*catch|\.catch\(" output_mode="content" -A), code:bash (Grep pattern="process\.env\." output_mode="content" -A 0), code:bash (Grep pattern="@Entity|CREATE TABLE" output_mode="files_with_), code:bash (Glob pattern="**/*.test.ts"), Common Questions, "How are tests structured?", "How is error handling done?", "What database tables exist?" (+1 more)
+Cohesion: 0.36
+Nodes (8): getAllSpecialistStatus(), LegacySpecialistRuntimeStatus, displaySpecialist(), getRelativeTime(), getStatusColor(), getStatusIcon(), listCommand(), ListOptions
 
 ### Community 793 - "Community 793"
 Cohesion: 0.22
-Nodes (8): Blocking Issues, code:bash (bd list               # See all tasks), code:bash (bd dep tree <id>        # See what's blocking this issue), code:bash (# Close multiple beads atomically), code:bash (bd create --title "Implement feature X" --parent <parent-id>), code:bash (# Make issue-A blocked by issue-B (A cannot start until B is), Creating Sub-Tasks, Task Tracking (Beads)
+Nodes (9): After making changes, Building and Running, code:bash (npm run build           # Compiles TypeScript to dist/ via t), code:bash (npm run dev             # Dashboard with hot reload (Vite fr), code:bash (# ALWAYS use the explicit Node 22 path), code:bash (npm run build && npm link   # Rebuild + re-link `pan` global), Development mode, Full build (+1 more)
 
 ### Community 794 - "Community 794"
 Cohesion: 0.22
-Nodes (8): Algorithm Complexity, Blocking Operations (CRITICAL for Node.js), code:typescript (// Replace execSync with async version), Concurrency, Database/API Patterns, Memory & Resources, Output Format, Performance Review
+Nodes (9): code:bash (# Activate Node 22 (always required)), code:bash (cp .env.example ~/.panopticon.env), code:bash (cd /path/to/panopticon-cli), code:bash (pan status          # Should show "Panopticon is running" or), Development Setup, Environment, Initialize beads (once per project), Prerequisites (+1 more)
 
 ### Community 795 - "Community 795"
 Cohesion: 0.22
-Nodes (9): Agent Logs, Capture Full Session, code:bash (# Watch agent in real-time (Ctrl+b d to detach)), code:bash (# Capture entire scrollback buffer), code:bash (# Search for errors), code:bash (# Capture all agents), Live Output, Multiple Agents (+1 more)
+Nodes (8): code:markdown (## Summary), code:block5 (panopticon-cli/), Contributing to Panopticon CLI, Filing Bugs, Issue Tracking, Key Invariants, Repository Layout, Table of Contents
 
 ### Community 796 - "Community 796"
 Cohesion: 0.22
-Nodes (9): code:markdown (## Database Conventions), code:markdown (## Build Commands), code:markdown (## Architecture: CQRS Pattern), code:markdown (## Testing Philosophy), Example 1: Database Schema, Example 2: Build System, Example 3: Architecture Pattern, Example 4: Testing Approach (+1 more)
+Nodes (8): [0.7.0] — Command Taxonomy Reorganization, Breaking Changes, Changed, Changelog, Changes, Deprecations Removed, New Commands, Unreleased
 
 ### Community 797 - "Community 797"
 Cohesion: 0.22
-Nodes (8): code:bash (rm -rf .claude/skills/knowledge-capture/), code:yaml (---), File Locations, For New/Legacy Codebases, Integration with Other Skills, Knowledge Capture, Override Skill Format, User Commands (Escalating Silence)
+Nodes (9): 1. Reviewer canonical sessions (PAN-830) — persistent across rounds, 2. Other specialist dispatches (test-agent, merge-agent, etc.) — fresh per dispatch, code:block14 (specialist-<projectKey>-<issueId>-review-<role>), code:block15 (IMPORTANT: This is a NEW task dispatch. You may have context), code:bash (# Reset via CLI — clears session state and context digest), Context Digest (cross-dispatch memory), Event-driven status (PAN-915), Resetting a Specialist (+1 more)
 
 ### Community 798 - "Community 798"
 Cohesion: 0.22
-Nodes (8): code:bash (pan unarchive-conversation <query>), code:bash (pan unarchive-conversation "Models, Models, Models"), Notes, See Also, unarchive-conversation, Usage, What It Does, When to Use
+Nodes (8): Current State (2026), Decision Log, Guiding Principle, Panopticon Product Vision, Phase 1 — Shared Instance, Phase 2 — Multi-Tenant SaaS, Vision Roadmap, Why local-first?
 
 ### Community 799 - "Community 799"
 Cohesion: 0.22
-Nodes (9): code:bash (# Don't use --no-daemon for CRUD operations), code:bash (bd --no-daemon update issue-1 --status in_progress), code:bash (bd --no-daemon update issue-1 --status in_progress), code:bash (bd --no-daemon update issue-1 --status in_progress), Resolution, Root Cause, Status Updates Not Visible, Symptom (+1 more)
+Nodes (9): code:bash (# Register a project), code:json ([), code:bash (LINEAR_API_KEY=lin_api_xxxxx), Configuration, Environment File, Issue Trackers, Map Linear Projects to Local Directories, Rally Features and Derived Status (+1 more)
 
 ### Community 800 - "Community 800"
 Cohesion: 0.22
-Nodes (9): code:bash (# Create proto), code:bash (# Patrol proto exists), code:bash (bd mol spawn mol-deploy --attach mol-rollback --attach-type ), code:bash (# After completing a good workflow organically), Common Patterns, Pattern: Capture Tribal Knowledge, Pattern: Ephemeral Patrol Cycle, Pattern: Feature with Rollback (+1 more)
+Nodes (9): code:block3 (┌───────────────────────────────────────────────────────────), code:block4 (┌───────────────────────────────────────────────────────────), code:block5 (~/.panopticon/), code:bash (# CLI equivalent of /work-issue MIN-648), Panopticon Ships Batteries-Included, The Mayor Architecture: Dual-Interface Design, The Mayor Concept (from Gastown), What `pan sync` Syncs (+1 more)
 
 ### Community 801 - "Community 801"
 Cohesion: 0.22
-Nodes (9): Basic Spawn (Creates Wisp by Default), code:bash (bd mol spawn mol-patrol                    # Creates wisp (e), code:bash (bd mol pour mol-feature                    # Shortcut for sp), code:bash (bd mol run mol-release --var version=2.0), code:bash (bd mol spawn mol-feature --attach mol-testing --var name=aut), code:bash (bd mol spawn mol-deploy --attach mol-rollback --attach-type ), Spawn with Attachments, Spawn with Immediate Execution (+1 more)
+Nodes (8): Automatic Recovery, code:block50 (┌───────────────────────────────────────────────────────────), code:typescript (interface AgentHealth {), code:typescript (async function handleStuckAgent(agentId: string) {), Health Check Flow, Panopticon Health Dashboard, Part 7: Stuck Detection and Health Monitoring, The Deacon Pattern
 
 ### Community 802 - "Community 802"
 Cohesion: 0.22
-Nodes (9): Advanced Patterns, code:block36 (setup), code:block37 (core-feature (ready immediately)), code:block38 (research-main), code:block39 (auth-epic), Pattern: Diamond Dependencies, Pattern: Discovery Cascade, Pattern: Epic with Phases (+1 more)
+Nodes (8): Brief authoring, code:text (${PANOPTICON_HOME:-~/.panopticon}/flywheel/runs/<RUN-ID>/), Flywheel, Lifecycle, Settings → Roles → Flywheel, Skill → CLI → API → UI map, Status contract, Status vs State
 
 ### Community 803 - "Community 803"
 Cohesion: 0.22
-Nodes (8): Agent Beads, Bead Types, CLI Reference, code:block1 (idle → spawning → running/working → done → idle), Monitoring Integration, Slot Architecture, State Machine, When to Use Agent Beads
+Nodes (9): 2.1 Workspace Creation Flow, code:bash (exe ssh min-667 "cd /workspace && docker compose up -d fe ap), code:bash (# exe.dev's HTTPS proxy handles this automatically), code:yaml (# ~/.panopticon/workspaces/min-667.yaml), code:bash (pan workspace create MIN-667 --remote), code:bash (exe vm create min-667), code:bash (exe ssh min-667 "git clone git@github.com:org/repo.git /work), code:bash (exe ssh min-667 "cat > /workspace/.env << 'EOF') (+1 more)
 
 ### Community 804 - "Community 804"
 Cohesion: 0.22
-Nodes (9): code:bash (# Import issues from JSONL), code:bash (# Migrate databases after version upgrade), code:bash (# List all running daemons), code:bash (# Commit pending local Dolt changes), Daemon Management, Database Management, Import/Export, Migration (+1 more)
+Nodes (8): Acceptance Criteria, code:block24 (Foundation), Implementation — Single Branch, Hard Cut, Open Questions, PAN-1048: Unify Agent Type System — Role Primitive with Reactive Cloister, Problem, Related Issues, Vision
 
 ### Community 805 - "Community 805"
 Cohesion: 0.22
-Nodes (9): code:bash (# Explicitly enable sandbox mode), code:bash (# Skip staleness check (emergency escape hatch)), code:bash (# Force metadata update even when DB appears synced), code:bash (# JSON output for programmatic use), Force Import, Global Flags, Other Global Flags, Sandbox Mode (+1 more)
+Nodes (8): Acceptance Criteria, Backend: Deacon stuck detection, Background, Files Modified, Frontend: Recovery UI indicators, PRD: Stuck Parallel Review Detection, Recovery, and UI Indicators (PAN-794), Risks and Mitigations, Solution Overview
 
 ### Community 806 - "Community 806"
 Cohesion: 0.22
-Nodes (9): Batch Operations, Claim and Complete Work, code:bash (# 1. Find available work), code:bash (# While working on bd-100, discover a bug), code:bash (# Update multiple issues at once), code:bash (# Start of session), Common Patterns for AI Agents, Discover and Link Work (+1 more)
+Nodes (9): Problem 1: Dead/stuck parallel review sessions are invisible to deacon, Problem 2: No circuit breaker for infrastructure-failure cycling, Problem 3: Verification passed but review blocks the pipeline forever, Problem 4: Incomplete parallel reviews waste completed findings, Problem 5: `stuck` flag is never checked in re-dispatch path, Problem 6: No cycle boundary for the circuit breaker, Problem 7: No UI indication that recovery is happening, Problem 8: Multiple actors can manipulate the same review tmux sessions (+1 more)
 
 ### Community 807 - "Community 807"
 Cohesion: 0.22
-Nodes (9): Close/Reopen Issues, code:bash (# Basic creation), code:bash (# Update one or more issues), code:bash (# Complete work (supports multiple IDs)), code:bash (# Show dependency tree), Create Issues, Issue Management, Update Issues (+1 more)
+Nodes (9): C.1 Add migration in `schema.ts`, C.2 Update `upsertReviewStatus` in `review-status-db.ts`, C.3 Update `rowToReviewStatus` in `review-status-db.ts`, C. Database schema changes (`src/lib/database/schema.ts` + `src/lib/database/review-status-db.ts`), code:typescript (// v24 → v25: add review_retry_count and recovery_started_at), code:typescript (export const ReviewStatusSnapshot = Schema.Struct({), D.1 Add new fields to `ReviewStatusSnapshot`, D. `packages/contracts/src/types.ts` (+1 more)
 
 ### Community 808 - "Community 808"
 Cohesion: 0.22
-Nodes (9): Advanced Operations, Cleanup, code:bash (# Clean up closed issues (bulk deletion)), code:bash (# Find and merge duplicate issues), code:bash (# Agent-driven compaction), code:bash (# Rename issue prefix (e.g., from 'knowledge-work-' to 'kw-'), Compaction (Memory Decay), Duplicate Detection & Merging (+1 more)
+Nodes (9): code:typescript (describe('isInfrastructureFailure', () => {), F.1 Unit test: `isInfrastructureFailure`, F.2 Unit test: circuit breaker in `checkOrphanedReviewStatuses`, F.3 Unit test: `checkStuckReviewing` with dead parallel sessions, F.4 Unit test: `isProcessActive` etime parsing, F.5 Frontend test: recovery and infra-stuck badges, F.6 Unit test: breaker honors recovery window boundary, F.7 Unit test: unstick route resets recovery window (+1 more)
 
 ### Community 809 - "Community 809"
 Cohesion: 0.22
-Nodes (9): Checklist Templates, code:block30 (- [ ] Check for .beads/ directory), code:block31 (- [ ] Notice new work needed), code:block32 (- [ ] Implementation done), code:block33 (- [ ] Create epic for overall goal), Completing Work, Creating Issues During Work, Planning Complex Features (+1 more)
+Nodes (9): code:block4 (┌───────────────────────────────────────────────────────────), code:block5 (┌──────────────────────────────────────────────────────────┐), First-run welcome, Project detail page (`/projects/:projectKey`), Project list page (`/projects`), Setup Agent in the agent list, Steps, UX Specification (+1 more)
 
 ### Community 810 - "Community 810"
 Cohesion: 0.22
-Nodes (9): code:block26 (1. Create research issue with question to answer), code:block27 (1. Create bug issue), code:block28 (1. Create issues for each refactoring step), code:block29 (1. Create spike issue: "Investigate caching options"), Common Workflow Patterns, Pattern: Bug Investigation, Pattern: Refactoring with Dependencies, Pattern: Spike Investigation (+1 more)
+Nodes (9): US-1 — First project (zero state), US-2 — Second project (existing user), US-3 — Watch the Setup Agent work, US-4 — Review generated docs, US-5 — Edit an existing project's config, US-6 — Re-run setup after adding repos, US-7 — Remove a project, US-8 — Dogfood through the dashboard (+1 more)
 
 ### Community 811 - "Community 811"
 Cohesion: 0.22
-Nodes (9): code:bash (# See issues from your tracker), code:bash (# Replace PAN-3 with your issue ID), code:bash (# Check agent status), code:bash (# Send message to agent), Create Workspace and Spawn Agent, Interact with Agent, List Available Issues, Monitor Agent Progress (+1 more)
+Nodes (8): Acceptance Criteria, Backend: Deacon stuck detection, Background, Files Modified, Frontend: Recovery UI indicators, PRD: Stuck Parallel Review Detection, Recovery, and UI Indicators (PAN-794), Risks and Mitigations, Solution Overview
 
 ### Community 812 - "Community 812"
 Cohesion: 0.22
-Nodes (9): Agent session not starting, code:bash (# Start Docker daemon), code:bash (# Find what's using the port), code:bash (# Verify API key is set), code:bash (# Check tmux is installed), Common First-Time Issues, Docker not running, Issue tracker not configured (+1 more)
+Nodes (9): Build System: esbuild → tsdown + Vite, code:typescript (// Auto-detect runtime for HTTP server), code:typescript (// T3Code pattern: apps/server/src/terminal/Layers/BunPTY.ts), Effect Version: `4.0.0-beta.43` (pinned), Package Manager: npm → Bun, PTY: Dual-Runtime Terminal, Runtime: Dual-Mode (Bun + Node), SQLite: Dual-Runtime (+1 more)
 
 ### Community 813 - "Community 813"
 Cohesion: 0.22
-Nodes (8): code:bash (npx add-skill google-labs-code/stitch-skills --skill react:c), code:text (Convert my Landing Page screen in my Podcast Stitch Project ), code:text (skills/react-components/), Example Prompt, How it Works, Install, Skill Structure, Stitch to React Components Skill
+Nodes (9): Agent Events, Cost / Bead Events, Domain Events Catalog, Issue Events, Pipeline Events, Planning Events, Resource Events, Specialist Events (+1 more)
 
 ### Community 814 - "Community 814"
 Cohesion: 0.22
-Nodes (9): code:bash (# Check port availability), code:bash (# Check API is running), code:bash (# Restart the API server), code:bash (# Check server logs), "CORS error" in browser, Dashboard Issues, Dashboard shows stale data, Dashboard won't start (+1 more)
+Nodes (9): Implementation plan, Phase 0 — Reading, Phase 1 — Reviewer canonical naming + resumption (server-side), Phase 2 — Three-zone Command Deck shell (frontend), Phase 3 — Liveness building blocks, Phase 4 — Issue-selected mode, Phase 5 — Action surface parity (additive only), Phase 6 — Tree node redesign + dividers (+1 more)
 
 ### Community 815 - "Community 815"
 Cohesion: 0.22
-Nodes (9): code:bash (# Check config file exists), code:bash (# Test the key), code:bash (# Test the token), code:bash (# Fix permissions (should be readable only by owner)), Config file permissions, Configuration Issues, "GitHub token invalid", "Invalid Linear API key" (+1 more)
+Nodes (9): Acceptance criteria, Action parity, Density, Issue-selected mode, JSONL resolution, Liveness, Reviewer canonical naming + resumption, Three-zone Command Deck (+1 more)
 
 ### Community 816 - "Community 816"
 Cohesion: 0.22
-Nodes (9): Agent crashed, Agent is stuck, Agent Issues, Agent won't start, code:bash (# Check if session exists), code:bash (# List all), code:bash (# Check tmux is available), code:bash (# Check what it's doing) (+1 more)
+Nodes (8): Critical Discovery: PAN-759 Root Cause, Documents, Files to Modify, Guiding Principle, Open Questions / Research Needed, PAN-798: Eliminate All tmux capture-pane Usage, Problem Statement, Success Criteria
 
 ### Community 817 - "Community 817"
 Cohesion: 0.22
-Nodes (8): code:bash (npx add-skill google-labs-code/stitch-skills --skill design-), code:text (Analyze my Furniture Collection project's Home screen and ge), code:text (design-md/), Example Prompt, How it Works, Install, Skill Structure, Stitch Design System Documentation Skill
+Nodes (8): Current Status, Decisions, PAN-408: Wire vBRIEF Acceptance Criteria into Specialist Pipeline, Part 1: Wire AC into Specialist Pipeline, Part 2: Documentation Alignment, Remaining Work, Specialist Feedback, What Was Done
 
 ### Community 818 - "Community 818"
 Cohesion: 0.22
-Nodes (8): code:bash (cd /home/eltmon/projects/panopticon/src/dashboard/frontend &), code:bash (pkill -f "node.*dashboard" 2>/dev/null || true), code:bash (cd /home/eltmon/projects/panopticon/src/dashboard && npm run), code:bash (sleep 6), Notes, Pan Dashboard Restart, Steps, Triggers
+Nodes (8): Not In Scope Here, PAN-632 Implementation Plan, Principles, Slice 1: Foundation, Slice 2: Review Artifact Creation, Slice 3: Readiness and Verification, Slice 4: Merge Orchestration, Slice 5: Recovery and Validation
 
 ### Community 819 - "Community 819"
 Cohesion: 0.22
-Nodes (9): code:bash (RALLY_API_KEY=_xxxxx), code:yaml (# ~/.panopticon/projects.yaml), code:yaml (issue_prefixes: [F, US, DE, TA, TC]), code:yaml (projects:), Configuration, Rally ID Formats, Rally Integration, Setup (+1 more)
+Nodes (8): Acceptance summary, Approach (chosen), Changes, Files touched, Out of scope, PAN-699 — Conversation view renders tool calls out of terminal order, Problem, Testing
 
 ### Community 820 - "Community 820"
-Cohesion: 0.25
-Nodes (7): composeCall, globalSettings, hookPath, { mockExecAsync }, result, validHookPath, workspaceSettings
+Cohesion: 0.22
+Nodes (8): Approach, code:block1 (vitest --run --no-file-parallelism && cd src/dashboard/front), code:block2 (vitest --run --no-file-parallelism), Convention, Decision, PAN-645: Tests: root Vitest config does not discover ActionsSection.test.tsx, Problem, Scope
 
 ### Community 821 - "Community 821"
-Cohesion: 0.25
-Nodes (5): devroot, mockGetDevrootPath, result, skillsDir, userSkillDir
+Cohesion: 0.22
+Nodes (8): Acceptance Criteria, Approach, Difficulty, Goal, Out of Scope, PAN-655: PRD Pipeline Test Marker, Risks, Scope
 
 ### Community 822 - "Community 822"
-Cohesion: 0.25
-Nodes (7): capturedArgs, capturedCmds, closedBeads, mockExecFileFn, mockExecFn, mockGetVBriefACStatus, mockSyncBeadStatusToVBrief
+Cohesion: 0.22
+Nodes (8): Approach, Decision, Difficulty, Files Modified, PAN-494: pan start fails if workspace doesn't exist, Problem, Root Cause, Scope
 
 ### Community 823 - "Community 823"
-Cohesion: 0.32
-Nodes (7): bin(), main(), repoRoot, run(), source, target, venvDir
+Cohesion: 0.22
+Nodes (9): Cache invalidation, code:typescript (import { renderPrompt } from './prompts.js';), code:typescript (export function renderPrompt(options: RenderPromptOptions): ), code:block3 (Prompt "work" (.../prompts/work.md) requires variables that ), Error handling, Prompts directory resolution, Signature, The `renderPrompt` API (+1 more)
 
 ### Community 824 - "Community 824"
-Cohesion: 0.25
-Nodes (7): RallyApiConfig, RallyCreateConfig, RallyCreateResult, RallyQueryConfig, RallyQueryResult, RallyUpdateConfig, RallyUpdateResult
+Cohesion: 0.22
+Nodes (9): 1. Start Broad, Then Narrow, 2. Follow the Imports, 3. Read Tests to Understand Usage, 4. Look for README and Docs, 5. Use Multiple Techniques, Best Practices, code:typescript (Read file_path="src/index.ts"  // See what it imports), code:bash (Glob pattern="**/*.test.ts") (+1 more)
 
 ### Community 825 - "Community 825"
-Cohesion: 0.25
-Nodes (4): clientMock, octokitMock, result, states
+Cohesion: 0.22
+Nodes (9): code:bash (Grep pattern="try.*catch|\.catch\(" output_mode="content" -A), code:bash (Grep pattern="process\.env\." output_mode="content" -A 0), code:bash (Grep pattern="@Entity|CREATE TABLE" output_mode="files_with_), code:bash (Glob pattern="**/*.test.ts"), Common Questions, "How are tests structured?", "How is error handling done?", "What database tables exist?" (+1 more)
 
 ### Community 826 - "Community 826"
-Cohesion: 0.25
-Nodes (3): PendingCompletion, _pendingCompletions, SpecialistCompletionResult
+Cohesion: 0.22
+Nodes (8): Blocking Issues, code:bash (bd list               # See all tasks), code:bash (bd dep tree <id>        # See what's blocking this issue), code:bash (# Close multiple beads atomically), code:bash (bd create --title "Implement feature X" --parent <parent-id>), code:bash (# Make issue-A blocked by issue-B (A cannot start until B is), Creating Sub-Tasks, Task Tracking (Beads)
 
 ### Community 827 - "Community 827"
-Cohesion: 0.36
-Nodes (6): ClaudeAuthStatus, getClaudeAuthStatus(), parseOAuthPayload(), readKeychainCredentials(), raw, result
+Cohesion: 0.22
+Nodes (8): Algorithm Complexity, Blocking Operations (CRITICAL for Node.js), code:typescript (// Replace execSync with async version), Concurrency, Database/API Patterns, Memory & Resources, Output Format, Performance Review
 
 ### Community 828 - "Community 828"
-Cohesion: 0.32
-Nodes (7): BASE_TIME, loadAgents(), loadDeaconWithResumeMock(), saveStoppedAgent(), state, updated, workspaceFor()
+Cohesion: 0.22
+Nodes (9): Agent Logs, Capture Full Session, code:bash (# Watch agent in real-time (Ctrl+b d to detach)), code:bash (# Capture entire scrollback buffer), code:bash (# Search for errors), code:bash (# Capture all agents), Live Output, Multiple Agents (+1 more)
 
 ### Community 829 - "Community 829"
-Cohesion: 0.25
-Nodes (7): baseSettings, exp, method, section, sections, settingsBtn, toggle
+Cohesion: 0.22
+Nodes (9): code:markdown (## Database Conventions), code:markdown (## Build Commands), code:markdown (## Architecture: CQRS Pattern), code:markdown (## Testing Philosophy), Example 1: Database Schema, Example 2: Build System, Example 3: Architecture Pattern, Example 4: Testing Approach (+1 more)
 
 ### Community 830 - "Community 830"
-Cohesion: 0.39
-Nodes (6): getAllActiveQueues(), MergeTriggerHandler, resumeQueuedMerges(), setMergeQueueTriggerHandler(), { getAllActiveQueuesMock }, triggerHandler
+Cohesion: 0.22
+Nodes (8): code:bash (rm -rf .claude/skills/knowledge-capture/), code:yaml (---), File Locations, For New/Legacy Codebases, Integration with Other Skills, Knowledge Capture, Override Skill Format, User Commands (Escalating Silence)
 
 ### Community 831 - "Community 831"
-Cohesion: 0.32
-Nodes (6): execAsync, restoreTrackedBeadsExport(), after, before, content, notGit
+Cohesion: 0.22
+Nodes (8): code:bash (pan unarchive-conversation <query>), code:bash (pan unarchive-conversation "Models, Models, Models"), Notes, See Also, unarchive-conversation, Usage, What It Does, When to Use
 
 ### Community 832 - "Community 832"
-Cohesion: 0.32
-Nodes (6): agentDir(), AGENTS_DIR, cleanup(), ctxFile(), id, ids
+Cohesion: 0.22
+Nodes (9): code:bash (# Don't use --no-daemon for CRUD operations), code:bash (bd --no-daemon update issue-1 --status in_progress), code:bash (bd --no-daemon update issue-1 --status in_progress), code:bash (bd --no-daemon update issue-1 --status in_progress), Resolution, Root Cause, Status Updates Not Visible, Symptom (+1 more)
 
 ### Community 833 - "Community 833"
-Cohesion: 0.25
-Nodes (8): Activity Log, code:block17 (Agent runs `pan done` (Bash command)), Full Review Flow, Human Intervention, Key API Endpoints, Review Cycle Circuit Breaker, verificationStatus semantics, What Happens at the Limit
+Cohesion: 0.22
+Nodes (9): Basic Spawn (Creates Wisp by Default), code:bash (bd mol spawn mol-patrol                    # Creates wisp (e), code:bash (bd mol pour mol-feature                    # Shortcut for sp), code:bash (bd mol run mol-release --var version=2.0), code:bash (bd mol spawn mol-feature --attach mol-testing --var name=aut), code:bash (bd mol spawn mol-deploy --attach mol-rollback --attach-type ), Spawn with Attachments, Spawn with Immediate Execution (+1 more)
 
 ### Community 834 - "Community 834"
-Cohesion: 0.25
-Nodes (7): code:bash (pan workspace rebuild <issue-id>), Compose contract, Health surfaces, Recovery commands, Single-deacon invariant, Spawn gate and break-glass, Workspace Containers
+Cohesion: 0.22
+Nodes (9): code:bash (# Create proto), code:bash (# Patrol proto exists), code:bash (bd mol spawn mol-deploy --attach mol-rollback --attach-type ), code:bash (# After completing a good workflow organically), Common Patterns, Pattern: Capture Tribal Knowledge, Pattern: Ephemeral Patrol Cycle, Pattern: Feature with Rollback (+1 more)
 
 ### Community 835 - "Community 835"
-Cohesion: 0.25
-Nodes (7): code:block24 (Worker Agent completes work), Getting Help, Panopticon Usage Guide, Specialist Types, Specialist Workflow, Specialists, Table of Contents
+Cohesion: 0.22
+Nodes (9): Advanced Patterns, code:block36 (setup), code:block37 (core-feature (ready immediately)), code:block38 (research-main), code:block39 (auth-epic), Pattern: Diamond Dependencies, Pattern: Discovery Cascade, Pattern: Epic with Phases (+1 more)
 
 ### Community 836 - "Community 836"
-Cohesion: 0.25
-Nodes (8): Appendix B: Comparisons (FAQ), Can Panopticon and Gastown work together?, Can Panopticon and Vibe Kanban work together?, code:block140 (┌─────────────┐     ┌─────────────┐     ┌─────────────┐), How does Panopticon compare to Gastown?, How does Panopticon compare to Vibe Kanban?, Should I use Panopticon, Gastown, or Vibe Kanban?, Why build Panopticon when these tools exist?
+Cohesion: 0.22
+Nodes (8): Agent Beads, Bead Types, CLI Reference, code:block1 (idle → spawning → running/working → done → idle), Monitoring Integration, Slot Architecture, State Machine, When to Use Agent Beads
 
 ### Community 837 - "Community 837"
-Cohesion: 0.25
-Nodes (8): CLI Distribution Strategy, code:bash (# First time - zero install), code:bash (# pan init adds to ~/.bashrc or ~/.zshrc:), code:bash (npm install -g panopticon), code:bash (brew install panopticon      # macOS), Future: Homebrew/apt (v2), Primary: npx + Auto-Aliasing, Secondary: Global npm Install
+Cohesion: 0.22
+Nodes (9): code:bash (# Explicitly enable sandbox mode), code:bash (# Skip staleness check (emergency escape hatch)), code:bash (# Force metadata update even when DB appears synced), code:bash (# JSON output for programmatic use), Force Import, Global Flags, Other Global Flags, Sandbox Mode (+1 more)
 
 ### Community 838 - "Community 838"
-Cohesion: 0.25
-Nodes (7): Brief authoring, code:text (${PANOPTICON_HOME:-~/.panopticon}/flywheel/runs/<RUN-ID>/), Flywheel, Lifecycle, Settings → Roles → Flywheel, Skill → CLI → API → UI map, Status contract
+Cohesion: 0.22
+Nodes (9): Advanced Operations, Cleanup, code:bash (# Clean up closed issues (bulk deletion)), code:bash (# Find and merge duplicate issues), code:bash (# Agent-driven compaction), code:bash (# Rename issue prefix (e.g., from 'knowledge-work-' to 'kw-'), Compaction (Memory Decay), Duplicate Detection & Merging (+1 more)
 
 ### Community 839 - "Community 839"
-Cohesion: 0.25
-Nodes (8): 2. Panopticon's Current Distribution (Broken), code:block5 (TIER 1: REPO SOURCE), code:typescript (if (!existsSync(destPath)) {), Current Inventory, Problem 1: Stale Copies, Problem 2: Known Symlink Bug, Problem 3: Wrong Priority Level, The Three-Tier Flow
+Cohesion: 0.22
+Nodes (9): code:bash (# Import issues from JSONL), code:bash (# Migrate databases after version upgrade), code:bash (# List all running daemons), code:bash (# Commit pending local Dolt changes), Daemon Management, Database Management, Import/Export, Migration (+1 more)
 
 ### Community 840 - "Community 840"
-Cohesion: 0.25
-Nodes (8): 3.1 Agent Spawning, 3.2 Agent Monitoring, 3.3 Agent Lifecycle Events, code:bash (pan agent start MIN-667 --remote), code:bash (# SSH to workspace VM and start agent in tmux), code:bash (# Get agent output), code:typescript (// Agent events forwarded to dashboard via SSH polling or We), Phase 3: Remote Agent Execution
+Cohesion: 0.22
+Nodes (9): Batch Operations, Claim and Complete Work, code:bash (# 1. Find available work), code:bash (# While working on bd-100, discover a bug), code:bash (# Update multiple issues at once), code:bash (# Start of session), Common Patterns for AI Agents, Discover and Link Work (+1 more)
 
 ### Community 841 - "Community 841"
-Cohesion: 0.25
-Nodes (8): Agent Detail View, Agents Page Layout, Cloister Control Bar, code:block35 (┌───────────────────────────────────────────────────────────), code:block36 (┌───────────────────────────────────────────────────────────), code:block37 (┌───────────────────────────────────────────────────────────), code:block38 (┌───────────────────────────────────────────────────────────), Dashboard UI
+Cohesion: 0.22
+Nodes (9): Close/Reopen Issues, code:bash (# Basic creation), code:bash (# Update one or more issues), code:bash (# Complete work (supports multiple IDs)), code:bash (# Show dependency tree), Create Issues, Issue Management, Update Issues (+1 more)
 
 ### Community 842 - "Community 842"
-Cohesion: 0.25
-Nodes (8): Risk 1: Retros produce too much noise (every issue triggers a "proposal"), Risk 2: Retro-agent cost escalates, Risk 3: The skill-change pipeline introduces new failure modes, Risk 4: Autonomous daemon runs during user's active work and causes unwanted side effects, Risk 5: Q&A detection false positives (agent gets marked `waiting-on-human` when it's actually stuck), Risk 6: Proposed skill changes by the retro-agent are low-quality or hallucinated, Risk 7: Existing skills break when we add the audience field, Risks and mitigations
+Cohesion: 0.22
+Nodes (9): Checklist Templates, code:block30 (- [ ] Check for .beads/ directory), code:block31 (- [ ] Notice new work needed), code:block32 (- [ ] Implementation done), code:block33 (- [ ] Create epic for overall goal), Completing Work, Creating Issues During Work, Planning Complex Features (+1 more)
 
 ### Community 843 - "Community 843"
-Cohesion: 0.25
-Nodes (8): 9.1 Header, 9.2 Tabs, 9.3 Terminal Tab, 9.4 Info Tab, 9.5 Actions Footer, 9. Agent Detail Panel (Slide-out), code:block8 (agent-pan-505                                [X]), code:block9 (+---------------+---------------+)
+Cohesion: 0.22
+Nodes (9): code:block26 (1. Create research issue with question to answer), code:block27 (1. Create bug issue), code:block28 (1. Create issues for each refactoring step), code:block29 (1. Create spike issue: "Investigate caching options"), Common Workflow Patterns, Pattern: Bug Investigation, Pattern: Refactoring with Dependencies, Pattern: Spike Investigation (+1 more)
 
 ### Community 844 - "Community 844"
-Cohesion: 0.25
-Nodes (8): Acceptance Criteria, CLI parity, Discovery, Embeddings, Enrichment, Page, Search, Settings UI
+Cohesion: 0.22
+Nodes (9): Agent session not starting, code:bash (# Start Docker daemon), code:bash (# Find what's using the port), code:bash (# Verify API key is set), code:bash (# Check tmux is installed), Common First-Time Issues, Docker not running, Issue tracker not configured (+1 more)
 
 ### Community 845 - "Community 845"
-Cohesion: 0.25
-Nodes (8): code:bash (pan conversations scan <dir> [<dir>...]   # Targeted directo), code:typescript (interface SystemCapabilities {), code:block8 (Scanning ~/.claude/projects/...), Discovery Subsystem, MUST NOT delete or modify JSONL files, Performance-adaptive parallelism (system scan), Scripted extraction (zero LLM), Three discovery modes
+Cohesion: 0.22
+Nodes (9): code:bash (# See issues from your tracker), code:bash (# Replace PAN-3 with your issue ID), code:bash (# Check agent status), code:bash (# Send message to agent), Create Workspace and Spawn Agent, Interact with Agent, List Available Issues, Monitor Agent Progress (+1 more)
 
 ### Community 846 - "Community 846"
-Cohesion: 0.25
-Nodes (8): code:block18 (┌───────────────────────────────────────────────────────────), Conversation viewer reuse (PAN-451 dependency), Dashboard: Archived Conversations Page, Page layout, Real-time updates, Route + navigation, Row badges (`source` field), Settings panel additions — "Conversations & Search"
+Cohesion: 0.22
+Nodes (8): code:bash (npx add-skill google-labs-code/stitch-skills --skill react:c), code:text (Convert my Landing Page screen in my Podcast Stitch Project ), code:text (skills/react-components/), Example Prompt, How it Works, Install, Skill Structure, Stitch to React Components Skill
 
 ### Community 847 - "Community 847"
-Cohesion: 0.25
-Nodes (8): B.1 Add new fields to `ReviewStatus` interface, B.2 Increment `reviewRetryCount` on each deacon re-dispatch, B.3 Reset recovery window on clean completion and on new commits, B. `src/lib/review-status.ts`, code:typescript (const { dispatchParallelReview } = await import('./review-ag), code:typescript (.then(result => {), code:typescript (setReviewStatus(issueId, {), code:typescript (export interface ReviewStatus {)
+Cohesion: 0.22
+Nodes (8): Close-Out Configuration, code:bash (pan close <issue-id>), code:bash (pan close <issue-id> --json), code:yaml (close_out:), pan close, See Also, What It Does, When to Use
 
 ### Community 848 - "Community 848"
-Cohesion: 0.25
-Nodes (8): code:block4 (panopticon-cli/), code:block5 (panopticon-cli/), code:json ({), code:json ({), Current Layout, Monorepo Structure, Target Layout, Workspace Configuration
+Cohesion: 0.22
+Nodes (9): code:bash (# Check port availability), code:bash (# Check API is running), code:bash (# Restart the API server), code:bash (# Check server logs), "CORS error" in browser, Dashboard Issues, Dashboard shows stale data, Dashboard won't start (+1 more)
 
 ### Community 849 - "Community 849"
-Cohesion: 0.25
-Nodes (8): code:block16 (8 sessions · 1 alive · 7 ended · last activity 2m ago · idle), code:block21 (Select a session in the tree to send a message …), Composer behavior in issue-selected mode, Issue-selected mode, Selection rules, Why have this mode, Zone B in issue-selected mode, Zone C tab strip (NEW)
+Cohesion: 0.22
+Nodes (9): Agent crashed, Agent is stuck, Agent Issues, Agent won't start, code:bash (# Check if session exists), code:bash (# List all), code:bash (# Check tmux is available), code:bash (# Check what it's doing) (+1 more)
 
 ### Community 850 - "Community 850"
-Cohesion: 0.25
-Nodes (7): code:block1 ([IssueDataService] Rally poll error: Rally API query failed:), Dependencies, Follow-up Work, PAN-166: Rally WSAPI Query Parse Error Fix, Problem Statement, Risk Assessment, Success Criteria
+Cohesion: 0.22
+Nodes (9): code:bash (# Check config file exists), code:bash (# Test the key), code:bash (# Test the token), code:bash (# Fix permissions (should be readable only by owner)), Config file permissions, Configuration Issues, "GitHub token invalid", "Invalid Linear API key" (+1 more)
 
 ### Community 851 - "Community 851"
-Cohesion: 0.25
-Nodes (7): Acceptance Criteria, Decision, Out of Scope, PAN-448: Start Agent confirmation timeout too short, Problem, Scope, Status: Planning Complete
+Cohesion: 0.22
+Nodes (8): code:bash (npx add-skill google-labs-code/stitch-skills --skill design-), code:text (Analyze my Furniture Collection project's Home screen and ge), code:text (design-md/), Example Prompt, How it Works, Install, Skill Structure, Stitch Design System Documentation Skill
 
 ### Community 852 - "Community 852"
-Cohesion: 0.25
-Nodes (8): Additional Windows 10 Workarounds, code:ini ([wsl2]), code:powershell (wsl --shutdown), code:bash (# Check resources), code:powershell (# 1. Update WSL to latest version), Recommended Configuration, Windows 10 Limitations, WSL2 Stability Issues (Windows Users)
+Cohesion: 0.22
+Nodes (8): code:bash (cd /home/eltmon/projects/panopticon/src/dashboard/frontend &), code:bash (pkill -f "node.*dashboard" 2>/dev/null || true), code:bash (cd /home/eltmon/projects/panopticon/src/dashboard && npm run), code:bash (sleep 6), Notes, Pan Dashboard Restart, Steps, Triggers
 
 ### Community 853 - "Community 853"
-Cohesion: 0.25
-Nodes (8): Can't reach workspace URLs, code:bash (ls ~/.panopticon/traefik/certs/), code:bash (cd ~/.panopticon/traefik/certs), code:bash (mkcert -install), code:bash (docker ps | grep traefik), code:bash (ping feature-min-123.localhost), HTTPS not working, Network Issues
+Cohesion: 0.22
+Nodes (9): code:bash (RALLY_API_KEY=_xxxxx), code:yaml (# ~/.panopticon/projects.yaml), code:yaml (issue_prefixes: [F, US, DE, TA, TC]), code:yaml (projects:), Configuration, Rally ID Formats, Rally Integration, Setup (+1 more)
 
 ### Community 854 - "Community 854"
 Cohesion: 0.25
-Nodes (8): Bootstrap templates, Deleted (replaced by the loader), Legacy (ad-hoc) templates, Legacy templates, Planning agent templates, Specialist agent templates, Template catalogue, Work agent templates
+Nodes (7): composeCall, globalSettings, hookPath, { mockExecAsync }, result, validHookPath, workspaceSettings
 
 ### Community 855 - "Community 855"
 Cohesion: 0.25
-Nodes (8): Architecture Map, code:markdown (# Codebase Architecture), code:block12, code:markdown (# Feature: User Authentication), code:markdown (# Dependencies), Dependency Report, Feature Location Report, Output Formats
+Nodes (5): devroot, mockGetDevrootPath, result, skillsDir, userSkillDir
 
 ### Community 856 - "Community 856"
 Cohesion: 0.25
-Nodes (7): code:bash (# View agent output), Log Levels, Overview, Quick Commands, Related Skills, View Logs, When to Use
+Nodes (7): capturedArgs, capturedCmds, closedBeads, mockExecFileFn, mockExecFn, mockGetVBriefACStatus, mockSyncBeadStatusToVBrief
 
 ### Community 857 - "Community 857"
-Cohesion: 0.25
-Nodes (8): Available Categories, code:bash (# AI will add this section if it doesn't exist), code:bash (# Edit directly), code:bash (# Remove the AI Suggestion Preferences section), code:markdown (## AI Suggestion Preferences), Updating Preferences, User Preferences in ~/.claude/CLAUDE.md, Why Skip Categories?
+Cohesion: 0.32
+Nodes (7): bin(), main(), repoRoot, run(), source, target, venvDir
 
 ### Community 858 - "Community 858"
 Cohesion: 0.25
-Nodes (7): code:bash (pan pause <issue-id>), code:bash (pan pause PAN-123), pan pause, See Also, Usage, What It Does, When to Use
+Nodes (5): ExtractedPayload, fetchFn, provider, result, StubExtractionProvider
 
 ### Community 859 - "Community 859"
 Cohesion: 0.25
-Nodes (8): Bond Types, Bonding Molecules, code:bash (# Found bug during wisp patrol? Persist it:), code:bash (bd mol bond mol-feature mol-deploy --as "Feature with Deploy), code:bash (bd mol bond A B                    # Sequential: B runs afte), Custom Compound Names, Operand Combinations, Phase Control in Bonds
+Nodes (7): baseSettings, exp, method, section, sections, settingsBtn, toggle
 
 ### Community 860 - "Community 860"
-Cohesion: 0.25
-Nodes (7): code:bash (pan untroubled <issue-id>), code:bash (pan untroubled PAN-123), pan untroubled, See Also, Usage, What It Does, When to Use
+Cohesion: 0.39
+Nodes (7): getLiveIssueCostForIssue(), LIVE_AGENT_STATUSES, normalizeIssueId(), normalizePositiveCost(), ResolvedIssueHeadlineCost, resolveIssueHeadlineCost(), ResolveIssueHeadlineCostOptions
 
 ### Community 861 - "Community 861"
 Cohesion: 0.25
-Nodes (7): 1. Audit Current State, 2. Update Strategy, 3. For Each Update, 4. Verify, code:bash (npm outdated          # See what's outdated), code:bash (npm install package@version), Dependency Update
+Nodes (6): execSyncMock, first, parsed, result, second, settingsPath
 
 ### Community 862 - "Community 862"
-Cohesion: 0.25
-Nodes (7): code:bash (pan unpause <issue-id>), code:bash (pan unpause PAN-123), pan unpause, See Also, Usage, What It Does, When to Use
+Cohesion: 0.32
+Nodes (7): BASE_TIME, loadAgents(), loadDeaconWithResumeMock(), saveStoppedAgent(), state, updated, workspaceFor()
 
 ### Community 863 - "Community 863"
-Cohesion: 0.25
-Nodes (7): Add Repos to Workspace, After adding repos, code:bash (pan workspace add-repo <workspace-id> <repo-name> [repo-name), code:bash (# Add specific repos), How to decide which repos you need, Notes, Usage
+Cohesion: 0.32
+Nodes (6): agentDir(), AGENTS_DIR, cleanup(), ctxFile(), id, ids
 
 ### Community 864 - "Community 864"
 Cohesion: 0.25
-Nodes (7): code:bash (pan VERB <args>), code:block2 (pan VERB <id>           # Primary usage), pan VERB, See Also, Usage, What It Does, When to Use
+Nodes (8): Activity Log, code:block17 (Agent runs `pan done` (Bash command)), Full Review Flow, Human Intervention, Key API Endpoints, Review Cycle Circuit Breaker, verificationStatus semantics, What Happens at the Limit
 
 ### Community 865 - "Community 865"
 Cohesion: 0.25
-Nodes (7): code:bash (pan admin config <subcommand>), code:block2 (pan admin config shadow --status), pan admin config, See Also, Usage, What It Does, When to Use
+Nodes (7): code:bash (pan workspace rebuild <issue-id>), Compose contract, Health surfaces, Recovery commands, Single-deacon invariant, Spawn gate and break-glass, Workspace Containers
 
 ### Community 866 - "Community 866"
 Cohesion: 0.25
-Nodes (7): code:bash (pan start <issue-id>), code:block2 (pan start PAN-123          # Spawn agent for issue PAN-123), pan start, See Also, Usage, What It Does, When to Use
+Nodes (7): code:block24 (Worker Agent completes work), Getting Help, Panopticon Usage Guide, Specialist Types, Specialist Workflow, Specialists, Table of Contents
 
 ### Community 867 - "Community 867"
 Cohesion: 0.25
-Nodes (7): code:bash (pan admin tracker <subcommand>), code:block2 (pan admin tracker linear-states    # List Linear workflow st), pan admin tracker, See Also, Usage, What It Does, When to Use
+Nodes (8): CLI Distribution Strategy, code:bash (# First time - zero install), code:bash (# pan init adds to ~/.bashrc or ~/.zshrc:), code:bash (npm install -g panopticon), code:bash (brew install panopticon      # macOS), Future: Homebrew/apt (v2), Primary: npx + Auto-Aliasing, Secondary: Global npm Install
 
 ### Community 868 - "Community 868"
 Cohesion: 0.25
-Nodes (7): 1. Understand Requirements, 2. Design Approach, 3. Implement, 4. Test, 5. Self-Review, 6. Submit, Feature Work
+Nodes (8): Appendix B: Comparisons (FAQ), Can Panopticon and Gastown work together?, Can Panopticon and Vibe Kanban work together?, code:block140 (┌─────────────┐     ┌─────────────┐     ┌─────────────┐), How does Panopticon compare to Gastown?, How does Panopticon compare to Vibe Kanban?, Should I use Panopticon, Gastown, or Vibe Kanban?, Why build Panopticon when these tools exist?
 
 ### Community 869 - "Community 869"
 Cohesion: 0.25
-Nodes (7): code:block1 (pan review pending                                 # List co), Merging is NOT here, pan review, See also, Usage, What each subcommand does, When to use each
+Nodes (8): 2. Panopticon's Current Distribution (Broken), code:block5 (TIER 1: REPO SOURCE), code:typescript (if (!existsSync(destPath)) {), Current Inventory, Problem 1: Stale Copies, Problem 2: Known Symlink Bug, Problem 3: Wrong Priority Level, The Three-Tier Flow
 
 ### Community 870 - "Community 870"
 Cohesion: 0.25
-Nodes (7): code:bash (pan show <issue-id>), code:block2 (pan show PAN-123           # Summary: shadow state + CV + he), pan show, See Also, Usage, What It Does, When to Use
+Nodes (8): 3.1 Agent Spawning, 3.2 Agent Monitoring, 3.3 Agent Lifecycle Events, code:bash (pan agent start MIN-667 --remote), code:bash (# SSH to workspace VM and start agent in tmux), code:bash (# Get agent output), code:typescript (// Agent events forwarded to dashboard via SSH polling or We), Phase 3: Remote Agent Execution
 
 ### Community 871 - "Community 871"
 Cohesion: 0.25
-Nodes (7): Available MCP tools, Cost comparison, See also, The workflow, Troubleshooting, Use TLDR for code exploration, When TLDR is NOT a good fit
+Nodes (8): Agent Detail View, Agents Page Layout, Cloister Control Bar, code:block35 (┌───────────────────────────────────────────────────────────), code:block36 (┌───────────────────────────────────────────────────────────), code:block37 (┌───────────────────────────────────────────────────────────), code:block38 (┌───────────────────────────────────────────────────────────), Dashboard UI
 
 ### Community 872 - "Community 872"
 Cohesion: 0.25
-Nodes (7): code:bash (pan admin tldr <subcommand>), code:block2 (pan admin tldr status              # Show TLDR daemon state), pan admin tldr, See Also, Usage, What It Does, When to Use
+Nodes (8): Risk 1: Retros produce too much noise (every issue triggers a "proposal"), Risk 2: Retro-agent cost escalates, Risk 3: The skill-change pipeline introduces new failure modes, Risk 4: Autonomous daemon runs during user's active work and causes unwanted side effects, Risk 5: Q&A detection false positives (agent gets marked `waiting-on-human` when it's actually stuck), Risk 6: Proposed skill changes by the retro-agent are low-quality or hallucinated, Risk 7: Existing skills break when we add the audience field, Risks and mitigations
 
 ### Community 873 - "Community 873"
 Cohesion: 0.25
-Nodes (8): code:bash (# Authenticate with GitHub CLI (recommended)), code:block4 (PAN-45       # GitHub issue #45 on the panopticon-cli projec), code:yaml (projects:), code:bash (# Via CLI), Creating Issues, GitHub Issues, Issue Prefix, Setup
+Nodes (8): 9.1 Header, 9.2 Tabs, 9.3 Terminal Tab, 9.4 Info Tab, 9.5 Actions Footer, 9. Agent Detail Panel (Slide-out), code:block8 (agent-pan-505                                [X]), code:block9 (+---------------+---------------+)
 
 ### Community 874 - "Community 874"
 Cohesion: 0.25
-Nodes (8): 4. Surfaces & Depth, code:block7 (Level 0 (Page):     bg-background     — the deepest surface), code:css (shadow-xs/5    — buttons, inputs (barely visible)), code:css (/* Light mode: top edge highlight */), Inner Shadows (Cards), Shadow Scale, Tonal Layering (not shadows), When to Use Shadows
+Nodes (8): Acceptance Criteria, CLI parity, Discovery, Embeddings, Enrichment, Page, Search, Settings UI
 
 ### Community 875 - "Community 875"
 Cohesion: 0.25
-Nodes (7): End of run, Entrypoint, Hardcoding them here would override the user's per-role settings., No `model:` or `effort:` pin — Cloister resolves these from config.yaml roles.flywheel., Panopticon Flywheel Role, Substrate bug policy, Tick loop
+Nodes (8): code:block18 (┌───────────────────────────────────────────────────────────), Conversation viewer reuse (PAN-451 dependency), Dashboard: Archived Conversations Page, Page layout, Real-time updates, Route + navigation, Row badges (`source` field), Settings panel additions — "Conversations & Search"
 
 ### Community 876 - "Community 876"
+Cohesion: 0.25
+Nodes (8): code:bash (pan conversations scan <dir> [<dir>...]   # Targeted directo), code:typescript (interface SystemCapabilities {), code:block8 (Scanning ~/.claude/projects/...), Discovery Subsystem, MUST NOT delete or modify JSONL files, Performance-adaptive parallelism (system scan), Scripted extraction (zero LLM), Three discovery modes
+
+### Community 877 - "Community 877"
+Cohesion: 0.25
+Nodes (8): B.1 Add new fields to `ReviewStatus` interface, B.2 Increment `reviewRetryCount` on each deacon re-dispatch, B.3 Reset recovery window on clean completion and on new commits, B. `src/lib/review-status.ts`, code:typescript (const { dispatchParallelReview } = await import('./review-ag), code:typescript (.then(result => {), code:typescript (setReviewStatus(issueId, {), code:typescript (export interface ReviewStatus {)
+
+### Community 878 - "Community 878"
+Cohesion: 0.25
+Nodes (8): code:block4 (panopticon-cli/), code:block5 (panopticon-cli/), code:json ({), code:json ({), Current Layout, Monorepo Structure, Target Layout, Workspace Configuration
+
+### Community 879 - "Community 879"
+Cohesion: 0.25
+Nodes (8): code:block16 (8 sessions · 1 alive · 7 ended · last activity 2m ago · idle), code:block21 (Select a session in the tree to send a message …), Composer behavior in issue-selected mode, Issue-selected mode, Selection rules, Why have this mode, Zone B in issue-selected mode, Zone C tab strip (NEW)
+
+### Community 880 - "Community 880"
+Cohesion: 0.25
+Nodes (7): code:block1 ([IssueDataService] Rally poll error: Rally API query failed:), Dependencies, Follow-up Work, PAN-166: Rally WSAPI Query Parse Error Fix, Problem Statement, Risk Assessment, Success Criteria
+
+### Community 881 - "Community 881"
+Cohesion: 0.25
+Nodes (7): Acceptance Criteria, Decision, Out of Scope, PAN-448: Start Agent confirmation timeout too short, Problem, Scope, Status: Planning Complete
+
+### Community 882 - "Community 882"
+Cohesion: 0.25
+Nodes (8): Additional Windows 10 Workarounds, code:ini ([wsl2]), code:powershell (wsl --shutdown), code:bash (# Check resources), code:powershell (# 1. Update WSL to latest version), Recommended Configuration, Windows 10 Limitations, WSL2 Stability Issues (Windows Users)
+
+### Community 883 - "Community 883"
+Cohesion: 0.25
+Nodes (8): Can't reach workspace URLs, code:bash (ls ~/.panopticon/traefik/certs/), code:bash (cd ~/.panopticon/traefik/certs), code:bash (mkcert -install), code:bash (docker ps | grep traefik), code:bash (ping feature-min-123.localhost), HTTPS not working, Network Issues
+
+### Community 884 - "Community 884"
+Cohesion: 0.25
+Nodes (8): Bootstrap templates, Deleted (replaced by the loader), Legacy (ad-hoc) templates, Legacy templates, Planning agent templates, Specialist agent templates, Template catalogue, Work agent templates
+
+### Community 885 - "Community 885"
+Cohesion: 0.25
+Nodes (8): Architecture Map, code:markdown (# Codebase Architecture), code:block12, code:markdown (# Feature: User Authentication), code:markdown (# Dependencies), Dependency Report, Feature Location Report, Output Formats
+
+### Community 886 - "Community 886"
+Cohesion: 0.25
+Nodes (7): code:bash (# View agent output), Log Levels, Overview, Quick Commands, Related Skills, View Logs, When to Use
+
+### Community 887 - "Community 887"
+Cohesion: 0.25
+Nodes (8): Available Categories, code:bash (# AI will add this section if it doesn't exist), code:bash (# Edit directly), code:bash (# Remove the AI Suggestion Preferences section), code:markdown (## AI Suggestion Preferences), Updating Preferences, User Preferences in ~/.claude/CLAUDE.md, Why Skip Categories?
+
+### Community 888 - "Community 888"
+Cohesion: 0.25
+Nodes (7): code:bash (pan pause <issue-id>), code:bash (pan pause PAN-123), pan pause, See Also, Usage, What It Does, When to Use
+
+### Community 889 - "Community 889"
+Cohesion: 0.25
+Nodes (8): code:bash (bd dep add issue-2 issue-1 --type blocks), code:bash (ps aux | grep "bd daemon"), code:bash (# Instead of: bd --no-daemon dep add ...), code:bash (cat .beads/issues.jsonl | jq '.dependencies'), Dependencies Not Persisting, Root Cause (Fixed in v0.15.0+), Still Not Working?, Symptom
+
+### Community 890 - "Community 890"
+Cohesion: 0.25
+Nodes (8): Bond Types, Bonding Molecules, code:bash (# Found bug during wisp patrol? Persist it:), code:bash (bd mol bond mol-feature mol-deploy --as "Feature with Deploy), code:bash (bd mol bond A B                    # Sequential: B runs afte), Custom Compound Names, Operand Combinations, Phase Control in Bonds
+
+### Community 891 - "Community 891"
+Cohesion: 0.25
+Nodes (7): code:bash (pan untroubled <issue-id>), code:bash (pan untroubled PAN-123), pan untroubled, See Also, Usage, What It Does, When to Use
+
+### Community 892 - "Community 892"
+Cohesion: 0.25
+Nodes (7): 1. Audit Current State, 2. Update Strategy, 3. For Each Update, 4. Verify, code:bash (npm outdated          # See what's outdated), code:bash (npm install package@version), Dependency Update
+
+### Community 893 - "Community 893"
+Cohesion: 0.25
+Nodes (7): code:bash (pan unpause <issue-id>), code:bash (pan unpause PAN-123), pan unpause, See Also, Usage, What It Does, When to Use
+
+### Community 894 - "Community 894"
+Cohesion: 0.25
+Nodes (7): Add Repos to Workspace, After adding repos, code:bash (pan workspace add-repo <workspace-id> <repo-name> [repo-name), code:bash (# Add specific repos), How to decide which repos you need, Notes, Usage
+
+### Community 895 - "Community 895"
+Cohesion: 0.25
+Nodes (7): code:bash (pan VERB <args>), code:block2 (pan VERB <id>           # Primary usage), pan VERB, See Also, Usage, What It Does, When to Use
+
+### Community 896 - "Community 896"
+Cohesion: 0.25
+Nodes (7): code:bash (pan admin config <subcommand>), code:block2 (pan admin config shadow --status), pan admin config, See Also, Usage, What It Does, When to Use
+
+### Community 897 - "Community 897"
+Cohesion: 0.25
+Nodes (7): code:bash (pan start <issue-id>), code:block2 (pan start PAN-123          # Spawn agent for issue PAN-123), pan start, See Also, Usage, What It Does, When to Use
+
+### Community 898 - "Community 898"
+Cohesion: 0.25
+Nodes (7): code:bash (pan admin tracker <subcommand>), code:block2 (pan admin tracker linear-states    # List Linear workflow st), pan admin tracker, See Also, Usage, What It Does, When to Use
+
+### Community 899 - "Community 899"
+Cohesion: 0.25
+Nodes (7): 1. Understand Requirements, 2. Design Approach, 3. Implement, 4. Test, 5. Self-Review, 6. Submit, Feature Work
+
+### Community 900 - "Community 900"
+Cohesion: 0.25
+Nodes (7): code:block1 (pan review pending                                 # List co), Merging is NOT here, pan review, See also, Usage, What each subcommand does, When to use each
+
+### Community 901 - "Community 901"
+Cohesion: 0.25
+Nodes (7): code:bash (pan show <issue-id>), code:block2 (pan show PAN-123           # Summary: shadow state + CV + he), pan show, See Also, Usage, What It Does, When to Use
+
+### Community 902 - "Community 902"
+Cohesion: 0.25
+Nodes (7): Available MCP tools, Cost comparison, See also, The workflow, Troubleshooting, Use TLDR for code exploration, When TLDR is NOT a good fit
+
+### Community 903 - "Community 903"
+Cohesion: 0.25
+Nodes (7): code:bash (pan admin tldr <subcommand>), code:block2 (pan admin tldr status              # Show TLDR daemon state), pan admin tldr, See Also, Usage, What It Does, When to Use
+
+### Community 904 - "Community 904"
+Cohesion: 0.25
+Nodes (8): code:bash (# Authenticate with GitHub CLI (recommended)), code:block4 (PAN-45       # GitHub issue #45 on the panopticon-cli projec), code:yaml (projects:), code:bash (# Via CLI), Creating Issues, GitHub Issues, Issue Prefix, Setup
+
+### Community 905 - "Community 905"
+Cohesion: 0.25
+Nodes (8): 4. Surfaces & Depth, code:block7 (Level 0 (Page):     bg-background     — the deepest surface), code:css (shadow-xs/5    — buttons, inputs (barely visible)), code:css (/* Light mode: top edge highlight */), Inner Shadows (Cards), Shadow Scale, Tonal Layering (not shadows), When to Use Shadows
+
+### Community 906 - "Community 906"
+Cohesion: 0.25
+Nodes (7): End of run, Entrypoint, No `model:` pin — Cloister resolves it from config.yaml roles.flywheel., Panopticon Flywheel Role, Status vs State, Substrate bug policy, Tick loop
+
+### Community 907 - "Community 907"
 Cohesion: 0.33
 Nodes (5): createTerminalWindow(), MockWindow, openTerminalWindow(), terminalWindows, win
 
-### Community 877 - "Community 877"
+### Community 908 - "Community 908"
 Cohesion: 0.33
 Nodes (5): execFileAsync, hooksLog, runHook(), runtimeRequests, SCRIPT_PATH
 
-### Community 878 - "Community 878"
+### Community 909 - "Community 909"
 Cohesion: 0.29
 Nodes (5): actual, CLI_PATH, __dirname, expected, FIXTURE_PATH
 
-### Community 879 - "Community 879"
+### Community 910 - "Community 910"
 Cohesion: 0.29
 Nodes (5): actual, __dirname, expected, FIXTURE_PATH, SKILLS_SOURCE_DIR
 
-### Community 880 - "Community 880"
+### Community 911 - "Community 911"
 Cohesion: 0.29
 Nodes (5): CLI_PATH, __dirname, { stdout }, { stdout, status }, { stdout, stderr }
 
-### Community 881 - "Community 881"
+### Community 912 - "Community 912"
 Cohesion: 0.29
 Nodes (5): next, restored, s, start, withAgent
 
-### Community 882 - "Community 882"
+### Community 913 - "Community 913"
 Cohesion: 0.29
 Nodes (6): alicePos, bobPos, longBody, result, subDir, wsPath
 
-### Community 883 - "Community 883"
+### Community 914 - "Community 914"
 Cohesion: 0.29
 Nodes (4): BIN_DIR, __dirname, NATIVE_MODULES, PACKAGE_ROOT
 
-### Community 884 - "Community 884"
+### Community 915 - "Community 915"
 Cohesion: 0.29
 Nodes (6): bridge, DesktopSettings, IPC, NotificationEventType, PanopticonBridge, Window
 
-### Community 885 - "Community 885"
-Cohesion: 0.29
-Nodes (6): calls, logSpy, now, output, payload, {
-  shadowMock, cvMock, contextMock, healthMock,
-  getShadowStateMock, pingAgentMock, getAgentCVMock, getAgentRuntimeStateMock,
-}
-
-### Community 886 - "Community 886"
-Cohesion: 0.29
-Nodes (6): defectQuery, hrQuery, mockCreate, mockQuery, mockUpdate, tracker
-
-### Community 887 - "Community 887"
-Cohesion: 0.43
-Nodes (6): checkNodeVersion(), checkServerBundle(), __dirname, launch(), packageDir, resolveElectron()
-
-### Community 888 - "Community 888"
-Cohesion: 0.29
-Nodes (6): EDITOR_IDS, EditorEntry, EditorId, EditorIdSchema, EDITORS, OpenInEditorInput
-
-### Community 889 - "Community 889"
-Cohesion: 0.48
-Nodes (6): execAsync, RebaseAllResult, rebaseAndPushRepos(), rebaseOneRepo(), RebaseResult, tryResolvePlanningConflicts()
-
-### Community 890 - "Community 890"
-Cohesion: 0.29
-Nodes (3): mockFetch, mockGetGitHubConfig, program
-
-### Community 891 - "Community 891"
-Cohesion: 0.29
-Nodes (7): Auto (non-interactive), Auto-Start (skip planning), code:bash (pan plan <id>), code:bash (pan plan <id> --auto), code:bash (pan start <id> --auto), Interactive (default), Planning Modes
-
-### Community 892 - "Community 892"
-Cohesion: 0.29
-Nodes (7): Auto-Behaviors, code:block7 (draft (in .pan/drafts/*.md) ──► proposed ──► approved ──► ac), Dashboard Viewer, Legacy paths, Status is a JSON field, not a directory, The four-artifact model (PAN-1124: single-spec-on-main), vBRIEF Plans & Lifecycle
-
-### Community 893 - "Community 893"
-Cohesion: 0.29
-Nodes (7): code:block13 (<type>(<scope>): <short description> (PAN-<number>)), code:block14 (feat(cloister): add preTrustDirectory to initializeSpecialis), Commit Message Convention, Examples, Issue references, Scope (optional but encouraged), Types
-
-### Community 894 - "Community 894"
-Cohesion: 0.29
-Nodes (7): Branch and PR Workflow, Branch naming, code:block10 (feature/pan-<number>), code:bash (git checkout -b feature/pan-<number>), code:block12 (1. Create feature branch from latest main), PR checklist, The flow
-
-### Community 895 - "Community 895"
-Cohesion: 0.29
-Nodes (7): API, CLI, code:block21 (POST /api/issues/:issueId/sync-main), code:bash (pan sync-main PAN-143), Design Decisions, How It Works, Sync with Main (PAN-242)
-
-### Community 896 - "Community 896"
-Cohesion: 0.29
-Nodes (7): Agent Workflow, Checkpoint System, CLI Reference, code:bash (# After closing a bead), code:bash (pan inspect <issueId> --bead <beadId>           # Fast inspe), Inspect Specialist (PAN-382), What Inspect Checks
-
-### Community 897 - "Community 897"
-Cohesion: 0.29
-Nodes (7): code:typescript (interface MergeResult {), code:typescript (interface ReviewResult {), code:typescript (interface TestResult {), Merge Agent Results, Result Monitoring, Review Agent Results, Test Agent Results
-
-### Community 898 - "Community 898"
-Cohesion: 0.29
-Nodes (7): code:typescript (// Worker agent creates PR using gh CLI), code:bash (# Worker signals done — triggers verification gate → review-), Step 1: Complete Implementation, Step 2: Create Pull Request, Step 3: Signal Completion, Step 4: Specialist Pipeline Takes Over, Worker Agent Integration
-
-### Community 899 - "Community 899"
-Cohesion: 0.29
-Nodes (7): code:bash (# Check if specialist is running), code:toml ([specialists.test_agent]), code:bash (cat ~/.panopticon/specialists/merge-agent/history.jsonl | ta), Merge agent conflict resolution failed, Review agent not dispatching, Test agent not detecting test runner, Troubleshooting
-
-### Community 900 - "Community 900"
-Cohesion: 0.29
-Nodes (7): Adding a New Template, Available Templates, code:yaml (---), Frontmatter Contract, Prompt Templates, Template Location, Template Syntax
-
-### Community 901 - "Community 901"
-Cohesion: 0.29
-Nodes (7): code:markdown (---), code:bash (# Create skill directory), code:block27 (/my-skill), Creating Skills, Skill Structure, Skills, Using Skills
-
-### Community 902 - "Community 902"
-Cohesion: 0.29
-Nodes (7): code:bash (# ~/.panopticon.env), code:yaml (models:), code:bash (chmod 600 ~/.panopticon/config.yaml ~/.panopticon.env), Configuration via Dashboard, Multi-Model Support, Router Configuration, Supported Providers and Models
-
-### Community 903 - "Community 903"
-Cohesion: 0.29
-Nodes (7): code:bash (# From Linear issue), code:block22 (~/.panopticon/workspaces/), code:block23 (https://feature-pan-123.localhost:3000     # Frontend), Creating Workspaces, Workspace Structure, Workspace URLs, Workspaces
-
-### Community 904 - "Community 904"
-Cohesion: 0.29
-Nodes (7): Advanced Topics, code:bash (# Create remote workspace), code:yaml (# ~/.panopticon/work-types.yaml), code:json (// ~/.claude/hooks.json), Custom Work Types, Heartbeat Monitoring, Remote Workspaces
-
-### Community 905 - "Community 905"
-Cohesion: 0.29
-Nodes (7): About the Name, Core Insight, Executive Summary, Industry Convergence, Key Insights, Opinionated Decisions, Skills over Molecules
-
-### Community 906 - "Community 906"
-Cohesion: 0.29
-Nodes (7): code:bash (# Expose port on VM), code:yaml (# pan-infra:/etc/traefik/docker-compose.yml), code:bash (# Tunnel remote services to local ports), Option A: exe.dev Native HTTPS Proxy, Option B: Traefik on Infra VM, Option C: Local SSH Tunnels (Fallback), Phase 4: URL Routing & Access
-
-### Community 907 - "Community 907"
-Cohesion: 0.29
-Nodes (7): Architecture, code:block1 (┌───────────────────────────────────────────────────────────), code:block2 (Shared infra:     0.5 GB), High-Level Design, Memory Budget (16GB Plan), Per-Workspace VMs, Shared Infrastructure VM
-
-### Community 908 - "Community 908"
-Cohesion: 0.29
-Nodes (7): 6.1 Workspace Hibernation, 6.2 Workspace Cleanup, 6.3 Resource Monitoring, code:bash (pan workspace stop MIN-667), code:bash (pan workspace delete MIN-667), code:bash (pan remote resources), Phase 6: Lifecycle Management
-
-### Community 909 - "Community 909"
-Cohesion: 0.29
-Nodes (6): Agent Directory Structure, Cleanup, code:bash (# Preview orphaned directories), Legacy Directories, Standard Directory Contents, Valid Directory Naming Patterns
-
-### Community 910 - "Community 910"
-Cohesion: 0.29
-Nodes (7): API Keys: `~/.panopticon.env`, code:yaml (models:), code:yaml (models:), code:env (# Anthropic (required)), Configuration Files, Global Configuration: `~/.panopticon/config.yaml`, Per-Project Configuration: `.panopticon.yaml`
-
-### Community 911 - "Community 911"
-Cohesion: 0.29
-Nodes (7): Adding New Integrations, Cloudflare Tunnels, code:yaml (workspace:), code:yaml (workspace:), code:yaml (env_file:), External Service Integrations, Hume EVI (Voice AI)
-
-### Community 912 - "Community 912"
-Cohesion: 0.29
-Nodes (7): code:toml (# Each entry controls one parallel reviewer.), code:yaml (models:), Configuration Schema, Default Reviewers, Fields, Parallel Review Agents, Per-Reviewer Model Overrides
-
-### Community 913 - "Community 913"
-Cohesion: 0.29
-Nodes (7): Available Work Types, code:yaml (models:), code:yaml (models:), code:yaml (models:), code:yaml (models:), Override Examples, Per-Work-Type Overrides
-
-### Community 914 - "Community 914"
-Cohesion: 0.29
-Nodes (7): Balanced Preset (Recommended), Budget Preset, code:yaml (models:), code:yaml (models:), code:yaml (models:), Premium Preset, Presets
-
-### Community 915 - "Community 915"
-Cohesion: 0.29
-Nodes (5): code:block12 (┌─────────────┐     ┌─────────────┐     ┌─────────────┐), code:block14 (┌─────────────┐     ┌─────────────┐     ┌─────────────┐), Handoff Mechanics, Method 1: Kill & Spawn (Issue Agents), Method 2: Specialist Wake (--resume)
-
 ### Community 916 - "Community 916"
-Cohesion: 0.29
-Nodes (7): Agent Management, API Endpoints, Cloister Control, code:typescript (// Get Cloister status), code:typescript (// List all agents (specialists + issue agents)), code:typescript (// Initialize a specialist agent), Specialist Management
+Cohesion: 0.33
+Nodes (4): resolveServerStaticDir(), registerDesktopProtocol(), resolveStaticPath(), result
 
 ### Community 917 - "Community 917"
-Cohesion: 0.29
-Nodes (6): Active Pipeline, Cycling Alerts, Flywheel State — 2026-05-18 (Run 1), Infrastructure Gaps, Pattern Ledger, Skill Gaps
-
-### Community 918 - "Community 918"
-Cohesion: 0.29
-Nodes (6): 1. Context Budget Manager (PRD Phase 12.8), 2. Runtime Metrics (PRD Phase 13.6), 3. Multi-Runtime Dashboard (PRD Phase 13), Critical Gaps (Missing Functionality), Panopticon Implementation Gaps, Summary
+Cohesion: 0.33
+Nodes (5): DesktopSettings, DesktopSettingsSection(), isDesktopApp(), NOTIFICATION_LABELS, NotificationEventType
 
 ### Community 919 - "Community 919"
 Cohesion: 0.29
-Nodes (7): 1. Operator skills are already renamed, 2. Skill naming — operator vs. agent split, 3. `pan sync` — two changes, one codebase, 4. Dashboard API routes follow PAN-705 conventions, 5. Audience backfill and skill renaming, 6. Operator-skill description format for any new operator skills PAN-709 adds, Dependencies — aligned with PAN-705 (Command Taxonomy Reorg)
+Nodes (3): mockFetch, mockGetGitHubConfig, program
 
 ### Community 920 - "Community 920"
-Cohesion: 0.29
-Nodes (7): 4.1 Color Palette (Obsidian Dark), 4.2 Signal Colors, 4.3 Typography, 4.4 Spacing & Radius, 4.5 Shadows & Elevation, 4.6 Animations, 4. Visual Design System
+Cohesion: 0.38
+Nodes (4): resetCommand(), ResetOptions, wakeCommand(), WakeOptions
 
 ### Community 921 - "Community 921"
-Cohesion: 0.29
-Nodes (7): 3.1 Page Layout, 3.2 Detail Panel (Slide-out), 3.3 Component Tree, 3. Architecture Overview, code:block1 (+-----------------------------------------------------------), code:block2 (+-----------------------------------+ +---------------------), code:block3 (AgentsPage (new, replaces AgentList + GodView agent display))
+Cohesion: 0.38
+Nodes (5): decode, decodeCandidate(), ev, bodyToEvent(), decodeDomainEvent
 
 ### Community 922 - "Community 922"
 Cohesion: 0.29
-Nodes (7): 5.1 Live Grid (Default), 5.2 Command Table, 5.3 Timeline, 5.4 Topology, 5. View Modes (Detailed), code:block4 (+----------------------------------+), code:block5 (●  2m ago)
+Nodes (7): Auto-Behaviors, code:block7 (draft (in .pan/drafts/*.md) ──► proposed ──► approved ──► ac), Dashboard Viewer, Legacy paths, Status is a JSON field, not a directory, The four-artifact model (PAN-1124: single-spec-on-main), vBRIEF Plans & Lifecycle
 
 ### Community 923 - "Community 923"
 Cohesion: 0.29
-Nodes (7): 11.1 View Switching, 11.2 Agent Selection, 11.3 Filtering, 11.4 Filtering (Global), 11.5 Keyboard Shortcuts, 11.6 Empty States, 11. Interactions & Behaviors
+Nodes (7): Auto (non-interactive), Auto-Start (skip planning), code:bash (pan plan <id>), code:bash (pan plan <id> --auto), code:bash (pan start <id> --auto), Interactive (default), Planning Modes
 
 ### Community 924 - "Community 924"
 Cohesion: 0.29
-Nodes (7): After — Workhorse panel + 5 role cards, Before — 17 agent cards in 4 groups (`AgentCardsPanel.tsx:8-114`), code:block13 (Issue Agent (5 phases: Exploration, Implementation, Testing,), code:block14 (┌─ Workhorse Models ────────────────────────────────────────), code:typescript (const ROLES = [), Implementation, Settings UI Changes
+Nodes (7): Branch and PR Workflow, Branch naming, code:block10 (feature/pan-<number>), code:bash (git checkout -b feature/pan-<number>), code:block12 (1. Create feature branch from latest main), PR checklist, The flow
 
 ### Community 925 - "Community 925"
 Cohesion: 0.29
-Nodes (7): code:bash (pan conversations search "redis cache invalidation"), code:bash (pan conversations search --semantic "debugging a race condit), code:bash (pan conversations search --workspace ~/Projects/myn), Search, Tier 1: Structured filters (instant, no LLM), Tier 2: Full-text search (FTS5, no LLM), Tier 3: Semantic search (optional, requires embeddings)
+Nodes (7): code:block13 (<type>(<scope>): <short description> (PAN-<number>)), code:block14 (feat(cloister): add preTrustDirectory to initializeSpecialis), Commit Message Convention, Examples, Issue references, Scope (optional but encouraged), Types
 
 ### Community 926 - "Community 926"
 Cohesion: 0.29
-Nodes (7): Implementation Plan, Phase 1 — Backend extraction, Phase 2 — Project list & detail pages (no wizard yet), Phase 3 — Wizard UI (without Setup Agent), Phase 4 — Setup Agent integration, Phase 5 — First-run welcome, Phase 6 — Polish
+Nodes (7): code:typescript (interface MergeResult {), code:typescript (interface ReviewResult {), code:typescript (interface TestResult {), Merge Agent Results, Result Monitoring, Review Agent Results, Test Agent Results
 
 ### Community 927 - "Community 927"
 Cohesion: 0.29
-Nodes (7): B.1 Add `reviewRetryCount` to `ReviewStatus` interface, B.2 Increment `reviewRetryCount` on each deacon re-dispatch, B.3 Reset `reviewRetryCount` on successful review completion, B. `src/lib/review-status.ts`, code:typescript (setReviewStatus(opts.issueId, {), code:typescript (export interface ReviewStatus {), code:typescript (setReviewStatus(issueId, {)
+Nodes (7): Adding a New Template, Available Templates, code:yaml (---), Frontmatter Contract, Prompt Templates, Template Location, Template Syntax
 
 ### Community 928 - "Community 928"
 Cohesion: 0.29
-Nodes (7): Problem 1: Dead/stuck parallel review sessions are invisible to deacon, Problem 2: No circuit breaker for infrastructure-failure cycling, Problem 3: Verification passed but review blocks the pipeline forever, Problem 4: Incomplete parallel reviews waste completed findings, Problem 5: `stuck` flag is never set, so re-dispatch never stops, Problem 6: No UI indication that recovery is happening, Problems Enumerated
+Nodes (7): code:bash (# Check if specialist is running), code:toml ([specialists.test_agent]), code:bash (cat ~/.panopticon/specialists/merge-agent/history.jsonl | ta), Merge agent conflict resolution failed, Review agent not dispatching, Test agent not detecting test runner, Troubleshooting
 
 ### Community 929 - "Community 929"
 Cohesion: 0.29
-Nodes (7): code:block7 (DockerStatsCollector (5s poll)), code:block8 (DockerStatsCollector.getHistory(containerId) (60 samples)), code:block9 (resource-discovery.ts (30s cache)), Container history path (new, lazy), Container stats path (new), Data flow, Resource detail identifiers path (existing)
+Nodes (7): code:typescript (// Worker agent creates PR using gh CLI), code:bash (# Worker signals done — triggers verification gate → review-), Step 1: Complete Implementation, Step 2: Create Pull Request, Step 3: Signal Completion, Step 4: Specialist Pipeline Takes Over, Worker Agent Integration
 
 ### Community 930 - "Community 930"
 Cohesion: 0.29
-Nodes (7): code:typescript ({), code:typescript ({), Commands (mutations), Key Type Definitions, RPC Methods, Streaming (server → client), Unary (request → response)
+Nodes (7): API, CLI, code:block21 (POST /api/issues/:issueId/sync-main), code:bash (pan sync-main PAN-143), Design Decisions, How It Works, Sync with Main (PAN-242)
 
 ### Community 931 - "Community 931"
 Cohesion: 0.29
-Nodes (7): code:typescript (interface RoundMarker {), code:block14 (── Round 1 · 14:02 → 14:06 · passed · 8 findings ─────), code:block15 (addressing: specialist-panopticon-540-review-correctness    ), Composer addressing, Session-tab strip (NEW), What changes, Zone C — Conversation + composer (agent-selected)
+Nodes (7): Agent Workflow, Checkpoint System, CLI Reference, code:bash (# After closing a bead), code:bash (pan inspect <issueId> --bead <beadId>           # Fast inspe), Inspect Specialist (PAN-382), What Inspect Checks
 
 ### Community 932 - "Community 932"
 Cohesion: 0.29
-Nodes (7): From `BadgeBar` modals, From `InspectorPanel` sections, From `IssueCard` (kanban card), From `StatusFlowControl`, From `WorkspacePane`, Parity smoke test, Reunified action layer (parity, additive)
+Nodes (7): code:bash (# ~/.panopticon.env), code:yaml (models:), code:bash (chmod 600 ~/.panopticon/config.yaml ~/.panopticon.env), Configuration via Dashboard, Multi-Model Support, Router Configuration, Supported Providers and Models
 
 ### Community 933 - "Community 933"
 Cohesion: 0.29
-Nodes (7): P2 — Readiness and delivery (trust hooks, remove fallbacks), `src/dashboard/server/routes/conversations.ts:81` — `waitForClaudeReady()`, `src/lib/agents.ts:1041` — `startAgent` inline prompt-ready check, `src/lib/agents.ts:244` — `waitForReadySignal()`, `src/lib/cloister/specialists.ts:2484,2495` — specialist delivery confirmation, `src/lib/tmux.ts:527` — `waitForClaudePrompt()`, `src/lib/tmux.ts:559` — `confirmDelivery()`
+Nodes (7): Advanced Topics, code:bash (# Create remote workspace), code:yaml (# ~/.panopticon/work-types.yaml), code:json (// ~/.claude/hooks.json), Custom Work Types, Heartbeat Monitoring, Remote Workspaces
 
 ### Community 934 - "Community 934"
 Cohesion: 0.29
-Nodes (7): P1 — Deacon health/stuck detection (structured state), `src/dashboard/lib/health-filtering.ts:13` — `checkAgentHealthAsync()`, `src/lib/cloister/deacon.ts:651` — `checkLazyAgent()`, `src/lib/cloister/deacon.ts:849` — `isAgentActiveInTmux()`, `src/lib/cloister/deacon.ts:935` — `parseThinkingDuration()`, `src/lib/cloister/deacon.ts:955` — `checkStuckWorkAgents()`, `src/lib/health.ts:91` — `getAgentOutput()`
+Nodes (7): code:markdown (---), code:bash (# Create skill directory), code:block27 (/my-skill), Creating Skills, Skill Structure, Skills, Using Skills
 
 ### Community 935 - "Community 935"
 Cohesion: 0.29
-Nodes (6): Approach, Decision, Difficulty: trivial, PAN-415: Test: trace what calls complete-planning after agent finishes, Scope, Status: Planning Complete
+Nodes (7): code:bash (# From Linear issue), code:block22 (~/.panopticon/workspaces/), code:block23 (https://feature-pan-123.localhost:3000     # Frontend), Creating Workspaces, Workspace Structure, Workspace URLs, Workspaces
 
 ### Community 936 - "Community 936"
 Cohesion: 0.29
-Nodes (7): 1. Core Fix (CRITICAL), 2. Comprehensive Testing, 3. Error Handling Improvements, 4. Configuration Validation, 5. Documentation, code:typescript (// Before:), Solution Design
+Nodes (7): About the Name, Core Insight, Executive Summary, Industry Convergence, Key Insights, Opinionated Decisions, Skills over Molecules
 
 ### Community 937 - "Community 937"
 Cohesion: 0.29
-Nodes (6): Agent State: PAN-647, Blockers/Concerns, Current Position, Decisions Made During Planning, Notes, Planned Tasks
+Nodes (7): code:bash (# Expose port on VM), code:yaml (# pan-infra:/etc/traefik/docker-compose.yml), code:bash (# Tunnel remote services to local ports), Option A: exe.dev Native HTTPS Proxy, Option B: Traefik on Infra VM, Option C: Local SSH Tunnels (Fallback), Phase 4: URL Routing & Access
 
 ### Community 938 - "Community 938"
 Cohesion: 0.29
-Nodes (6): Agent State: MIN-794, Blockers/Concerns, Current Position, Decisions Made During Planning, Notes, Planned Tasks
+Nodes (7): 6.1 Workspace Hibernation, 6.2 Workspace Cleanup, 6.3 Resource Monitoring, code:bash (pan workspace stop MIN-667), code:bash (pan workspace delete MIN-667), code:bash (pan remote resources), Phase 6: Lifecycle Management
 
 ### Community 939 - "Community 939"
 Cohesion: 0.29
-Nodes (6): Decision (per PRD), Out of scope (confirmed from PRD), PAN-705: Command Taxonomy Reorganization, Pipeline handoff notes for specialists, Problem, Scope anchors
+Nodes (7): Architecture, code:block1 (┌───────────────────────────────────────────────────────────), code:block2 (Shared infra:     0.5 GB), High-Level Design, Memory Budget (16GB Plan), Per-Workspace VMs, Shared Infrastructure VM
 
 ### Community 940 - "Community 940"
 Cohesion: 0.29
-Nodes (7): Agent Issues, Agent keeps failing, Agent stuck / not responding, code:bash (# Check tmux session), code:bash (cat ~/.panopticon/agents/agent-min-123/state.json | jq .hand), code:bash (# Correct), Messages not reaching agent
+Nodes (6): Agent Directory Structure, Cleanup, code:bash (# Preview orphaned directories), Legacy Directories, Standard Directory Contents, Valid Directory Naming Patterns
 
 ### Community 941 - "Community 941"
 Cohesion: 0.29
-Nodes (7): code:bash (# Check container logs), code:bash (# Create the network), code:bash (# Use sudo to remove), Container won't start, Docker Issues, "No such network: panopticon", Permission denied on mounted volumes
+Nodes (7): API Keys: `~/.panopticon.env`, code:yaml (models:), code:yaml (models:), code:env (# Anthropic (required)), Configuration Files, Global Configuration: `~/.panopticon/config.yaml`, Per-Project Configuration: `.panopticon.yaml`
 
 ### Community 942 - "Community 942"
 Cohesion: 0.29
-Nodes (7): Analyze Structure, code:bash (# By name), code:bash (# Function definitions), code:bash (# Directory tree (shallow)), Find Files, Quick Reference Commands, Search Code
+Nodes (7): code:toml (# Each entry controls one parallel reviewer.), code:yaml (models:), Configuration Schema, Default Reviewers, Fields, Parallel Review Agents, Per-Reviewer Model Overrides
 
 ### Community 943 - "Community 943"
 Cohesion: 0.29
-Nodes (7): code:bash (# Count errors per agent), code:bash (# If logs have timestamps, extract timeline), code:bash (# Count tool calls by type), Count Errors, Log Analysis, Timeline of Actions, Tool Usage Analysis
+Nodes (7): Adding New Integrations, Cloudflare Tunnels, code:yaml (workspace:), code:yaml (workspace:), code:yaml (env_file:), External Service Integrations, Hume EVI (Voice AI)
 
 ### Community 944 - "Community 944"
 Cohesion: 0.29
-Nodes (7): code:bash (# Check if session exists), code:bash (# Truncate log file), code:bash (# Add timestamps when capturing), Logs Too Large, Missing Timestamps, No Output from Agent, Troubleshooting
+Nodes (7): Balanced Preset (Recommended), Budget Preset, code:yaml (models:), code:yaml (models:), code:yaml (models:), Premium Preset, Presets
 
 ### Community 945 - "Community 945"
 Cohesion: 0.29
-Nodes (6): 1. Assess (First 5 minutes), 2. Mitigate (Stop the bleeding), 3. Investigate (Once stable), 4. Fix, 5. Postmortem, Incident Response
+Nodes (7): Available Work Types, code:yaml (models:), code:yaml (models:), code:yaml (models:), code:yaml (models:), Override Examples, Per-Work-Type Overrides
 
 ### Community 946 - "Community 946"
 Cohesion: 0.29
-Nodes (7): code:bash (bd daemon), code:bash (# In your project directory), code:bash (# If you don't want daemon to pull from remote), Daemon Won't Start, Resolution, Root Cause, Symptom
+Nodes (5): code:block12 (┌─────────────┐     ┌─────────────┐     ┌─────────────┐), code:block14 (┌─────────────┐     ┌─────────────┐     ┌─────────────┐), Handoff Mechanics, Method 1: Kill & Spawn (Issue Agents), Method 2: Specialist Wake (--resume)
 
 ### Community 947 - "Community 947"
 Cohesion: 0.29
-Nodes (7): code:bash (bd init myproject), code:bash (bd daemon --global=false &), code:bash (#!/bin/bash), JSONL File Not Created, Resolution, Root Cause, Symptom
+Nodes (7): Agent Management, API Endpoints, Cloister Control, code:typescript (// Get Cloister status), code:typescript (// List all agents (specialists + issue agents)), code:typescript (// Initialize a specialist agent), Specialist Management
 
 ### Community 948 - "Community 948"
 Cohesion: 0.29
-Nodes (7): code:bash (# Manual creation), code:bash (bd formula list                 # List all formulas (protos)), code:bash (bd mol show mol-release         # Show template structure an), Creating a Proto, Listing Formulas, Proto Management, Viewing Proto Structure
+Nodes (6): 1. Context Budget Manager (PRD Phase 12.8), 2. Runtime Metrics (PRD Phase 13.6), 3. Multi-Runtime Dashboard (PRD Phase 13), Critical Gaps (Missing Functionality), Panopticon Implementation Gaps, Summary
 
 ### Community 949 - "Community 949"
 Cohesion: 0.29
-Nodes (7): code:bash (# Project A ships a capability), code:bash (bd ship <capability>            # Ship capability (requires ), code:bash (bd dep add <issue> external:<project>:<capability>), Concept, Cross-Project Dependencies, Depending on External Capabilities, Shipping Capabilities
+Nodes (6): AgentList and GodView/AgentGrid deletion notes, Cleanup decision, Deletion gate, Inspector sub-file inventory, InspectorPanel feature inventory, InspectorPanel parity checklist
 
 ### Community 950 - "Community 950"
 Cohesion: 0.29
-Nodes (6): code:bash (pan wipe <issue-id>), pan wipe, See Also, Warning, What It Does, When to Use
+Nodes (7): 1. Operator skills are already renamed, 2. Skill naming — operator vs. agent split, 3. `pan sync` — two changes, one codebase, 4. Dashboard API routes follow PAN-705 conventions, 5. Audience backfill and skill renaming, 6. Operator-skill description format for any new operator skills PAN-709 adds, Dependencies — aligned with PAN-705 (Command Taxonomy Reorg)
 
 ### Community 951 - "Community 951"
 Cohesion: 0.29
-Nodes (7): Check Current Status, code:bash (pan doctor), code:bash (# Clone the repository), code:bash (# Use automated installer), Install Panopticon, Install Prerequisites, Step 2: Installation (5 minutes)
+Nodes (7): 3.1 Page Layout, 3.2 Detail Panel (Slide-out), 3.3 Component Tree, 3. Architecture Overview, code:block1 (+-----------------------------------------------------------), code:block2 (+-----------------------------------+ +---------------------), code:block3 (AgentsPage (new, replaces AgentList + GodView agent display))
 
 ### Community 952 - "Community 952"
 Cohesion: 0.29
-Nodes (6): code:block1 (pan admin cloister status [--json]   # Show watchdog service), Confirm before emergency-stop, pan admin cloister, See also, Usage, When to use each subcommand
+Nodes (7): 11.1 View Switching, 11.2 Agent Selection, 11.3 Filtering, 11.4 Filtering (Global), 11.5 Keyboard Shortcuts, 11.6 Empty States, 11. Interactions & Behaviors
 
 ### Community 953 - "Community 953"
 Cohesion: 0.29
-Nodes (7): Auto-Start on Boot, code:ini ([Unit]), code:bash (sudo systemctl enable panopticon), code:xml (<?xml version="1.0" encoding="UTF-8"?>), code:bash (launchctl load ~/Library/LaunchAgents/com.panopticon.dashboa), Using launchd (macOS), Using systemd (Linux)
+Nodes (7): 4.1 Color Palette (Obsidian Dark), 4.2 Signal Colors, 4.3 Typography, 4.4 Spacing & Radius, 4.5 Shadows & Elevation, 4.6 Animations, 4. Visual Design System
 
 ### Community 954 - "Community 954"
 Cohesion: 0.29
-Nodes (7): Advanced Usage, code:bash (# Start with hot reload for development), code:bash (# Start only dashboard (no API)), code:bash (# Use environment variables), Custom Ports, Start in Development Mode, Start Specific Services
+Nodes (7): 5.1 Live Grid (Default), 5.2 Command Table, 5.3 Timeline, 5.4 Topology, 5. View Modes (Detailed), code:block4 (+----------------------------------+), code:block5 (●  2m ago)
 
 ### Community 955 - "Community 955"
 Cohesion: 0.29
-Nodes (7): Check Resource Usage, Check Service Status, Check Specific Agent, code:bash (# Check if dashboard is running), code:bash (# Verbose status with CPU/memory), code:bash (# Show detailed status for one agent), Detailed Status Checks
+Nodes (7): After — Workhorse panel + 5 role cards, Before — 17 agent cards in 4 groups (`AgentCardsPanel.tsx:8-114`), code:block13 (Issue Agent (5 phases: Exploration, Implementation, Testing,), code:block14 (┌─ Workhorse Models ────────────────────────────────────────), code:typescript (const ROLES = [), Implementation, Settings UI Changes
 
 ### Community 956 - "Community 956"
 Cohesion: 0.29
-Nodes (7): Border Radius, Border & Shadow, code:block5 (rounded-md   (6px)  Buttons, inputs, small cards), code:block6 (shadow-sm   Sidebar cards, secondary), code:tsx (bg-muted/40         // Very subtle containers), Opacity Modifiers, Shadows
+Nodes (7): code:bash (pan conversations search "redis cache invalidation"), code:bash (pan conversations search --semantic "debugging a race condit), code:bash (pan conversations search --workspace ~/Projects/myn), Search, Tier 1: Structured filters (instant, no LLM), Tier 2: Full-text search (FTS5, no LLM), Tier 3: Semantic search (optional, requires embeddings)
 
 ### Community 957 - "Community 957"
 Cohesion: 0.29
-Nodes (7): App Background, code:block2 (--background       Page background (white / slate-950)), Color System, MYN Task Type Colors (Methodology), Priority Colors, Semantic Colors, Shadcn/UI Semantic Tokens (CSS Variables)
+Nodes (7): Implementation Plan, Phase 1 — Backend extraction, Phase 2 — Project list & detail pages (no wizard yet), Phase 3 — Wizard UI (without Setup Agent), Phase 4 — Setup Agent integration, Phase 5 — First-run welcome, Phase 6 — Polish
 
 ### Community 958 - "Community 958"
 Cohesion: 0.29
-Nodes (6): code:block14 (src/), Design Principles, File Structure, Key Files, Mind Your Now Design System & Coding Standards, Tech Stack
+Nodes (7): B.1 Add `reviewRetryCount` to `ReviewStatus` interface, B.2 Increment `reviewRetryCount` on each deacon re-dispatch, B.3 Reset `reviewRetryCount` on successful review completion, B. `src/lib/review-status.ts`, code:typescript (setReviewStatus(opts.issueId, {), code:typescript (export interface ReviewStatus {), code:typescript (setReviewStatus(issueId, {)
 
 ### Community 959 - "Community 959"
 Cohesion: 0.29
-Nodes (6): Code Review, Correctness, Design, Output Format, Performance, Security
+Nodes (7): Problem 1: Dead/stuck parallel review sessions are invisible to deacon, Problem 2: No circuit breaker for infrastructure-failure cycling, Problem 3: Verification passed but review blocks the pipeline forever, Problem 4: Incomplete parallel reviews waste completed findings, Problem 5: `stuck` flag is never set, so re-dispatch never stops, Problem 6: No UI indication that recovery is happening, Problems Enumerated
 
 ### Community 960 - "Community 960"
 Cohesion: 0.29
-Nodes (6): 1. Reproduce, 2. Investigate Root Cause, 3. Implement Fix, 4. Add Regression Test, 5. Verify, Bug Fix
+Nodes (7): code:block7 (DockerStatsCollector (5s poll)), code:block8 (DockerStatsCollector.getHistory(containerId) (60 samples)), code:block9 (resource-discovery.ts (30s cache)), Container history path (new, lazy), Container stats path (new), Data flow, Resource detail identifiers path (existing)
 
 ### Community 961 - "Community 961"
 Cohesion: 0.29
-Nodes (7): code:bash (# Check sync status), code:bash (# Check what's there), code:bash (# Check trigger patterns in SKILL.md), "Skill already exists", Skill Issues, Skill not triggering, Skills not showing up
+Nodes (7): code:typescript ({), code:typescript ({), Commands (mutations), Key Type Definitions, RPC Methods, Streaming (server → client), Unary (request → response)
 
 ### Community 962 - "Community 962"
 Cohesion: 0.29
-Nodes (6): code:bash (# System info), Collecting Diagnostics, Issue Categories, Overview, Related Skills, Troubleshooting Guide
+Nodes (7): From `BadgeBar` modals, From `InspectorPanel` sections, From `IssueCard` (kanban card), From `StatusFlowControl`, From `WorkspacePane`, Parity smoke test, Reunified action layer (parity, additive)
 
 ### Community 963 - "Community 963"
 Cohesion: 0.29
-Nodes (7): "Cannot find module" errors, code:bash (# Check if installed), code:bash (# Reinstall dependencies), code:bash (# Check version), Installation Issues, Node.js version issues, "pan: command not found"
+Nodes (7): code:typescript (interface RoundMarker {), code:block14 (── Round 1 · 14:02 → 14:06 · passed · 8 findings ─────), code:block15 (addressing: specialist-panopticon-540-review-correctness    ), Composer addressing, Session-tab strip (NEW), What changes, Zone C — Conversation + composer (agent-selected)
 
 ### Community 964 - "Community 964"
 Cohesion: 0.29
-Nodes (7): Can't reach Linear API, code:bash (# Test connectivity), code:bash (# Check Traefik is running), code:bash (# Get WSL2 IP), Network Issues, Traefik not routing, WSL2 networking
+Nodes (7): P2 — Readiness and delivery (trust hooks, remove fallbacks), `src/dashboard/server/routes/conversations.ts:81` — `waitForClaudeReady()`, `src/lib/agents.ts:1041` — `startAgent` inline prompt-ready check, `src/lib/agents.ts:244` — `waitForReadySignal()`, `src/lib/cloister/specialists.ts:2484,2495` — specialist delivery confirmation, `src/lib/tmux.ts:527` — `waitForClaudePrompt()`, `src/lib/tmux.ts:559` — `confirmDelivery()`
 
 ### Community 965 - "Community 965"
 Cohesion: 0.29
-Nodes (6): code:block1 (LIFECYCLE VERBS (top-level)), code:bash (pan <args>), Command Taxonomy (0.7.0), Dispatch, Panopticon CLI Umbrella Skill, Usage
+Nodes (7): P1 — Deacon health/stuck detection (structured state), `src/dashboard/lib/health-filtering.ts:13` — `checkAgentHealthAsync()`, `src/lib/cloister/deacon.ts:651` — `checkLazyAgent()`, `src/lib/cloister/deacon.ts:849` — `isAgentActiveInTmux()`, `src/lib/cloister/deacon.ts:935` — `parseThinkingDuration()`, `src/lib/cloister/deacon.ts:955` — `checkStuckWorkAgents()`, `src/lib/health.ts:91` — `getAgentOutput()`
 
 ### Community 966 - "Community 966"
 Cohesion: 0.29
-Nodes (6): 1. High-Level Structure, 2. Tech Stack, 3. Architecture Patterns, 4. Development Workflow, 5. Document Findings, Codebase Onboarding
+Nodes (6): Approach, Decision, Difficulty: trivial, PAN-415: Test: trace what calls complete-planning after agent finishes, Scope, Status: Planning Complete
 
 ### Community 967 - "Community 967"
 Cohesion: 0.29
-Nodes (7): Advanced Usage, code:bash (# Force kill all processes), code:bash (# Stop only dashboard (keep API running)), code:bash (# Stop dashboard and Traefik), Force Stop, Stop and Clean Up Workspaces, Stop Specific Services
+Nodes (7): 1. Core Fix (CRITICAL), 2. Comprehensive Testing, 3. Error Handling Improvements, 4. Configuration Validation, 5. Documentation, code:typescript (// Before:), Solution Design
 
 ### Community 968 - "Community 968"
 Cohesion: 0.29
-Nodes (6): code:bash (GITHUB_TOKEN=ghp_xxxxx     # For GitHub-tracked projects), Configuration, Issue Tracker Integration, Related Guides, Supported Trackers, Unified Dashboard
+Nodes (6): Agent State: PAN-647, Blockers/Concerns, Current Position, Decisions Made During Planning, Notes, Planned Tasks
 
 ### Community 969 - "Community 969"
 Cohesion: 0.29
-Nodes (7): code:yaml (# In projects.yaml), code:bash (# Add manually or let Panopticon manage it), code:yaml (dns:), DNS Configuration, Option 1: .localhost (Recommended), Option 2: /etc/hosts, Option 3: WSL2 Hosts Sync (Windows)
+Nodes (6): Agent State: MIN-794, Blockers/Concerns, Current Position, Decisions Made During Planning, Notes, Planned Tasks
 
 ### Community 970 - "Community 970"
 Cohesion: 0.29
-Nodes (6): code:bash (# Install mkcert), Docker & HTTPS Setup, Overview, Prerequisites, Quick Setup, Related Guides
+Nodes (6): Decision (per PRD), Out of scope (confirmed from PRD), PAN-705: Command Taxonomy Reorganization, Pipeline handoff notes for specialists, Problem, Scope anchors
 
 ### Community 971 - "Community 971"
 Cohesion: 0.29
-Nodes (7): requestReviewCommand(), 13. Icons, code:block31 (Default:  18px (w-[18px] h-[18px])), code:block32 (Command Deck:  Compass), Color, Nav Icons, Sizing
+Nodes (7): Agent Issues, Agent keeps failing, Agent stuck / not responding, code:bash (# Check tmux session), code:bash (cat ~/.panopticon/agents/agent-min-123/state.json | jq .hand), code:bash (# Correct), Messages not reaching agent
 
 ### Community 972 - "Community 972"
 Cohesion: 0.29
-Nodes (7): 11. Theme Toggle, code:html (<script>), code:css (.no-transitions,), code:typescript (function toggleTheme() {), Flash Prevention, Implementation, Transition Suppression
+Nodes (7): code:bash (# Check container logs), code:bash (# Create the network), code:bash (# Use sudo to remove), Container won't start, Docker Issues, "No such network: panopticon", Permission denied on mounted volumes
 
 ### Community 973 - "Community 973"
 Cohesion: 0.29
-Nodes (6): code:bash (# Set up Kimi API), Files, Model Capability Research Framework, Overview, Research Workflow, Using Kimi 2.5 for Research
+Nodes (7): Analyze Structure, code:bash (# By name), code:bash (# Function definitions), code:bash (# Directory tree (shallow)), Find Files, Quick Reference Commands, Search Code
 
 ### Community 974 - "Community 974"
-Cohesion: 0.33
-Nodes (4): CLI_DIST, CONTRACTS_DIST, __dirname, ROOT
+Cohesion: 0.29
+Nodes (7): code:bash (# Count errors per agent), code:bash (# If logs have timestamps, extract timeline), code:bash (# Count tool calls by type), Count Errors, Log Analysis, Timeline of Actions, Tool Usage Analysis
 
 ### Community 975 - "Community 975"
-Cohesion: 0.33
-Nodes (5): cache, cacheKey, config, configRepos, keys
+Cohesion: 0.29
+Nodes (7): code:bash (# Check if session exists), code:bash (# Truncate log file), code:bash (# Add timestamps when capturing), Logs Too Large, Missing Timestamps, No Output from Agent, Troubleshooting
 
 ### Community 976 - "Community 976"
-Cohesion: 0.33
-Nodes (5): beads, capturedArgs, err, mockExecFileFn, mockExecFn
+Cohesion: 0.29
+Nodes (6): 1. Assess (First 5 minutes), 2. Mitigate (Stop the bleeding), 3. Investigate (Once stable), 4. Fix, 5. Postmortem, Incident Response
 
 ### Community 977 - "Community 977"
-Cohesion: 0.33
-Nodes (4): desktopVersion, __dirname, repoRoot, rootVersion
+Cohesion: 0.29
+Nodes (7): code:bash (bd daemon), code:bash (# In your project directory), code:bash (# If you don't want daemon to pull from remote), Daemon Won't Start, Resolution, Root Cause, Symptom
 
 ### Community 978 - "Community 978"
-Cohesion: 0.47
-Nodes (5): create_agent(), get_agent_path(), main(), Get the appropriate agent directory based on scope., Create a new subagent file.
+Cohesion: 0.29
+Nodes (7): code:bash (bd init myproject), code:bash (bd daemon --global=false &), code:bash (#!/bin/bash), JSONL File Not Created, Resolution, Root Cause, Symptom
 
 ### Community 979 - "Community 979"
-Cohesion: 0.47
-Nodes (5): main(), package_skill(), Validate skill structure and contents., Package a skill folder into a .skill file., validate_skill()
+Cohesion: 0.29
+Nodes (7): code:bash (# Manual creation), code:bash (bd formula list                 # List all formulas (protos)), code:bash (bd mol show mol-release         # Show template structure an), Creating a Proto, Listing Formulas, Proto Management, Viewing Proto Structure
 
 ### Community 980 - "Community 980"
-Cohesion: 0.47
-Nodes (3): emit(), load_model(), main()
+Cohesion: 0.29
+Nodes (7): code:bash (# Project A ships a capability), code:bash (bd ship <capability>            # Ship capability (requires ), code:bash (bd dep add <issue> external:<project>:<capability>), Concept, Cross-Project Dependencies, Depending on External Capabilities, Shipping Capabilities
 
 ### Community 981 - "Community 981"
-Cohesion: 0.33
-Nodes (3): body, content, { frontmatter, body }
+Cohesion: 0.29
+Nodes (6): CLI Command Reference, Dependency Types, Issue Types, Priorities, Quick Navigation, See Also
 
 ### Community 982 - "Community 982"
-Cohesion: 0.33
-Nodes (5): mockConversation, mockMessages, raw, toggle, url
+Cohesion: 0.29
+Nodes (6): code:bash (pan wipe <issue-id>), pan wipe, See Also, Warning, What It Does, When to Use
 
 ### Community 983 - "Community 983"
-Cohesion: 0.33
-Nodes (5): baseSettings, flywheelCard, method, settings, settingsBtn
+Cohesion: 0.29
+Nodes (7): Check Current Status, code:bash (pan doctor), code:bash (# Clone the repository), code:bash (# Use automated installer), Install Panopticon, Install Prerequisites, Step 2: Installation (5 minutes)
 
 ### Community 984 - "Community 984"
-Cohesion: 0.4
-Nodes (3): LogViewerProps, SpecialistLogViewer(), SSEMessage
+Cohesion: 0.29
+Nodes (6): code:block1 (pan admin cloister status [--json]   # Show watchdog service), Confirm before emergency-stop, pan admin cloister, See also, Usage, When to use each subcommand
+
+### Community 985 - "Community 985"
+Cohesion: 0.29
+Nodes (7): Advanced Usage, code:bash (# Start with hot reload for development), code:bash (# Start only dashboard (no API)), code:bash (# Use environment variables), Custom Ports, Start in Development Mode, Start Specific Services
 
 ### Community 986 - "Community 986"
-Cohesion: 0.33
-Nodes (5): after, body, result, { saveAgentRuntimeStateMock, getAgentRuntimeStateMock }, processResetReviewPipeline()
+Cohesion: 0.29
+Nodes (7): Auto-Start on Boot, code:ini ([Unit]), code:bash (sudo systemctl enable panopticon), code:xml (<?xml version="1.0" encoding="UTF-8"?>), code:bash (launchctl load ~/Library/LaunchAgents/com.panopticon.dashboa), Using launchd (macOS), Using systemd (Linux)
 
 ### Community 987 - "Community 987"
-Cohesion: 0.33
-Nodes (5): Audit Prompt: Distinct Data Captured from tmux Scrollback, Constraints, Instructions, Objective, Output Format
+Cohesion: 0.29
+Nodes (7): Check Resource Usage, Check Service Status, Check Specific Agent, code:bash (# Check if dashboard is running), code:bash (# Verbose status with CPU/memory), code:bash (# Show detailed status for one agent), Detailed Status Checks
 
 ### Community 988 - "Community 988"
-Cohesion: 0.33
-Nodes (6): Auth Flow, code:bash (pan specialists done uat <issueId> --status passed   # Signa), Four Verification Phases, Pipeline Trigger, UAT Specialist (PAN-383), Why UAT Exists
+Cohesion: 0.29
+Nodes (7): App Background, code:block2 (--background       Page background (white / slate-950)), Color System, MYN Task Type Colors (Methodology), Priority Colors, Semantic Colors, Shadcn/UI Semantic Tokens (CSS Variables)
 
 ### Community 989 - "Community 989"
-Cohesion: 0.33
-Nodes (6): Agent Behavior After Reopen, Preserving History, Preventing Stale Dispatch, Reopening Issues for Re-Work, What Reopen Resets, Why "In Progress" and Not Backlog
+Cohesion: 0.29
+Nodes (7): Border Radius, Border & Shadow, code:block5 (rounded-md   (6px)  Buttons, inputs, small cards), code:block6 (shadow-sm   Sidebar cards, secondary), code:tsx (bg-muted/40         // Very subtle containers), Opacity Modifiers, Shadows
 
 ### Community 990 - "Community 990"
-Cohesion: 0.33
-Nodes (5): Central gate, CLI and dashboard break-glass, Non-agent tmux sessions, Spawn entrypoint audit, Spawn Gating
+Cohesion: 0.29
+Nodes (6): code:block14 (src/), Design Principles, File Structure, Key Files, Mind Your Now Design System & Coding Standards, Tech Stack
 
 ### Community 991 - "Community 991"
-Cohesion: 0.33
-Nodes (6): Browser-Only Mode, code:bash (npx panopticon serve), Desktop App, Installation, Key Features, `pan up` Electron Detection
+Cohesion: 0.29
+Nodes (6): Code Review, Correctness, Design, Output Format, Performance, Security
 
 ### Community 992 - "Community 992"
-Cohesion: 0.33
-Nodes (6): code:block1 (┌───────────────────────────────────────────────────────────), code:block2 (┌───────────────────────────────────────────────────────────), Core Concept, Part 1: Architecture Vision, Success Metrics, Unified Architecture
+Cohesion: 0.29
+Nodes (6): 1. Reproduce, 2. Investigate Root Cause, 3. Implement Fix, 4. Add Regression Test, 5. Verify, Bug Fix
 
 ### Community 993 - "Community 993"
-Cohesion: 0.33
-Nodes (6): 3. Real-World Conflict: Mind Your Now, code:block7 (pan workspace create MIN-678), code:yaml (agent:), MYN Project Configuration, Skill Audit (Feb 2026), The Override Problem
+Cohesion: 0.29
+Nodes (7): Can't reach Linear API, code:bash (# Test connectivity), code:bash (# Check Traefik is running), code:bash (# Get WSL2 IP), Network Issues, Traefik not routing, WSL2 networking
 
 ### Community 994 - "Community 994"
-Cohesion: 0.33
-Nodes (6): 8. Complete Content Inventory, MYN Project Template Content, Panopticon Agents (8), Panopticon Dev-Skills (3), Panopticon Skills (64), Project-Scoped (Panopticon repo only)
+Cohesion: 0.29
+Nodes (6): code:bash (# System info), Collecting Diagnostics, Issue Categories, Overview, Related Skills, Troubleshooting Guide
 
 ### Community 995 - "Community 995"
-Cohesion: 0.33
-Nodes (6): Advanced Configuration, code:bash (# View effective configuration), code:bash (# Automatic migration (coming soon in PAN-118-6)), Debugging Model Resolution, Migration from settings.json, Validation
+Cohesion: 0.29
+Nodes (7): "Cannot find module" errors, code:bash (# Check if installed), code:bash (# Reinstall dependencies), code:bash (# Check version), Installation Issues, Node.js version issues, "pan: command not found"
 
 ### Community 996 - "Community 996"
-Cohesion: 0.33
-Nodes (6): code:yaml (models:), code:block27 (Warning: Model gpt-5.2-codex requires openai API key - falli), Example Scenario, Fallback Behavior, Fallback Mappings, Fallback Strategy
+Cohesion: 0.29
+Nodes (7): code:bash (# Check sync status), code:bash (# Check what's there), code:bash (# Check trigger patterns in SKILL.md), "Skill already exists", Skill Issues, Skill not triggering, Skills not showing up
 
 ### Community 997 - "Community 997"
-Cohesion: 0.33
-Nodes (6): 10.1 Agent Object (Unified), 10.2 API Endpoints Needed, 10.3 Existing Endpoints to Reuse, 10.4 Real-time Updates, 10. Data Requirements, code:typescript (interface UnifiedAgent {)
+Cohesion: 0.29
+Nodes (6): code:block1 (LIFECYCLE VERBS (top-level)), code:bash (pan <args>), Command Taxonomy (0.7.0), Dispatch, Panopticon CLI Umbrella Skill, Usage
 
 ### Community 998 - "Community 998"
-Cohesion: 0.33
-Nodes (6): 13. Implementation Plan, Phase 1: Foundation, Phase 2: Live Grid, Phase 3: Detail Panel, Phase 4: Additional Views, Phase 5: Polish
+Cohesion: 0.29
+Nodes (6): 1. High-Level Structure, 2. Tech Stack, 3. Architecture Patterns, 4. Development Workflow, 5. Document Findings, Codebase Onboarding
 
 ### Community 999 - "Community 999"
-Cohesion: 0.33
-Nodes (6): code:typescript (// workspaces.ts processUnstickRequest — skip git check for ), code:typescript (setReviewStatusBase(issueId, {), G.1 Reuse existing unstick route — do NOT add a new endpoint, G.2 Session ownership, G.3 Liveness-check caveats, G. Recovery flow, session ownership, liveness caveats
+Cohesion: 0.29
+Nodes (7): Advanced Usage, code:bash (# Force kill all processes), code:bash (# Stop only dashboard (keep API running)), code:bash (# Stop dashboard and Traefik), Force Stop, Stop and Clean Up Workspaces, Stop Specific Services
 
 ### Community 1000 - "Community 1000"
-Cohesion: 0.33
-Nodes (6): Detailed flows, Flow A — First-run, Flow B — Adding a second project, Flow C — Editing branch config, Flow D — Re-detecting repos, Flow E — Killing a stuck Setup Agent
+Cohesion: 0.29
+Nodes (6): code:bash (GITHUB_TOKEN=ghp_xxxxx     # For GitHub-tracked projects), Configuration, Issue Tracker Integration, Related Guides, Supported Trackers, Unified Dashboard
 
 ### Community 1001 - "Community 1001"
-Cohesion: 0.33
-Nodes (6): Agent Instructions, Bead Assignments, code:typescript (// src/dashboard/server/routes/{category}.ts), Pattern, Route Conversion Cheat Sheet, Route Migration Details (B6–B17)
+Cohesion: 0.29
+Nodes (6): code:bash (# Install mkcert), Docker & HTTPS Setup, Overview, Prerequisites, Quick Setup, Related Guides
 
 ### Community 1002 - "Community 1002"
-Cohesion: 0.33
-Nodes (6): 1. Reviewers fan out as fresh sessions on every round, 2. Conversation view never loads for agent sessions, 3. The Command Deck has no opinion on issue + agent + workflow as one surface, 4. The view doesn't feel alive, code:block1 (review                  ○ ended), Problem
+Cohesion: 0.29
+Nodes (7): code:yaml (# In projects.yaml), code:bash (# Add manually or let Panopticon manage it), code:yaml (dns:), DNS Configuration, Option 1: .localhost (Recommended), Option 2: /etc/hosts, Option 3: WSL2 Hosts Sync (Windows)
 
 ### Community 1003 - "Community 1003"
-Cohesion: 0.33
-Nodes (6): P3 — Merge/test/review structured events, `src/lib/cloister/merge-agent.ts:1071` — test failure baseline, `src/lib/cloister/merge-agent.ts:1744` — `resolveConflictsWithAgent()` sync-main polling, `src/lib/cloister/merge-agent.ts:412` — `parseAgentOutput()`, `src/lib/cloister/merge-agent.ts:684` — `scanGitPatterns()`, `src/lib/cloister/review-agent.ts:139` — `parseAgentOutput()`
+Cohesion: 0.29
+Nodes (7): 11. Theme Toggle, code:html (<script>), code:css (.no-transitions,), code:typescript (function toggleTheme() {), Flash Prevention, Implementation, Transition Suppression
 
 ### Community 1004 - "Community 1004"
-Cohesion: 0.33
-Nodes (5): Context, Decision, Difficulty: trivial, PAN-448: Start Agent confirmation timeout too short, Scope
+Cohesion: 0.29
+Nodes (6): code:bash (# Set up Kimi API), Files, Model Capability Research Framework, Overview, Research Workflow, Using Kimi 2.5 for Research
 
 ### Community 1005 - "Community 1005"
 Cohesion: 0.33
-Nodes (6): code:bash (# Restart the dashboard), code:bash (# Check Docker memory), Dashboard slow to load, High CPU usage, High memory usage, Performance Issues
+Nodes (4): CLI_DIST, CONTRACTS_DIST, __dirname, ROOT
 
 ### Community 1006 - "Community 1006"
 Cohesion: 0.33
-Nodes (6): code:bash (# Option 1: Manual cleanup), Common Causes, Corrupted Workspaces, Prevention, Resolution, Symptoms
+Nodes (5): cache, cacheKey, config, configRepos, keys
 
 ### Community 1007 - "Community 1007"
 Cohesion: 0.33
-Nodes (6): 1. Fail loud, fail early, 2. One template, one API, 3. Composition happens in TypeScript, 4. Variables are declared, not discovered, 5. Prompts are not docstrings, Core principles
+Nodes (5): beads, capturedArgs, err, mockExecFileFn, mockExecFn
 
 ### Community 1008 - "Community 1008"
 Cohesion: 0.33
-Nodes (5): code:block9 (<!-- panopticon:orchestration-context-start -->), Further reading, Orchestration markers, Prompt Templates, Why templates at all
+Nodes (4): desktopVersion, __dirname, repoRoot, rootVersion
 
 ### Community 1009 - "Community 1009"
-Cohesion: 0.33
-Nodes (5): Boundaries, Outputs, Panopticon Planning Agent, Process, State model
+Cohesion: 0.47
+Nodes (5): create_agent(), get_agent_path(), main(), Get the appropriate agent directory based on scope., Create a new subagent file.
 
 ### Community 1010 - "Community 1010"
-Cohesion: 0.33
-Nodes (5): Boundaries, code:bash (npm test), Completion, Panopticon Work Agent, Per-Bead Workflow
+Cohesion: 0.47
+Nodes (5): main(), package_skill(), Validate skill structure and contents., Package a skill folder into a .skill file., validate_skill()
 
 ### Community 1011 - "Community 1011"
-Cohesion: 0.33
-Nodes (5): Additional Context (Optional), code:markdown (## Agent: {ISSUE_ID} - {ISSUE_TITLE}), Required Information Table, When to Apply This Format, Workspace Status Display Format
+Cohesion: 0.47
+Nodes (3): emit(), load_model(), main()
 
 ### Community 1012 - "Community 1012"
 Cohesion: 0.33
-Nodes (5): code:bash (pan done <issue-id>), pan done, See Also, What It Does, When to Use
+Nodes (3): body, content, { frontmatter, body }
 
 ### Community 1013 - "Community 1013"
 Cohesion: 0.33
-Nodes (6): code:python (# Want: "task-2 depends on task-1" (task-1 blocks task-2)), code:python (# Correct: task-2 depends on task-1), code:bash (bd dep add task-2 task-1 --type blocks), code:bash (bd show task-2), Dependencies Created Backwards, MCP-Specific Issues
+Nodes (5): mockConversation, mockMessages, raw, toggle, url
 
 ### Community 1014 - "Community 1014"
 Cohesion: 0.33
-Nodes (5): Contents, Interface-Specific Troubleshooting, Quick Reference: Common Fixes, Related Documentation, Troubleshooting Guide
-
-### Community 1015 - "Community 1015"
-Cohesion: 0.33
-Nodes (6): Claude Code Skill Issues, code:bash (# 1. Version), code:bash (ls -la ~/.claude/skills/bd-issue-tracking/), Debug Checklist, Getting Help, Report to beads GitHub
+Nodes (5): baseSettings, flywheelCard, method, settings, settingsBtn
 
 ### Community 1016 - "Community 1016"
-Cohesion: 0.33
-Nodes (5): Limitations, Reference Databases / Glossaries (Alternative Use), Using bd for Static Reference Data, When to Use This Pattern, Work Tracking (Primary Use Case)
+Cohesion: 0.4
+Nodes (3): LogViewerProps, SpecialistLogViewer(), SSEMessage
 
 ### Community 1017 - "Community 1017"
 Cohesion: 0.33
-Nodes (5): code:bash (pan resources), code:bash (pan resources --json), Interpreting results, JSON output, System Resource Inventory
+Nodes (5): Audit Prompt: Distinct Data Captured from tmux Scrollback, Constraints, Instructions, Objective, Output Format
 
 ### Community 1018 - "Community 1018"
 Cohesion: 0.33
-Nodes (5): code:bash (pan admin hooks install), pan admin hooks install, See Also, What It Does, When to Use
+Nodes (6): Auth Flow, code:bash (pan specialists done uat <issueId> --status passed   # Signa), Four Verification Phases, Pipeline Trigger, UAT Specialist (PAN-383), Why UAT Exists
 
 ### Community 1019 - "Community 1019"
 Cohesion: 0.33
-Nodes (5): code:block1 (https://raw.githubusercontent.com/vercel-labs/web-interface-), Guidelines Source, How It Works, Usage, Web Interface Guidelines
+Nodes (6): Agent Behavior After Reopen, Preserving History, Preventing Stale Dispatch, Reopening Issues for Re-Work, What Reopen Resets, Why "In Progress" and Not Backlog
 
 ### Community 1020 - "Community 1020"
 Cohesion: 0.33
-Nodes (5): Canonical paths, code:bash (# Build first if dashboard server or CLI code changed), Execution, Important Notes, Restart Panopticon
+Nodes (5): Central gate, CLI and dashboard break-glass, Non-agent tmux sessions, Spawn entrypoint audit, Spawn Gating
 
 ### Community 1021 - "Community 1021"
 Cohesion: 0.33
-Nodes (5): After Refactoring, Before Starting, During Refactoring, Refactoring, Refactoring Types
+Nodes (6): Browser-Only Mode, code:bash (npx panopticon serve), Desktop App, Installation, Key Features, `pan up` Electron Detection
 
 ### Community 1022 - "Community 1022"
 Cohesion: 0.33
-Nodes (6): code:bash (# One-liner to check everything), code:bash (# Watch agent status (updates every 2 seconds)), Continuous Monitoring, Dashboard Monitoring, Monitoring Workflows, Quick Health Check
+Nodes (6): code:block1 (┌───────────────────────────────────────────────────────────), code:block2 (┌───────────────────────────────────────────────────────────), Core Concept, Part 1: Architecture Vision, Success Metrics, Unified Architecture
 
 ### Community 1023 - "Community 1023"
 Cohesion: 0.33
-Nodes (6): Alert on Agent Crash, code:bash (#!/bin/bash), code:bash (chmod +x ~/scripts/pan-dashboard.sh), code:bash (#!/bin/bash), Custom Status Dashboard, Status Scripts
+Nodes (6): code:bash (pan workspace create my-feature --template node-fullstack), code:block102 (~/.panopticon/templates/), code:toml ([template]), Starter Templates (Optional), Template Metadata (template.toml), Template Structure
 
 ### Community 1024 - "Community 1024"
 Cohesion: 0.33
-Nodes (5): Architectural rules, Execution steps, Retrieval and networking, Stitch to React Components, Troubleshooting
+Nodes (6): 8. Complete Content Inventory, MYN Project Template Content, Panopticon Agents (8), Panopticon Dev-Skills (3), Panopticon Skills (64), Project-Scoped (Panopticon repo only)
 
 ### Community 1025 - "Community 1025"
 Cohesion: 0.33
-Nodes (5): code:bash (pan reload), Command, Notes, Options, Pan Reload
+Nodes (6): Advanced Configuration, code:bash (# View effective configuration), code:bash (# Automatic migration (coming soon in PAN-118-6)), Debugging Model Resolution, Migration from settings.json, Validation
 
 ### Community 1026 - "Community 1026"
 Cohesion: 0.33
-Nodes (5): code:bash (pan issues), pan issues, See Also, What It Does, When to Use
+Nodes (6): code:yaml (models:), code:block27 (Warning: Model gpt-5.2-codex requires openai API key - falli), Example Scenario, Fallback Behavior, Fallback Mappings, Fallback Strategy
 
 ### Community 1027 - "Community 1027"
 Cohesion: 0.33
-Nodes (5): 1. Version Bump, 2. Final Verification, 3. Create Release, 4. Post-Release, Release Process
+Nodes (6): 10.1 Agent Object (Unified), 10.2 API Endpoints Needed, 10.3 Existing Endpoints to Reuse, 10.4 Real-time Updates, 10. Data Requirements, code:typescript (interface UnifiedAgent {)
 
 ### Community 1028 - "Community 1028"
 Cohesion: 0.33
-Nodes (5): code:bash (pan close <issue-id>), pan close, See Also, What It Does, When to Use
+Nodes (6): 13. Implementation Plan, Phase 1: Foundation, Phase 2: Live Grid, Phase 3: Detail Panel, Phase 4: Additional Views, Phase 5: Polish
 
 ### Community 1029 - "Community 1029"
 Cohesion: 0.33
-Nodes (6): code:bash (LINEAR_API_KEY=lin_api_xxxxx), code:yaml (projects:), Issue States, Linear Integration, Setup, Team Mapping
+Nodes (6): code:ts (interface Room {), HTTP API, Room state (in-memory), The Signaling Service, WebSocket API — `WS /signal`, What the signaling service can and cannot see
 
 ### Community 1030 - "Community 1030"
 Cohesion: 0.33
-Nodes (6): code:bash (# In ~/.panopticon.env), code:bash (DEBUG=rally pan up), code:bash (curl -X POST http://localhost:3011/api/rally/validate \), Finding Workspace and Project IDs, Rally Troubleshooting, WSAPI Query Parse Errors
+Nodes (6): Architecture, code:block1 (HOST machine                  panopticon-cli.com            ), Components, Reuse: the terminal-sharing primitive, Two-role decomposition of "host", Why the hub is the host's server, not the host's browser
 
 ### Community 1031 - "Community 1031"
 Cohesion: 0.33
-Nodes (6): code:block2 (~/.panopticon/traefik/), code:yaml (api:), code:yaml (http:), Dynamic Configuration, Static Configuration, Traefik Configuration
+Nodes (6): code:typescript (// workspaces.ts processUnstickRequest — skip git check for ), code:typescript (setReviewStatusBase(issueId, {), G.1 Reuse existing unstick route — do NOT add a new endpoint, G.2 Session ownership, G.3 Liveness-check caveats, G. Recovery flow, session ownership, liveness caveats
 
 ### Community 1032 - "Community 1032"
 Cohesion: 0.33
-Nodes (6): 12. Animation & Motion, code:block29 (Duration: 200ms (default for all state transitions)), code:block30 (Hover highlight:   transition-colors duration-200), Patterns, Rules, Standard Timing
+Nodes (6): Detailed flows, Flow A — First-run, Flow B — Adding a second project, Flow C — Editing branch config, Flow D — Re-detecting repos, Flow E — Killing a stuck Setup Agent
 
 ### Community 1033 - "Community 1033"
 Cohesion: 0.33
-Nodes (6): 15. Page-Specific Notes, Agents, Board (Kanban), Command Deck (formerly Mission Control), God View, Settings
+Nodes (6): Agent Instructions, Bead Assignments, code:typescript (// src/dashboard/server/routes/{category}.ts), Pattern, Route Conversion Cheat Sheet, Route Migration Details (B6–B17)
 
 ### Community 1034 - "Community 1034"
 Cohesion: 0.33
-Nodes (6): 14. Accessibility, code:block33 (focus-visible:ring-[3px] focus-visible:ring-ring/24 focus-vi), Contrast Ratios, Focus Indicators, Keyboard Navigation, Touch Targets
+Nodes (6): 1. Reviewers fan out as fresh sessions on every round, 2. Conversation view never loads for agent sessions, 3. The Command Deck has no opinion on issue + agent + workflow as one surface, 4. The view doesn't feel alive, code:block1 (review                  ○ ended), Problem
 
 ### Community 1035 - "Community 1035"
 Cohesion: 0.33
-Nodes (5): Agent Resumed — {{ISSUE_ID}}, Last Known Status: {{STATE_STATUS}}, Operator Message, What To Do Now, Where You Left Off
+Nodes (6): P3 — Merge/test/review structured events, `src/lib/cloister/merge-agent.ts:1071` — test failure baseline, `src/lib/cloister/merge-agent.ts:1744` — `resolveConflictsWithAgent()` sync-main polling, `src/lib/cloister/merge-agent.ts:412` — `parseAgentOutput()`, `src/lib/cloister/merge-agent.ts:684` — `scanGitPatterns()`, `src/lib/cloister/review-agent.ts:139` — `parseAgentOutput()`
 
 ### Community 1036 - "Community 1036"
 Cohesion: 0.33
-Nodes (5): Auto-Clarity, Boundaries, Intensity, Persistence, Rules
+Nodes (5): Context, Decision, Difficulty: trivial, PAN-448: Start Agent confirmation timeout too short, Scope
 
 ### Community 1037 - "Community 1037"
+Cohesion: 0.33
+Nodes (6): code:bash (# Restart the dashboard), code:bash (# Check Docker memory), Dashboard slow to load, High CPU usage, High memory usage, Performance Issues
+
+### Community 1038 - "Community 1038"
+Cohesion: 0.33
+Nodes (6): code:bash (# Option 1: Manual cleanup), Common Causes, Corrupted Workspaces, Prevention, Resolution, Symptoms
+
+### Community 1039 - "Community 1039"
+Cohesion: 0.33
+Nodes (6): 1. Fail loud, fail early, 2. One template, one API, 3. Composition happens in TypeScript, 4. Variables are declared, not discovered, 5. Prompts are not docstrings, Core principles
+
+### Community 1040 - "Community 1040"
+Cohesion: 0.33
+Nodes (5): code:block9 (<!-- panopticon:orchestration-context-start -->), Further reading, Orchestration markers, Prompt Templates, Why templates at all
+
+### Community 1041 - "Community 1041"
+Cohesion: 0.33
+Nodes (5): Boundaries, Outputs, Panopticon Planning Agent, Process, State model
+
+### Community 1042 - "Community 1042"
+Cohesion: 0.33
+Nodes (5): Boundaries, code:bash (npm test), Completion, Panopticon Work Agent, Per-Bead Workflow
+
+### Community 1043 - "Community 1043"
+Cohesion: 0.33
+Nodes (5): Additional Context (Optional), code:markdown (## Agent: {ISSUE_ID} - {ISSUE_TITLE}), Required Information Table, When to Apply This Format, Workspace Status Display Format
+
+### Community 1044 - "Community 1044"
+Cohesion: 0.33
+Nodes (5): code:bash (pan done <issue-id>), pan done, See Also, What It Does, When to Use
+
+### Community 1045 - "Community 1045"
+Cohesion: 0.33
+Nodes (5): Contents, Interface-Specific Troubleshooting, Quick Reference: Common Fixes, Related Documentation, Troubleshooting Guide
+
+### Community 1046 - "Community 1046"
+Cohesion: 0.33
+Nodes (6): code:python (# Want: "task-2 depends on task-1" (task-1 blocks task-2)), code:python (# Correct: task-2 depends on task-1), code:bash (bd dep add task-2 task-1 --type blocks), code:bash (bd show task-2), Dependencies Created Backwards, MCP-Specific Issues
+
+### Community 1047 - "Community 1047"
+Cohesion: 0.33
+Nodes (6): Claude Code Skill Issues, code:bash (# 1. Version), code:bash (ls -la ~/.claude/skills/bd-issue-tracking/), Debug Checklist, Getting Help, Report to beads GitHub
+
+### Community 1048 - "Community 1048"
+Cohesion: 0.33
+Nodes (5): Limitations, Reference Databases / Glossaries (Alternative Use), Using bd for Static Reference Data, When to Use This Pattern, Work Tracking (Primary Use Case)
+
+### Community 1049 - "Community 1049"
+Cohesion: 0.33
+Nodes (5): code:bash (pan resources), code:bash (pan resources --json), Interpreting results, JSON output, System Resource Inventory
+
+### Community 1050 - "Community 1050"
+Cohesion: 0.33
+Nodes (5): code:bash (pan admin hooks install), pan admin hooks install, See Also, What It Does, When to Use
+
+### Community 1051 - "Community 1051"
+Cohesion: 0.33
+Nodes (5): code:block1 (https://raw.githubusercontent.com/vercel-labs/web-interface-), Guidelines Source, How It Works, Usage, Web Interface Guidelines
+
+### Community 1052 - "Community 1052"
+Cohesion: 0.33
+Nodes (5): Canonical paths, code:bash (# Build first if dashboard server or CLI code changed), Execution, Important Notes, Restart Panopticon
+
+### Community 1053 - "Community 1053"
+Cohesion: 0.33
+Nodes (5): After Refactoring, Before Starting, During Refactoring, Refactoring, Refactoring Types
+
+### Community 1054 - "Community 1054"
+Cohesion: 0.33
+Nodes (6): code:bash (# One-liner to check everything), code:bash (# Watch agent status (updates every 2 seconds)), Continuous Monitoring, Dashboard Monitoring, Monitoring Workflows, Quick Health Check
+
+### Community 1055 - "Community 1055"
+Cohesion: 0.33
+Nodes (6): Alert on Agent Crash, code:bash (#!/bin/bash), code:bash (chmod +x ~/scripts/pan-dashboard.sh), code:bash (#!/bin/bash), Custom Status Dashboard, Status Scripts
+
+### Community 1056 - "Community 1056"
+Cohesion: 0.33
+Nodes (5): Architectural rules, Execution steps, Retrieval and networking, Stitch to React Components, Troubleshooting
+
+### Community 1057 - "Community 1057"
+Cohesion: 0.33
+Nodes (5): code:bash (pan reload), Command, Notes, Options, Pan Reload
+
+### Community 1058 - "Community 1058"
+Cohesion: 0.33
+Nodes (5): code:bash (pan issues), pan issues, See Also, What It Does, When to Use
+
+### Community 1059 - "Community 1059"
+Cohesion: 0.33
+Nodes (5): 1. Version Bump, 2. Final Verification, 3. Create Release, 4. Post-Release, Release Process
+
+### Community 1060 - "Community 1060"
+Cohesion: 0.33
+Nodes (6): code:bash (# In ~/.panopticon.env), code:bash (DEBUG=rally pan up), code:bash (curl -X POST http://localhost:3011/api/rally/validate \), Finding Workspace and Project IDs, Rally Troubleshooting, WSAPI Query Parse Errors
+
+### Community 1061 - "Community 1061"
+Cohesion: 0.33
+Nodes (6): code:bash (LINEAR_API_KEY=lin_api_xxxxx), code:yaml (projects:), Issue States, Linear Integration, Setup, Team Mapping
+
+### Community 1062 - "Community 1062"
+Cohesion: 0.33
+Nodes (6): code:block2 (~/.panopticon/traefik/), code:yaml (api:), code:yaml (http:), Dynamic Configuration, Static Configuration, Traefik Configuration
+
+### Community 1063 - "Community 1063"
+Cohesion: 0.33
+Nodes (6): 15. Page-Specific Notes, Agents, Board (Kanban), Command Deck (formerly Mission Control), God View, Settings
+
+### Community 1064 - "Community 1064"
+Cohesion: 0.33
+Nodes (6): 14. Accessibility, code:block33 (focus-visible:ring-[3px] focus-visible:ring-ring/24 focus-vi), Contrast Ratios, Focus Indicators, Keyboard Navigation, Touch Targets
+
+### Community 1065 - "Community 1065"
+Cohesion: 0.33
+Nodes (6): 12. Animation & Motion, code:block29 (Duration: 200ms (default for all state transitions)), code:block30 (Hover highlight:   transition-colors duration-200), Patterns, Rules, Standard Timing
+
+### Community 1066 - "Community 1066"
+Cohesion: 0.33
+Nodes (5): Agent Resumed — {{ISSUE_ID}}, Last Known Status: {{STATE_STATUS}}, Operator Message, What To Do Now, Where You Left Off
+
+### Community 1067 - "Community 1067"
+Cohesion: 0.33
+Nodes (5): Auto-Clarity, Boundaries, Intensity, Persistence, Rules
+
+### Community 1068 - "Community 1068"
 Cohesion: 0.5
 Nodes (4): computeStaleResets(), hasSessionForSpecialist(), StatusSnapshot, updates
 
-### Community 1038 - "Community 1038"
+### Community 1069 - "Community 1069"
 Cohesion: 0.4
 Nodes (3): badge, { container }, DIFFICULTY_COLORS
 
-### Community 1039 - "Community 1039"
+### Community 1070 - "Community 1070"
 Cohesion: 0.4
 Nodes (4): consoleLogs, edges, mockGetStatus, output
 
-### Community 1040 - "Community 1040"
+### Community 1071 - "Community 1071"
 Cohesion: 0.4
 Nodes (4): hiddenDir, mockExecFn, subA, subB
 
-### Community 1041 - "Community 1041"
-Cohesion: 0.4
-Nodes (4): chunks, emitter, googleMocks, stream
-
-### Community 1042 - "Community 1042"
+### Community 1072 - "Community 1072"
 Cohesion: 0.4
 Nodes (3): content, LEGACY_TEMPLATE_FLAVORS, REVIEW_SUB_ROLES
 
-### Community 1043 - "Community 1043"
+### Community 1073 - "Community 1073"
 Cohesion: 0.4
 Nodes (4): REMOTE_PROVISIONERS, REPO_ROOT, src, stripped
 
-### Community 1044 - "Community 1044"
+### Community 1074 - "Community 1074"
 Cohesion: 0.4
 Nodes (3): entries, messages, workLog
 
-### Community 1047 - "Community 1047"
+### Community 1077 - "Community 1077"
 Cohesion: 0.5
 Nodes (4): APP_DIR, generateJWT(), main(), WEBHOOK_EVENTS
 
-### Community 1048 - "Community 1048"
-Cohesion: 0.5
-Nodes (4): execFile(), kCustom, mockExecFile, isBranchAlreadyRebased()
-
-### Community 1049 - "Community 1049"
+### Community 1078 - "Community 1078"
 Cohesion: 0.4
 Nodes (4): mockCleanupUnreferencedConversationAttachments, mockListActiveConversations, mockListSessionNamesAsync, mockMarkConversationEnded
 
-### Community 1050 - "Community 1050"
-Cohesion: 0.4
-Nodes (5): code:block26 (Issue Created), code:block27 (mergeStatus:  pending → merging → merged), How the Agent Pipeline Works, Review status state machine, Specialist initialization
-
-### Community 1051 - "Community 1051"
-Cohesion: 0.4
-Nodes (5): Optional, Platform Support, Required, Requirements, Why CLI tools instead of API tokens?
-
-### Community 1052 - "Community 1052"
-Cohesion: 0.4
-Nodes (5): code:block22 (Replace stale copies in ~/.panopticon/skills/ with fresh con), code:block23 (For each symlink in ~/.claude/skills/ pointing to ~/.panopti), code:block24 (Copy all skills, agents, rules from ~/.panopticon/ cache → <), code:block25 (Panopticon sync migration:), Migration Path
-
-### Community 1053 - "Community 1053"
-Cohesion: 0.4
-Nodes (5): code:bash (# Existing local workspace), code:bash (pan workspace migrate MIN-667 --to local), From Local to Remote, Migration Path, Rollback to Local
-
-### Community 1054 - "Community 1054"
-Cohesion: 0.4
-Nodes (5): code:toml ([remote]), code:yaml (# Project-specific remote settings), Configuration, Project Config (`.panopticon/remote.yaml`), User Config (`~/.panopticon/config.toml`)
-
-### Community 1055 - "Community 1055"
-Cohesion: 0.4
-Nodes (5): code:yaml (models:), code:yaml (models:), Example Resolution, Precedence Rules, Resolution Order
-
-### Community 1056 - "Community 1056"
-Cohesion: 0.4
-Nodes (5): code:typescript (interface AgentRuntime {), code:yaml (# ~/.panopticon/cloister.yaml), Model Selection, Runtime Architecture, Runtime Interface
-
-### Community 1057 - "Community 1057"
-Cohesion: 0.4
-Nodes (5): code:yaml (# ~/.panopticon/cloister.yaml), code:bash (# Override config file location), Configuration, Default Config File, Environment Variables
-
-### Community 1058 - "Community 1058"
-Cohesion: 0.4
-Nodes (4): Claude Code Skills Inventory, Duplicate names, Maintenance, Skills
-
-### Community 1059 - "Community 1059"
-Cohesion: 0.4
-Nodes (5): 8.1 Activity Feed, 8.2 Phase Distribution (Donut Chart), 8.3 System Health Gauges, 8. Right Panel (Persistent), code:block7 (2m    ●  agent-pan-505 started)
-
-### Community 1060 - "Community 1060"
-Cohesion: 0.4
-Nodes (5): code:typescript (function readRole(state: any): Role {), Enum mapping table, Migration — Backward Compatibility, Old agent .md files, Reading old state.json files
-
-### Community 1061 - "Community 1061"
-Cohesion: 0.4
-Nodes (5): Component, End-to-end (Playwright), Integration, Testing, Unit
-
-### Community 1062 - "Community 1062"
-Cohesion: 0.4
-Nodes (5): Branch node (new), Container node (new), Data inventory, PR node (new), Resources group node (new)
-
-### Community 1063 - "Community 1063"
-Cohesion: 0.4
-Nodes (5): Visual / data inventory by zone, Zone A — Issue header (always visible), Zone B — Agent context (selected session), Zone C — Conversation + composer (agent-selected), Zone C — Issue-selected mode (no agent selected)
-
-### Community 1064 - "Community 1064"
-Cohesion: 0.4
-Nodes (5): JSONL Session Files (use existing), `runtime.json` (extend existing schema), Specialist Event Files (new, lightweight), WebSocket Terminal (in-memory ring buffer), What Goes Where
-
-### Community 1065 - "Community 1065"
-Cohesion: 0.4
-Nodes (5): Hook Extensions Required, Hook reliability (PAN-759), PostToolUse hook, SessionStart hook, Specialist hooks (new)
-
-### Community 1066 - "Community 1066"
-Cohesion: 0.4
-Nodes (5): code:block1 (Agent → tmux pane → capture-pane → regex parsing → consumer), code:block2 (Agent → hooks → runtime.json ──┬──→ Dashboard (structured st), Data Flow: Today vs Target, Target (2 layers), Today (3 overlapping layers)
-
-### Community 1067 - "Community 1067"
-Cohesion: 0.4
-Nodes (5): Implementation Sequence (4 Phases), Phase 1: Fix hooks (BLOCKS EVERYTHING), Phase 2: Structured event files + JSONL readers (can start after Phase 1), Phase 3: Remove high-risk tmux patterns (can start after Phase 1), Phase 4: Migrate remaining consumers (can start after Phase 1)
-
-### Community 1068 - "Community 1068"
-Cohesion: 0.4
-Nodes (5): `AgentRuntimeState` (`src/lib/agents.ts:359`), code:typescript (export interface AgentRuntimeState {), code:typescript (// review-results.json), Interface Changes, Specialist Result Files (new)
-
-### Community 1069 - "Community 1069"
-Cohesion: 0.4
-Nodes (5): Core Changes, Documentation, Error Handling & Validation, Files Modified, Testing
-
-### Community 1070 - "Community 1070"
-Cohesion: 0.4
-Nodes (4): code:javascript (server: {), Related Guides, Slow Vite/React Frontend with Multiple Workspaces, Troubleshooting
-
-### Community 1071 - "Community 1071"
-Cohesion: 0.4
-Nodes (5): Can't delete workspace, code:bash (# Check for existing workspace), code:bash (# Via Panopticon (handles Docker cleanup)), Workspace creation fails, Workspace Issues
-
-### Community 1072 - "Community 1072"
-Cohesion: 0.4
-Nodes (5): code:markdown (---), Fields, Frontmatter contract, `requires` vs `optional`, Unknown keys are an error
-
-### Community 1073 - "Community 1073"
-Cohesion: 0.4
-Nodes (5): code:mustache ({{#PENDING_FEEDBACK_BLOCK}}), code:typescript (const pendingFeedbackBlock = ctx.pendingFeedback.length > 0), Composition pattern, Example: `resume-work.md`, When to use in-template conditionals vs pre-built blocks
-
-### Community 1074 - "Community 1074"
-Cohesion: 0.4
-Nodes (5): Adding a new template, Authoring workflow, code:typescript (import { renderPrompt } from './prompts.js';), Editing an existing template, Migrating a legacy ad-hoc prompt
-
-### Community 1075 - "Community 1075"
-Cohesion: 0.4
-Nodes (5): 1. Loader contract tests, 2. Live-template smoke tests, 3. Caller-side tests, Testing prompts, Writing a new smoke test
-
-### Community 1076 - "Community 1076"
-Cohesion: 0.4
-Nodes (5): code:bash (# Command history (if configured)), code:bash (# Traefik logs), Docker Logs (if using), Panopticon Commands, System Logs
-
-### Community 1077 - "Community 1077"
-Cohesion: 0.4
-Nodes (5): Clean Old Logs, code:bash (# Create log archive for an issue), code:bash (# Remove logs older than 7 days), Log Retention, Save Important Logs
-
-### Community 1078 - "Community 1078"
-Cohesion: 0.4
-Nodes (5): code:block15 (# Automatic logging), code:javascript (// Enable verbose logging), Configuring Log Output, Dashboard Logging, Enable tmux Logging
-
 ### Community 1079 - "Community 1079"
-Cohesion: 0.4
-Nodes (5): API Requests, code:bash (# If running in foreground, logs go to stdout), code:bash (# Filter API calls), Dashboard Logs, Server Logs
+Cohesion: 0.6
+Nodes (5): cleanupAllLogs(), cleanupOldLogs(), listProjectsWithSpecialists(), getSpecialistRetention(), cleanupLogsCommand()
 
 ### Community 1080 - "Community 1080"
 Cohesion: 0.4
-Nodes (5): code:bash (rm .panopticon/knowledge-capture.json), code:bash (rm -rf .claude/skills/project-knowledge/), code:bash (rm -rf .claude/skills/knowledge-capture/), code:bash (# Edit ~/.claude/CLAUDE.md and remove the "AI Suggestion Pre), Reset / Clean Slate
+Nodes (5): code:block26 (Issue Created), code:block27 (mergeStatus:  pending → merging → merged), How the Agent Pipeline Works, Review status state machine, Specialist initialization
 
 ### Community 1081 - "Community 1081"
 Cohesion: 0.4
-Nodes (5): Breaking Changes, code:bash (bd version), code:bash (# Update Claude Code beads plugin), Minimum Version for Dependency Persistence, Version Requirements
+Nodes (5): Optional, Platform Support, Required, Requirements, Why CLI tools instead of API tokens?
 
 ### Community 1082 - "Community 1082"
 Cohesion: 0.4
-Nodes (5): code:bash (# Link discovered work (old way - two commands)), code:bash (# Label management (supports multiple IDs)), Dependencies, Dependencies & Labels, Labels
+Nodes (5): code:block22 (Replace stale copies in ~/.panopticon/skills/ with fresh con), code:block23 (For each symlink in ~/.claude/skills/ pointing to ~/.panopti), code:block24 (Copy all skills, agents, rules from ~/.panopticon/ cache → <), code:block25 (Panopticon sync migration:), Migration Path
 
 ### Community 1083 - "Community 1083"
 Cohesion: 0.4
-Nodes (5): Basic Operations, Check Status, code:bash (# Check database path and daemon status), code:bash (# Find ready work (no blockers)), Find Work
+Nodes (5): code:toml ([remote]), code:yaml (# Project-specific remote settings), Configuration, Project Config (`.panopticon/remote.yaml`), User Config (`~/.panopticon/config.toml`)
 
 ### Community 1084 - "Community 1084"
 Cohesion: 0.4
-Nodes (5): Background vs Foreground, Check Running Processes, code:bash (# Using pan), code:bash (# Foreground (default) - see logs in real time), Process Management
+Nodes (5): code:bash (# Existing local workspace), code:bash (pan workspace migrate MIN-667 --to local), From Local to Remote, Migration Path, Rollback to Local
 
 ### Community 1085 - "Community 1085"
 Cohesion: 0.4
-Nodes (5): Brand Colors, Brand Identity, Brand Wordmark, code:tsx (<h1>), Logo
+Nodes (5): code:yaml (models:), code:yaml (models:), Example Resolution, Precedence Rules, Resolution Order
 
 ### Community 1086 - "Community 1086"
 Cohesion: 0.4
-Nodes (5): Breakpoints, code:tsx (// Page container), Common Patterns, Spacing & Layout, Spacing Scale
+Nodes (5): code:typescript (interface AgentRuntime {), code:yaml (# ~/.panopticon/cloister.yaml), Model Selection, Runtime Architecture, Runtime Interface
 
 ### Community 1087 - "Community 1087"
 Cohesion: 0.4
-Nodes (5): code:block3 (text-foreground         Primary text), Font Stack, Text Colors, Type Scale, Typography
+Nodes (5): code:yaml (# ~/.panopticon/cloister.yaml), code:bash (# Override config file location), Configuration, Default Config File, Environment Variables
 
 ### Community 1088 - "Community 1088"
 Cohesion: 0.4
-Nodes (5): Animation System, code:tsx (// Container: stagger children by 0.1s), Framer Motion (Auth/Splash), Tailwind Keyframes, Task Completion
+Nodes (4): Claude Code Skills Inventory, Duplicate names, Maintenance, Skills
 
 ### Community 1089 - "Community 1089"
 Cohesion: 0.4
-Nodes (4): Architecture Quality Gate, Structural integrity, Styling and theming, Type safety and syntax
+Nodes (5): 8.1 Activity Feed, 8.2 Phase Distribution (Donut Chart), 8.3 System Health Gauges, 8. Right Panel (Persistent), code:block7 (2m    ●  agent-pan-505 started)
 
 ### Community 1090 - "Community 1090"
 Cohesion: 0.4
-Nodes (4): Additional Checks, Output Format, OWASP Top 10 Checklist, Security Review
+Nodes (5): code:typescript (function readRole(state: any): Role {), Enum mapping table, Migration — Backward Compatibility, Old agent .md files, Reading old state.json files
 
 ### Community 1091 - "Community 1091"
 Cohesion: 0.4
-Nodes (5): code:yaml (projects:), Configuration Fields, Custom ID Patterns, Supported Formats, Unified Issue ID Parser
+Nodes (5): Component, End-to-end (Playwright), Integration, Testing, Unit
 
 ### Community 1092 - "Community 1092"
 Cohesion: 0.4
-Nodes (5): code:yaml (projects:), code:markdown (<!-- In an agent's STATE.md -->), Mixed Tracker Pattern, Multi-Tracker Workflows, Syncing Between Trackers
+Nodes (5): Branch node (new), Container node (new), Data inventory, PR node (new), Resources group node (new)
 
 ### Community 1093 - "Community 1093"
 Cohesion: 0.4
-Nodes (5): code:block10 (myproject!23  # GitLab issue/MR), code:bash (# Authenticate with GitLab CLI), GitLab Issues, Issue Prefix, Setup
+Nodes (5): Visual / data inventory by zone, Zone A — Issue header (always visible), Zone B — Agent context (selected session), Zone C — Conversation + composer (agent-selected), Zone C — Issue-selected mode (no agent selected)
 
 ### Community 1094 - "Community 1094"
 Cohesion: 0.4
-Nodes (5): code:bash (pan up), code:bash (# Start Traefik container), Manually, Starting Traefik, Via Dashboard
+Nodes (5): Hook Extensions Required, Hook reliability (PAN-759), PostToolUse hook, SessionStart hook, Specialist hooks (new)
 
 ### Community 1095 - "Community 1095"
 Cohesion: 0.4
-Nodes (5): code:yaml (# infra/.devcontainer-template/docker-compose.yml.template), code:bash (docker network create panopticon), Docker Compose Template, Network Setup, Workspace Container Setup
+Nodes (5): `AgentRuntimeState` (`src/lib/agents.ts:359`), code:typescript (export interface AgentRuntimeState {), code:typescript (// review-results.json), Interface Changes, Specialist Result Files (new)
 
 ### Community 1096 - "Community 1096"
 Cohesion: 0.4
-Nodes (5): Certificate Generation, code:bash (# Generate certificates for localhost domains), code:bash (# Generate certificates for custom domain), For Custom Domains, Using mkcert
+Nodes (5): JSONL Session Files (use existing), `runtime.json` (extend existing schema), Specialist Event Files (new, lightweight), WebSocket Terminal (in-memory ring buffer), What Goes Where
 
 ### Community 1097 - "Community 1097"
 Cohesion: 0.4
-Nodes (5): 8. Navigation (Sidebar), code:block22 (Sidebar), code:block23 (Expanded width:  256px  (16rem)), Specs, Structure
+Nodes (5): Implementation Sequence (4 Phases), Phase 1: Fix hooks (BLOCKS EVERYTHING), Phase 2: Structured event files + JSONL readers (can start after Phase 1), Phase 3: Remove high-risk tmux patterns (can start after Phase 1), Phase 4: Migrate remaining consumers (can start after Phase 1)
 
 ### Community 1098 - "Community 1098"
 Cohesion: 0.4
-Nodes (4): Acceptance Criteria, Scope, Summary, What NOT to do
+Nodes (5): code:block1 (Agent → tmux pane → capture-pane → regex parsing → consumer), code:block2 (Agent → hooks → runtime.json ──┬──→ Dashboard (structured st), Data Flow: Today vs Target, Target (2 layers), Today (3 overlapping layers)
 
 ### Community 1099 - "Community 1099"
 Cohesion: 0.4
-Nodes (4): Auto-Clarity, Boundaries, Examples, Rules
+Nodes (5): Core Changes, Documentation, Error Handling & Validation, Files Modified, Testing
 
 ### Community 1100 - "Community 1100"
-Cohesion: 0.5
-Nodes (3): client, content, mockExeca
+Cohesion: 0.4
+Nodes (5): Can't delete workspace, code:bash (# Check for existing workspace), code:bash (# Via Panopticon (handles Docker cleanup)), Workspace creation fails, Workspace Issues
 
 ### Community 1101 - "Community 1101"
-Cohesion: 0.5
-Nodes (3): mockGetVBriefACStatus, mockSyncBeadStatusToVBrief, result
+Cohesion: 0.4
+Nodes (4): code:javascript (server: {), Related Guides, Slow Vite/React Frontend with Multiple Workspaces, Troubleshooting
 
 ### Community 1102 - "Community 1102"
-Cohesion: 0.5
-Nodes (3): { mockMessageAgent, mockResolveProjectFromIssue, mockGetReviewStatus, mockWriteFeedbackFile }, reviewDir, workspace
+Cohesion: 0.4
+Nodes (5): code:mustache ({{#PENDING_FEEDBACK_BLOCK}}), code:typescript (const pendingFeedbackBlock = ctx.pendingFeedback.length > 0), Composition pattern, Example: `resume-work.md`, When to use in-template conditionals vs pre-built blocks
 
 ### Community 1103 - "Community 1103"
-Cohesion: 0.5
-Nodes (3): config, env, mockExistsSync
+Cohesion: 0.4
+Nodes (5): Adding a new template, Authoring workflow, code:typescript (import { renderPrompt } from './prompts.js';), Editing an existing template, Migrating a legacy ad-hoc prompt
 
 ### Community 1104 - "Community 1104"
-Cohesion: 0.5
-Nodes (3): src, stripped, topLevelAwaits
+Cohesion: 0.4
+Nodes (5): code:markdown (---), Fields, Frontmatter contract, `requires` vs `optional`, Unknown keys are an error
 
 ### Community 1105 - "Community 1105"
-Cohesion: 0.5
-Nodes (3): agentDir, missing, discoverNewAgentIds()
+Cohesion: 0.4
+Nodes (5): 1. Loader contract tests, 2. Live-template smoke tests, 3. Caller-side tests, Testing prompts, Writing a new smoke test
+
+### Community 1106 - "Community 1106"
+Cohesion: 0.4
+Nodes (5): code:block15 (# Automatic logging), code:javascript (// Enable verbose logging), Configuring Log Output, Dashboard Logging, Enable tmux Logging
 
 ### Community 1107 - "Community 1107"
-Cohesion: 0.67
-Nodes (3): execAsync, rebaseFeatureBranch(), RebaseResult
+Cohesion: 0.4
+Nodes (5): API Requests, code:bash (# If running in foreground, logs go to stdout), code:bash (# Filter API calls), Dashboard Logs, Server Logs
+
+### Community 1108 - "Community 1108"
+Cohesion: 0.4
+Nodes (5): Clean Old Logs, code:bash (# Create log archive for an issue), code:bash (# Remove logs older than 7 days), Log Retention, Save Important Logs
 
 ### Community 1109 - "Community 1109"
-Cohesion: 0.5
-Nodes (3): mockSystemHealth, pill, requests
+Cohesion: 0.4
+Nodes (5): code:bash (# Command history (if configured)), code:bash (# Traefik logs), Docker Logs (if using), Panopticon Commands, System Logs
 
 ### Community 1110 - "Community 1110"
-Cohesion: 0.67
-Nodes (3): fetchWithRetry(), isNetworkError(), RETRY_DELAYS
+Cohesion: 0.4
+Nodes (5): code:bash (rm .panopticon/knowledge-capture.json), code:bash (rm -rf .claude/skills/project-knowledge/), code:bash (rm -rf .claude/skills/knowledge-capture/), code:bash (# Edit ~/.claude/CLAUDE.md and remove the "AI Suggestion Pre), Reset / Clean Slate
 
 ### Community 1111 - "Community 1111"
-Cohesion: 0.5
-Nodes (3): MOTION_CATALOG, MotionEntry, MotionEventType
+Cohesion: 0.4
+Nodes (4): code:bash (pan memory search <query> [--project <id>] [--workspace <id>), Commands, Notes, Pan Memory
 
 ### Community 1112 - "Community 1112"
-Cohesion: 0.5
-Nodes (3): mockExecAsync, mockSpawn, program
+Cohesion: 0.4
+Nodes (5): code:bash (bd version), code:bash (# Via Homebrew (macOS/Linux)), code:bash (pkill -f "bd daemon"  # Kill old daemon), code:bash (bd create "Test A" -t task), Resolution
 
 ### Community 1113 - "Community 1113"
-Cohesion: 0.5
-Nodes (3): agentMocks, readlineMocks, written
+Cohesion: 0.4
+Nodes (5): Breaking Changes, code:bash (bd version), code:bash (# Update Claude Code beads plugin), Minimum Version for Dependency Persistence, Version Requirements
 
 ### Community 1114 - "Community 1114"
-Cohesion: 0.5
-Nodes (4): Beads Issue Tracker, code:bash (bd ready              # Find available work), Quick Reference, Rules
+Cohesion: 0.4
+Nodes (5): code:bash (# Link discovered work (old way - two commands)), code:bash (# Label management (supports multiple IDs)), Dependencies, Dependencies & Labels, Labels
 
 ### Community 1115 - "Community 1115"
-Cohesion: 0.5
-Nodes (4): code:block19 (~/.claude/skills/my-override/               ← WINS (personal), code:block20 (~/.claude/skills/my-override/               ← WINS (personal), code:block21 (workspace/.claude/skills/session-health/   ← MYN template ve), Precedence in Practice
+Cohesion: 0.4
+Nodes (5): Basic Operations, Check Status, code:bash (# Check database path and daemon status), code:bash (# Find ready work (no blockers)), Find Work
 
 ### Community 1116 - "Community 1116"
-Cohesion: 0.5
-Nodes (4): Comparison, Cost Analysis, exe.dev Pricing, Recommended Setup
+Cohesion: 0.4
+Nodes (5): code:bash (# Single issue), code:bash (bd ready), Human-Readable Output, JSON Output (Recommended for Agents), Output Formats
 
 ### Community 1117 - "Community 1117"
-Cohesion: 0.5
-Nodes (4): Component architecture, Existing components reused, Modified components, New components
+Cohesion: 0.4
+Nodes (5): Background vs Foreground, Check Running Processes, code:bash (# Using pan), code:bash (# Foreground (default) - see logs in real time), Process Management
 
 ### Community 1118 - "Community 1118"
-Cohesion: 0.5
-Nodes (4): Implementation phases, Phase 1: Core resource tree, Phase 2: Container actions, Phase 3: Data enrichment
+Cohesion: 0.4
+Nodes (5): Brand Colors, Brand Identity, Brand Wordmark, code:tsx (<h1>), Logo
 
 ### Community 1119 - "Community 1119"
-Cohesion: 0.5
-Nodes (4): Integration Tests, Manual Testing, Testing Strategy, Unit Tests
+Cohesion: 0.4
+Nodes (5): Breakpoints, code:tsx (// Page container), Common Patterns, Spacing & Layout, Spacing Scale
 
 ### Community 1120 - "Community 1120"
-Cohesion: 0.5
-Nodes (4): code:typescript (// Before error throw:), code:typescript (// Add debug logging:), code:typescript (// Improve error logging:), Task 4: Improve Error Context & Logging
+Cohesion: 0.4
+Nodes (5): code:block3 (text-foreground         Primary text), Font Stack, Text Colors, Type Scale, Typography
 
 ### Community 1121 - "Community 1121"
-Cohesion: 0.5
-Nodes (4): code:markdown (### Rally Troubleshooting), code:block15, code:block16 (This will log the actual WSAPI queries being sent.), Task 8: Update Documentation
+Cohesion: 0.4
+Nodes (5): Animation System, code:tsx (// Container: stagger children by 0.1s), Framer Motion (Auth/Splash), Tailwind Keyframes, Task Completion
 
 ### Community 1122 - "Community 1122"
-Cohesion: 0.5
-Nodes (4): code:typescript (return conditions.length > 0 ? conditions.join(' AND ') : ''), code:block3 (((ScheduleState != "Completed") AND (ScheduleState != "Accep), code:block4 ((((ScheduleState != "Completed") AND (ScheduleState != "Acce), Root Cause Analysis
+Cohesion: 0.4
+Nodes (4): Architecture Quality Gate, Structural integrity, Styling and theming, Type safety and syntax
 
 ### Community 1123 - "Community 1123"
-Cohesion: 0.5
-Nodes (4): Phase 1: Core Fix (Immediate), Phase 2: Validation & Testing (Same PR), Phase 3: Integration & Documentation (Follow-up), Rollout Plan
+Cohesion: 0.4
+Nodes (4): Additional Checks, Output Format, OWASP Top 10 Checklist, Security Review
 
 ### Community 1124 - "Community 1124"
-Cohesion: 0.5
-Nodes (4): code:bash (# System info), Diagnostic Information, Getting Help, Resources
+Cohesion: 0.4
+Nodes (5): code:yaml (projects:), code:markdown (<!-- In an agent's STATE.md -->), Mixed Tracker Pattern, Multi-Tracker Workflows, Syncing Between Trackers
 
 ### Community 1125 - "Community 1125"
-Cohesion: 0.5
-Nodes (3): Boundaries, Panopticon Review Agent, Responsibilities
+Cohesion: 0.4
+Nodes (5): code:block10 (myproject!23  # GitLab issue/MR), code:bash (# Authenticate with GitLab CLI), GitLab Issues, Issue Prefix, Setup
 
 ### Community 1126 - "Community 1126"
-Cohesion: 0.5
-Nodes (3): Boundaries, Panopticon Merge Agent, Responsibilities
+Cohesion: 0.4
+Nodes (5): code:yaml (projects:), Configuration Fields, Custom ID Patterns, Supported Formats, Unified Issue ID Parser
 
 ### Community 1127 - "Community 1127"
-Cohesion: 0.5
-Nodes (3): Boundaries, Panopticon UAT Agent, Responsibilities
+Cohesion: 0.4
+Nodes (5): code:yaml (# infra/.devcontainer-template/docker-compose.yml.template), code:bash (docker network create panopticon), Docker Compose Template, Network Setup, Workspace Container Setup
 
 ### Community 1128 - "Community 1128"
-Cohesion: 0.5
-Nodes (3): Boundaries, Panopticon Test Agent, Responsibilities
+Cohesion: 0.4
+Nodes (5): code:bash (pan up), code:bash (# Start Traefik container), Manually, Starting Traefik, Via Dashboard
 
 ### Community 1129 - "Community 1129"
-Cohesion: 0.5
-Nodes (3): Boundaries, Panopticon Inspect Agent, Responsibilities
+Cohesion: 0.4
+Nodes (5): Certificate Generation, code:bash (# Generate certificates for localhost domains), code:bash (# Generate certificates for custom domain), For Custom Domains, Using mkcert
 
 ### Community 1130 - "Community 1130"
-Cohesion: 0.5
-Nodes (4): High-Confidence Triggers (Always Invoke), Low-Confidence Triggers (Check Config First), Medium-Confidence Triggers (Invoke After 2+ Occurrences), When to Trigger (Self-Assessment)
+Cohesion: 0.4
+Nodes (5): 13. Icons, code:block31 (Default:  18px (w-[18px] h-[18px])), code:block32 (Command Deck:  Compass), Nav Icons, Sizing
 
 ### Community 1131 - "Community 1131"
-Cohesion: 0.5
-Nodes (3): pan approve — REMOVED, What to do instead, Why
+Cohesion: 0.4
+Nodes (5): 8. Navigation (Sidebar), code:block22 (Sidebar), code:block23 (Expanded width:  256px  (16rem)), Specs, Structure
 
 ### Community 1132 - "Community 1132"
-Cohesion: 0.5
-Nodes (4): code:block2 (After Compaction:), code:block3 (bd update issue-42 --notes "COMPLETED: User authentication -), code:block4 (bd update issue-42 --notes "Working on auth feature. Made so), Compaction Survival {#compaction-survival}
+Cohesion: 0.4
+Nodes (4): Acceptance Criteria, Scope, Summary, What NOT to do
 
 ### Community 1133 - "Community 1133"
-Cohesion: 0.5
-Nodes (4): Advanced Features, Learn More, Next Steps, Productivity Tips
+Cohesion: 0.4
+Nodes (4): Auto-Clarity, Boundaries, Examples, Rules
 
 ### Community 1134 - "Community 1134"
 Cohesion: 0.5
-Nodes (4): Agent States, Service States, Status Interpretation, Workspace States
+Nodes (3): client, content, mockExeca
 
 ### Community 1135 - "Community 1135"
 Cohesion: 0.5
-Nodes (4): Critical Issues, Healthy System, Needs Attention, Performance Indicators
+Nodes (3): mockGetVBriefACStatus, mockSyncBeadStatusToVBrief, result
 
 ### Community 1136 - "Community 1136"
 Cohesion: 0.5
-Nodes (3): Metadata schema, Stitch API reference, Technical mapping rules
+Nodes (3): { mockMessageAgent, mockResolveProjectFromIssue, mockGetReviewStatus, mockWriteFeedbackFile }, reviewDir, workspace
 
 ### Community 1137 - "Community 1137"
 Cohesion: 0.5
-Nodes (4): code:bash (pan down), Graceful Shutdown (default), Graceful vs Forceful Shutdown, Hung Shutdown
+Nodes (3): config, env, mockExistsSync
 
 ### Community 1138 - "Community 1138"
 Cohesion: 0.5
+Nodes (3): src, stripped, topLevelAwaits
+
+### Community 1140 - "Community 1140"
+Cohesion: 0.67
+Nodes (4): appendBridgeLog(), handleUnixPost(), pushChannelNotification(), pushPermissionDecisionNotification()
+
+### Community 1141 - "Community 1141"
+Cohesion: 0.5
+Nodes (3): agentDir, missing, discoverNewAgentIds()
+
+### Community 1144 - "Community 1144"
+Cohesion: 0.5
+Nodes (3): mockSystemHealth, pill, requests
+
+### Community 1145 - "Community 1145"
+Cohesion: 0.67
+Nodes (3): fetchWithRetry(), isNetworkError(), RETRY_DELAYS
+
+### Community 1146 - "Community 1146"
+Cohesion: 0.5
+Nodes (3): MOTION_CATALOG, MotionEntry, MotionEventType
+
+### Community 1147 - "Community 1147"
+Cohesion: 0.5
+Nodes (3): mockExecAsync, mockSpawn, program
+
+### Community 1148 - "Community 1148"
+Cohesion: 0.5
+Nodes (3): agentMocks, readlineMocks, written
+
+### Community 1149 - "Community 1149"
+Cohesion: 0.5
+Nodes (4): Beads Issue Tracker, code:bash (bd ready              # Find available work), Quick Reference, Rules
+
+### Community 1150 - "Community 1150"
+Cohesion: 0.5
+Nodes (4): Merge Agent Workflow, Review Agent Workflow, Specialist Agent Processing, Test Agent Workflow
+
+### Community 1151 - "Community 1151"
+Cohesion: 0.5
+Nodes (4): code:block19 (~/.claude/skills/my-override/               ← WINS (personal), code:block20 (~/.claude/skills/my-override/               ← WINS (personal), code:block21 (workspace/.claude/skills/session-health/   ← MYN template ve), Precedence in Practice
+
+### Community 1152 - "Community 1152"
+Cohesion: 0.5
+Nodes (4): Comparison, Cost Analysis, exe.dev Pricing, Recommended Setup
+
+### Community 1153 - "Community 1153"
+Cohesion: 0.5
+Nodes (4): Access Control — Invite-Only, Controller actions, Defense in depth — the host gates content itself, The lobby
+
+### Community 1154 - "Community 1154"
+Cohesion: 0.5
+Nodes (4): code:ts (interface SharedEnvelope {), Peer connections and data channels, Scoped, versioned wire format, Transport & Wire Format
+
+### Community 1155 - "Community 1155"
+Cohesion: 0.5
+Nodes (4): Conversation Sharing, Default surface & terminal toggle, Host side, Viewer side
+
+### Community 1156 - "Community 1156"
+Cohesion: 0.5
+Nodes (4): CLI, Clients & Join Paths, Cold start, Dashboard
+
+### Community 1157 - "Community 1157"
+Cohesion: 0.5
+Nodes (3): Data Model, Host-side persistence, Signaling service
+
+### Community 1158 - "Community 1158"
+Cohesion: 0.5
+Nodes (3): A.6 Partial results from incomplete parallel reviews, code:typescript (// ── Phase 3: Synthesis ───────────────────────────────────), code:typescript (const incompleteNote = incompleteReviewers.length > 0)
+
+### Community 1159 - "Community 1159"
+Cohesion: 0.5
+Nodes (4): Component architecture, Existing components reused, Modified components, New components
+
+### Community 1160 - "Community 1160"
+Cohesion: 0.5
+Nodes (4): Implementation phases, Phase 1: Core resource tree, Phase 2: Container actions, Phase 3: Data enrichment
+
+### Community 1161 - "Community 1161"
+Cohesion: 0.5
+Nodes (4): Integration Tests, Manual Testing, Testing Strategy, Unit Tests
+
+### Community 1162 - "Community 1162"
+Cohesion: 0.5
+Nodes (4): code:typescript (// Before error throw:), code:typescript (// Add debug logging:), code:typescript (// Improve error logging:), Task 4: Improve Error Context & Logging
+
+### Community 1163 - "Community 1163"
+Cohesion: 0.5
+Nodes (4): code:markdown (### Rally Troubleshooting), code:block15, code:block16 (This will log the actual WSAPI queries being sent.), Task 8: Update Documentation
+
+### Community 1164 - "Community 1164"
+Cohesion: 0.5
+Nodes (4): Phase 1: Core Fix (Immediate), Phase 2: Validation & Testing (Same PR), Phase 3: Integration & Documentation (Follow-up), Rollout Plan
+
+### Community 1165 - "Community 1165"
+Cohesion: 0.5
+Nodes (4): code:typescript (return conditions.length > 0 ? conditions.join(' AND ') : ''), code:block3 (((ScheduleState != "Completed") AND (ScheduleState != "Accep), code:block4 ((((ScheduleState != "Completed") AND (ScheduleState != "Acce), Root Cause Analysis
+
+### Community 1166 - "Community 1166"
+Cohesion: 0.5
+Nodes (4): code:bash (# System info), Diagnostic Information, Getting Help, Resources
+
+### Community 1167 - "Community 1167"
+Cohesion: 0.5
+Nodes (3): Boundaries, Panopticon Review Agent, Responsibilities
+
+### Community 1168 - "Community 1168"
+Cohesion: 0.5
+Nodes (3): Boundaries, Panopticon Merge Agent, Responsibilities
+
+### Community 1169 - "Community 1169"
+Cohesion: 0.5
+Nodes (3): Boundaries, Panopticon UAT Agent, Responsibilities
+
+### Community 1170 - "Community 1170"
+Cohesion: 0.5
+Nodes (3): Boundaries, Panopticon Test Agent, Responsibilities
+
+### Community 1171 - "Community 1171"
+Cohesion: 0.5
+Nodes (3): Boundaries, Panopticon Inspect Agent, Responsibilities
+
+### Community 1172 - "Community 1172"
+Cohesion: 0.5
+Nodes (4): High-Confidence Triggers (Always Invoke), Low-Confidence Triggers (Check Config First), Medium-Confidence Triggers (Invoke After 2+ Occurrences), When to Trigger (Self-Assessment)
+
+### Community 1173 - "Community 1173"
+Cohesion: 0.5
+Nodes (3): pan approve — REMOVED, What to do instead, Why
+
+### Community 1174 - "Community 1174"
+Cohesion: 0.5
+Nodes (4): code:block2 (After Compaction:), code:block3 (bd update issue-42 --notes "COMPLETED: User authentication -), code:block4 (bd update issue-42 --notes "Working on auth feature. Made so), Compaction Survival {#compaction-survival}
+
+### Community 1175 - "Community 1175"
+Cohesion: 0.5
+Nodes (4): Advanced Features, Learn More, Next Steps, Productivity Tips
+
+### Community 1176 - "Community 1176"
+Cohesion: 0.5
+Nodes (4): Agent States, Service States, Status Interpretation, Workspace States
+
+### Community 1177 - "Community 1177"
+Cohesion: 0.5
+Nodes (4): Critical Issues, Healthy System, Needs Attention, Performance Indicators
+
+### Community 1178 - "Community 1178"
+Cohesion: 0.5
+Nodes (3): Metadata schema, Stitch API reference, Technical mapping rules
+
+### Community 1179 - "Community 1179"
+Cohesion: 0.5
+Nodes (4): code:bash (pan down), Graceful Shutdown (default), Graceful vs Forceful Shutdown, Hung Shutdown
+
+### Community 1180 - "Community 1180"
+Cohesion: 0.5
 Nodes (4): Auto-Shutdown, code:bash (# Stop on user logout), Manual Triggers, On System Shutdown (systemd)
 
-### Community 1139 - "Community 1139"
+### Community 1181 - "Community 1181"
 Cohesion: 0.5
 Nodes (4): Best Practices, Performance, Resource Management, Security
 
-### Community 1150 - "Community 1150"
+### Community 1192 - "Community 1192"
 Cohesion: 0.67
 Nodes (3): Available MCP Tools, Recommended Workflow, TLDR: Token-Efficient Code Analysis
 
-### Community 1151 - "Community 1151"
+### Community 1193 - "Community 1193"
 Cohesion: 0.67
-Nodes (3): C.5 Update `phaseLabel` to show recovery state, code:typescript (const phaseLabel =), code:typescript (const phaseLabel =)
+Nodes (3): code:block10 (pan sync), code:block11 (pan sync), What `pan sync` Does: Today vs End-State
 
-### Community 1152 - "Community 1152"
+### Community 1194 - "Community 1194"
+Cohesion: 0.67
+Nodes (3): code:json ({), code:json ({), Manifest Tracking
+
+### Community 1195 - "Community 1195"
+Cohesion: 0.67
+Nodes (3): Dependencies & Sequencing, New native dependency, PAN-1249 — `src/lib/` Effect migration (in flight on `feature/pan-1249`)
+
+### Community 1196 - "Community 1196"
+Cohesion: 0.67
+Nodes (3): Host disconnect & reconnect, Link lifecycle, Link Lifecycle & Disconnect/Reconnect
+
+### Community 1197 - "Community 1197"
+Cohesion: 0.67
+Nodes (3): C.1 Update `isReviewPipelineStuck` in `src/dashboard/frontend/src/lib/pipeline-state.ts`, code:typescript (export function isReviewPipelineStuck(status?: PipelineState), code:typescript (export function isReviewPipelineStuck(status?: PipelineState)
+
+### Community 1198 - "Community 1198"
 Cohesion: 0.67
 Nodes (3): code:block1 (<Project: mind-your-now>), Problem, What the user wants
 
-### Community 1156 - "Community 1156"
-Cohesion: 0.67
-Nodes (3): code:bash (cat .panopticon/knowledge-capture.json 2>/dev/null || echo "), code:json ({), Step 1: Check Configuration
-
-### Community 1157 - "Community 1157"
+### Community 1202 - "Community 1202"
 Cohesion: 0.67
 Nodes (3): code:bash (grep -A 20 "## AI Suggestion Preferences" ~/.claude/CLAUDE.m), code:markdown (## AI Suggestion Preferences), Step 0.5: Check User Preferences for Category Exclusions
 
-### Community 1158 - "Community 1158"
+### Community 1203 - "Community 1203"
+Cohesion: 0.67
+Nodes (3): code:block23 (Unblocking Workflow:), code:block24 (Situation: bd ready shows nothing), Unblocking Work {#unblocking}
+
+### Community 1204 - "Community 1204"
 Cohesion: 0.67
 Nodes (3): code:block13 (Side Quest Workflow:), code:block14 (Main task: Adding user profiles), Side Quest Handling {#side-quests}
 
 ## Knowledge Gaps
-- **12659 isolated node(s):** `__dirname`, `FIXTURES_DIR`, `TEMP_ROOT_DIR`, `__dirname`, `ROOT` (+12654 more)
+- **13275 isolated node(s):** `__dirname`, `FIXTURES_DIR`, `TEMP_ROOT_DIR`, `__dirname`, `ROOT` (+13270 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **48 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **50 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `fetch` connect `Community 22` to `Community 1`, `Community 5`, `Community 9`, `Community 10`, `Community 11`, `Community 12`, `Community 13`, `Community 142`, `Community 655`, `Community 16`, `Community 20`, `Community 662`, `Community 1047`, `Community 24`, `Community 25`, `Community 278`, `Community 540`, `Community 28`, `Community 541`, `Community 31`, `Community 162`, `Community 36`, `Community 37`, `Community 38`, `Community 40`, `Community 42`, `Community 299`, `Community 428`, `Community 300`, `Community 46`, `Community 47`, `Community 175`, `Community 49`, `Community 429`, `Community 61`, `Community 65`, `Community 707`, `Community 67`, `Community 325`, `Community 710`, `Community 68`, `Community 74`, `Community 971`, `Community 589`, `Community 79`, `Community 208`, `Community 1110`, `Community 88`, `Community 217`, `Community 227`, `Community 103`, `Community 616`, `Community 617`, `Community 238`, `Community 242`, `Community 121`, `Community 122`, `Community 123`, `Community 252`, `Community 127`?**
-  _High betweenness centrality (0.083) - this node is a cross-community bridge._
-- **Why does `postMergeLifecycle()` connect `Community 10` to `Community 0`, `Community 1`, `Community 227`, `Community 4`, `Community 69`, `Community 6`, `Community 40`, `Community 73`, `Community 170`, `Community 202`, `Community 15`, `Community 17`, `Community 86`, `Community 278`, `Community 151`, `Community 22`, `Community 120`?**
-  _High betweenness centrality (0.035) - this node is a cross-community bridge._
-- **Why does `VBriefDocument` connect `Community 28` to `Community 102`, `Community 43`, `Community 12`, `Community 45`, `Community 396`, `Community 304`, `Community 17`, `Community 661`, `Community 280`, `Community 57`, `Community 27`, `Community 93`?**
-  _High betweenness centrality (0.014) - this node is a cross-community bridge._
-- **Are the 206 inferred relationships involving `fetch` (e.g. with `main()` and `main()`) actually correct?**
-  _`fetch` has 206 INFERRED edges - model-reasoned connections that need verification._
+- **Why does `fetch` connect `Community 56` to `Community 5`, `Community 390`, `Community 7`, `Community 10`, `Community 267`, `Community 11`, `Community 12`, `Community 14`, `Community 142`, `Community 16`, `Community 17`, `Community 141`, `Community 147`, `Community 20`, `Community 149`, `Community 22`, `Community 279`, `Community 280`, `Community 24`, `Community 538`, `Community 27`, `Community 23`, `Community 790`, `Community 30`, `Community 26`, `Community 42`, `Community 43`, `Community 45`, `Community 174`, `Community 46`, `Community 48`, `Community 47`, `Community 1077`, `Community 54`, `Community 697`, `Community 57`, `Community 698`, `Community 60`, `Community 189`, `Community 61`, `Community 584`, `Community 73`, `Community 202`, `Community 205`, `Community 334`, `Community 335`, `Community 80`, `Community 79`, `Community 469`, `Community 470`, `Community 471`, `Community 88`, `Community 342`, `Community 85`, `Community 218`, `Community 214`, `Community 230`, `Community 743`, `Community 360`, `Community 233`, `Community 747`, `Community 630`, `Community 1145`?**
+  _High betweenness centrality (0.055) - this node is a cross-community bridge._
+- **Why does `VBriefDocument` connect `Community 14` to `Community 32`, `Community 1`, `Community 5`, `Community 10`, `Community 204`, `Community 13`, `Community 15`, `Community 308`, `Community 31`?**
+  _High betweenness centrality (0.038) - this node is a cross-community bridge._
+- **Why does `FsError` connect `Community 387` to `Community 0`, `Community 513`, `Community 1`, `Community 3`, `Community 388`, `Community 2`, `Community 389`, `Community 263`, `Community 7`, `Community 264`, `Community 6`, `Community 5`, `Community 14`, `Community 15`, `Community 17`, `Community 660`, `Community 148`, `Community 149`, `Community 279`, `Community 153`, `Community 282`, `Community 155`, `Community 156`, `Community 36`, `Community 166`, `Community 295`, `Community 41`, `Community 172`, `Community 46`, `Community 437`, `Community 309`, `Community 55`, `Community 62`, `Community 66`, `Community 450`, `Community 199`, `Community 329`, `Community 201`, `Community 332`, `Community 79`, `Community 81`, `Community 83`, `Community 467`, `Community 341`, `Community 216`, `Community 90`, `Community 91`, `Community 99`, `Community 100`, `Community 484`, `Community 105`, `Community 491`, `Community 623`, `Community 112`, `Community 243`, `Community 117`, `Community 118`, `Community 251`?**
+  _High betweenness centrality (0.009) - this node is a cross-community bridge._
+- **Are the 198 inferred relationships involving `fetch` (e.g. with `main()` and `main()`) actually correct?**
+  _`fetch` has 198 INFERRED edges - model-reasoned connections that need verification._
 - **What connects `__dirname`, `FIXTURES_DIR`, `TEMP_ROOT_DIR` to the rest of the system?**
-  _12659 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _13275 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.03 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1,7446 +1,7846 @@
 {
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/commitlint.config.js": {
-    "mtime": 1779108265.8560317,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/commitlint.config.js": {
+    "mtime": 1779420420.729954,
     "hash": "cb79a27c4ddab322aad3ee9a95b89bb3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/dev": {
-    "mtime": 1779108277.3346477,
-    "hash": "eea0ceb8c485e49a1dde25a551bbec5d"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/vitest.config.ts": {
+    "mtime": 1779420421.0598896,
+    "hash": "a9f70e4673227de70728d50acaef613a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/vitest.config.ts": {
-    "mtime": 1779108266.1876757,
-    "hash": "9d1c316b53bc0d62daecd6b660987c74"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/vitest.workspace.ts": {
-    "mtime": 1779108266.1876757,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/vitest.workspace.ts": {
+    "mtime": 1779420421.0598896,
     "hash": "cbc3380b6a195aae98176e83ce3d57a8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/debug-review.mjs": {
-    "mtime": 1779108265.856574,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/debug-review.mjs": {
+    "mtime": 1779420420.730466,
     "hash": "95c1ea3285625a68fab26dcfce58657b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tsdown.config.ts": {
-    "mtime": 1779108266.1745427,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tsdown.config.ts": {
+    "mtime": 1779420421.0551996,
     "hash": "b16379351624eca6509372131ef4c73d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/setup.ts": {
-    "mtime": 1779108266.172836,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/setup.ts": {
+    "mtime": 1779420421.0528228,
     "hash": "8da04bf10d7f91be21ec7a6aa3444bbc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/global-setup.ts": {
-    "mtime": 1779108266.1701849,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/global-setup.ts": {
+    "mtime": 1779420421.0491252,
     "hash": "a030f95d8d2347444b7f2e65fd9d3a95"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/resource-utils.test.ts": {
-    "mtime": 1779108266.172836,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/resource-utils.test.ts": {
+    "mtime": 1779420421.0528228,
     "hash": "c7f261242622a6bc5482aede4de06db7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/e2e/handoff-stuck-escalation.test.ts": {
-    "mtime": 1779108266.170127,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/e2e/handoff-stuck-escalation.test.ts": {
+    "mtime": 1779420421.0488927,
     "hash": "82b206b675a6786bebd0d261d87a3b0d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/e2e/handoff-planning-complete.test.ts": {
-    "mtime": 1779108266.1695275,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/e2e/styleguide-conformance.spec.ts": {
+    "mtime": 1779420421.0489244,
+    "hash": "44e3523a0859f78c6e6a390c87eb6367"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/e2e/handoff-planning-complete.test.ts": {
+    "mtime": 1779420421.0488794,
     "hash": "20a1946e33a8ecc0dea53f798b83f976"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/e2e/work-flow.test.ts": {
-    "mtime": 1779108266.170127,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/e2e/work-flow.test.ts": {
+    "mtime": 1779420421.0489244,
     "hash": "94ca9312d39f4613f2bbc55e1d80cb9d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/desktop/ipc-terminal.test.ts": {
-    "mtime": 1779108266.1695275,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/desktop/ipc-terminal.test.ts": {
+    "mtime": 1779420421.0488355,
     "hash": "b7c161af1463628e220e06548dc2787c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cloister/inspect-checkpoints.test.ts": {
-    "mtime": 1779108266.169175,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cloister/inspect-checkpoints.test.ts": {
+    "mtime": 1779420421.0479043,
     "hash": "d7603a04d0ddd05680a68756350a9300"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cloister/verification-gate.test.ts": {
-    "mtime": 1779108266.169175,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cloister/verification-gate.test.ts": {
+    "mtime": 1779420421.0479043,
     "hash": "be44795cff4ad15df4bb76d96e560252"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cloister/verification-runner.test.ts": {
-    "mtime": 1779108266.169175,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cloister/verification-runner.test.ts": {
+    "mtime": 1779420421.048113,
     "hash": "26a844f8c3f3468efcd0651e034fc821"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cloister/sync-main.test.ts": {
-    "mtime": 1779108266.169175,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cloister/sync-main.test.ts": {
+    "mtime": 1779420421.0479043,
     "hash": "0418c23ca44107708853db2f82225f59"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cloister/fpp-violations.test.ts": {
-    "mtime": 1779108266.169175,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cloister/fpp-violations.test.ts": {
+    "mtime": 1779420421.0479043,
     "hash": "343524e78b68fcc278964044a731a3ec"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cloister/cost-monitor.test.ts": {
-    "mtime": 1779108266.1690514,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cloister/cost-monitor.test.ts": {
+    "mtime": 1779420421.047866,
     "hash": "3e6f1384eb7dfd0a1c44143641776e47"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cloister/session-rotation.test.ts": {
-    "mtime": 1779108266.169175,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cloister/session-rotation.test.ts": {
+    "mtime": 1779420421.0479043,
     "hash": "1bcde34b3a3e21fe9315d195f8414b31"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/scripts/work-agent-stop-hook.test.ts": {
-    "mtime": 1779108266.172836,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/scripts/work-agent-stop-hook.test.ts": {
+    "mtime": 1779420421.0528228,
     "hash": "22a472214855e6dc45137ce5caa43cfd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/fixtures/pan-help.test.ts": {
-    "mtime": 1779108266.1701849,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/fixtures/pan-help.test.ts": {
+    "mtime": 1779420421.049028,
     "hash": "8a79cea40a8699c6150f0b262af01b0e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/fixtures/rally-api-mock.ts": {
-    "mtime": 1779108266.1701849,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/fixtures/rally-api-mock.ts": {
+    "mtime": 1779420421.049083,
     "hash": "3de068ea021312d05a5727760c35a825"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/fixtures/index.ts": {
-    "mtime": 1779108266.1701849,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/fixtures/index.ts": {
+    "mtime": 1779420421.0489922,
     "hash": "76d7a6fb25fc91aa06e90d089a614d0d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/fixtures/synced-skills.test.ts": {
-    "mtime": 1779108266.1701849,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/fixtures/synced-skills.test.ts": {
+    "mtime": 1779420421.049083,
     "hash": "58e32624ffeb681ff5569420e4a06788"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/event-store.test.ts": {
-    "mtime": 1779108266.1737437,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/event-store.test.ts": {
+    "mtime": 1779420421.0538044,
     "hash": "31ecefc407c94911dcbeb22da6d18545"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/git-operations.test.ts": {
-    "mtime": 1779108266.1744747,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/git-operations.test.ts": {
+    "mtime": 1779420421.0543678,
     "hash": "1ae57c79aed0f9bf0f95217c1aa64e33"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/work-agent-prompt-pan977.test.ts": {
-    "mtime": 1779108266.1745427,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/work-agent-prompt-pan977.test.ts": {
+    "mtime": 1779420421.0551996,
     "hash": "93bc8e2d7e67aebc024d4b85accb863c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/pan-330-dead-session.test.ts": {
-    "mtime": 1779108266.1745427,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/pan-330-dead-session.test.ts": {
+    "mtime": 1779420421.0546484,
     "hash": "670fb181e803f1ff3c0404d0b008fb8f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/forge.test.ts": {
-    "mtime": 1779108266.1742232,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/forge.test.ts": {
+    "mtime": 1779420421.0543678,
     "hash": "c26c6e52477c5c98be3114167d9457b2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/review-status-clearstuck.test.ts": {
-    "mtime": 1779108266.1745427,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/review-status-clearstuck.test.ts": {
+    "mtime": 1779420421.0550315,
     "hash": "02814a04476bfdf93cab061c6d9463a5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/costs-wal.test.ts": {
-    "mtime": 1779108266.173953,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/costs-wal.test.ts": {
+    "mtime": 1779420421.0540926,
     "hash": "afda20979b00d1db1cd7d8310d24f9cd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/database.test.ts": {
-    "mtime": 1779108266.173953,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/database.test.ts": {
+    "mtime": 1779420421.0540926,
     "hash": "e5ba718229424191e7db022c68a702fb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/pan-639-beads-tracking.test.ts": {
-    "mtime": 1779108266.1745427,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/pan-639-beads-tracking.test.ts": {
+    "mtime": 1779420421.054858,
     "hash": "9a1e834c2428f4cb14b44da088a01404"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/project-specialist-status.test.ts": {
-    "mtime": 1779108266.1745427,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/project-specialist-status.test.ts": {
+    "mtime": 1779420421.054858,
     "hash": "5a2792ec707b81c6d970c751d1a4a375"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/skills-merge.test.ts": {
-    "mtime": 1779108266.1745427,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/skills-merge.test.ts": {
+    "mtime": 1779420421.0550315,
     "hash": "7decc6d58c90eb286e95cc280e34a267"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/git-utils.test.ts": {
-    "mtime": 1779108266.1744747,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/git-utils.test.ts": {
+    "mtime": 1779420421.0543678,
     "hash": "8d399f14c51208fcdd79eeaf9510469d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/difficulty-estimation.test.ts": {
-    "mtime": 1779108266.1742232,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/difficulty-estimation.test.ts": {
+    "mtime": 1779420421.0543678,
     "hash": "3894f8461f12c6c052e719af44056647"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/webhook-handlers.test.ts": {
-    "mtime": 1779108266.1745427,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/webhook-handlers.test.ts": {
+    "mtime": 1779420421.0551748,
     "hash": "91b3cededc92c7171e75a851225d55f6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/clean-stale-specialist-statuses.test.ts": {
-    "mtime": 1779108266.1737437,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/clean-stale-specialist-statuses.test.ts": {
+    "mtime": 1779420421.0538044,
     "hash": "0d80b7a1dd7261513497d1fdde89f3ad"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/pan-639-compact-beads-persistence.test.ts": {
-    "mtime": 1779108266.1745427,
-    "hash": "e994005c1fe75234c5a922b193bc20b9"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/pan-639-compact-beads-persistence.test.ts": {
+    "mtime": 1779420421.054858,
+    "hash": "42f9cfd131ab02be94761fda4c2ef4a2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/config.test.ts": {
-    "mtime": 1779108266.173953,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/config.test.ts": {
+    "mtime": 1779420421.0540926,
     "hash": "dbb6f655b6ffae20e4b15e76de66caa0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/review-artifacts.test.ts": {
-    "mtime": 1779108266.1745427,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/review-artifacts.test.ts": {
+    "mtime": 1779420421.054858,
     "hash": "eb590649d2d29c5ad4ae798f1748b239"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/smee.test.ts": {
-    "mtime": 1779108266.1745427,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/smee.test.ts": {
+    "mtime": 1779420421.0550315,
     "hash": "708271c2b7a6b6c4404ee5556677bd7e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/paths.test.ts": {
-    "mtime": 1779108266.1745427,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/paths.test.ts": {
+    "mtime": 1779420421.054858,
     "hash": "0b266dc3f17930bc3de58b23f5575a12"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/pan-444-post-merge-step0.test.ts": {
-    "mtime": 1779108266.1745427,
-    "hash": "58f5209d8011df06ee60c0305ad87843"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/pan-444-post-merge-step0.test.ts": {
+    "mtime": 1779420421.054858,
+    "hash": "2db3bc46e65dd9a1c5aad8d422885540"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/platform-lifecycle.test.ts": {
-    "mtime": 1779108266.1745427,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/platform-lifecycle.test.ts": {
+    "mtime": 1779420421.054858,
     "hash": "75a905fd463b9bb5d5735e642e517a5f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/queue-position.test.ts": {
-    "mtime": 1779108266.1745427,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/queue-position.test.ts": {
+    "mtime": 1779420421.054858,
     "hash": "c497ae3865b2aa074ac48aa2c618ee65"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/pan-444-pending-lifecycle.test.ts": {
-    "mtime": 1779108266.1745427,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/pan-444-pending-lifecycle.test.ts": {
+    "mtime": 1779420421.0546484,
     "hash": "12e0ef4b72231b5b61c2a85f343010b8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/sync-remove-legacy-skills.test.ts": {
-    "mtime": 1779108266.1745427,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/sync-remove-legacy-skills.test.ts": {
+    "mtime": 1779420421.0550315,
     "hash": "6a9ea3bda2385e41e3bd87cff9b42b4d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/smee-process.test.ts": {
-    "mtime": 1779108266.1745427,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/smee-process.test.ts": {
+    "mtime": 1779420421.0550315,
     "hash": "3cfb079f1aa0193fb0a1ed690f12c4c3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/cloister/validation.test.ts": {
-    "mtime": 1779108266.173953,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/cloister/validation.test.ts": {
+    "mtime": 1779420421.0540926,
     "hash": "897b331e543d620138ce92378bd828d6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/cloister/merge-agent-spawn.test.ts": {
-    "mtime": 1779108266.173953,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/cloister/merge-agent-spawn.test.ts": {
+    "mtime": 1779420421.0539763,
     "hash": "4af5cc9f8747ff450517ce8d3dccc880"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/cloister/pan-344-auto-merge.test.ts": {
-    "mtime": 1779108266.173953,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/cloister/pan-344-auto-merge.test.ts": {
+    "mtime": 1779420421.0539763,
     "hash": "1cdbcef879cbde28732d69124b197d0d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/cloister/scan-git-patterns.test.ts": {
-    "mtime": 1779108266.173953,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/cloister/scan-git-patterns.test.ts": {
+    "mtime": 1779420421.0540926,
     "hash": "e62b9111f613bb228be95d75e2973885"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/cloister/merge-agent-quality-gates.test.ts": {
-    "mtime": 1779108266.1739204,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/cloister/merge-agent-quality-gates.test.ts": {
+    "mtime": 1779420421.0539508,
     "hash": "f1181f7b778bba902380ae1ed62fdd9c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/database/health-events-db.test.ts": {
-    "mtime": 1779108266.1742232,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/database/health-events-db.test.ts": {
+    "mtime": 1779420421.0542574,
     "hash": "86b2f4f4dcd37dd8a121616576f05a16"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/database/schema-migrations.test.ts": {
-    "mtime": 1779108266.1742232,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/database/schema-migrations.test.ts": {
+    "mtime": 1779420421.0543678,
     "hash": "02263d23e459d57fa5ed6f0e841fdf6f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/database/merge-queue-db.test.ts": {
-    "mtime": 1779108266.1742232,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/database/merge-queue-db.test.ts": {
+    "mtime": 1779420421.0542574,
     "hash": "43898a58eaf84dc9dc2bff342baab141"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/database/conversations-db.test.ts": {
-    "mtime": 1779108266.173953,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/database/conversations-db.test.ts": {
+    "mtime": 1779420421.0540926,
     "hash": "c74cba6e2a5a487e327039f818f8e33c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/database/merge-set-db.test.ts": {
-    "mtime": 1779108266.1742232,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/database/merge-set-db.test.ts": {
+    "mtime": 1779420421.0542574,
     "hash": "6eb4b97860a7c8e59ef55f77b2a7e655"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/database/git-activity-db.test.ts": {
-    "mtime": 1779108266.1742232,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/database/git-activity-db.test.ts": {
+    "mtime": 1779420421.0542574,
     "hash": "612e609ca97e160ca649c4448c2048da"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/database/review-status-db.test.ts": {
-    "mtime": 1779108266.1742232,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/database/review-status-db.test.ts": {
+    "mtime": 1779420421.0543678,
     "hash": "e542f9c9b749de3ffbf025285dce93d5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/database/cost-events-db.test.ts": {
-    "mtime": 1779108266.1742232,
-    "hash": "48d67493bf11b381c1114d1d225e8c14"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/database/cost-events-db.test.ts": {
+    "mtime": 1779420421.0542574,
+    "hash": "c414195a85504a87594d92a7403205d5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/lifecycle/workflows.test.ts": {
-    "mtime": 1779108266.1745427,
-    "hash": "8203587da3b71d32346eec52a27eef8d"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/lifecycle/workflows.test.ts": {
+    "mtime": 1779420421.0546484,
+    "hash": "750890e17cf2413dae63ffa88f1f1107"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/lifecycle/teardown-workspace.test.ts": {
-    "mtime": 1779108266.1745427,
-    "hash": "9d20283b37a0b865c253ca4a7042949e"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/lifecycle/teardown-workspace.test.ts": {
+    "mtime": 1779420421.0546484,
+    "hash": "c7622ec8f8e041d7663f5e54e3c9d028"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/lifecycle/compact-beads.test.ts": {
-    "mtime": 1779108266.1745427,
-    "hash": "f079a1ff9129d857d14da12ccc078725"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/lifecycle/compact-beads.test.ts": {
+    "mtime": 1779420421.054592,
+    "hash": "52f2368ea5b1b04e58749fe74e700ecb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/lifecycle/label-cleanup.test.ts": {
-    "mtime": 1779108266.1745427,
-    "hash": "26fe6e1e737751ef4b5f8e1883be14cb"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/lifecycle/label-cleanup.test.ts": {
+    "mtime": 1779420421.054592,
+    "hash": "af358fa432c33bfec3ca10745bd21856"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/lifecycle/archive-planning.test.ts": {
-    "mtime": 1779108266.1744747,
-    "hash": "fb6e435e8397bd76b3ca006b00ef31fd"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/lifecycle/archive-planning.test.ts": {
+    "mtime": 1779420421.0545273,
+    "hash": "dcf840e53b6f60143e366833923cb1f7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/lib/lifecycle/close-issue.test.ts": {
-    "mtime": 1779108266.1745427,
-    "hash": "b4a543385b5a8b70041749bf37fdc1b8"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/lib/lifecycle/close-issue.test.ts": {
+    "mtime": 1779420421.0545645,
+    "hash": "9f6130c609cccb7ed32b7bb4a71419d6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/frontend/DifficultyBadge.test.tsx": {
-    "mtime": 1779108266.1737437,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/frontend/DifficultyBadge.test.tsx": {
+    "mtime": 1779420421.0538044,
     "hash": "3ec114aa917a19a086e98b3cb8250c2b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/metrics-stuck-count.test.ts": {
-    "mtime": 1779108266.1731143,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/metrics-stuck-count.test.ts": {
+    "mtime": 1779420421.0531168,
     "hash": "5893b1b8a4e21bf5f3671fb175209e64"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/git-activity-route.test.ts": {
-    "mtime": 1779108266.1731143,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/git-activity-route.test.ts": {
+    "mtime": 1779420421.0531168,
     "hash": "2b472fc13b7a093a9484ad555582e50f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/domain-services.test.ts": {
-    "mtime": 1779108266.1731143,
-    "hash": "18fdade0912194754f78d0db16ee7793"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/domain-services.test.ts": {
+    "mtime": 1779420421.0531168,
+    "hash": "e4b97bdb4496fdd9990a96ecaa21f07c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/unstick-endpoint.test.ts": {
-    "mtime": 1779108266.1737437,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/unstick-endpoint.test.ts": {
+    "mtime": 1779420421.0538044,
     "hash": "d518b45d45433021792dd06638a1d8c3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/config.test.ts": {
-    "mtime": 1779108266.1729918,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/config.test.ts": {
+    "mtime": 1779420421.052988,
     "hash": "dc5595dd5954eaf058fcfb993454b09f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/pan-343-test-delivery.test.ts": {
-    "mtime": 1779108266.1731143,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/pan-343-test-delivery.test.ts": {
+    "mtime": 1779420421.0532482,
     "hash": "0d46c766b16d54e846eb3d52254bd716"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/routes/webhooks.test.ts": {
-    "mtime": 1779108266.1731143,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/routes/webhooks.test.ts": {
+    "mtime": 1779420421.0532482,
     "hash": "3b0d62cb407128a713db41d681bdc538"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/server/routes/no-op-rebase.test.ts": {
-    "mtime": 1779108266.1733043,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/server/routes/no-op-rebase.test.ts": {
+    "mtime": 1779420421.0535252,
     "hash": "8e0004cb07ff66e0aa873027034a397d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/server/routes/issue-pr.test.ts": {
-    "mtime": 1779108266.1733043,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/server/routes/issue-pr.test.ts": {
+    "mtime": 1779420421.0533433,
     "hash": "7d02d2d8ad72d9cadeb6e1a50c1e2e97"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/server/routes/reset-review-route.test.ts": {
-    "mtime": 1779108266.1733043,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/server/routes/reset-review-route.test.ts": {
+    "mtime": 1779420421.0535252,
     "hash": "b1aaa0d00c5d9c97fa55e38aa3c5bd30"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/server/routes/conversations-favorite.test.ts": {
-    "mtime": 1779108266.1733043,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/server/routes/conversations-favorite.test.ts": {
+    "mtime": 1779420421.0533433,
     "hash": "018b444d003fdfc75e125e08b70a600b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/server/routes/show.test.ts": {
-    "mtime": 1779108266.1733043,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/server/routes/show.test.ts": {
+    "mtime": 1779420421.0536788,
     "hash": "36e820531369840e22e856bdcfc34302"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/server/routes/unstick-route.test.ts": {
-    "mtime": 1779108266.1733043,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/server/routes/unstick-route.test.ts": {
+    "mtime": 1779420421.0536788,
     "hash": "eb4f2d7fe560def2ec3f939050e41d4e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/server/routes/specialists-reviewed-at-commit.test.ts": {
-    "mtime": 1779159764.5053546,
-    "hash": "35e78641f76c5a07443d0ca049a99bad"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/server/routes/specialists-reviewed-at-commit.test.ts": {
+    "mtime": 1779420421.0536788,
+    "hash": "a225a6b941e5af8069bd5b994eed7ead"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/server/routes/approve-push.test.ts": {
-    "mtime": 1779108266.1733043,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/server/routes/approve-push.test.ts": {
+    "mtime": 1779420421.0533433,
     "hash": "a371e8f6c82349e425b119460240175f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/server/routes/command-deck-cache.test.ts": {
-    "mtime": 1779108266.1733043,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/server/routes/command-deck-cache.test.ts": {
+    "mtime": 1779420421.0533433,
     "hash": "2b1108a944a906f65a19a66d04cf46f1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/server/routes/resume-gate.test.ts": {
-    "mtime": 1779108266.1733043,
-    "hash": "a8c7664166352fae35350470b69e8390"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/server/routes/resume-gate.test.ts": {
+    "mtime": 1779420421.0535252,
+    "hash": "01d9f99c9cdd97d2c783b221488fb472"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/server/routes/command-deck.test.ts": {
-    "mtime": 1779108266.1733043,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/server/routes/command-deck.test.ts": {
+    "mtime": 1779420421.0533433,
     "hash": "a8b87adc549a9b614f7c7b88a80edfe9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/server/routes/admin.test.ts": {
-    "mtime": 1779108266.1732762,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/server/routes/admin.test.ts": {
+    "mtime": 1779420421.0533133,
     "hash": "c801e8e0b855193d5f2d63a428d2c145"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/server/routes/workspace-planning-markdown.test.ts": {
-    "mtime": 1779108266.1733043,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/server/routes/workspace-planning-markdown.test.ts": {
+    "mtime": 1779420421.0536788,
     "hash": "c5bf15b87c99067e56323ae13e87c2fe"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/server/routes/merge-reconciliation.test.ts": {
-    "mtime": 1779108266.1733043,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/server/routes/merge-reconciliation.test.ts": {
+    "mtime": 1779420421.0533433,
     "hash": "623f4d3be332257e4ab60f85286951dc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/server/routes/projects.test.ts": {
-    "mtime": 1779108266.1733043,
-    "hash": "27730c4728eb9dd133266ca478ac84a1"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/server/routes/projects.test.ts": {
+    "mtime": 1779420421.0535252,
+    "hash": "1aaeab7dd17f1840b56881a97e1d4dd6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/server/routes/issue-discussions.test.ts": {
-    "mtime": 1779108266.1733043,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/server/routes/issue-discussions.test.ts": {
+    "mtime": 1779420421.0533433,
     "hash": "aa68dd7580c10fd2e02be3b2e6168917"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/server/services/merge-queue-service.test.ts": {
-    "mtime": 1779108266.1737072,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/server/services/merge-queue-service.test.ts": {
+    "mtime": 1779420421.0536788,
     "hash": "c9417887014a6bcdcec7cfd1f911aa77"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/dashboard/server/services/resource-discovery.test.ts": {
-    "mtime": 1779108266.1737437,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/dashboard/server/services/resource-discovery.test.ts": {
+    "mtime": 1779420421.0538044,
     "hash": "fafaae3c5fedb5ba5991a0ff4f23ff52"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/cli/sync-main.test.ts": {
-    "mtime": 1779108266.1729918,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/cli/sync-main.test.ts": {
+    "mtime": 1779420421.052988,
     "hash": "44a3ab97a4d4f361ed7728216eefa112"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/cli/plan-difficulty.test.ts": {
-    "mtime": 1779108266.1729918,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/cli/plan-difficulty.test.ts": {
+    "mtime": 1779420421.052988,
     "hash": "40d4f34f7759e53d828c7e07960b4748"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/cli/option-parsing.test.ts": {
-    "mtime": 1779108266.1729918,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/cli/option-parsing.test.ts": {
+    "mtime": 1779420421.052988,
     "hash": "0c29095b666aa3f16f0dbc98cc861ea0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/unit/cli/commands/system-health.test.ts": {
-    "mtime": 1779108266.1729918,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/unit/cli/commands/system-health.test.ts": {
+    "mtime": 1779420421.052988,
     "hash": "935a4a4b763d123aa69d7b1761aa8eb9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/contracts/heartbeat-ingestion.test.ts": {
-    "mtime": 1779108266.1694448,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/contracts/heartbeat-ingestion.test.ts": {
+    "mtime": 1779420421.0481448,
     "hash": "7a4b8c4bbc5232325c8355b7412555a4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/contracts/agent-runtime-reducers.test.ts": {
-    "mtime": 1779108266.169175,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/contracts/agent-runtime-reducers.test.ts": {
+    "mtime": 1779420421.0481448,
     "hash": "1f2b45225d5642886cb20e52068e0e81"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/core/state-mapping.test.ts": {
-    "mtime": 1779108266.1694448,
-    "hash": "09aa8cc958a19416a7c3692e77b8ce86"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/contracts/memory-events.test.ts": {
+    "mtime": 1779420421.0481448,
+    "hash": "20e3ca9d1d47b7e726d0c81504458acd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/backup.test.ts": {
-    "mtime": 1779108266.170562,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/core/state-mapping.test.ts": {
+    "mtime": 1779420421.0481448,
+    "hash": "a80b9fe6dd64d29ecb51287ff4a484ff"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/backup.test.ts": {
+    "mtime": 1779420421.049589,
     "hash": "02313f37af9203b401f27f07339cc1d5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/health-runtime-state.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/health-runtime-state.test.ts": {
+    "mtime": 1779420421.0506604,
     "hash": "01f7ed57e2eaa1978060319a25da7558"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/router-config.test.ts": {
-    "mtime": 1779108266.1720548,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/router-config.test.ts": {
+    "mtime": 1779420421.0519257,
     "hash": "a769ee091dddcffc499f939f1a99a62a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/tracker-utils.test.ts": {
-    "mtime": 1779108266.1720548,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/tracker-utils.test.ts": {
+    "mtime": 1779420421.0522141,
     "hash": "84706555ad67d5396984e892f69f5cc4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/format-duration.test.ts": {
-    "mtime": 1779108266.170744,
-    "hash": "a1194a1e019dd543281d1c190807136b"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/format-duration.test.ts": {
+    "mtime": 1779420421.0506604,
+    "hash": "7093298f0857a88eae631e7c9fc97768"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/cost.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/cost.test.ts": {
+    "mtime": 1779420421.0505621,
     "hash": "4b5de91a63f0325b3fd2e2205bdeccf9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/multi-tool-sync.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/multi-tool-sync.test.ts": {
+    "mtime": 1779420421.0513666,
     "hash": "b87abe34696416d80373f4507f7fe07a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/hooks.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/hooks.test.ts": {
+    "mtime": 1779420421.0506604,
     "hash": "a7580e1858636e2ebe3835bd55595b9d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/pan-artifacts.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/pan-artifacts.test.ts": {
+    "mtime": 1779420421.0513666,
     "hash": "c061700a8269f41d15183a20d597af10"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/autopreso-session.test.ts": {
-    "mtime": 1779108266.170562,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/autopreso-session.test.ts": {
+    "mtime": 1779420421.049459,
     "hash": "f69d0cc7eaf8449b13e0e3c3577b8839"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/workspace-manager.test.ts": {
-    "mtime": 1779108266.172836,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/workspace-manager.test.ts": {
+    "mtime": 1779420421.0528228,
     "hash": "efa795fbac26cc88250259d078ff4037"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/issue-id.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/issue-id.test.ts": {
+    "mtime": 1779420421.0506604,
     "hash": "80f8cd0884e35f02e1b20fa3c131e4b0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/settings-api.test.ts": {
-    "mtime": 1779108266.1720548,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/settings-api.test.ts": {
+    "mtime": 1779420421.0519257,
     "hash": "22a25223a476084f99ded6d37bfe4ec7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/openai-compatible-proxy.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/openai-compatible-proxy.test.ts": {
+    "mtime": 1779420421.0513666,
     "hash": "5da3f3986912e694119a4d4ce54c57e1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/agents-auth-routing.test.ts": {
-    "mtime": 1779108266.170562,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/agents-auth-routing.test.ts": {
+    "mtime": 1779420421.049459,
     "hash": "45471cdb4bdc363783b81e382aac006c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/git-utils.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/git-utils.test.ts": {
+    "mtime": 1779420421.0506604,
     "hash": "5f307ce8a7b6aaffde4f010fa3ec7516"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/google-cloud-transcription.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/google-cloud-transcription.test.ts": {
+    "mtime": 1779420421.0506604,
     "hash": "134258ca984e38a4994e6b384e2a66f9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/model-deprecation.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/model-deprecation.test.ts": {
+    "mtime": 1779420421.0513666,
     "hash": "44d051bb408a166ee2ee96c52c9bbfb6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/agent-enrichment.test.ts": {
-    "mtime": 1779108266.170425,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/agent-enrichment.test.ts": {
+    "mtime": 1779420421.0493338,
     "hash": "eabb0e6d6c3e4c7a83dafe86f35825fc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/config-yaml.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/config-yaml.test.ts": {
+    "mtime": 1779420421.0503929,
     "hash": "ca91d845433e1fe61039c8cc9ef8fa2a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/reopen.test.ts": {
-    "mtime": 1779108266.1720548,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/reopen.test.ts": {
+    "mtime": 1779420421.0519257,
     "hash": "f23f55e1446bba86cff7b3013dc91afe"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/provider-health.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/provider-health.test.ts": {
+    "mtime": 1779420421.0513666,
     "hash": "9835def4c1fe308064f5889d6d9603b1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/whiteboard-tools.test.ts": {
-    "mtime": 1779108266.1724217,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/whiteboard-tools.test.ts": {
+    "mtime": 1779420421.0525193,
     "hash": "00eccb1421a5155195e54aa381b16581"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/shadow-mode.test.ts": {
-    "mtime": 1779108266.1720548,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/shadow-mode.test.ts": {
+    "mtime": 1779420421.0522141,
     "hash": "5e1c9252aac072bf95dd73f4a46e0fc0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/turn-queue.test.ts": {
-    "mtime": 1779108266.1724217,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/turn-queue.test.ts": {
+    "mtime": 1779420421.0525193,
     "hash": "af26f6dd957dadf55c138fb600287a6b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/config.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/config.test.ts": {
+    "mtime": 1779420421.0503929,
     "hash": "005b88c4d325de1621272facdde806c6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/config-migration.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/config-migration.test.ts": {
+    "mtime": 1779420421.0503929,
     "hash": "4d6e895a6fd2c64864c8341cc5a26fb5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/settings.test.ts": {
-    "mtime": 1779108266.1720548,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/settings.test.ts": {
+    "mtime": 1779420421.0519257,
     "hash": "c90de894ed65af14abfeee7239af5340"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/providers.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/providers.test.ts": {
+    "mtime": 1779420421.0513666,
     "hash": "2bc820e435653f020ebb53900cd07e84"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/tmux-exact-session.test.ts": {
-    "mtime": 1779108266.1720548,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/tmux-exact-session.test.ts": {
+    "mtime": 1779420421.0522141,
     "hash": "2055193e23f9300838aec4a8741eb112"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/tmux-detect-terminal-api-error.test.ts": {
-    "mtime": 1779108266.1720548,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/tmux-detect-terminal-api-error.test.ts": {
+    "mtime": 1779420421.0522141,
     "hash": "2005b58ac06e55e1a45a99a41be1f51a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/paths.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/paths.test.ts": {
+    "mtime": 1779420421.0513666,
     "hash": "b5d00495a4eb2d29041cd145badbce93"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/claude-mcp.test.ts": {
-    "mtime": 1779108266.170562,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/claude-mcp.test.ts": {
+    "mtime": 1779420421.049589,
     "hash": "80a0cee99c85d0deadf77e83fa0231d7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/project-repos.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/project-repos.test.ts": {
+    "mtime": 1779420421.0513666,
     "hash": "0aee78eb7f46a921a88deab89232dcbb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/mirrorProjectSkills.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/mirrorProjectSkills.test.ts": {
+    "mtime": 1779420421.0513666,
     "hash": "66913ddb83950cfa534802b86fb1b6aa"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/child-env.test.ts": {
-    "mtime": 1779108266.170562,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/child-env.test.ts": {
+    "mtime": 1779420421.049589,
     "hash": "d8649a6608084f4e8fa4d7c134e5cc40"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/work-agent-lifecycle.test.ts": {
-    "mtime": 1779108266.1724217,
-    "hash": "2b25c07e7ee17066ac27d8790ef3e54f"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/work-agent-lifecycle.test.ts": {
+    "mtime": 1779420421.0525193,
+    "hash": "0d5b36ddd29f006a6b4ecf5e3e2fb5c8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/model-fallback.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/model-fallback.test.ts": {
+    "mtime": 1779420421.0513666,
     "hash": "0808c8e4897123062101f7d5e39e4115"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/status-context.test.ts": {
-    "mtime": 1779108266.1720548,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/status-context.test.ts": {
+    "mtime": 1779420421.0522141,
     "hash": "37df8a5a1341dd6369c79ae4bedf2a8e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/prd-draft.test.ts": {
-    "mtime": 1779108266.170744,
-    "hash": "22da2926a8e06341c36e672850882f49"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/prd-draft.test.ts": {
+    "mtime": 1779420421.0513666,
+    "hash": "75fe7f5d9f02017a0b173581a006bfb1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/migrate-stale-personal-content.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/migrate-stale-personal-content.test.ts": {
+    "mtime": 1779420421.0513666,
     "hash": "66dd3f2aad90743d078b9b960567fa2c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/shadow-state.test.ts": {
-    "mtime": 1779108266.1720548,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/shadow-state.test.ts": {
+    "mtime": 1779420421.0522141,
     "hash": "8c524c8597468e52d4384f097968fd2a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/tldr-status.test.ts": {
-    "mtime": 1779108266.1720548,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/tldr-status.test.ts": {
+    "mtime": 1779420421.0522141,
     "hash": "9861ec0b04f5444cc9e19835f9496593"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/cost-parsers/jsonl-parser.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/cost-parsers/jsonl-parser.test.ts": {
+    "mtime": 1779420421.0505621,
     "hash": "8040dc079e4c03e5b1b4b1b873f6cbff"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/work/runPreflightChecks.test.ts": {
-    "mtime": 1779108266.172836,
-    "hash": "9ee6884b67e75ab98aa0dfe6e1770694"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/work/runPreflightChecks.test.ts": {
+    "mtime": 1779420421.0528228,
+    "hash": "bb02c261aca569ab819152334b221d08"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/work/checkVBriefACStatus.test.ts": {
-    "mtime": 1779108266.172836,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/work/checkVBriefACStatus.test.ts": {
+    "mtime": 1779420421.0528228,
     "hash": "a2d0a7145833902cbd25df434d659f56"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/work/checkUncommittedChanges.test.ts": {
-    "mtime": 1779108266.172836,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/work/checkUncommittedChanges.test.ts": {
+    "mtime": 1779420421.0528228,
     "hash": "b9eac7f682b339e375ec681d0c233661"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/work/checkOpenBeads.test.ts": {
-    "mtime": 1779108266.1724217,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/work/checkOpenBeads.test.ts": {
+    "mtime": 1779420421.0525193,
     "hash": "cb85f2f858bca530e30745d005d54ab7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/tracker/factory.test.ts": {
-    "mtime": 1779108266.1720548,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/tracker/factory.test.ts": {
+    "mtime": 1779420421.0522141,
     "hash": "fbf692c58371ff097f16dbf131718051"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/tracker/github.test.ts": {
-    "mtime": 1779108266.1724217,
-    "hash": "18fff5f14d5ff5503dd228ed0c60d511"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/tracker/github.test.ts": {
+    "mtime": 1779420421.0523875,
+    "hash": "ac3e91bfe7e927605a70b1f661787483"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/tracker/interface.test.ts": {
-    "mtime": 1779108266.1724217,
-    "hash": "eea8346b1bb050151248ff538fc516ad"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/tracker/interface.test.ts": {
+    "mtime": 1779420421.0523875,
+    "hash": "3832163ca2a77c893f6860273847b5f5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/tracker/linear.test.ts": {
-    "mtime": 1779108266.1724217,
-    "hash": "9736891205e5070cbda859be9d32cc4a"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/tracker/linear.test.ts": {
+    "mtime": 1779420421.0525193,
+    "hash": "070989d82a325060811243d9bf3284ca"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/tracker/rally.test.ts": {
-    "mtime": 1779108266.1724217,
-    "hash": "1a4ead5c60553ff8f2af489bdeb0bb55"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/tracker/rally.test.ts": {
+    "mtime": 1779420421.0525193,
+    "hash": "532c7a391211a8d3bd6e1e3d3271df31"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/tracker/linking.test.ts": {
-    "mtime": 1779108266.1724217,
-    "hash": "cc974748d4543670a0686c7c39c357d0"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/tracker/linking.test.ts": {
+    "mtime": 1779420421.0525193,
+    "hash": "e002f8ff319cc7bd8b1e5445ec7cff22"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/cloister/failure-tracking.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/cloister/failure-tracking.test.ts": {
+    "mtime": 1779420421.0499637,
     "hash": "bfcf41150e44cde0a0b806d54c7f047a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/cloister/review-agent.test.ts": {
-    "mtime": 1779159745.119131,
-    "hash": "597d70e9794d9cd7590ae52011732e73"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/cloister/review-agent.test.ts": {
+    "mtime": 1779420421.0499637,
+    "hash": "dc9c563f903f8205ab65b5d05f3a5c01"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/cloister/deacon-ci-retry.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/cloister/deacon-ci-retry.test.ts": {
+    "mtime": 1779420421.0496988,
     "hash": "670c16a37ca11558630ae26b783b8307"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/cloister/work-agent-prompt.test.ts": {
-    "mtime": 1779108266.170744,
-    "hash": "6634b0f5467c31eeb1420dd57a7a473a"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/cloister/work-agent-prompt.test.ts": {
+    "mtime": 1779420421.0503929,
+    "hash": "4bd96a272227322c5d2499d3bc7200a1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/cloister/specialist-logs.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/cloister/specialist-logs.test.ts": {
+    "mtime": 1779420421.0502944,
     "hash": "1d55b14ba7c1e93e89727d727853d316"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/cloister/review-verdict-feedback.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/cloister/review-verdict-feedback.test.ts": {
+    "mtime": 1779420421.0499637,
     "hash": "307e9d557a0e0ce33ac6764ec685c155"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/cloister/deacon-orphan-recovery.test.ts": {
-    "mtime": 1779108266.170744,
-    "hash": "e1672051dfd360242297292bd9490a41"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/cloister/deacon-orphan-recovery.test.ts": {
+    "mtime": 1779420421.04985,
+    "hash": "f5d290abb0d156124132d48e3cb595b5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/cloister/service.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/cloister/service.test.ts": {
+    "mtime": 1779420421.0499637,
     "hash": "f4802c9b8e4ec69f3e2f2cf35d9e20c4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/cloister/specialist-context.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/cloister/specialist-context.test.ts": {
+    "mtime": 1779420421.0499637,
     "hash": "747327be70c2b0f687b50685a135a42b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/cloister/config.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/cloister/config.test.ts": {
+    "mtime": 1779420421.0496988,
     "hash": "d9eeaccb6a05cbbab5c9708de0914eaf"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/cloister/auto-resume-gating.test.ts": {
-    "mtime": 1779108266.170562,
-    "hash": "7aa0d546dd92c6995acf47674077c204"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/cloister/auto-resume-gating.test.ts": {
+    "mtime": 1779420421.0496988,
+    "hash": "4ec048735ae01ed3e70ad0544c49f5e1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/cloister/test-agent.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/cloister/test-agent.test.ts": {
+    "mtime": 1779420421.0503929,
     "hash": "5af4a5e5b935a9481b27da786bd78876"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/cloister/health.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/cloister/health.test.ts": {
+    "mtime": 1779420421.0499637,
     "hash": "7500e243d9fdbcc44cb109f212542a35"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/cloister/specialist-handoff-logger.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/cloister/specialist-handoff-logger.test.ts": {
+    "mtime": 1779420421.0502944,
     "hash": "7f14391a811ce43be0539683a291cfa6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/cloister/deacon-queue.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/cloister/deacon-queue.test.ts": {
+    "mtime": 1779420421.04985,
     "hash": "1a92fe5d5ee63d717907bcc8656a1231"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/cloister/deacon-cleanup.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/cloister/deacon-cleanup.test.ts": {
+    "mtime": 1779420421.0496988,
     "hash": "4503153cbb267433e9059b6110c85cf4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/cloister/pan-464-container-health.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/cloister/pan-464-container-health.test.ts": {
+    "mtime": 1779420421.0499637,
     "hash": "1539ce1f21ddaa87966afce190126972"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/planning/triage-agent.test.ts": {
-    "mtime": 1779108266.170744,
-    "hash": "ac8bc8c8635a66fecd9fb1e3292e3dda"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/planning/triage-agent.test.ts": {
+    "mtime": 1779420421.0513666,
+    "hash": "507aa7e1ff9685ee5c31d0996031b68f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/remote/fly-api.test.ts": {
-    "mtime": 1779108266.170744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/remote/fly-api.test.ts": {
+    "mtime": 1779420421.0513666,
     "hash": "037a4e75c1f77fda7a275714a6db6fc5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/lib/remote/fly-provider.test.ts": {
-    "mtime": 1779108266.1720548,
-    "hash": "dd7bea53d0c9eb6fdb1b59ca314d08ff"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/remote/fly-provider.test.ts": {
+    "mtime": 1779420421.0519257,
+    "hash": "f62e7860d40a7faf9f1b414cf78a3cc5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/vbrief/full-spec.test.ts": {
-    "mtime": 1779108266.1745427,
-    "hash": "37c08899f34e6e5b6cca6137d64a08c2"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/provider-policy.test.ts": {
+    "mtime": 1779420421.0511217,
+    "hash": "2d647758686e2e9c263044784d172e01"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/integration/rally-tracker.test.ts": {
-    "mtime": 1779108266.170425,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/search.test.ts": {
+    "mtime": 1779420421.0513666,
+    "hash": "010e98b2a5568df09341314fd574617e"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/pending.test.ts": {
+    "mtime": 1779420421.0511217,
+    "hash": "6106257c9c676b6a0533d86dc8397b48"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/reconciliation.test.ts": {
+    "mtime": 1779420421.0511217,
+    "hash": "ece8ed382e27520f7210499f327e2ed6"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/observations.test.ts": {
+    "mtime": 1779420421.050935,
+    "hash": "54571788e0cf74ef23ff6b78e37d94de"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/injection.test.ts": {
+    "mtime": 1779420421.050935,
+    "hash": "b405589402918d2d01f2f9c64e92ada3"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/query-expansion.test.ts": {
+    "mtime": 1779420421.0511217,
+    "hash": "ec841fc312f1e461f45d5195b7feea13"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/poller.test.ts": {
+    "mtime": 1779420421.0511217,
+    "hash": "275f01f54605ec393633fc0ecf425f56"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/rollup.test.ts": {
+    "mtime": 1779420421.0511217,
+    "hash": "7c59b887e0b1b2c37cd68d42e7e388d2"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/compress.test.ts": {
+    "mtime": 1779420421.0508485,
+    "hash": "ede908f9820d69faf819edb7f813e193"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/extract.test.ts": {
+    "mtime": 1779420421.050935,
+    "hash": "61ba360b751f00058a5401e76cd9b4fc"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/cli.test.ts": {
+    "mtime": 1779420421.0508485,
+    "hash": "38808d1e03405a21487cf48c263b41c0"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/fts-db.test.ts": {
+    "mtime": 1779420421.050935,
+    "hash": "daa13dbc61f4970ba968743b5a4c10d8"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/providers.test.ts": {
+    "mtime": 1779420421.0511217,
+    "hash": "4207eef8ac59b78ea5c47ff44e06e99a"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/checkpoints.test.ts": {
+    "mtime": 1779420421.0508485,
+    "hash": "8f773cfee19b23063a15685880c7b749"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/subagent-filter.test.ts": {
+    "mtime": 1779420421.0513666,
+    "hash": "98006de000bfac05fadc22fd925d580b"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/paths.test.ts": {
+    "mtime": 1779420421.051105,
+    "hash": "09cb9eec153be5459f386427d719ac85"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/pipeline.test.ts": {
+    "mtime": 1779420421.0511217,
+    "hash": "45b5b08efaa2ef47fa56d368f19e5443"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/transcript-source.test.ts": {
+    "mtime": 1779420421.0513666,
+    "hash": "478a696dd7755f4bd88a4790c8762ae5"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/e2e.test.ts": {
+    "mtime": 1779420421.050935,
+    "hash": "3896880da8a666c1e53b802bd622af8f"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/lib/memory/worker-pool.test.ts": {
+    "mtime": 1779420421.0513666,
+    "hash": "5cb6d0f2a18ff9d0849081b269c782d9"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/vbrief/full-spec.test.ts": {
+    "mtime": 1779420421.0551996,
+    "hash": "4d17d9f20d84b1a7ac62c31fd1662e98"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/integration/rally-tracker.test.ts": {
+    "mtime": 1779420421.0493338,
     "hash": "55783773bdab4f95cee021d71fcd0d65"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/integration/merge-validation.test.ts": {
-    "mtime": 1779108266.170425,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/integration/merge-validation.test.ts": {
+    "mtime": 1779420421.0493338,
     "hash": "ba3c5c2f2e0f83da0ce45ece48ed6f49"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/integration/config-precedence.test.ts": {
-    "mtime": 1779108266.170425,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/integration/config-precedence.test.ts": {
+    "mtime": 1779420421.0492747,
     "hash": "8c512ad8a13d05e03147e8ec6effecab"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/integration/agent-spawning.test.ts": {
-    "mtime": 1779108266.1701849,
-    "hash": "c97e1ed23040e1d70b79e469f25f4d3e"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/integration/post-review-rebase-scenario.test.ts": {
+    "mtime": 1779420421.0493338,
+    "hash": "024e29a88e7b1c9d2c87762a57b6a7df"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/integration/cli/doctor.test.ts": {
-    "mtime": 1779108266.1704044,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/integration/agent-spawning.test.ts": {
+    "mtime": 1779420421.049216,
+    "hash": "782c50569e07e7d21ee3bea120ad473d"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/integration/cli/doctor.test.ts": {
+    "mtime": 1779420421.049216,
     "hash": "0a729deee7bf89a2d768d9ffe3f75e30"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/integration/cli/sync.test.ts": {
-    "mtime": 1779108266.170425,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/integration/cli/sync.test.ts": {
+    "mtime": 1779420421.0492747,
     "hash": "d7d0001e151b255012aed96361dee8c1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/dashboard/projection-cache.test.ts": {
-    "mtime": 1779108266.1695275,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/dashboard/projection-cache.test.ts": {
+    "mtime": 1779420421.0486088,
     "hash": "e1308423258a26372298c735744587f9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/dashboard/issue-data-service.test.ts": {
-    "mtime": 1779108266.1695275,
-    "hash": "d834b6cf44fc92f540c553abeafec502"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/dashboard/issue-data-service.test.ts": {
+    "mtime": 1779420421.0484993,
+    "hash": "b225df7f42d64a1cc2d72628984d39b8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/dashboard/health-api.test.ts": {
-    "mtime": 1779108266.1695275,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/dashboard/health-api.test.ts": {
+    "mtime": 1779420421.0484521,
     "hash": "61190745df3e6dadf6e6f3c3ff3a5420"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/dashboard/review-status.test.ts": {
-    "mtime": 1779108266.1695275,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/dashboard/review-status.test.ts": {
+    "mtime": 1779420421.0487208,
     "hash": "963e95c3179102ef36fdfa0eb485e745"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/dashboard/god-view-endpoints.test.ts": {
-    "mtime": 1779108266.1695275,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/dashboard/god-view-endpoints.test.ts": {
+    "mtime": 1779420421.0484521,
     "hash": "1064dcec435b5bbbbcad80e4b5fc964d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/dashboard/conversations-patch.test.ts": {
-    "mtime": 1779108266.1695275,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/dashboard/conversations-patch.test.ts": {
+    "mtime": 1779420421.0482814,
     "hash": "cd145005ab3e59912684929a9ae42766"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/dashboard/nav-layout.test.ts": {
-    "mtime": 1779108266.1695275,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/dashboard/nav-layout.test.ts": {
+    "mtime": 1779420421.0485635,
     "hash": "c301cea2e862a6a5cc19e0526bf5c1ee"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/dashboard/event-reducers.test.ts": {
-    "mtime": 1779108266.1695275,
-    "hash": "022607813caffa35d0086da5985b5dd1"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/dashboard/event-reducers.test.ts": {
+    "mtime": 1779420421.0483859,
+    "hash": "32c971ebda703f45e644c920a261c6e1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/dashboard/issues-cleanup.test.ts": {
-    "mtime": 1779108266.1695275,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/dashboard/issues-cleanup.test.ts": {
+    "mtime": 1779420421.0485635,
     "hash": "ded584c91d944e486486948acc978db9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/dashboard/event-store-open.test.ts": {
-    "mtime": 1779108266.1695275,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/dashboard/event-store-open.test.ts": {
+    "mtime": 1779420421.048416,
     "hash": "31915b94cf18701fde34341b3fbf352a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/dashboard/cache-service-init-home.test.ts": {
-    "mtime": 1779108266.1694448,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/dashboard/cache-service-init-home.test.ts": {
+    "mtime": 1779420421.0481448,
     "hash": "24558790b4989cc82ee4c4b735d2cbe7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/dashboard/read-model-new-agents.test.ts": {
-    "mtime": 1779108266.1695275,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/dashboard/read-model-new-agents.test.ts": {
+    "mtime": 1779420421.048639,
     "hash": "0a92a6f59dc23c788da6e72da0b4717b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/dashboard/completedAt-field.test.ts": {
-    "mtime": 1779108266.1695275,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/dashboard/completedAt-field.test.ts": {
+    "mtime": 1779420421.0482814,
     "hash": "b5e9d1d3541c444a28312fbcb9b0441d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/dashboard/event-store.test.ts": {
-    "mtime": 1779108266.1695275,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/dashboard/event-store.test.ts": {
+    "mtime": 1779420421.0484352,
     "hash": "862c0021d02a9c7e33f9710ef1d2d248"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/dashboard/tracker-config.test.ts": {
-    "mtime": 1779108266.1695275,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/dashboard/tracker-config.test.ts": {
+    "mtime": 1779420421.0487692,
     "hash": "2d020d17346590a54bf7c6c046007b70"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/dashboard/issue-filtering.test.ts": {
-    "mtime": 1779108266.1695275,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/dashboard/issue-filtering.test.ts": {
+    "mtime": 1779420421.0485497,
     "hash": "69b728a5388e4f606bbec68932d177f5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/dashboard/read-model-validators.test.ts": {
-    "mtime": 1779108266.1695275,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/dashboard/read-model-validators.test.ts": {
+    "mtime": 1779420421.0486543,
     "hash": "86f8c984af36a7a4bce0ef42909ee038"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/dashboard/version-api.test.ts": {
-    "mtime": 1779108266.1695275,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/dashboard/version-api.test.ts": {
+    "mtime": 1779420421.048789,
     "hash": "900d95867e9dd559bc2bb869ec81d6ea"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/dashboard/settings-minimax-defaults.test.ts": {
-    "mtime": 1779108266.1695275,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/dashboard/settings-minimax-defaults.test.ts": {
+    "mtime": 1779420421.0487208,
     "hash": "fa49e0c479d2bb1d45589217c178419d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/dashboard/utils/vtt-parser.test.ts": {
-    "mtime": 1779108266.1695275,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/dashboard/utils/vtt-parser.test.ts": {
+    "mtime": 1779420421.048789,
     "hash": "bae0d00450d28926eb8eded003ef5776"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cli/commands/cost.test.ts": {
-    "mtime": 1779108266.1687138,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cli/commands/cost.test.ts": {
+    "mtime": 1779420421.04743,
     "hash": "1754f009c94ee84250c00e6724ac864d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cli/commands/review-reset.test.ts": {
-    "mtime": 1779108266.1687405,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cli/commands/review-reset.test.ts": {
+    "mtime": 1779420421.0474567,
     "hash": "e911652aa9c100070544e4ee87dde628"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cli/commands/show.test.ts": {
-    "mtime": 1779108266.1687405,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cli/commands/show.test.ts": {
+    "mtime": 1779420421.0474567,
     "hash": "1cbd151b8437284d5ca4ea7e3ddf5b89"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cli/commands/sync-mirror.test.ts": {
-    "mtime": 1779108266.168933,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cli/commands/sync-mirror.test.ts": {
+    "mtime": 1779420421.0476549,
     "hash": "c95fd1e511b11196dd136d278a2bfd5d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cli/commands/release-monorepo-version.test.ts": {
-    "mtime": 1779108266.1687405,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cli/commands/release-monorepo-version.test.ts": {
+    "mtime": 1779420421.0474567,
     "hash": "b57a4b2207418d1047b069633b057289"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cli/commands/setup-hooks.test.ts": {
-    "mtime": 1779108266.1687405,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cli/commands/setup-hooks.test.ts": {
+    "mtime": 1779420421.0474567,
     "hash": "733934480923d95c3e6c3c3397d92964"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cli/commands/issues-shadow-only.test.ts": {
-    "mtime": 1779108266.1687405,
-    "hash": "1d2827b1fe265bcca47d6e6eb374bd1f"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cli/commands/issues-shadow-only.test.ts": {
+    "mtime": 1779420421.0474567,
+    "hash": "03276d215e0415a80f56f480267bc46f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cli/commands/workspace-beads-version.test.ts": {
-    "mtime": 1779108266.1690514,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cli/commands/workspace-beads-version.test.ts": {
+    "mtime": 1779420421.047866,
     "hash": "cb202d87059760fae696dce3af895cce"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cli/commands/review-spawn-reviewer.test.ts": {
-    "mtime": 1779108266.1687405,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cli/commands/review-spawn-reviewer.test.ts": {
+    "mtime": 1779420421.0474567,
     "hash": "79a6c6b91b900520ab86723679dabc9e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cli/commands/reopen-tracker-routing.test.ts": {
-    "mtime": 1779108266.1687405,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cli/commands/reopen-tracker-routing.test.ts": {
+    "mtime": 1779420421.0474567,
     "hash": "f17044301525d57ece78f0f53dc42a45"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cli/commands/release-command-parsing.test.ts": {
-    "mtime": 1779108266.1687405,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cli/commands/release-command-parsing.test.ts": {
+    "mtime": 1779420421.0474567,
     "hash": "b7c8893bedb903137c1bc0c75672e91a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cli/commands/work/linear-states.test.ts": {
-    "mtime": 1779108266.1690514,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cli/commands/work/linear-states.test.ts": {
+    "mtime": 1779420421.0477886,
     "hash": "47dfbeae39fa1c709007340050cc192b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cli/commands/work/reopen.test.ts": {
-    "mtime": 1779108266.1690514,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cli/commands/work/reopen.test.ts": {
+    "mtime": 1779420421.0478356,
     "hash": "204cbe4e101430012c43029ff85179dc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cli/commands/work/issue-beads-check.test.ts": {
-    "mtime": 1779108266.1690514,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cli/commands/work/issue-beads-check.test.ts": {
+    "mtime": 1779420421.0477886,
     "hash": "6327be5d2e5ea39c4e3addd314410f5f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cli/commands/work/start-workspace-rollback.test.ts": {
-    "mtime": 1779108266.1690514,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cli/commands/work/start-workspace-rollback.test.ts": {
+    "mtime": 1779420421.0478356,
     "hash": "3a1fb261dc7cd8694cd5cb0680d1791c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cli/commands/work/done.test.ts": {
-    "mtime": 1779108266.168933,
-    "hash": "8dcfa6afc0b35a797fc18310d9172b1b"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cli/commands/work/done.test.ts": {
+    "mtime": 1779420421.0476549,
+    "hash": "88506a2f08bf42470707bfd6395a8bc5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cli/commands/specialists/logs.test.ts": {
-    "mtime": 1779108266.168933,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cli/commands/specialists/logs.test.ts": {
+    "mtime": 1779420421.0476549,
     "hash": "53d192494146256b205dd2b9812ea1d3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/cli/commands/specialists/done.test.ts": {
-    "mtime": 1779108266.1687405,
-    "hash": "e36340495f371cde79cf7f3df63f701b"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/cli/commands/specialists/done.test.ts": {
+    "mtime": 1779420421.0474567,
+    "hash": "98c6a077e3fedb5c9bc674d28bda2703"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/session-health/scripts/check_sessions.py": {
-    "mtime": 1779108266.1066525,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/session-health/scripts/check_sessions.py": {
+    "mtime": 1779420420.9773085,
     "hash": "edb889c7d9deb39b8e06ada6db747103"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/conv-lookup/scripts/conv-find.py": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/conv-lookup/scripts/conv-find.py": {
+    "mtime": 1779420420.9747198,
     "hash": "dcdedb4823ddd234a2985584358094de"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-tts/scripts/tts_daemon.py": {
-    "mtime": 1779108266.1060865,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-tts/scripts/tts_daemon.py": {
+    "mtime": 1779420420.97674,
     "hash": "07f6c970c34b46a44995fa1ff34a3835"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/stitch-react-components/scripts/validate.js": {
-    "mtime": 1779108266.1080248,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/stitch-react-components/scripts/validate.js": {
+    "mtime": 1779420420.9786916,
     "hash": "fbf7dabd228f0020f04f081cc3add696"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/stitch-react-components/examples/gold-standard-card.tsx": {
-    "mtime": 1779108266.1071193,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/stitch-react-components/examples/gold-standard-card.tsx": {
+    "mtime": 1779420420.9777653,
     "hash": "5fd5875a691ca4b8f826a30ee8351799"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/stitch-react-components/resources/component-template.tsx": {
-    "mtime": 1779108266.1079695,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/stitch-react-components/resources/component-template.tsx": {
+    "mtime": 1779420420.9786198,
     "hash": "31412d04b5db5703e2c10af4c3dac2b7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-subagent-creator/scripts/init_agent.py": {
-    "mtime": 1779108266.1057632,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-subagent-creator/scripts/init_agent.py": {
+    "mtime": 1779420420.9764092,
     "hash": "8d43dd7a844950874d17dca8b25c7b89"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/skill-creator/scripts/package_skill.py": {
-    "mtime": 1779108266.106757,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/skill-creator/scripts/package_skill.py": {
+    "mtime": 1779420420.9774137,
     "hash": "ba9699983233de75680a05cc0c422af2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/skill-creator/scripts/init_skill.py": {
-    "mtime": 1779108266.1067321,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/skill-creator/scripts/init_skill.py": {
+    "mtime": 1779420420.9773893,
     "hash": "11e0b66607edc525d07356cf16ad5a87"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-skill-creator/scripts/init_skill.py": {
-    "mtime": 1779108266.1055593,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-skill-creator/scripts/init_skill.py": {
+    "mtime": 1779420420.9762032,
     "hash": "ca4d6f4af886299cd0291577cb5a153a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/update-github-app-webhooks.mjs": {
-    "mtime": 1779108266.0172694,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/sweep-zombie-specialist-state.ts": {
+    "mtime": 1779420420.8936658,
+    "hash": "408a265a2d886ec654164a7db3bb665a"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/update-github-app-webhooks.mjs": {
+    "mtime": 1779420420.8936658,
     "hash": "11b3d15f2e515be942bd1506f46dc335"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/build-cli.mjs": {
-    "mtime": 1779108266.017085,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/build-cli.mjs": {
+    "mtime": 1779420420.8925066,
     "hash": "87dc929eb0a1653fdafe4445ba8786a2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/session-start-hook": {
-    "mtime": 1779108266.0172694,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/session-start-hook": {
+    "mtime": 1779420420.8936658,
     "hash": "6c53c6450a7f0b27e4a03ddca09b056c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/heartbeat-hook": {
-    "mtime": 1779108266.017145,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/heartbeat-hook": {
+    "mtime": 1779420420.8925066,
     "hash": "b8dfb121be35445a22f96a65da8ed22e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/work-agent-stop-hook": {
-    "mtime": 1779108266.0172694,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/work-agent-stop-hook": {
+    "mtime": 1779420420.8936658,
     "hash": "7943e6ebc181f955f667b5e4a3bc7639"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/tldr-post-edit": {
-    "mtime": 1779108266.0172694,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/tldr-post-edit": {
+    "mtime": 1779420420.8936658,
     "hash": "bc697e48a1be3dc66a0ffa9128f84f36"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/moonshine-sidecar.py": {
-    "mtime": 1779108266.017145,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/moonshine-sidecar.py": {
+    "mtime": 1779420420.8925066,
     "hash": "dd52649bc1aacbe76d12527406c1922b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/record-cost-event.d.ts": {
-    "mtime": 1779167418.4743514,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/record-cost-event.d.ts": {
+    "mtime": 1779420420.8925066,
     "hash": "f05b2a12c7e7c8dffbbcc073e1431bcb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/notify-complete": {
-    "mtime": 1779108266.017145,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/notify-complete": {
+    "mtime": 1779420420.8925066,
     "hash": "373ba01f551cd1ff98252fd01e937ebd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/notification-hook": {
-    "mtime": 1779108266.017145,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/notification-hook": {
+    "mtime": 1779420420.8925066,
     "hash": "11aab69f3ae07bb3a9fa91af07aa7c79"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/user-prompt-submit-hook": {
-    "mtime": 1779108266.0172694,
-    "hash": "1802e1692d6d8f410e38005e14c56b2b"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/user-prompt-submit-hook": {
+    "mtime": 1779420420.8936658,
+    "hash": "ebb4f23be84b8444d41fa79b53540503"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/recover-costs.mjs": {
-    "mtime": 1779108266.0172694,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/recover-costs.mjs": {
+    "mtime": 1779420420.8936658,
     "hash": "3bba7bc97c978cde2b2b3b34cf945fed"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/record-cost-event.ts": {
-    "mtime": 1779108266.0172694,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/record-cost-event.ts": {
+    "mtime": 1779420420.8936658,
     "hash": "2a52684ec1ddf2864a2eec8eb1ecfe95"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/verify-effect-api.mjs": {
-    "mtime": 1779108266.0172694,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/analyze-effect-migration.ts": {
+    "mtime": 1779420420.8923857,
+    "hash": "809c156194adc7f26499610f23d3a308"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/verify-effect-api.mjs": {
+    "mtime": 1779420420.8936658,
     "hash": "d9a51438ef07ba8bad3ed0f46861f12b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/stop-hook": {
-    "mtime": 1779108266.0172694,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/stop-hook": {
+    "mtime": 1779420420.8936658,
     "hash": "7a96940df93bf1ab291aa2f4824eebf6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/postinstall.mjs": {
-    "mtime": 1779108266.017145,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/postinstall.mjs": {
+    "mtime": 1779420420.8925066,
     "hash": "bf9171c60eb0e7009190b32dd92a8636"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/recover-costs-proportional.mjs": {
-    "mtime": 1779108266.0172694,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/recover-costs-proportional.mjs": {
+    "mtime": 1779420420.8936658,
     "hash": "dee572dcf271a2216aae520eb171f234"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/deacon-ignore-bulk.ts": {
-    "mtime": 1779108266.017145,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/deacon-ignore-bulk.ts": {
+    "mtime": 1779420420.8925066,
     "hash": "c00e7fe92897e41712bf9cee981348d5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/pre-compact-hook": {
-    "mtime": 1779108266.017145,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/pre-compact-hook": {
+    "mtime": 1779420420.8925066,
     "hash": "796e1268261306ba664d8b760afc87a8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/tsdown.config.ts": {
-    "mtime": 1779108266.0172694,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/tsdown.config.ts": {
+    "mtime": 1779420420.8936658,
     "hash": "12317d493a25e3a5a52339cfa051e833"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/recover-costs-deep.mjs": {
-    "mtime": 1779108266.0172694,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/recover-costs-deep.mjs": {
+    "mtime": 1779420420.8936658,
     "hash": "3bda25e40763e73f37abc15c46d3c5be"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/tldr-read-enforcer": {
-    "mtime": 1779108266.0172694,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/tldr-read-enforcer": {
+    "mtime": 1779420420.8936658,
     "hash": "cb3472cb9b05fd024543397c50a09e32"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/fs-helper.mjs": {
-    "mtime": 1779108266.017145,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/fs-helper.mjs": {
+    "mtime": 1779420420.8925066,
     "hash": "12c749ad32efbec936592c6430e72a08"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/specialist-stop-hook": {
-    "mtime": 1779108266.0172694,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/specialist-stop-hook": {
+    "mtime": 1779420420.8936658,
     "hash": "15323fa53c26a76be0db547013da52dc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/permission-event-hook": {
-    "mtime": 1779108266.017145,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/permission-event-hook": {
+    "mtime": 1779420420.8925066,
     "hash": "b59d58f43a2c72a9c1ce05d958e32c4b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/pre-tool-hook": {
-    "mtime": 1779108266.017145,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/pre-tool-hook": {
+    "mtime": 1779420420.8925066,
     "hash": "69f27faa826ce6141bf1ae3f17d643f5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/migrate-continue-files-to-pan.mjs": {
-    "mtime": 1779108266.017145,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/migrate-continue-files-to-pan.mjs": {
+    "mtime": 1779420420.8925066,
     "hash": "ade81e698286420c571c0ec82f86089a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/post-compact-hook": {
-    "mtime": 1779108266.017145,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/post-compact-hook": {
+    "mtime": 1779420420.8925066,
     "hash": "4635a0e3086d9c5f1320c83ae855a2bc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/create-github-app.mjs": {
-    "mtime": 1779108266.017145,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/create-github-app.mjs": {
+    "mtime": 1779420420.8925066,
     "hash": "a8f87c19664399d9e6d5767e0d3d2e88"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/build-moonshine-sidecars.js": {
-    "mtime": 1779108266.017145,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/build-moonshine-sidecars.js": {
+    "mtime": 1779420420.8925066,
     "hash": "c85a332498ba9c3743d3c7fd7bd109bd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/git-hooks/post-checkout": {
-    "mtime": 1779108266.017145,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/git-hooks/post-checkout": {
+    "mtime": 1779420420.8925066,
     "hash": "fa4183f76138ee41312ea776d1991e83"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/scripts/patches/llm-tldr-tsx-support.py": {
-    "mtime": 1779108266.017145,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/scripts/patches/llm-tldr-tsx-support.py": {
+    "mtime": 1779420420.8925066,
     "hash": "e7af69323fcd6910e74083e270f49d24"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/infra/wsl2hosts/install-scheduled-task.ps1": {
-    "mtime": 1779108265.9830418,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/infra/wsl2hosts/install-scheduled-task.ps1": {
+    "mtime": 1779420420.8577757,
     "hash": "0dfcf7eab29991454afb7482d1103bd4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/infra/wsl2hosts/sync-wsl2hosts.ps1": {
-    "mtime": 1779108265.9830418,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/infra/wsl2hosts/sync-wsl2hosts.ps1": {
+    "mtime": 1779420420.8577757,
     "hash": "29162f49c7f1285c2097d1c66c8473cd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/vitest.config.ts": {
-    "mtime": 1779108265.8547819,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/vitest.config.ts": {
+    "mtime": 1779420420.728583,
     "hash": "2822ce1c07919b5509ec92ce5765ab70"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/tsdown.config.ts": {
-    "mtime": 1779108265.8547819,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/tsdown.config.ts": {
+    "mtime": 1779420420.728583,
     "hash": "71904c49ba04c5c2cafb294f4250908a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/tests/package-structure.test.ts": {
-    "mtime": 1779108265.8547819,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/tests/package-structure.test.ts": {
+    "mtime": 1779420420.728583,
     "hash": "8caeb38143ef891644793e5947083355"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/tests/settings.test.ts": {
-    "mtime": 1779108265.8547819,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/tests/settings.test.ts": {
+    "mtime": 1779420420.728583,
     "hash": "4ac708369b1c7d3d163348609eeeda23"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/tests/menu.test.ts": {
-    "mtime": 1779108265.8545413,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/tests/menu.test.ts": {
+    "mtime": 1779420420.7283442,
     "hash": "d94e6951a357d832b583fe092eca7936"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/tests/updater.test.ts": {
-    "mtime": 1779108265.8547819,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/tests/updater.test.ts": {
+    "mtime": 1779420420.728583,
     "hash": "77ebd60a850b3ac422cdc00d8e5a9542"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/tests/protocol.test.ts": {
-    "mtime": 1779108265.8547819,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/tests/protocol.test.ts": {
+    "mtime": 1779420420.728583,
     "hash": "7612d21d2eefe1fd039ebb9c499d2fb2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/bin/panctl.mjs": {
-    "mtime": 1779108265.8540044,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/bin/panctl.mjs": {
+    "mtime": 1779420420.7278154,
     "hash": "e6b6da4e7ae9d4736f5d40fb5e478f09"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/scripts/start-electron.mjs": {
-    "mtime": 1779108265.8544476,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/scripts/start-electron.mjs": {
+    "mtime": 1779420420.7282498,
     "hash": "0a3ab15d90ca0b54c22301d2ac273817"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/scripts/wait-for-resources.mjs": {
-    "mtime": 1779108265.8544476,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/scripts/wait-for-resources.mjs": {
+    "mtime": 1779420420.7282498,
     "hash": "7548bd99318349d85dba36a702a5bb45"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/scripts/electron-launcher.mjs": {
-    "mtime": 1779108265.8544476,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/scripts/electron-launcher.mjs": {
+    "mtime": 1779420420.7282498,
     "hash": "796208b4d45e782973148ed46f08f0c5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/scripts/dev-electron.mjs": {
-    "mtime": 1779108265.8544476,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/scripts/dev-electron.mjs": {
+    "mtime": 1779420420.7282498,
     "hash": "42e4226af56c39a34b0a45b57d99f7db"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/scripts/build-for-publish.mjs": {
-    "mtime": 1779108265.8544476,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/scripts/build-for-publish.mjs": {
+    "mtime": 1779420420.7282498,
     "hash": "439f4579aa9f749c8722c2ea450e2965"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/src/notifications.ts": {
-    "mtime": 1779108265.8545413,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/src/notifications.ts": {
+    "mtime": 1779420420.7283442,
     "hash": "68b3870a7feb936385d73b2a42ecb079"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/src/autostart.ts": {
-    "mtime": 1779108265.8544476,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/src/autostart.ts": {
+    "mtime": 1779420420.7282498,
     "hash": "2bb046ccbbb8208378ded79f889a6bd1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/src/settings.ts": {
-    "mtime": 1779108265.8545413,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/src/settings.ts": {
+    "mtime": 1779420420.7283442,
     "hash": "93abbeea6cb6348ce1a0c97bdfc9b84f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/src/tray.ts": {
-    "mtime": 1779108265.8545413,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/src/tray.ts": {
+    "mtime": 1779420420.7283442,
     "hash": "12b338a2d84be3cb44c34a0f897c7969"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/src/protocol.ts": {
-    "mtime": 1779108265.8545413,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/src/protocol.ts": {
+    "mtime": 1779420420.7283442,
     "hash": "dc3f78739b88aa109817cb8bfdfc94d1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/src/main.ts": {
-    "mtime": 1779108265.8545413,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/src/main.ts": {
+    "mtime": 1779420420.7283442,
     "hash": "f2ef47ea6b335191b3b2766620f34b11"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/src/server.ts": {
-    "mtime": 1779108265.8545413,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/src/server.ts": {
+    "mtime": 1779420420.7283442,
     "hash": "355e85efa31532d0fc64e26fc710d2a6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/src/updater.ts": {
-    "mtime": 1779108265.8545413,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/src/updater.ts": {
+    "mtime": 1779420420.7283442,
     "hash": "9dc36b6beefa067cfda401de50cabc9f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/src/menu.ts": {
-    "mtime": 1779150733.5328226,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/src/menu.ts": {
+    "mtime": 1779420420.7283442,
     "hash": "aa9902b1b2afbf5e1bb35af4539ce233"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/src/preload.ts": {
-    "mtime": 1779108265.8545413,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/src/preload.ts": {
+    "mtime": 1779420420.7283442,
     "hash": "3519459b8825ea40e7e9f44809a786d7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/dist-electron/preload.js": {
-    "mtime": 1779108265.8541443,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/dist-electron/preload.js": {
+    "mtime": 1779420420.7279468,
     "hash": "91e4add79a24fbf2ed74c2add30c5085"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/dist-electron/main.js": {
-    "mtime": 1779108265.8540044,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/dist-electron/main.js": {
+    "mtime": 1779420420.7278154,
     "hash": "4751fbd9d9be84f78024a3cd4213e501"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/index.ts": {
-    "mtime": 1779108266.151274,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/index.ts": {
+    "mtime": 1779420421.0246701,
     "hash": "f23cde06107702a599133e9bd6f759ce"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/autopreso/session.ts": {
-    "mtime": 1779108266.1083095,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/autopreso/session.ts": {
+    "mtime": 1779420420.9789753,
     "hash": "8df6f6c76f5ef4a031a8b34e6470f74a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/autopreso/whiteboard-tools.ts": {
-    "mtime": 1779108266.1083095,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/autopreso/whiteboard-tools.ts": {
+    "mtime": 1779420420.9789753,
     "hash": "45eecbcd1e5a8ca4bb8edac52934f15c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/autopreso/agent.ts": {
-    "mtime": 1779108266.1082802,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/autopreso/agent.ts": {
+    "mtime": 1779420420.9789462,
     "hash": "264094b604173e3020066845433cf052"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/autopreso/whiteboard-elements.ts": {
-    "mtime": 1779108266.1083095,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/autopreso/whiteboard-elements.ts": {
+    "mtime": 1779420420.9789753,
     "hash": "c5fc0158aeb0d7da7c7482c4e1628ac4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/autopreso/limits.ts": {
-    "mtime": 1779108266.1083095,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/autopreso/limits.ts": {
+    "mtime": 1779420420.9789753,
     "hash": "e96a667f11d2acbf7c168189b8488dbc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/autopreso/whiteboard-keywords.ts": {
-    "mtime": 1779108266.1083095,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/autopreso/whiteboard-keywords.ts": {
+    "mtime": 1779420420.9789753,
     "hash": "cee5fe330dfb7b0ced11a8ba65189a8c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/core/state-mapping.ts": {
-    "mtime": 1779108266.1109004,
-    "hash": "f790c1b5419641339d10a47b2dd5d345"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/prd-draft.ts": {
-    "mtime": 1779108266.1627212,
-    "hash": "157b2c2cf791a8f3d13a3527d2a49731"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/subscription-types.ts": {
-    "mtime": 1779108266.1651804,
-    "hash": "5f5a16b0c5f53e2c5d020e9fc32d42fc"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/shadow-utils.ts": {
-    "mtime": 1779108266.1651804,
-    "hash": "2d07bb4aaee13e0b66d99be641735531"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/beads-query.ts": {
-    "mtime": 1779108266.152274,
-    "hash": "08d2098191302cd646a239eefdb200b4"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/agents.ts": {
-    "mtime": 1779165265.914596,
-    "hash": "8313073153ef0dc277c2c8f049415e2b"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/git-activity.ts": {
-    "mtime": 1779108266.1605232,
-    "hash": "e55c35c0022414a1d7108592c8bec307"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/model-capabilities.ts": {
-    "mtime": 1779108266.1617014,
-    "hash": "d288c699ca4565734ca8a71a9e8c3845"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/hume.ts": {
-    "mtime": 1779108266.16131,
-    "hash": "1619c837258e7356ea1bc1d858426820"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/tts-speak.ts": {
-    "mtime": 1779108266.1659575,
-    "hash": "cea72b978516b73bf64142843514b238"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/reopen.ts": {
-    "mtime": 1779108266.1635168,
-    "hash": "c1711ea8f6d0ab8099ae4db0de78bf1d"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/paths.ts": {
-    "mtime": 1779108266.1624482,
-    "hash": "2e665d58625635c53f552cfe1bb5328e"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/beads-restore.ts": {
-    "mtime": 1779108266.152274,
-    "hash": "eee43d2fee6883a22ea1deefc4c6794d"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/harness-policy.ts": {
-    "mtime": 1779108266.16131,
-    "hash": "ff02dc2d5a87d7e71094ce44f2cc0827"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/review-status-normalize.ts": {
-    "mtime": 1779108266.1635168,
-    "hash": "e7da230ae3c85504ce6fdc6e3f3de9c6"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cv.ts": {
-    "mtime": 1779108266.159302,
-    "hash": "6ad38d3b24af89fbfb9133b7d87367c1"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/agent-enrichment.ts": {
-    "mtime": 1779162970.3803222,
-    "hash": "0d4e7f5de98cf36e7e2d8842983cc19f"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/smee.ts": {
-    "mtime": 1779108266.1651804,
-    "hash": "265f3acf8a2ebe4f3a3fc288f539ea5d"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/codex-auth.ts": {
-    "mtime": 1779108266.15632,
-    "hash": "f3df411e33d049131e25f91ce762aa9e"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/review-status-enrichment.ts": {
-    "mtime": 1779108266.1635168,
-    "hash": "17bec0c463ecf88f496174ed10f442ba"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/providers.ts": {
-    "mtime": 1779108266.1627212,
-    "hash": "8a17a7315432d89ae150ed48b8e37605"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/browser.ts": {
-    "mtime": 1779108266.152274,
-    "hash": "cce906ae2efb02fab2f139a9229205b8"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/config-migration.ts": {
-    "mtime": 1779108266.15632,
-    "hash": "bc951c2c734fe10eab55b205e848512f"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/claude-mcp.ts": {
-    "mtime": 1779108266.1540782,
-    "hash": "9816a83b4084fd46e512726ab93f07f2"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/webhook-handlers.ts": {
-    "mtime": 1779108266.1665595,
-    "hash": "066631caa5cfa858d35758c6e821c81c"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/claude-auth.ts": {
-    "mtime": 1779108266.1540782,
-    "hash": "06b0cabef42032c208bb21653b8610eb"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/review-artifacts.ts": {
-    "mtime": 1779108266.1635168,
-    "hash": "cfcfcec2ce7b0f2baedc8c2c1b186192"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/tts-daemon.ts": {
-    "mtime": 1779150733.4068184,
-    "hash": "fed59cb490eece9729477925272eea21"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/traefik.ts": {
-    "mtime": 1779108266.1659575,
-    "hash": "f45fc50c5af93bb3a9a628e927f194be"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/env-loader.ts": {
-    "mtime": 1779108266.1605232,
-    "hash": "77f1d2adbf951575ca3ae4fb02af3aca"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/provider-health.ts": {
-    "mtime": 1779108266.1627212,
-    "hash": "48c7d175aac42ead68d4108cb9fea699"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/context.ts": {
-    "mtime": 1779108266.1572742,
-    "hash": "f223cca4c1ad751a14b0b88a08cc18af"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/bd-mutex.ts": {
-    "mtime": 1779108266.152274,
-    "hash": "1fdb9db7c95a3ed35be2b79b5eb7b5d9"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/smart-model-selector.ts": {
-    "mtime": 1779108266.1651804,
-    "hash": "19ea41b2a856d40525d9d58c223ccd29"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/workspace-manager.ts": {
-    "mtime": 1779108266.1665595,
-    "hash": "7490e96a6a36c20816dd64ce1a98c994"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/activity-logger.ts": {
-    "mtime": 1779108266.1522126,
-    "hash": "602df5895769c9ac705f7934bd7a2335"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cost.ts": {
-    "mtime": 1779108266.1590133,
-    "hash": "c489b056c0e9e7ffa7c5e9f1e95865b8"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/merge-set.ts": {
-    "mtime": 1779108266.1617014,
-    "hash": "3d79151a33fa963b709dd5bcc27d1394"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/tracker-utils.ts": {
-    "mtime": 1779108266.1651804,
-    "hash": "ed0b563a1cb5c5978e9a1551c84a59ac"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/pipeline-notifier.ts": {
-    "mtime": 1779108266.1624482,
-    "hash": "51e129a0475f7b605ce219d708f4e435"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/hooks.ts": {
-    "mtime": 1779108266.16131,
-    "hash": "cbc973f7c4b410d84b521b28ef0ce25b"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/settings.ts": {
-    "mtime": 1779108266.1648948,
-    "hash": "b19ac2291cc51c7cab6f80ef4c393b7a"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/prd-locations.ts": {
-    "mtime": 1779108266.1627212,
-    "hash": "3b406baf99f3527cbeb399e9683a98cc"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/dns.ts": {
-    "mtime": 1779108266.1605232,
-    "hash": "3c4e70cd1f2c3e5523af2daae8243d47"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/queue-position.ts": {
-    "mtime": 1779108266.1627212,
-    "hash": "690283d967f17ebe410237708627798e"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/review-status-json.ts": {
-    "mtime": 1779108266.1635168,
-    "hash": "4174a73acc608e25cc34afc6d55dc7b6"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/agent-runtime.ts": {
-    "mtime": 1779108266.152274,
-    "hash": "d9d18916dedf548acd7aca79c40eb18b"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/tmux.ts": {
-    "mtime": 1779108266.1651804,
-    "hash": "fbef2103797ce21247f6573bf9a0bc4e"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/rebase-helper.ts": {
-    "mtime": 1779108266.1627212,
-    "hash": "b2fb0f0c44e92c5664977c65211354f1"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/sync.ts": {
-    "mtime": 1779108266.1651804,
-    "hash": "3394155f0b28d25525b8e0d475246557"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/backup.ts": {
-    "mtime": 1779108266.152274,
-    "hash": "c5e645531a6650aacb9e66bbd6fd00be"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/close-out.ts": {
-    "mtime": 1779108266.15632,
-    "hash": "ebd98be9d1b507b0dcace7c8839dceb1"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/agent-directory-cleanup.ts": {
-    "mtime": 1779108266.152274,
-    "hash": "759b9a7a08ed1a3036b0d6a36a602730"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/resource-utils.ts": {
-    "mtime": 1779108266.1635168,
-    "hash": "85e7bfdd382efb09b6b6a4d7f9f2f96c"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/stashes.ts": {
-    "mtime": 1779108266.1651804,
-    "hash": "301e34b577c9ce813148fff1de297506"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/health.ts": {
-    "mtime": 1779108266.16131,
-    "hash": "c7d570635be11239786620abb7da2be0"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/issue-id.ts": {
-    "mtime": 1779108266.16131,
-    "hash": "2b177c1e2d41e441c4dd15cfeabaed2c"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/shadow-state.ts": {
-    "mtime": 1779108266.1651804,
-    "hash": "98e2bd0dc23da63269e4eb716a43e176"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/concurrency.ts": {
-    "mtime": 1779108266.15632,
-    "hash": "4a495de02e8c74df91775b55c4885497"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/template.ts": {
-    "mtime": 1779108266.1651804,
-    "hash": "2d9efda79665444f7fe1d6fe01617685"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/github-app.ts": {
-    "mtime": 1779108266.16131,
-    "hash": "93ef56ed67038b7cda3f0c104c2fcf84"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/forge.ts": {
-    "mtime": 1779108266.1605232,
-    "hash": "3d60921fb5987bf0ac76683cfa38ca6a"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/supervisor.ts": {
-    "mtime": 1779108266.1651804,
-    "hash": "4add4bc2baeadc1d1ed800fce8926a4a"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/restart-lock.ts": {
-    "mtime": 1779108266.1635168,
-    "hash": "5f7113d829dbf8417a03607a2a742a09"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cliproxy.ts": {
-    "mtime": 1779108266.1540782,
-    "hash": "7ca0c4c395eba9468fe1167007e60917"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/persistent-logger.ts": {
-    "mtime": 1779108266.1624482,
-    "hash": "4b184136e497146debea126f1720407e"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/claude-permissions.ts": {
-    "mtime": 1779108266.1540782,
-    "hash": "627c6d658c7d673c123d251edfbe10b3"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/work-agent-lifecycle.ts": {
-    "mtime": 1779108266.1665595,
-    "hash": "0a6c89b0f68f2f2e8fad9bbd664e215f"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/session-format-converter.ts": {
-    "mtime": 1779108266.1648948,
-    "hash": "a2ba219aca06ef3192113c9bc18f01a1"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/tts-voices.ts": {
-    "mtime": 1779108266.1659575,
-    "hash": "d2d47954adb4c96562ea186e736f8201"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/review-status.ts": {
-    "mtime": 1779108266.1635168,
-    "hash": "19fac42c6e7384fcbd3bc908e657b1d4"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/project-repos.ts": {
-    "mtime": 1779108266.1627212,
-    "hash": "d63313658b71d09563ab3a46320026b0"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/claude-settings-overlay.ts": {
-    "mtime": 1779108266.1540782,
-    "hash": "4b36754d328f5c44bb360086f393987f"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/agent-runtime-mirror.ts": {
-    "mtime": 1779108266.152274,
-    "hash": "3df93ca514fab7f7b7ffc4d7f568a7ce"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/git-utils.ts": {
-    "mtime": 1779108266.1605232,
-    "hash": "9aba40942b7c322928e93dc6a7a26984"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/config-yaml.ts": {
-    "mtime": 1779150733.7258291,
-    "hash": "5f3ad07eb134e639b6040fca814d0c83"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/format-duration.ts": {
-    "mtime": 1779108266.1605232,
-    "hash": "c9c0bb7460dc88a05a494af2170ef126"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/shell.ts": {
-    "mtime": 1779108266.1651804,
-    "hash": "cd7a2c80509f40f066f9cbb3d0db5177"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/openai-auth.ts": {
-    "mtime": 1779108266.1621656,
-    "hash": "e2eb81a51b0837b10086befdacb2c6ce"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/model-fallback.ts": {
-    "mtime": 1779108266.1617014,
-    "hash": "12410aa40ca1ceb6c15843338a3fbf8b"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/test-runner.ts": {
-    "mtime": 1779108266.1651804,
-    "hash": "c57f9295db98f85508e429d761107ac1"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/worktree.ts": {
-    "mtime": 1779108266.1678364,
-    "hash": "670487cb3ded520474d73f678673f42f"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/platform.ts": {
-    "mtime": 1779108266.1627212,
-    "hash": "3d5fd20a65f36130e1476f7fdd62735f"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/openai-compatible-proxy.ts": {
-    "mtime": 1779108266.1621656,
-    "hash": "3654e3035bdc92963b4e5196ef5232d3"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/docker-stats.ts": {
-    "mtime": 1779108266.1605232,
-    "hash": "6d5ddd6c7236c47a0971bc93ebca9c4a"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/projects.ts": {
-    "mtime": 1779108266.1627212,
-    "hash": "a5a20a7354c2673eb02675b231e7db4a"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/skills-merge.ts": {
-    "mtime": 1779108266.1651804,
-    "hash": "c30a548df34acf015772788d95d3d318"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/multi-tool-sync.ts": {
-    "mtime": 1779108266.1621656,
-    "hash": "4d627cc8fd2588c60275ce4fa3a76e96"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/remote-workspace.ts": {
-    "mtime": 1779108266.1627212,
-    "hash": "7f8163392c3fd6067db0cadf75b27299"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/shadow-mode.ts": {
-    "mtime": 1779108266.1651804,
-    "hash": "1c0176c102236547dbdad91cff697a84"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/model-validation.ts": {
-    "mtime": 1779108266.1621656,
-    "hash": "c43aff27e938844bbd5b9786651e91ad"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/launcher-generator.ts": {
-    "mtime": 1779150733.4058182,
-    "hash": "c845148c8b72ecec1463e5f22a3f7035"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/manifest.ts": {
-    "mtime": 1779108266.1617014,
-    "hash": "349694a6338d97da355d77a450cf0d16"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/restart-status.ts": {
-    "mtime": 1779108266.1635168,
-    "hash": "f1f5d6844d3983a45d91a569dc153b3f"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/child-env.ts": {
-    "mtime": 1779108266.1540782,
-    "hash": "259248f5bc3bd558f5fdde6a751d661b"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/config.ts": {
-    "mtime": 1779108266.1572742,
-    "hash": "e1c51d60082928296f8f90afe975e79a"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/tunnel.ts": {
-    "mtime": 1779108266.1659575,
-    "hash": "7e21cca05441d287d41bbd50a13308e7"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/platform-lifecycle.ts": {
-    "mtime": 1779108266.1627212,
-    "hash": "d0964e778bf1560552015ac5f0607bfb"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/agent-input-detection.ts": {
-    "mtime": 1779108266.152274,
-    "hash": "3516eb2af9777a1c247fe92c5282e76d"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/tldr-daemon.ts": {
-    "mtime": 1779108266.1651804,
-    "hash": "10e2d5aadc2bffa73efbc6625c8f1873"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/workspace-config.ts": {
-    "mtime": 1779108266.1665595,
-    "hash": "82af9f1281a5a44f01946f8194b1324d"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/router-config.ts": {
-    "mtime": 1779150733.7258291,
-    "hash": "ba22813a69e4d3d637cdc1240a89a7ee"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/settings-api.ts": {
-    "mtime": 1779150733.7258291,
-    "hash": "87fc96c1bb70ef8a3bbe272a97b822ed"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/runtimes/pi-fifo.ts": {
-    "mtime": 1779108266.1643062,
-    "hash": "9ae01eb4784a4f8b542c43a6f904a94b"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/runtimes/index.ts": {
-    "mtime": 1779108266.1643062,
-    "hash": "6cb19d840a7f1371bcf461c93dc6beaa"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/runtimes/pi.ts": {
-    "mtime": 1779108266.1643062,
-    "hash": "82b9e2093c215bb65850883beaabf7fe"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/runtimes/types.ts": {
-    "mtime": 1779108266.1643062,
-    "hash": "8aee38424520d2355cc078655d2821fc"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/runtimes/claude-code.ts": {
-    "mtime": 1779108266.1643062,
-    "hash": "2e1f96d7c1dd0a5bab0f04404cf20dfd"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/runtimes/__tests__/pi-fifo.test.ts": {
-    "mtime": 1779108266.164245,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/core/state-mapping.ts": {
+    "mtime": 1779420420.983213,
+    "hash": "1d97d5e239b305b67c3f00e084ccd54d"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/prd-draft.ts": {
+    "mtime": 1779420421.040705,
+    "hash": "17783efd1470e49ad71ef294e437424c"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/subscription-types.ts": {
+    "mtime": 1779420421.043403,
+    "hash": "b0ac6898cd878d749a1fbf82951de933"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/shadow-utils.ts": {
+    "mtime": 1779420421.0431318,
+    "hash": "c3e9ea86284db0e439a46ee31b20582e"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/beads-query.ts": {
+    "mtime": 1779420421.0276704,
+    "hash": "e30b886c8dd772953a341f8bed228b2c"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/agents.ts": {
+    "mtime": 1779420769.2613285,
+    "hash": "8296b86546f8c2627fe9ad14d4299a23"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/git-activity.ts": {
+    "mtime": 1779420421.0375533,
+    "hash": "e39e5a6687025fa82051354570f4de1b"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/model-capabilities.ts": {
+    "mtime": 1779420421.0391636,
+    "hash": "45b8d23fb23fa0e51de3467cd8198c13"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/hume.ts": {
+    "mtime": 1779420421.038077,
+    "hash": "639a84835550b9ab04fe147d70948d4e"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/tts-speak.ts": {
+    "mtime": 1779420421.0445752,
+    "hash": "d59d19de9a8313d7ad17189a722a829d"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/reopen.ts": {
+    "mtime": 1779420421.0416498,
+    "hash": "5119f6bd5c0297efbb5acd8bc5a3960e"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/paths.ts": {
+    "mtime": 1779420421.0403025,
+    "hash": "8d5dcb902b6572e82a9742898844d3b2"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/beads-restore.ts": {
+    "mtime": 1779420421.0276704,
+    "hash": "d33465179aa41e774603efd89e4c5d48"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/errors.ts": {
+    "mtime": 1779420421.0372627,
+    "hash": "96db7369f28934e9b40c6784351deb62"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/harness-policy.ts": {
+    "mtime": 1779420421.0378118,
+    "hash": "12570c31c73f18cd638e1d6f8d836f03"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/review-status-normalize.ts": {
+    "mtime": 1779420421.0419607,
+    "hash": "222b22db593f68b348ac74c43057a855"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cv.ts": {
+    "mtime": 1779420421.0358355,
+    "hash": "11f10f4b242f142575ea147231ad3ce8"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/agent-enrichment.ts": {
+    "mtime": 1779420421.0266702,
+    "hash": "63c1bd35deabc22a18690c5cdeb1f383"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/smee.ts": {
+    "mtime": 1779420421.043403,
+    "hash": "73323b566a9aaeb9214aace69fb2c15d"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/codex-auth.ts": {
+    "mtime": 1779420421.0326705,
+    "hash": "e6b13598894bda0fffe6ccacab0af2e1"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/review-status-enrichment.ts": {
+    "mtime": 1779420421.041924,
+    "hash": "60f4933f19ec51021f152f6412e19380"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/providers.ts": {
+    "mtime": 1779420421.0411313,
+    "hash": "26b6b759cd546a6cab702f8226ec3119"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/browser.ts": {
+    "mtime": 1779420421.0283277,
+    "hash": "d0381004ba3ef47e4689ac696d06838e"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/config-migration.ts": {
+    "mtime": 1779420421.0326705,
+    "hash": "ac30f4bbad433515ccb59c6cb0d2b22e"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/claude-mcp.ts": {
+    "mtime": 1779420421.0288315,
+    "hash": "b5933d1dbefbe920589b7ebcdf1e73c8"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/webhook-handlers.ts": {
+    "mtime": 1779420421.0458703,
+    "hash": "95e1fb99cc01a84b0aa168c0d693f73e"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/claude-auth.ts": {
+    "mtime": 1779420421.0288315,
+    "hash": "2290d589f6397a7b7e9f7548e44c11c6"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/review-artifacts.ts": {
+    "mtime": 1779420421.0416498,
+    "hash": "3b259fa24ae97aa2980f7bd4532be74a"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/tts-daemon.ts": {
+    "mtime": 1779420421.0445752,
+    "hash": "d67c682a10aae67e334aea055be33867"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/traefik.ts": {
+    "mtime": 1779420421.0445752,
+    "hash": "4f7eeaf89d24132614ff002f9404d9db"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/env-loader.ts": {
+    "mtime": 1779420421.037151,
+    "hash": "f74f1b4921078c7ce03657732d4dabd2"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/provider-health.ts": {
+    "mtime": 1779420421.0411313,
+    "hash": "a197e5169796e7a91e5b96ef7c06ea9f"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/context.ts": {
+    "mtime": 1779420421.0336704,
+    "hash": "332b12d9603ceabbeb2ed37f8d496865"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/bd-mutex.ts": {
+    "mtime": 1779420421.0276704,
+    "hash": "b6d115617ebf91d4d9b85d5c75c84e83"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/smart-model-selector.ts": {
+    "mtime": 1779420421.043403,
+    "hash": "40445f123ec7b8f090dbe689616e4587"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/workspace-manager.ts": {
+    "mtime": 1779420421.0463428,
+    "hash": "e0cf7cb93a6c55a0706b2a19ec9f17b6"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/activity-logger.ts": {
+    "mtime": 1779420421.0266702,
+    "hash": "f61e7066db9b12f88d924efe17696362"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cost.ts": {
+    "mtime": 1779420421.0354843,
+    "hash": "f3dd2a8d805ecfa1b8448bb29dd59913"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/merge-set.ts": {
+    "mtime": 1779420421.0391636,
+    "hash": "1f5fc1c78d5e693d2a4b54ac36ace445"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/tracker-utils.ts": {
+    "mtime": 1779420421.0440488,
+    "hash": "3f2d64f57bab445cc18b0b38ac83b08c"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/pipeline-notifier.ts": {
+    "mtime": 1779420421.0403025,
+    "hash": "0a657e35ca9bcc1e87943dd73f0a939b"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/hooks.ts": {
+    "mtime": 1779420421.0378118,
+    "hash": "7257a0257bff0e0262eb718903939a96"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/settings.ts": {
+    "mtime": 1779420421.0426843,
+    "hash": "8d41a989fc9198c56f4f7f88ed7debab"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/prd-locations.ts": {
+    "mtime": 1779420421.040705,
+    "hash": "754987feea44be54a3f8ca739af0b415"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/dns.ts": {
+    "mtime": 1779420421.037151,
+    "hash": "0cee0c010697cfc4d63f86dd8628f1dd"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/queue-position.ts": {
+    "mtime": 1779420421.0411313,
+    "hash": "dd23c2fb56a33262869ac3eb71e63a25"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/review-status-json.ts": {
+    "mtime": 1779420421.0419607,
+    "hash": "5d0d100f7f464068a620f84d36597154"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/agent-runtime.ts": {
+    "mtime": 1779420421.0266702,
+    "hash": "3f7517f235c095764e3759eec85f3451"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/tmux.ts": {
+    "mtime": 1779420421.0439184,
+    "hash": "3ee28b702ae46510046bca05b63eaf6c"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/rebase-helper.ts": {
+    "mtime": 1779420421.0411313,
+    "hash": "cef745f2cec58c71abf2018b5d9fc818"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/sync.ts": {
+    "mtime": 1779420421.043403,
+    "hash": "b5a5374146ee1bcacf77ce22b17e2a76"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/backup.ts": {
+    "mtime": 1779420421.0276704,
+    "hash": "d9ca3e271d060c9963071a1b38020824"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/close-out.ts": {
+    "mtime": 1779420421.0326705,
+    "hash": "24847e65bd347e88626ca6f823a9d213"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/agent-directory-cleanup.ts": {
+    "mtime": 1779420421.0266702,
+    "hash": "06dc8a4567bc79e60d4a7da931a8a3ec"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/resource-utils.ts": {
+    "mtime": 1779420421.0416498,
+    "hash": "b7151af02982d0e4752c6dfa2754de1e"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/stashes.ts": {
+    "mtime": 1779420421.043403,
+    "hash": "5abbfef19480367f8c81e2307c060f04"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/health.ts": {
+    "mtime": 1779420421.0378118,
+    "hash": "ed0122b1c66dd9b1b68f9bd74c2cf72b"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/issue-id.ts": {
+    "mtime": 1779420421.0381713,
+    "hash": "c529dd3408a1b97179eeae8afc172e27"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/shadow-state.ts": {
+    "mtime": 1779420421.0431318,
+    "hash": "fc1feb6b314fa80a85ced7dc312f3af3"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/concurrency.ts": {
+    "mtime": 1779420421.0326705,
+    "hash": "97b5d5fa280f4ee3cd52fde20e683b8b"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/template.ts": {
+    "mtime": 1779420421.043403,
+    "hash": "676c4ba079f22009be0d482bfdab9093"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/github-app.ts": {
+    "mtime": 1779420421.0378118,
+    "hash": "4f0f72a555153971e87ceea39f508138"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/forge.ts": {
+    "mtime": 1779420421.0374422,
+    "hash": "d0d9910fd1968020bce69be312c8b303"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/supervisor.ts": {
+    "mtime": 1779420421.043403,
+    "hash": "f8d64b4ecce9eb22f29c55e512bff0d0"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/restart-lock.ts": {
+    "mtime": 1779420421.0416498,
+    "hash": "e935a89c7dbe69be1ff5cff1e11dfef1"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cliproxy.ts": {
+    "mtime": 1779420421.029415,
+    "hash": "274829d88b259c4bb3323a9109d8e922"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/persistent-logger.ts": {
+    "mtime": 1779420421.0403025,
+    "hash": "f490d47b6c2f1da85ccd75c2790e1758"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/claude-permissions.ts": {
+    "mtime": 1779420421.0293937,
+    "hash": "20c606da90777b0d471fa819fe1cd01b"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/work-agent-lifecycle.ts": {
+    "mtime": 1779420421.0458703,
+    "hash": "35a2aa02604eaef70c17609951eacdb7"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/session-format-converter.ts": {
+    "mtime": 1779420421.0426843,
+    "hash": "14566b0f38b7baa950e625384901b0fe"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/tts-voices.ts": {
+    "mtime": 1779420421.0445752,
+    "hash": "74c56d9a2648d1cdef7380375ea88ced"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/review-status.ts": {
+    "mtime": 1779420421.0419607,
+    "hash": "e722e1bfcfb6674dbc569a986995b6b7"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/project-repos.ts": {
+    "mtime": 1779420421.041004,
+    "hash": "77b1de8fb58f20bf2adde04cc0ea0ecb"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/claude-settings-overlay.ts": {
+    "mtime": 1779420421.029415,
+    "hash": "8c55419b456c22b1e9952781c19fb8c8"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/agent-runtime-mirror.ts": {
+    "mtime": 1779420421.0266702,
+    "hash": "2582ed1cf424865d8f6470bd13da0d8f"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/git-utils.ts": {
+    "mtime": 1779420421.0375533,
+    "hash": "1e078d841bf5e66fbdc975b9223323e8"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/config-yaml.ts": {
+    "mtime": 1779420421.0336704,
+    "hash": "2b28a1f688a2c73bf7509aab4167b798"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/format-duration.ts": {
+    "mtime": 1779420421.0375533,
+    "hash": "093e4afe8aff4edfc20875fb0e66eb40"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/shell.ts": {
+    "mtime": 1779420421.0431318,
+    "hash": "96f9dfa0e6d85f66d880011a4b7e2ff8"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/openai-auth.ts": {
+    "mtime": 1779420421.0397692,
+    "hash": "1a0d9bcc3c172364d8ed378470520a27"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/model-fallback.ts": {
+    "mtime": 1779420421.0391636,
+    "hash": "300fd7ed464b4eaf979b1922a5f6b554"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/test-runner.ts": {
+    "mtime": 1779420421.0437727,
+    "hash": "e0de0dbb95ea34d47cd4c9af66ed5095"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/worktree.ts": {
+    "mtime": 1779420421.0466442,
+    "hash": "f1ef52d3307159649281ff4c61b6643b"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/platform.ts": {
+    "mtime": 1779420421.040705,
+    "hash": "5ced4e67a0f12b6ff6c43cacf0d5c3a3"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/openai-compatible-proxy.ts": {
+    "mtime": 1779420421.0397692,
+    "hash": "34713d8bcc0a5d6e7845d147086fd619"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/flywheel-merge-order.ts": {
+    "mtime": 1779420421.0374422,
+    "hash": "de34d81c17e37fd6c5c7b39e681bd18a"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/docker-stats.ts": {
+    "mtime": 1779420421.037151,
+    "hash": "b62228c86ddb6e6f79e93225a47c3a72"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/projects.ts": {
+    "mtime": 1779420421.0411313,
+    "hash": "0eb46769de0a7d226693ad9a66a8565a"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/skills-merge.ts": {
+    "mtime": 1779420421.0431318,
+    "hash": "e183c1387a3a78021459e87a61ac9c67"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/multi-tool-sync.ts": {
+    "mtime": 1779420421.0397692,
+    "hash": "f22fe1e7ecd61fc00d0d75792bc5de91"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/remote-workspace.ts": {
+    "mtime": 1779420421.0411313,
+    "hash": "3672a310106b1f7024e1601a68fd6935"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/shadow-mode.ts": {
+    "mtime": 1779420421.0431318,
+    "hash": "6aba2d8f9e69cee2525354c4cf6f58b4"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/model-validation.ts": {
+    "mtime": 1779420421.0397692,
+    "hash": "446175d2642a41a568d67ae182b30bb1"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/launcher-generator.ts": {
+    "mtime": 1779420421.0381713,
+    "hash": "92fe863b48495146042c64d11f733739"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/manifest.ts": {
+    "mtime": 1779420421.038691,
+    "hash": "35c79ade7fb2ccef2ab9a57bc21bfb07"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/restart-status.ts": {
+    "mtime": 1779420421.0416498,
+    "hash": "9192736b340df829d07277d245ba2838"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/child-env.ts": {
+    "mtime": 1779420421.0288315,
+    "hash": "c1b36f2431d2c01d6c99a9fc2ee48f90"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/config.ts": {
+    "mtime": 1779420421.0336704,
+    "hash": "900455a2bb26e1b3f5e65545b61b627c"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/tunnel.ts": {
+    "mtime": 1779420421.0445752,
+    "hash": "00eb606a4d4559600b03cad47a99e7ec"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/platform-lifecycle.ts": {
+    "mtime": 1779420421.040705,
+    "hash": "f01cc4ff03a360f860dc2a11ba518e2c"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/agent-input-detection.ts": {
+    "mtime": 1779420421.0266702,
+    "hash": "73050f9acdec90e1b19a684700ed967b"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/tldr-daemon.ts": {
+    "mtime": 1779420421.0437727,
+    "hash": "0e5b31b470b24fdf9e677027a505baff"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/workspace-config.ts": {
+    "mtime": 1779420421.0458703,
+    "hash": "e5c4f0cf5c61cdb2711b80af1e779d9e"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/router-config.ts": {
+    "mtime": 1779420421.0419607,
+    "hash": "3adc0add80cbe95c852b8162ef35b614"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/settings-api.ts": {
+    "mtime": 1779420421.0426843,
+    "hash": "75f66c4cc3f713847fd16c15770be7fb"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/runtimes/pi-fifo.ts": {
+    "mtime": 1779420421.0423734,
+    "hash": "32ca3f4007bc9c6ae3cad11731b71bd4"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/runtimes/index.ts": {
+    "mtime": 1779420421.0423734,
+    "hash": "89b7176c5c25bfb276cc271b7d18ffcf"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/runtimes/pi.ts": {
+    "mtime": 1779420421.0423734,
+    "hash": "1299a297dc08928b84982a2c1de8733a"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/runtimes/types.ts": {
+    "mtime": 1779420421.0426388,
+    "hash": "daaf73bf2717621e4237038080d1ea4e"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/runtimes/claude-code.ts": {
+    "mtime": 1779420421.0423734,
+    "hash": "53041043be19e3a7bd83a3950baff671"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/runtimes/__tests__/pi-fifo.test.ts": {
+    "mtime": 1779420421.0423412,
     "hash": "73cd2292d237d1ac1d44c3b60ce0c92c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/runtimes/__tests__/registry-dispatch.test.ts": {
-    "mtime": 1779108266.1643062,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/runtimes/__tests__/registry-dispatch.test.ts": {
+    "mtime": 1779420421.0423734,
     "hash": "a139e80c456ae8ad8f02f769f12a3eb7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/runtimes/__tests__/pi.test.ts": {
-    "mtime": 1779108266.1643062,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/runtimes/__tests__/pi.test.ts": {
+    "mtime": 1779420421.0423734,
     "hash": "13131fc041c2121b233f905ba0ede9d7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cost-parsers/jsonl-parser.ts": {
-    "mtime": 1779108266.1590133,
-    "hash": "a835a966cbf3e7b020c5e723169f2656"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cost-parsers/jsonl-parser.ts": {
+    "mtime": 1779420421.0354843,
+    "hash": "b04bc95541166a3bf7e66d1fed8880f4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cost-parsers/pi-parser.ts": {
-    "mtime": 1779108266.1590133,
-    "hash": "429c1d30fd006dc87a996fb63b6c665e"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cost-parsers/pi-parser.ts": {
+    "mtime": 1779420421.0354843,
+    "hash": "6ec2a8f22bc2ef0c146c2b8e2250a7c9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cost-parsers/session-map.ts": {
-    "mtime": 1779108266.1590133,
-    "hash": "d526b5827f1d4a7e4c68868c5dc9dd39"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cost-parsers/session-map.ts": {
+    "mtime": 1779420421.0354843,
+    "hash": "bacca33556d25cf776687e8e42fb60a1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cost-parsers/__tests__/pi-parser.test.ts": {
-    "mtime": 1779108266.1590133,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cost-parsers/__tests__/pi-parser.test.ts": {
+    "mtime": 1779420421.0354843,
     "hash": "e7635cdba27c818a2c98e56526f99ef0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/work/done-preflight.ts": {
-    "mtime": 1779108266.1665595,
-    "hash": "65130fe5c3d0530ab4639eed3484d96e"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/work/done-preflight.ts": {
+    "mtime": 1779420421.0458703,
+    "hash": "30756984b5789c5f7157cbfe9d6edffd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/tracker/interface.ts": {
-    "mtime": 1779108266.1659575,
-    "hash": "1056646e6f649aa6c2dc447da564b1fd"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/tracker/interface.ts": {
+    "mtime": 1779420421.0442224,
+    "hash": "93c0c9f2666c64eb695d2c29df31058d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/tracker/rally-api.ts": {
-    "mtime": 1779108266.1659575,
-    "hash": "e5c898467dd687bbd8ce9d504cdf31c3"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/tracker/rally-api.ts": {
+    "mtime": 1779420421.0442224,
+    "hash": "64ecb0497a755ebb92530db478d16ed3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/tracker/linear.ts": {
-    "mtime": 1779108266.1659575,
-    "hash": "1bfc1c24f6a90b18dd0e1da51c455f1b"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/tracker/linear.ts": {
+    "mtime": 1779420421.0442224,
+    "hash": "8a6dbfc5419824f616b47f03b183fade"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/tracker/github.ts": {
-    "mtime": 1779108266.1659575,
-    "hash": "c53e854eff5468ae57c33ee3202841a6"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/tracker/github.ts": {
+    "mtime": 1779420421.0442011,
+    "hash": "8a1410b3829214056c33e6d6518929f6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/tracker/rally.ts": {
-    "mtime": 1779108266.1659575,
-    "hash": "04a52098928f4dace583109021984353"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/tracker/rally.ts": {
+    "mtime": 1779420421.0445037,
+    "hash": "3e9da6ddfbcb524622de20796bd74e9d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/tracker/gitlab.ts": {
-    "mtime": 1779108266.1659575,
-    "hash": "042914f99345fbca2fd721e0cd79d029"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/tracker/gitlab.ts": {
+    "mtime": 1779420421.0442224,
+    "hash": "4ba1f79911e3afc26177618fb060c8dd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/tracker/factory.ts": {
-    "mtime": 1779108266.1659575,
-    "hash": "47720e4aaf6c50d7c5141c7009cb3c71"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/tracker/factory.ts": {
+    "mtime": 1779420421.0441694,
+    "hash": "023d5fd74450f093051a900215423e3f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/tracker/index.ts": {
-    "mtime": 1779108266.1659575,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/tracker/index.ts": {
+    "mtime": 1779420421.0442224,
     "hash": "1b062472d36ba14282005eb5605f60c2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/tracker/linking.ts": {
-    "mtime": 1779108266.1659575,
-    "hash": "41367631eebab9dd1d382c7a6636a615"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/tracker/linking.ts": {
+    "mtime": 1779420421.0442224,
+    "hash": "2af8a3674d66a0a47017fb2b418b4048"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/tracker/__tests__/rally-getChildIssues.test.ts": {
-    "mtime": 1779108266.1659575,
-    "hash": "3a434eb1153bf48252f773f177bc9dc8"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/tracker/__tests__/rally-getChildIssues.test.ts": {
+    "mtime": 1779420421.0441132,
+    "hash": "ac42a7338bb03ac10be28297233db729"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/tracker/__tests__/in-review-transition.test.ts": {
-    "mtime": 1779108266.1659265,
-    "hash": "aed1e85b95eb23501f679a0544dc63a9"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/tracker/__tests__/in-review-transition.test.ts": {
+    "mtime": 1779420421.044071,
+    "hash": "46b76791b188d7c3432602185133e309"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/workspace/devcontainer-renderer.ts": {
-    "mtime": 1779108266.1678364,
-    "hash": "652a613cdb6c205547aa7dc55bdcd651"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/workspace/devcontainer-renderer.ts": {
+    "mtime": 1779420421.0464375,
+    "hash": "f7bf9b4334a16e487cab3157e96c924c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/workspace/stack-health.ts": {
-    "mtime": 1779108266.1678364,
-    "hash": "1c73f6d30abc685e747b5c8282c2ec32"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/workspace/stack-health.ts": {
+    "mtime": 1779420421.0465863,
+    "hash": "01f246bfa5a23bd73b722c1bb3f9aaf1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/workspace/ensure-devcontainer.ts": {
-    "mtime": 1779108266.1678364,
-    "hash": "c35fb2c5be6dc038ee098c1bdd9a6ead"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/workspace/ensure-devcontainer.ts": {
+    "mtime": 1779420421.0464375,
+    "hash": "68ee9dcdb3c09fa7399aae3abc38b04d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/workspace/__tests__/ensure-devcontainer.test.ts": {
-    "mtime": 1779108266.1678047,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/workspace/rebuild-stack.ts": {
+    "mtime": 1779420421.0465863,
+    "hash": "f81e128ba44694add394d747eba6393f"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/workspace/__tests__/ensure-devcontainer.test.ts": {
+    "mtime": 1779420421.046407,
     "hash": "81e2904b6370557528434ddf67f0031b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/workspace/__tests__/stack-health.test.ts": {
-    "mtime": 1779108266.1678364,
-    "hash": "ace58e8f78fee4657888af946ce88aff"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/workspace/__tests__/stack-health.test.ts": {
+    "mtime": 1779420421.0464375,
+    "hash": "623884918fc2cb7e703478b39248c89e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/safety/protected-paths.ts": {
-    "mtime": 1779108266.1648948,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/safety/protected-paths.ts": {
+    "mtime": 1779420421.0426843,
     "hash": "e3da21c7aa950b1dc5cc4d9de014f2e2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/safety/dangerous-git-ops.ts": {
-    "mtime": 1779108266.1648948,
-    "hash": "4dbbb48421faf08aaf0a63cb12e6979c"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/safety/dangerous-git-ops.ts": {
+    "mtime": 1779420421.0426843,
+    "hash": "b08f46cb4bea35602304d79860e0db2c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/safety/__tests__/dangerous-git-ops.test.ts": {
-    "mtime": 1779108266.1648948,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/safety/__tests__/dangerous-git-ops.test.ts": {
+    "mtime": 1779420421.0426843,
     "hash": "9149441cf67b82d884e05efc234b46a8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/shadow-engineering/monitoring-agent.ts": {
-    "mtime": 1779108266.1651804,
-    "hash": "36be8eb37c7680c9ff86132331169082"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/shadow-engineering/monitoring-agent.ts": {
+    "mtime": 1779420421.0430532,
+    "hash": "a8b88efb233f71682d149ca845db9b90"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/shadow-engineering/index.ts": {
-    "mtime": 1779108266.1651804,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/shadow-engineering/index.ts": {
+    "mtime": 1779420421.0430532,
     "hash": "ee9b46e6e882dd4d79f73eb5822ff41c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/shadow-engineering/observer-agent.ts": {
-    "mtime": 1779108266.1651804,
-    "hash": "ae01b0c41951df9bc367fe42b35dea29"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/shadow-engineering/observer-agent.ts": {
+    "mtime": 1779420421.0431318,
+    "hash": "3e2a0e82f82a4f6b9f5b9be0d171bb92"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/shadow-engineering/__tests__/observer-agent.test.ts": {
-    "mtime": 1779108266.1651804,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/shadow-engineering/__tests__/observer-agent.test.ts": {
+    "mtime": 1779420421.0430532,
     "hash": "f990abe907be61ca5204699b25e8b02d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/shadow-engineering/__tests__/monitoring-agent.test.ts": {
-    "mtime": 1779108266.1651525,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/shadow-engineering/__tests__/monitoring-agent.test.ts": {
+    "mtime": 1779420421.0430214,
     "hash": "830375906bcf28d3464e531dc45f1293"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/review-monitor.ts": {
-    "mtime": 1779108266.15632,
-    "hash": "983c9791cd8bfe70530f9f8a4afe974e"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/review-monitor.ts": {
+    "mtime": 1779420421.032242,
+    "hash": "09f5ca973a0e9b9990ec540b8a6645c3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/complexity.ts": {
-    "mtime": 1779108266.154482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/complexity.ts": {
+    "mtime": 1779420421.0296702,
     "hash": "de0836b619d4769cc1e545725b06de28"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/review-agent.ts": {
-    "mtime": 1779159580.6384895,
-    "hash": "3e983aa8558eaa092c80d83558dd0bb9"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/review-agent.ts": {
+    "mtime": 1779420421.032242,
+    "hash": "2e773ac85322f5189523ca80fe1afb49"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/specialist-logs.ts": {
-    "mtime": 1779108266.15632,
-    "hash": "e81f9679d4307a2853f581e505e85aa8"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/specialist-logs.ts": {
+    "mtime": 1779420421.0326705,
+    "hash": "fac39339f84fe4feb45e826881191459"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/review-verdict-feedback.ts": {
-    "mtime": 1779108266.15632,
-    "hash": "d147eeadbf7da62a9601cf2c3d32ea87"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/review-verdict-feedback.ts": {
+    "mtime": 1779420421.032242,
+    "hash": "41b640325be6b9a08cc4d8fa4fd3b259"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/test-agent.ts": {
-    "mtime": 1779108266.15632,
-    "hash": "922fcd709f706c550b22033ce78e333e"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/test-agent.ts": {
+    "mtime": 1779420421.0326705,
+    "hash": "d30f0c8ac2d0e74b01ffb9500a55eca8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/fpp-violations.ts": {
-    "mtime": 1779108266.154482,
-    "hash": "2f8d606035b7883d22f6998f75df6ade"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/fpp-violations.ts": {
+    "mtime": 1779420421.0312817,
+    "hash": "127083c1c96f329de2246fc184baa456"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/inspect-checkpoints.ts": {
-    "mtime": 1779108266.154482,
-    "hash": "abbb5f6092ccb1490c309dd1c6a4d4aa"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/inspect-checkpoints.ts": {
+    "mtime": 1779420421.03155,
+    "hash": "62a715aece6d14d312e6a0b4b414acd5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/handoff-logger.ts": {
-    "mtime": 1779108266.154482,
-    "hash": "3ee8f8c0fcd21cc6100492da70ded4c9"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/handoff-logger.ts": {
+    "mtime": 1779420421.0314052,
+    "hash": "19f4a0f8c62097dc68a4602f5b53293f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/specialist-completion.ts": {
-    "mtime": 1779108266.15632,
-    "hash": "6cc3c1844b88a39441bb8ee27ac342d5"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/specialist-completion.ts": {
+    "mtime": 1779420421.032242,
+    "hash": "3db1f1539173924541ef6cb80b2d1375"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/work-agent-prompt.ts": {
-    "mtime": 1779108266.15632,
-    "hash": "6c4373abd3c8b80f870bf55cd7bad646"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/work-agent-prompt.ts": {
+    "mtime": 1779420421.0326705,
+    "hash": "c0b2a64dfd332486bac528b82adcbcdb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/service.ts": {
-    "mtime": 1779161768.6669738,
-    "hash": "ac0d134107788956c01d4db7dcd07f7a"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/service.ts": {
+    "mtime": 1779420421.032242,
+    "hash": "9508dec5acde07162e0fbd1e2d600227"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/verification-runner.ts": {
-    "mtime": 1779108266.15632,
-    "hash": "775d02827ed3c3b3fb2935ace5e44202"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/verification-runner.ts": {
+    "mtime": 1779420421.0326705,
+    "hash": "c2238809977f4dc3e7d728986ad008a8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/health.ts": {
-    "mtime": 1779108266.154482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/health.ts": {
+    "mtime": 1779420421.0314052,
     "hash": "ed5d2d6d219a2519c60d16cddc6b9364"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/handoff.ts": {
-    "mtime": 1779108266.154482,
-    "hash": "e90b09c70b379f54aa90770cd3c4aca9"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/handoff.ts": {
+    "mtime": 1779420421.0314052,
+    "hash": "c7c298e76ea59a3f374d08e49e50278d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/validation.ts": {
-    "mtime": 1779108266.15632,
-    "hash": "d4cca7d175eef4383ff8a85d7190bd2c"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/validation.ts": {
+    "mtime": 1779420421.0326705,
+    "hash": "793add455e07640ec064eea0757dcf40"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/database.ts": {
-    "mtime": 1779108266.154482,
-    "hash": "974221ec83420af3407251864747f928"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/database.ts": {
+    "mtime": 1779420421.0304053,
+    "hash": "8e6b4b68d586202cc6cbdae1aeacead1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/auto-resume-config.ts": {
-    "mtime": 1779108266.154482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/auto-resume-config.ts": {
+    "mtime": 1779420421.0296702,
     "hash": "29cc72dc4ffc27c31606b10983ff53b7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/specialist-handoff-logger.ts": {
-    "mtime": 1779108266.15632,
-    "hash": "4b912a664c79e3af411e71e41df18fba"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/specialist-handoff-logger.ts": {
+    "mtime": 1779420421.032242,
+    "hash": "0753eea5a7c6d1a1cf2576cf27abf411"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/index.ts": {
-    "mtime": 1779108266.154482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/index.ts": {
+    "mtime": 1779420421.0314052,
     "hash": "3cf2778a800950eb46a85a39334deb64"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/router.ts": {
-    "mtime": 1779108266.15632,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/router.ts": {
+    "mtime": 1779420421.032242,
     "hash": "f387d2d888b3764f70aba4aa9ced5441"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/no-resume-mode.ts": {
-    "mtime": 1779108266.1552742,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/no-resume-mode.ts": {
+    "mtime": 1779420421.0316937,
     "hash": "b19710394a1d5b55099e44cb5eb358bf"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/handoff-context.ts": {
-    "mtime": 1779108266.154482,
-    "hash": "f0ae3edbb46d26fedafbf96a31b8531d"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/handoff-context.ts": {
+    "mtime": 1779420421.0312817,
+    "hash": "8bdeb9bf3f566bf973cbf31a5dbaa025"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/task-readiness.ts": {
-    "mtime": 1779108266.15632,
-    "hash": "6d45e7ffdc9cef4059d07cf856637649"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/task-readiness.ts": {
+    "mtime": 1779420421.0326705,
+    "hash": "5c54abfee9b1b9f57c1c313710c610ac"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/flywheel.ts": {
-    "mtime": 1779167172.9369254,
-    "hash": "01d89c3a770930ebea167a18e7044dad"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/flywheel.ts": {
+    "mtime": 1779420421.0312817,
+    "hash": "bb3e54306b1df59a92cddbd8313f71d3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/test-agent-queue.ts": {
-    "mtime": 1779108266.15632,
-    "hash": "acc917fe2a82c41d584e5921cef712ef"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/test-agent-queue.ts": {
+    "mtime": 1779420421.0326705,
+    "hash": "5e4031125475e295cd5f9410da8ae536"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/review-context.ts": {
-    "mtime": 1779108266.15632,
-    "hash": "09aad5338bff63788bfb800f05ee049d"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/review-context.ts": {
+    "mtime": 1779420421.032242,
+    "hash": "3062906ae8763ef2952ab352f87a8fb4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/session-rotation.ts": {
-    "mtime": 1779108266.15632,
-    "hash": "fc6395ee76f287fe832df66e599053e3"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/session-rotation.ts": {
+    "mtime": 1779420421.032242,
+    "hash": "09c89dc91f450985e10a31e17513f62e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/specialists.ts": {
-    "mtime": 1779108266.15632,
-    "hash": "786ade1883306d0c5867816e81030a44"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/specialists.ts": {
+    "mtime": 1779420421.0326705,
+    "hash": "fad475e2c9ed55c83b8fa46b6843dc3b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/triggers.ts": {
-    "mtime": 1779108266.15632,
-    "hash": "b534ce4bfb6bf69b350bb98fb7384507"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/triggers.ts": {
+    "mtime": 1779420421.0326705,
+    "hash": "79396cc66a49f17c07eeae9d3e9d1320"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/merge-rebase.ts": {
-    "mtime": 1779108266.1552742,
-    "hash": "f22ef8fd59f55cffb12b60ee2ebbc300"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/merge-rebase.ts": {
+    "mtime": 1779420421.0316937,
+    "hash": "1be2e16dff4030d8731be1844b569a31"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/merge-agent.ts": {
-    "mtime": 1779108266.1552742,
-    "hash": "53dd91969e6ab792d22fc1d768448e94"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/merge-agent.ts": {
+    "mtime": 1779420421.0316937,
+    "hash": "70c0add16120fc3fdddd6c452d86f39c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/config.ts": {
-    "mtime": 1779108266.154482,
-    "hash": "764014e1da24b7cd7da7b80742de2701"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/config.ts": {
+    "mtime": 1779420421.0296702,
+    "hash": "faa974f14360cee05828de40d29235f4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/deacon.ts": {
-    "mtime": 1779159580.6384895,
-    "hash": "c151643243c38e776dc4dbd1161013bd"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/deacon.ts": {
+    "mtime": 1779420421.0309856,
+    "hash": "f48f80663d40103eef44982632dfa6e3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/feedback-writer.ts": {
-    "mtime": 1779108266.154482,
-    "hash": "a3893fe02957b14b53cf7b1d9da08b0b"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/feedback-writer.ts": {
+    "mtime": 1779420421.0312326,
+    "hash": "f182dfb2e399c53ec1db04f7a12385b4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/prompts.ts": {
-    "mtime": 1779108266.1552742,
-    "hash": "3238aa05ffd4bd616e0a135a8e361f9e"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/prompts.ts": {
+    "mtime": 1779420421.0316937,
+    "hash": "7598f3db91ba45910e6000e8f9dbaa45"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/specialist-context.ts": {
-    "mtime": 1779108266.15632,
-    "hash": "e7a382a6f4f18e665fb8daafa143a837"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/specialist-context.ts": {
+    "mtime": 1779420421.032242,
+    "hash": "70a73392a9264e4124c51c1478f5686c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/cost-monitor.ts": {
-    "mtime": 1779108266.154482,
-    "hash": "582f3c03e35cc1ba9ea3d58094fc33ae"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/cost-monitor.ts": {
+    "mtime": 1779420421.0304053,
+    "hash": "7106d633502680ae607749bdd636995a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/inspect-agent.ts": {
-    "mtime": 1779150733.4048183,
-    "hash": "76eceefff52fe06132c9b2185d623a06"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/inspect-agent.ts": {
+    "mtime": 1779420421.03155,
+    "hash": "e73db0a7cd619a98ddd64b8ef1521327"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/startup-recovery.test.ts": {
-    "mtime": 1779108266.154482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/startup-recovery.test.ts": {
+    "mtime": 1779420421.0296702,
     "hash": "b9a565924beb9bcfd3aec8760a65b474"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/specialists-reviewer-name.test.ts": {
-    "mtime": 1779108266.154482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/deacon-swarm-slot-merge.test.ts": {
+    "mtime": 1779420421.0296278,
+    "hash": "e04bb362e9eb836c36807d92cad20cc2"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/specialists-reviewer-name.test.ts": {
+    "mtime": 1779420421.0296702,
     "hash": "f78ac855a3fffe403281c72c04d259fa"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/specialists-caveman.test.ts": {
-    "mtime": 1779108266.154482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/review-agent.test.ts": {
+    "mtime": 1779420421.0296702,
+    "hash": "3a6cdedfbb34f5d3447d195c63fc0d7a"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/specialists-caveman.test.ts": {
+    "mtime": 1779420421.0296702,
     "hash": "e3df651b64f0482256e9022a9ba14c07"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/specialist-harness-router.test.ts": {
-    "mtime": 1779108266.154482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/specialist-harness-router.test.ts": {
+    "mtime": 1779420421.0296702,
     "hash": "fa931ee4f0c823c9cfb534b87a2f0f24"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/review-monitor.test.ts": {
-    "mtime": 1779108266.154482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/review-monitor.test.ts": {
+    "mtime": 1779420421.0296702,
     "hash": "dc71232e3438aebf69f4e813f6dbb8cb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/review-context.test.ts": {
-    "mtime": 1779108266.154482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/review-context.test.ts": {
+    "mtime": 1779420421.0296702,
     "hash": "c760f56b3e2e58a14d91d3615e2a3134"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/deacon-stuck-skip.test.ts": {
-    "mtime": 1779108266.154482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/deacon-stuck-skip.test.ts": {
+    "mtime": 1779420421.0296278,
     "hash": "d1666e0b9402cfc8d6958546f07e8486"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/deacon-stash-janitor.test.ts": {
-    "mtime": 1779108266.154482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/deacon-stash-janitor.test.ts": {
+    "mtime": 1779420421.0296278,
     "hash": "28e34e412730ae5fc785ff54f129398b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/specialist-base-command.test.ts": {
-    "mtime": 1779108266.154482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/specialist-base-command.test.ts": {
+    "mtime": 1779420421.0296702,
     "hash": "9fa03fb52d4454f86cef5318c811e80c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/pan-871-auto-resume.test.ts": {
-    "mtime": 1779108266.154482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/pan-871-auto-resume.test.ts": {
+    "mtime": 1779420421.0296278,
     "hash": "bc8e0d22614667c3b174d039a76fef8c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/task-readiness.test.ts": {
-    "mtime": 1779108266.154482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/task-readiness.test.ts": {
+    "mtime": 1779420421.0296702,
     "hash": "9fe6c88fe0b746c8ddc730b4c0420353"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/prompts.test.ts": {
-    "mtime": 1779108266.154482,
-    "hash": "0cf99f5d5a099151cc084a448beffb75"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/prompts.test.ts": {
+    "mtime": 1779420421.0296278,
+    "hash": "af7d0d77f96aad0faf6d5e90bd468d73"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/deacon-undispatched-ship.test.ts": {
-    "mtime": 1779108266.154482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/deacon-undispatched-ship.test.ts": {
+    "mtime": 1779420421.0296278,
     "hash": "d252f3689c66fdfaf81fe8bd4d5d699b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/merge-agent-stash.test.ts": {
-    "mtime": 1779108266.154482,
-    "hash": "17215ff2b296fe5bd40805844efec9a5"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/merge-agent-stash.test.ts": {
+    "mtime": 1779420421.0296278,
+    "hash": "f6798e177f4b1ed18e1c05d86a85a3a6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/reactive-scheduler.test.ts": {
-    "mtime": 1779108266.154482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/reactive-scheduler.test.ts": {
+    "mtime": 1779420421.0296702,
     "hash": "2b39ad5057ed9ae48f3279f469472351"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/config.test.ts": {
-    "mtime": 1779108266.154482,
-    "hash": "0419bcf0491ebd7413b34ba6e1890f91"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/config.test.ts": {
+    "mtime": 1779420421.0296042,
+    "hash": "76e06cb632b654f7804d82b41cbe8f6d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/beads-scoping.test.ts": {
-    "mtime": 1779108266.1544533,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/beads-scoping.test.ts": {
+    "mtime": 1779420421.0295718,
     "hash": "9456ad4005a975c233488fd6e52a6aa6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/feature-context.test.ts": {
-    "mtime": 1779108266.154482,
-    "hash": "95fe947385d68fca9258fc961dea86fc"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/deacon-auto-closeout.test.ts": {
+    "mtime": 1779420421.0296278,
+    "hash": "9cac82508298d4c43717ca472b4e2491"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/specialist-harnesses-config.test.ts": {
-    "mtime": 1779108266.154482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/feature-context.test.ts": {
+    "mtime": 1779420421.0296278,
+    "hash": "74a79b121b6f1adaf84eb6b43b638c28"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/specialist-harnesses-config.test.ts": {
+    "mtime": 1779420421.0296702,
     "hash": "27d2fa4ff45d30c2ead17d8632e7a0a4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/test-agent-queue.test.ts": {
-    "mtime": 1779108266.154482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/test-agent-queue.test.ts": {
+    "mtime": 1779420421.0296702,
     "hash": "5f206284ef0d13effa6e4a6bc66c95f7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/__tests__/flywheel.test.ts": {
-    "mtime": 1779167279.688588,
-    "hash": "b142ec0fe2a298d503c8c2b067e5165c"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/__tests__/flywheel.test.ts": {
+    "mtime": 1779420421.0296278,
+    "hash": "97d464c0ca52c38014825ea1203b8b44"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/planning/triage-agent.ts": {
-    "mtime": 1779108266.1627212,
-    "hash": "e33e165f92640fb578f47e78852dce7f"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/planning/triage-agent.ts": {
+    "mtime": 1779420421.040705,
+    "hash": "4020b7bbd732065175469deddff6acb3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/planning/spawn-planning-session.ts": {
-    "mtime": 1779150733.4058182,
-    "hash": "e8266728f0501473292c8f45d0ad7946"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/planning/spawn-planning-session.ts": {
+    "mtime": 1779420421.040705,
+    "hash": "93b3ffb7fdb4458fe04309162f14cf5a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/planning/index.ts": {
-    "mtime": 1779108266.1627212,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/planning/index.ts": {
+    "mtime": 1779420421.0405524,
     "hash": "242d122192ceb648ffb8a4123515feaa"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/planning/__tests__/spawn-planning-session.test.ts": {
-    "mtime": 1779108266.1627212,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/planning/__tests__/spawn-planning-session.test.ts": {
+    "mtime": 1779420421.0405524,
     "hash": "828d410a5336a111fd5f083e749b5708"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/runtime/interface.ts": {
-    "mtime": 1779108266.1641667,
-    "hash": "6bc7fbd9f6b5f0ee8419d3eb5be697f8"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/runtime/interface.ts": {
+    "mtime": 1779420421.0422332,
+    "hash": "d133ae9ba23d9fa87d3fd896b33d406c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/runtime/index.ts": {
-    "mtime": 1779108266.1641667,
-    "hash": "f7c09007547e704ed2947463ba5c2acd"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/runtime/index.ts": {
+    "mtime": 1779420421.0422332,
+    "hash": "296ce460e2a9ab2b9de2d956c7dac92d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/runtime/metrics.ts": {
-    "mtime": 1779108266.1641667,
-    "hash": "e0b796a703abd7acdcef64ea455d3201"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/runtime/metrics.ts": {
+    "mtime": 1779420421.0422332,
+    "hash": "4495e53fee41d8678bd88d26a200def0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/runtime/claude.ts": {
-    "mtime": 1779108266.1635168,
-    "hash": "354b90d50d29c74318955ff0bdec2d7c"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/runtime/claude.ts": {
+    "mtime": 1779420421.0421975,
+    "hash": "38200df2702c25aacb90fb39bc1605b1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/pan-dir/specs.ts": {
-    "mtime": 1779108266.1624482,
-    "hash": "dcb1967f2c91058fb123264c6d9badb4"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/pan-dir/specs.ts": {
+    "mtime": 1779420421.0403025,
+    "hash": "cea0bc682856afac87e8a8dc0e0f9834"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/pan-dir/sessions.ts": {
-    "mtime": 1779108266.1624482,
-    "hash": "359f8b887c7bb420789362af10b92917"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/pan-dir/sessions.ts": {
+    "mtime": 1779420421.0400517,
+    "hash": "388bb49e624a90f520b2ba70f5121ece"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/pan-dir/context.ts": {
-    "mtime": 1779108266.1624482,
-    "hash": "43cb3013e64273c056eee9be89b31046"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/pan-dir/context.ts": {
+    "mtime": 1779420421.0400517,
+    "hash": "886c10931b3b108b8b9b055132b88b6e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/pan-dir/drafts.ts": {
-    "mtime": 1779108266.1624482,
-    "hash": "5cb88f411921df33d046ce21b4292565"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/pan-dir/drafts.ts": {
+    "mtime": 1779420421.0400517,
+    "hash": "e9abbb626c4ee4ea3a5fd5772068388d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/pan-dir/continues.ts": {
-    "mtime": 1779108266.1624482,
-    "hash": "d8cc44f1da7ab2d24db33a6dc8aa768b"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/pan-dir/continues.ts": {
+    "mtime": 1779420421.0400517,
+    "hash": "59499df57ad13efba63b0483c63c88a1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/pan-dir/index.ts": {
-    "mtime": 1779108266.1624482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/pan-dir/index.ts": {
+    "mtime": 1779420421.0400517,
     "hash": "5e65dbecc63f12f8ba48e37ec0e1e41e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/pan-dir/feedback.ts": {
-    "mtime": 1779108266.1624482,
-    "hash": "fc6e46cb9019709f6a5133a3ee7eb31d"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/pan-dir/feedback.ts": {
+    "mtime": 1779420421.0400517,
+    "hash": "1c90384f8abe2dbd0d8d489772f5b632"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/pan-dir/auto-commit.ts": {
-    "mtime": 1779108266.1624482,
-    "hash": "ad6a19a82dd64d1760447f87601621de"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/pan-dir/auto-commit.ts": {
+    "mtime": 1779420421.0400517,
+    "hash": "c3b705b82553128950f7af8dc17f83a4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/pan-dir/continue.ts": {
-    "mtime": 1779108266.1624482,
-    "hash": "e8fca4481e4f5819e476cd78618587a4"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/pan-dir/continue.ts": {
+    "mtime": 1779420421.0400517,
+    "hash": "7763e729d51a85c97c163d20a52c7a84"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/pan-dir/types.ts": {
-    "mtime": 1779108266.1624482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/pan-dir/types.ts": {
+    "mtime": 1779420421.0403025,
     "hash": "7b94e3b6c0ef11b388305ea571edf755"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/pan-dir/__tests__/pan-dir.test.ts": {
-    "mtime": 1779108266.1624482,
-    "hash": "2de21ead7ed7237336a86f7db693dd42"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/pan-dir/__tests__/pan-dir.test.ts": {
+    "mtime": 1779420421.0400517,
+    "hash": "fcba3e1d31cac7806b2bcf8018d3f308"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/pan-dir/__tests__/auto-commit.test.ts": {
-    "mtime": 1779108266.1624172,
-    "hash": "fdc4b3eecac2e348ab8c8d177bf45744"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/pan-dir/__tests__/auto-commit.test.ts": {
+    "mtime": 1779420421.0400038,
+    "hash": "7cf164c77c0ec2135a9590e8a6b78034"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/summary-fork.ts": {
-    "mtime": 1779108266.1586092,
-    "hash": "6132684bd7e051984a0d462707a1251b"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/summary-fork.ts": {
+    "mtime": 1779420421.0349355,
+    "hash": "47a52abf59de83b381291b8bc017b84d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/hash-resolver.ts": {
-    "mtime": 1779108266.1586092,
-    "hash": "cf02d573bebed7454e126081758a6f63"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/hash-resolver.ts": {
+    "mtime": 1779420421.0349355,
+    "hash": "3a96a9625b6becdbff1932956a6a12fe"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/work-pool.ts": {
-    "mtime": 1779108266.1586092,
-    "hash": "bd54f26f6ef4415e467c18df407710b8"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/work-pool.ts": {
+    "mtime": 1779420421.0349355,
+    "hash": "730110636d925dc7cc7474c20b77dcab"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/smart-compaction.ts": {
-    "mtime": 1779108266.1586092,
-    "hash": "b51cb7107629350814e6ebbd624bdbfe"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/smart-compaction.ts": {
+    "mtime": 1779420421.0349355,
+    "hash": "71fb405b5649b8a6c143fbe92cdac0de"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/scanner.ts": {
-    "mtime": 1779108266.1586092,
-    "hash": "cf3d2dc02ebdd1ddd33ec75c8c080a8b"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/scanner.ts": {
+    "mtime": 1779420421.0349355,
+    "hash": "779b7930fcefd62f82498aa03b7b1de5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/jsonl-async.ts": {
-    "mtime": 1779108266.1586092,
-    "hash": "83ba238805f3efd60124da4222439182"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/jsonl-async.ts": {
+    "mtime": 1779420421.0349355,
+    "hash": "0b513f06f0dd358280c6155da0c5be1b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/search.ts": {
-    "mtime": 1779108266.1586092,
-    "hash": "30aaeefd14301d6ef070a2dd3f2ad29c"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/search.ts": {
+    "mtime": 1779420421.0349355,
+    "hash": "2214c9548e54d125a87e929b44aa90d7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/correlator.ts": {
-    "mtime": 1779108266.1582525,
-    "hash": "3317edb4d5d9ae21aef4e8234482ba9e"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/correlator.ts": {
+    "mtime": 1779420421.0345078,
+    "hash": "640750401538ebf7bf9420a5bb595ef1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/system-probe.ts": {
-    "mtime": 1779108266.1586092,
-    "hash": "ecfd05b5fdd01d869cc3522f02432da7"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/system-probe.ts": {
+    "mtime": 1779420421.0349355,
+    "hash": "0bb345c29e445abae519c9aa709c316c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/__tests__/system-probe.test.ts": {
-    "mtime": 1779108266.1582525,
-    "hash": "68f3025819a9a7022511d5408e48cab8"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/__tests__/system-probe.test.ts": {
+    "mtime": 1779420421.0345078,
+    "hash": "220a96d39281a5782820332b25df6361"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/__tests__/search.test.ts": {
-    "mtime": 1779108266.1582525,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/__tests__/search.test.ts": {
+    "mtime": 1779420421.0345078,
     "hash": "4936a99c01e66b7f146c52f99cd9b7f8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/__tests__/integration.test.ts": {
-    "mtime": 1779108266.1582525,
-    "hash": "c8d8f144e23fef02fd06fbefef2ddf8e"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/__tests__/integration.test.ts": {
+    "mtime": 1779420421.0343738,
+    "hash": "fbdd875ba7cab8a2acbffe7f1c9acac8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/__tests__/embeddings.test.ts": {
-    "mtime": 1779108266.1582122,
-    "hash": "4a5b62bf6cb68b8d2e194cf5b3745991"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/__tests__/embeddings.test.ts": {
+    "mtime": 1779420421.0343204,
+    "hash": "92de34d6097dff1480ff51900c9ec4a1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/__tests__/enrichment.test.ts": {
-    "mtime": 1779108266.1582525,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/__tests__/enrichment.test.ts": {
+    "mtime": 1779420421.0343738,
     "hash": "06816d466578829460d4f15faf33c95e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/__tests__/scanner.test.ts": {
-    "mtime": 1779108266.1582525,
-    "hash": "b25b62ce97610a25bd777bf6089837df"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/__tests__/scanner.test.ts": {
+    "mtime": 1779420421.0345078,
+    "hash": "ae569e59e915fa1d5c4a9b464c298df0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/__tests__/hash-resolver.test.ts": {
-    "mtime": 1779108266.1582525,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/__tests__/hash-resolver.test.ts": {
+    "mtime": 1779420421.0343738,
     "hash": "971a02b04979025ec194422eb1727ee1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/__tests__/jsonl-async.test.ts": {
-    "mtime": 1779108266.1582525,
-    "hash": "ecfc7a49cabe5974274f7cae57bd6bd0"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/__tests__/jsonl-async.test.ts": {
+    "mtime": 1779420421.0345078,
+    "hash": "0b84020415877758c7578b49375c8c26"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/embeddings/providers.ts": {
-    "mtime": 1779108266.1585293,
-    "hash": "afb91429201ccf6d40b786f10ee1a401"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/embeddings/providers.ts": {
+    "mtime": 1779420421.0348315,
+    "hash": "4e3183aee4ddd220dd6db9db0f0e409f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/embeddings/index.ts": {
-    "mtime": 1779108266.1582525,
-    "hash": "18075e1c29449004247375cd837a3aa0"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/embeddings/index.ts": {
+    "mtime": 1779420421.0345078,
+    "hash": "5690dac860d306b7aa725bcba6d836ec"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/enrichment/index.ts": {
-    "mtime": 1779108266.1586092,
-    "hash": "ff35629ee4e936d1ba28dc80bde12146"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/enrichment/index.ts": {
+    "mtime": 1779420421.0349355,
+    "hash": "8c2b859798b26e34d67187b1f2a02d5f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/enrichment/enrich-session.ts": {
-    "mtime": 1779108266.1585293,
-    "hash": "deeb2365a3b6723c9d1cd7bb20778e05"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/enrichment/enrich-session.ts": {
+    "mtime": 1779420421.0348315,
+    "hash": "048a4fc24167966e8d91399408031ce9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/conversations/enrichment/model-fallback.ts": {
-    "mtime": 1779108266.1586092,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/conversations/enrichment/model-fallback.ts": {
+    "mtime": 1779420421.0349355,
     "hash": "86b71f6610bb521ce78e8d37c25dd9e8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/builder.ts": {
-    "mtime": 1779108266.1665595,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/builder.ts": {
+    "mtime": 1779420421.044855,
     "hash": "3f5fcfcbb2b4a2468e7e36cbdd26efc2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/continue-state.ts": {
-    "mtime": 1779108266.1665595,
-    "hash": "6814ba710291864bc70c2f34d97942b8"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/continue-state.ts": {
+    "mtime": 1779420421.044855,
+    "hash": "0cbea9339cf7f58d8564e3131a0178a8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/beads.ts": {
-    "mtime": 1779108266.1665595,
-    "hash": "fc579e360ef695adfdf9fe14b4aacba6"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/beads.ts": {
+    "mtime": 1779420421.044855,
+    "hash": "047b2856ae2190a9f1407cba00c68ba0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/dag-cli.ts": {
-    "mtime": 1779108266.1665595,
-    "hash": "d93485315d4bb1e6f952625b7d72d5f4"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/dag-cli.ts": {
+    "mtime": 1779420421.0455492,
+    "hash": "67fb67c48ec573f3d585e65a00e5dd54"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/acceptance-criteria.ts": {
-    "mtime": 1779108266.1665595,
-    "hash": "a3a0279ea8d4982e01ea37c411228412"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/acceptance-criteria.ts": {
+    "mtime": 1779420421.044855,
+    "hash": "b66fbeddc64a87a93880bf025806d1a6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/vbrief-index.ts": {
-    "mtime": 1779108266.1665595,
-    "hash": "a787083f3579edb9be449e6acbab9c57"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/vbrief-index.ts": {
+    "mtime": 1779420421.0458703,
+    "hash": "ea193993c9633664729c579e85507a18"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/lifecycle-io.ts": {
-    "mtime": 1779108266.1665595,
-    "hash": "0e2d58c41f4823cf2ce7ab42f0a9bf32"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/lifecycle-io.ts": {
+    "mtime": 1779420421.0458302,
+    "hash": "6d37ba31ec694a2994010cbc81f9dfe2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/lifecycle.ts": {
-    "mtime": 1779108266.1665595,
-    "hash": "f0070426c4c12a6a2312406b78501fcd"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/lifecycle.ts": {
+    "mtime": 1779420421.0458703,
+    "hash": "9f4bb8eee1c631e031ad807a87c35103"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/auto-synthesize.ts": {
-    "mtime": 1779108266.1665595,
-    "hash": "3313b68e2fc2913cac4c92a494b30a18"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/auto-synthesize.ts": {
+    "mtime": 1779420421.044855,
+    "hash": "2b52eb4f10891718cf924acab3090603"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/index.ts": {
-    "mtime": 1779108266.1665595,
-    "hash": "11301d5a1bc3252aa0a56507b50c8e0b"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/index.ts": {
+    "mtime": 1779420421.0455892,
+    "hash": "e596fc588e7cca7ab508e9d202f21843"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/io.ts": {
-    "mtime": 1779108266.1665595,
-    "hash": "e02ec882641d644d004a833c333a8c24"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/io.ts": {
+    "mtime": 1779420421.0455892,
+    "hash": "81a5a9875c8f761405a4a84da937d122"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/types.ts": {
-    "mtime": 1779108266.1665595,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/types.ts": {
+    "mtime": 1779420421.0458703,
     "hash": "77158e9f6538cd39d1e0f2e8bb2923d8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/dag.ts": {
-    "mtime": 1779108266.1665595,
-    "hash": "61b39d60b193145693203b1eb48bbd99"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/dag.ts": {
+    "mtime": 1779420421.0455892,
+    "hash": "7b597a5d893481cc8d71ba0ba6953514"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/__tests__/dag-writer-lock-dead-pid.test.ts": {
-    "mtime": 1779108266.1665595,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/__tests__/dag-writer-lock-dead-pid.test.ts": {
+    "mtime": 1779420421.044855,
     "hash": "c0b33cf218a57db69989d7ba75bfb48d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/__tests__/auto-synthesize.test.ts": {
-    "mtime": 1779108266.1665595,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/__tests__/auto-synthesize.test.ts": {
+    "mtime": 1779420421.044855,
     "hash": "271c8537a7c5760899e21243140de94a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/__tests__/continue-state.test.ts": {
-    "mtime": 1779108266.1665595,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/__tests__/continue-state.test.ts": {
+    "mtime": 1779420421.044855,
     "hash": "f193a4b6d0b8565fa9d83e581e1cd7d8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/__tests__/dag-writer-lock-recovery.test.ts": {
-    "mtime": 1779108266.1665595,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/__tests__/dag-writer-lock-recovery.test.ts": {
+    "mtime": 1779420421.044855,
     "hash": "eb456f01c70c90e5cd6fe22b6291e180"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/__tests__/continue-state-swarm.test.ts": {
-    "mtime": 1779108266.1665595,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/__tests__/continue-state-swarm.test.ts": {
+    "mtime": 1779420421.044855,
     "hash": "69e39dc6dd1b44851cb0960c54d0b69c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/__tests__/beads.test.ts": {
-    "mtime": 1779108266.1665595,
-    "hash": "7d05ffc8fda28eb4f9b17242c8706066"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/__tests__/beads.test.ts": {
+    "mtime": 1779420421.044855,
+    "hash": "b6eba675c2f349b09853541f19cf1576"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/__tests__/lifecycle-io.test.ts": {
-    "mtime": 1779108266.1665595,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/__tests__/lifecycle-io.test.ts": {
+    "mtime": 1779420421.044855,
     "hash": "ab7ced2e5c092fe95267753a65f5bd27"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/__tests__/dag-pan977.test.ts": {
-    "mtime": 1779108266.1665595,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/__tests__/dag-pan977.test.ts": {
+    "mtime": 1779420421.044855,
     "hash": "66ec338be5240c0a9a29d183db5dfb0f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/__tests__/acceptance-criteria.test.ts": {
-    "mtime": 1779108266.1665044,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/__tests__/acceptance-criteria.test.ts": {
+    "mtime": 1779420421.044855,
     "hash": "0aa8ca0254ea91a3982db0feb3d6216d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/__tests__/dag.test.ts": {
-    "mtime": 1779108266.1665595,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/__tests__/dag.test.ts": {
+    "mtime": 1779420421.044855,
     "hash": "34dc1e76884b958fb9488307d1bdc396"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/__tests__/lifecycle.test.ts": {
-    "mtime": 1779108266.1665595,
-    "hash": "306912b722605abb3c007f854940706a"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/__tests__/lifecycle.test.ts": {
+    "mtime": 1779420421.044855,
+    "hash": "30dddad3454ab869ae86e9cca675a18e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/__tests__/create-beads.test.ts": {
-    "mtime": 1779108266.1665595,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/__tests__/create-beads.test.ts": {
+    "mtime": 1779420421.044855,
     "hash": "c477422a6090563bb00c0683ea1de139"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/vbrief/__tests__/io.test.ts": {
-    "mtime": 1779108266.1665595,
-    "hash": "aaea34b926a50c428051c2ad6b2a0cb7"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/vbrief/__tests__/io.test.ts": {
+    "mtime": 1779420421.044855,
+    "hash": "4fb0536e44302a31c552919f0abae9ff"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/git/operations.ts": {
-    "mtime": 1779108266.16131,
-    "hash": "c8c9e6da8017f07d476b6cedaee50549"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/git/operations.ts": {
+    "mtime": 1779420421.0378118,
+    "hash": "646effff0b6258b0adc58b99f14533ab"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/git/__tests__/operations.test.ts": {
-    "mtime": 1779108266.16131,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/git/__tests__/operations.test.ts": {
+    "mtime": 1779420421.037788,
     "hash": "ff09eb6673a390362e4897566bc42244"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/git/__tests__/divergence-e2e.test.ts": {
-    "mtime": 1779108266.161271,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/git/__tests__/divergence-e2e.test.ts": {
+    "mtime": 1779420421.0377245,
     "hash": "90a6f1d77e6348cee775333ceda887ec"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/code-review-agent-definitions.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/code-review-agent-definitions.test.ts": {
+    "mtime": 1779420421.0259705,
     "hash": "181a7b1c1a05058dc5004e8711badd92"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/agent-directory-cleanup.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/agent-directory-cleanup.test.ts": {
+    "mtime": 1779420421.0259705,
     "hash": "a504b2689ad3a3fbe47d7478d13fe21e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/activity-logger.test.ts": {
-    "mtime": 1779108266.1521883,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/activity-logger.test.ts": {
+    "mtime": 1779420421.0259466,
     "hash": "3420574dc2d3ee1dfcfc09de39eaf7db"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/docker-stats.test.ts": {
-    "mtime": 1779108266.1522126,
-    "hash": "52fb8025f73b3f4209cd080b8909f1ee"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/docker-stats.test.ts": {
+    "mtime": 1779420421.0259705,
+    "hash": "9ea4fb91c613c2949439ea37d7881015"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/agents-caveman.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/agents-caveman.test.ts": {
+    "mtime": 1779420421.0259705,
     "hash": "724842fe1816e1031316202885dd5430"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/settings-api.test.ts": {
-    "mtime": 1779150733.724829,
-    "hash": "fbf622e309777ac8c710ef0c42c9898d"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/settings-api.test.ts": {
+    "mtime": 1779420421.0266702,
+    "hash": "17bbe11affff33b01f45d51a510c28b8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/pan-871-agent-id-normalization.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/pan-871-agent-id-normalization.test.ts": {
+    "mtime": 1779420421.0259705,
     "hash": "37e2700378aa46d8e33ca5e83412d008"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/claude-auth.test.ts": {
-    "mtime": 1779108266.1522126,
-    "hash": "2862fc68703f587f8b3859e5de8fc803"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/errors.test.ts": {
+    "mtime": 1779420421.0259705,
+    "hash": "758ba3bdb0bf05d239d598a82e1e039f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/tts-speak.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/claude-auth.test.ts": {
+    "mtime": 1779420421.0259705,
+    "hash": "63b10ba8207841625d5e7e93134ddda5"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/tts-speak.test.ts": {
+    "mtime": 1779420421.0266702,
     "hash": "3b92b1633231530fcaa6c974accafc3c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/claude-settings-overlay.test.ts": {
-    "mtime": 1779108266.1522126,
-    "hash": "ae308c6f0373abd13dea49388c1b12a4"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/claude-settings-overlay.test.ts": {
+    "mtime": 1779420421.0259705,
+    "hash": "1f8ad8bdbab69d6c8b8c95151a2629a4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/harness.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/harness.test.ts": {
+    "mtime": 1779420421.0259705,
     "hash": "fa7c2d64791b5cab3c86a1be49d8629f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/harness-policy.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/harness-policy.test.ts": {
+    "mtime": 1779420421.0259705,
     "hash": "05122b9fccebf3788eaa77f22494d1d2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/config-yaml-async.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/config-yaml-async.test.ts": {
+    "mtime": 1779420421.0259705,
     "hash": "36385a53c426ee6f013ae453dd13975b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/agents-mark-running.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/agents-mark-running.test.ts": {
+    "mtime": 1779420421.0259705,
     "hash": "69760189895db895285bb75e3d79c27c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/tracker-priority.test.ts": {
-    "mtime": 1779108266.1522126,
-    "hash": "115a2b409e072a3f4bdabc90ec66f582"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/tracker-priority.test.ts": {
+    "mtime": 1779420421.0266702,
+    "hash": "62f9794782ed7b5003655d926774c6e1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/restart-lock.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/restart-lock.test.ts": {
+    "mtime": 1779420421.0266702,
     "hash": "b483e56dd26e06dee628945f27eb91be"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/agent-state-role.test.ts": {
-    "mtime": 1779165426.1981256,
-    "hash": "ad46eaa27cceb275c5492eeceb8737bf"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/agent-state-role.test.ts": {
+    "mtime": 1779420421.0259705,
+    "hash": "c40acb4de3618ecd2b8f334faa686a04"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/tts-daemon.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/tts-daemon.test.ts": {
+    "mtime": 1779420421.0266702,
     "hash": "74c6c89397e9b937983c1d847b37f4cc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/restart-status.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/restart-status.test.ts": {
+    "mtime": 1779420421.0266702,
     "hash": "1c1fa397518ca6ca21e4308c7ef964a9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/permission-mode-leak.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/permission-mode-leak.test.ts": {
+    "mtime": 1779420421.0259705,
     "hash": "ccc8b85ec679954efc880fa8a6d41ec6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/role-definitions.test.ts": {
-    "mtime": 1779108266.1522126,
-    "hash": "1105b96126cbd3d0aed36d96b1ebb583"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/role-definitions.test.ts": {
+    "mtime": 1779420421.0266702,
+    "hash": "b1ea4d3993d915abd448a54e1833fd72"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/manifest.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/manifest.test.ts": {
+    "mtime": 1779420421.0259705,
     "hash": "660fdf1751d64fd214772861ecfd83b8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/deliver-agent-message.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/deliver-agent-message.test.ts": {
+    "mtime": 1779420421.0259705,
     "hash": "26d4ea56e2d0d85d0e80008d634c0cd6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/beads-restore.test.ts": {
-    "mtime": 1779108266.1522126,
-    "hash": "0e217005a14c7507175a0dca7a753e2c"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/beads-restore.test.ts": {
+    "mtime": 1779420421.0259705,
+    "hash": "303a7add0e8ef009f6e1cb3ef1ec6640"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/paths.test.ts": {
-    "mtime": 1779108266.1522126,
-    "hash": "5ecfce95a1b5056d1565f55933498494"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/paths.test.ts": {
+    "mtime": 1779420421.0259705,
+    "hash": "28921e7f92d69ba4af1712d6c4417c12"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/claude-permissions.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/claude-permissions.test.ts": {
+    "mtime": 1779420421.0259705,
     "hash": "9261482cf23b4489bf4126a1ba63670d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/config-yaml-roles.test.ts": {
-    "mtime": 1779150733.724829,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/config-yaml-roles.test.ts": {
+    "mtime": 1779420421.0259705,
     "hash": "457088a45f2958a6e4bc9575832b32ec"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/remote-settings-no-leak.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/remote-settings-no-leak.test.ts": {
+    "mtime": 1779420421.0259705,
     "hash": "df5b7eb79e6a6edd4515a110bb199cf6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/model-validation.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/model-validation.test.ts": {
+    "mtime": 1779420421.0259705,
     "hash": "80759a4b6d70b9c3843c4947d65c39ba"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/stashes.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/stashes.test.ts": {
+    "mtime": 1779420421.0266702,
     "hash": "2a7dbf16f5cb90c015c2a8477a38ec6a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/tldr-metrics.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/tldr-metrics.test.ts": {
+    "mtime": 1779420421.0266702,
     "hash": "57402523bb13165fd74d32dd15cca367"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/agent-input-detection.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/agent-input-detection.test.ts": {
+    "mtime": 1779420421.0259705,
     "hash": "f69459fc1e5f50b7690aa84474365a60"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/tts-voices.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/tts-voices.test.ts": {
+    "mtime": 1779420421.0266702,
     "hash": "39f01f956eb12b9bfd815c104e1f873b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/agent-state-harness.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/agent-state-harness.test.ts": {
+    "mtime": 1779420421.0259705,
     "hash": "3bb102b8bc639d601f068bccdfe24540"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/sync-pi-settings.test.ts": {
-    "mtime": 1779108266.1522126,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/sync-pi-settings.test.ts": {
+    "mtime": 1779420421.0266702,
     "hash": "1916fd6ddf062e7094bff2ec9c35ea2e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/__tests__/launcher-generator.test.ts": {
-    "mtime": 1779150733.4048183,
-    "hash": "773a878c6e52e3ece32bbf5c98351fdd"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/__tests__/launcher-generator.test.ts": {
+    "mtime": 1779420421.0259705,
+    "hash": "ae3b9c1836b83fc3d665e0cfe2535eff"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/channels/panopticon-bridge.ts": {
-    "mtime": 1779108266.1540782,
-    "hash": "154522d0ce287ef0aeef7169c54f1382"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/channels/panopticon-bridge.ts": {
+    "mtime": 1779420421.0288315,
+    "hash": "6394f4bd19489e396a07fb5844391c8f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/channels/permission-payload.ts": {
-    "mtime": 1779108266.1540782,
-    "hash": "c8c8b52fa7552136b48784203af30cac"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/channels/permission-payload.ts": {
+    "mtime": 1779420421.0288315,
+    "hash": "dafadda16ae982938a27d9ff61bad588"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/channels/__tests__/panopticon-bridge.test.ts": {
-    "mtime": 1779108266.1540782,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/channels/__tests__/panopticon-bridge.test.ts": {
+    "mtime": 1779420421.0288315,
     "hash": "529c2e6b9c97fee736e11476c314ae72"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/model-research/test-selection.ts": {
-    "mtime": 1779108266.1621656,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/model-research/test-selection.ts": {
+    "mtime": 1779420421.0397692,
     "hash": "0d3fa3473d2f8000514424715a5951a0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/database/merge-set-db.ts": {
-    "mtime": 1779108266.1605232,
-    "hash": "1313aae10fbd1f6fe88ece416cb3cde7"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/database/merge-set-db.ts": {
+    "mtime": 1779420421.0367672,
+    "hash": "f4d67faff624bcfbecc322cbbd3b592a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/database/merge-queue-db.ts": {
-    "mtime": 1779108266.1605232,
-    "hash": "1ab9484609ade425779f8c6822fabfc1"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/database/merge-queue-db.ts": {
+    "mtime": 1779420421.0367672,
+    "hash": "87e3da2f6e8205a0c91da3967ad75781"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/database/review-status-db.ts": {
-    "mtime": 1779108266.1605232,
-    "hash": "8b54b4796c95d16d79930dc70a98019c"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/database/review-status-db.ts": {
+    "mtime": 1779420421.0367672,
+    "hash": "1005b473281491cdf7d3fefa9ef7f20d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/database/app-settings.ts": {
-    "mtime": 1779150733.6538267,
-    "hash": "1d035e4fe74f162a0f1a21a127f0fe8a"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/database/app-settings.ts": {
+    "mtime": 1779420421.0364208,
+    "hash": "fd62f29325bf5f148a847348cfc1ee5a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/database/schema.ts": {
-    "mtime": 1779108266.1605232,
-    "hash": "b6ed2839d25bf3cf1828f7adc506a567"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/database/schema.ts": {
+    "mtime": 1779420421.037075,
+    "hash": "d09388cd7f4cbac192d42c5366377536"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/database/index.ts": {
-    "mtime": 1779108266.1605232,
-    "hash": "9444edf51e88d80a7e5e99fc33cfbb27"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/database/index.ts": {
+    "mtime": 1779420421.0367672,
+    "hash": "ecd52932d384292e98d3591da28337fc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/database/conversations-db.ts": {
-    "mtime": 1779108266.1605232,
-    "hash": "e1b22ca6240499e7f8f8e64d034ee1d9"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/database/conversations-db.ts": {
+    "mtime": 1779420421.0364208,
+    "hash": "b8dad17dbe3e26426db0d77148801901"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/database/cost-events-db.ts": {
-    "mtime": 1779108266.1605232,
-    "hash": "64088c973095d5b491d3fa38ef51fdfe"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/database/cost-events-db.ts": {
+    "mtime": 1779420421.0364208,
+    "hash": "bcd207016eb8198eb8a8e7d128b760d4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/database/discovered-sessions-db.ts": {
-    "mtime": 1779108266.1605232,
-    "hash": "8f64c4b6bfe39a463a9696be48d92688"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/database/discovered-sessions-db.ts": {
+    "mtime": 1779420421.0367672,
+    "hash": "f69a0bf502be9f7ed8f38b769911d966"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/database/health-events-db.ts": {
-    "mtime": 1779108266.1605232,
-    "hash": "639bcbd955253cd86997246fd5e9005f"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/database/health-events-db.ts": {
+    "mtime": 1779420421.0367672,
+    "hash": "4fb67e762786eea9f7f3e4955476b5c5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/database/__tests__/stuck-schema.test.ts": {
-    "mtime": 1779108266.1605232,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/database/__tests__/stuck-schema.test.ts": {
+    "mtime": 1779420421.0364208,
     "hash": "a3aef80a232e620d49fcfa68bc9ae9b5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/database/__tests__/conversations-db.test.ts": {
-    "mtime": 1779108266.160482,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/database/__tests__/conversations-db.test.ts": {
+    "mtime": 1779420421.0363843,
     "hash": "cb1083e2b226f8fe6709d7dacb90cc9e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/database/__tests__/discovered-sessions-db.test.ts": {
-    "mtime": 1779108266.1605232,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/database/__tests__/discovered-sessions-db.test.ts": {
+    "mtime": 1779420421.0364208,
     "hash": "0afbe40634a826c550f59afb0a4d14f5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/database/__tests__/cost-events-caveman.test.ts": {
-    "mtime": 1779108266.1605232,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/database/__tests__/cost-events-caveman.test.ts": {
+    "mtime": 1779420421.0364208,
     "hash": "b70b5a33bdfe13f386aa205edfb94541"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/database/__tests__/git-activity.test.ts": {
-    "mtime": 1779108266.1605232,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/database/__tests__/git-activity.test.ts": {
+    "mtime": 1779420421.0364208,
     "hash": "1714c4d34f3a61972031c9818e50627d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/prereqs/registry.ts": {
-    "mtime": 1779108266.1627212,
-    "hash": "3387e41ac2cfe8ab894d8576a80a8c89"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/prereqs/registry.ts": {
+    "mtime": 1779420421.041004,
+    "hash": "d3ac0ea3e3ab0ac5fc1b6136bb54d292"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/lifecycle/archive-planning.ts": {
-    "mtime": 1779108266.16131,
-    "hash": "d7db68696e401be49a659c65a957358b"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/lifecycle/archive-planning.ts": {
+    "mtime": 1779420421.0381713,
+    "hash": "263748de1bc1d6df8fd0b5877b3c1b6f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/lifecycle/workflows.ts": {
-    "mtime": 1779108266.1617014,
-    "hash": "47985a5e4ace6fb616c41796c8f3e955"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/lifecycle/workflows.ts": {
+    "mtime": 1779420421.0384476,
+    "hash": "1ea987b421d36812c5e7ca9a109b9ca1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/lifecycle/compact-beads.ts": {
-    "mtime": 1779108266.1617014,
-    "hash": "44d0fd217c1481d3529aa502782e4526"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/lifecycle/compact-beads.ts": {
+    "mtime": 1779420421.0384068,
+    "hash": "0f2fa067d5566c95196f371d55664cbe"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/lifecycle/label-cleanup.ts": {
-    "mtime": 1779108266.1617014,
-    "hash": "dabcd1eba8635fbcf5f7f50c31d7dbf9"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/lifecycle/label-cleanup.ts": {
+    "mtime": 1779420421.0384476,
+    "hash": "2b3e55dadd5878e47276edbc0867dabb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/lifecycle/index.ts": {
-    "mtime": 1779108266.1617014,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/lifecycle/index.ts": {
+    "mtime": 1779420421.0384068,
     "hash": "bce01ad9c1c88b9ccd373bcddaf16689"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/lifecycle/teardown-workspace.ts": {
-    "mtime": 1779108266.1617014,
-    "hash": "47edec6b5e8ca29ab8083ac5a98d479a"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/lifecycle/teardown-workspace.ts": {
+    "mtime": 1779420421.0384476,
+    "hash": "90209b22a46d55b8acd806f21b9fb7a6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/lifecycle/close-issue.ts": {
-    "mtime": 1779108266.1617014,
-    "hash": "981cef36e37c23be94a49ef28cbc4bf6"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/lifecycle/close-issue.ts": {
+    "mtime": 1779420421.0383232,
+    "hash": "ae000fd0cb74869c4e7fac3e8c2e28d8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/lifecycle/types.ts": {
-    "mtime": 1779108266.1617014,
-    "hash": "7f301076c8c2dedeb43d9ddee6ad1d28"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/lifecycle/types.ts": {
+    "mtime": 1779420421.0384476,
+    "hash": "cfdd7c552f908238cb9af4b3e858accb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/checkpoint/checkpoint-manager.ts": {
-    "mtime": 1779108266.1540782,
-    "hash": "2e8102440d30577258f6b21a01c96b2e"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/checkpoint/checkpoint-manager.ts": {
+    "mtime": 1779420421.0288315,
+    "hash": "33dda1251feba1204931e19013272075"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/remote/interface.ts": {
-    "mtime": 1779108266.1635168,
-    "hash": "9122d75e44b26924d2c7e247667d3d79"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/remote/interface.ts": {
+    "mtime": 1779420421.0414193,
+    "hash": "12a2653bbe3114b6b1e5e6874560afe8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/remote/fly-provider.ts": {
-    "mtime": 1779108266.1635168,
-    "hash": "a9919999e2ab66a2ebd43f6c3074c7fd"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/remote/fly-provider.ts": {
+    "mtime": 1779420421.0414193,
+    "hash": "5a2bb3abb95f73cdb0e3deeae5780a9c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/remote/workspace-metadata.ts": {
-    "mtime": 1779108266.1635168,
-    "hash": "829500af844eebf2aa558f5d6978d6bf"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/remote/workspace-metadata.ts": {
+    "mtime": 1779420421.0416498,
+    "hash": "b795f9b469df03fe638c38cc8327592c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/remote/remote-agents.ts": {
-    "mtime": 1779108266.1635168,
-    "hash": "e362caac014e624c63e96cdade070039"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/remote/remote-agents.ts": {
+    "mtime": 1779420421.0416498,
+    "hash": "d5250260d8acc612ac5387f0d77106c5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/remote/fly-api.ts": {
-    "mtime": 1779108266.1627212,
-    "hash": "613340b33f3e1191592b88f65c9641ff"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/remote/fly-api.ts": {
+    "mtime": 1779420421.0414193,
+    "hash": "e3af133eb1efb850e71b27203d70ec34"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/remote/index.ts": {
-    "mtime": 1779108266.1635168,
-    "hash": "f70d442a40dcf4b131bfc81ba37ce343"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/remote/index.ts": {
+    "mtime": 1779420421.0414193,
+    "hash": "4b2a12216ff57ff644aff86a703131c1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/costs/aggregator.ts": {
-    "mtime": 1779108266.159302,
-    "hash": "39e3b86e591fc435ee29fedf31337b3f"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/costs/aggregator.ts": {
+    "mtime": 1779420421.0358355,
+    "hash": "ae59e97973dfc06f7e4fe43922c45576"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/costs/events.ts": {
-    "mtime": 1779108266.159302,
-    "hash": "5979ab6d884849a69552bb95f7c618cc"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/costs/events.ts": {
+    "mtime": 1779420421.0358355,
+    "hash": "433ab3d40fdc4e94dadce70923601f7f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/costs/migration.ts": {
-    "mtime": 1779108266.159302,
-    "hash": "02f8e7f5be0ec0c6030191885feae75d"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/costs/migration.ts": {
+    "mtime": 1779420421.0358355,
+    "hash": "e1006efe8ff0c31f3510db705c9463d3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/costs/sync-wal.ts": {
-    "mtime": 1779108266.159302,
-    "hash": "88cde7ead34ed986fb36cd9b16ffdc19"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/costs/sync-wal.ts": {
+    "mtime": 1779420421.0358355,
+    "hash": "30202c7d57bb3e08e31585d4e51dc8f8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/costs/wal.ts": {
-    "mtime": 1779108266.159302,
-    "hash": "44b5567bf45c5b8ba7456d25cbaeafb9"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/costs/wal.ts": {
+    "mtime": 1779420421.0358355,
+    "hash": "158f0867182ac2cf06f70456bd9c43c3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/costs/index.ts": {
-    "mtime": 1779108266.159302,
-    "hash": "86f5ff1f5835692b20da958b786ae3a8"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/costs/index.ts": {
+    "mtime": 1779420421.0358355,
+    "hash": "7f6ded5a6da38aca1e022bbec21719d8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/costs/retention.ts": {
-    "mtime": 1779108266.159302,
-    "hash": "3597efb7eceaed391eb3d8994ab117bb"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/costs/retention.ts": {
+    "mtime": 1779420421.0358355,
+    "hash": "cae5122019c54251cf548fb95fb05bbc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/costs/reconciler.ts": {
-    "mtime": 1779108266.159302,
-    "hash": "3a542aa49bdbae7d36c1a712b4e1c7f8"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/costs/reconciler.ts": {
+    "mtime": 1779420421.0358355,
+    "hash": "ba5031f840aa7211d5cf365fa6a0725a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/costs/__tests__/retention.test.ts": {
-    "mtime": 1779108266.159302,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/costs/__tests__/retention.test.ts": {
+    "mtime": 1779420421.0358355,
     "hash": "f715ea472c6abce972c984b57bbe1f2f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/costs/__tests__/cost-calculation.test.ts": {
-    "mtime": 1779108266.159302,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/costs/__tests__/cost-calculation.test.ts": {
+    "mtime": 1779420421.0358355,
     "hash": "f07b7110fe795b766b5fc16a4f7c7071"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/costs/__tests__/events.test.ts": {
-    "mtime": 1779108266.159302,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/costs/__tests__/events.test.ts": {
+    "mtime": 1779420421.0358355,
     "hash": "aeb35733c2a149a855f3bd02e2ce9eb8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/costs/__tests__/aggregator.test.ts": {
-    "mtime": 1779108266.1592665,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/costs/__tests__/aggregator.test.ts": {
+    "mtime": 1779420421.035797,
     "hash": "8f2d8c603ba3bcc2f6c34a5863dcf820"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/costs/__tests__/migration.test.ts": {
-    "mtime": 1779108266.159302,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/costs/__tests__/migration.test.ts": {
+    "mtime": 1779420421.0358355,
     "hash": "80178e4fca7d8c14aafca3e6fdd9ac9a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/caveman/setup.ts": {
-    "mtime": 1779108266.1538281,
-    "hash": "9740b9de84c60a5a80d7d1afcd11c46e"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/caveman/setup.ts": {
+    "mtime": 1779420421.0285335,
+    "hash": "de4b6b7779c822c93ab862886f058c4f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/caveman/workspace.ts": {
-    "mtime": 1779108266.1539624,
-    "hash": "04109f395a7c6a65453a604a959cacfb"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/caveman/workspace.ts": {
+    "mtime": 1779420421.028682,
+    "hash": "cda19a993a2419e9b5e537470552f80d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/caveman/compress/cli.py": {
-    "mtime": 1779108266.1538281,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/caveman/compress/cli.py": {
+    "mtime": 1779420421.0285335,
     "hash": "177865ec2a59e796fb8ba7f4d1398fc2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/caveman/compress/validate.py": {
-    "mtime": 1779108266.1538281,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/caveman/compress/validate.py": {
+    "mtime": 1779420421.0285335,
     "hash": "4f286afdcf421c18131de3505516a5d7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/caveman/compress/__main__.py": {
-    "mtime": 1779108266.1538281,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/caveman/compress/__main__.py": {
+    "mtime": 1779420421.0285335,
     "hash": "746aff14c3a098a28fe9d01d54f174a9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/caveman/compress/compress.py": {
-    "mtime": 1779108266.1538281,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/caveman/compress/compress.py": {
+    "mtime": 1779420421.0285335,
     "hash": "f384d7a8b875063322051e4c46998af0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/caveman/compress/detect.py": {
-    "mtime": 1779108266.1538281,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/caveman/compress/detect.py": {
+    "mtime": 1779420421.0285335,
     "hash": "7917f0cb798e36bf4710ba81bee2b95c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/caveman/compress/__init__.py": {
-    "mtime": 1779108266.1537168,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/caveman/compress/__init__.py": {
+    "mtime": 1779420421.028408,
     "hash": "4bfea67395a7ba04f363df51355d1ef8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/caveman/__tests__/setup.test.ts": {
-    "mtime": 1779108266.1536791,
-    "hash": "389b8b0378dfa39019943e93a28d4a47"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/caveman/__tests__/setup.test.ts": {
+    "mtime": 1779420421.0283577,
+    "hash": "d6ffcb21055763b975a1aa4e8a3200a9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/caveman/__tests__/workspace.test.ts": {
-    "mtime": 1779108266.1537168,
-    "hash": "db86cf73631401d7800fe64df31bc89a"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/caveman/__tests__/workspace.test.ts": {
+    "mtime": 1779420421.028408,
+    "hash": "424137614f756b41563a417168ba67cc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/voice/turn-queue.ts": {
-    "mtime": 1779108266.1681511,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/paths.ts": {
+    "mtime": 1779420421.039005,
+    "hash": "65f90271ec2362c2759d763a18edf892"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/reconciliation.ts": {
+    "mtime": 1779420421.0391636,
+    "hash": "a279d09d4c2617c5204b74e48c09953f"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/observations.ts": {
+    "mtime": 1779420421.039005,
+    "hash": "454010c44f56146c6f35758737d7d54b"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/cli.ts": {
+    "mtime": 1779420421.038751,
+    "hash": "d9098c137aed0a6eea37014e764be329"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/checkpoint-client.ts": {
+    "mtime": 1779420421.0387259,
+    "hash": "4c3c7d8f3d6f9571aab69b5dc2dd3b9f"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/subagent-filter.ts": {
+    "mtime": 1779420421.0391636,
+    "hash": "ea6a0235a12d89d09f6d2002f936b29f"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/pending.ts": {
+    "mtime": 1779420421.039005,
+    "hash": "62e1f21dac03c67e05b11de444e4b902"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/fts-db.ts": {
+    "mtime": 1779420421.038751,
+    "hash": "7e933dcd83bda9d57edf1b42bda4ea7e"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/settings.ts": {
+    "mtime": 1779420421.0391636,
+    "hash": "a7ba1a12ac55e65e7ff39d5cb71ef27c"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/pipeline.ts": {
+    "mtime": 1779420421.039005,
+    "hash": "8b2c01979e9e7077c597443d3ac660a0"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/poller.ts": {
+    "mtime": 1779420421.039005,
+    "hash": "e036b46243bab4d563b282db688ad3ef"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/health.ts": {
+    "mtime": 1779420421.038751,
+    "hash": "e23774e08c9124cf8a37636b96a3d099"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/transcript-source.ts": {
+    "mtime": 1779420421.0391636,
+    "hash": "cb1b72bc9c61bb8d4da9b47d9e808997"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/rollup.ts": {
+    "mtime": 1779420421.0391636,
+    "hash": "1f948524a20790e46d65786388453bfa"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/extract.ts": {
+    "mtime": 1779420421.038751,
+    "hash": "cf0efe46a738d7019b4fe08ae880e055"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/checkpoints.ts": {
+    "mtime": 1779420421.038751,
+    "hash": "f9216d663c144354cdbad28ada4564ac"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/compress.ts": {
+    "mtime": 1779420421.038751,
+    "hash": "0922462394fdbc775e5c8cdaee0a378f"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/checkpoint-worker.ts": {
+    "mtime": 1779420421.038751,
+    "hash": "8ac15110a1e741882c73387a9dd17bb7"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/injection.ts": {
+    "mtime": 1779420421.0389676,
+    "hash": "01b7fd3d373a0b81df918647dbf32f9b"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/query-expansion.ts": {
+    "mtime": 1779420421.0391636,
+    "hash": "a317f4e327bddb45617f77cfe5cc00e8"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/search.ts": {
+    "mtime": 1779420421.0391636,
+    "hash": "d0480d6b7a7a98893293fb36f46e2423"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/worker-pool.ts": {
+    "mtime": 1779420421.0391636,
+    "hash": "f6c4a3127d0d8049f320bf869802e9f0"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/providers/registry.ts": {
+    "mtime": 1779420421.0391636,
+    "hash": "cf493e596e1d280b14284524e4df01e4"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/providers/cliproxy.ts": {
+    "mtime": 1779420421.0391636,
+    "hash": "90d1a44a849887037aad89a02778a8fe"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/providers/policy.ts": {
+    "mtime": 1779420421.0391636,
+    "hash": "e8cd12dbffc45cd102c39256e50354c7"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/providers/anthropic.ts": {
+    "mtime": 1779420421.039005,
+    "hash": "aa05b4be7daee9da38d35cdd16d6b5cb"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/providers/index.ts": {
+    "mtime": 1779420421.0391636,
+    "hash": "cfcd3c2a10bf64390e38685f112de089"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/memory/providers/types.ts": {
+    "mtime": 1779420421.0391636,
+    "hash": "5d264b38c6f4a92a8ce9fad7c36151b5"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/voice/turn-queue.ts": {
+    "mtime": 1779420421.0468533,
     "hash": "d69d8b12a1b11ec5bd713bded956a72f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/voice/google-cloud-transcription.ts": {
-    "mtime": 1779108266.16801,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/voice/google-cloud-transcription.ts": {
+    "mtime": 1779420421.0467155,
     "hash": "1eef416b26f59aeb7b74b0f09f07f8de"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/voice/transcription.ts": {
-    "mtime": 1779108266.1681511,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/voice/transcription.ts": {
+    "mtime": 1779420421.0468533,
     "hash": "352ec0e5502ec7d2460a195315f1f417"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/voice/transcription-manager.ts": {
-    "mtime": 1779108266.1681511,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/voice/transcription-manager.ts": {
+    "mtime": 1779420421.0468533,
     "hash": "6071df580e62be18e85a2786cad696a8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/supervisor/server.ts": {
-    "mtime": 1779108266.16801,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/supervisor/server.ts": {
+    "mtime": 1779420421.0467155,
     "hash": "32e5e79dff63eaa46f77ac2a96ed2aad"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/supervisor/tts-watchdog.ts": {
-    "mtime": 1779108266.16801,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/supervisor/tts-watchdog.ts": {
+    "mtime": 1779420421.0467155,
     "hash": "8f129b56cb3f3f3d1ca4c7956f9557f2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/supervisor/watchdog.ts": {
-    "mtime": 1779108266.16801,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/supervisor/watchdog.ts": {
+    "mtime": 1779420421.0467155,
     "hash": "cd47701351ddf7a77fa922c8679b1d49"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/supervisor/__tests__/tts-watchdog.test.ts": {
-    "mtime": 1779108266.1679804,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/supervisor/__tests__/tts-watchdog.test.ts": {
+    "mtime": 1779420421.0466847,
     "hash": "7c2f1fc5d51509154004629d0b8a2804"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/supervisor/__tests__/watchdog.test.ts": {
-    "mtime": 1779108266.16801,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/supervisor/__tests__/watchdog.test.ts": {
+    "mtime": 1779420421.0467155,
     "hash": "cd46dd93438d2dd2eb0e605d37eb3950"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/lib/health-filtering.ts": {
-    "mtime": 1779108266.1302733,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/lib/health-filtering.ts": {
+    "mtime": 1779420421.0027323,
     "hash": "a96d2b47959a3c79d89729e041a50ada"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/tailwind.config.js": {
-    "mtime": 1779108266.1255121,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/tailwind.config.js": {
+    "mtime": 1779420420.9970863,
     "hash": "07f428ce857d6370c2bebe1ad4367d4c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/postcss.config.js": {
-    "mtime": 1779108266.1123042,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/postcss.config.js": {
+    "mtime": 1779420420.983647,
     "hash": "c735540bb63936a123bc867d950c9f69"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/playwright.config.ts": {
-    "mtime": 1779108266.1123042,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/playwright.config.ts": {
+    "mtime": 1779420420.983647,
     "hash": "f2ba985b7cb2a8ad4459e621745d7092"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/vitest.config.ts": {
-    "mtime": 1779108266.1302733,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/vitest.config.ts": {
+    "mtime": 1779420421.0027323,
     "hash": "2ca29329f5d3bfebbfe3fbe9be528bf8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/vite.config.ts": {
-    "mtime": 1779108266.1302733,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/vite.config.ts": {
+    "mtime": 1779420421.0027323,
     "hash": "7f5cafe9a348dc8a8d75ad42bf7cdca8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/tests/terminal-latency.spec.ts": {
-    "mtime": 1779108266.1256812,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/tests/terminal-latency.spec.ts": {
+    "mtime": 1779420420.9979978,
     "hash": "c9db9c6d1a5fd7cbd11825655e382734"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/tests/multi-model-settings.spec.ts": {
-    "mtime": 1779108266.1256812,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/tests/multi-model-settings.spec.ts": {
+    "mtime": 1779420420.9973366,
     "hash": "59d6e3a48e62a39a016551c409a6fa1d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/tests/command-deck-resource-strip.spec.ts": {
-    "mtime": 1779108266.1255121,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/tests/command-deck-resource-strip.spec.ts": {
+    "mtime": 1779420420.9970863,
     "hash": "bd66bb0878573d50f443383c1c275cab"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/tests/theme-screenshots.spec.ts": {
-    "mtime": 1779108266.1256812,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/tests/theme-screenshots.spec.ts": {
+    "mtime": 1779420420.9979978,
     "hash": "b5a1119973de3a78366766923890f6e7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/tests/hide-tool-calls.spec.ts": {
-    "mtime": 1779108266.1256812,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/tests/hide-tool-calls.spec.ts": {
+    "mtime": 1779420420.9973366,
     "hash": "fb3dd87a493dcc78106801cf018c2e02"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/tests/experimental-channels-toggle.spec.ts": {
-    "mtime": 1779108266.1256812,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/tests/pan-1190-verify-close-out.spec.ts": {
+    "mtime": 1779420420.997534,
+    "hash": "314e6fae5213fdb776d6bce63acd1453"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/tests/experimental-channels-toggle.spec.ts": {
+    "mtime": 1779420420.9973366,
     "hash": "1b1a4324d75b2bc3fa85c8938ebda41e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/tests/ephemeral-specialist-ui.spec.ts": {
-    "mtime": 1779108266.1256812,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/tests/drawer-active-agent-stream.spec.ts": {
+    "mtime": 1779420420.9973366,
+    "hash": "697bee6c551b191289ae8336bd69beda"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/tests/ephemeral-specialist-ui.spec.ts": {
+    "mtime": 1779420420.9973366,
     "hash": "5168e832371cb1afab6f9ce57df9de1d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/tests/pan866-zone-c-tabs.spec.ts": {
-    "mtime": 1779108266.1256812,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/tests/pan-1230-command-deck-lens.spec.ts": {
+    "mtime": 1779420420.997534,
+    "hash": "5884449cb97dc8e3b2bc93502242a335"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/tests/pan866-zone-c-tabs.spec.ts": {
+    "mtime": 1779420420.9979978,
     "hash": "7614ea839dfb199368534030d41caca8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/tests/flywheel-role-settings.spec.ts": {
-    "mtime": 1779150733.7618303,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/tests/flywheel-role-settings.spec.ts": {
+    "mtime": 1779420420.9973366,
     "hash": "7135556724df08944eb95e6a5e0e85ed"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/tests/conversation-ordering.spec.ts": {
-    "mtime": 1779108266.1256812,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/tests/conversation-ordering.spec.ts": {
+    "mtime": 1779420420.9973366,
     "hash": "7b940d3856d4873abab6eb8a010962f0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/tests/pan-865-command-deck-overview.spec.ts": {
-    "mtime": 1779108266.1256812,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/tests/pan-865-command-deck-overview.spec.ts": {
+    "mtime": 1779420420.997534,
     "hash": "1a583996687c637312f3d33e2e3d4bff"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/tests/specialist-workflow.spec.ts": {
-    "mtime": 1779108266.1256812,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/tests/specialist-workflow.spec.ts": {
+    "mtime": 1779420420.9979978,
     "hash": "b18791bfbe1846b5ed69dba954ec64ae"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/tests/system-health-pill.spec.ts": {
-    "mtime": 1779108266.1256812,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/tests/system-health-pill.spec.ts": {
+    "mtime": 1779420420.9979978,
     "hash": "6d499b1268901cadfd71b78db0056f2a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/tests/flywheel-page-status.spec.ts": {
-    "mtime": 1779166082.0677204,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/tests/flywheel-page-status.spec.ts": {
+    "mtime": 1779420420.9973366,
     "hash": "ccc384b799d17e70dd9e237860d9c940"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/App.tsx": {
-    "mtime": 1779153782.647762,
-    "hash": "4ec33e847b13d732b5011912bf02fb4f"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/App.tsx": {
+    "mtime": 1779420420.9837928,
+    "hash": "3b5e4dadc96900bc81ace305a93ef93f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/App.test.tsx": {
-    "mtime": 1779150733.6178255,
-    "hash": "3af0b0cc993dce1773469cf53a5aadf5"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/App.test.tsx": {
+    "mtime": 1779420420.983647,
+    "hash": "25beffa2fd0ecab2077e3f53335cefa2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/vite-env.d.ts": {
-    "mtime": 1779108266.1255121,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/vite-env.d.ts": {
+    "mtime": 1779420420.9970863,
     "hash": "41dbeedad52eb577e0234c7c9c80dab5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/main.tsx": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/main.tsx": {
+    "mtime": 1779420420.996946,
     "hash": "149d21cdc0abbb2945adda49c6c4f8d0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/test-setup.ts": {
-    "mtime": 1779108266.1255121,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/test-setup.ts": {
+    "mtime": 1779420420.9970863,
     "hash": "63bc4789ba926c3e2c1b637c7b60338f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/editorPreferences.ts": {
-    "mtime": 1779108266.1240659,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/editorPreferences.ts": {
+    "mtime": 1779420420.995664,
     "hash": "0a0d413607be10f443ca8b01d059b11e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/types.ts": {
-    "mtime": 1779160817.2512052,
-    "hash": "77f0de150057d10f8d78fdfd34492d37"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/types.ts": {
+    "mtime": 1779420420.9970863,
+    "hash": "71a1c42a8adce3052f3b8e6242ca7deb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/StopAgentButton.tsx": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/StopAgentButton.tsx": {
+    "mtime": 1779420420.992477,
     "hash": "8c4fcc8ca6d6830b753eda2286997ffe"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CloisterStatusBar.tsx": {
-    "mtime": 1779161378.1735315,
-    "hash": "9cbcd57eb6a186cfe19025fd60ed2b96"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CloisterStatusBar.tsx": {
+    "mtime": 1779420420.9845707,
+    "hash": "3cb1c559e8a70a9f8ae20cc0d46fff4d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/TldrServiceStatus.tsx": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/TldrServiceStatus.tsx": {
+    "mtime": 1779420420.9925582,
     "hash": "ac2891ca53887188fafce6bd6ea2e18b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CloisterStatusBar.test.tsx": {
-    "mtime": 1779108266.1134186,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CloisterStatusBar.test.tsx": {
+    "mtime": 1779420420.9845707,
     "hash": "654d10a7ec4cb0096f940b5fcb8d0e26"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/KanbanBoard.test.tsx": {
-    "mtime": 1779108266.1173162,
-    "hash": "570628adc694bf19ee54d696440ec331"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/KanbanBoard.test.tsx": {
+    "mtime": 1779420420.989691,
+    "hash": "495d5d1033e7ad1a3be4e95f2adb65f1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/SpecialistLogViewer.tsx": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/SpecialistLogViewer.tsx": {
+    "mtime": 1779420420.992477,
     "hash": "455bac3005a0550267b9f8a3057274cb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/PlanDialog.test.tsx": {
-    "mtime": 1779108266.1182728,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/PlanDialog.test.tsx": {
+    "mtime": 1779420420.990443,
     "hash": "e78a5d3c011346fcdbc4b3f99c8ea9fe"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/ResourceCard.tsx": {
-    "mtime": 1779108266.1182728,
-    "hash": "8ae61a975d494151e95d7490834b4f61"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/EventRouter.test.tsx": {
+    "mtime": 1779420420.9881074,
+    "hash": "7add2820c99c8b44cc28c15814b28a2a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/ContainerDetailPanel.tsx": {
-    "mtime": 1779108266.1159744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/ResourceCard.tsx": {
+    "mtime": 1779420420.9908452,
+    "hash": "2df961dd4802cee0b3836c3536a52b2d"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/ContainerDetailPanel.tsx": {
+    "mtime": 1779420420.98793,
     "hash": "c035904b746f125da8019de1c298d26a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/InspectorPanel.tsx": {
-    "mtime": 1779108266.1173162,
-    "hash": "76c312417f4da470159661a75e91b6e0"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/DeepWipeDialog.tsx": {
-    "mtime": 1779108266.1159744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/DeepWipeDialog.tsx": {
+    "mtime": 1779420420.9881074,
     "hash": "761de306b030b06a96e2deba2f22468f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/SwitchModelModal.tsx": {
-    "mtime": 1779108266.120651,
-    "hash": "dc6988ec1788d4e4ccfb4e281cc7ef20"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/SwitchModelModal.tsx": {
+    "mtime": 1779420420.9925582,
+    "hash": "37acba697d052212c38948a0dc8995e4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CostsPage.tsx": {
-    "mtime": 1779108266.1159744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CostsPage.tsx": {
+    "mtime": 1779420420.9881074,
     "hash": "87729df3eea415a88902b29e2b6a10ce"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/ProjectSpecialistPanel.tsx": {
-    "mtime": 1779108266.1182728,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/ProjectSpecialistPanel.tsx": {
+    "mtime": 1779420420.990443,
     "hash": "e6dd2775a4aaa28cb8f7bd2f23fc1c8e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/ResourcesPanel.tsx": {
-    "mtime": 1779108266.1182728,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/ResourcesPanel.tsx": {
+    "mtime": 1779420420.9908452,
     "hash": "e92fc39b63bc9cc8391b13b538898db2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/MetricsPage.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/MetricsPage.tsx": {
+    "mtime": 1779420420.9899387,
     "hash": "4e83dba3fcce07e77a4866558c0e0780"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/MetricsSummaryRow.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/MetricsSummaryRow.tsx": {
+    "mtime": 1779420420.9899387,
     "hash": "4c86420e7a877e0332a77201638ac565"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CostBreakdownModal.tsx": {
-    "mtime": 1779108266.1159744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CostBreakdownModal.tsx": {
+    "mtime": 1779420420.9881074,
     "hash": "714baf86f4f13fd9727bca672a679f57"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/XTerminal.test.tsx": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/XTerminal.test.tsx": {
+    "mtime": 1779420420.9925582,
     "hash": "b427ad0456d504cdc1c49d17e19508b7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/PanOpenInPicker.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/PanOpenInPicker.tsx": {
+    "mtime": 1779420420.9899387,
     "hash": "a8ab2157225f976d090bf6088110e9eb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/TerminalView.tsx": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/VerifyingOnMainBadge.tsx": {
+    "mtime": 1779420420.9925582,
+    "hash": "e95dd0e61d6140477e7d98b7606c6b40"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/TerminalView.tsx": {
+    "mtime": 1779420420.9925582,
     "hash": "9f6144b93deb192eb7f9d274c59459e8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/InspectorPanel.test.tsx": {
-    "mtime": 1779108266.1173162,
-    "hash": "5736bfad45e2de13d6ded1c3c1686636"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/ConfirmationDialog.tsx": {
-    "mtime": 1779108266.1159744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/ConfirmationDialog.tsx": {
+    "mtime": 1779420420.98793,
     "hash": "e3f3f2fed7390a35f89a1635153a323e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/ResetIssueButton.tsx": {
-    "mtime": 1779108266.1182728,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/ResetIssueButton.tsx": {
+    "mtime": 1779420420.990769,
     "hash": "39cd3adbc581f52e199901e2dde68138"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/SensitiveText.tsx": {
-    "mtime": 1779108266.1182728,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/SensitiveText.tsx": {
+    "mtime": 1779420420.9908452,
     "hash": "dc13301a6630e3475081f34a2dd0c61b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/BulkCloseOutProgress.tsx": {
-    "mtime": 1779108266.1134186,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/BulkCloseOutProgress.tsx": {
+    "mtime": 1779420420.9845707,
     "hash": "41c7c7d6635d31a530b84f78ee0e9551"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/HandoffPanel.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/HandoffPanel.tsx": {
+    "mtime": 1779420420.9887102,
     "hash": "f12004d072060c18e4862768ecf08eb7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CodexAuthBanner.tsx": {
-    "mtime": 1779108266.1134186,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CodexAuthBanner.tsx": {
+    "mtime": 1779420420.9845707,
     "hash": "df4ee6eb2e2d0288d76e593fdbf6722a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Sparkline.tsx": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Sparkline.tsx": {
+    "mtime": 1779420420.9923787,
     "hash": "774c4cb576541e824f88c7382512c4ae"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/XTerminal.tsx": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/XTerminal.tsx": {
+    "mtime": 1779420420.9925582,
     "hash": "f39e29260c1f323bce393b04de79c6cf"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/ChannelPermissionDialog.test.tsx": {
-    "mtime": 1779108266.1134186,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/ChannelPermissionDialog.test.tsx": {
+    "mtime": 1779420420.9845707,
     "hash": "98efe937eeb77a2a3d0adfeb442a5579"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandPalette.test.tsx": {
-    "mtime": 1779153294.4960248,
-    "hash": "7c3cbc7c0a86d5ce2fb507302c33ff9f"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandPalette.test.tsx": {
+    "mtime": 1779420420.98793,
+    "hash": "61ee81e1ba8805d22b52b2de93c31fc0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/DialogProvider.tsx": {
-    "mtime": 1779108266.1162727,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/DialogProvider.tsx": {
+    "mtime": 1779420420.9881074,
     "hash": "44ba4d7a72b97dba7731df0a32b9d4f0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/WorkspaceStatusOverview.tsx": {
-    "mtime": 1779108266.120651,
-    "hash": "022016b889d84d1200e070776b5c9329"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/WorkspaceStatusOverview.tsx": {
+    "mtime": 1779420420.9925582,
+    "hash": "0de2444ad3c3a71db11772930a8f9792"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/ActivityPanel.test.tsx": {
-    "mtime": 1779108266.1132624,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/ActivityPanel.test.tsx": {
+    "mtime": 1779420420.9840767,
     "hash": "18e621cbcfd3bc16b6f95716ebc77580"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/AgentOutputPanel.tsx": {
-    "mtime": 1779108266.1134186,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/AgentOutputPanel.tsx": {
+    "mtime": 1779420420.98417,
     "hash": "fcd8e1ed90f5b61b6b4853211ec7fb28"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/BeadsTasksPanel.tsx": {
-    "mtime": 1779108266.1134186,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/BeadsTasksPanel.tsx": {
+    "mtime": 1779420420.9842892,
     "hash": "91b91068d909017f18688372d7817cc1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/BudgetWidget.tsx": {
-    "mtime": 1779108266.1134186,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/BudgetWidget.tsx": {
+    "mtime": 1779420420.9842892,
     "hash": "d73dc49ea2474d3c8211c125ef3d94c2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/ProviderEnvOverrideDialog.tsx": {
-    "mtime": 1779108266.1182728,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/ProviderEnvOverrideDialog.tsx": {
+    "mtime": 1779420420.990443,
     "hash": "83e96a931d814f721280a2072520c88b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/MetricsSummary.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/MetricsSummary.tsx": {
+    "mtime": 1779420420.9899387,
     "hash": "588be2189967a50a85a374c20a4c3140"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/ResourcesPanel.test.tsx": {
-    "mtime": 1779108266.1182728,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/ResourcesPanel.test.tsx": {
+    "mtime": 1779420420.9908452,
     "hash": "968e839ee3830e7b807912c6837e1943"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/HealthDashboard.tsx": {
-    "mtime": 1779108266.1173162,
-    "hash": "33d75db68a55e4d21ebd045b8911375e"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/HealthDashboard.tsx": {
+    "mtime": 1779420420.9887102,
+    "hash": "17c9d415a7e7a5965b29dd61ce6a9aa9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/DetailPanelLayout.tsx": {
-    "mtime": 1779108266.1159744,
-    "hash": "ddb8b8bf5f9b3ac9c8e4dab09946fc19"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CloseOutIssueButton.tsx": {
+    "mtime": 1779420420.9845707,
+    "hash": "91769fa19dcbbf193da2e053d50bdf18"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/EventRouter.tsx": {
-    "mtime": 1779108266.1162727,
-    "hash": "bf361452d5620dadf26e35a0081590ab"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/EventRouter.tsx": {
+    "mtime": 1779420420.9881074,
+    "hash": "b5f367e9c81433efe55de5eed8ee542c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/StandaloneTerminal.tsx": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/StandaloneTerminal.tsx": {
+    "mtime": 1779420420.992477,
     "hash": "95b4193fad9df8dd259ad3f6d4142402"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/MergeButton.tsx": {
-    "mtime": 1779108266.1173162,
-    "hash": "338fe3ea7e4e8dca101c655ad7e1ba10"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/MergeButton.tsx": {
+    "mtime": 1779420420.9899387,
+    "hash": "8c758a2ef96b91b34f1ebcc684e0e520"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/BulkAgentWarningDialog.tsx": {
-    "mtime": 1779108266.1134186,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/BulkAgentWarningDialog.tsx": {
+    "mtime": 1779420420.9845707,
     "hash": "383cfaaf40c1d3d24b8cd8ddf5266f4a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/RestartFromPlanButton.tsx": {
-    "mtime": 1779108266.1182728,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/RestartFromPlanButton.tsx": {
+    "mtime": 1779420420.9908452,
     "hash": "89b07eff460f529beb895728c62a3e83"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/ChannelPermissionDialog.tsx": {
-    "mtime": 1779108266.1134186,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/ChannelPermissionDialog.tsx": {
+    "mtime": 1779420420.9845707,
     "hash": "3c83cc59e3b68aba92b68fc5a3a57684"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/BulkActionBar.tsx": {
-    "mtime": 1779108266.1134186,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/BulkActionBar.tsx": {
+    "mtime": 1779420420.9845707,
     "hash": "f8cedc87367e39fe48dbbad05bc5435d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/TerminalPanel.test.tsx": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/TerminalPanel.test.tsx": {
+    "mtime": 1779420420.9925582,
     "hash": "628e9e1b4d3eb598222d81f436f0899a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/SystemHealthPill.test.tsx": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/SystemHealthPill.test.tsx": {
+    "mtime": 1779420420.9925582,
     "hash": "34d258b8e8216979a00af9f0cd3302b7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/HealthHistoryTimeline.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/HealthHistoryTimeline.tsx": {
+    "mtime": 1779420420.989114,
     "hash": "f74be14115e37711537c9536c1334bde"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/ResourceBar.test.tsx": {
-    "mtime": 1779108266.1182728,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/ResourceBar.test.tsx": {
+    "mtime": 1779420420.990769,
     "hash": "854af8284a1ff7aa0937ac0c94c64f02"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/GraceCountdown.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/GraceCountdown.tsx": {
+    "mtime": 1779420420.9887102,
     "hash": "bbdbe82f7e6fc0807c7b06dba42da5e2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/AwaitingMergePage.tsx": {
-    "mtime": 1779108266.1134186,
-    "hash": "9878353b52b539c4d5adc07d2e333704"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/AwaitingMergePage.tsx": {
+    "mtime": 1779420420.9842892,
+    "hash": "8f4bab103c2bd767d7ef734cf5cd6b6d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/SkillsList.tsx": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/SkillsList.tsx": {
+    "mtime": 1779420420.9923787,
     "hash": "bd629104b4c6b925dea6148f64fbf428"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/ResourceBar.tsx": {
-    "mtime": 1779108266.1182728,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/ResourceBar.tsx": {
+    "mtime": 1779420420.990769,
     "hash": "171ea2939b38e6b10b8454d9ad404d1e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/PlanSetupScreen.tsx": {
-    "mtime": 1779108266.1182728,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/PlanSetupScreen.tsx": {
+    "mtime": 1779420420.990443,
     "hash": "5f9324323e0b357c8741a225c8acb405"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/PlanDAG.tsx": {
-    "mtime": 1779108266.1182728,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/PlanDAG.tsx": {
+    "mtime": 1779420420.990443,
     "hash": "0e5f17c8206e5e48c10dd641a4d8f56f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/AgentDetailView.tsx": {
-    "mtime": 1779108266.1134186,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/AgentDetailView.tsx": {
+    "mtime": 1779420420.98417,
     "hash": "92e80fc9453f4b382953abc646690ebc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Header.tsx": {
-    "mtime": 1779150733.6178255,
-    "hash": "880e3c59ed5f194ab4c2f4404b24d270"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Header.tsx": {
+    "mtime": 1779420420.9887102,
+    "hash": "a0f8b7d0afdb6cbea6ce08f3a3eeee0c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/FreshnessIndicator.tsx": {
-    "mtime": 1779108266.1162727,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/FreshnessIndicator.tsx": {
+    "mtime": 1779420420.9881074,
     "hash": "705a407799e8e30b94d937fab904d287"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/BootstrapGate.tsx": {
-    "mtime": 1779108266.1134186,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/BootstrapGate.tsx": {
+    "mtime": 1779420420.9842892,
     "hash": "8790064cc441e09356fd8056c482cb8a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandPalette.tsx": {
-    "mtime": 1779153262.9957955,
-    "hash": "338ad449c37d003bb7c8a2d528c0f85e"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandPalette.tsx": {
+    "mtime": 1779420420.98793,
+    "hash": "6ef8edbfcbe499a843c4e7138710d7eb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/SystemHealthPill.tsx": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/SystemHealthPill.tsx": {
+    "mtime": 1779420420.9925582,
     "hash": "3b345e510999705cab512db22053d54c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Sidebar.tsx": {
-    "mtime": 1779163069.307726,
-    "hash": "dbf69dd5755dcf265f66b93a293d3baa"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Sidebar.tsx": {
+    "mtime": 1779420420.9920955,
+    "hash": "ef5c310708c4d937bf09adffb52ecf2f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/PlanDialog.tsx": {
-    "mtime": 1779108266.1182728,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/PlanDialog.tsx": {
+    "mtime": 1779420420.990443,
     "hash": "05638f79bbebaa7b861b0298e96e45d6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/ActivityPanel.tsx": {
-    "mtime": 1779108266.1134186,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/ActivityPanel.tsx": {
+    "mtime": 1779420420.9840767,
     "hash": "32d4bd009a39542713883b858cba6feb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/DialogProvider.test.tsx": {
-    "mtime": 1779108266.1159744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/DialogProvider.test.tsx": {
+    "mtime": 1779420420.9881074,
     "hash": "237b0ce362a55d78228966d416ba6d13"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/DiffWorkerPoolProvider.tsx": {
-    "mtime": 1779108266.1162727,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/DiffWorkerPoolProvider.tsx": {
+    "mtime": 1779420420.9881074,
     "hash": "14c68748b2f7b4a8192ce89855182bc9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/RecoverButton.tsx": {
-    "mtime": 1779108266.1182728,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/RecoverButton.tsx": {
+    "mtime": 1779420420.990443,
     "hash": "d313636accdd2f5244abdc3c3ec1cbe9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/ArtifactLinks.tsx": {
-    "mtime": 1779108266.1134186,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/ArtifactLinks.tsx": {
+    "mtime": 1779420420.9842892,
     "hash": "60e1cf4e52f9e01c41e33931b0b5a511"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/RuntimeComparison.tsx": {
-    "mtime": 1779108266.1182728,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/RuntimeComparison.tsx": {
+    "mtime": 1779420420.9908452,
     "hash": "89974175b7990a75ad70f770d5b65382"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/SpecialistAgentCard.tsx": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/SpecialistAgentCard.tsx": {
+    "mtime": 1779420420.9923787,
     "hash": "93a2c4b56107735a549a0b87a9c7532d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/DiffPanel.tsx": {
-    "mtime": 1779108266.1162727,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/DiffPanel.tsx": {
+    "mtime": 1779420420.9881074,
     "hash": "653860ee1702378f0983410a033f312a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/StoppedAgentsBanner.tsx": {
-    "mtime": 1779108266.120651,
-    "hash": "804109a61831eb0d95c02255c9887635"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/StoppedAgentsBanner.tsx": {
+    "mtime": 1779420420.9925582,
+    "hash": "cfb19d133ee61068d292403ecc9b5a38"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/AgentList.tsx": {
-    "mtime": 1779108266.1134186,
-    "hash": "efc8a83a140ddd627921462f719dedf0"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/DeaconPauseToggle.tsx": {
-    "mtime": 1779108266.1159744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/DeaconPauseToggle.tsx": {
+    "mtime": 1779420420.9881074,
     "hash": "19fee797dd099e868fe5605b6a2ee0bc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/TerminalPanel.tsx": {
-    "mtime": 1779108266.120651,
-    "hash": "e0b77f447a2f8df20330949ff3492479"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/TerminalPanel.tsx": {
+    "mtime": 1779420420.9925582,
+    "hash": "27a56df41a5efc5ec94eba4c0ca0999b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/BeadsDialog.tsx": {
-    "mtime": 1779108266.1134186,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/BeadsDialog.tsx": {
+    "mtime": 1779420420.9842892,
     "hash": "6ca5139693774d4362972a3ac1085ef9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/ResourceCard.test.tsx": {
-    "mtime": 1779108266.1182728,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/ResourceCard.test.tsx": {
+    "mtime": 1779420420.990769,
     "hash": "b42ac05e61059d2319410afd80a6d1ad"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Sidebar.test.tsx": {
-    "mtime": 1779163082.8311913,
-    "hash": "94c37030655d2e31b61da697801e2a84"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Sidebar.test.tsx": {
+    "mtime": 1779420420.9920955,
+    "hash": "f3ce207a29b70d4e1de06dd102f42ef8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/DiffPanelShell.tsx": {
-    "mtime": 1779108266.1162727,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/DiffPanelShell.tsx": {
+    "mtime": 1779420420.9881074,
     "hash": "2c2ae8ca37aaa692fc977075a2a771fc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/HealthHistoryChart.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/HealthHistoryChart.tsx": {
+    "mtime": 1779420420.989114,
     "hash": "7225cf900524b934c82e70f3702d6756"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/KanbanBoard.tsx": {
-    "mtime": 1779108266.1173162,
-    "hash": "831b380f1e72cff1d70c9baa62a2d257"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/TerminalSessionWrapper.tsx": {
+    "mtime": 1779420420.9925582,
+    "hash": "2d993e98089f8174b5443aaf1e97cb73"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/NoResumeBanner.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/KanbanBoard.tsx": {
+    "mtime": 1779420420.9899387,
+    "hash": "600f944bddfece060ad86756219693e0"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/NoResumeBanner.tsx": {
+    "mtime": 1779420420.9899387,
     "hash": "12ef9ec28b4363dda80e879f820b813a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/IssueAgentCard.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/IssueAgentCard.tsx": {
+    "mtime": 1779420420.9894505,
     "hash": "53ff9e1ab5d5b9f94f271e5f1a0a3d0f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/autopreso/AutoPresoView.tsx": {
-    "mtime": 1779108266.1219513,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/autopreso/AutoPresoView.tsx": {
+    "mtime": 1779420420.9931855,
     "hash": "a3ec6995d02f70dcebef0a2526128f94"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/autopreso/AutoPresoControls.tsx": {
-    "mtime": 1779108266.1217995,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/autopreso/AutoPresoControls.tsx": {
+    "mtime": 1779420420.9931324,
     "hash": "079a2ee4089127686ad6fa36260042ff"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/autopreso/TranscriptPanel.tsx": {
-    "mtime": 1779108266.1219513,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/autopreso/TranscriptPanel.tsx": {
+    "mtime": 1779420420.9931855,
     "hash": "5de6fd0f0806c284388b793e55658325"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/RoleBadge.tsx": {
-    "mtime": 1779108266.1146915,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/RoleBadge.tsx": {
+    "mtime": 1779420420.9858048,
     "hash": "48c4e56de45da3eebf7c0aafa6087c89"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ZoneA.tsx": {
-    "mtime": 1779108266.115189,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ZoneA.tsx": {
+    "mtime": 1779420420.9862318,
     "hash": "78c3c7163624607c4a7f8b8c952b94ce"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ProjectOverview.tsx": {
-    "mtime": 1779108266.1144333,
-    "hash": "bcce7e9a064f8b1f94a86f368cf75ae1"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ProjectOverview.tsx": {
+    "mtime": 1779420420.9853837,
+    "hash": "bf77181372f9e7945fdd251ff31378d7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/LiveCounter.tsx": {
-    "mtime": 1779108266.1144333,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/LiveCounter.tsx": {
+    "mtime": 1779420420.9853837,
     "hash": "0e21808d589f7db92a38d45a387efac1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/IssueComposer.tsx": {
-    "mtime": 1779108266.1144333,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/WorkspaceStatusCard.test.tsx": {
+    "mtime": 1779420420.9862318,
+    "hash": "0b0c6b2d0b402a7a221a8da88a04e887"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/IssueComposer.tsx": {
+    "mtime": 1779420420.9853837,
     "hash": "63e7a3ce46f4a8211cd32400cf152dfc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/index.tsx": {
-    "mtime": 1779108266.1159744,
-    "hash": "44c39a0ed628e5bc4cb875ac51467bd5"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/index.tsx": {
+    "mtime": 1779420420.9875956,
+    "hash": "395b4efc4c09606347bca01110282e37"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ConversationTerminal.tsx": {
-    "mtime": 1779108266.1140742,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ConversationTerminal.tsx": {
+    "mtime": 1779420420.9848864,
     "hash": "e4c489c4c55b29ce84eea058b4e598d2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ZoneActionStrip.tsx": {
-    "mtime": 1779108266.115189,
-    "hash": "3b22e63ee631bf36ee4a46a3867aa192"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ZoneActionStrip.tsx": {
+    "mtime": 1779420420.9863312,
+    "hash": "c9e5dde6e9bb86544959b71db58b9c69"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/IssueWorkbench.tsx": {
-    "mtime": 1779108266.1144333,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/IssueWorkbench.tsx": {
+    "mtime": 1779420420.9853837,
     "hash": "fc096f8a17775aaf9f8f3dce28b2a415"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverview.tsx": {
-    "mtime": 1779108266.115189,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverview.tsx": {
+    "mtime": 1779420420.9863312,
     "hash": "60d371301cf5863f53ad11003996c62f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/StatusDot.tsx": {
-    "mtime": 1779108266.115189,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/StatusDot.tsx": {
+    "mtime": 1779420420.9861076,
     "hash": "fa131dd32d800502400eed831f8d71ae"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ConversationRow.tsx": {
-    "mtime": 1779108266.1140742,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ConversationRow.tsx": {
+    "mtime": 1779420420.9848864,
     "hash": "72aa734c6c6076577ab23e99a726f404"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/useConversationMutations.ts": {
-    "mtime": 1779108266.1159744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/useConversationMutations.ts": {
+    "mtime": 1779420420.9878883,
     "hash": "6f653df1ae510da0480570b3bc1cd4e3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ConversationList.tsx": {
-    "mtime": 1779108266.1140742,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ConversationList.tsx": {
+    "mtime": 1779420420.9848864,
     "hash": "87e6baeadf0e50045d7b8b1235d4304a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/CommandDeck.test.tsx": {
-    "mtime": 1779108266.1140742,
-    "hash": "55e71995e42248c0f3b64e8d05cc65ec"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/CommandDeck.test.tsx": {
+    "mtime": 1779420420.9848864,
+    "hash": "a8c1131c134df993c63acc7d6b5ae05c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ZoneBActionStrip.tsx": {
-    "mtime": 1779108266.115189,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ZoneBActionStrip.tsx": {
+    "mtime": 1779420420.9863312,
     "hash": "f26af3016171b73d48a3a418d31c99f2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ForkModal.tsx": {
-    "mtime": 1779108266.1144333,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ForkModal.tsx": {
+    "mtime": 1779420420.9853837,
     "hash": "34d7f6ec9815acfad845fd04b3588590"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/GeneralSection.tsx": {
-    "mtime": 1779108266.1144333,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/WorkspaceStatusCard.tsx": {
+    "mtime": 1779420420.9862318,
+    "hash": "f8c1992ef2975ea2f974ba125cbd20f8"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/GeneralSection.tsx": {
+    "mtime": 1779420420.9853837,
     "hash": "299dff00fbf3a09482d57006b5215e76"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/RoundCard.tsx": {
-    "mtime": 1779108266.1146915,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ActivityFeedSidebar.test.tsx": {
+    "mtime": 1779420420.9845707,
+    "hash": "d1992bb67d3426573bb1aada3a6c3ca6"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ActivityFeedSidebar.tsx": {
+    "mtime": 1779420420.9847941,
+    "hash": "5b966c7d16de917a6d3841427de0af60"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/RoundCard.tsx": {
+    "mtime": 1779420420.9858048,
     "hash": "25b4c54e769b9c4c1f095a396ae44432"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/DeaconStatus.tsx": {
-    "mtime": 1779108266.1140742,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/DeaconStatus.tsx": {
+    "mtime": 1779420420.9848864,
     "hash": "79a12d8911e6fd552eaf9fb5676fed9d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/InlineSparkline.tsx": {
-    "mtime": 1779108266.1144333,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/InlineSparkline.tsx": {
+    "mtime": 1779420420.9853837,
     "hash": "a0ff531e203cd0216abf7d75c00fba79"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ToolFlash.tsx": {
-    "mtime": 1779108266.115189,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ToolFlash.tsx": {
+    "mtime": 1779420420.9862318,
     "hash": "74a15eeec9f52efa01563d3fafb0d79e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/useZoneAActions.ts": {
-    "mtime": 1779108266.1159744,
-    "hash": "80852a7dfa7b33268f096448c3c1ea05"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/useZoneAActions.ts": {
+    "mtime": 1779420420.98793,
+    "hash": "4cff68fa2a613fd15cf7b00dade936f7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ZoneB.tsx": {
-    "mtime": 1779108266.115189,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ZoneB.tsx": {
+    "mtime": 1779420420.9863312,
     "hash": "b273f520f8a7f547485529fa629e4666"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ZoneCConversation.tsx": {
-    "mtime": 1779108266.115189,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ZoneCConversation.tsx": {
+    "mtime": 1779420420.9863312,
     "hash": "aa6c0605c68542c4dcfb522ffa6a5f4b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ActivitySparkline.tsx": {
-    "mtime": 1779108266.1134186,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ActivitySparkline.tsx": {
+    "mtime": 1779420420.9847941,
     "hash": "9a74a1bd630fe2cfaccd20d4638e1444"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/SessionView/ReviewSummary.tsx": {
-    "mtime": 1779108266.115189,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/SessionView/ReviewSummary.tsx": {
+    "mtime": 1779420420.9861076,
     "hash": "bb9023a673aa4071e9d71ce681342739"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/SessionView/IssueHeader.tsx": {
-    "mtime": 1779108266.1146915,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/SessionView/IssueHeader.tsx": {
+    "mtime": 1779420420.9858048,
     "hash": "04b7953f52751002ca121b365782d536"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/SessionView/SessionPanel.test.tsx": {
-    "mtime": 1779108266.115189,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/SessionView/SessionPanel.test.tsx": {
+    "mtime": 1779420420.9861076,
     "hash": "b5c25055fdcfa69f0c5dfa83bb75580a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/SessionView/SessionPanel.tsx": {
-    "mtime": 1779108266.115189,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/SessionView/SessionPanel.tsx": {
+    "mtime": 1779420420.9861076,
     "hash": "8f74894a9e7c4735c40b451c6750a8d4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/ActivityTab.tsx": {
-    "mtime": 1779108266.115189,
-    "hash": "c40233b94bdb3f78677147edb451e8de"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/ActivityTab.tsx": {
+    "mtime": 1779420420.9863312,
+    "hash": "652152c60a3fd515d0e9a5f78b37fd64"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/OverviewTab.tsx": {
-    "mtime": 1779108266.115545,
-    "hash": "932e0c08f321645b723d066d5bf66948"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/OverviewTab.tsx": {
+    "mtime": 1779420420.9865563,
+    "hash": "72476d7419aadacb405d32e7bd4117c8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/CostsTab.tsx": {
-    "mtime": 1779108266.115545,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/CostsTab.tsx": {
+    "mtime": 1779420420.9865563,
     "hash": "d7a8431d4a20a2e53804df3195ea570c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/PrDiffTab.tsx": {
-    "mtime": 1779108266.115545,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/PrDiffTab.tsx": {
+    "mtime": 1779420420.9865563,
     "hash": "ecd0953340474e1a5cb045a8d82638b4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/VBriefTab.tsx": {
-    "mtime": 1779108266.115545,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/VBriefTab.tsx": {
+    "mtime": 1779420420.9865563,
     "hash": "f1f8fbfcfb6ca0fc1c110715bb3573e1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/BeadsTab.tsx": {
-    "mtime": 1779108266.115545,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/StatusHistory.tsx": {
+    "mtime": 1779420420.9865563,
+    "hash": "fbd5ea6db4eb6e46ee4baf623ef97737"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/ContainerSection.tsx": {
+    "mtime": 1779420420.9865563,
+    "hash": "36bc930523bfb6c9572255c6c181aecd"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/BeadsTab.tsx": {
+    "mtime": 1779420420.9865563,
     "hash": "a4af325f95ad6591e2523623c4d9f82c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/MarkdownTab.tsx": {
-    "mtime": 1779108266.115545,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/ReviewPipelineSection.tsx": {
+    "mtime": 1779420420.9865563,
+    "hash": "12ec7713fa36a0171133ed037c4f85a5"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/MarkdownTab.tsx": {
+    "mtime": 1779420420.9865563,
     "hash": "adbd2b198d30b38bd5fb65d7ed776d65"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/DiscussionsTab.tsx": {
-    "mtime": 1779108266.115545,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/DiscussionsTab.tsx": {
+    "mtime": 1779420420.9865563,
     "hash": "1fd31c9a1db3c82e3c5ecfa1554d2253"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/queries.ts": {
-    "mtime": 1779108266.1158726,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/queries.ts": {
+    "mtime": 1779420420.986989,
     "hash": "da9e7aac40dfa55884fd5cf9a7df1f79"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/__tests__/PrDiffTab.test.tsx": {
-    "mtime": 1779108266.1158726,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/__tests__/PrDiffTab.test.tsx": {
+    "mtime": 1779420420.986989,
     "hash": "4d296517567a8eeef83962a9f5bdbf1e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/__tests__/DiscussionsTab.test.tsx": {
-    "mtime": 1779108266.115545,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ZoneCOverviewTabs/__tests__/DiscussionsTab.test.tsx": {
+    "mtime": 1779420420.9865563,
     "hash": "8e8cb27d1aeffb3510e315dd13abbb02"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/__tests__/ZoneCOverview.test.tsx": {
-    "mtime": 1779108266.1159744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/__tests__/ZoneCOverview.test.tsx": {
+    "mtime": 1779420420.987108,
     "hash": "78b45c6af8df89e2b658c9325b259085"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/__tests__/LiveCounter.test.tsx": {
-    "mtime": 1779108266.1159744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/__tests__/LiveCounter.test.tsx": {
+    "mtime": 1779420420.987108,
     "hash": "557ff4323a2b62b706007da28afb2783"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/__tests__/RoundCard.test.tsx": {
-    "mtime": 1779108266.1159744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/__tests__/RoundCard.test.tsx": {
+    "mtime": 1779420420.987108,
     "hash": "2cb90ec85078000709b53fb9324c11b4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/__tests__/ProjectOverview.test.tsx": {
-    "mtime": 1779108266.1159744,
-    "hash": "b8383574b0938fb534f9fa863e9e57e5"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/__tests__/ProjectOverview.test.tsx": {
+    "mtime": 1779420420.987108,
+    "hash": "20c6591c4b1871659349c23cf80949fd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/__tests__/ConversationList.sort.test.ts": {
-    "mtime": 1779108266.1159744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/__tests__/ZoneActionStrip.test.tsx": {
+    "mtime": 1779420420.987108,
+    "hash": "1e5097c81789c8905fc7087cb2811865"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/__tests__/ConversationList.sort.test.ts": {
+    "mtime": 1779420420.9870896,
     "hash": "5a810506f0217cbeec1935eb48ad5e3e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/__tests__/StatusDot.test.tsx": {
-    "mtime": 1779108266.1159744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/__tests__/StatusDot.test.tsx": {
+    "mtime": 1779420420.987108,
     "hash": "331d76166110891101bf04a1b7f0c3f6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/__tests__/IssueWorkbench.test.tsx": {
-    "mtime": 1779108266.1159744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/__tests__/IssueWorkbench.test.tsx": {
+    "mtime": 1779420420.987108,
     "hash": "c193f09220070f301f0935db614b75fe"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/__tests__/action-parity.test.ts": {
-    "mtime": 1779108266.1159744,
-    "hash": "1f05181bbb0883aa5e3a61fc30220776"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/__tests__/action-parity.test.ts": {
+    "mtime": 1779420420.987108,
+    "hash": "13c5dc81314dd62a686056c51707a51b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/__tests__/ToolFlash.test.tsx": {
-    "mtime": 1779108266.1159744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/__tests__/ToolFlash.test.tsx": {
+    "mtime": 1779420420.987108,
     "hash": "85f55fbabde6e90f068b7118a98d0188"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/__tests__/IssueComposer.test.tsx": {
-    "mtime": 1779108266.1159744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/__tests__/IssueComposer.test.tsx": {
+    "mtime": 1779420420.987108,
     "hash": "5c260a6c615ecb80c5a622ec0e812c35"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/__tests__/ActivitySparkline.test.tsx": {
-    "mtime": 1779108266.1158726,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/__tests__/ActivitySparkline.test.tsx": {
+    "mtime": 1779420420.987052,
     "hash": "b7c3b1e22d522150d1a712d9d71c060b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/__tests__/RoleBadge.test.tsx": {
-    "mtime": 1779108266.1159744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/__tests__/RoleBadge.test.tsx": {
+    "mtime": 1779420420.987108,
     "hash": "9c6f7346342ced156c56d2fb913d3a0b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/__tests__/ConversationList.test.tsx": {
-    "mtime": 1779108266.1159744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/__tests__/ConversationList.test.tsx": {
+    "mtime": 1779420420.987108,
     "hash": "f4b5301606a5b88db33d77b5088bd30a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/__tests__/IssueHeader.test.tsx": {
-    "mtime": 1779108266.1159744,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/__tests__/IssueHeader.test.tsx": {
+    "mtime": 1779420420.987108,
     "hash": "b140f761272e24b066afc4e7dcb52b16"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ActivityView/index.tsx": {
-    "mtime": 1779108266.1140742,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ActivityView/index.tsx": {
+    "mtime": 1779420420.9848864,
     "hash": "dfa6f4ad24227bb0434605ccd151aaf5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ActivityView/IsolationMode.tsx": {
-    "mtime": 1779108266.1140742,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ActivityView/IsolationMode.tsx": {
+    "mtime": 1779420420.9848864,
     "hash": "191c5ed9c3ae718c9332ff69efbf188e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ActivityView/AgentSection.tsx": {
-    "mtime": 1779108266.1140294,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ActivityView/AgentSection.tsx": {
+    "mtime": 1779420420.9847941,
     "hash": "5eb3bcbec2297d5dc91b3410203dff74"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/SessionNode.tsx": {
-    "mtime": 1779108266.1146915,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/SessionNode.tsx": {
+    "mtime": 1779420420.9858048,
     "hash": "2f5b385856bd1656e83408d7db1d1fe5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ProjectNode.tsx": {
-    "mtime": 1779108266.1146915,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ProjectNode.tsx": {
+    "mtime": 1779420420.9858048,
     "hash": "3bf3c3f664fc316e2989241abe5a784d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.tsx": {
-    "mtime": 1779108266.1146915,
-    "hash": "ff308395c45b7a97bd8cb80e846d0120"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.tsx": {
+    "mtime": 1779420420.9856997,
+    "hash": "b9b2851dfe20e2d55f659617051002a0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.test.tsx": {
-    "mtime": 1779108266.1146915,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.test.tsx": {
+    "mtime": 1779420420.985618,
     "hash": "5df8d6d381509b22cda51cd8bb752702"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ContainerNode.tsx": {
-    "mtime": 1779108266.1146915,
-    "hash": "83a1a64783739d16ca2e0f1ff6b5bd8b"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ContainerNode.tsx": {
+    "mtime": 1779420420.985618,
+    "hash": "32ac89e952007cd7f1528c01207a5804"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/BranchNode.tsx": {
-    "mtime": 1779108266.1144333,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/BranchNode.tsx": {
+    "mtime": 1779420420.9853837,
     "hash": "901ce45008383e36cda20e29eb76c49e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ResourcesGroup.tsx": {
-    "mtime": 1779108266.1146915,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ResourcesGroup.tsx": {
+    "mtime": 1779420420.9858048,
     "hash": "691ed6244c1d04523c45a16bee88d595"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/PrNode.tsx": {
-    "mtime": 1779108266.1146915,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/PrNode.tsx": {
+    "mtime": 1779420420.9858048,
     "hash": "41d7004f142dcff6293d2cb2536533d6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ProjectNode.test.tsx": {
-    "mtime": 1779108266.1146915,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ProjectNode.test.tsx": {
+    "mtime": 1779420420.9858048,
     "hash": "4ccac8c7a717665f146638ea689c47d1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/SessionNode.test.tsx": {
-    "mtime": 1779108266.1146915,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/SessionNode.test.tsx": {
+    "mtime": 1779420420.9858048,
     "hash": "ee23c64c1ec6092a4d1dea0fc0c67fa6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/FeatureMetadata/BadgeBar.tsx": {
-    "mtime": 1779108266.1140742,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/FeatureMetadata/BadgeBar.tsx": {
+    "mtime": 1779420420.9848864,
     "hash": "4be43f22201164880a46e722eac41c10"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/FeatureMetadata/TranscriptUpload.tsx": {
-    "mtime": 1779108266.1144333,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/FeatureMetadata/TranscriptUpload.tsx": {
+    "mtime": 1779420420.9852922,
     "hash": "a354c7f9ab88b22aa9f0e3dd77119879"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/CommandDeck/FeatureMetadata/MarkdownModal.tsx": {
-    "mtime": 1779108266.1144333,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/CommandDeck/FeatureMetadata/MarkdownModal.tsx": {
+    "mtime": 1779420420.9852922,
     "hash": "20a565b74a4ff7c32d34736a8855b221"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/GodView/ConnectionLines.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/GodView/ConnectionLines.tsx": {
+    "mtime": 1779420420.9887102,
     "hash": "10775680b66c4e1d149282a933612825"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/GodView/AgentTimeline.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/GodView/AgentTimeline.tsx": {
+    "mtime": 1779420420.9887102,
     "hash": "d3eb3c4c61775bb781738c4711b97c9e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/GodView/FileActivityTree.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/GodView/FileActivityTree.tsx": {
+    "mtime": 1779420420.9887102,
     "hash": "e233301a7c227a78eabe383b1877faa0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/GodView/AgentGrid.tsx": {
-    "mtime": 1779108266.1173162,
-    "hash": "4cbdd756e8a6b051af865ecfc171a72e"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/GodView/TopBar.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/GodView/TopBar.tsx": {
+    "mtime": 1779420420.9887102,
     "hash": "36096b80dc6a76dca3d84dbfe194b069"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/GodView/ActivityFeed.tsx": {
-    "mtime": 1779108266.1173162,
-    "hash": "2ab4f4358ac6946240de2e7edbd5d263"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/GodView/ActivityFeed.tsx": {
+    "mtime": 1779420420.9886436,
+    "hash": "28a7bd6a56078a9b37be6a29065c64d0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/GodView/index.tsx": {
-    "mtime": 1779108266.1173162,
-    "hash": "2a5ae0c5b8ecd1e864ab6375183b4792"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/GodView/index.tsx": {
+    "mtime": 1779420420.9887102,
+    "hash": "55b0d507e4bcecf2b50e01841a8a83cb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/GodView/AgentCard.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/GodView/AgentCard.tsx": {
+    "mtime": 1779420420.9886436,
     "hash": "e108495ecd43d9eeea63a97cb372952e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/GodView/BeadsKanban.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/GodView/BeadsKanban.tsx": {
+    "mtime": 1779420420.9887102,
     "hash": "873226d66cd4a565f1e1fbcc5a286f85"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/GodView/CostDonut.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/GodView/CostDonut.tsx": {
+    "mtime": 1779420420.9887102,
     "hash": "57e525b2565de2b71afd3da9ae9d943d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/GodView/CanvasTerminal.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/GodView/CanvasTerminal.tsx": {
+    "mtime": 1779420420.9887102,
     "hash": "5c8bd68f64e5fd1886cd76c1d889399a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/GodView/ActionBar.tsx": {
-    "mtime": 1779108266.1162727,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/GodView/ActionBar.tsx": {
+    "mtime": 1779420420.9886174,
     "hash": "b1e7478b8cdbfd45c6c6cc52a6ad08fc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/GodView/Sidebar.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/GodView/Sidebar.tsx": {
+    "mtime": 1779420420.9887102,
     "hash": "e81c62f35b9033324239344055b49eea"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/GodView/InfraGauges.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/GodView/InfraGauges.tsx": {
+    "mtime": 1779420420.9887102,
     "hash": "4ee416fe4120b9119c4f9049853ad4b6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/GodView/FocusView.tsx": {
-    "mtime": 1779108266.1173162,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/GodView/FocusView.tsx": {
+    "mtime": 1779420420.9887102,
     "hash": "a64d7db87e537d5e6e6cc24179752d5f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/GodView/__tests__/GodView.test.tsx": {
-    "mtime": 1779108266.1173162,
-    "hash": "bc94677106d94b9a9a34a1df286f5525"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/GodView/__tests__/GodView.test.tsx": {
+    "mtime": 1779420420.9887102,
+    "hash": "4724de6eaada811aeed15b36b0d1547e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/skeletons/GodViewSkeleton.tsx": {
-    "mtime": 1779108266.1240025,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/skeletons/AgentsSkeleton.tsx": {
+    "mtime": 1779420420.9952576,
+    "hash": "cd208100456f59c590822a72489b273b"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/skeletons/GodViewSkeleton.tsx": {
+    "mtime": 1779420420.9954457,
     "hash": "5b32c27d5f01b1cd23eb211dda6527dc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/skeletons/AgentListSkeleton.tsx": {
-    "mtime": 1779108266.1238272,
-    "hash": "cb7bf0ccbb0d09ad25ce85f52608e0e9"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/skeletons/HeaderSkeleton.tsx": {
-    "mtime": 1779108266.1240025,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/skeletons/HeaderSkeleton.tsx": {
+    "mtime": 1779420420.9954457,
     "hash": "06a5651b8e47d7b94398869c54d8fdc3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/skeletons/KanbanSkeleton.tsx": {
-    "mtime": 1779108266.1240025,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/skeletons/KanbanSkeleton.tsx": {
+    "mtime": 1779420420.9954457,
     "hash": "e9f0f83d24072ccc3d83ffb80510b6e0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/conversations/FacetPanel.tsx": {
-    "mtime": 1779108266.1229165,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/skeletons/PipelineSkeleton.tsx": {
+    "mtime": 1779420420.9954982,
+    "hash": "d652b9cfc48d54eccc1e40c69a1267b2"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/drawer/useDrawerData.ts": {
+    "mtime": 1779420420.994573,
+    "hash": "1c0f7c9d9a84f2f137704662f0b4a466"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/drawer/DrawerBeadsList.tsx": {
+    "mtime": 1779420420.9943035,
+    "hash": "53d8f97f70d313ed0147b68acd350a1a"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/drawer/DrawerActiveAgent.test.tsx": {
+    "mtime": 1779420420.9943035,
+    "hash": "27c7fc8a1bd2582223f3fa3537057d34"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/drawer/DrawerActivityRail.tsx": {
+    "mtime": 1779420420.9943035,
+    "hash": "26144e380b49dd89b7f1c43a0e22c06e"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/drawer/IssueDrawer.tsx": {
+    "mtime": 1779420420.994465,
+    "hash": "c08778f90a6c4faa6f9430ace2902dfc"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/drawer/DrawerReviewSpecialists.tsx": {
+    "mtime": 1779420420.9943035,
+    "hash": "499abc87268d671380cefec9857d30b8"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/drawer/DrawerVerificationGates.tsx": {
+    "mtime": 1779420420.9943035,
+    "hash": "6d27675f97cc03cbacafbc9118239689"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/drawer/DrawerTabs.tsx": {
+    "mtime": 1779420420.9943035,
+    "hash": "457906c4b7e70bc025ed77ed7b5317c4"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/drawer/DrawerActionBar.tsx": {
+    "mtime": 1779420420.9942205,
+    "hash": "f273768379dfa5e3ae4e418236a5cebf"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/drawer/IssueDrawer.test.tsx": {
+    "mtime": 1779420420.994465,
+    "hash": "f187218677fcf33bf97db55b9ed1c911"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/drawer/DrawerActiveAgent.tsx": {
+    "mtime": 1779420420.9943035,
+    "hash": "662d460a203dd762ff68da63ca355f68"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/drawer/PhaseTimeline.tsx": {
+    "mtime": 1779420420.994553,
+    "hash": "aada7adf5780dcfee89791a80d88b7cd"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Pipeline/PipelineView.tsx": {
+    "mtime": 1779420420.990443,
+    "hash": "fcc3768157729fe6fccdf7d08363f0a7"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Pipeline/PipelineView.test.tsx": {
+    "mtime": 1779420420.9903622,
+    "hash": "15639602e9c814aeca3da09a68f6d5ef"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/conversations/FacetPanel.tsx": {
+    "mtime": 1779420420.9940743,
     "hash": "f5b8fe00c0dc8d73124658a69285b96a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/conversations/SessionDetail.tsx": {
-    "mtime": 1779108266.1229165,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/conversations/SessionDetail.tsx": {
+    "mtime": 1779420420.9941273,
     "hash": "6a05780574be61b8ca9169c332b08a73"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/conversations/SessionTable.tsx": {
-    "mtime": 1779108266.1229165,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/conversations/SessionTable.tsx": {
+    "mtime": 1779420420.9941273,
     "hash": "e5b00cf828837ac2c2f52e96cdcbf4e7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/conversations/ScanButton.tsx": {
-    "mtime": 1779108266.1229165,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/conversations/ScanButton.tsx": {
+    "mtime": 1779420420.9940743,
     "hash": "0a8299de59d217504f61f80244b41d4f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/conversations/ConversationsPage.tsx": {
-    "mtime": 1779108266.1226754,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/conversations/ConversationsPage.tsx": {
+    "mtime": 1779420420.993981,
     "hash": "2b0cfdb87609e4a1b522ff1cdfe263c4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/conversations/__tests__/SessionDetail.test.tsx": {
-    "mtime": 1779108266.123062,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/conversations/__tests__/SessionDetail.test.tsx": {
+    "mtime": 1779420420.9942205,
     "hash": "ef8435d262c26960348b0fad41a8eba0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/conversations/__tests__/ScanButton.test.tsx": {
-    "mtime": 1779108266.123062,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/conversations/__tests__/ScanButton.test.tsx": {
+    "mtime": 1779420420.9942205,
     "hash": "9dc3fe74bbe7307ea4da4ec95e4343ce"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/conversations/__tests__/ConversationsPage.test.tsx": {
-    "mtime": 1779108266.1229165,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/conversations/__tests__/ConversationsPage.test.tsx": {
+    "mtime": 1779420420.9941273,
     "hash": "e84daaf6885131d0c63211b42f444a50"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/vbrief/VBriefViewer.test.tsx": {
-    "mtime": 1779108266.1240659,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/vbrief/VBriefViewer.test.tsx": {
+    "mtime": 1779420420.995524,
     "hash": "447fe34b3d144ce5376524ecc4ce65c8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/vbrief/VBriefItemCard.tsx": {
-    "mtime": 1779108266.1240659,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/vbrief/VBriefItemCard.tsx": {
+    "mtime": 1779420420.995524,
     "hash": "ec9f12aa7af364eb7e405cd4c500bf49"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/vbrief/VBriefDialog.tsx": {
-    "mtime": 1779108266.1240025,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/vbrief/VBriefDialog.tsx": {
+    "mtime": 1779420420.9954982,
     "hash": "1289e50c64fcec8da2c81313f464d880"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/vbrief/VBriefNarratives.tsx": {
-    "mtime": 1779108266.1240659,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/vbrief/VBriefNarratives.tsx": {
+    "mtime": 1779420420.995524,
     "hash": "c987e5e711c990746c874ef7c98e0a3d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/vbrief/VBriefItemList.tsx": {
-    "mtime": 1779108266.1240659,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/vbrief/VBriefItemList.tsx": {
+    "mtime": 1779420420.995524,
     "hash": "e73f061a40c3e624899d54db5c6f42bf"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/vbrief/index.ts": {
-    "mtime": 1779108266.1240659,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/vbrief/index.ts": {
+    "mtime": 1779420420.995524,
     "hash": "658f4535e4e7b32f2955280116669098"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/vbrief/VBriefHeader.tsx": {
-    "mtime": 1779108266.1240659,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/vbrief/VBriefHeader.tsx": {
+    "mtime": 1779420420.995524,
     "hash": "b1f89a6aa545cd58566b68238255de0d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/vbrief/VBriefViewer.tsx": {
-    "mtime": 1779108266.1240659,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/vbrief/VBriefViewer.tsx": {
+    "mtime": 1779420420.995524,
     "hash": "39efb00ca8f804f16abd1f1c34b88f39"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/vbrief/VBriefReferences.tsx": {
-    "mtime": 1779108266.1240659,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/vbrief/VBriefReferences.tsx": {
+    "mtime": 1779420420.995524,
     "hash": "43e5e2258a2f4c29bc7bd985a22bf14a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/vbrief/types.ts": {
-    "mtime": 1779108266.1240659,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/vbrief/types.ts": {
+    "mtime": 1779420420.995664,
     "hash": "7299b3a5143d4baad9017b0ded927cc5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/search/SearchModal.test.tsx": {
-    "mtime": 1779108266.1231537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/search/SearchModal.test.tsx": {
+    "mtime": 1779420420.9950542,
     "hash": "114f0cbdd06aceb6cb1ef2adc24128b0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/search/SearchModal.tsx": {
-    "mtime": 1779108266.1237197,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/search/SearchModal.tsx": {
+    "mtime": 1779420420.9951503,
     "hash": "51e7f31206a092729f4aec032ae6cc1c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/search/SearchResults.tsx": {
-    "mtime": 1779108266.1237197,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/search/SearchResults.tsx": {
+    "mtime": 1779420420.9951503,
     "hash": "82c38946666d4afc14ab200a1de36320"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/__tests__/DetailPanelLayout.test.tsx": {
-    "mtime": 1779108266.1217995,
-    "hash": "2425032a4edad3fff9370138bab4d327"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Agents/FleetAgentsView.tsx": {
+    "mtime": 1779420420.9842892,
+    "hash": "31270699e8e324b70aeba235ce40ea4d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/__tests__/TerminalPanel.test.tsx": {
-    "mtime": 1779108266.1217995,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Agents/FleetAgentsView.test.tsx": {
+    "mtime": 1779420420.98417,
+    "hash": "71105da4571ee10922cac7673b006f67"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/__tests__/TerminalPanel.test.tsx": {
+    "mtime": 1779420420.9931324,
     "hash": "252a8b22bef09b71da42135514233e99"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/__tests__/AgentOutputPanel.test.tsx": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/__tests__/AgentOutputPanel.test.tsx": {
+    "mtime": 1779420420.992669,
     "hash": "e08052b51025acdab66de832f9d71da7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/__tests__/IssueAgentCard-harness.test.tsx": {
-    "mtime": 1779108266.1217995,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/__tests__/IssueAgentCard-harness.test.tsx": {
+    "mtime": 1779420420.9930828,
     "hash": "99599b3d0d32e7d878e5b54e5f2109b5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/__tests__/StandaloneTerminal.test.tsx": {
-    "mtime": 1779108266.1217995,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/__tests__/StandaloneTerminal.test.tsx": {
+    "mtime": 1779420420.9930828,
     "hash": "c9fb77c63be5f2b7f21121329f46fa0d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/inspector/TerminalTabs.tsx": {
-    "mtime": 1779108266.1231537,
-    "hash": "5d6edc794a1cd5a9ade176c25870e2c5"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/inspector/utils.ts": {
-    "mtime": 1779108266.1231537,
-    "hash": "c91a16100fe0c5fce957db53413a9cc2"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/inspector/TerminalSessionWrapper.test.tsx": {
-    "mtime": 1779108266.1231537,
-    "hash": "72be8f78c2500300b8fb655c53a4799f"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/inspector/MergedSummaryCard.tsx": {
-    "mtime": 1779108266.1231537,
-    "hash": "4cb21672050548c2bea48d9b1848adce"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/inspector/MergedSummaryCard.test.tsx": {
-    "mtime": 1779108266.1231537,
-    "hash": "e718a0305ee7df74b11ecf4722f29ede"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/inspector/TerminalTabs.test.tsx": {
-    "mtime": 1779108266.1231537,
-    "hash": "ee299c79cbe1443c391b36929a911039"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/inspector/AgentInfoSection.test.tsx": {
-    "mtime": 1779108266.1231537,
-    "hash": "2701e23ed8daea3d8670dc9d84334d5f"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/inspector/StatusHistory.test.tsx": {
-    "mtime": 1779108266.1231537,
-    "hash": "bd3858435dea77cd7ecd3befe7b7704b"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/inspector/AgentInfoSection.tsx": {
-    "mtime": 1779108266.1231537,
-    "hash": "ca1c21a71e629f927629761b72334e5e"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/inspector/usePipelinePhase.test.ts": {
-    "mtime": 1779108266.1231537,
-    "hash": "89ce89b6d3fe5c0e8aa14fc497dda708"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/inspector/StatusHistory.tsx": {
-    "mtime": 1779108266.1231537,
-    "hash": "27db40550c311b8af18646bacca7236e"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/inspector/ActionsSection.tsx": {
-    "mtime": 1779108266.1231537,
-    "hash": "d8077c6d6ed8b333ffc2b240e17d3b89"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/inspector/ReviewPipelineSection.test.tsx": {
-    "mtime": 1779108266.1231537,
-    "hash": "9278ed76139ead892a5e4fcaeedc5974"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/inspector/ContainerSection.tsx": {
-    "mtime": 1779108266.1231537,
-    "hash": "a85c573a06d18f2d81aa94cc365a7682"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/inspector/ReviewPipelineSection.tsx": {
-    "mtime": 1779108266.1231537,
-    "hash": "5c11093aeda9e2e73456bf1df7b42639"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/inspector/ContainerSection.test.tsx": {
-    "mtime": 1779108266.1231537,
-    "hash": "30156b9ce098116e8c19870433982cf7"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/inspector/ActionsSection.test.tsx": {
-    "mtime": 1779108266.123062,
-    "hash": "4d88db8ee0a2db08e6fa308873b91c2f"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/inspector/usePipelinePhase.ts": {
-    "mtime": 1779108266.1231537,
-    "hash": "f9597a4a15420a8dbee2420e2fc8fecf"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/inspector/TerminalSessionWrapper.tsx": {
-    "mtime": 1779108266.1231537,
-    "hash": "9df01bdec3129597ca40ca4a35e016b4"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/inspector/types.ts": {
-    "mtime": 1779108266.1231537,
-    "hash": "67c744b3228e3a54d57ae36602fecdbf"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/ChatMarkdown.tsx": {
-    "mtime": 1779108266.1220183,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/ChatMarkdown.tsx": {
+    "mtime": 1779420420.9932683,
     "hash": "7e042d7d15c870bffea6580a4091916b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/MessagesTimeline.tsx": {
-    "mtime": 1779108266.1220183,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/MessagesTimeline.tsx": {
+    "mtime": 1779420420.9936073,
     "hash": "97633bf24a8ca5e8d141aed25d566ca4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/ModelPicker.tsx": {
-    "mtime": 1779108266.1220183,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/ModelPicker.tsx": {
+    "mtime": 1779420420.9936073,
     "hash": "4e1869b013550a6e8cb451d1975096dc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/ComposerPromptEditor.tsx": {
-    "mtime": 1779108266.1220183,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/ComposerPromptEditor.tsx": {
+    "mtime": 1779420420.9933784,
     "hash": "dbbfd60939e1a75c8fa440a5952fcfb9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/ProviderIcons.tsx": {
-    "mtime": 1779108266.1220183,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/ProviderIcons.tsx": {
+    "mtime": 1779420420.9936073,
     "hash": "65ebfd23ab2f7b5bec136801da45c256"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/DiffStatLabel.tsx": {
-    "mtime": 1779108266.1220183,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/DiffStatLabel.tsx": {
+    "mtime": 1779420420.9933784,
     "hash": "ccd40ffda0d01e29c0bb89d2562ab1c6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/chat-types.ts": {
-    "mtime": 1779108266.1226754,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/chat-types.ts": {
+    "mtime": 1779420420.9938376,
     "hash": "5522fb862a46da9cf34e5ecc5d0459db"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/ChangedFilesTree.tsx": {
-    "mtime": 1779108266.1219513,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/ChangedFilesTree.tsx": {
+    "mtime": 1779420420.9931855,
     "hash": "a87a29abc1229f2fe2c3538b631bb383"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/EffortPicker.tsx": {
-    "mtime": 1779108266.1220183,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/EffortPicker.tsx": {
+    "mtime": 1779420420.9935226,
     "hash": "6b62810f568a840ae9d0cb87039cde50"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/VoiceWidget.tsx": {
-    "mtime": 1779108266.1220183,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/VoiceWidget.tsx": {
+    "mtime": 1779420420.9936073,
     "hash": "326b8f560bb06fcf3918a6324db5da0b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/usePickerPosition.ts": {
-    "mtime": 1779108266.1226754,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/usePickerPosition.ts": {
+    "mtime": 1779420420.993981,
     "hash": "cd09eaae183c78b0a09ea1a9d5cdbb8d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/defaultConversationModel.ts": {
-    "mtime": 1779108266.1226754,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/defaultConversationModel.ts": {
+    "mtime": 1779420420.993981,
     "hash": "cab0f52cf6cae81c287e63b5bee5f7b2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/MessagesTimeline.logic.ts": {
-    "mtime": 1779108266.1220183,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/MessagesTimeline.logic.ts": {
+    "mtime": 1779420420.9935226,
     "hash": "31ae0d97df50886c2a84a7da9eb9412e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/ComposerFooter.tsx": {
-    "mtime": 1779108266.1220183,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/ComposerFooter.tsx": {
+    "mtime": 1779420420.9933784,
     "hash": "ca0f4c94cc246e3f1e244db019982268"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/PlanCard.tsx": {
-    "mtime": 1779108266.1220183,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/PlanCard.tsx": {
+    "mtime": 1779420420.9936073,
     "hash": "91832aa8e35de75c6a3e68cbf22bf766"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/ConversationPanel.tsx": {
-    "mtime": 1779108266.1220183,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/ConversationPanel.tsx": {
+    "mtime": 1779420420.9933784,
     "hash": "a8881e39eff949e61cd6ec39730baa6a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/__tests__/ComposerPromptEditor.test.tsx": {
-    "mtime": 1779108266.1226754,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/__tests__/ComposerPromptEditor.test.tsx": {
+    "mtime": 1779420420.9938376,
     "hash": "32eb41ac3b5a5b780e5eb960901f1811"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/__tests__/ComposerFooter.test.tsx": {
-    "mtime": 1779108266.1220183,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/__tests__/ComposerFooter.test.tsx": {
+    "mtime": 1779420420.9936073,
     "hash": "73779fd3f2f0f4aeab05cfb327de8040"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/__tests__/MessagesTimeline.test.tsx": {
-    "mtime": 1779108266.1226754,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/__tests__/MessagesTimeline.test.tsx": {
+    "mtime": 1779420420.9938376,
     "hash": "781dc4a786bc9e0a627e7dc8971f9a20"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/__tests__/ConversationPanel.test.tsx": {
-    "mtime": 1779108266.1226754,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/__tests__/ConversationPanel.test.tsx": {
+    "mtime": 1779420420.9938376,
     "hash": "30a72a3baa7649e9171afb50c0aeb760"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/chat/__tests__/MessagesTimeline.logic.test.ts": {
-    "mtime": 1779108266.1226754,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/chat/__tests__/MessagesTimeline.logic.test.ts": {
+    "mtime": 1779420420.9938376,
     "hash": "6cc9ed261897e7227d0ffbda4ec292f3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/RolesPanel.tsx": {
-    "mtime": 1779150733.7618303,
-    "hash": "8cea89d5fa5e7f8a2878534381b4243e"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/RolesPanel.tsx": {
+    "mtime": 1779420420.9911559,
+    "hash": "071a3e27a7f26f451bf6fc69d921914a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/SettingsPage.tsx": {
-    "mtime": 1779108266.1197698,
-    "hash": "4273f7ec3203ca12c952232a37c2ebe3"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/SettingsPage.tsx": {
+    "mtime": 1779420420.9913845,
+    "hash": "4e326061c97c7857c78784fe27cc1025"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/VoicePresetsTab.tsx": {
-    "mtime": 1779108266.1201556,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/VoicePresetsTab.tsx": {
+    "mtime": 1779420420.9915583,
     "hash": "f253f9ca08f400d3d3d68099a0a1b1b4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/SavedVoicesTab.tsx": {
-    "mtime": 1779108266.1197698,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/SavedVoicesTab.tsx": {
+    "mtime": 1779420420.9911559,
     "hash": "525c21bb55c22cf949c5bbc26b343495"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/VoiceDesignTab.tsx": {
-    "mtime": 1779108266.1201556,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/VoiceDesignTab.tsx": {
+    "mtime": 1779420420.9915583,
     "hash": "c61866fbae1a9743a5a771a7b4c7047c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/OpenRouterPage.tsx": {
-    "mtime": 1779108266.1196685,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/OpenRouterPage.tsx": {
+    "mtime": 1779420420.9911005,
     "hash": "ea808492ff0e5fc9b86e8c4277eda1fa"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/OpenRouterModelBrowser.tsx": {
-    "mtime": 1779108266.1196685,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/OpenRouterModelBrowser.tsx": {
+    "mtime": 1779420420.9910557,
     "hash": "dcb8266d4093f07d2dcf2cb6c793a3ef"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/index.ts": {
-    "mtime": 1779108266.1204062,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/index.ts": {
+    "mtime": 1779420420.991812,
     "hash": "e6a5b3e38b784dcdb0067ec46abd4ff8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/modelCatalog.ts": {
-    "mtime": 1779108266.1204062,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/modelCatalog.ts": {
+    "mtime": 1779420420.991812,
     "hash": "e59b9d862c3ebf3f0529a3bad3bb76e4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/TtsSystemVoicePicker.tsx": {
-    "mtime": 1779108266.1201556,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/TtsSystemVoicePicker.tsx": {
+    "mtime": 1779420420.9915583,
     "hash": "7b6accb37c0adaf4221923067b5d73bf"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/DesktopSettingsSection.tsx": {
-    "mtime": 1779108266.1182728,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/DesktopSettingsSection.tsx": {
+    "mtime": 1779420420.9908452,
     "hash": "c35f6a62e2e03e2f3e82b6d76d655acc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/WorkhorsePanel.tsx": {
-    "mtime": 1779108266.1201556,
-    "hash": "cc6155c813becdce60cca8bcfc5ccd64"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/WorkhorsePanel.tsx": {
+    "mtime": 1779420420.9915583,
+    "hash": "79904faa92db5e191c5af4cb12585fbe"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/types.ts": {
-    "mtime": 1779108266.120651,
-    "hash": "ac8b533a19db8cc7012a3e765cd73b42"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/types.ts": {
+    "mtime": 1779420420.9920955,
+    "hash": "4b060c8d864284f726bed4a1e090322c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/Shared/Toggle.tsx": {
-    "mtime": 1779108266.1201556,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/Shared/Toggle.tsx": {
+    "mtime": 1779420420.9915583,
     "hash": "d2d60d5b6601ce9ae5d50ac7f11d29bc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/Shared/Button.tsx": {
-    "mtime": 1779108266.1201556,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/Shared/Button.tsx": {
+    "mtime": 1779420420.9915583,
     "hash": "a8f3c04e9a29c256e80fbb1a25445c00"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/Shared/Badge.tsx": {
-    "mtime": 1779108266.1197698,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/Shared/Badge.tsx": {
+    "mtime": 1779420420.9913845,
     "hash": "4431f2325e057192cbb159f3229f37f6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/Shared/StatusDot.tsx": {
-    "mtime": 1779108266.1201556,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/Shared/StatusDot.tsx": {
+    "mtime": 1779420420.9915583,
     "hash": "197634c0a0e2cf041d73c2693584a072"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/Provider/ThinkingLevelSlider.tsx": {
-    "mtime": 1779108266.1197698,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/Provider/ThinkingLevelSlider.tsx": {
+    "mtime": 1779420420.9911559,
     "hash": "be2678d42b5c0168507fed8234f48a61"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/Provider/ProviderCard.tsx": {
-    "mtime": 1779108266.1196685,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/Provider/ProviderCard.tsx": {
+    "mtime": 1779420420.9911005,
     "hash": "31f208b197eaa3f88ad8733c27fd2f80"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/Provider/ProviderPanel.tsx": {
-    "mtime": 1779108266.1197698,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/Provider/ProviderPanel.tsx": {
+    "mtime": 1779420420.9911559,
     "hash": "cfffc305b84f68cbff8d374230cfca81"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/__tests__/RolesPanel.test.tsx": {
-    "mtime": 1779150733.7618303,
-    "hash": "fc0ebf7ac97c6bcaca768d9be566c9a7"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/__tests__/RolesPanel.test.tsx": {
+    "mtime": 1779420420.991812,
+    "hash": "39c4bc7bf846070e06eec6598a26a08d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/__tests__/SavedVoicesTab.test.tsx": {
-    "mtime": 1779108266.1204062,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/__tests__/SavedVoicesTab.test.tsx": {
+    "mtime": 1779420420.991812,
     "hash": "03c2f49df24ecc7bbcbe0f943b770f47"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/__tests__/SettingsPage.test.ts": {
-    "mtime": 1779108266.1204062,
-    "hash": "bb2807d3ce884b80f40b13e3556a9d26"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/__tests__/SettingsPage.test.ts": {
+    "mtime": 1779420420.991812,
+    "hash": "a861a48cc49ae459ca93ddc05a57cf6a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/__tests__/TtsSystemVoicePicker.test.tsx": {
-    "mtime": 1779108266.1204062,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/__tests__/TtsSystemVoicePicker.test.tsx": {
+    "mtime": 1779420420.991812,
     "hash": "449206dcd249763e2f7c609c15a3de02"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/__tests__/VoiceDesignTab.test.tsx": {
-    "mtime": 1779108266.1204062,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/__tests__/VoiceDesignTab.test.tsx": {
+    "mtime": 1779420420.991812,
     "hash": "18986f981cf34ee4d501654f7187625d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/__tests__/OpenRouterModelBrowser.test.tsx": {
-    "mtime": 1779108266.1201556,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/__tests__/OpenRouterModelBrowser.test.tsx": {
+    "mtime": 1779420420.9915583,
     "hash": "4c3b6caaa7866fc72679da81c47a9996"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/__tests__/VoicePresetsTab.test.tsx": {
-    "mtime": 1779108266.1204062,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/__tests__/VoicePresetsTab.test.tsx": {
+    "mtime": 1779420420.991812,
     "hash": "d3f997a2d68a27c458852ca2b4e4dd26"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/__tests__/OpenRouterPage.test.tsx": {
-    "mtime": 1779108266.1204062,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/__tests__/OpenRouterPage.test.tsx": {
+    "mtime": 1779420420.991812,
     "hash": "1413228691eed901c070bf3353902fc8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/__tests__/WorkhorsePanel.test.tsx": {
-    "mtime": 1779108266.1204062,
-    "hash": "b42c30ff2ad64bd06fa81f6a16907420"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/__tests__/WorkhorsePanel.test.tsx": {
+    "mtime": 1779420420.991812,
+    "hash": "26be56c26b32fb281e5c98392555c678"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/primitives/SettingsSection.tsx": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/primitives/SettingsSection.tsx": {
+    "mtime": 1779420420.9920955,
     "hash": "7ba249273cc62ab8d74462f4aadd3af0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/primitives/SettingsCardSection.tsx": {
-    "mtime": 1779108266.1204062,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/primitives/SettingsCardSection.tsx": {
+    "mtime": 1779420420.991812,
     "hash": "1764493c6b4d37ce183ed755ce167f18"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/primitives/SettingsRow.tsx": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/primitives/SettingsRow.tsx": {
+    "mtime": 1779420420.9920955,
     "hash": "1ab6d92c8d751484e338f62d52764fd8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/primitives/SettingsLayout.tsx": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/primitives/SettingsLayout.tsx": {
+    "mtime": 1779420420.9920955,
     "hash": "e7a788b68506c6266da0492fa29f8d2c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/primitives/index.ts": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/primitives/index.ts": {
+    "mtime": 1779420420.9920955,
     "hash": "769eabb674583b8b6dec78481efe52a6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/primitives/SettingsRowStatus.tsx": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/primitives/SettingsRowStatus.tsx": {
+    "mtime": 1779420420.9920955,
     "hash": "e04aee33033c8f6691ab148fd15ea7b9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/primitives/SettingsSidebarNav.tsx": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/primitives/SettingsSidebarNav.tsx": {
+    "mtime": 1779420420.9920955,
     "hash": "04e0c5f247e3d53b090d102921662aa0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/primitives/__tests__/primitives.test.tsx": {
-    "mtime": 1779108266.120651,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/primitives/__tests__/primitives.test.tsx": {
+    "mtime": 1779420420.9920955,
     "hash": "aa20be786f6e4e2db477139f1e93f444"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/Settings/SmartSelection/SmartSelectionExplainer.tsx": {
-    "mtime": 1779108266.1201556,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/Settings/SmartSelection/SmartSelectionExplainer.tsx": {
+    "mtime": 1779420420.9915583,
     "hash": "bb084699d959af1f62dc92256e9b34a2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/shared/statusPrimitives.tsx": {
-    "mtime": 1779154247.8681908,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/primitives/VerbBadge.tsx": {
+    "mtime": 1779420420.9950542,
+    "hash": "1ac8172e6034444b68a8081f27c03e42"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/primitives/IssueRow.test.tsx": {
+    "mtime": 1779420420.994844,
+    "hash": "21b1839f0f666d21e44ac0d18c4b15be"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/primitives/TopBar.tsx": {
+    "mtime": 1779420420.9950542,
+    "hash": "f0e98391daa44eda3ae2adc6b1b5d45a"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/primitives/Button.tsx": {
+    "mtime": 1779420420.994844,
+    "hash": "2bc83aab6db9267f743e8b5996eb8bb2"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/primitives/AgentCard.test.tsx": {
+    "mtime": 1779420420.9947643,
+    "hash": "445513b70e570850fc82af1c320ff68d"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/primitives/AgentCard.tsx": {
+    "mtime": 1779420420.9948194,
+    "hash": "44ad0e7f1ad0b75e2af7d7b7ef7da0f3"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/primitives/MetricTile.tsx": {
+    "mtime": 1779420420.994844,
+    "hash": "39b506a339ddf774a44d6f707417f6e1"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/primitives/PhaseHeader.test.tsx": {
+    "mtime": 1779420420.994844,
+    "hash": "6fd9ad48ddb31c3061fc3a5a27f03675"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/primitives/IssueRow.tsx": {
+    "mtime": 1779420420.994844,
+    "hash": "1b6c8dac8e87236eea3d53f980dea81e"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/primitives/MetricStrip.tsx": {
+    "mtime": 1779420420.994844,
+    "hash": "a76c698df2b5d90c9899f90c88f41903"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/primitives/MetricTile.test.tsx": {
+    "mtime": 1779420420.994844,
+    "hash": "17fc46a4a31bcc1b7ccdc498345f7e27"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/primitives/PhaseHeader.tsx": {
+    "mtime": 1779420420.9950318,
+    "hash": "64589403f320e7a0709a731d79833be9"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/primitives/PhaseGlyph.test.tsx": {
+    "mtime": 1779420420.994844,
+    "hash": "6c52633846c42443aacd6834865287e0"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/primitives/PhaseGlyph.tsx": {
+    "mtime": 1779420420.994844,
+    "hash": "825a16f4ac6b31bf1f3e93f7c5e04da5"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/primitives/IssueCard.tsx": {
+    "mtime": 1779420420.994844,
+    "hash": "520ce97d4141f4bd609fff8f148df157"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/primitives/VerbBadge.test.tsx": {
+    "mtime": 1779420420.9950542,
+    "hash": "340786ff73bdd245c5ef5f6925b25d09"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/shared/statusPrimitives.tsx": {
+    "mtime": 1779420420.9952576,
     "hash": "f1e39b351c42d7a22886ecb19dbca60a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/shared/costWarning.tsx": {
-    "mtime": 1779108266.1238272,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/shared/costWarning.tsx": {
+    "mtime": 1779420420.9952576,
     "hash": "80d665d34fef387653ba8248638a66b0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/shared/ContextMenu.tsx": {
-    "mtime": 1779108266.1237197,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/shared/ContextMenu.tsx": {
+    "mtime": 1779420420.9951503,
     "hash": "f544e7390b0c8734e954dae9fdfe9676"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/shared/ModelPicker/ModelPicker.tsx": {
-    "mtime": 1779108266.1238272,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/shared/ModelPicker/ModelPicker.tsx": {
+    "mtime": 1779420420.9952576,
     "hash": "3e6a4d89054584096f8a1ece9ecb3b5b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/shared/ModelPicker/index.ts": {
-    "mtime": 1779108266.1238272,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/shared/ModelPicker/index.ts": {
+    "mtime": 1779420420.9952576,
     "hash": "cd8e604305c200c91f3398880df4f631"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/shared/ModelPicker/ModelPicker.test.ts": {
-    "mtime": 1779108266.1238272,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/shared/ModelPicker/ModelPicker.test.ts": {
+    "mtime": 1779420420.9952576,
     "hash": "c824e83a726b0d1897ee2d111402a657"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/flywheel/FlywheelConversationPane.tsx": {
-    "mtime": 1779163514.71005,
-    "hash": "355a55a097e9d47ee0e999b86e24e206"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/flywheel/FlywheelConversationPane.tsx": {
+    "mtime": 1779420420.994573,
+    "hash": "f401263291a15d12604bade8c0a12235"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/flywheel/FlywheelStatusDetails.tsx": {
-    "mtime": 1779160848.1522708,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/flywheel/FlywheelStatusDetails.tsx": {
+    "mtime": 1779420420.9946768,
     "hash": "7e6e01613b49052b6b6b66148c9fbce4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/flywheel/__tests__/FlywheelConversationPane.test.tsx": {
-    "mtime": 1779163508.9428518,
-    "hash": "0675088635bf467ca0b28e7083dbde2a"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/flywheel/FlywheelStatePane.tsx": {
+    "mtime": 1779420420.9946768,
+    "hash": "b36c202141196cba0117317cb6d26d54"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/components/flywheel/__tests__/FlywheelStatusDetails.test.tsx": {
-    "mtime": 1779161025.4353817,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/flywheel/__tests__/FlywheelConversationPane.test.tsx": {
+    "mtime": 1779420420.9947393,
+    "hash": "cc8ae5cf5dd62642e741258151046a66"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/components/flywheel/__tests__/FlywheelStatusDetails.test.tsx": {
+    "mtime": 1779420420.9947643,
     "hash": "70b6f1465146be1d18c8c907dfa2004f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useResourceStats.test.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useResourceStats.test.ts": {
+    "mtime": 1779420420.995779,
     "hash": "cb4c159e65d01e24ecfc2238f9184e09"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useCodexAutoRetry.ts": {
-    "mtime": 1779108266.1242743,
-    "hash": "dc304a75354cf12391635adc86201221"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useCodexAutoRetry.ts": {
+    "mtime": 1779420420.995779,
+    "hash": "32693f95caa9f67d497ee19656d87d39"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useSystemHealth.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useSystemHealth.ts": {
+    "mtime": 1779420420.995779,
     "hash": "fdf8167cb4f8e93e40f705fa2cf3ef9f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useKillAgent.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useKillAgent.ts": {
+    "mtime": 1779420420.995779,
     "hash": "747a4fc21bed9cb22a0960f5d4492df0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useCodexAuthStatus.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useCodexAuthStatus.ts": {
+    "mtime": 1779420420.995779,
     "hash": "69453d25cacc460d744b6c2d52375459"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useTtsIssueMute.test.tsx": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useTtsIssueMute.test.tsx": {
+    "mtime": 1779420420.995779,
     "hash": "dede004a1c9fbfb389724ec22062b33b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useVoiceTranscription.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useVoiceTranscription.ts": {
+    "mtime": 1779420420.995779,
     "hash": "36bcd1e80d241c4c2d787778c4891615"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useRestartFromPlan.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useRestartFromPlan.ts": {
+    "mtime": 1779420420.995779,
     "hash": "6bb23a2393ef890d307aa344ab01b31d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useConversationUiState.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useConversationUiState.ts": {
+    "mtime": 1779420420.995779,
     "hash": "203d4e9cb85a2ccae49c4a614fcd44be"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useResourceStats.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useResourceStats.ts": {
+    "mtime": 1779420420.995779,
     "hash": "58daa42fd015e84ff35d8dab21d07804"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useNow.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useNow.ts": {
+    "mtime": 1779420420.995779,
     "hash": "36e2538c25930c9b0aac0a6377f74aa2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useTtsIssueMute.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useTtsIssueMute.ts": {
+    "mtime": 1779420420.995779,
     "hash": "2bb68c759ec950619f46c74f3f49c2dc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useAutoPresoWebSocket.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useAutoPresoWebSocket.ts": {
+    "mtime": 1779420420.995779,
     "hash": "1a2254a352a15760d6964422b179519e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useBulkSelection.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useBulkSelection.ts": {
+    "mtime": 1779420420.995779,
     "hash": "1df4bfd3dfc4168b380520f0e21e49c2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useGodViewSocket.ts": {
-    "mtime": 1779108266.1242743,
-    "hash": "aee173a475d729148b6c90d209abbe4d"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useCodexAutoRetry.test.tsx": {
+    "mtime": 1779420420.995779,
+    "hash": "3addccf71c7f015aaa4a48b62f049c41"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useSwitchModel.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useGodViewSocket.ts": {
+    "mtime": 1779420420.995779,
+    "hash": "fe3c20b130b2353b99d113146c8069de"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useSwitchModel.ts": {
+    "mtime": 1779420420.995779,
     "hash": "bb6ff06fff8e6af5a4e972abdf46d36e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useUIPreferences.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useUIPreferences.ts": {
+    "mtime": 1779420420.995779,
     "hash": "1b1bee812293df0ca04189190c60e67c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useRestartAgent.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useRestartAgent.ts": {
+    "mtime": 1779420420.995779,
     "hash": "7de677e6167661a1c562026e59fd73a9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useHandoffData.ts": {
-    "mtime": 1779108266.1242743,
-    "hash": "5f76bd81bdb95e5e8952695d352b6d5f"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useHandoffData.ts": {
+    "mtime": 1779420420.995779,
+    "hash": "e882ef15028ad85fda954f8af92a8ec4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useResetIssue.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useResetIssue.ts": {
+    "mtime": 1779420420.995779,
     "hash": "888bd1031c9e63e17ac17acc22079ecc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useDiffPreferences.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useDiffPreferences.ts": {
+    "mtime": 1779420420.995779,
     "hash": "f23c832d02e15da19b735d189c3b36e5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useTheme.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useTheme.ts": {
+    "mtime": 1779420420.995779,
     "hash": "574e9f94b2a958e9052508741dea1bac"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useSearch.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useSearch.ts": {
+    "mtime": 1779420420.995779,
     "hash": "14bd6ac05dcb547801576215d806a639"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/useCostStream.ts": {
-    "mtime": 1779108266.1242743,
-    "hash": "eaaaca6744c4f7b41f7bb9de961b08a4"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/useCostStream.ts": {
+    "mtime": 1779420420.995779,
+    "hash": "9adda2f241a4506887a326a922e66374"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/__tests__/useTheme.test.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/__tests__/useTheme.test.ts": {
+    "mtime": 1779420420.995779,
     "hash": "b2f7422ece271e1bbb4bcb951d687fdf"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/__tests__/useSearch.test.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/__tests__/useSearch.test.ts": {
+    "mtime": 1779420420.995779,
     "hash": "8b5a2f264e26a9c6057192775655ec9c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/__tests__/useNow.test.ts": {
-    "mtime": 1779108266.1242743,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/__tests__/useNow.test.ts": {
+    "mtime": 1779420420.9957294,
     "hash": "d61d64b8669df9fcc822ecc13b4cfbf4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/hooks/__tests__/useConversationUiState.test.ts": {
-    "mtime": 1779108266.1242547,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/hooks/__tests__/useConversationUiState.test.ts": {
+    "mtime": 1779420420.9957106,
     "hash": "fd1548805393aec26d699e5771bd9bf5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/types/ambient.d.ts": {
-    "mtime": 1779108266.1255121,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/types/ambient.d.ts": {
+    "mtime": 1779420420.9970863,
     "hash": "26a23cf1803ff327c3eede0d6ced22ce"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/wsTransport.ts": {
-    "mtime": 1779164977.897654,
-    "hash": "4f4e05c5e7c26e0ba0d2d969b1c1bb6b"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/wsTransport.ts": {
+    "mtime": 1779420420.996946,
+    "hash": "c2a00a9ad4335e3a3a66396e1e1920e2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/utils.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/utils.ts": {
+    "mtime": 1779420420.9968653,
     "hash": "b363fdbcf721c60995550e7718bb1097"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/pipeline-state.ts": {
-    "mtime": 1779108266.1248775,
-    "hash": "bb72952ac27dad494fcdc10f1caa4b7d"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/pipeline-state.ts": {
+    "mtime": 1779420420.996674,
+    "hash": "a3d157b36d2fc9b0c88a32979c4ee136"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/commandDeckSelection.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/commandDeckSelection.ts": {
+    "mtime": 1779420420.9963946,
     "hash": "78059a3f8f4248f73aee704ed579ea7f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/useSharedTick.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/useSharedTick.ts": {
+    "mtime": 1779420420.9968653,
     "hash": "f0169998006b3781131ce8cca6729dbd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/diffRouteSearch.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/diffRouteSearch.ts": {
+    "mtime": 1779420420.9963946,
     "hash": "8ab1bbb0e152fbcc8f129843fdc79066"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/formatRelativeTime.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/formatRelativeTime.ts": {
+    "mtime": 1779420420.996674,
     "hash": "39adf0e3b066a05292d2e6e7b7fd7e99"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/snapshotCache.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/snapshotCache.ts": {
+    "mtime": 1779420420.9967637,
     "hash": "18632c0fa9b5bcaa2f71416051f60d80"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/turnDiffTree.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/turnDiffTree.ts": {
+    "mtime": 1779420420.9968653,
     "hash": "250407a0e7c8bad0cfe79964301cb0ec"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/resource-utils.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/workspace-types.ts": {
+    "mtime": 1779420420.996946,
+    "hash": "47ddfaaba27b95ce93b71bdc2b5c573d"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/resource-utils.ts": {
+    "mtime": 1779420420.9967637,
     "hash": "72d129ee384a701c2e9cac19d30bf3a3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/pending-codex-spawn.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/pending-codex-spawn.ts": {
+    "mtime": 1779420420.996674,
     "hash": "3ed50670ca0af77c448cabf0b70941b2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/fetchWithRetry.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/fetchWithRetry.ts": {
+    "mtime": 1779420420.9963946,
     "hash": "3f02d6a6f8b6b70255f859259f73e251"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/recoveryCoordinator.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/timeBuckets.ts": {
+    "mtime": 1779420420.9968653,
+    "hash": "82c391b419bd8731020f2e31e289f4ff"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/recoveryCoordinator.ts": {
+    "mtime": 1779420420.996674,
     "hash": "7fa5775ca97227010c3641643cf79555"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/refresh-dashboard-state.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/refresh-dashboard-state.ts": {
+    "mtime": 1779420420.9967637,
     "hash": "6cec6cf0fed55a6f0ca07697ee6f4405"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/workingPhase.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/workingPhase.ts": {
+    "mtime": 1779420420.996946,
     "hash": "e6fae7b6e18c508fa30264901a1aa37e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/motionCatalog.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/motionCatalog.ts": {
+    "mtime": 1779420420.996674,
     "hash": "e85c6effd975f306c9d5b2928fc2077c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/useLiveFlash.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/useLiveFlash.ts": {
+    "mtime": 1779420420.9968653,
     "hash": "fc8e09b0e917e16111e083f1cf935b37"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/deriveRoundMarkers.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/deriveRoundMarkers.ts": {
+    "mtime": 1779420420.9963946,
     "hash": "4bbc4df88776fdd982bbf44b83817d18"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/store.ts": {
-    "mtime": 1779108266.1248775,
-    "hash": "76160b0fa24388f204400e1c2f41d3ec"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/store.ts": {
+    "mtime": 1779420420.9967637,
+    "hash": "20a69203e521d499fefb5da8a2dfeb99"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/useResolvedModels.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/dashboard-utils.ts": {
+    "mtime": 1779420420.9963946,
+    "hash": "ed1948070f9f6c7d7a3749d72804094a"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/useResolvedModels.ts": {
+    "mtime": 1779420420.9968653,
     "hash": "56dcd4ca3f4aadf365c15ab35df45d74"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/swarmSlots.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/swarmSlots.ts": {
+    "mtime": 1779420420.9967637,
     "hash": "183bb497b4d463359c36899d1b8ca438"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/diffRendering.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/diffRendering.ts": {
+    "mtime": 1779420420.9963946,
     "hash": "69c66026ca66ac91215c81b1b09506e2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/commandDeckActions.ts": {
-    "mtime": 1779108266.1248775,
-    "hash": "f05d47a2ed7f9cbad5cdece49f57acde"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/commandDeckActions.ts": {
+    "mtime": 1779420420.9963946,
+    "hash": "0c1a825a7e41a3b4cc63a883a1af2f37"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/commandDeckSurfaceRegistry.ts": {
-    "mtime": 1779108266.1248775,
-    "hash": "cb1f0d30588da2de3bc758ef734f881d"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/commandDeckSurfaceRegistry.ts": {
+    "mtime": 1779420420.9963946,
+    "hash": "d2735e58636c280aaf3a845dcacbdcfe"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/__tests__/formatRelativeTime.test.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/__tests__/formatRelativeTime.test.ts": {
+    "mtime": 1779420420.9963946,
     "hash": "d51d04801b079d4ac94a205bd44df940"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/__tests__/swarmSlots.test.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/__tests__/swarmSlots.test.ts": {
+    "mtime": 1779420420.9963946,
     "hash": "5458581f837025a83d557227685149ab"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/__tests__/commandDeckActions.test.ts": {
-    "mtime": 1779108266.1248105,
-    "hash": "2a78bc334e08b0f2d5f6b11fa4310c3f"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/__tests__/timeBuckets.test.ts": {
+    "mtime": 1779420420.9963946,
+    "hash": "a69703e266dcae2ca8e0b0acd75dafba"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/__tests__/deriveRoundMarkers.test.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/__tests__/commandDeckActions.test.ts": {
+    "mtime": 1779420420.9963324,
+    "hash": "b5b77cc57f6c851b272229794c7d12cc"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/__tests__/deriveRoundMarkers.test.ts": {
+    "mtime": 1779420420.9963946,
     "hash": "2f1ca586181ef77bcd7e51da295cea8c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/__tests__/snapshotCache.test.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/__tests__/snapshotCache.test.ts": {
+    "mtime": 1779420420.9963946,
     "hash": "f1ce18e21dfefa22714701b86376bfef"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/__tests__/recoveryCoordinator.test.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/__tests__/recoveryCoordinator.test.ts": {
+    "mtime": 1779420420.9963946,
     "hash": "4d94e6a801d31546dfeda70b127bb343"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/lib/__tests__/commandDeckSelection.test.ts": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/lib/__tests__/commandDeckSelection.test.ts": {
+    "mtime": 1779420420.9963946,
     "hash": "4dddf07cd402016edcb17264d30f4aed"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/__tests__/store.test.ts": {
-    "mtime": 1779108266.1132624,
-    "hash": "c853875e704bddf848647394c69ad0a4"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/__tests__/store.test.ts": {
+    "mtime": 1779420420.983943,
+    "hash": "3220396ea35eaa0ed716addb6d6d109e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/__tests__/recoveryCoordinator.test.ts": {
-    "mtime": 1779108266.1132624,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/__tests__/recoveryCoordinator.test.ts": {
+    "mtime": 1779420420.983943,
     "hash": "68944acb60d3e94e82b45ac4e18ed572"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/__tests__/pipeline-state.test.ts": {
-    "mtime": 1779108266.1130152,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/__tests__/pipeline-state.test.ts": {
+    "mtime": 1779420420.9837928,
     "hash": "7ed20a054a8a0fa9884f9d281a7789fa"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/pages/FlywheelPage.tsx": {
-    "mtime": 1779165296.1826403,
-    "hash": "13e2768e17edd35d12a37deac56c08f3"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/pages/FlywheelPage.tsx": {
+    "mtime": 1779420420.996946,
+    "hash": "88845bb4868aab69ad41a1954e9ad558"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/pages/SpecialistDetail.tsx": {
-    "mtime": 1779108266.1248775,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/pages/SpecialistDetail.tsx": {
+    "mtime": 1779420420.9970863,
     "hash": "476035525108be29c75c6722ab09c4c4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/pages/SpecialistRunLog.tsx": {
-    "mtime": 1779108266.1255121,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/pages/SpecialistRunLog.tsx": {
+    "mtime": 1779420420.9970863,
     "hash": "d8e06d79ba1bf9668cdd48db4845a86e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/src/pages/__tests__/FlywheelPage.test.tsx": {
-    "mtime": 1779165345.6753478,
-    "hash": "b01d94aa4e355b901902f56a0f94d3e5"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/src/pages/__tests__/FlywheelPage.test.tsx": {
+    "mtime": 1779420420.9970863,
+    "hash": "f30939285f02f31778d7f577498e4fb2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/read-model.ts": {
-    "mtime": 1779162970.3303206,
-    "hash": "ce98d0d3a1c70b6e96cb26d3cbf98493"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/read-model.ts": {
+    "mtime": 1779420421.0036695,
+    "hash": "745d3d72dd14e4ae4f929f31714e7ba5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/http-helpers.ts": {
-    "mtime": 1779108266.1315958,
-    "hash": "cbdbf645570e9e3c7cc1c05e2f03e10b"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/http-helpers.ts": {
+    "mtime": 1779420421.003544,
+    "hash": "1e9d5f7919de313375273c2feba5185f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/ws-autopreso.ts": {
-    "mtime": 1779108266.1362734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/ws-autopreso.ts": {
+    "mtime": 1779420421.0106697,
     "hash": "5267d2c46eff4eafa92438dfaecba17b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/pty-hub.ts": {
-    "mtime": 1779108266.1315958,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/pty-hub.ts": {
+    "mtime": 1779420421.0036695,
     "hash": "294f4bee8baec4df06a80c18a9fbb69c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/ws-voice.ts": {
-    "mtime": 1779108266.1362734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/ws-voice.ts": {
+    "mtime": 1779420421.0106697,
     "hash": "defae6b61ab26a40f5907327f6f8e70a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/ws-terminal.ts": {
-    "mtime": 1779108266.1362734,
-    "hash": "38d868090c3f925ca0d0b8090d42a408"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/ws-terminal.ts": {
+    "mtime": 1779420421.0106697,
+    "hash": "25422d5f13595e3a994b1553a42dfca2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/main.ts": {
-    "mtime": 1779108266.1315958,
-    "hash": "aab4b5f5a522fb67cc517d25540b74bd"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/main.ts": {
+    "mtime": 1779420421.003544,
+    "hash": "d9052e9c09c9663edf2c1de8431731cd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/ws-rpc.ts": {
-    "mtime": 1779167344.4838116,
-    "hash": "1e36b2fc1f0c7c2887c688103da8259c"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/ws-rpc.ts": {
+    "mtime": 1779420421.0106697,
+    "hash": "14e23eeba27342d2c8a334ca2423a107"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/review-status.ts": {
-    "mtime": 1779108266.1315958,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/review-status.ts": {
+    "mtime": 1779420421.0036695,
     "hash": "c8e3f1171b2a141524d6014b0d66d9d2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/tsdown.config.ts": {
-    "mtime": 1779108266.1362734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/tsdown.config.ts": {
+    "mtime": 1779420421.0106697,
     "hash": "bda879dbf6d7844ae42ee2f7cc20ada0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/server.ts": {
-    "mtime": 1779150733.480821,
-    "hash": "54d0ce501d5d0bd8b3c63e97b630a743"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/server.ts": {
+    "mtime": 1779420421.0078542,
+    "hash": "713bc8b76f8187314dbd262eae14449d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/event-store.ts": {
-    "mtime": 1779108266.1315958,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/event-store.ts": {
+    "mtime": 1779420421.003544,
     "hash": "a665d2096273d05248b0da904e56dbd9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/pending-feedback.ts": {
-    "mtime": 1779108266.1315958,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/pending-feedback.ts": {
+    "mtime": 1779420421.003544,
     "hash": "117cfa9f021d254de21efb04b52df5b5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/pending-lifecycle.ts": {
-    "mtime": 1779108266.1315958,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/pending-lifecycle.ts": {
+    "mtime": 1779420421.003544,
     "hash": "c480ed128311ed1acc51dc2896e7c109"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/config.ts": {
-    "mtime": 1779108266.1315958,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/config.ts": {
+    "mtime": 1779420421.003544,
     "hash": "9bc4939b6ad019153dd99d0d3693264d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/utils/vtt-parser.ts": {
-    "mtime": 1779108266.1362734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/utils/vtt-parser.ts": {
+    "mtime": 1779420421.0106697,
     "hash": "6e1b0483b32593e0f0ed25d009a5f9a5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/tts.ts": {
-    "mtime": 1779108266.1342733,
-    "hash": "52677c15719fbc06eb85f4d68815d1b8"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/tts.ts": {
+    "mtime": 1779420421.0078542,
+    "hash": "d870f476952205832caa54e7bb800618"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/agents.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "edf564e2b1d898e46eb9bd9bd9b0ad83"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/agents.ts": {
+    "mtime": 1779420421.0046694,
+    "hash": "804913a043506d93e752a0d46c6563bb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/events.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "faa576fedd9533d20fabacb4afb46b73"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/events.ts": {
+    "mtime": 1779420421.0056696,
+    "hash": "39ee0e350de72d2fb10b2ba3a02bef34"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/show.ts": {
-    "mtime": 1779108266.1332734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/show.ts": {
+    "mtime": 1779420421.007085,
     "hash": "72b61724dae4d7c05a560bf516c2b17f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/issues.ts": {
-    "mtime": 1779108266.1332734,
-    "hash": "2cb69613bb00cbffab673470cba96efd"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/issues.ts": {
+    "mtime": 1779420421.0056696,
+    "hash": "17a25414d3f8849e7cd4fd6b3e1fef1c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/autopreso.ts": {
-    "mtime": 1779108266.1323402,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/autopreso.ts": {
+    "mtime": 1779420421.0046694,
     "hash": "29737e4cd8791b5ba201796536e7b5a2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/diffs.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "07ce61728663c7c8d2809b1c64c6f0e3"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/diffs.ts": {
+    "mtime": 1779420421.0056696,
+    "hash": "a5373d05125a1945d15ec08dd699f7a3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/conversations.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "4e81ebbafca317397ee561d0bf9de25c"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/conversations.ts": {
+    "mtime": 1779420421.0056696,
+    "hash": "6161a9841fc244116bd9a569954d827a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/codex-auth.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "92950ac0a66c8824572f90f553cad5f7"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/codex-auth.ts": {
+    "mtime": 1779420421.0046694,
+    "hash": "8789e0c24b5796ceb5721858d4fc232e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/http-handler.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "f20943abdc1f58823d2c9a6fe211cb5f"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/http-handler.ts": {
+    "mtime": 1779420421.0056696,
+    "hash": "41a82f17462b4c5624bc8018d46be334"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/admin.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "7e7125571b1ea66e203fdf794dd78fc0"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/admin.ts": {
+    "mtime": 1779420421.0042312,
+    "hash": "611f3ec3d4204f7e22ed1349555012f7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/remote.ts": {
-    "mtime": 1779108266.1332734,
-    "hash": "bc13452efabac503caee0f363aa39e25"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/remote.ts": {
+    "mtime": 1779420421.007085,
+    "hash": "ab2d5621afb3708080e422ce063c126e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/costs.ts": {
-    "mtime": 1779108266.1323402,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/costs.ts": {
+    "mtime": 1779420421.0056696,
     "hash": "f98803db0137e10aec96b26f4e41c3e4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/cloister.ts": {
-    "mtime": 1779108266.1323402,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/cloister.ts": {
+    "mtime": 1779420421.0046694,
     "hash": "6c43347598bf90d8bb15ee0e49095063"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/hooks.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "26ae6378599523d6431e4bdd35400d07"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/hooks.ts": {
+    "mtime": 1779420421.0056696,
+    "hash": "0c7e8722ad83eb4a4ac275727c05eb2b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/settings.ts": {
-    "mtime": 1779108266.1332734,
-    "hash": "4b0e1ac72d1da5d5bd1fbae26462b537"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/settings.ts": {
+    "mtime": 1779420421.007085,
+    "hash": "062da66996b66818ed847bed955e620c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/command-deck.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "a04a4873e04359f2f03eb877b9290f38"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/command-deck.ts": {
+    "mtime": 1779420421.0046694,
+    "hash": "94d802774ab2b078ba1dfd80de1622de"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/misc.ts": {
-    "mtime": 1779108266.1332734,
-    "hash": "1e6fa261e745458f0de68a2ee68cf7a6"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/misc.ts": {
+    "mtime": 1779420421.007085,
+    "hash": "ade155fadc997c8780b1b6be8779dd6a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/reviewer-tree.ts": {
-    "mtime": 1779108266.1332734,
-    "hash": "dd13fbeadece3a88305c8f7acb15c250"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/reviewer-tree.ts": {
+    "mtime": 1779420421.007085,
+    "hash": "292cc813d636729c80f213ffb2abb9b9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/swarm.ts": {
-    "mtime": 1779108266.1342733,
-    "hash": "3b5a7f98f46d4a22d1da0839b08f29eb"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/swarm.ts": {
+    "mtime": 1779420421.0078542,
+    "hash": "d895b35e0f0cf9f7c6f49e6cb1b12054"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/origin-validation.ts": {
-    "mtime": 1779108266.1332734,
-    "hash": "47813012a1f3ba49f180854adb85cdad"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/origin-validation.ts": {
+    "mtime": 1779420421.007085,
+    "hash": "477f979573b3d905253f978276c47bc1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/cliproxy.ts": {
-    "mtime": 1779108266.1323402,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/cliproxy.ts": {
+    "mtime": 1779420421.0046694,
     "hash": "868ed27642371211ce7a3bd44e7fd946"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/prereqs.ts": {
-    "mtime": 1779108266.1332734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/prereqs.ts": {
+    "mtime": 1779420421.007085,
     "hash": "539f8c92aa4af15fc3071765e50f606f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/agent-permissions.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "8125192ed41c7d9c21a9ff45825dd291"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/agent-permissions.ts": {
+    "mtime": 1779420421.0046694,
+    "hash": "dc5b3c2fcd242913d60335b88477cd4a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/voice.ts": {
-    "mtime": 1779108266.1342733,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/voice.ts": {
+    "mtime": 1779420421.0078542,
     "hash": "9b095a20976129b367359697ec9d45c3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/projects.ts": {
-    "mtime": 1779108266.1332734,
-    "hash": "93a2b3c27a743af7221030dd6d8eb4b2"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/projects.ts": {
+    "mtime": 1779420421.007085,
+    "hash": "2dd6352843a64b5fb6e051c18f24879b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/flywheel.ts": {
-    "mtime": 1779167333.0704198,
-    "hash": "c0bc5f129bdcb0a668eccece9e5be92d"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/flywheel.ts": {
+    "mtime": 1779420421.0056696,
+    "hash": "4cc89963df31f429234fd00135b64823"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/jsonl-resolver.ts": {
-    "mtime": 1779108266.1332734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/jsonl-resolver.ts": {
+    "mtime": 1779420421.0056696,
     "hash": "5a47744698f658ec97850dd3db037d64"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/metrics.ts": {
-    "mtime": 1779108266.1332734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/metrics.ts": {
+    "mtime": 1779420421.0056696,
     "hash": "8bf704414886cddc060759292cf3d90a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/dashboard-auth.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "cb7ddbd68643ab87b3602ae1e03c2d88"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/dashboard-auth.ts": {
+    "mtime": 1779420421.0056696,
+    "hash": "0ffd82c6107592b862f4544ea269abca"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/specialists.ts": {
-    "mtime": 1779108266.1332734,
-    "hash": "c96ec62b1d1961a9b7fcb8d9c7292366"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/specialists.ts": {
+    "mtime": 1779420421.007085,
+    "hash": "e5004a528c8d23b7c454249ac4820c5e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/discovered-sessions.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "8b18b03174dcf7ecc6d708e508a6616d"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/discovered-sessions.ts": {
+    "mtime": 1779420421.0056696,
+    "hash": "fdbd78df6e4de30e6a414789e83b507d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/workspaces.ts": {
-    "mtime": 1779108266.1342733,
-    "hash": "c48bdc379ab6b22a1ab140799a1d4476"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/workspaces.ts": {
+    "mtime": 1779420421.0078542,
+    "hash": "d407bb44e0d1fb3ba8db073162364b7b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/webhooks.ts": {
-    "mtime": 1779108266.1342733,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/webhooks.ts": {
+    "mtime": 1779420421.0078542,
     "hash": "15a3447c1e0d662ea5c464d38a933d8b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/resources.ts": {
-    "mtime": 1779108266.1332734,
-    "hash": "4ff6d32834f6851d10f6bb9546ab62f9"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/resources.ts": {
+    "mtime": 1779420421.007085,
+    "hash": "98b9229e40fa9bdf9f672197cdde30bc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/__tests__/jsonl-resolver.test.ts": {
-    "mtime": 1779108266.1323402,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/jsonl-resolver.test.ts": {
+    "mtime": 1779420421.0042312,
     "hash": "9b3d80ad091d49911b251abd0381b77a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/__tests__/discovered-sessions.test.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "694dff13659451b4a119826db50058ef"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/issues-reopen.test.ts": {
+    "mtime": 1779420421.0042312,
+    "hash": "e54f88d6c19417b91f1eaa29d65a9298"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/__tests__/agents-delivery-method.test.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "e4f707990b8b1ced0304a00d997263a3"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/discovered-sessions.test.ts": {
+    "mtime": 1779420421.0042312,
+    "hash": "4ba5552821bb0811fb5a90f5c12c3825"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/__tests__/conversations.test.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "96d05c797785b684c8a9a5721f0c9b5b"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/agents-delivery-method.test.ts": {
+    "mtime": 1779420421.0042312,
+    "hash": "f287a98a7f53b828e5d8819f7d3ac75c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/__tests__/conversation-compaction.test.ts": {
-    "mtime": 1779108266.1323402,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/agents-lifecycle-event.test.ts": {
+    "mtime": 1779420421.0042312,
+    "hash": "f14697df3044a817eab9a9d8c4431a5f"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/conversations.test.ts": {
+    "mtime": 1779420421.0042312,
+    "hash": "eb8ba892b6a2b867acb0c1753086d6c9"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/conversation-compaction.test.ts": {
+    "mtime": 1779420421.0042312,
     "hash": "b1908396173d3b64c77ef033ccdc4561"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/__tests__/effect-patterns.test.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "61858c01cea867eca2e5ca10cadde44b"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/issues-close-out.test.ts": {
+    "mtime": 1779420421.0042312,
+    "hash": "f85cf3e0c86000ef1b3cedf9241a295c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/__tests__/issues-rally-children.test.ts": {
-    "mtime": 1779108266.1323402,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/effect-patterns.test.ts": {
+    "mtime": 1779420421.0042312,
+    "hash": "a25c955f747bd3f0375b7c9b9f005a69"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/issues-rally-children.test.ts": {
+    "mtime": 1779420421.0042312,
     "hash": "c35ac153dd7102fac986957d415a6972"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/__tests__/complete-planning.test.ts": {
-    "mtime": 1779108266.1323402,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/complete-planning.test.ts": {
+    "mtime": 1779420421.0042312,
     "hash": "eb96eb1faf9e6c6662686108e8f96548"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/__tests__/agents-guardrails.test.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "aaaa730cedca5e661fde0954fbb22ed9"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/agents-guardrails.test.ts": {
+    "mtime": 1779420421.0042312,
+    "hash": "69a37ef9e4b69d05464a74753e5494c3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/__tests__/reviewer-tree.test.ts": {
-    "mtime": 1779108266.1323402,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/reviewer-tree.test.ts": {
+    "mtime": 1779420421.0042312,
     "hash": "299c5363d29c7fd94b5874301414518f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/__tests__/agent-permissions.test.ts": {
-    "mtime": 1779108266.1323018,
-    "hash": "f1fe165dec85b1719b899baccd983efc"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/agent-permissions.test.ts": {
+    "mtime": 1779420421.004197,
+    "hash": "5957039ca6d0b8d8e34b20c6009fcb05"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/__tests__/tts.test.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "3b02cc8d7b9be28a9ae8162891372911"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/tts.test.ts": {
+    "mtime": 1779420421.0042312,
+    "hash": "0f4478e613441f7f24ef448cbf9dab49"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/__tests__/buildRichPRBody.test.ts": {
-    "mtime": 1779108266.1323402,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/buildRichPRBody.test.ts": {
+    "mtime": 1779420421.0042312,
     "hash": "806041ff3e8b9b25a07c82820d564509"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/__tests__/agents-conversation.test.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "46bdee8405d46f2035d36739b8981e6d"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/agents-conversation.test.ts": {
+    "mtime": 1779420421.0042312,
+    "hash": "6c5935b36b0ef56fce1e7116d9feb2f9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/__tests__/swarm.test.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "fded9c6c1d751c5495ebf9809853ad98"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/swarm.test.ts": {
+    "mtime": 1779420421.0042312,
+    "hash": "04d131c48a142a2896036a35043d3c9c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/__tests__/costs-experiments.test.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "129893b707b6e615110ef167ef8582b3"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/costs-experiments.test.ts": {
+    "mtime": 1779420421.0042312,
+    "hash": "92c3c7386ccbeb59a3720b0bb171cb5c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/__tests__/http-handler.test.ts": {
-    "mtime": 1779108266.1323402,
-    "hash": "b7e78c56d7ce0f87f25f65aae1157dc3"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/http-handler.test.ts": {
+    "mtime": 1779420421.0042312,
+    "hash": "65ae011a55c05d3cf338d180c09c6879"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/routes/__tests__/flywheel.test.ts": {
-    "mtime": 1779167369.9746864,
-    "hash": "089df7ac5c50866b192d1232e10dd3f1"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/routes/__tests__/flywheel.test.ts": {
+    "mtime": 1779420421.0042312,
+    "hash": "95631c577c095e60c0eca90f430d01c2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/__tests__/read-model-diff-summaries.test.ts": {
-    "mtime": 1779108266.1315958,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/__tests__/read-model-diff-summaries.test.ts": {
+    "mtime": 1779420421.0034137,
     "hash": "f8e4131302f93c731584f6abfe88a587"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/__tests__/pending-feedback.test.ts": {
-    "mtime": 1779108266.1315958,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/__tests__/pending-feedback.test.ts": {
+    "mtime": 1779420421.0034137,
     "hash": "3b1806b55950dacc819e54cba7e6590a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/__tests__/swarm-slot-session-mapping.test.ts": {
-    "mtime": 1779108266.1315958,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/__tests__/swarm-slot-session-mapping.test.ts": {
+    "mtime": 1779420421.0034137,
     "hash": "69f1bdbcfcdf910d8d41a6718c58c23a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/__tests__/ws-rpc.test.ts": {
-    "mtime": 1779108266.1315958,
-    "hash": "a5038107b29463cf5e5844dc03dcf9a8"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/__tests__/ws-rpc.test.ts": {
+    "mtime": 1779420421.0035088,
+    "hash": "5bd8ca76f909bb2682b3a381ddb803a5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/__tests__/pty-hub.test.ts": {
-    "mtime": 1779108266.1315958,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/__tests__/pty-hub.test.ts": {
+    "mtime": 1779420421.0034137,
     "hash": "62cbe2838e44dd705b0c93e08a516bc9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/__tests__/event-store-discovered-sessions-schema.test.ts": {
-    "mtime": 1779108266.1315541,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/__tests__/event-store-discovered-sessions-schema.test.ts": {
+    "mtime": 1779420421.0033724,
     "hash": "340edd398d080f784e0ac01361f2f8ea"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/dashboard-db-task.ts": {
-    "mtime": 1779164999.5004,
-    "hash": "a1634ec4ae0e9f0de4477b6e0761c940"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/dashboard-db-task.ts": {
+    "mtime": 1779420421.0100977,
+    "hash": "3f16286de9d8da4f9ca613c7b28f2ee6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/issue-data-service.ts": {
-    "mtime": 1779108266.1362734,
-    "hash": "00b8be48796d9e78022ff58b0ddb1736"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/issue-data-service.ts": {
+    "mtime": 1779420421.0100977,
+    "hash": "2cac593ef4a5a08bce173c3a529d9b75"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/git-activity.ts": {
-    "mtime": 1779108266.1359885,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/agent-output-service.ts": {
+    "mtime": 1779420421.0088816,
+    "hash": "5e21a6052f6f404e7ea4ac1284ee6bb8"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/git-activity.ts": {
+    "mtime": 1779420421.0100977,
     "hash": "fa6b3310c9b48346e3ed07acb0e29bed"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/pi-conversation-parser.ts": {
-    "mtime": 1779108266.1362734,
-    "hash": "652d34cf3bc6d08b664ee497320d27ba"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/pi-conversation-parser.ts": {
+    "mtime": 1779420421.0100977,
+    "hash": "e7ec866c299ba9c98421063a4b26bf90"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/linear-client.ts": {
-    "mtime": 1779108266.1362734,
-    "hash": "8368e39dc932de0a56b2435f3f4533f2"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/linear-client.ts": {
+    "mtime": 1779420421.0100977,
+    "hash": "228862b468d7bf56bdb23961515b8ea9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/tts-runtime-config.ts": {
-    "mtime": 1779108266.1362734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/tts-runtime-config.ts": {
+    "mtime": 1779420421.0106697,
     "hash": "2b0cfc9890611d3f9c66957a17266a21"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/conversation-compaction.ts": {
-    "mtime": 1779108266.1359885,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/conversation-compaction.ts": {
+    "mtime": 1779420421.0088816,
     "hash": "3e9839f2c6172363684b1d403ead2a3e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/cache-service.ts": {
-    "mtime": 1779108266.1359885,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/cache-service.ts": {
+    "mtime": 1779420421.0088816,
     "hash": "d124ea5ca44d91bd1c2bee0a3d618924"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/tts-summarizer.ts": {
-    "mtime": 1779108266.1362734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/tts-summarizer.ts": {
+    "mtime": 1779420421.0106697,
     "hash": "6c276443898937a816211189c6c833c0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/agent-event-utils.ts": {
-    "mtime": 1779108266.1359885,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/agent-event-utils.ts": {
+    "mtime": 1779420421.0088816,
     "hash": "de4410f12243d32c6e8affabccbc8991"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/system-health-service.ts": {
-    "mtime": 1779108266.1362734,
-    "hash": "f713524ff667a0213ef3e7fd4d7dadb9"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/system-health-service.ts": {
+    "mtime": 1779420421.0106697,
+    "hash": "7a57e279d2767e81ae71d299734104c9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/typed-errors.ts": {
-    "mtime": 1779108266.1362734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/typed-errors.ts": {
+    "mtime": 1779420421.0106697,
     "hash": "43d2d107b4fdccf098afbefea27ba0a6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/rally-client.ts": {
-    "mtime": 1779108266.1362734,
-    "hash": "1627fa220793ebafb6bb1af0df1930e3"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/rally-client.ts": {
+    "mtime": 1779420421.0100977,
+    "hash": "1523808024833c0389c367f0093a91ef"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/projection-cache.ts": {
-    "mtime": 1779108266.1362734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/flywheel-state.ts": {
+    "mtime": 1779420421.0100977,
+    "hash": "2f316990a3f57e76173e87eeee13c6dd"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/projection-cache.ts": {
+    "mtime": 1779420421.0100977,
     "hash": "648019333233a535d674ee163fcdd42a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/merge-queue-service.ts": {
-    "mtime": 1779108266.1362734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/merge-queue-service.ts": {
+    "mtime": 1779420421.0100977,
     "hash": "861a0dfb86afb0ff3a2daf799455eb33"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/resource-discovery.ts": {
-    "mtime": 1779108266.1362734,
-    "hash": "828917cb60668f1a3bf304981a8846ff"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/resource-discovery.ts": {
+    "mtime": 1779420421.0100977,
+    "hash": "a77909cdd4bd70e2a7464fc78a23183e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/agent-state-service.ts": {
-    "mtime": 1779108266.1359885,
-    "hash": "31b6b8316f4c98ad208a35c6c17762e3"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/agent-state-service.ts": {
+    "mtime": 1779420421.0088816,
+    "hash": "dd1d19e2b6a8b804002e69f428735cf7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/running-agents-cache.ts": {
-    "mtime": 1779108266.1362734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/running-agents-cache.ts": {
+    "mtime": 1779420421.0100977,
     "hash": "6aafd19b6834a339b04c04b0c00dbc85"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/conversation-attachments.ts": {
-    "mtime": 1779108266.1359885,
-    "hash": "ccba81a2aeea95a3e176ab2b3ccc2315"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/conversation-attachments.ts": {
+    "mtime": 1779420421.0088816,
+    "hash": "76d35862e6547aac96875a92cee683c6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/conversation-service.ts": {
-    "mtime": 1779108266.1359885,
-    "hash": "d3ac8480c5fdb21063656d5cbba2ad3c"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/conversation-service.ts": {
+    "mtime": 1779420421.0099647,
+    "hash": "496e79e95cdff857b9d45ded0d754520"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/issue-lifecycle.ts": {
-    "mtime": 1779108266.1362734,
-    "hash": "14f92774b7d5f838453f8b8d98a2ed99"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/issue-lifecycle.ts": {
+    "mtime": 1779420421.0100977,
+    "hash": "1dc6f7b691caff8feea81f1c6ee40472"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/agent-spawner.ts": {
-    "mtime": 1779108266.1359885,
-    "hash": "07822327bd8c91896c1b49226924ef96"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/agent-spawner.ts": {
+    "mtime": 1779420421.0088816,
+    "hash": "31bb7c0ff095f920ea9feece1f801c25"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/conversation-lifecycle.ts": {
-    "mtime": 1779108266.1359885,
-    "hash": "7350109015ca388db17c1124e0914ba8"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/conversation-lifecycle.ts": {
+    "mtime": 1779420421.0088816,
+    "hash": "3fc3cf5bcb67afbeafbf95f3c05479fe"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/github-client.ts": {
-    "mtime": 1779108266.1359885,
-    "hash": "f55aad9dcd460e3f1f6c2f784a7c381c"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/github-client.ts": {
+    "mtime": 1779420421.0100977,
+    "hash": "d3851aaf5023283cbf79cf18324df388"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/flywheel-actions.ts": {
-    "mtime": 1779167144.3119438,
-    "hash": "9f6559b5692f534716f4f61a46161f37"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/flywheel-actions.ts": {
+    "mtime": 1779420421.0100977,
+    "hash": "25a9c6c4a694d36e5add33c5c9995a07"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/issue-service-singleton.ts": {
-    "mtime": 1779108266.1362734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/issue-service-singleton.ts": {
+    "mtime": 1779420421.0100977,
     "hash": "7089a2b5b16c16763f2cbdf805337ae7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/domain-services.ts": {
-    "mtime": 1779108266.1359885,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/domain-services.ts": {
+    "mtime": 1779420421.0100977,
     "hash": "83b019ce5e4adeae5026631bafae6cc2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/agent-status.ts": {
-    "mtime": 1779108266.1359885,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/agent-status.ts": {
+    "mtime": 1779420421.0088816,
     "hash": "1ea3dc68fb49bebbb2ceb1e3a3c01ef8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/tts-playback.ts": {
-    "mtime": 1779108266.1362734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/tts-playback.ts": {
+    "mtime": 1779420421.0106697,
     "hash": "1267848f726e9a6e4f3e57f8d9edea24"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/workspace-service.ts": {
-    "mtime": 1779108266.1362734,
-    "hash": "0a579b44d1dc4c2a32613fb4540d831e"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/workspace-service.ts": {
+    "mtime": 1779420421.0106697,
+    "hash": "dcbbf8978101650b1557e3a50edec484"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/issue-cost-resolver.ts": {
-    "mtime": 1779108266.1359885,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/issue-cost-resolver.ts": {
+    "mtime": 1779420421.0100977,
     "hash": "ab8505af332ec9eb6c36b606e9b2cedd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/resource-discovery.bench.ts": {
-    "mtime": 1779108266.1362734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/resource-discovery.bench.ts": {
+    "mtime": 1779420421.0100977,
     "hash": "411bbf099fa064a3bf65a62b43d414b3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/agent-enrichment-service.ts": {
-    "mtime": 1779108266.1359885,
-    "hash": "ad760a0cf3dba2645f37cc3cf7ae677c"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/agent-enrichment-service.ts": {
+    "mtime": 1779420421.0088816,
+    "hash": "5ce1ae1c973de46fef63b890c74d0403"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/dashboard-db-worker.ts": {
-    "mtime": 1779165018.6420612,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/dashboard-db-worker.ts": {
+    "mtime": 1779420421.0100977,
     "hash": "a96c8b9eb6cae7c6fbc13bd0bde6e941"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/tracker-config.ts": {
-    "mtime": 1779108266.1362734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/tracker-config.ts": {
+    "mtime": 1779420421.0106697,
     "hash": "6fdaeb8c2620d23f889644ee50f8240d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/pending-respawn.ts": {
-    "mtime": 1779108266.1362734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/pending-respawn.ts": {
+    "mtime": 1779420421.0100977,
     "hash": "cd379392aa7c1bb29bd7e07757034bf6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/open.ts": {
-    "mtime": 1779108266.1362734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/open.ts": {
+    "mtime": 1779420421.0100977,
     "hash": "b52501aea9ae5dac6f097ad3ccfbd134"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/terminal-service.ts": {
-    "mtime": 1779108266.1362734,
-    "hash": "779d8ba58d7fe628b9d4546359cbf640"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/terminal-service.ts": {
+    "mtime": 1779420421.0106697,
+    "hash": "fd4c7702bafdbf9792bd997b1cf5fbc3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/flywheel-run-state.ts": {
-    "mtime": 1779167119.7761023,
-    "hash": "ecbfff9225bc3fbe819b7d55da02e757"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/flywheel-run-state.ts": {
+    "mtime": 1779420421.0100977,
+    "hash": "868b393972ac93454aaf34dfd7f12f2a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/openrouter-service.ts": {
-    "mtime": 1779108266.1362734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/openrouter-service.ts": {
+    "mtime": 1779420421.0100977,
     "hash": "415c4d41cdf25644c334720bbe9bd022"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/session-presence.ts": {
-    "mtime": 1779108266.1362734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/session-presence.ts": {
+    "mtime": 1779420421.0100977,
     "hash": "5c73d40fc0c0b13da2848422b9aa6120"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/__tests__/pending-respawn.test.ts": {
-    "mtime": 1779108266.1359885,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/pending-respawn.test.ts": {
+    "mtime": 1779420421.0088816,
     "hash": "57f5babf7830f5a01c5e9e40b61be6a3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/__tests__/running-agents-cache.test.ts": {
-    "mtime": 1779108266.1359885,
-    "hash": "21148fd517f9f3780386e129ac41498c"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/running-agents-cache.test.ts": {
+    "mtime": 1779420421.0088816,
+    "hash": "ab588cbca7a1dee3a259437dcfd3cb86"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/__tests__/github-client.test.ts": {
-    "mtime": 1779108266.1359885,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/github-client.test.ts": {
+    "mtime": 1779420421.0088816,
     "hash": "28dd65a96d0e37c0a5cbb47623f8d412"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/__tests__/flywheel-run-state.test.ts": {
-    "mtime": 1779150733.4978213,
-    "hash": "b439f3393f395cb6488dbd16261067c5"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/issue-data-service.test.ts": {
+    "mtime": 1779420421.0088816,
+    "hash": "49d3aaaef57ea480195282b0a26ce18b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/__tests__/issue-lifecycle.unit.test.ts": {
-    "mtime": 1779108266.1359885,
-    "hash": "7f6c2c4ca9225132c2d6ae3dcbf064dc"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/flywheel-run-state.test.ts": {
+    "mtime": 1779420421.0088816,
+    "hash": "1d901aaeb49252df7c08202d6bbcd7c6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/__tests__/tts-playback.test.ts": {
-    "mtime": 1779108266.1359885,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/issue-lifecycle.unit.test.ts": {
+    "mtime": 1779420421.0088816,
+    "hash": "68604fa14fdb641327d6cfd6811cbe6a"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/tts-playback.test.ts": {
+    "mtime": 1779420421.0088816,
     "hash": "07bce99a1c95697d6e1bccdda3789988"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/__tests__/conversation-lifecycle.test.ts": {
-    "mtime": 1779108266.1359885,
-    "hash": "84572443d6d87c6d6e83f3d569c19829"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/conversation-lifecycle.test.ts": {
+    "mtime": 1779420421.0088816,
+    "hash": "301eb1183c61d671ffa9cdbbbbb2e5ed"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/__tests__/openrouter-service.test.ts": {
-    "mtime": 1779108266.1359885,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/openrouter-service.test.ts": {
+    "mtime": 1779420421.0088816,
     "hash": "6057e9436d50575eb83c3dd55c4cf8fc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/__tests__/agent-spawner.test.ts": {
-    "mtime": 1779108266.1359105,
-    "hash": "1b2a0221e12cb8feeb6bb111786ef105"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/agent-spawner.test.ts": {
+    "mtime": 1779420421.0088816,
+    "hash": "d9196767ec79bc759e7710cca500ca59"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/__tests__/rally-client.test.ts": {
-    "mtime": 1779108266.1359885,
-    "hash": "1aef1a9b70fb84edd37749ff32a2f0ec"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/flywheel-state.test.ts": {
+    "mtime": 1779420421.0088816,
+    "hash": "999a3df8930cc029721a5954ad955361"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/__tests__/agent-spawner.unit.test.ts": {
-    "mtime": 1779108266.1359885,
-    "hash": "283b63ab509637e8196968dba3a53be0"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/rally-client.test.ts": {
+    "mtime": 1779420421.0088816,
+    "hash": "3b40f1e449d9d72dc3473e6b6160e218"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/__tests__/tts-runtime-config.test.ts": {
-    "mtime": 1779108266.1359885,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/agent-spawner.unit.test.ts": {
+    "mtime": 1779420421.0088816,
+    "hash": "f9c855447b6ba98bcb059f61fca72b4c"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/tts-runtime-config.test.ts": {
+    "mtime": 1779420421.0088816,
     "hash": "16d7209f24d3ab2fa04aeb9970d2de4e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/__tests__/linear-client.test.ts": {
-    "mtime": 1779108266.1359885,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/agent-output-service.test.ts": {
+    "mtime": 1779420421.0088131,
+    "hash": "28d0fd3b47ea987bfa47b9e0adf72e8a"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/linear-client.test.ts": {
+    "mtime": 1779420421.0088816,
     "hash": "a92a30ea3b6a2ed2286ee6ddf704ebac"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/__tests__/workspace-service.unit.test.ts": {
-    "mtime": 1779108266.1359885,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/workspace-service.unit.test.ts": {
+    "mtime": 1779420421.0088816,
     "hash": "dced8083a58008d037aef64dd4ced669"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/__tests__/error-channel.test.ts": {
-    "mtime": 1779108266.1359885,
-    "hash": "4213fbec6e893ed502601f3a95cc3574"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/error-channel.test.ts": {
+    "mtime": 1779420421.0088816,
+    "hash": "edb3ab656845f8d18b9cdaae53006998"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/__tests__/open.test.ts": {
-    "mtime": 1779108266.1359885,
-    "hash": "50adc8f5202ca64318eb24f70de6bd27"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/open.test.ts": {
+    "mtime": 1779420421.0088816,
+    "hash": "245f21062c47efc214a6ea1344060f95"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/__tests__/issue-lifecycle.test.ts": {
-    "mtime": 1779108266.1359885,
-    "hash": "b837b9e512c22fe211e598cef5997eef"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/issue-lifecycle.test.ts": {
+    "mtime": 1779420421.0088816,
+    "hash": "c81a6a4e5f718dfca3bf35756a6b9072"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/__tests__/conversation-service.test.ts": {
-    "mtime": 1779108266.1359885,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/conversation-service.test.ts": {
+    "mtime": 1779420421.0088816,
     "hash": "c3afc77514b18641bcb2dab3c560ee28"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/server/services/__tests__/workspace-service.test.ts": {
-    "mtime": 1779108266.1359885,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/server/services/__tests__/workspace-service.test.ts": {
+    "mtime": 1779420421.0088816,
     "hash": "024dca58ca35a466dcb447d43e5accdb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/index.ts": {
-    "mtime": 1779150733.5858243,
-    "hash": "58e2e4e9b09b1910cf937db84369b1f1"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/index.ts": {
+    "mtime": 1779420420.9830618,
+    "hash": "8b6bd26bb9bfbfb6e7573cbcc777b72c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/fork.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/fork.ts": {
+    "mtime": 1779420420.9805534,
     "hash": "3683f23396c068cf0a914612cfcbc47d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/shadow.ts": {
-    "mtime": 1779108266.1106389,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/shadow.ts": {
+    "mtime": 1779420420.981692,
     "hash": "e3c44d3296d52d5191208b0117852041"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/tts.ts": {
-    "mtime": 1779108266.1109004,
-    "hash": "9596f99fd3501230921d9dd32cdc9a3d"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/tts.ts": {
+    "mtime": 1779420420.9825218,
+    "hash": "d1ba59a9d663246e6af9655e524a45c3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/workspace-reap.ts": {
-    "mtime": 1779108266.1109004,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/workspace-reap.ts": {
+    "mtime": 1779420420.9827533,
     "hash": "961453dca5b0a048697bad663324d8c1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/caveman.ts": {
-    "mtime": 1779108266.1086736,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/caveman.ts": {
+    "mtime": 1779420420.979475,
     "hash": "e70fd748df29d09e9ee45ab9c5c3ba74"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/reset-session.ts": {
-    "mtime": 1779108266.1101503,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/reset-session.ts": {
+    "mtime": 1779420420.9813569,
     "hash": "99bd47258006cd485ab06d430c5dbf9d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/show.ts": {
-    "mtime": 1779108266.1106389,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/show.ts": {
+    "mtime": 1779420420.981692,
     "hash": "7b4062539fba34d5ddf3d1d17a60cf90"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/approve.ts": {
-    "mtime": 1779108266.1086736,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/approve.ts": {
+    "mtime": 1779420420.979475,
     "hash": "c6df19e1768651dc75e5d67c58473e96"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/install.ts": {
-    "mtime": 1779108266.1090465,
-    "hash": "c978269ce6d5a6965eb698a4ef843f1a"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/install.ts": {
+    "mtime": 1779420420.9805734,
+    "hash": "b09f230a99185d6d54ce2fbdcfdc78b1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/tell.ts": {
-    "mtime": 1779108266.1109004,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/tell.ts": {
+    "mtime": 1779420420.9819565,
     "hash": "9b2310d9381589f3e098a9d419e45128"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/issues.ts": {
-    "mtime": 1779108266.1090465,
-    "hash": "3ad880d0d91b4863a84dfde508dbccbe"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/issues.ts": {
+    "mtime": 1779420420.9805734,
+    "hash": "29963342c78b09b2b9a3f8037931ba5b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/reopen.ts": {
-    "mtime": 1779108266.1101503,
-    "hash": "4c4152136c522f9773fbea20e640c125"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/reopen.ts": {
+    "mtime": 1779420420.981247,
+    "hash": "274e378618148628144c1895c386ce58"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/init.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/init.ts": {
+    "mtime": 1779420420.9805734,
     "hash": "8ec4ad5c244ebfdf5d6256e13aa78ebb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/pause.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/pause.ts": {
+    "mtime": 1779420420.9805734,
     "hash": "8a035044bcd8e9270f280c375241f363"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/beads.ts": {
-    "mtime": 1779108266.1086736,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/beads.ts": {
+    "mtime": 1779420420.979475,
     "hash": "2eaaf6d5723eeb7364d7116542509206"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/recover.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/recover.ts": {
+    "mtime": 1779420420.9809275,
     "hash": "5a32609829f430b30a0654342bc493ef"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/reload.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/reload.ts": {
+    "mtime": 1779420420.9809275,
     "hash": "58867f67c75f5e0a7ed6b8508eb4e53a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/close.ts": {
-    "mtime": 1779108266.108883,
-    "hash": "407a22170591d334daed101481ba7e14"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/close.ts": {
+    "mtime": 1779420420.979695,
+    "hash": "9fbb0d313298d518e214640932a47676"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/workspace-deep-clean.ts": {
-    "mtime": 1779108266.1109004,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/workspace-deep-clean.ts": {
+    "mtime": 1779420420.982575,
     "hash": "e463f4b804c558f66781f819fc5f10e3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/cv.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/cv.ts": {
+    "mtime": 1779420420.980049,
     "hash": "8e675ffb489ef00291c4778d25b5be91"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/sync-main.ts": {
-    "mtime": 1779108266.1109004,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/memory.ts": {
+    "mtime": 1779420420.9805734,
+    "hash": "a71adf384f27cb8bfe1f4ac0668362c8"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/sync-main.ts": {
+    "mtime": 1779420420.9819565,
     "hash": "3518e1574ec46e0d2ab2a1d3f3ffab77"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/kill.ts": {
-    "mtime": 1779108266.1090465,
-    "hash": "38e0876b04c239ec4464448f8bd52860"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/kill.ts": {
+    "mtime": 1779420420.9805734,
+    "hash": "6f1af63290c4478e9db4b57d31ed448b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/workspace.ts": {
-    "mtime": 1779108266.1109004,
-    "hash": "2965627a37c58ca5117f7ee73b8cff7e"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/workspace.ts": {
+    "mtime": 1779420420.982921,
+    "hash": "f025f61a46d8ef867b471de1eb8ed55b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/restore.ts": {
-    "mtime": 1779108266.1101503,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/restore.ts": {
+    "mtime": 1779420420.9814923,
     "hash": "9eaca7d99db6be20e977820b5452e7cc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/wipe.ts": {
-    "mtime": 1779108266.1109004,
-    "hash": "e05f68c691886d250204e47a5d842571"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/wipe.ts": {
+    "mtime": 1779420420.982575,
+    "hash": "fcf48cc790ed4d34a313ad0089f2bdc8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/test.ts": {
-    "mtime": 1779108266.1109004,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/test.ts": {
+    "mtime": 1779420420.9819565,
     "hash": "eeba7500bcd11a288034f954c16cf4d0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/abort-review.ts": {
-    "mtime": 1779108266.108441,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/abort-review.ts": {
+    "mtime": 1779420420.9791224,
     "hash": "ec7bc1d52d571f90bbe2940d80138382"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/reset-review.ts": {
-    "mtime": 1779108266.1101503,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/reset-review.ts": {
+    "mtime": 1779420420.9813569,
     "hash": "9484e3c39d76ddb4b57dbe344a777328"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/context.ts": {
-    "mtime": 1779108266.108883,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/context.ts": {
+    "mtime": 1779420420.979695,
     "hash": "470d6717b96a464c3a145adc1db41464"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/pending.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/pending.ts": {
+    "mtime": 1779420420.9805734,
     "hash": "3fad1ffb3b71d0b715ccd9627e4e71e3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/cost.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/cost.ts": {
+    "mtime": 1779420420.980049,
     "hash": "3ce936d1312c2e3efd194b1e6a6d5cf6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/start.ts": {
-    "mtime": 1779108266.1109004,
-    "hash": "4848f490b901ea989b56a5daabef87b8"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/start.ts": {
+    "mtime": 1779420420.9819565,
+    "hash": "98002d10b922948335b483001fb4d202"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/done.ts": {
-    "mtime": 1779108266.1090465,
-    "hash": "1aab9c24b453dc4bafaae72cdd70a792"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/done.ts": {
+    "mtime": 1779420420.9803684,
+    "hash": "beac3a08687e342bbc3e351e28885f62"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/plan-finalize.ts": {
-    "mtime": 1779108266.1090465,
-    "hash": "a48c529c8e69e220284ffa2c3c7c5037"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/plan-finalize.ts": {
+    "mtime": 1779420420.9809275,
+    "hash": "f23d66905ee3e9b6e7b8ef565eb5d17e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/release.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/release.ts": {
+    "mtime": 1779420420.9809275,
     "hash": "78ebe6e9df8913f61e7eba1e7bc33603"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/inspect.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/inspect.ts": {
+    "mtime": 1779420420.9805734,
     "hash": "2eab5f8d19fb1ef61b64e73367b4f0b7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/project.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/project.ts": {
+    "mtime": 1779420420.9809275,
     "hash": "86853b23584801771374cbfc1e3bc3b1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/untroubled.ts": {
-    "mtime": 1779108266.1109004,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/untroubled.ts": {
+    "mtime": 1779420420.9825218,
     "hash": "081dc6df77dc5408ad4322489502ff98"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/sync.ts": {
-    "mtime": 1779108266.1109004,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/sync.ts": {
+    "mtime": 1779420420.9819565,
     "hash": "505ce07cd1621bc1eeea75ea594ec608"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/backup.ts": {
-    "mtime": 1779108266.1086736,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/backup.ts": {
+    "mtime": 1779420420.979475,
     "hash": "c9bf01a072baebfee523aeacb315caf2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/health.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/health.ts": {
+    "mtime": 1779420420.9805734,
     "hash": "cfc5ee989925270a7b1ecda7f0440d53"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/status.ts": {
-    "mtime": 1779108266.1109004,
-    "hash": "a5259b92050419ae9734368180356efe"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/status.ts": {
+    "mtime": 1779420420.9819565,
+    "hash": "6634941430ba77238e5b57aa3435e031"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/unpause.ts": {
-    "mtime": 1779108266.1109004,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/unpause.ts": {
+    "mtime": 1779420420.9825218,
     "hash": "3e438f918f6e2cf978de0bb9a2bea0dd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/migrate-config.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/migrate-config.ts": {
+    "mtime": 1779420420.9805734,
     "hash": "99caafccb0ccba30127b877db86991bd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/swarm.ts": {
-    "mtime": 1779108266.1109004,
-    "hash": "36b1d39e3be11d9699e5575967121cdc"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/swarm.ts": {
+    "mtime": 1779420420.9819565,
+    "hash": "65ab20c0d3892552fbf366518e0e2e18"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/triage.ts": {
-    "mtime": 1779108266.1109004,
-    "hash": "95676a56347bbcf68c50e3259eb4d048"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/triage.ts": {
+    "mtime": 1779420420.9824507,
+    "hash": "115b384f7bc99ed504e0e161a4a64fa7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/plan-done.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/plan-done.ts": {
+    "mtime": 1779420420.9805734,
     "hash": "69e5eb19ed53f6223b6b6615b7595a11"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/plan.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/plan.ts": {
+    "mtime": 1779420420.9809275,
     "hash": "7074966fed091d5ed75cc3a19267cb43"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/update.ts": {
-    "mtime": 1779108266.1109004,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/update.ts": {
+    "mtime": 1779420420.982575,
     "hash": "d1003b57cc8017f58947582b15b4ddb9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/scope.ts": {
-    "mtime": 1779108266.1101503,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/scope.ts": {
+    "mtime": 1779420420.981599,
     "hash": "161a7578c9e13ec1404522b3dff93451"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/request-review.ts": {
-    "mtime": 1779108266.1101503,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/request-review.ts": {
+    "mtime": 1779420420.981247,
     "hash": "60022dd8b24d04231863e76da26ef1ac"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/unarchive-conversation.ts": {
-    "mtime": 1779108266.1109004,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/unarchive-conversation.ts": {
+    "mtime": 1779420420.9825218,
     "hash": "a1d49662c5c6395d09dd7b9abdc1f2e0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/doctor.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/doctor.ts": {
+    "mtime": 1779420420.9802547,
     "hash": "bdac43066476a5969e25dafdfbdaea21"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/workspace-rebuild.ts": {
-    "mtime": 1779108266.1109004,
-    "hash": "9650312b14fada636f87fd0dddd11bfa"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/workspace-rebuild.ts": {
+    "mtime": 1779420420.9827824,
+    "hash": "ba5b4553152b06cd140d123ad3366532"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/agent-status.ts": {
-    "mtime": 1779108266.1086736,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/agent-status.ts": {
+    "mtime": 1779420420.979475,
     "hash": "d544c19cfcd740444cb1f0f56da64004"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/refresh.ts": {
-    "mtime": 1779108266.1090465,
-    "hash": "2aadfe1c7ba96ed503befa2ee77bdbc1"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/refresh.ts": {
+    "mtime": 1779420420.9809275,
+    "hash": "873611583b26bff7c17d0684673fa398"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/review-spawn-reviewer.ts": {
-    "mtime": 1779108266.1101503,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/review-spawn-reviewer.ts": {
+    "mtime": 1779420420.9814923,
     "hash": "86ca07e550cb3744ab9e721c99cf0643"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/flywheel.ts": {
-    "mtime": 1779167166.6977115,
-    "hash": "632fa1b805f2d80bbb0e9b8771bfdd9e"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/flywheel.ts": {
+    "mtime": 1779420420.9803684,
+    "hash": "311aa81b422228bdd020b4b03e18cba6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/workspace-render-devcontainer.ts": {
-    "mtime": 1779108266.1109004,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/workspace-render-devcontainer.ts": {
+    "mtime": 1779420420.9827824,
     "hash": "702affc9e0ab554c50db6b7f6655ae99"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/system-health.ts": {
-    "mtime": 1779108266.1109004,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/system-health.ts": {
+    "mtime": 1779420420.9819565,
     "hash": "b1b23c540506bb0e6987e5bb60291c1f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/workspace-migrate.ts": {
-    "mtime": 1779108266.1109004,
-    "hash": "c24f3ac82cd9a1f63d6a2be5190b3371"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/workspace-migrate.ts": {
+    "mtime": 1779420420.982575,
+    "hash": "fb5ca57bf57db1ec88b2e57118d1b4f3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/restart.ts": {
-    "mtime": 1779108266.1101503,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/restart.ts": {
+    "mtime": 1779420420.9813569,
     "hash": "d32dc89aa983d1e646a37db7d934df54"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/db.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/db.ts": {
+    "mtime": 1779420420.9802547,
     "hash": "dc6cd8f813a81d53e18107269ce21475"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/review-restart.ts": {
-    "mtime": 1779108266.1101503,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/review-restart.ts": {
+    "mtime": 1779420420.9814923,
     "hash": "6f91e42d420f385810a7034acdcaee07"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/dev.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/dev.ts": {
+    "mtime": 1779420420.9802547,
     "hash": "ba0cebc350d52dc5740be5e5fa3b10ab"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/copy-config.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/copy-config.ts": {
+    "mtime": 1779420420.980049,
     "hash": "772e2da7681228f9724806ab2fec65fc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/open.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/open.ts": {
+    "mtime": 1779420420.9805734,
     "hash": "92377e5404e9b7f83a37473d8429108e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/config.ts": {
-    "mtime": 1779108266.108883,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/config.ts": {
+    "mtime": 1779420420.979695,
     "hash": "099bf2893acec288cbf07fac056cadeb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/skills.ts": {
-    "mtime": 1779108266.1106389,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/skills.ts": {
+    "mtime": 1779420420.981692,
     "hash": "acf5199ee0540f542e637c47450b0df4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/resume.ts": {
-    "mtime": 1779150733.4038181,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/resume.ts": {
+    "mtime": 1779420420.9814923,
     "hash": "7554757fd4350fbe263e335d24273507"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/resources.ts": {
-    "mtime": 1779108266.1101503,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/resources.ts": {
+    "mtime": 1779420420.9813569,
     "hash": "cecd4cb391040e5fd89d401a1786f4b8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/admin/tracker-handler.ts": {
-    "mtime": 1779108266.1086736,
-    "hash": "6f3a931d3deb772f61de383194a98873"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/admin/tracker-handler.ts": {
+    "mtime": 1779420420.979475,
+    "hash": "878d9bac39b110c31687a7b7412f64e7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/admin/fpp-handler.ts": {
-    "mtime": 1779108266.108441,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/admin/fpp-handler.ts": {
+    "mtime": 1779420420.9791224,
     "hash": "e2135c3792b461c3c34d7edb714311c4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/admin/tldr-handler.ts": {
-    "mtime": 1779108266.1086736,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/admin/tldr-handler.ts": {
+    "mtime": 1779420420.979475,
     "hash": "30a51c30d09b6aed010c1a1c7e0e915e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/admin/index.ts": {
-    "mtime": 1779108266.1086736,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/admin/index.ts": {
+    "mtime": 1779420420.979475,
     "hash": "29f76bbdabf84948f62bab204a441012"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/specialists/done.ts": {
-    "mtime": 1779108266.1106389,
-    "hash": "9b5966f90a52f83f81388787a8777a84"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/specialists/done.ts": {
+    "mtime": 1779420420.981692,
+    "hash": "b9e843b1961941fc1b505c2a8370285b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/specialists/list.ts": {
-    "mtime": 1779108266.1109004,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/specialists/list.ts": {
+    "mtime": 1779420420.9819565,
     "hash": "0f499f4631c78558cd660ec381a7c021"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/specialists/index.ts": {
-    "mtime": 1779108266.1109004,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/specialists/index.ts": {
+    "mtime": 1779420420.9819565,
     "hash": "b295a06cfbfd2171e91e5270134ef598"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/specialists/logs.ts": {
-    "mtime": 1779108266.1109004,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/specialists/logs.ts": {
+    "mtime": 1779420420.9819565,
     "hash": "859f17d6967d513ae05b887954f83df9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/specialists/reset.ts": {
-    "mtime": 1779108266.1109004,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/specialists/reset.ts": {
+    "mtime": 1779420420.9819565,
     "hash": "6546b5f6514ebc26ba67cc0579498481"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/specialists/wake.ts": {
-    "mtime": 1779108266.1109004,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/specialists/wake.ts": {
+    "mtime": 1779420420.9819565,
     "hash": "acade08e5b7a4057b54086edee0972c5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/cloister/start.ts": {
-    "mtime": 1779108266.108883,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/cloister/start.ts": {
+    "mtime": 1779420420.979695,
     "hash": "c1f70badbd7d5c710a94f8241e8d02a2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/cloister/status.ts": {
-    "mtime": 1779108266.108883,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/cloister/status.ts": {
+    "mtime": 1779420420.979695,
     "hash": "ee978e88e0f8d4089a28a4fbe6af37af"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/cloister/index.ts": {
-    "mtime": 1779108266.1086736,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/cloister/index.ts": {
+    "mtime": 1779420420.979475,
     "hash": "c2dbd55e980bea7b1fd45b2563d757a8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/cloister/stop.ts": {
-    "mtime": 1779108266.108883,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/cloister/stop.ts": {
+    "mtime": 1779420420.979695,
     "hash": "d7451beb95e8f365087a5a89af1cfcb1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/conversations/show.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/conversations/show.ts": {
+    "mtime": 1779420420.980049,
     "hash": "7d24bfc4be9f290c32732c489788b75d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/conversations/cost.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/conversations/cost.ts": {
+    "mtime": 1779420420.9798748,
     "hash": "a689d1145fd465e02ad1fe2a579c7a6b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/conversations/list.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/conversations/list.ts": {
+    "mtime": 1779420420.980049,
     "hash": "f7a60e04a8716553a4f707c053c7940b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/conversations/scan.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/conversations/scan.ts": {
+    "mtime": 1779420420.980049,
     "hash": "2b4fe96e0a3d49dcb6be79ab903b4995"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/conversations/index.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/conversations/index.ts": {
+    "mtime": 1779420420.980049,
     "hash": "84b9cf9f0957541d8ec8bce8b2b3d937"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/conversations/enrich.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/conversations/enrich.ts": {
+    "mtime": 1779420420.9800246,
     "hash": "0015d8a89b03026ad0d672ae5ee785a5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/conversations/search.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/conversations/search.ts": {
+    "mtime": 1779420420.980049,
     "hash": "39736f9f326a0bae9248c1db34c3a567"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/conversations/format.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/conversations/format.ts": {
+    "mtime": 1779420420.980049,
     "hash": "a24999824e789ee7fb366d39e1075b0d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/conversations/embed.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/conversations/embed.ts": {
+    "mtime": 1779420420.9798748,
     "hash": "f93a4fabde8937351e6ee0de462e318d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/conversations/__tests__/enrich.test.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/conversations/__tests__/enrich.test.ts": {
+    "mtime": 1779420420.9798748,
     "hash": "7c4508342d170d3848e546fcc435adfb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/conversations/__tests__/scan.test.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/conversations/__tests__/scan.test.ts": {
+    "mtime": 1779420420.9798748,
     "hash": "2783cc462e20040015cac8f2a9893e45"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/conversations/__tests__/cost.test.ts": {
-    "mtime": 1779108266.1090035,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/conversations/__tests__/cost.test.ts": {
+    "mtime": 1779420420.9798331,
     "hash": "0adbb2af0d363f27ba4e937582e0888b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/conversations/__tests__/list.test.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/conversations/__tests__/list.test.ts": {
+    "mtime": 1779420420.9798748,
     "hash": "a2969c7568ee2d31af31081d89a1a6c8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/conversations/__tests__/search.test.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/conversations/__tests__/search.test.ts": {
+    "mtime": 1779420420.9798748,
     "hash": "08759a0a7213d43943d7bf6951c08717"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/conversations/__tests__/show.test.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/conversations/__tests__/show.test.ts": {
+    "mtime": 1779420420.9798748,
     "hash": "17b02ee5bf5da558aff744bcb17fb054"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/__tests__/start-harness.test.ts": {
-    "mtime": 1779108266.108441,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/__tests__/close.test.ts": {
+    "mtime": 1779420420.9790688,
+    "hash": "eac620199c391342419a8e320a660c83"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/__tests__/start-harness.test.ts": {
+    "mtime": 1779420420.9791224,
     "hash": "1fb6f75c905e1a5cc137d48a54b3b2ae"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/__tests__/plan-finalize.test.ts": {
-    "mtime": 1779108266.108441,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/__tests__/plan-finalize.test.ts": {
+    "mtime": 1779420420.9791224,
     "hash": "746dcc98cd3d1d036ae924b0edb4dd7c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/__tests__/inspect.test.ts": {
-    "mtime": 1779108266.108441,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/__tests__/inspect.test.ts": {
+    "mtime": 1779420420.9791224,
     "hash": "cd17a8a1913e3df786c3d2e03559e68c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/__tests__/reload.test.ts": {
-    "mtime": 1779108266.108441,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/__tests__/reload.test.ts": {
+    "mtime": 1779420420.9791224,
     "hash": "c0650601f907bb66de24444d92b79e8c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/__tests__/setup-hooks.test.ts": {
-    "mtime": 1779108266.108441,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/__tests__/setup-hooks.test.ts": {
+    "mtime": 1779420420.9791224,
     "hash": "06c29790d7d312d3116e6fe0c1838d05"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/__tests__/status-harness.test.ts": {
-    "mtime": 1779108266.108441,
-    "hash": "097b75e570a0d3f5604c2e6c92a4bec7"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/__tests__/status-harness.test.ts": {
+    "mtime": 1779420420.9791224,
+    "hash": "3cb16410fc4009f151ef952726374fc1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/__tests__/doctor-pi.test.ts": {
-    "mtime": 1779108266.108405,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/__tests__/doctor-pi.test.ts": {
+    "mtime": 1779420420.9791224,
     "hash": "8ab27efe8526c4a0aa25cf152920b973"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/__tests__/workspace-rebuild.test.ts": {
-    "mtime": 1779108266.108441,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/__tests__/workspace-rebuild.test.ts": {
+    "mtime": 1779420420.9791224,
     "hash": "88f1fb6ea4180cfe5ce485ea34f0592c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/__tests__/tts.test.ts": {
-    "mtime": 1779108266.108441,
-    "hash": "6f312f5d2c8174089e8cc44c1871822d"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/__tests__/tts.test.ts": {
+    "mtime": 1779420420.9791224,
+    "hash": "a2d339e893b5f36a72aaaaeec69c246a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/__tests__/workspace-reap.test.ts": {
-    "mtime": 1779108266.108441,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/__tests__/swarm.test.ts": {
+    "mtime": 1779420420.9791224,
+    "hash": "24206253f8ef5164a49a3b86556af81f"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/__tests__/workspace-reap.test.ts": {
+    "mtime": 1779420420.9791224,
     "hash": "4cf25036792fbf5fa13154822b31fe3e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/__tests__/flywheel.test.ts": {
-    "mtime": 1779167258.2488523,
-    "hash": "16a5e222aa5e82e0b9d848407a2c5069"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/__tests__/flywheel.test.ts": {
+    "mtime": 1779420420.9791224,
+    "hash": "5991dcc6d2e2cf96739544657af3f2bd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/setup/safe-settings.ts": {
-    "mtime": 1779108266.1106389,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/setup/safe-settings.ts": {
+    "mtime": 1779420420.981692,
     "hash": "2bf71af44ff76daedf5843f87d313a03"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/setup/hooks.ts": {
-    "mtime": 1779108266.1101503,
-    "hash": "cdf2f44ac4f804187603bb0582a6f3ba"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/setup/hooks.ts": {
+    "mtime": 1779420420.981599,
+    "hash": "aac58188319f22039b46a6ec45e919d8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/remote/init.ts": {
-    "mtime": 1779108266.1101503,
-    "hash": "7b73a35303e1dd3b698cabf12a058a55"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/remote/init.ts": {
+    "mtime": 1779420420.9811401,
+    "hash": "29d9a71064165f365f7785774d540d09"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/remote/setup.ts": {
-    "mtime": 1779108266.1101503,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/remote/setup.ts": {
+    "mtime": 1779420420.9812038,
     "hash": "b470c43dbe23bd656ae6fe29efc00dff"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/remote/status.ts": {
-    "mtime": 1779108266.1101503,
-    "hash": "d62e99ea885d11990c26d222969dfdf3"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/remote/status.ts": {
+    "mtime": 1779420420.981247,
+    "hash": "b042fc9780f1b39f01ef5d493751e444"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/remote/index.ts": {
-    "mtime": 1779108266.1090465,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/remote/index.ts": {
+    "mtime": 1779420420.9811401,
     "hash": "c95c2ebf12da121992b03e9bb65bdd05"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/cli/commands/remote/resources.ts": {
-    "mtime": 1779108266.1101503,
-    "hash": "6da41352e6d89159fa5977c8e4f0a0d2"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/cli/commands/remote/resources.ts": {
+    "mtime": 1779420420.9811401,
+    "hash": "abfa6ed3d8d16f61573098ceafd8333a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/packages/pi-extension/vitest.config.ts": {
-    "mtime": 1779108266.0145776,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/packages/pi-extension/vitest.config.ts": {
+    "mtime": 1779420420.8897982,
     "hash": "ee3a22aefda869d3fe29da99b9b1e38f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/packages/pi-extension/tsdown.config.ts": {
-    "mtime": 1779108266.0145776,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/packages/pi-extension/tsdown.config.ts": {
+    "mtime": 1779420420.8897982,
     "hash": "8ec39fe596fb6e8edca644edcb54d06f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/packages/pi-extension/src/index.ts": {
-    "mtime": 1779108266.0145776,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/packages/pi-extension/src/index.ts": {
+    "mtime": 1779420420.8897982,
     "hash": "e15788e4d3d35fb1cdd433c7977c1a7c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/packages/pi-extension/src/__tests__/index.test.ts": {
-    "mtime": 1779108266.0145776,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/packages/pi-extension/src/__tests__/index.test.ts": {
+    "mtime": 1779420420.8897982,
     "hash": "caef0a8a41a721bf8c8f8bb386e53486"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/packages/contracts/vitest.config.ts": {
-    "mtime": 1779150733.4338193,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/packages/contracts/vitest.config.ts": {
+    "mtime": 1779420420.889327,
     "hash": "381a67f5ac1953cbde4333bdd6a723f3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/packages/contracts/tsdown.config.ts": {
-    "mtime": 1779108266.0141625,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/packages/contracts/tsdown.config.ts": {
+    "mtime": 1779420420.889327,
     "hash": "910fec51468ca1227ab82e4d5ae40c08"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/packages/contracts/src/events.ts": {
-    "mtime": 1779108266.0141625,
-    "hash": "f770e12fa5f35627f20fa1cd88f1cf3b"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/packages/contracts/src/events.ts": {
+    "mtime": 1779420420.889327,
+    "hash": "9f2b1e2d73e1f7a055d7651742352f74"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/packages/contracts/src/rpc.ts": {
-    "mtime": 1779164971.1314204,
-    "hash": "a2a0c5aac0edc64bbd6371cf37ca68e6"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/packages/contracts/src/rpc.ts": {
+    "mtime": 1779420420.889327,
+    "hash": "ef6f290a30d3571d96419f451e208d79"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/packages/contracts/src/event-reducers.ts": {
-    "mtime": 1779108266.0141625,
-    "hash": "1512aa4f820935bf7fe21fb91c282c44"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/packages/contracts/src/memory.ts": {
+    "mtime": 1779420420.889327,
+    "hash": "9804dd19a510016845ecf9f494678046"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/packages/contracts/src/index.ts": {
-    "mtime": 1779150733.4338193,
-    "hash": "eb804d5273c379f27b1a9dfbc52ee9e9"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/packages/contracts/src/event-reducers.ts": {
+    "mtime": 1779420420.889327,
+    "hash": "e4279fae012005d4c0b79dc7bf5d6405"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/packages/contracts/src/flywheel.ts": {
-    "mtime": 1779161100.9870555,
-    "hash": "e5896e9b6c111fcbd2a174f9701e58e5"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/packages/contracts/src/index.ts": {
+    "mtime": 1779420420.889327,
+    "hash": "d8a4f452f6c0d877ebf2e0fa9ac78557"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/packages/contracts/src/editor.ts": {
-    "mtime": 1779108266.014141,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/packages/contracts/src/flywheel.ts": {
+    "mtime": 1779420420.889327,
+    "hash": "c920cd5705e32ce76bae781e974aaf66"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/packages/contracts/src/editor.ts": {
+    "mtime": 1779420420.8893096,
     "hash": "01f6a8964ec0849e7680f9b0bbd60c91"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/packages/contracts/src/flywheel.test.ts": {
-    "mtime": 1779160876.1902375,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/packages/contracts/src/flywheel.test.ts": {
+    "mtime": 1779420420.889327,
     "hash": "50df29eb845f58707e7b12877a90e52e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/packages/contracts/src/types.ts": {
-    "mtime": 1779162970.2983196,
-    "hash": "3ef6bc9998c16b0cbc4f1860a3d55c00"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/packages/contracts/src/types.ts": {
+    "mtime": 1779420420.889327,
+    "hash": "55563c0c00f3dbe6fc79aaabf5b63568"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/local-server-root-snapshot.md": {
-    "mtime": 1779108265.9830418,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/local-server-root-snapshot.md": {
+    "mtime": 1779420420.8577757,
     "hash": "5e05876a38efc65b8dab156951ed6a1b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/BACKLOG-TRIAGE-2026-04-30.md": {
-    "mtime": 1779108265.8532362,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/BACKLOG-TRIAGE-2026-04-30.md": {
+    "mtime": 1779420420.7269862,
     "hash": "5ae41c90641b6a33069dafa127d59d1b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tmux-data-audit-prompt.md": {
-    "mtime": 1779108266.1745427,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tmux-data-audit-prompt.md": {
+    "mtime": 1779420421.0551996,
     "hash": "4817437bfd511e82d05b639a7cabd87a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/pan866-workspace-md-requests.txt": {
-    "mtime": 1779108266.0145776,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/pan866-workspace-md-requests.txt": {
+    "mtime": 1779420420.8897982,
     "hash": "7b8170ccd52d011a7060e07712b7825e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/CLAUDE.md": {
-    "mtime": 1779108265.8532362,
-    "hash": "38e222ee4272b5e09fe1e89b92e35f68"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/CLAUDE.md": {
+    "mtime": 1779420420.7272818,
+    "hash": "54a34f34f7cf338a35828ec1c9c45257"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/agent-page-snapshot.md": {
-    "mtime": 1779108265.8532362,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/agent-page-snapshot.md": {
+    "mtime": 1779420420.7274265,
     "hash": "d41d8cd98f00b204e9800998ecf8427e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/concepts.mdx": {
-    "mtime": 1779108265.8560317,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/concepts.mdx": {
+    "mtime": 1779420420.729954,
     "hash": "acef171d42ab8faf3190aa82b8bd11f8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/README.md": {
-    "mtime": 1779108265.8532362,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/README.md": {
+    "mtime": 1779420420.7274265,
     "hash": "8a4fca37f65f46b6bffa1ea388ec6103"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/CONTRIBUTING.md": {
-    "mtime": 1779108265.8532362,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/CONTRIBUTING.md": {
+    "mtime": 1779420420.7272818,
     "hash": "b33afab549f0d05b898124e8b2b1ab86"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/AGENTS.md": {
-    "mtime": 1779108265.8532362,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/AGENTS.md": {
+    "mtime": 1779420420.7269862,
     "hash": "42affabfc215eee12abc6718faa75679"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/CHANGELOG.md": {
-    "mtime": 1779108265.8532362,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/CHANGELOG.md": {
+    "mtime": 1779420420.7269862,
     "hash": "baba8447b3799382b1a903c0ba6727e3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/introduction.mdx": {
-    "mtime": 1779108265.9830418,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/introduction.mdx": {
+    "mtime": 1779420420.8577757,
     "hash": "5631db2ed0432182a9d58ce6122533e7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/quickstart.mdx": {
-    "mtime": 1779108266.0152693,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/quickstart.mdx": {
+    "mtime": 1779420420.8906658,
     "hash": "725a4fa573e76414489b3cb0185a3bea"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/cleanup-radius.md": {
-    "mtime": 1779108265.854893,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/cleanup-radius.md": {
+    "mtime": 1779420420.7286963,
     "hash": "4a87e31fba1163a020fc4fb0b5fe51e7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docker-compose.devcontainer.yml": {
-    "mtime": 1779108277.3346477,
-    "hash": "b590e4ab11a82062150ba4ec684f627a"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/E2E_TEST_PLAN.md": {
-    "mtime": 1779108266.1686506,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/E2E_TEST_PLAN.md": {
+    "mtime": 1779420421.0473669,
     "hash": "4ca5b423748f2c274ee5c07cf2266bf8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/fixtures/e2e-test.txt": {
-    "mtime": 1779108266.1701849,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/fixtures/e2e-test.txt": {
+    "mtime": 1779420421.0489922,
     "hash": "e170d738b37b54ef16d4d3ce85a7284f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/fixtures/synced-skills.txt": {
-    "mtime": 1779150733.7778308,
-    "hash": "666bf5663c7b86da49c1f39f9b29f87b"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/fixtures/synced-skills.txt": {
+    "mtime": 1779420421.0491252,
+    "hash": "98e7da9e38f347104d0ec28d34e90f3c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/fixtures/handoff-test.txt": {
-    "mtime": 1779108266.1701849,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/fixtures/handoff-test.txt": {
+    "mtime": 1779420421.0489922,
     "hash": "1b7b97cf48ff4f6c7f7f34beeb73e443"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/fixtures/specialist-test.txt": {
-    "mtime": 1779108266.1701849,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/fixtures/specialist-test.txt": {
+    "mtime": 1779420421.049083,
     "hash": "189f6b9a77979c51796810170824ae12"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/tests/fixtures/pan-help.txt": {
-    "mtime": 1779108266.1701849,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/tests/fixtures/pan-help.txt": {
+    "mtime": 1779420421.0490623,
     "hash": "112a1d4ba887a800bc9d784626723ba6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/workflow-orchestration-landscape.md": {
-    "mtime": 1779108265.9492671,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/workflow-orchestration-landscape.md": {
+    "mtime": 1779420420.8246636,
     "hash": "a92068a5b3557041d99da60168263746"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/HOOKS.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/HOOKS.md": {
+    "mtime": 1779420420.7366607,
     "hash": "893b339ec60d66d55b1da3e40c91131a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/SPECIALIST_WORKFLOW.md": {
-    "mtime": 1779108265.8632643,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/SPECIALIST_WORKFLOW.md": {
+    "mtime": 1779420420.7376606,
     "hash": "665c821a6183e425961b309267ce742d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/DESKTOP-APP.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/DESKTOP-APP.md": {
+    "mtime": 1779420420.7363317,
     "hash": "5e321aec4b3cbcc2d4f1c6746934456a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/CODEX-AUTH.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/CODEX-AUTH.md": {
+    "mtime": 1779420420.7363317,
     "hash": "e66de7c6c46eb7e383f4ce1980082822"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/QUICK-REFERENCE.md": {
-    "mtime": 1779108265.8632643,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/QUICK-REFERENCE.md": {
+    "mtime": 1779420420.7376606,
     "hash": "d8da62d6cc87beb0f0fe826187556b42"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/VISION.md": {
-    "mtime": 1779108265.8642642,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/VISION.md": {
+    "mtime": 1779420420.7391663,
     "hash": "a29e97ab2123274486b87d4a8a449805"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/TESTING-PROVIDERS.md": {
-    "mtime": 1779108265.8642642,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/TESTING-PROVIDERS.md": {
+    "mtime": 1779420420.7376606,
     "hash": "a94329226fda8bea8d422ceda6fe512f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/SPAWN-GATING.md": {
-    "mtime": 1779108265.8632643,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/SPAWN-GATING.md": {
+    "mtime": 1779420420.7376606,
     "hash": "90d9e94ab4192e80944104dfcb6179f4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/TERMINAL-INTERACTION-LAYERS.md": {
-    "mtime": 1779108265.8642642,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/TERMINAL-INTERACTION-LAYERS.md": {
+    "mtime": 1779420420.7376606,
     "hash": "cf11cf28993344c0b800e3520a327f90"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/WORKSPACE-CONTAINERS.md": {
-    "mtime": 1779108265.8642642,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/WORKSPACE-CONTAINERS.md": {
+    "mtime": 1779420420.7391663,
     "hash": "fedd6de9e0f72fc52598bc01e4c9cbc2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/MODEL_RECOMMENDATIONS.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/MODEL_RECOMMENDATIONS.md": {
+    "mtime": 1779420420.7366607,
     "hash": "a7518d9493b0dbee24bc0d1782f35f6b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/PANOPTICON_DEV_SOP.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/PANOPTICON_DEV_SOP.md": {
+    "mtime": 1779420420.7366607,
     "hash": "3f8027d43f76bcaefc4de32dfeffedfa"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prd-pipeline-test-marker.md": {
-    "mtime": 1779108265.8769138,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prd-pipeline-test-marker.md": {
+    "mtime": 1779420420.7508311,
     "hash": "3e75db9e71cef718064ac096a760ed4f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/KANBAN-MODEL.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/KANBAN-MODEL.md": {
+    "mtime": 1779420420.7366607,
     "hash": "8dc48f7f592710061e92c8289cf70af1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/command-deck-layout-audit.html": {
-    "mtime": 1779108265.8656087,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/command-deck-layout-audit.html": {
+    "mtime": 1779420420.7394218,
     "hash": "ac22658e214c9c1cd9808da0b85f9cef"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/RELEASING.md": {
-    "mtime": 1779108265.8632643,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/RELEASING.md": {
+    "mtime": 1779420420.7376606,
     "hash": "e3c31f4b98103f3d25e2bd2fa00be1ee"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/MODEL_ROUTING.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/MODEL_ROUTING.md": {
+    "mtime": 1779420420.7366607,
     "hash": "692dbf63571f19ab8db3d97ec1bb27a1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/MISSION-CONTROL.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/MISSION-CONTROL.md": {
+    "mtime": 1779420420.7366607,
     "hash": "c6d83c77afd29fd30bd203ac2bc79d18"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/USAGE.md": {
-    "mtime": 1779108265.8642642,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/USAGE.md": {
+    "mtime": 1779420420.7386606,
     "hash": "d30d1ffab336a630b1d8070e54b9252d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/TLDR.md": {
-    "mtime": 1779108265.8642642,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/TLDR.md": {
+    "mtime": 1779420420.7386606,
     "hash": "0487776c2ada9d14fe30890291ace7e2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/PRD.md": {
-    "mtime": 1779108265.8632643,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/PRD.md": {
+    "mtime": 1779420420.7376606,
     "hash": "1abd8b2297b21456935a5d2f6855b092"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/FORKS.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/FORKS.md": {
+    "mtime": 1779420420.7363317,
     "hash": "e803c6f39f531580387152c04c16c500"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/FLYWHEEL.md": {
-    "mtime": 1779150733.8148322,
-    "hash": "a1222f3218b8311f3a9303b00e7bd9d6"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/FLYWHEEL.md": {
+    "mtime": 1779420420.7363317,
+    "hash": "49dd7dc97345a6496832d38023e3a76d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/REPO-ARTIFACTS.md": {
-    "mtime": 1779108265.8632643,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/REPO-ARTIFACTS.md": {
+    "mtime": 1779420420.7376606,
     "hash": "69593a6130cf148904d3b7f2fda33537"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/workflow-orchestration-enhancement-proposal.md": {
-    "mtime": 1779108265.9492671,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/workflow-orchestration-enhancement-proposal.md": {
+    "mtime": 1779420420.8246636,
     "hash": "a2f449818140e123a351c4f993c1527c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/SKILLS-CONVENTION.md": {
-    "mtime": 1779150733.7938313,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/SKILLS-CONVENTION.md": {
+    "mtime": 1779420420.7376606,
     "hash": "1d844e3b3363cf5e9c6b823769722a53"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/INDEX.md": {
-    "mtime": 1779150733.8148322,
-    "hash": "695ee7a8b9b0fd56f1e5e5399e333205"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/INDEX.md": {
+    "mtime": 1779420420.7366607,
+    "hash": "bd12b58967608aa1249ad7de2c35a1c0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/SKILL-DISTRIBUTION-ANALYSIS.md": {
-    "mtime": 1779108265.8632643,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/SKILL-DISTRIBUTION-ANALYSIS.md": {
+    "mtime": 1779420420.7376606,
     "hash": "e6bb8de9e3df15c827a9ae3f1f0e7823"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/HARNESSES.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/HARNESSES.md": {
+    "mtime": 1779420420.7363317,
     "hash": "8ed5de332b242178a0ff13e46b5711bb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/AGENT_TYPES_INDEX.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/AGENT_TYPES_INDEX.md": {
+    "mtime": 1779420420.7363317,
     "hash": "00fcaae13cc310a334c46bfe5de9469c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/LEGACY-CODEBASE.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/LEGACY-CODEBASE.md": {
+    "mtime": 1779420420.7366607,
     "hash": "93019e678fb047d491022663ac66b27c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/VBRIEF.md": {
-    "mtime": 1779108265.8642642,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/VBRIEF.md": {
+    "mtime": 1779420420.7391663,
     "hash": "71d928c78191dce51fe2646a163c8a69"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/PRD-REMOTE-WORKSPACES.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/PRD-REMOTE-WORKSPACES.md": {
+    "mtime": 1779420420.7366607,
     "hash": "687be011ec163c5c2694c3503877b008"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/WORK-TYPES.md": {
-    "mtime": 1779108265.8642642,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/WORK-TYPES.md": {
+    "mtime": 1779420420.7391663,
     "hash": "15761f0e35e2edb684d24b8a5c931528"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/AGENTS.md": {
-    "mtime": 1779108265.8623986,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/AGENTS.md": {
+    "mtime": 1779420420.736251,
     "hash": "1b9ff06c216e7240b88191ca8d3365fc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/CONFIGURATION.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/CONFIGURATION.md": {
+    "mtime": 1779420420.7363317,
     "hash": "9775e8beec4b49b76e5befe75de902a2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/OPERATION-FIX-ALL.md": {
-    "mtime": 1779150733.8148322,
-    "hash": "f2d8203cfe7d21fa83e5a32e66445efd"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/OPERATION-FIX-ALL.md": {
+    "mtime": 1779420420.7366607,
+    "hash": "27f2a8c9e0667a31fc313e9460f8a242"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/workflow-orchestration-landscape-kimi-k2.6.md": {
-    "mtime": 1779108265.9492671,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/workflow-orchestration-landscape-kimi-k2.6.md": {
+    "mtime": 1779420420.8246636,
     "hash": "a4336ad98f4bdec5721a3591d69b1b9f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/EXTERNAL-EVENT-STREAM.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/EXTERNAL-EVENT-STREAM.md": {
+    "mtime": 1779420420.7363317,
     "hash": "65d43fa512e987fd5822cbe593d31f52"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/ROLES.md": {
-    "mtime": 1779108265.8632643,
-    "hash": "6ff91f9d6577ac585e2b35b1d3ce3494"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/ROLES.md": {
+    "mtime": 1779420420.7376606,
+    "hash": "6abd07be8ad5cd258478b6faaae9522a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/PRD-CLOISTER.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/PRD-CLOISTER.md": {
+    "mtime": 1779420420.7366607,
     "hash": "f3647da1042e275ad27ab6c091e99212"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/SWARM.md": {
-    "mtime": 1779108265.8642642,
-    "hash": "f75128406ca9619ef39f6db7faf8efcd"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/SWARM.md": {
+    "mtime": 1779420420.7376606,
+    "hash": "3aaf8e02cf638ab94b472afa1baab44b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/REVIEW-AGENT-ARCHITECTURE.md": {
-    "mtime": 1779108265.8632643,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/REVIEW-AGENT-ARCHITECTURE.md": {
+    "mtime": 1779420420.7376606,
     "hash": "203f6a6ce4293bd1eb7430aea0fada6c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/TESTING.md": {
-    "mtime": 1779108265.8642642,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/TESTING.md": {
+    "mtime": 1779420420.7376606,
     "hash": "3c79db2640be10aa52373de0ecaab5b2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/E2E_TEST_PLAN.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/E2E_TEST_PLAN.md": {
+    "mtime": 1779420420.7363317,
     "hash": "5aa50cbaf8515b7be2fa1e611bde9c99"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/SKILLS-INVENTORY.md": {
-    "mtime": 1779150733.8158321,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/SKILLS-INVENTORY.md": {
+    "mtime": 1779420420.7376606,
     "hash": "b9ca832f72d723490e3cfcb88f60c2f5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/DEACON-HEALTH-MONITORING.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/DEACON-HEALTH-MONITORING.md": {
+    "mtime": 1779420420.7363317,
     "hash": "fe512f29a6569096a74b0cb598d5ef69"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/fly-provider.md": {
-    "mtime": 1779108265.8752646,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/fly-provider.md": {
+    "mtime": 1779420420.749661,
     "hash": "f6244ba7c6e315429cdb0da8d196b0e1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/god-view.md": {
-    "mtime": 1779108265.8752646,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/god-view.md": {
+    "mtime": 1779420420.749661,
     "hash": "61e03f2d2450f3e39414fc649e854d8e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/DNS_SETUP.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/DNS_SETUP.md": {
+    "mtime": 1779420420.7363317,
     "hash": "a25177a46b0830098644972e57d96d5c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/FIX-ALL-PRD.md": {
-    "mtime": 1779150733.8148322,
-    "hash": "d445c997b810b890504afd32cb986d98"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/FIX-ALL-PRD.md": {
+    "mtime": 1779420420.7363317,
+    "hash": "da6ecbadcacbc22ce1026a2871144640"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/FLYWHEEL-STATE.md": {
-    "mtime": 1779150733.8148322,
-    "hash": "c6f88f3d8ddd96a385803250044507ad"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/FLYWHEEL-STATE.md": {
+    "mtime": 1779420420.7363317,
+    "hash": "9d1ed4f1de3b7043032833eadedb8d39"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/WORKSPACE-DEPENDENCIES.md": {
-    "mtime": 1779108265.8642642,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/WORKSPACE-DEPENDENCIES.md": {
+    "mtime": 1779420420.7391663,
     "hash": "ba1a7c83fdb0aa9de28b15e265dfc906"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/flywheel-brief.md": {
-    "mtime": 1779150733.4658203,
-    "hash": "7666637de844dfe8b0a6582d9a111ba9"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/flywheel-brief.md": {
+    "mtime": 1779420420.749661,
+    "hash": "11582fd0438e03be13b5fc0302511dbe"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/HIERARCHICAL-PLANNING.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/HIERARCHICAL-PLANNING.md": {
+    "mtime": 1779420420.7363317,
     "hash": "5cae9149aa9b86ad9906f987bb3698c4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/BUILD.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/BUILD.md": {
+    "mtime": 1779420420.7363317,
     "hash": "405e6a05d39be67a9d950b3e67a02c8d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/SETTINGS-UI-DESIGN.md": {
-    "mtime": 1779108265.8632643,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/SETTINGS-UI-DESIGN.md": {
+    "mtime": 1779420420.7376606,
     "hash": "e7cac93f647028f123a629e05232b147"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/cost-tracking.md": {
-    "mtime": 1779108265.8656087,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/cost-tracking.md": {
+    "mtime": 1779420420.7394218,
     "hash": "67b70264bddf457845073b783e814dd1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/ARCHITECTURE-CACHING.md": {
-    "mtime": 1779108265.8624537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/ARCHITECTURE-CACHING.md": {
+    "mtime": 1779420420.7363317,
     "hash": "6707cfad5f142cde07b5c4829af469af"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/audits/BUGS_FOUND.md": {
-    "mtime": 1779108265.8656087,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/audits/BUGS_FOUND.md": {
+    "mtime": 1779420420.7394218,
     "hash": "dd08c9f9a55ee2efc0ff8dbc3fc9d980"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/audits/AGENT_AUDIT_REPORT.md": {
-    "mtime": 1779108265.8642642,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/audits/AGENT_AUDIT_REPORT.md": {
+    "mtime": 1779420420.7391663,
     "hash": "eb537b8ed85014f88d2519cdacccac1c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/audits/gemini-gaps-found.md": {
-    "mtime": 1779108265.8656087,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/audits/gemini-gaps-found.md": {
+    "mtime": 1779420420.7394218,
     "hash": "5bc5d6ec0b995782e44885e653e94cea"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/design/mockups/agents-redesign-custom.html": {
-    "mtime": 1779108265.8682644,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/inspector-parity-checklist.md": {
+    "mtime": 1779420420.7396607,
+    "hash": "632e57f2ac01dc119d3918de52523ec7"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/mockups/agents-redesign-custom.html": {
+    "mtime": 1779420420.7420087,
     "hash": "f1dab41edd1f74340b2dfafdcb60fcf3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/design/mockups/pipeline-cross-project-gpt5.html": {
-    "mtime": 1779108265.8692646,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/mockups/pipeline-cross-project-gpt5.html": {
+    "mtime": 1779420420.7439446,
     "hash": "e6a9c3e3fd6e31fba2f0d22aca037f9e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/design/mockups/board-opus.html": {
-    "mtime": 1779108265.8682644,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/mockups/board-opus.html": {
+    "mtime": 1779420420.7426608,
     "hash": "0bac9958f5c6cfe9c14d12118f17a860"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/design/mockups/command-deck-terminology-map.html": {
-    "mtime": 1779108265.8682644,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/mockups/command-deck-terminology-map.html": {
+    "mtime": 1779420420.7435853,
     "hash": "294391ca74043261c53680e9874b01ff"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/design/mockups/pipeline-cross-project-opus.html": {
-    "mtime": 1779108265.8692646,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/mockups/pipeline-cross-project-opus.html": {
+    "mtime": 1779420420.7443566,
     "hash": "af54e6f3716dd4c7f8e2cf35e099848b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/design/mockups/system-map-opus.html": {
-    "mtime": 1779108265.8692646,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/mockups/system-map-opus.html": {
+    "mtime": 1779420420.7444203,
     "hash": "e17f84e30b984d5f71fbd0a568d81041"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/design/mockups/pipeline-cross-project-kimi.html": {
-    "mtime": 1779108265.8692646,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/mockups/pipeline-cross-project-kimi.html": {
+    "mtime": 1779420420.7442667,
     "hash": "622456fb09a646ccda966c23b109c9be"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/design/mockups/pipeline-command-deck-opus.html": {
-    "mtime": 1779108265.8692646,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/mockups/pipeline-command-deck-opus.html": {
+    "mtime": 1779420420.7439446,
     "hash": "ee7ebcd338f9394b1a4314f7dde26214"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/design/mockups/issue-detail-opus.html": {
-    "mtime": 1779108265.8692646,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/mockups/issue-detail-opus.html": {
+    "mtime": 1779420420.7439446,
     "hash": "6114b4a3d3c8c8d3df7c1da9c8ad36e6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/design/mockups/flywheel-opus.html": {
-    "mtime": 1779108265.8682644,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/mockups/flywheel-opus.html": {
+    "mtime": 1779420420.7438736,
     "hash": "9b0e1e8f0b290532e3b61c66b906aaf2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/design/mockups/agents-redesign-stitch.html": {
-    "mtime": 1779108265.8682644,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/mockups/agents-redesign-stitch.html": {
+    "mtime": 1779420420.7426608,
     "hash": "4761e3da686154998cd5176887439045"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/design/mockups/agents-opus.html": {
-    "mtime": 1779108265.8665645,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/mockups/agents-opus.html": {
+    "mtime": 1779420420.740535,
     "hash": "9c8b480509901751495eb4f639f1ffbe"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/design/mockups/PAN-830-unified-command-deck.html": {
-    "mtime": 1779108265.866461,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/mockups/PAN-830-unified-command-deck.html": {
+    "mtime": 1779420420.740392,
     "hash": "07f1b03aab606353e729abcb54c31f47"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/design/mockups/pipeline-cross-project-minimax.html": {
-    "mtime": 1779108265.8692646,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/mockups/pipeline-cross-project-minimax.html": {
+    "mtime": 1779420420.7442667,
     "hash": "4258c7d21a9f3d400f70225d44c7fab5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/history/IMPLEMENTATION_SUMMARY.md": {
-    "mtime": 1779108265.8752646,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/history/IMPLEMENTATION_SUMMARY.md": {
+    "mtime": 1779420420.749661,
     "hash": "a3c6f7f5c72fb7bf13502d04a8921eab"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/history/PAN-428-CODEX-FEEDBACK.md": {
-    "mtime": 1779108265.8769138,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/history/PAN-428-CODEX-FEEDBACK.md": {
+    "mtime": 1779420420.7508311,
     "hash": "e535ce87f8e54c9eaa22f53d3869934b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/reporting-prd.md": {
-    "mtime": 1779108265.885265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/reporting-prd.md": {
+    "mtime": 1779420420.7612839,
     "hash": "dd4fc94537de67160ebcd2df9d357ba9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/pan-451-conversation-view.md": {
-    "mtime": 1779108265.884265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/pan-451-conversation-view.md": {
+    "mtime": 1779420420.7596614,
     "hash": "5fc58116194eca3e0c5ff2965067779d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/progressive-polyrepo-workspaces.md": {
-    "mtime": 1779108265.885265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/progressive-polyrepo-workspaces.md": {
+    "mtime": 1779420420.7610302,
     "hash": "a340d4863a52ff3271cef7c1e3d49c9e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/rally-feature-planning-ux.md": {
-    "mtime": 1779108265.885265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/rally-feature-planning-ux.md": {
+    "mtime": 1779420420.7610302,
     "hash": "3cb7e627fab4d6f8eb0c0d37225468c0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/project-setup-wizard.md": {
-    "mtime": 1779108265.885265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/project-setup-wizard.md": {
+    "mtime": 1779420420.7610302,
     "hash": "57e92d700b3cde2bff3d011d4431a233"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/pan-709-self-improving-flywheel.md": {
-    "mtime": 1779108265.884265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/pan-709-self-improving-flywheel.md": {
+    "mtime": 1779420420.7596614,
     "hash": "12e5692290ac9556f23064e1e9e8be58"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/pan-453-vbrief-full-spec-support.md": {
-    "mtime": 1779108265.884265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/pan-453-vbrief-full-spec-support.md": {
+    "mtime": 1779420420.7596614,
     "hash": "c550f9c733a042fdc26682caba2707b0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/agents-page-redesign-spec.md": {
-    "mtime": 1779108265.884265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/agents-page-redesign-spec.md": {
+    "mtime": 1779420420.7596614,
     "hash": "7cedf697c0891bf92dd125db65bf2a4d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-1204-home-tab-briefing-compliance.md": {
-    "mtime": 1779150733.4028182,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-1204-home-tab-briefing-compliance.md": {
+    "mtime": 1779420420.7580733,
     "hash": "881ccc3dea1b9acb517350342e658fde"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/fizzy-visual-pipeline.md": {
-    "mtime": 1779108265.884265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-658-shared-sessions.md": {
+    "mtime": 1779420420.7585351,
+    "hash": "dfe5df9349b196a9b25901f752eeef54"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/fizzy-visual-pipeline.md": {
+    "mtime": 1779420420.7596614,
     "hash": "dc3765dd1e57f6d25733bad875e81988"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-798-research.md": {
-    "mtime": 1779108265.883589,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-798-research.md": {
+    "mtime": 1779420420.7591367,
     "hash": "dc6acbe11ce88337be2984a8001a603d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-1048-role-primitive.md": {
-    "mtime": 1779108265.883589,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-1048-role-primitive.md": {
+    "mtime": 1779420420.757966,
     "hash": "14fa59a6a1fadeaf298251a1d5fc53aa"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/pan-457-archived-conversations.md": {
-    "mtime": 1779108265.884265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/pan-457-archived-conversations.md": {
+    "mtime": 1779420420.7596614,
     "hash": "f9742a143e71440073b7e93496cd4401"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-794-stuck-review-detection-recovery-opus47.md": {
-    "mtime": 1779108265.883589,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-794-stuck-review-detection-recovery-opus47.md": {
+    "mtime": 1779420420.7588875,
     "hash": "4af786f6e9fbdda4c89896c5ff952744"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-XXX-deft-directive-integration.md": {
-    "mtime": 1779108265.884265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-XXX-deft-directive-integration.md": {
+    "mtime": 1779420420.7591367,
     "hash": "2d47c3650793b04d47e96c4018eabf26"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-724-agent-usage-analytics-dashboard.md": {
-    "mtime": 1779108265.883589,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-724-agent-usage-analytics-dashboard.md": {
+    "mtime": 1779420420.758645,
     "hash": "995a41c9e899a5397e500fc0e7b9456e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-578-plan.md": {
-    "mtime": 1779108265.883589,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-578-plan.md": {
+    "mtime": 1779420420.7583795,
     "hash": "168dc07114c44ff8ee7ebe21bd2354e9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-1203-panopticon-docs-rag.md": {
-    "mtime": 1779150733.4028182,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-1203-panopticon-docs-rag.md": {
+    "mtime": 1779420420.7580733,
     "hash": "7f36c4a5f9a9537910f3bbe1ff2849ac"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-982-claude-code-agent-integration.md": {
-    "mtime": 1779108265.884265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-982-claude-code-agent-integration.md": {
+    "mtime": 1779420420.7591367,
     "hash": "c35a809a1060021338dc9753cf858b8c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-1044-project-overview-panel.md": {
-    "mtime": 1779108265.883589,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-1044-project-overview-panel.md": {
+    "mtime": 1779420420.7578206,
     "hash": "edd181a1dc5055f0aaf3593ec0373843"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-794-stuck-review-detection-recovery-opus47-feedback.md": {
-    "mtime": 1779108265.883589,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-794-stuck-review-detection-recovery-opus47-feedback.md": {
+    "mtime": 1779420420.7587461,
     "hash": "54094e9c947ddd6e207349b346e35814"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-966-editor-integration.md": {
-    "mtime": 1779108265.884265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-966-editor-integration.md": {
+    "mtime": 1779420420.7591367,
     "hash": "8070c066011e57de16eecd6deaae461a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/pan-fix-all.md": {
-    "mtime": 1779108265.885265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/pan-fix-all.md": {
+    "mtime": 1779420420.7607498,
     "hash": "0c17406c2e5590ad96c1ca4df1d52b8b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-722-remove-specialist-queues.md": {
-    "mtime": 1779108265.883589,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-722-remove-specialist-queues.md": {
+    "mtime": 1779420420.7585351,
     "hash": "b4f06a80eeed1ff9ef911da6e38dbfc9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/project-setup-wizard-ui.md": {
-    "mtime": 1779108265.885265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/project-setup-wizard-ui.md": {
+    "mtime": 1779420420.7610302,
     "hash": "029221f8a35e844aaa867d3a6cb587b8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-1205-html-artifacts.md": {
-    "mtime": 1779150733.4028182,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-1205-html-artifacts.md": {
+    "mtime": 1779420420.7580733,
     "hash": "ffa3608c13b5364e71b1c079b25f62d7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-632-merge-system-refactor.md": {
-    "mtime": 1779108265.883589,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-632-merge-system-refactor.md": {
+    "mtime": 1779420420.7583795,
     "hash": "0b369a17fdd94b473f42820d89b7388c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-970-swarm.md": {
-    "mtime": 1779108265.884265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-970-swarm.md": {
+    "mtime": 1779420420.7591367,
     "hash": "b66d81f9e0112ca7c6bd831d7f4bb4a6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-794-stuck-review-detection-recovery.md": {
-    "mtime": 1779108265.883589,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-794-stuck-review-detection-recovery.md": {
+    "mtime": 1779420420.7588875,
     "hash": "8ecfdf8f0fd4a85b45bde9082cb71574"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-965-command-deck-resource-tree.md": {
-    "mtime": 1779108265.884265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-965-command-deck-resource-tree.md": {
+    "mtime": 1779420420.7591367,
     "hash": "1f3ae121f519b10fd063f7d7eeeb377b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/flexible-tracker-id-resolution.md": {
-    "mtime": 1779108265.884265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/flexible-tracker-id-resolution.md": {
+    "mtime": 1779420420.7596614,
     "hash": "161a48289ad01400b5bc9f85f4e7c3cf"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/pan-428-dashboard-data-layer-architecture.md": {
-    "mtime": 1779108265.884265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/pan-428-dashboard-data-layer-architecture.md": {
+    "mtime": 1779420420.7596614,
     "hash": "e0efc61bcddf9c84660d3766fa66efbe"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-980-agent-restart-refactor.md": {
-    "mtime": 1779108265.884265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-980-agent-restart-refactor.md": {
+    "mtime": 1779420420.7591367,
     "hash": "0809b783c30d816744f690d5aa7edd8a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/pan-dashboard-typography-cleanup.md": {
-    "mtime": 1779108265.885265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/pan-dashboard-typography-cleanup.md": {
+    "mtime": 1779420420.7607498,
     "hash": "4992b63466b78f8796767e13e3a4f168"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-1029-harness-picker-ui.md": {
-    "mtime": 1779108265.8830721,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-1029-harness-picker-ui.md": {
+    "mtime": 1779420420.7577446,
     "hash": "f9b4ac8ee38255a4b925b7fc4828692f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-382-inspect-specialist.md": {
-    "mtime": 1779108265.883589,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-382-inspect-specialist.md": {
+    "mtime": 1779420420.7580733,
     "hash": "50d1da6df642aa5ea750bd6cda209ed1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/remote-workspace-parity-plan.md": {
-    "mtime": 1779108265.885265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/remote-workspace-parity-plan.md": {
+    "mtime": 1779420420.7612839,
     "hash": "679ceec96320953b88808bc5f960b6c7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-800.md": {
-    "mtime": 1779108265.883589,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-800.md": {
+    "mtime": 1779420420.7591367,
     "hash": "258c593eb9a93409bed1dac8f95022ab"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-830-unified-command-deck.md": {
-    "mtime": 1779108265.883589,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-830-unified-command-deck.md": {
+    "mtime": 1779420420.7591367,
     "hash": "80ba3b64387b690b522a3e69a34c3ff6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-1200-universal-context-system.md": {
-    "mtime": 1779150733.4028182,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-1200-universal-context-system.md": {
+    "mtime": 1779420420.757966,
     "hash": "15a0b1ae5493761529bc032d3de9484c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-798-audit.md": {
-    "mtime": 1779108265.883589,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-798-audit.md": {
+    "mtime": 1779420420.7588875,
     "hash": "0592c542445db30e96c7151eeb9d8ae6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-383-uat-specialist.md": {
-    "mtime": 1779108265.883589,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-383-uat-specialist.md": {
+    "mtime": 1779420420.7582774,
     "hash": "42b0b0ae527a1ac145343d324368b134"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/pan-settings-ui-redesign.md": {
-    "mtime": 1779108265.885265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/pan-settings-ui-redesign.md": {
+    "mtime": 1779420420.7607498,
     "hash": "96fb21604073e6e6345dda988d562865"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/pan-dashboard-unified-redesign.md": {
-    "mtime": 1779108265.885265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/pan-dashboard-unified-redesign.md": {
+    "mtime": 1779420420.7607498,
     "hash": "7c3216e36542612bd45530f5f1176160"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-969-directive-flow.md": {
-    "mtime": 1779108265.884265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-969-directive-flow.md": {
+    "mtime": 1779420420.7591367,
     "hash": "1bb69e80036c590ef47f0a8c5e3db3ac"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-821-command-deck-project-session-tree.md": {
-    "mtime": 1779108265.883589,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-821-command-deck-project-session-tree.md": {
+    "mtime": 1779420420.7591367,
     "hash": "efe67a5205d64ef45bed1c8fad4d3946"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/workspace-migration-plan.md": {
-    "mtime": 1779108265.885265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/workspace-migration-plan.md": {
+    "mtime": 1779420420.7612839,
     "hash": "411c862f36b50d3714a925ed2c38683e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-1201-hybrid-context-distribution.md": {
-    "mtime": 1779150733.4028182,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-1201-hybrid-context-distribution.md": {
+    "mtime": 1779420420.758038,
     "hash": "8b6848c597d227f0772cc0e5a6d847b1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-785-terminal-performance.md": {
-    "mtime": 1779108265.883589,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-785-terminal-performance.md": {
+    "mtime": 1779420420.7587461,
     "hash": "2679f2174c7765cc83ab380ca182baa1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/pan-309-evidence-based-completion-spec.md": {
-    "mtime": 1779108265.884265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/pan-309-evidence-based-completion-spec.md": {
+    "mtime": 1779420420.7596614,
     "hash": "1aa8da622e1e45849517fc492a4d3726"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-self-modify-permission-handling.md": {
-    "mtime": 1779108265.884265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-self-modify-permission-handling.md": {
+    "mtime": 1779420420.7596614,
     "hash": "ac49cce64b9c8afd568fd62ad95974d4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-754-specialist-identity-and-model-resolution.md": {
-    "mtime": 1779108265.883589,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-754-specialist-identity-and-model-resolution.md": {
+    "mtime": 1779420420.758645,
     "hash": "f60c5a015032cb292c0220e27907f433"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/planned/PAN-798.md": {
-    "mtime": 1779108265.883589,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/planned/PAN-798.md": {
+    "mtime": 1779420420.7591367,
     "hash": "6ba32a39b6c78ebafaf6e582c9c84d1c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-488-plan.md": {
-    "mtime": 1779108265.8772647,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-488-plan.md": {
+    "mtime": 1779420420.7523077,
     "hash": "0209d0df1bba24318825d630d1753715"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-402-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-402-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "c36fffdb0592dc1cfac05dc3aa956f17"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-445-plan.md": {
-    "mtime": 1779108265.8772647,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-445-plan.md": {
+    "mtime": 1779420420.751661,
     "hash": "8c06fbb831566a7707fce5429a804eb7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-826-conversation-integration-refactor-spec.md": {
-    "mtime": 1779108265.8806865,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-826-conversation-integration-refactor-spec.md": {
+    "mtime": 1779420420.7548087,
     "hash": "44f82ccb71a34a1dc7aa2e5a78d13e3d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-79-plan.md": {
-    "mtime": 1779108265.8785138,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-79-plan.md": {
+    "mtime": 1779420420.7525487,
     "hash": "6b08c1684452694e7b789f00fbf8cda3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-611-caveman-integration-spec.md": {
-    "mtime": 1779108265.8797715,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-611-caveman-integration-spec.md": {
+    "mtime": 1779420420.7539644,
     "hash": "ecf73232ebca660fec1aa818e4c00ec9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-253-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-253-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "ea80191b6f5db54eca51eba885c0a7af"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-34-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-34-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "0321eba10f954c2a0b9d029eae74001e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/1.0-audit-results.md": {
-    "mtime": 1779108265.8769841,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/1.0-audit-results.md": {
+    "mtime": 1779420420.7509015,
     "hash": "61969a9c7113b0c293a37096615fdaa0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-341-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-341-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "a678598e224b6720787a13b39b5d0263"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-410-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-410-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "b7429cabb1b6c41c0e37258e9489e853"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/1.0-stabilization-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/1.0-stabilization-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "5fc76e225a60d49311408c4353ef9139"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-697-root-artifact-cleanup-spec.md": {
-    "mtime": 1779108265.8800702,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-697-root-artifact-cleanup-spec.md": {
+    "mtime": 1779420420.7542908,
     "hash": "65531599d09dd93c4e004f087045ae1a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-161-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-161-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "dde8b32fd53eaea3f6996cf47df54032"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-78-plan.md": {
-    "mtime": 1779108265.8785138,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-78-plan.md": {
+    "mtime": 1779420420.7525487,
     "hash": "db3b1697a9e3056f5604548eb1010fb1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-415-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-415-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "7a1c6210f2471013f2686604fee0ce73"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-444-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-444-plan.md": {
+    "mtime": 1779420420.751661,
     "hash": "3b53d7e8393aa2971d9917d1ec3a8fb0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-426-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-426-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "927daa0ef9028a3cadab44c2fd23b6ca"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-591-karpathy-guidelines-spec.md": {
-    "mtime": 1779108265.8797715,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-591-karpathy-guidelines-spec.md": {
+    "mtime": 1779420420.7539644,
     "hash": "992026e40c673bb54a2115bda05d76fd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-739-unsent-message-persistence-spec.md": {
-    "mtime": 1779108265.8806865,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-739-unsent-message-persistence-spec.md": {
+    "mtime": 1779420420.7548087,
     "hash": "1fdaa408b3ce8922efec6dbbe0fa57bf"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-209-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-209-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "ddb5c84f221ac1587cdea1bb585bbd1a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-302-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-302-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "84e6a815c346753f35545c5a6826db2a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-470-plan.md": {
-    "mtime": 1779108265.8772647,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-470-plan.md": {
+    "mtime": 1779420420.7523077,
     "hash": "5a1b8563d0b6b2d72c5fae931e0da933"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-406-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-406-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "05b7ef02b1b4e39e46f7aac92f54580f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-451-plan.md": {
-    "mtime": 1779108265.8772647,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-451-plan.md": {
+    "mtime": 1779420420.751661,
     "hash": "c59d89a0924e3db4381061c41efb8371"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-327-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-327-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "63e8e1ad661b59cb0ce015c97e6da537"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-440-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-440-plan.md": {
+    "mtime": 1779420420.751661,
     "hash": "251e25be11794123809ed806a7557ac5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-166-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-166-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "32951c997ac5e50364ff63692d49f5d3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-142-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-142-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "f573c963bae55a8ebf2442da1cad55f9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-340-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-340-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "c77ee4ff33b40561811ce9a899a381b0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-293-project-living-memory-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-293-project-living-memory-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "06ffd34cbf353eb4317dc1fe1c78ee15"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-436-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-436-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "7dacdafd11f3edfdd3c8e9b8aa181737"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-85-plan.md": {
-    "mtime": 1779108265.8785138,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-85-plan.md": {
+    "mtime": 1779420420.7525487,
     "hash": "16509b3737957679e980d719795003dd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-256-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-256-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "daa2029dbe274abc4caaee1f93d18060"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-437-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-437-plan.md": {
+    "mtime": 1779420420.751661,
     "hash": "9e566760eeb99c9faf1383ca8d037ffd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-136-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-136-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "1d4e9b2673b086ccfde73607b09b2f55"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-453-plan.md": {
-    "mtime": 1779108265.8772647,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-453-plan.md": {
+    "mtime": 1779420420.7523077,
     "hash": "e7706a00143de68dd811557e2ecdd30b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-448-plan.md": {
-    "mtime": 1779108265.8772647,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-448-plan.md": {
+    "mtime": 1779420420.751661,
     "hash": "5f99fb03227c9349fee78beacde85199"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-647-plan.md": {
-    "mtime": 1779108265.8797715,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-647-plan.md": {
+    "mtime": 1779420420.7539644,
     "hash": "3a8d31ee8e35b8bf39dd6aee73b0f8e5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-295-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-295-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "781085e81c6502dd40e152014732d244"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-416-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-416-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "44003dd76f335a348df1ce523e337ffc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-208-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-208-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "4f616be1397359a9c277e089340f0277"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-428-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-428-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "6102f0d09d3893d09017ae3a9f9b2f54"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-290-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-290-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "66862a136b8901e706a3387b91eb7126"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-388-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-388-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "9aa2c934b3f4c35e43614bc040003ac7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/min-794-plan.md": {
-    "mtime": 1779108265.8785138,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/min-794-plan.md": {
+    "mtime": 1779420420.7525487,
     "hash": "5bc728acd85340d134aec17bacefe7e0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-408-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-408-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "130e6a8aee3c7788e58cdc08a910cfde"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-342-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-342-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "5996f0ee9dcc5b2f90d3e9fbcff43b55"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-632-implementation-plan.md": {
-    "mtime": 1779108265.8772647,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-632-implementation-plan.md": {
+    "mtime": 1779420420.7523077,
     "hash": "33a8cc39c20cec63b6ab8ba7e8ec009f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-415-plan.md": {
-    "mtime": 1779108265.8785138,
-    "hash": "7a1c6210f2471013f2686604fee0ce73"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-288-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-288-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "a100e3210a1eef8adf2f2733e2f890ee"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-337-plan.md": {
-    "mtime": 1779108265.8770196,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-337-plan.md": {
+    "mtime": 1779420420.7509382,
     "hash": "fc2eef04e2bc3a611096e1c2e32a590f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-460/STATE.md": {
-    "mtime": 1779108265.8789272,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-460/STATE.md": {
+    "mtime": 1779420420.752919,
     "hash": "b8a62f736f2e3aca20ed04e89da0224d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-557/STATE.md": {
-    "mtime": 1779108265.8795986,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-557/STATE.md": {
+    "mtime": 1779420420.7537735,
     "hash": "5c6476a487da02df40d8e0a14489f3b6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-540/STATE.md": {
-    "mtime": 1779108265.8795204,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-540/STATE.md": {
+    "mtime": 1779420420.753685,
     "hash": "7301454e2d0e78000db38bdb247a2f8c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-697/STATE.md": {
-    "mtime": 1779108265.8800702,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-697/STATE.md": {
+    "mtime": 1779420420.7542908,
     "hash": "67ec571edd30604b57a61d5efccfe3f3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-457/STATE.md": {
-    "mtime": 1779108265.878856,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-457/STATE.md": {
+    "mtime": 1779420420.7528458,
     "hash": "a31dbe45389510ef8b489d58d32e2182"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-448/STATE.md": {
-    "mtime": 1779108265.878776,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-448/STATE.md": {
+    "mtime": 1779420420.7527642,
     "hash": "21f05b62f177a565b3cb8724d9e5af5c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-699/STATE.md": {
-    "mtime": 1779108265.8802226,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-699/STATE.md": {
+    "mtime": 1779420420.754451,
     "hash": "2e8ad19b7b459252131055371792c162"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-645/STATE.md": {
-    "mtime": 1779108265.8772647,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-645/STATE.md": {
+    "mtime": 1779420420.7523077,
     "hash": "7e8ff1644c45527f0017dcb30b5b5986"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-712/STATE.md": {
-    "mtime": 1779108265.8804314,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-712/STATE.md": {
+    "mtime": 1779420420.7546694,
     "hash": "57122abc28fdd6a2012251da64849943"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-482/STATE.md": {
-    "mtime": 1779108265.8790507,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-482/STATE.md": {
+    "mtime": 1779420420.7531755,
     "hash": "29c3429144c174317b4796e4162f4939"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-831/PAN-831-spec.md": {
-    "mtime": 1779108265.8806865,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-831/PAN-831-spec.md": {
+    "mtime": 1779420420.7550101,
     "hash": "dc973e37a847adb223b62e10ecdc33eb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-653/STATE.md": {
-    "mtime": 1779108265.8785138,
-    "hash": "53e8d60e43ba9c976e60500ef3570ca6"
-  },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-655/STATE.md": {
-    "mtime": 1779108265.8799696,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-655/STATE.md": {
+    "mtime": 1779420420.7541835,
     "hash": "7c4f43d38ec63c1d79c82987df39e9de"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-705/STATE.md": {
-    "mtime": 1779108265.8803315,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-705/STATE.md": {
+    "mtime": 1779420420.7545645,
     "hash": "8a0e8b158cf1d2fae54a280b898a99bd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-705/pan-command-taxonomy-reorg.md": {
-    "mtime": 1779108265.8804314,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-705/pan-command-taxonomy-reorg.md": {
+    "mtime": 1779420420.7546694,
     "hash": "c5c2f71b4f5dcd574925385488012fa2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-539/STATE.md": {
-    "mtime": 1779108265.8794446,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-539/STATE.md": {
+    "mtime": 1779420420.7536006,
     "hash": "45e994e03b25ebe1bb52f610f6e90398"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-821/STATE.md": {
-    "mtime": 1779108265.8806865,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-821/STATE.md": {
+    "mtime": 1779420420.7548087,
     "hash": "324aaf9d4b0ddf759cae1c7cb2340f2f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-653/STATE.md": {
-    "mtime": 1779108265.8797715,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-653/STATE.md": {
+    "mtime": 1779420420.7539644,
     "hash": "53e8d60e43ba9c976e60500ef3570ca6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/PAN-596/STATE.md": {
-    "mtime": 1779108265.8772647,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/PAN-596/STATE.md": {
+    "mtime": 1779420420.7523077,
     "hash": "f2c4692cb32eba38732ab2f7f712709d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-488/STATE.md": {
-    "mtime": 1779108265.879124,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-488/STATE.md": {
+    "mtime": 1779420420.753251,
     "hash": "0209d0df1bba24318825d630d1753715"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-442/STATE.md": {
-    "mtime": 1779108265.8785138,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-442/STATE.md": {
+    "mtime": 1779420420.7525487,
     "hash": "1cc053d902eef2e789d7d3f447e7dc12"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-558/STATE.md": {
-    "mtime": 1779108265.8796685,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-558/STATE.md": {
+    "mtime": 1779420420.7538514,
     "hash": "b7ea9ef34346d99a9b6c8f854bfc4ead"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-698/STATE.md": {
-    "mtime": 1779108265.8801546,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-698/STATE.md": {
+    "mtime": 1779420420.7543795,
     "hash": "3713cf9d088fb9a2cae1cd7a05b382bc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-507/STATE.md": {
-    "mtime": 1779108265.8793187,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-507/STATE.md": {
+    "mtime": 1779420420.753461,
     "hash": "5f512f580bd573237b554003eda11e23"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-598/STATE.md": {
-    "mtime": 1779108265.8797715,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-598/STATE.md": {
+    "mtime": 1779420420.7539644,
     "hash": "8b799e8d1d2fd155679db2ee03d938ce"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-560/STATE.md": {
-    "mtime": 1779108265.8797374,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-560/STATE.md": {
+    "mtime": 1779420420.7539256,
     "hash": "e22bcb4be1d4ac14fbcd11162cf816b5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-494/STATE.md": {
-    "mtime": 1779108265.8792138,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-494/STATE.md": {
+    "mtime": 1779420420.753345,
     "hash": "ddad25847d39a644e067d7b3af7c1c3d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-509/STATE.md": {
-    "mtime": 1779108265.8793693,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-509/STATE.md": {
+    "mtime": 1779420420.7535172,
     "hash": "1d2c35f2f9e31858191b80a9f973313d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/prds/active/pan-506/STATE.md": {
-    "mtime": 1779108265.8792734,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/prds/active/pan-506/STATE.md": {
+    "mtime": 1779420420.75341,
     "hash": "8de3749537d7db99379cb7f90fcd5de9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/t3code-research.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/t3code-research.md": {
+    "mtime": 1779420420.761785,
     "hash": "9986c22c6b8a2972d73a988c61a36f11"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/kimi-k2.5-k2.6-work-type-fit.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/kimi-k2.5-k2.6-work-type-fit.md": {
+    "mtime": 1779420420.761785,
     "hash": "a0dd77fe148dc939c44b2e7c5d13db7b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/claude-haiku-4.5-work-type-fit.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/claude-haiku-4.5-work-type-fit.md": {
+    "mtime": 1779420420.7614346,
     "hash": "cd525cc7e9c0edb8ab000db690c11b79"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/claude-opus-4.7-work-type-fit.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/claude-opus-4.7-work-type-fit.md": {
+    "mtime": 1779420420.7614346,
     "hash": "ddc83ad11f98f9a784324baa18d82090"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/ai-memory-layer-research.md": {
-    "mtime": 1779108265.885265,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/ai-memory-layer-research.md": {
+    "mtime": 1779420420.7612839,
     "hash": "c534b1b3d0e2455fb1ab4d3354e31283"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/gemini-3.1-pro-work-type-fit.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/gemini-3.1-pro-work-type-fit.md": {
+    "mtime": 1779420420.761785,
     "hash": "03526da7f413a8de7e7c526c8bfbc60d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/claude-opus-4.6-work-type-fit.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/claude-opus-4.6-work-type-fit.md": {
+    "mtime": 1779420420.7614346,
     "hash": "9738b8f481f0a16bc330b3f376b00e57"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/specialist-redesign.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/specialist-redesign.md": {
+    "mtime": 1779420420.761785,
     "hash": "c45675180516056447acd654350dabe4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/mission-control-feature-adoption.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/mission-control-feature-adoption.md": {
+    "mtime": 1779420420.761785,
     "hash": "a6dc7f92b9724e8b1ad6d5b4d30d0d62"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/gemini-3-flash-work-type-fit.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/gemini-3-flash-work-type-fit.md": {
+    "mtime": 1779420420.7614346,
     "hash": "4703c1348f0c0c7ad821be884cfb4482"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/t3code-drift-plan.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/t3code-drift-plan.md": {
+    "mtime": 1779420420.761785,
     "hash": "dcdc4a53f4fb6417c02516330fa79040"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/gpt-5.4-work-type-fit.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/gpt-5.4-work-type-fit.md": {
+    "mtime": 1779420420.761785,
     "hash": "3d632588530d5a49681ea6779ffeee72"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/evals-framework.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/evals-framework.md": {
+    "mtime": 1779420420.7614346,
     "hash": "f3465e1143a34e72bd1412721f307578"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/glm-5.1-work-type-fit.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/glm-5.1-work-type-fit.md": {
+    "mtime": 1779420420.761785,
     "hash": "66d66d1a4a77c0128ef28349ba7f6c50"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/workflow-orchestration-landscape-opus.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/workflow-orchestration-landscape-opus.md": {
+    "mtime": 1779420420.761785,
     "hash": "ca4b015273c406c5f3f7ed92465388da"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/minimax-m2.7-work-type-fit.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/minimax-m2.7-work-type-fit.md": {
+    "mtime": 1779420420.761785,
     "hash": "4405829c6e96be5d703bb2edd5a631cb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/gpt-5.4-pro-work-type-fit.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/gpt-5.4-pro-work-type-fit.md": {
+    "mtime": 1779420420.761785,
     "hash": "698607152b3a78c68a72e10b495c7735"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/gpt-5.4-nano-work-type-fit.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/gpt-5.4-nano-work-type-fit.md": {
+    "mtime": 1779420420.761785,
     "hash": "ece868785fe96956f3a16bbf8cb3d067"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/gemini-3.1-flash-lite-work-type-fit.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/gemini-3.1-flash-lite-work-type-fit.md": {
+    "mtime": 1779420420.7614346,
     "hash": "386648ddd9a0a11995e1598de547dcd7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/gpt-5.4-mini-work-type-fit.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/gpt-5.4-mini-work-type-fit.md": {
+    "mtime": 1779420420.761785,
     "hash": "4df8bf77063237165036f4f5b0eaa193"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/qwen-3.6-work-type-fit.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/qwen-3.6-work-type-fit.md": {
+    "mtime": 1779420420.761785,
     "hash": "4a2ddc1f0a2c1f94bdaaeada80c8ae08"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/research/claude-sonnet-4.6-work-type-fit.md": {
-    "mtime": 1779108265.8867767,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/research/claude-sonnet-4.6-work-type-fit.md": {
+    "mtime": 1779420420.7614346,
     "hash": "a57bf21f9e83b01b3610aadc21ac1d5c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/reference/troubleshooting.mdx": {
-    "mtime": 1779108266.0166872,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/reference/troubleshooting.mdx": {
+    "mtime": 1779420420.8919275,
     "hash": "00e391d9b1ad6db3e052bac41821a66b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/reference/architecture.mdx": {
-    "mtime": 1779108266.0152693,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/reference/architecture.mdx": {
+    "mtime": 1779420420.8906658,
     "hash": "37b1be932c0c5d1140964b3dd782b54e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/reference/prompts.mdx": {
-    "mtime": 1779108266.0166872,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/reference/prompts.mdx": {
+    "mtime": 1779420420.8919275,
     "hash": "7c226f021e417fb6664d633e07486305"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/agents/pan-review-agent.md": {
-    "mtime": 1779108265.8537216,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/agents/pan-review-agent.md": {
+    "mtime": 1779420420.727507,
     "hash": "d079035447c46d746ca15354441dcd10"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/agents/codebase-explorer.md": {
-    "mtime": 1779108265.8532362,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/agents/codebase-explorer.md": {
+    "mtime": 1779420420.727507,
     "hash": "7f2bd08ee3be06f56831b5405074365e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/agents/pan-planning-agent.md": {
-    "mtime": 1779108265.8537216,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/agents/pan-planning-agent.md": {
+    "mtime": 1779420420.727507,
     "hash": "6653b2bcd8187166e4b177bdd1bedb7a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/agents/pan-merge-agent.md": {
-    "mtime": 1779108265.8537216,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/agents/pan-merge-agent.md": {
+    "mtime": 1779420420.727507,
     "hash": "8ea18e2602d0f3befc39da8e1f375a7f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/agents/pan-uat-agent.md": {
-    "mtime": 1779108265.8537216,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/agents/pan-uat-agent.md": {
+    "mtime": 1779420420.727507,
     "hash": "47198ed1c49dddc675682e55b003a933"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/agents/pan-test-agent.md": {
-    "mtime": 1779108265.8537216,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/agents/pan-test-agent.md": {
+    "mtime": 1779420420.727507,
     "hash": "7454592928a78b555f53006027ce2e48"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/agents/planning-agent.md": {
-    "mtime": 1779108265.8537216,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/agents/planning-agent.md": {
+    "mtime": 1779420420.727507,
     "hash": "802d4bf626d5d60ed07b680295da3809"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/agents/triage-agent.md": {
-    "mtime": 1779108265.8537216,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/agents/triage-agent.md": {
+    "mtime": 1779420420.727507,
     "hash": "4b1a2dc5c2ee3e18291a896aa7ef98bc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/agents/pan-work-agent.md": {
-    "mtime": 1779108265.8537216,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/agents/pan-work-agent.md": {
+    "mtime": 1779420420.727507,
     "hash": "cc2f4ea153b8283fe808e15aef2fffb6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/agents/pan-inspect-agent.md": {
-    "mtime": 1779108265.8537216,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/agents/pan-inspect-agent.md": {
+    "mtime": 1779420420.727507,
     "hash": "c5f615826257c1edc8bf9285af57fbad"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/agents/health-monitor.md": {
-    "mtime": 1779108265.8537216,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/agents/health-monitor.md": {
+    "mtime": 1779420420.727507,
     "hash": "e98d03b9fdc422721768c13e4ade87ac"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/templates/claude-md/sections/commands-skills.md": {
-    "mtime": 1779108266.1682427,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/templates/claude-md/sections/commands-skills.md": {
+    "mtime": 1779420421.0469413,
     "hash": "d8fd80125df4b35df4746b38c171fa1e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/templates/claude-md/sections/beads.md": {
-    "mtime": 1779108266.1682153,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/templates/claude-md/sections/beads.md": {
+    "mtime": 1779420421.0469131,
     "hash": "aea0b1838d93f2ff339e606b89540b5e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/templates/claude-md/sections/workspace-info.md": {
-    "mtime": 1779108266.1682427,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/templates/claude-md/sections/workspace-info.md": {
+    "mtime": 1779420421.0469413,
     "hash": "dfbfe268dcdfba09ff32488f6cd52799"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/templates/claude-md/sections/warnings.md": {
-    "mtime": 1779108266.1682427,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/templates/claude-md/sections/warnings.md": {
+    "mtime": 1779420421.0469413,
     "hash": "bc2efec76cf1a2db0e213a13f33bebd6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/templates/docker/react-vite/README.md": {
-    "mtime": 1779108266.168522,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/templates/docker/react-vite/README.md": {
+    "mtime": 1779420421.0472322,
     "hash": "ee18b8a669ee0e59c2b4d26c9550aa56"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/templates/docker/react-vite/docker-compose.yml": {
-    "mtime": 1779108266.168522,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/templates/docker/react-vite/docker-compose.yml": {
+    "mtime": 1779420421.0472322,
     "hash": "0d89c5fb963518a477d73ec445f10be0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/templates/docker/spring-boot/README.md": {
-    "mtime": 1779108266.168567,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/templates/docker/spring-boot/README.md": {
+    "mtime": 1779420421.0472798,
     "hash": "ce57bda68b2129c0ee2f0a51573984f6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/templates/docker/spring-boot/docker-compose.yml": {
-    "mtime": 1779108266.168567,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/templates/docker/spring-boot/docker-compose.yml": {
+    "mtime": 1779420421.0472798,
     "hash": "f81a6af9033411385c3235991d2c782b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/templates/docker/dotnet/README.md": {
-    "mtime": 1779108266.1683214,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/templates/docker/dotnet/README.md": {
+    "mtime": 1779420421.0470228,
     "hash": "606390ec9e005b08ce3b78f315544996"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/templates/docker/dotnet/docker-compose.yml": {
-    "mtime": 1779108266.1683214,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/templates/docker/dotnet/docker-compose.yml": {
+    "mtime": 1779420421.0470228,
     "hash": "6a56bc029e2537b65c62d5b8ba633e8c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/templates/docker/python-fastapi/README.md": {
-    "mtime": 1779108266.1684844,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/templates/docker/python-fastapi/README.md": {
+    "mtime": 1779420421.0471938,
     "hash": "ed1c3be09790079014efd513bfa41220"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/templates/docker/python-fastapi/docker-compose.yml": {
-    "mtime": 1779108266.1684844,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/templates/docker/python-fastapi/docker-compose.yml": {
+    "mtime": 1779420421.0471938,
     "hash": "7d57c60cdc964431b1206931ba8ef0c8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/templates/docker/monorepo/README.md": {
-    "mtime": 1779108266.168369,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/templates/docker/monorepo/README.md": {
+    "mtime": 1779420421.047081,
     "hash": "b189c9fcff4d26ad7e80589b74f6cb89"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/templates/docker/monorepo/docker-compose.yml": {
-    "mtime": 1779108266.168369,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/templates/docker/monorepo/docker-compose.yml": {
+    "mtime": 1779420421.047081,
     "hash": "58f04873e7564385a19a36c850cc4748"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/templates/docker/nextjs/README.md": {
-    "mtime": 1779108266.168436,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/templates/docker/nextjs/README.md": {
+    "mtime": 1779420421.0471451,
     "hash": "7a2f3bc99481b2df5e2c22ba67f09543"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/templates/docker/nextjs/docker-compose.yml": {
-    "mtime": 1779108266.168436,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/templates/docker/nextjs/docker-compose.yml": {
+    "mtime": 1779420421.0471451,
     "hash": "afd96fd147a918657acbac5da11ad184"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/templates/traefik/traefik.yml": {
-    "mtime": 1779108266.1686506,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/templates/traefik/traefik.yml": {
+    "mtime": 1779420421.0473669,
     "hash": "9148f7eb54990da5bd4f5917c6eb7a49"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/templates/traefik/README.md": {
-    "mtime": 1779108266.168567,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/templates/traefik/README.md": {
+    "mtime": 1779420421.0472798,
     "hash": "7e9ab0355ec1caf4b84b1fc5144386eb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/templates/traefik/docker-compose.yml": {
-    "mtime": 1779108266.1686177,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/templates/traefik/docker-compose.yml": {
+    "mtime": 1779420421.0473313,
     "hash": "ed3b2d795856b80f21d80313918c183e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/code-review-performance/SKILL.md": {
-    "mtime": 1779108266.1027699,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/code-review-performance/SKILL.md": {
+    "mtime": 1779420420.9740338,
     "hash": "26eb43a1f88cdab9aae6dd066a566044"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-logs/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-logs/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "569e741d7f685186a79c194e0890b081"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-reopen/SKILL.md": {
-    "mtime": 1779108266.1042724,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-reopen/SKILL.md": {
+    "mtime": 1779420420.9756687,
     "hash": "0047fe8a76dd374f0e6ba49cb3163a14"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/knowledge-capture/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/knowledge-capture/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "e38344d4ead6863b9d28b33cf278797f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/unarchive-conversation/SKILL.md": {
-    "mtime": 1779108266.1080248,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/unarchive-conversation/SKILL.md": {
+    "mtime": 1779420420.9786916,
     "hash": "0f70297966fee090a6e36b5d5ea866b0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/workspace-status/SKILL.md": {
-    "mtime": 1779108266.1080248,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-memory/SKILL.md": {
+    "mtime": 1779420420.9747198,
+    "hash": "e0053d4ff5e69de7007c94e88e59bab8"
+  },
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/workspace-status/SKILL.md": {
+    "mtime": 1779420420.9786916,
     "hash": "821b9ea124ccb69eac5424bd01388b02"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/plan/SKILL.md": {
-    "mtime": 1779108266.1060865,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/plan/SKILL.md": {
+    "mtime": 1779420420.9770398,
     "hash": "1f12967fa4075e4b28e672792dfd02dd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/react-best-practices/SKILL.md": {
-    "mtime": 1779108266.1060865,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/react-best-practices/SKILL.md": {
+    "mtime": 1779420420.977128,
     "hash": "e2666f75d2c180a6e694014f88a55cd0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-approve/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-approve/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "6531b487af383e7a1cf3d1eac13867a8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/clear-writing/SKILL.md": {
-    "mtime": 1779108266.1015031,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/clear-writing/SKILL.md": {
+    "mtime": 1779420420.9733207,
     "hash": "01f059f7756a64e483561c53597fa3d5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/check-merged/SKILL.md": {
-    "mtime": 1779108266.1015031,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/check-merged/SKILL.md": {
+    "mtime": 1779420420.9733207,
     "hash": "3fadc2250b3e1521d82f06a2d1e1783a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-test-config/SKILL.md": {
-    "mtime": 1779108266.1057632,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-test-config/SKILL.md": {
+    "mtime": 1779420420.9764092,
     "hash": "e5d9433b7af46684f0823ffe6245bdb6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/incident-response/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/incident-response/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "fb041d8dc18cb469fdbbc27ce57f7eb6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-done/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-done/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "2960657030a1ad456d76046b7199658a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-fly/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-fly/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "18932be8c7b315dc5788460a25e2f310"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-pause/SKILL.md": {
-    "mtime": 1779108266.1042724,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-pause/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "398e95bf307378312c8231fcf166b52d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-sync/SKILL.md": {
-    "mtime": 1779108266.1057632,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-sync/SKILL.md": {
+    "mtime": 1779420420.9764092,
     "hash": "5742fadaf580b1d8de239350e1da5bf6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-kill/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-kill/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "2674056faee2fc1d399eb5a7c3313799"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/crash-investigation/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/crash-investigation/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "906d70a0676b0742bf7674b0ec9bf3bd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads/SKILL.md": {
-    "mtime": 1779108266.1013236,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads/SKILL.md": {
+    "mtime": 1779420420.973233,
     "hash": "70b548490fe2be93eb0d1239d9af9527"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads/README.md": {
-    "mtime": 1779108266.1009362,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads/README.md": {
+    "mtime": 1779420420.9730961,
     "hash": "19da734ac814fd4fc8c91eb6c7321383"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads/adr/0001-bd-prime-as-source-of-truth.md": {
-    "mtime": 1779108266.1013236,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads/adr/0001-bd-prime-as-source-of-truth.md": {
+    "mtime": 1779420420.973233,
     "hash": "c0ac9765a13652e8e514ff74f01f25b6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads/resources/TROUBLESHOOTING.md": {
-    "mtime": 1779108266.1015031,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads/resources/TROUBLESHOOTING.md": {
+    "mtime": 1779420420.9733207,
     "hash": "df837034a9255c498a030ccaab191d58"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads/resources/BATCH.md": {
-    "mtime": 1779108266.1015031,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads/resources/BATCH.md": {
+    "mtime": 1779420420.9733207,
     "hash": "a6fdbd8120ec5b849e080ddd74c7dd6d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads/resources/ASYNC_GATES.md": {
-    "mtime": 1779108266.1015031,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads/resources/ASYNC_GATES.md": {
+    "mtime": 1779420420.9733207,
     "hash": "e59d67571721eab0771d9e27df8c074d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads/resources/MOLECULES.md": {
-    "mtime": 1779108266.1015031,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads/resources/MOLECULES.md": {
+    "mtime": 1779420420.9733207,
     "hash": "7fa8480c3c6dcdedee095ab8cd245c56"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads/resources/INTEGRATION_PATTERNS.md": {
-    "mtime": 1779108266.1015031,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads/resources/INTEGRATION_PATTERNS.md": {
+    "mtime": 1779420420.9733207,
     "hash": "16235c794069c8ebbd498e3a957d88e4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads/resources/RESUMABILITY.md": {
-    "mtime": 1779108266.1015031,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads/resources/RESUMABILITY.md": {
+    "mtime": 1779420420.9733207,
     "hash": "0ae2c753d3fa6e6dfc0a67739fd56c73"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads/resources/DEPENDENCIES.md": {
-    "mtime": 1779108266.1015031,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads/resources/DEPENDENCIES.md": {
+    "mtime": 1779420420.9733207,
     "hash": "73b7d24c8f162a1f9bbb7d4f93da5191"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads/resources/RULES.md": {
-    "mtime": 1779108266.1015031,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads/resources/RULES.md": {
+    "mtime": 1779420420.9733207,
     "hash": "054cc1ac308cdda4679b83f1b5c925e7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads/resources/PATTERNS.md": {
-    "mtime": 1779108266.1015031,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads/resources/PATTERNS.md": {
+    "mtime": 1779420420.9733207,
     "hash": "ec70a964f3e74a097b7a855561ef2a68"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads/resources/AGENTS.md": {
-    "mtime": 1779108266.1013236,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads/resources/AGENTS.md": {
+    "mtime": 1779420420.973233,
     "hash": "352fe18808653958fdf2792747293002"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads/resources/CLI_REFERENCE.md": {
-    "mtime": 1779108266.1015031,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads/resources/CLI_REFERENCE.md": {
+    "mtime": 1779420420.9733207,
     "hash": "8875685ee4623a56053e738d5041ab54"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads/resources/BOUNDARIES.md": {
-    "mtime": 1779108266.1015031,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads/resources/BOUNDARIES.md": {
+    "mtime": 1779420420.9733207,
     "hash": "667cff6bbb03ec32721f4a8a50322b1e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads/resources/WORKFLOWS.md": {
-    "mtime": 1779108266.1015031,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads/resources/WORKFLOWS.md": {
+    "mtime": 1779420420.9733207,
     "hash": "eff60be5fe91b8b8debcd69dc8e1340c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads/resources/CHEMISTRY_PATTERNS.md": {
-    "mtime": 1779108266.1015031,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads/resources/CHEMISTRY_PATTERNS.md": {
+    "mtime": 1779420420.9733207,
     "hash": "b9c46e8ba2455e5a164a02b39d030a89"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads/resources/WORKTREES.md": {
-    "mtime": 1779108266.1015031,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads/resources/WORKTREES.md": {
+    "mtime": 1779420420.9733207,
     "hash": "ffe815083cdc89ede62c69405a1f1d57"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads/resources/ISSUE_CREATION.md": {
-    "mtime": 1779108266.1015031,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads/resources/ISSUE_CREATION.md": {
+    "mtime": 1779420420.9733207,
     "hash": "4cd087feb9ca82fad2e21089097ab6c2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads/resources/STATIC_DATA.md": {
-    "mtime": 1779108266.1015031,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads/resources/STATIC_DATA.md": {
+    "mtime": 1779420420.9733207,
     "hash": "323a2698f6c3fbb73d68593d163b8a5a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-convoy-synthesis/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-convoy-synthesis/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "0bc3feb45a181d7066ac8ea471172c3b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-untroubled/SKILL.md": {
-    "mtime": 1779108266.1060865,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-untroubled/SKILL.md": {
+    "mtime": 1779420420.97674,
     "hash": "fe1c48b0a4fcbb847ac8cd118f2680e7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/session-health/SKILL.md": {
-    "mtime": 1779108266.1060865,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/session-health/SKILL.md": {
+    "mtime": 1779420420.977128,
     "hash": "11469e8146d9edd4e257b64b0e46862c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-oversee/SKILL.md": {
-    "mtime": 1779108266.1042724,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-oversee/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "12545114ee24cd5be972f9070ea50c3b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/send-feedback-to-agent/SKILL.md": {
-    "mtime": 1779108266.1060865,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/send-feedback-to-agent/SKILL.md": {
+    "mtime": 1779420420.977128,
     "hash": "a9edf98c19c45859a9d85cd8c388669d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/conv-lookup/SKILL.md": {
-    "mtime": 1779108266.1027699,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/conv-lookup/SKILL.md": {
+    "mtime": 1779420420.9740338,
     "hash": "873d56086c191a0181fc67412b0d680e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-help/SKILL.md": {
-    "mtime": 1779150733.7428296,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-help/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "69a4efd9b0f7d00cc77979a4d69fa3a1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/work-complete/SKILL.md": {
-    "mtime": 1779108266.1080248,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/work-complete/SKILL.md": {
+    "mtime": 1779420420.9786916,
     "hash": "a1b12ed2efd0a91639f571fc4f7b5f66"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-wipe/SKILL.md": {
-    "mtime": 1779108266.1060865,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-wipe/SKILL.md": {
+    "mtime": 1779420420.9768968,
     "hash": "e51c777a4eeed3982b45f02d29cae883"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-docker/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-docker/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "1e723e0d9f75d2b6983fff6c1f34331a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/dependency-update/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/dependency-update/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "b4c8b5cdf8fb6d01593f4c0781c5e828"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-resources/SKILL.md": {
-    "mtime": 1779108266.1042724,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-resources/SKILL.md": {
+    "mtime": 1779420420.9756687,
     "hash": "0102b41a3ea5169bf5e031470feb75a7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-unpause/SKILL.md": {
-    "mtime": 1779108266.1060865,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-unpause/SKILL.md": {
+    "mtime": 1779420420.97674,
     "hash": "024ef35b307b9ad628a96237d0f8a2bb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-admin-hooks/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-admin-hooks/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "01efa70959d61fdf705900913a0f1465"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/workspace-add-repo/skill.md": {
-    "mtime": 1779108266.1080248,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/workspace-add-repo/skill.md": {
+    "mtime": 1779420420.9786916,
     "hash": "99ef483cf223e8834ca9e0ea18c25ef9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/web-design-guidelines/SKILL.md": {
-    "mtime": 1779108266.1080248,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/web-design-guidelines/SKILL.md": {
+    "mtime": 1779420420.9786916,
     "hash": "92690a32ccbee44097f68a731158e2e4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/stitch-setup/SKILL.md": {
-    "mtime": 1779108266.1080248,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/stitch-setup/SKILL.md": {
+    "mtime": 1779420420.9786916,
     "hash": "02017929d18b2d9a5665bae5c5f18ce8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-tts/SKILL.md": {
-    "mtime": 1779108266.1057632,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-tts/SKILL.md": {
+    "mtime": 1779420420.9764092,
     "hash": "795f448492717084a9f28505d4feaea1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-quickstart/SKILL.md": {
-    "mtime": 1779108266.1042724,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-quickstart/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "bbbc8d326ead15e7db760e6869d7694a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-projects/SKILL.md": {
-    "mtime": 1779108266.1042724,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-projects/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "4c7252c818dc3f3067e3cbb19237e2e9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-dev/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-dev/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "3bd7c726ae44f08cbf4b26ac69d2b8e3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-doctor/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-doctor/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "e89ecc3d0d0a3d875a34455b41e35e81"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-tell/SKILL.md": {
-    "mtime": 1779108266.1057632,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-tell/SKILL.md": {
+    "mtime": 1779420420.9764092,
     "hash": "77f67d068d5964b0cc80a3dbb86a70ba"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-sync-main/SKILL.md": {
-    "mtime": 1779108266.1057632,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-sync-main/SKILL.md": {
+    "mtime": 1779420420.9764092,
     "hash": "abc979e2f2c2c1fb4602720bda5f64b8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-restart/SKILL.md": {
-    "mtime": 1779108266.1042724,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-restart/SKILL.md": {
+    "mtime": 1779420420.9756687,
     "hash": "962a233b42172083722134bceb05f529"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-admin-cloister/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-admin-cloister/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "58b9d74412a27f745f49fbdf6245a96d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-up/SKILL.md": {
-    "mtime": 1779108266.1060865,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-up/SKILL.md": {
+    "mtime": 1779420420.97674,
     "hash": "8ef25838346f93fa0637ee919b35d65c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/refactor/SKILL.md": {
-    "mtime": 1779108266.1060865,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/refactor/SKILL.md": {
+    "mtime": 1779420420.977128,
     "hash": "b923b55f026dcc66e753037e91545382"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/spec-readiness-setup/SKILL.md": {
-    "mtime": 1779108266.106757,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/spec-readiness-setup/SKILL.md": {
+    "mtime": 1779420420.9774137,
     "hash": "06a62c1764d497de7406d2a593e7a0c8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/refactor-radar/SKILL.md": {
-    "mtime": 1779108266.1060865,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/refactor-radar/SKILL.md": {
+    "mtime": 1779420420.977128,
     "hash": "5ac85e8b4e18fcdec157d0df80713940"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/all-up/SKILL.md": {
-    "mtime": 1779150733.7938313,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/all-up/SKILL.md": {
+    "mtime": 1779420420.9730961,
     "hash": "5f27d295f382a42a021b76c4bc1745c1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-status/SKILL.md": {
-    "mtime": 1779108266.1055593,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-status/SKILL.md": {
+    "mtime": 1779420420.9762032,
     "hash": "919df3cc6b4402a8e8b39bb686cea954"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/_template/pan-verb-skill.md": {
-    "mtime": 1779108266.1009362,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/_template/pan-verb-skill.md": {
+    "mtime": 1779420420.9730961,
     "hash": "947c04e463608216b05ed1600c76ac60"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-admin-config/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-admin-config/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "113cd285a20f5b6c848065dbdb0e2947"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pipeline-status/SKILL.md": {
-    "mtime": 1779150733.8158321,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pipeline-status/SKILL.md": {
+    "mtime": 1779420420.9770398,
     "hash": "b978ea77eb977b371fdab132a677bd1f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-stop-all-agents/SKILL.md": {
-    "mtime": 1779108266.1055593,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-stop-all-agents/SKILL.md": {
+    "mtime": 1779420420.9762032,
     "hash": "0c230b4faa617488ab75d98635b61355"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-start/SKILL.md": {
-    "mtime": 1779108266.1055593,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-start/SKILL.md": {
+    "mtime": 1779420420.9762032,
     "hash": "9730aeffc74e1ed5aa82a1e83fdee3a2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-admin-tracker/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-admin-tracker/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "f48fa451eddb65472ef76e14a2309bc8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/feature-work/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/feature-work/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "ca7b28d495652c6e184a09618260086f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/myn-standards/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/myn-standards/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "dd9493c2c96bff5597a91d7a0f898682"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads-panopticon-guide/SKILL.md": {
-    "mtime": 1779108266.1009362,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads-panopticon-guide/SKILL.md": {
+    "mtime": 1779420420.9730961,
     "hash": "981d5823520fdc59e517ddbc98e193ae"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/stitch-react-components/SKILL.md": {
-    "mtime": 1779108266.1071193,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/stitch-react-components/SKILL.md": {
+    "mtime": 1779420420.9777653,
     "hash": "4a323a978b87a5fe259aa626ccc36604"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/stitch-react-components/README.md": {
-    "mtime": 1779108266.1070027,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/stitch-react-components/README.md": {
+    "mtime": 1779420420.977657,
     "hash": "0ad6674c98606716d4394b10531cfb8a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/stitch-react-components/resources/stitch-api-reference.md": {
-    "mtime": 1779108266.1079695,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/stitch-react-components/resources/stitch-api-reference.md": {
+    "mtime": 1779420420.9786198,
     "hash": "fd23a0de7746e1e6e5345a4f8f73f930"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/stitch-react-components/resources/architecture-checklist.md": {
-    "mtime": 1779108266.1071193,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/stitch-react-components/resources/architecture-checklist.md": {
+    "mtime": 1779420420.9785354,
     "hash": "634d99d6951b39cae709eb0863ad4ae2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/beads-completion-check/SKILL.md": {
-    "mtime": 1779108266.1009362,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/beads-completion-check/SKILL.md": {
+    "mtime": 1779420420.9730961,
     "hash": "8f5e44f68ed2b7f9dd59c3765b3cf458"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-plan/SKILL.md": {
-    "mtime": 1779108266.1042724,
-    "hash": "724d68b54d28ce1868ab49c4f3081379"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-plan/SKILL.md": {
+    "mtime": 1779420420.9747198,
+    "hash": "da0e1106b33d15858adb86e72f991f56"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-review/SKILL.md": {
-    "mtime": 1779108266.1042724,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-review/SKILL.md": {
+    "mtime": 1779420420.9756687,
     "hash": "454c8205a577e78ca73c83406582c084"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/github-cli/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/github-cli/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "523fc6ff137eb445ab7b9676e0a0eb03"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-code-review/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-code-review/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "131ebd7df44333edcf42d61aa926002f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-reload/SKILL.md": {
-    "mtime": 1779108266.1042724,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-reload/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "f82051b8ac3e4973f18b92f37e0fc66f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-issues/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-issues/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "d3f44e2efc05af08805d76f233886461"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/benchmark/SKILL.md": {
-    "mtime": 1779108266.1015031,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/benchmark/SKILL.md": {
+    "mtime": 1779420420.9733207,
     "hash": "101b29530086ba490ca2ec0a28b0cbe0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-show/SKILL.md": {
-    "mtime": 1779108266.1042724,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-show/SKILL.md": {
+    "mtime": 1779420420.9756687,
     "hash": "a328f37d7bce6c56f82183ba2ced088d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/release/SKILL.md": {
-    "mtime": 1779108266.1060865,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/release/SKILL.md": {
+    "mtime": 1779420420.977128,
     "hash": "f3dab474231533b6c07ad921275ac606"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-close/SKILL.md": {
-    "mtime": 1779108266.103837,
-    "hash": "99fde444b9d0aa7d13fb5ecc9da22072"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-close/SKILL.md": {
+    "mtime": 1779420420.9747198,
+    "hash": "bcdc043f1b8231ab72a757fdd1a92198"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-subagent-creator/SKILL.md": {
-    "mtime": 1779108266.1055593,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-subagent-creator/SKILL.md": {
+    "mtime": 1779420420.9762032,
     "hash": "01f731d8e71e9edaa6fa91b814e50df1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-subagent-creator/references/example-agents.md": {
-    "mtime": 1779108266.1057632,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-subagent-creator/references/example-agents.md": {
+    "mtime": 1779420420.9764092,
     "hash": "577f4a374033e6bbe023e6704dfb2f63"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-workspace-config/SKILL.md": {
-    "mtime": 1779108266.1060865,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-workspace-config/SKILL.md": {
+    "mtime": 1779420420.9768968,
     "hash": "60bcb836a5cecbce85cdcfa81f6b8b87"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/skill-creator/SKILL.md": {
-    "mtime": 1779108266.1066525,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/skill-creator/SKILL.md": {
+    "mtime": 1779420420.9773085,
     "hash": "6162fe30b76651dee413a9badde6e12e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-release/SKILL.md": {
-    "mtime": 1779108266.1042724,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-release/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "15b2c36c4d3a7cb0146b2d4f2e89e4bd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/code-review-security/SKILL.md": {
-    "mtime": 1779108266.1027699,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/code-review-security/SKILL.md": {
+    "mtime": 1779420420.9740338,
     "hash": "029c0667efa18b4a787de01496e4de59"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-docs/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-docs/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "3d614b794e79c424ee396c06d98edbe2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/code-review/SKILL.md": {
-    "mtime": 1779108266.1027699,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/code-review/SKILL.md": {
+    "mtime": 1779420420.9740338,
     "hash": "a5d2a5e8a932d42d3b5835eaf8cbcc7c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/bug-fix/SKILL.md": {
-    "mtime": 1779108266.1015031,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/bug-fix/SKILL.md": {
+    "mtime": 1779420420.9733207,
     "hash": "71da92be7a6fdc4b5629419c31535e3f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-tldr/SKILL.md": {
-    "mtime": 1779108266.1057632,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-tldr/SKILL.md": {
+    "mtime": 1779420420.9764092,
     "hash": "507e33c931e91875e6ab7026a23c2a1a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-admin-tldr/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-admin-tldr/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "c64ffa0333b7295e74cbc6eafdf70a20"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-diagnose/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-diagnose/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "720a9179663b8585f6e2985aac8fd942"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/spec-readiness/SKILL.md": {
-    "mtime": 1779108266.1068633,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/spec-readiness/SKILL.md": {
+    "mtime": 1779420420.977521,
     "hash": "ba0496079e0e1c0d31fe382a577e30cf"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/spec-readiness/SCORING-REFERENCE.md": {
-    "mtime": 1779108266.1068633,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/spec-readiness/SCORING-REFERENCE.md": {
+    "mtime": 1779420420.977521,
     "hash": "f901d6a438535d76eaef9c34ebe15283"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/spec-readiness/REPORT-TEMPLATE.md": {
-    "mtime": 1779108266.106757,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/spec-readiness/REPORT-TEMPLATE.md": {
+    "mtime": 1779420420.9774137,
     "hash": "47b8a6c95938f7dbd32c88acecd9594d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-new-project/SKILL.md": {
-    "mtime": 1779108266.1042724,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-new-project/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "b90fef64fc3c925448d33938ca55db64"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan/SKILL.md": {
-    "mtime": 1779108266.1060865,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan/SKILL.md": {
+    "mtime": 1779420420.9768968,
     "hash": "ab537d23d1eaabdb049ad1c4b3f7bc3a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-network/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-network/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "79dafd17d0689db304189c6738d693fc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/cliproxy/SKILL.md": {
-    "mtime": 1779108266.1027699,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/cliproxy/SKILL.md": {
+    "mtime": 1779420420.9740338,
     "hash": "28b03b82ec89ba9cb380307d6e872daa"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/write-spec/SKILL.md": {
-    "mtime": 1779108266.1080248,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/write-spec/SKILL.md": {
+    "mtime": 1779420420.9786916,
     "hash": "4e45aedd54f8bef831b917ff756e4ef3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-install/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-install/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "c197cd93624e624e0f5377af3806f513"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/onboard-codebase/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/onboard-codebase/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "7c96ef1e33dd96accf452bd579950dff"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/stitch-design-md/SKILL.md": {
-    "mtime": 1779108266.1070027,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/stitch-design-md/SKILL.md": {
+    "mtime": 1779420420.977657,
     "hash": "4b266b875f3395ac7f4ca794d6cab5f6"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/stitch-design-md/README.md": {
-    "mtime": 1779108266.1068633,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/stitch-design-md/README.md": {
+    "mtime": 1779420420.977521,
     "hash": "1935631d1b4b1688ea04d813b5d2b3f1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/stitch-design-md/examples/DESIGN.md": {
-    "mtime": 1779108266.1070027,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/stitch-design-md/examples/DESIGN.md": {
+    "mtime": 1779420420.977657,
     "hash": "40dd3711ad93801345ba8d0317feb28b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-skill-creator/SKILL.md": {
-    "mtime": 1779108266.1042724,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-skill-creator/SKILL.md": {
+    "mtime": 1779420420.9756687,
     "hash": "4cb4fb3f2224dbaf5c818d81ee85076a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-skill-creator/references/workflows.md": {
-    "mtime": 1779108266.1055593,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-skill-creator/references/workflows.md": {
+    "mtime": 1779420420.9762032,
     "hash": "bff2ef95bacc2973dbcec679e4b89304"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-skill-creator/references/output-patterns.md": {
-    "mtime": 1779108266.105537,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-skill-creator/references/output-patterns.md": {
+    "mtime": 1779420420.9761806,
     "hash": "1c114e41b0672ef464716859ee8cfd15"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-flywheel/SKILL.md": {
-    "mtime": 1779150733.7428296,
-    "hash": "3575dfb640e43ecc1dec2645f7a85636"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-flywheel/SKILL.md": {
+    "mtime": 1779420420.9747198,
+    "hash": "9849631444dd1a10b792dd652b271c82"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/skills/pan-down/SKILL.md": {
-    "mtime": 1779108266.103837,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/skills/pan-down/SKILL.md": {
+    "mtime": 1779420420.9747198,
     "hash": "179a88ddac3b289790e1d76419f129cd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/dev-skills/test-specialist-workflow/SKILL.md": {
-    "mtime": 1779108265.862253,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/dev-skills/test-specialist-workflow/SKILL.md": {
+    "mtime": 1779420420.7361038,
     "hash": "7701c4b1c26df6a5c632935080e83713"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/dev-skills/pan-commit/SKILL.md": {
-    "mtime": 1779108265.862253,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/dev-skills/pan-commit/SKILL.md": {
+    "mtime": 1779420420.7361038,
     "hash": "42330ae4e6b40b103754ea44823c5950"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/dev-skills/pan-dashboard-restart/skill.md": {
-    "mtime": 1779108265.862253,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/dev-skills/pan-dashboard-restart/skill.md": {
+    "mtime": 1779420420.7361038,
     "hash": "f136ef9afb023eeafdba60bbb70f50fb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/dev-skills/pan-skill-creator/SKILL.md": {
-    "mtime": 1779108265.862253,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/dev-skills/pan-skill-creator/SKILL.md": {
+    "mtime": 1779420420.7361038,
     "hash": "68bdde67ca9cac63dc8a9a551a25d986"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/infra/wsl2hosts/README.md": {
-    "mtime": 1779108265.9829242,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/infra/wsl2hosts/README.md": {
+    "mtime": 1779420420.8576474,
     "hash": "2c60927678f9166df7227216320d41b4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/configuration/meta-repos.mdx": {
-    "mtime": 1779108265.856574,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/configuration/meta-repos.mdx": {
+    "mtime": 1779420420.730466,
     "hash": "0e4bd1ae1c855a63638cc36ca9a44d05"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/configuration/progressive-polyrepo.mdx": {
-    "mtime": 1779108265.856574,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/configuration/progressive-polyrepo.mdx": {
+    "mtime": 1779420420.730466,
     "hash": "d82eea2baacb63487a53d35922ee664d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/configuration/issue-trackers.mdx": {
-    "mtime": 1779108265.8560317,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/configuration/issue-trackers.mdx": {
+    "mtime": 1779420420.729954,
     "hash": "10fb1b22a7f0229baad66b9baee8f72f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/configuration/polyrepo.mdx": {
-    "mtime": 1779108265.856574,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/configuration/polyrepo.mdx": {
+    "mtime": 1779420420.730466,
     "hash": "786dc1a330c710ac9b0bd34811682bdb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/configuration/projects.mdx": {
-    "mtime": 1779108265.856574,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/configuration/projects.mdx": {
+    "mtime": 1779420420.730466,
     "hash": "6fea5931e427deff35b0ea93af33f774"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/configuration/setup-wizard.mdx": {
-    "mtime": 1779108265.856574,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/configuration/setup-wizard.mdx": {
+    "mtime": 1779420420.730466,
     "hash": "c0624fbc5a4da89a46ac340f0fb65f99"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/guides/stitch-integration.mdx": {
-    "mtime": 1779108265.9538112,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/guides/stitch-integration.mdx": {
+    "mtime": 1779420420.8283212,
     "hash": "1824923566171337b02bc40ec7e5b3fd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/guides/docker-setup.mdx": {
-    "mtime": 1779108265.9522672,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/guides/docker-setup.mdx": {
+    "mtime": 1779420420.8276637,
     "hash": "f67b64f1b09abc22e0706e8fa3f45629"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/guides/legacy-codebases.mdx": {
-    "mtime": 1779108265.9538112,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/guides/legacy-codebases.mdx": {
+    "mtime": 1779420420.8283212,
     "hash": "bd38ad06acc1e31b480df190355d0c59"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/design/agents-redesign-custom.html": {
-    "mtime": 1779108265.856574,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/design/agents-redesign-custom.html": {
+    "mtime": 1779420420.730466,
     "hash": "f1dab41edd1f74340b2dfafdcb60fcf3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/design/agents-redesign-stitch.html": {
-    "mtime": 1779108265.8569047,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/design/agents-redesign-stitch.html": {
+    "mtime": 1779420420.7307885,
     "hash": "4761e3da686154998cd5176887439045"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/design/style-guide/STYLE-GUIDE.md": {
-    "mtime": 1779108265.8612642,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/design/style-guide/STYLE-GUIDE.md": {
+    "mtime": 1779420420.7356606,
     "hash": "cb7aa272109b8ba0055d3cc09e093f86"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/design/stitch-exports/agents-view-dark.html": {
-    "mtime": 1779108265.8592641,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/design/stitch-exports/agents-view-dark.html": {
+    "mtime": 1779420420.7347207,
     "hash": "067c8e8f1d8d6fa0576b28cca4f8b98b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/design/stitch-exports/board-v2-t3-dark.html": {
-    "mtime": 1779108265.8610194,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/design/stitch-exports/board-v2-t3-dark.html": {
+    "mtime": 1779420420.735043,
     "hash": "7be45f878b068b610c51a9424f844d8e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/design/stitch-exports/board-v2-t3-light.html": {
-    "mtime": 1779108265.8610194,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/design/stitch-exports/board-v2-t3-light.html": {
+    "mtime": 1779420420.735043,
     "hash": "c449641292f7683a13ff1dde5018d3aa"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/design/stitch-exports/board-view-light.html": {
-    "mtime": 1779108265.8610194,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/design/stitch-exports/board-view-light.html": {
+    "mtime": 1779420420.735043,
     "hash": "bb1d350d406788ad599b1960d8c1a112"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/design/stitch-exports/board-view-dark.html": {
-    "mtime": 1779108265.8610194,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/design/stitch-exports/board-view-dark.html": {
+    "mtime": 1779420420.735043,
     "hash": "f80ccd5280643c3d2d269dd66bc44294"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/design/stitch-exports/command-deck-dark.html": {
-    "mtime": 1779108265.8610194,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/design/stitch-exports/command-deck-dark.html": {
+    "mtime": 1779420420.7355733,
     "hash": "0c0b74c98d4aacd094f12d3a888e0f83"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/design/prd/PRD-REBRAND.md": {
-    "mtime": 1779108265.8569047,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/design/prd/PRD-REBRAND.md": {
+    "mtime": 1779420420.7307885,
     "hash": "24795bee4e1b55b0e3df28a9452bbb98"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/roles/work.md": {
-    "mtime": 1779108266.0168462,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/roles/work.md": {
+    "mtime": 1779420420.8920887,
     "hash": "8cac5e6d1c9b2e6cbda7aa67be871b66"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/roles/review-performance.md": {
-    "mtime": 1779108266.0168462,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/roles/review-performance.md": {
+    "mtime": 1779420420.8920887,
     "hash": "abbdc4eeebc77f25f6d7b86dc7412bf1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/roles/review-security.md": {
-    "mtime": 1779108266.0168462,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/roles/review-security.md": {
+    "mtime": 1779420420.8920887,
     "hash": "cb853c5bf7eb96603cb5bbe91a6efb15"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/roles/review-correctness.md": {
-    "mtime": 1779108266.0168462,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/roles/review-correctness.md": {
+    "mtime": 1779420420.8920887,
     "hash": "c7502c5b92f3801a98a95b8ed26901bc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/roles/ship.md": {
-    "mtime": 1779108266.0168462,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/roles/ship.md": {
+    "mtime": 1779420420.8920887,
     "hash": "0141b16c8ecfd93d95d1f3abe8690eff"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/roles/review.md": {
-    "mtime": 1779108266.0168462,
-    "hash": "9dbd85e3d6b706e291c1cd4ad70c58a1"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/roles/review.md": {
+    "mtime": 1779420420.8920887,
+    "hash": "7ed4c70edd12685cdeef4b7edc863b43"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/roles/review-requirements.md": {
-    "mtime": 1779108266.0168462,
-    "hash": "c62a77c9371e21b65ec933d55bcdf4c7"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/roles/review-requirements.md": {
+    "mtime": 1779420420.8920887,
+    "hash": "1d05bb7ed4f8f4d377fce0b6cece9658"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/roles/test.md": {
-    "mtime": 1779108266.0168462,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/roles/test.md": {
+    "mtime": 1779420420.8920887,
     "hash": "1f07c4dc902bfcf2fb2cf4b73658a605"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/roles/plan.md": {
-    "mtime": 1779108266.0166872,
-    "hash": "a4ee519351b203bd87f434a0796e1236"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/roles/plan.md": {
+    "mtime": 1779420420.8920887,
+    "hash": "f150b7d573af240544a7f7a7c9ee346d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/roles/flywheel.md": {
-    "mtime": 1779167226.2597547,
-    "hash": "a7f4ff13e0c169483d5de11197e7a6db"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/roles/flywheel.md": {
+    "mtime": 1779420420.8919275,
+    "hash": "2b8c730fa6eef5aac0a6f6f0e627b5da"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/benchmarks/templates/quantumllama.md": {
-    "mtime": 1779108265.854893,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/benchmarks/templates/quantumllama.md": {
+    "mtime": 1779420420.7286963,
     "hash": "7ffdae8093e2e385ffc3c31a15bbd08b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/benchmarks/specs/quantumllama.md": {
-    "mtime": 1779108265.854893,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/benchmarks/specs/quantumllama.md": {
+    "mtime": 1779420420.7286963,
     "hash": "dea8947b63713a4f128f17ee0f64dd61"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docker/pan-workspace/docker-compose.yml": {
-    "mtime": 1779108265.8623986,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docker/pan-workspace/docker-compose.yml": {
+    "mtime": 1779420420.736251,
     "hash": "e549cff3cf6d85811868ba17ca2320ce"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/features/convoys.mdx": {
-    "mtime": 1779108265.9510534,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/features/convoys.mdx": {
+    "mtime": 1779420420.8252869,
     "hash": "1c2be3a1f5ec7391e909762751c30aee"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/features/skills.mdx": {
-    "mtime": 1779108265.9510534,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/features/skills.mdx": {
+    "mtime": 1779420420.8252869,
     "hash": "4f3fa7a378c18354eedea3f55e98c173"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/features/workspaces.mdx": {
-    "mtime": 1779108265.9510534,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/features/workspaces.mdx": {
+    "mtime": 1779420420.8252869,
     "hash": "5f46fc50f458038f3eb3cc8aa6be7f51"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/features/specialists.mdx": {
-    "mtime": 1779108265.9510534,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/features/specialists.mdx": {
+    "mtime": 1779420420.8252869,
     "hash": "5c70fdb8f068b04f2de50bbd3f080650"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/features/mission-control.mdx": {
-    "mtime": 1779108265.9510534,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/features/mission-control.mdx": {
+    "mtime": 1779420420.8252869,
     "hash": "8fc01a84933c739ae1d3a0c32672eab1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/features/swarm.mdx": {
-    "mtime": 1779108265.9510534,
-    "hash": "089a59eddd196c4758cc988cbe805ce0"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/features/swarm.mdx": {
+    "mtime": 1779420420.8252869,
+    "hash": "ad4fc21305d26981e14920f6d69888fa"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/features/cloister.mdx": {
-    "mtime": 1779108265.9492671,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/features/cloister.mdx": {
+    "mtime": 1779420420.8246636,
     "hash": "0ba32d386b60deb488ca7a73027eb6fc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/prompts/inspect-agent.md": {
-    "mtime": 1779108266.15632,
-    "hash": "5820a270db19e87f50e3a520ac1d3d9a"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/prompts/inspect-agent.md": {
+    "mtime": 1779420421.0319374,
+    "hash": "b6e815877949ac23d486ff09687081cd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/prompts/work.md": {
-    "mtime": 1779108266.15632,
-    "hash": "9ad78fc0117e0dd9a932e944b8c03b4f"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/prompts/work.md": {
+    "mtime": 1779420421.032242,
+    "hash": "0d0f5b47c03e9f68511c920e3186fd64"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/prompts/sync-main.md": {
-    "mtime": 1779108266.15632,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/prompts/sync-main.md": {
+    "mtime": 1779420421.0319374,
     "hash": "6ebdabe32fa1909fdfe4441b225d5313"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/prompts/handoff-to-work.md": {
-    "mtime": 1779108266.1552742,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/prompts/handoff-to-work.md": {
+    "mtime": 1779420421.0316937,
     "hash": "e53c0c82faab2dea3dde6b408f81ad3c"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/prompts/planning.md": {
-    "mtime": 1779108266.15632,
-    "hash": "a6242fc78996c98f72a48bb92d693ae0"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/prompts/planning.md": {
+    "mtime": 1779420421.0319374,
+    "hash": "d3cfc7121d73a12f1f360c947cd5d245"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/prompts/review.md": {
-    "mtime": 1779108266.15632,
-    "hash": "bb1cca81669bf7b8f03fe250b1629ab7"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/prompts/review.md": {
+    "mtime": 1779420421.0319374,
+    "hash": "7fe0d405bd93c883eacc1ebd10ba4c7d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/prompts/merge.md": {
-    "mtime": 1779108266.15632,
-    "hash": "210cb1f4bbe30781578fecd38f4428a2"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/prompts/merge.md": {
+    "mtime": 1779420421.0319374,
+    "hash": "3c48bafaede21c7ae14ae6f946ba40c3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/prompts/test.md": {
-    "mtime": 1779108266.15632,
-    "hash": "82afc46296705582585397e1e9da64bd"
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/prompts/test.md": {
+    "mtime": 1779420421.03215,
+    "hash": "eac1c282413e4a243c2712ff51b70e5f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/prompts/identity-wake.md": {
-    "mtime": 1779108266.15632,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/prompts/identity-wake.md": {
+    "mtime": 1779420421.0319374,
     "hash": "5ff3c236299a53ab46b4453055bf2fe3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/prompts/resume-work.md": {
-    "mtime": 1779108266.15632,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/prompts/resume-work.md": {
+    "mtime": 1779420421.0319374,
     "hash": "59fd3de4c0d7a5fe7839e6ff4eb98f2a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/cloister/prompts/uat-agent.md": {
-    "mtime": 1779108266.15632,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/cloister/prompts/uat-agent.md": {
+    "mtime": 1779420421.03215,
     "hash": "beccc68e5cc182e8258828c441a3188f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/channels/SMOKE_TEST.md": {
-    "mtime": 1779108266.1539624,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/channels/SMOKE_TEST.md": {
+    "mtime": 1779420421.028682,
     "hash": "f2734d5158756b6ed633f54c416d1c99"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/model-research/research-summary.md": {
-    "mtime": 1779108266.1621656,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/model-research/research-summary.md": {
+    "mtime": 1779420421.0397258,
     "hash": "fd53107e1e1d8b25deae27f8d1db4455"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/model-research/research-prompt.md": {
-    "mtime": 1779108266.1621656,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/model-research/research-prompt.md": {
+    "mtime": 1779420421.0397258,
     "hash": "1a8454f7f7fbf4a0579792210057075f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/model-research/README.md": {
-    "mtime": 1779108266.1617014,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/model-research/README.md": {
+    "mtime": 1779420421.0391636,
     "hash": "d327b5265b073a9521d1f0aae210bed7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/caveman/skills/caveman-review/SKILL.md": {
-    "mtime": 1779108266.1539624,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/caveman/skills/caveman-review/SKILL.md": {
+    "mtime": 1779420421.028682,
     "hash": "fbb47ffb83198a1ed37a453417e691e2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/lib/caveman/skills/caveman/SKILL.md": {
-    "mtime": 1779108266.1539624,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/lib/caveman/skills/caveman/SKILL.md": {
+    "mtime": 1779420421.028682,
     "hash": "abc3c9e05065e4624d3c3ef489c17ed9"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/docker-compose.yml": {
-    "mtime": 1779108266.1112726,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/docker-compose.yml": {
+    "mtime": 1779420420.9832628,
     "hash": "f4c71b48425cf5eaaf298fd1448a3976"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/index.html": {
-    "mtime": 1779108266.1112726,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/index.html": {
+    "mtime": 1779420420.9832628,
     "hash": "ef72fdf58fb3bbfcaf4a74e52a9d11c8"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/rules/no-destructive-requests.md": {
-    "mtime": 1779108266.017085,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/rules/no-destructive-requests.md": {
+    "mtime": 1779420420.8923857,
     "hash": "3489c03d69f31228efafff2307fe7c51"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/rules/no-execsync-server.md": {
-    "mtime": 1779108266.017085,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/rules/no-execsync-server.md": {
+    "mtime": 1779420420.8923857,
     "hash": "ddc0827a40feab19a1373b3a9c6a4575"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/rules/prefer-async.md": {
-    "mtime": 1779108266.017085,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/rules/prefer-async.md": {
+    "mtime": 1779420420.8923857,
     "hash": "d68990aec30cd58814a7f856b7698375"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/rules/async-tmux.md": {
-    "mtime": 1779108266.0168462,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/rules/async-tmux.md": {
+    "mtime": 1779420420.8920887,
     "hash": "05f8835b1ab4c865a6383be7952341be"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/packages/moonshine-linux-x64/README.md": {
-    "mtime": 1779108266.0141625,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/packages/moonshine-linux-x64/README.md": {
+    "mtime": 1779420420.889327,
     "hash": "084a67eab7d182d1d8a9a352e1451f1a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/cli/core-commands.mdx": {
-    "mtime": 1779108265.8560317,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/cli/core-commands.mdx": {
+    "mtime": 1779420420.729954,
     "hash": "3285366409d83c9ca55029d2d7a2f4c3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/cli/workspace-commands.mdx": {
-    "mtime": 1779108265.8560317,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/cli/workspace-commands.mdx": {
+    "mtime": 1779420420.729954,
     "hash": "07f5dae3aeb2208252e3985a79b15f1e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/cli/agent-commands.mdx": {
-    "mtime": 1779108265.854893,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/cli/agent-commands.mdx": {
+    "mtime": 1779420420.7286963,
     "hash": "7371b217ddb3c248a0a23d1d89f114fd"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/cli/convoy-commands.mdx": {
-    "mtime": 1779108265.8560317,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/cli/convoy-commands.mdx": {
+    "mtime": 1779420420.729954,
     "hash": "7a15317af255ef7c3d812dacc8a407b7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/cli/overview.mdx": {
-    "mtime": 1779108265.8560317,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/cli/overview.mdx": {
+    "mtime": 1779420420.729954,
     "hash": "70c3ae329b9641651e5f87eea58ad5eb"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/pan866-zone-c-tabs-visual.png": {
-    "mtime": 1779108266.0152693,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/pan866-zone-c-tabs-visual.png": {
+    "mtime": 1779420420.8906658,
     "hash": "22bd25d04462ce1534f83e2a94c51eea"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/favicon.svg": {
-    "mtime": 1779108265.9492671,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/favicon.svg": {
+    "mtime": 1779420420.8246636,
     "hash": "2648874174aef7c21ecbda3d101b2298"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/screenshot-agents.png": {
-    "mtime": 1779108265.8872652,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/screenshot-agents.png": {
+    "mtime": 1779420420.761785,
     "hash": "9b75af0565882c26869e3023be0cf09d"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/screenshot-plan-dialog.png": {
-    "mtime": 1779108265.8962655,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/screenshot-plan-dialog.png": {
+    "mtime": 1779420420.7716618,
     "hash": "0ea924ff4e79bbda3f7a03e2526fe42e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/screenshot-board.png": {
-    "mtime": 1779108265.8922653,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/screenshot-board.png": {
+    "mtime": 1779420420.7676616,
     "hash": "d31df44ba4c0eefd7741d562e5ce82be"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/flywheel-diagram.png": {
-    "mtime": 1779108265.8752646,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/flywheel-diagram.png": {
+    "mtime": 1779420420.749661,
     "hash": "964b8d750e3e41656f070e99f9b3b071"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/dashboard-overview.png": {
-    "mtime": 1779108265.8656087,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/dashboard-overview.png": {
+    "mtime": 1779420420.7396607,
     "hash": "25f12feeef0cb208c3b107cf8ec8d8b4"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/screenshot-settings.png": {
-    "mtime": 1779108265.8972654,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/screenshot-settings.png": {
+    "mtime": 1779420420.7716618,
     "hash": "7782d0bd7d6465910e374553d6c4f1ec"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/diagrams/react-architecture.png": {
-    "mtime": 1779108265.8752646,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/diagrams/react-architecture.png": {
+    "mtime": 1779420420.748661,
     "hash": "93e94ee7fc7079946bfc46bed786cb7e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/diagrams/panopticon-architecture.png": {
-    "mtime": 1779108265.8722646,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/diagrams/panopticon-architecture.png": {
+    "mtime": 1779420420.7475893,
     "hash": "1f6a0ecc45b613a5de1df888cd4c939f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/diagrams/panopticon-specialist-pipeline.png": {
-    "mtime": 1779108265.8732646,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/diagrams/panopticon-specialist-pipeline.png": {
+    "mtime": 1779420420.748126,
     "hash": "d690be2f8677abbbd835a924a3622732"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/diagrams/claude-md-population.png": {
-    "mtime": 1779108265.8712647,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/diagrams/claude-md-population.png": {
+    "mtime": 1779420420.7459707,
     "hash": "500f3ee3a40d60816b544243329d7629"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/swarm-diagrams/dag-dispatch.png": {
-    "mtime": 1779108265.9484892,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/swarm-diagrams/dag-dispatch.png": {
+    "mtime": 1779420420.822701,
     "hash": "b4779924c1b125a1d30b5ec42798f586"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/swarm-diagrams/http-surface.png": {
-    "mtime": 1779108265.9484892,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/swarm-diagrams/http-surface.png": {
+    "mtime": 1779420420.8236635,
     "hash": "ed56f5e217e8bff7e426fd47f6e8d091"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/swarm-diagrams/slot-lifecycle.png": {
-    "mtime": 1779108265.9492671,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/swarm-diagrams/slot-lifecycle.png": {
+    "mtime": 1779420420.8236635,
     "hash": "6e307a06ab2cfa1e26136c6566f63da0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/design/mockups/command-deck-terminology-map.png": {
-    "mtime": 1779108265.8682644,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/mockups/command-deck-terminology-map.png": {
+    "mtime": 1779420420.743794,
     "hash": "9241888690d6cbb50c9f19f1ff984ee3"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/design/mockups/agents-redesign-stitch.png": {
-    "mtime": 1779108265.8682644,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/mockups/agents-redesign-stitch.png": {
+    "mtime": 1779420420.7426608,
     "hash": "f09f22e696074c1e6e98d67139d2847b"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/design/mockups/agents-redesign-custom-timeline.png": {
-    "mtime": 1779108265.8672645,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/mockups/agents-redesign-custom-timeline.png": {
+    "mtime": 1779420420.7420087,
     "hash": "fb67f8081b283e4a452868d76ceba23a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/design/mockups/agents-redesign-custom-grid.png": {
-    "mtime": 1779108265.8665645,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/mockups/agents-redesign-custom-grid.png": {
+    "mtime": 1779420420.7406607,
     "hash": "76877e74282b85d1b1bae8c50a5b48c2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/design/mockups/agents-redesign-custom-topology.png": {
-    "mtime": 1779108265.8672645,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/mockups/agents-redesign-custom-topology.png": {
+    "mtime": 1779420420.7420087,
     "hash": "fb67f8081b283e4a452868d76ceba23a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/docs/design/mockups/agents-redesign-custom-table.png": {
-    "mtime": 1779108265.8665645,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/docs/design/mockups/agents-redesign-custom-table.png": {
+    "mtime": 1779420420.7406607,
     "hash": "fb67f8081b283e4a452868d76ceba23a"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/images/specialists/07-inspector-attempt.png": {
-    "mtime": 1779108265.9702678,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/images/specialists/07-inspector-attempt.png": {
+    "mtime": 1779420420.844664,
     "hash": "2a1596d1b0052d42955959879339312f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/images/specialists/03-convoys.png": {
-    "mtime": 1779108265.9592676,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/images/specialists/03-convoys.png": {
+    "mtime": 1779420420.8346639,
     "hash": "ae431e86c519b3ce01f0eda1426423f2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/images/specialists/02-agents-page.png": {
-    "mtime": 1779108265.9582675,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/images/specialists/02-agents-page.png": {
+    "mtime": 1779420420.833664,
     "hash": "d887b380fc4680d4163d688346ef55dc"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/images/specialists/05-activity.png": {
-    "mtime": 1779108265.9642677,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/images/specialists/05-activity.png": {
+    "mtime": 1779420420.839664,
     "hash": "f47e7b29d79a3d6e409140e6e105d768"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/images/specialists/08-inspector.png": {
-    "mtime": 1779108265.973268,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/images/specialists/08-inspector.png": {
+    "mtime": 1779420420.8487391,
     "hash": "8902eb5d93687d4e2a7bafcb64689017"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/images/specialists/09-costs.png": {
-    "mtime": 1779108265.9752681,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/images/specialists/09-costs.png": {
+    "mtime": 1779420420.8506644,
     "hash": "7790032d9c0c522e3f68655ec5464f68"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/images/specialists/06-health.png": {
-    "mtime": 1779108265.9662678,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/images/specialists/06-health.png": {
+    "mtime": 1779420420.841664,
     "hash": "bed23309f7073977f7ab538689fd65e1"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/images/specialists/10-inspector-pan655.png": {
-    "mtime": 1779108265.979268,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/images/specialists/10-inspector-pan655.png": {
+    "mtime": 1779420420.8546646,
     "hash": "702bea9b7149fff27b3abca5b24590d5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/images/specialists/01-board-hero.png": {
-    "mtime": 1779108265.9562674,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/images/specialists/01-board-hero.png": {
+    "mtime": 1779420420.8316638,
     "hash": "19b15e2caf402a8b589844a7895e3d19"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/images/specialists/04-handoffs.png": {
-    "mtime": 1779108265.9622676,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/images/specialists/04-handoffs.png": {
+    "mtime": 1779420420.836664,
     "hash": "8dc7d3f3cf28f30da25171a8e2986f8f"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/images/swarm/dag-dispatch.png": {
-    "mtime": 1779108265.9802682,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/images/swarm/dag-dispatch.png": {
+    "mtime": 1779420420.8546646,
     "hash": "b4779924c1b125a1d30b5ec42798f586"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/images/swarm/http-surface.png": {
-    "mtime": 1779108265.9812682,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/images/swarm/http-surface.png": {
+    "mtime": 1779420420.8559246,
     "hash": "ed56f5e217e8bff7e426fd47f6e8d091"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/images/swarm/slot-lifecycle.png": {
-    "mtime": 1779108265.9812682,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/images/swarm/slot-lifecycle.png": {
+    "mtime": 1779420420.8566647,
     "hash": "6e307a06ab2cfa1e26136c6566f63da0"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/design/stitch-exports/board-view-light.png": {
-    "mtime": 1779108265.8610194,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/design/stitch-exports/board-view-light.png": {
+    "mtime": 1779420420.7355733,
     "hash": "f2ac1bfe983992d6cd80038377a9b3e7"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/design/stitch-exports/command-deck-dark.png": {
-    "mtime": 1779108265.8612642,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/design/stitch-exports/command-deck-dark.png": {
+    "mtime": 1779420420.7355733,
     "hash": "31266812117d61a964b1845f4e84d384"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/design/stitch-exports/board-v2-t3-dark.png": {
-    "mtime": 1779108265.8610194,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/design/stitch-exports/board-v2-t3-dark.png": {
+    "mtime": 1779420420.735043,
     "hash": "3affd993e673ebc7310394c0672720c2"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/design/stitch-exports/agents-view-dark.png": {
-    "mtime": 1779108265.8610194,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/design/stitch-exports/agents-view-dark.png": {
+    "mtime": 1779420420.735043,
     "hash": "dc2ad3175d5c0d58e210c63f878b72b5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/design/stitch-exports/board-view-dark.png": {
-    "mtime": 1779108265.8610194,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/design/stitch-exports/board-view-dark.png": {
+    "mtime": 1779420420.735043,
     "hash": "79f72e190eea0ec1e9dbdfe9304c6a0e"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/apps/desktop/resources/icon.png": {
-    "mtime": 1779108265.854393,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/apps/desktop/resources/icon.png": {
+    "mtime": 1779420420.7281961,
     "hash": "ca4808bb5ce2b042db1c702cc5c1f9c5"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/src/dashboard/frontend/tests/pan-865-command-deck-overview.spec.ts-snapshots/pan-865-overview-linux.png": {
-    "mtime": 1779108266.1256812,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/src/dashboard/frontend/tests/pan-865-command-deck-overview.spec.ts-snapshots/pan-865-overview-linux.png": {
+    "mtime": 1779420420.9979978,
     "hash": "68dac7ceae74bbb0d703d0db0836ae27"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/logo/panopticon-light.svg": {
-    "mtime": 1779108265.983151,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/logo/panopticon-light.svg": {
+    "mtime": 1779420420.8578813,
     "hash": "b9be4ec6d0e7a09b870b29f2c7921912"
   },
-  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1189/logo/panopticon-dark.svg": {
-    "mtime": 1779108265.9830418,
+  "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-1/logo/panopticon-dark.svg": {
+    "mtime": 1779420420.8577757,
     "hash": "c50c34f9508fa8b80365f36c6505da24"
   }
 }

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -8,7 +8,7 @@ import { promisify } from 'util';
 import { randomUUID } from 'crypto';
 import { AGENTS_DIR } from './paths.js';
 import { getClaudePermissionFlagsString, resolvePermissionMode, bypassPrefixForAgentFlag } from './claude-permissions.js';
-import { createSession, createSessionAsync, killSession, killSessionAsync, sendKeysAsync, sendRawKeystrokeAsync, sessionExists, sessionExistsAsync, getAgentSessions, getAgentSessionsAsync, capturePane, capturePaneAsync, listPaneValues, listPaneValuesAsync, waitForClaudePrompt, setOptionAsync } from './tmux.js';
+import { createSession, createSessionAsync, killSession, killSessionAsync, sendKeysAsync, sendRawKeystrokeAsync, sessionExists, sessionExistsAsync, getAgentSessions, getAgentSessionsAsync, getAgentSessionsAsyncEffect, capturePane, capturePaneAsync, capturePaneAsyncEffect, listPaneValues, listPaneValuesAsync, waitForClaudePrompt, setOptionAsync, sessionExistsAsyncEffect, killSessionAsyncEffect } from './tmux.js';
 import { initHook, checkHook, generateFixedPointPrompt } from './hooks.js';
 import { startWork, completeWork, getAgentCV } from './cv.js';
 import { BLANKED_PROVIDER_ENV } from './child-env.js';
@@ -37,6 +37,7 @@ import { canUseHarness } from './harness-policy.js';
 import type { RuntimeName } from './runtimes/types.js';
 import { createPiFifo, piFifoPaths, writePiCommand, PiNotReady } from './runtimes/pi-fifo.js';
 import { Effect } from 'effect';
+import { FsError, TmuxError } from './errors.js';
 import { assertIssueHasBeads } from './beads-query.js';
 import { getWorkspaceStackHealth } from './workspace/stack-health.js';
 import { normalizeModelOverride, requireModelOverride, shellQuoteModelId } from './model-validation.js';
@@ -44,6 +45,9 @@ import { resolveAutoResumeConfigForIssue } from './cloister/auto-resume-config.j
 import type { MemoryIdentity } from '@panctl/contracts';
 
 const execAsync = promisify(exec);
+
+const toAgentFsError = (operation: string, path: string, cause: unknown): FsError =>
+  new FsError({ operation, path, cause });
 
 export type Role = 'plan' | 'work' | 'review' | 'test' | 'ship' | 'flywheel';
 
@@ -693,6 +697,17 @@ export async function getAgentStateAsync(agentId: string): Promise<AgentState | 
   return parseAgentState(content, normalizedId);
 }
 
+export const getAgentStateEffect = (agentId: string): Effect.Effect<AgentState | null, FsError> => {
+  const normalizedId = normalizeAgentId(agentId);
+  const stateFile = join(getAgentDir(normalizedId), 'state.json');
+  if (!existsSync(stateFile)) return Effect.succeed(null);
+
+  return Effect.tryPromise({
+    try: () => readFile(stateFile, 'utf-8'),
+    catch: (cause) => toAgentFsError('read', stateFile, cause),
+  }).pipe(Effect.map((content) => parseAgentState(content, normalizedId)));
+};
+
 export function saveAgentState(state: AgentState): void {
   const dir = getAgentDir(state.id);
   mkdirSync(dir, { recursive: true });
@@ -749,6 +764,36 @@ export async function saveAgentStateAsync(state: AgentState): Promise<void> {
   }
 }
 
+export const saveAgentStateEffect = (state: AgentState): Effect.Effect<void, FsError> => {
+  const dir = getAgentDir(state.id);
+  const stateFile = join(dir, 'state.json');
+
+  return Effect.gen(function* () {
+    yield* Effect.tryPromise({
+      try: () => mkdirAsync(dir, { recursive: true }),
+      catch: (cause) => toAgentFsError('mkdir', dir, cause),
+    });
+
+    const oldState = yield* getAgentStateEffect(state.id);
+    const oldStatus = oldState?.status;
+
+    if (state.status === 'running' || state.status === 'starting') {
+      delete state.stoppedAt;
+    } else if (state.status === 'stopped' && !state.stoppedAt) {
+      state.stoppedAt = new Date().toISOString();
+    }
+
+    yield* Effect.tryPromise({
+      try: () => writeFileAsync(stateFile, JSON.stringify(cleanAgentState(state), null, 2)),
+      catch: (cause) => toAgentFsError('write', stateFile, cause),
+    });
+
+    if (oldStatus && oldStatus !== state.status) {
+      logAgentLifecycle(state.id, `status changed: ${oldStatus} → ${state.status} (saveAgentStateEffect)`);
+    }
+  });
+};
+
 function clearFailureTrackingFields(state: AgentState): void {
   state.consecutiveFailures = 0;
   delete state.firstFailureInRunAt;
@@ -793,6 +838,20 @@ export async function setAgentPausedAsync(agentId: string, reason?: string, stop
   return state;
 }
 
+export const setAgentPausedEffect = (
+  agentId: string,
+  reason?: string,
+  stoppedByPause = false,
+): Effect.Effect<AgentState | null, FsError> =>
+  Effect.gen(function* () {
+    const state = yield* getAgentStateEffect(agentId);
+    if (!state) return null;
+
+    applyAgentPaused(state, reason, stoppedByPause);
+    yield* saveAgentStateEffect(state);
+    return state;
+  });
+
 function applyAgentUnpaused(state: AgentState): void {
   if (state.stoppedByPause === true) {
     delete state.stoppedByUser;
@@ -828,6 +887,17 @@ export async function clearAgentPausedAsync(agentId: string): Promise<AgentState
   await saveAgentStateAsync(state);
   return state;
 }
+
+export const clearAgentPausedEffect = (agentId: string): Effect.Effect<AgentState | null, FsError> =>
+  Effect.gen(function* () {
+    const state = yield* getAgentStateEffect(agentId);
+    if (!state) return null;
+    if (isAgentPauseClear(state)) return state;
+
+    applyAgentUnpaused(state);
+    yield* saveAgentStateEffect(state);
+    return state;
+  });
 
 /** Marks an agent as troubled after repeated resume failures. */
 export function markAgentTroubled(agentId: string): boolean {
@@ -873,6 +943,17 @@ export async function clearAgentTroubledAsync(agentId: string): Promise<AgentSta
   await saveAgentStateAsync(state);
   return state;
 }
+
+export const clearAgentTroubledEffect = (agentId: string): Effect.Effect<AgentState | null, FsError> =>
+  Effect.gen(function* () {
+    const state = yield* getAgentStateEffect(agentId);
+    if (!state) return null;
+    if (isAgentTroubledClear(state)) return state;
+
+    applyAgentUntroubled(state);
+    yield* saveAgentStateEffect(state);
+    return state;
+  });
 
 function applyAgentFailure(state: AgentState, reason: string): void {
   const config = resolveAutoResumeConfigForIssue(state.issueId);
@@ -929,6 +1010,16 @@ export async function recordAgentFailureAsync(agentId: string, reason: string): 
   await saveAgentStateAsync(state);
   return state;
 }
+
+export const recordAgentFailureEffect = (agentId: string, reason: string): Effect.Effect<AgentState | null, FsError> =>
+  Effect.gen(function* () {
+    const state = yield* getAgentStateEffect(agentId);
+    if (!state) return null;
+
+    applyAgentFailure(state, reason);
+    yield* saveAgentStateEffect(state);
+    return state;
+  });
 
 /** Resets failure tracking after an agent reaches running state. */
 export function resetAgentFailureCount(agentId: string): boolean {
@@ -1535,6 +1626,16 @@ export async function getAgentRuntimeStateAsync(agentId: string): Promise<AgentR
   return snapshotToRuntimeState(snap);
 }
 
+export const getAgentRuntimeStateEffect = (agentId: string): Effect.Effect<AgentRuntimeState | null> =>
+  Effect.gen(function* () {
+    if (yield* isAgentStateServiceInProcess()) {
+      return snapshotToRuntimeState(yield* getRuntimeSnapshot(agentId));
+    }
+
+    const snap = yield* fetchAgentRuntimeSnapshot(agentId);
+    return snapshotToRuntimeState(snap);
+  });
+
 /**
  * Emit events derived from a legacy-shape patch. Callers gradually migrate to
  * direct emitAgentEvent calls; this adapter keeps existing code working.
@@ -1715,6 +1816,35 @@ export async function getLatestSessionIdAsync(agentId: string): Promise<string |
   const runtimeState = await getAgentRuntimeStateAsync(agentId);
   return runtimeState?.claudeSessionId ?? null;
 }
+
+export const getLatestSessionIdEffect = (agentId: string): Effect.Effect<string | null> => {
+  const agentDir = getAgentDir(agentId);
+  const sessionFile = join(agentDir, 'session.id');
+  const sessionsFile = join(agentDir, 'sessions.json');
+
+  return Effect.gen(function* () {
+    const sessionId = yield* Effect.tryPromise({
+      try: () => readFile(sessionFile, 'utf8'),
+      catch: (cause) => toAgentFsError('read', sessionFile, cause),
+    }).pipe(
+      Effect.map((content) => content.trim()),
+      Effect.orElseSucceed(() => ''),
+    );
+    if (sessionId) return sessionId;
+
+    const latestSession = yield* Effect.tryPromise({
+      try: async () => JSON.parse(await readFile(sessionsFile, 'utf8')) as unknown,
+      catch: (cause) => toAgentFsError('read', sessionsFile, cause),
+    }).pipe(
+      Effect.map((sessions) => Array.isArray(sessions) && sessions.length > 0 ? String(sessions[sessions.length - 1]) : null),
+      Effect.orElseSucceed(() => null),
+    );
+    if (latestSession) return latestSession;
+
+    const runtimeState = yield* getAgentRuntimeStateEffect(agentId);
+    return runtimeState?.claudeSessionId ?? null;
+  });
+};
 
 export interface SpawnOptions {
   issueId: string;
@@ -2843,6 +2973,37 @@ export async function listRunningAgentsAsync(): Promise<(AgentState & { tmuxActi
   return agents;
 }
 
+export const listRunningAgentsEffect = (): Effect.Effect<(AgentState & { tmuxActive: boolean })[], FsError | TmuxError> =>
+  Effect.gen(function* () {
+    const tmuxSessions = yield* getAgentSessionsAsyncEffect();
+    const tmuxNames = new Set(tmuxSessions.map(s => s.name));
+
+    if (!existsSync(AGENTS_DIR)) return [];
+
+    const entries = yield* Effect.tryPromise({
+      try: () => readdir(AGENTS_DIR),
+      catch: (cause) => toAgentFsError('readdir', AGENTS_DIR, cause),
+    }).pipe(Effect.orElseSucceed(() => [] as string[]));
+
+    const states = yield* Effect.forEach(
+      entries,
+      (entry) => getAgentStateEffect(entry).pipe(
+        Effect.map((state) => {
+          if (!state) return null;
+          const normalizedId = normalizeAgentId(state.id || entry);
+          return {
+            ...state,
+            id: normalizedId,
+            tmuxActive: tmuxNames.has(normalizedId),
+          };
+        }),
+      ),
+      { concurrency: 'unbounded' },
+    );
+
+    return states.filter((state): state is AgentState & { tmuxActive: boolean } => state !== null);
+  });
+
 /**
  * PAN-1048 P2: async startup migration.
  *
@@ -3035,6 +3196,47 @@ export async function stopAgentAsync(agentId: string): Promise<void> {
     lastActivity: new Date().toISOString(),
   });
 }
+
+export const stopAgentEffect = (agentId: string): Effect.Effect<void, FsError | TmuxError> => {
+  const normalizedId = normalizeAgentId(agentId);
+
+  return Effect.gen(function* () {
+    if (yield* sessionExistsAsyncEffect(normalizedId)) {
+      yield* Effect.gen(function* () {
+        const output = yield* capturePaneAsyncEffect(normalizedId, 5000);
+        if (!output) return;
+
+        const agentDir = getAgentDir(normalizedId);
+        const outputFile = join(agentDir, 'output.log');
+        yield* Effect.tryPromise({
+          try: () => mkdirAsync(agentDir, { recursive: true }),
+          catch: (cause) => toAgentFsError('mkdir', agentDir, cause),
+        });
+        yield* Effect.tryPromise({
+          try: () => writeFileAsync(outputFile, output),
+          catch: (cause) => toAgentFsError('write', outputFile, cause),
+        });
+      }).pipe(Effect.catch(() => Effect.void));
+
+      yield* killSessionAsyncEffect(normalizedId);
+    }
+
+    const state = yield* getAgentStateEffect(normalizedId);
+    if (state) {
+      if (!state.id) state.id = normalizedId;
+
+      markAgentStoppedState(state);
+      yield* saveAgentStateEffect(state);
+    }
+
+    const tmuxActive = yield* sessionExistsAsyncEffect(normalizedId);
+    console.log(`[agents] Stopping ${normalizedId} (async): tmux=${tmuxActive} stateStatus=${state?.status ?? 'none'}`);
+    yield* Effect.forkDetach(emitAgentEvent(normalizedId, {
+      kind: 'activity',
+      activity: 'stopped',
+    }));
+  });
+};
 
 function queueAgentMail(agentId: string, message: string): void {
   const mailDir = join(getAgentDir(agentId), 'mail');


### PR DESCRIPTION
## Summary
- Add native Effect-returning siblings for every `src/lib/agents.ts` `*Async` export.
- Preserve existing Promise-returning `*Async` functions unchanged for later migration waves.
- Update graphify generated code graph artifacts after the source change.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)