### PR TITLE
Migrate flywheel terminal services to Effect

### DIFF
--- a/src/dashboard/server/services/flywheel-actions.ts
+++ b/src/dashboard/server/services/flywheel-actions.ts
@@ -4,10 +4,11 @@ import { freemem, totalmem } from 'node:os';
 import { isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { promisify } from 'node:util';
 import type { FlywheelStatus } from '@panctl/contracts';
-import { loadConfigAsyncNoMigration, resolveModel, type FlywheelScope, type RoleEffort } from '../../../lib/config-yaml.js';
+import { Effect } from 'effect';
+import { loadConfigAsyncNoMigrationEffect, resolveModel, type FlywheelScope, type RoleEffort } from '../../../lib/config-yaml.js';
 import { FLYWHEEL_ORCHESTRATOR_AGENT_ID, isFlywheelDevcontainerRuntime, loadResumeSessionId, saveResumeSessionId, spawnFlywheelAgent } from '../../../lib/cloister/flywheel.js';
 import { FLYWHEEL_ACTIVE_RUN_ID_KEY, FLYWHEEL_GLOBAL_PAUSE_KEY } from '../../../lib/database/app-settings.js';
-import { sessionExistsAsync } from '../../../lib/tmux.js';
+import { sessionExistsAsyncEffect } from '../../../lib/tmux.js';
 import {
   abortFlywheelRun,
   getFlywheelRunDetail,
@@ -117,7 +118,7 @@ async function readGateSnapshot(): Promise<FlywheelGateSnapshot> {
 }
 
 async function resolveFlywheelRoleConfig(): Promise<ResolvedFlywheelRoleConfig> {
-  const { config } = await loadConfigAsyncNoMigration();
+  const { config } = await Effect.runPromise(loadConfigAsyncNoMigrationEffect());
   const flywheel = config.roles?.flywheel;
   return {
     harness: flywheel?.harness ?? 'claude-code',
@@ -244,7 +245,7 @@ export async function pauseFlywheelRunForDashboard(): Promise<{ before: Flywheel
     } catch { /* non-fatal: resume falls back to fresh if session.id is missing */ }
   }
   await setPaused(true);
-  await import('../../../lib/agents.js').then(({ stopAgentAsync }) => stopAgentAsync(FLYWHEEL_ORCHESTRATOR_AGENT_ID));
+  await import('../../../lib/agents.js').then(({ stopAgentEffect }) => Effect.runPromise(stopAgentEffect(FLYWHEEL_ORCHESTRATOR_AGENT_ID)));
   return { before, after: await readGateSnapshot(), changed: true };
 }
 
@@ -258,15 +259,15 @@ export async function abortFlywheelRunForDashboard(): Promise<{ aborted: string 
     const stale = await resolveLiveFlywheelRunId();
     return { aborted: stale ?? null };
   }
-  const { stopAgentAsync } = await import('../../../lib/agents.js');
-  await stopAgentAsync(FLYWHEEL_ORCHESTRATOR_AGENT_ID);
+  const { stopAgentEffect } = await import('../../../lib/agents.js');
+  await Effect.runPromise(stopAgentEffect(FLYWHEEL_ORCHESTRATOR_AGENT_ID));
   await abortFlywheelRun(candidate);
   return { aborted: candidate };
 }
 
 export async function resumeFlywheelRunForDashboard(): Promise<{ before: FlywheelGateSnapshot; after: FlywheelGateSnapshot; changed: boolean }> {
   const before = await readGateSnapshot();
-  if (!before.paused && await sessionExistsAsync(FLYWHEEL_ORCHESTRATOR_AGENT_ID)) {
+  if (!before.paused && await Effect.runPromise(sessionExistsAsyncEffect(FLYWHEEL_ORCHESTRATOR_AGENT_ID))) {
     return { before, after: before, changed: false };
   }
   if (!before.activeRunId) throw new Error('No active flywheel run to resume');

--- a/src/dashboard/server/services/terminal-service.ts
+++ b/src/dashboard/server/services/terminal-service.ts
@@ -14,7 +14,7 @@
 import { Cause, Effect, Layer, Queue, Context, Stream } from 'effect';
 import { homedir } from 'node:os';
 import { PanRpcError, TerminalOutput } from '@panctl/contracts';
-import { buildTmuxArgs, resizeWindowAsync, sessionExistsAsync } from '../../../lib/tmux.js';
+import { buildTmuxArgs, resizeWindowAsyncEffect, sessionExistsAsyncEffect } from '../../../lib/tmux.js';
 import { buildChildEnvWithoutTmux } from '../../../lib/child-env.js';
 
 // ─── Runtime detection ────────────────────────────────────────────────────────
@@ -111,7 +111,7 @@ class NodePtyProcess implements PtyProcess {
 async function waitForTmuxSession(sessionName: string, timeoutMs = 60000): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
-    if (await sessionExistsAsync(sessionName)) {
+    if (await Effect.runPromise(sessionExistsAsyncEffect(sessionName))) {
       return;
     }
     await new Promise(r => setTimeout(r, 1000));
@@ -232,12 +232,12 @@ export const TerminalServiceLive = Layer.effect(
         setTimeout(() => {
           if (!state.ptyProcess) return;
           try { proc.resize(cols - 1, rows); } catch { return; }
-          resizeWindowAsync(state.sessionName, cols - 1, rows)
+          Effect.runPromise(resizeWindowAsyncEffect(state.sessionName, cols - 1, rows))
             .then(() => new Promise<void>((r) => setTimeout(r, 50)))
             .then(() => {
               if (!state.ptyProcess) return;
               try { proc.resize(cols, rows); } catch { return; }
-              return resizeWindowAsync(state.sessionName, cols, rows);
+              return Effect.runPromise(resizeWindowAsyncEffect(state.sessionName, cols, rows));
             })
             .catch(() => {});
         }, 200);
@@ -336,8 +336,8 @@ export const TerminalServiceLive = Layer.effect(
         state.lastRows = rows;
         if (state.ptyProcess) {
           try { state.ptyProcess.resize(cols, rows); } catch { return; /* PTY dead */ }
-          yield* Effect.promise(() =>
-            resizeWindowAsync(sessionName, cols, rows).catch(() => {}),
+          yield* resizeWindowAsyncEffect(sessionName, cols, rows).pipe(
+            Effect.catch(() => Effect.void),
           );
         }
       });


### PR DESCRIPTION
## Summary
- Migrates dashboard flywheel actions from src/lib Promise Async helpers to existing Effect siblings.
- Migrates terminal-service tmux session/resize calls to Effect siblings without changing PTY lifecycle behavior.
- Closes bead workspace-sx8h for PAN-1312 wave 1c.

## Test plan
- [x] npm run typecheck
- [x] npm run lint
- [x] npm test

🤖 Generated with [Claude Code](https://claude.com/claude-code)