### PR TITLE
Migrate lifecycle services to Effect helpers

### DIFF
--- a/src/dashboard/server/services/__tests__/agent-spawner.test.ts
+++ b/src/dashboard/server/services/__tests__/agent-spawner.test.ts
@@ -17,17 +17,17 @@ vi.mock('node:fs', () => ({
 // ─── Mock agents.ts ───────────────────────────────────────────────────────────
 
 const mockGetAgentState = vi.fn();
-const mockGetAgentStateAsync = vi.fn();
+const mockGetAgentStateEffect = vi.fn();
 const mockSpawnAgent = vi.fn();
 const mockStopAgent = vi.fn();
 const mockMessageAgent = vi.fn();
 
 vi.mock('../../../../lib/agents.js', () => ({
   getAgentState: mockGetAgentState,
-  getAgentStateAsync: mockGetAgentStateAsync,
+  getAgentStateEffect: mockGetAgentStateEffect,
   spawnAgent: mockSpawnAgent,
   stopAgent: mockStopAgent,
-  stopAgentAsync: mockStopAgent,
+  stopAgentEffect: (agentId: string) => Effect.sync(() => mockStopAgent(agentId)),
   messageAgent: mockMessageAgent,
   normalizeAgentId: (id: string) => id.toLowerCase().replace(/[^a-z0-9-]/g, '-'),
 }));
@@ -80,7 +80,7 @@ describe('AgentSpawner Effect service', () => {
       return true; // workspace exists
     });
     mockGetAgentState.mockReturnValue(null);
-    mockGetAgentStateAsync.mockResolvedValue(null);
+    mockGetAgentStateEffect.mockReturnValue(Effect.succeed(null));
     mockSpawnAgent.mockResolvedValue({ id: 'pan-1', issueId: 'PAN-1' });
     mockStopAgent.mockReturnValue(undefined);
     mockMessageAgent.mockResolvedValue(undefined);
@@ -134,7 +134,7 @@ describe('AgentSpawner Effect service', () => {
     });
 
     it('fails with AgentAlreadyRunning when agent status is running', async () => {
-      mockGetAgentStateAsync.mockResolvedValue({ status: 'running', issueId: 'PAN-1' });
+      mockGetAgentStateEffect.mockReturnValue(Effect.succeed({ status: 'running', issueId: 'PAN-1' }));
 
       const { AgentSpawner, AgentSpawnerLive } = await import('../agent-spawner.js');
 

--- a/src/dashboard/server/services/__tests__/agent-spawner.unit.test.ts
+++ b/src/dashboard/server/services/__tests__/agent-spawner.unit.test.ts
@@ -21,15 +21,16 @@ vi.mock('node:fs', () => ({
 // ─── Mock lib/agents.ts ───────────────────────────────────────────────────────
 
 const mockGetAgentState = vi.fn();
-const mockGetAgentStateAsync = vi.fn();
+const mockGetAgentStateEffect = vi.fn();
 const mockSpawnAgent = vi.fn();
 const mockStopAgent = vi.fn();
 const mockMessageAgent = vi.fn();
 vi.mock('../../../../lib/agents.js', () => ({
   getAgentState: mockGetAgentState,
-  getAgentStateAsync: mockGetAgentStateAsync,
+  getAgentStateEffect: mockGetAgentStateEffect,
   spawnAgent: mockSpawnAgent,
   stopAgent: mockStopAgent,
+  stopAgentEffect: (agentId: string) => Effect.sync(() => mockStopAgent(agentId)),
   messageAgent: mockMessageAgent,
   normalizeAgentId: (id: string) => id.toLowerCase().replace(/[^a-z0-9-]/g, '-'),
 }));
@@ -78,6 +79,7 @@ describe('AgentSpawner — integration', () => {
     vi.clearAllMocks();
     mockExistsSync.mockReturnValue(true);
     mockGetAgentState.mockReturnValue(null);
+    mockGetAgentStateEffect.mockReturnValue(Effect.succeed(null));
     mockSpawnAgent.mockResolvedValue({ id: 'pan-1', issueId: 'PAN-1' });
     mockStopAgent.mockReturnValue(undefined);
     mockMessageAgent.mockResolvedValue(undefined);
@@ -128,7 +130,7 @@ describe('AgentSpawner — integration', () => {
     });
 
     it('fails with AgentAlreadyRunning when agent status is running', async () => {
-      mockGetAgentStateAsync.mockResolvedValue({ status: 'running', issueId: 'PAN-1' });
+      mockGetAgentStateEffect.mockReturnValue(Effect.succeed({ status: 'running', issueId: 'PAN-1' }));
       const { AgentSpawner, AgentSpawnerLive } = await import('../agent-spawner.js');
 
       const program = Effect.gen(function* () {

--- a/src/dashboard/server/services/__tests__/conversation-lifecycle.test.ts
+++ b/src/dashboard/server/services/__tests__/conversation-lifecycle.test.ts
@@ -1,10 +1,11 @@
+import { Effect } from 'effect';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock the conversations-db module
 const mockListActiveConversations = vi.fn();
 const mockMarkConversationEnded = vi.fn();
 const mockCleanupUnreferencedConversationAttachments = vi.fn();
-const mockListSessionNamesAsync = vi.fn();
+const mockListSessionNamesEffect = vi.fn();
 
 vi.mock('../../../../lib/database/conversations-db.js', () => ({
   listActiveConversations: mockListActiveConversations,
@@ -25,7 +26,7 @@ vi.mock('../conversation-attachments.js', () => ({
 }));
 
 vi.mock('../../../../lib/tmux.js', () => ({
-  listSessionNamesAsync: mockListSessionNamesAsync,
+  listSessionNamesAsyncEffect: mockListSessionNamesEffect,
 }));
 
 // Mock node:child_process so no real tmux processes are spawned
@@ -44,13 +45,13 @@ describe('ConversationLifecycleService — pollConversations', () => {
     mockListActiveConversations.mockReturnValue([
       { name: 'gone-session', tmuxSession: 'conv-gone-session', status: 'active', cwd: '/tmp/work', claudeSessionId: null },
     ]);
-    mockListSessionNamesAsync.mockResolvedValue([]); // no sessions alive
+    mockListSessionNamesEffect.mockReturnValue(Effect.succeed([])); // no sessions alive
 
     const { pollConversations } = await import('../conversation-lifecycle.js');
 
     await pollConversations();
 
-    expect(mockListSessionNamesAsync).toHaveBeenCalledTimes(1);
+    expect(mockListSessionNamesEffect).toHaveBeenCalledTimes(1);
     expect(mockMarkConversationEnded).toHaveBeenCalledWith('gone-session');
     expect(mockCleanupUnreferencedConversationAttachments).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'gone-session', sessionFile: null }),
@@ -61,7 +62,7 @@ describe('ConversationLifecycleService — pollConversations', () => {
     mockListActiveConversations.mockReturnValue([
       { name: 'alive-session', tmuxSession: 'conv-alive-session', status: 'active' },
     ]);
-    mockListSessionNamesAsync.mockResolvedValue(['conv-alive-session']);
+    mockListSessionNamesEffect.mockReturnValue(Effect.succeed(['conv-alive-session']));
 
     const { pollConversations } = await import('../conversation-lifecycle.js');
 
@@ -76,7 +77,7 @@ describe('ConversationLifecycleService — pollConversations', () => {
       // listActiveConversations only returns active conversations
       { name: 'active-session', tmuxSession: 'conv-active-session', status: 'active' },
     ]);
-    mockListSessionNamesAsync.mockResolvedValue(['conv-active-session']);
+    mockListSessionNamesEffect.mockReturnValue(Effect.succeed(['conv-active-session']));
 
     const { pollConversations } = await import('../conversation-lifecycle.js');
 
@@ -92,7 +93,7 @@ describe('ConversationLifecycleService — pollConversations', () => {
     const { pollConversations } = await import('../conversation-lifecycle.js');
 
     await expect(pollConversations()).resolves.toBeUndefined();
-    expect(mockListSessionNamesAsync).not.toHaveBeenCalled();
+    expect(mockListSessionNamesEffect).not.toHaveBeenCalled();
   });
 
   it('marks only gone sessions when multiple active conversations', async () => {
@@ -100,13 +101,13 @@ describe('ConversationLifecycleService — pollConversations', () => {
       { name: 'alive', tmuxSession: 'conv-alive', status: 'active', sessionFile: '/tmp/alive.jsonl' },
       { name: 'gone', tmuxSession: 'conv-gone', status: 'active', sessionFile: '/tmp/gone.jsonl' },
     ]);
-    mockListSessionNamesAsync.mockResolvedValue(['conv-alive']);
+    mockListSessionNamesEffect.mockReturnValue(Effect.succeed(['conv-alive']));
 
     const { pollConversations } = await import('../conversation-lifecycle.js');
 
     await pollConversations();
 
-    expect(mockListSessionNamesAsync).toHaveBeenCalledTimes(1);
+    expect(mockListSessionNamesEffect).toHaveBeenCalledTimes(1);
     expect(mockMarkConversationEnded).toHaveBeenCalledTimes(1);
     expect(mockMarkConversationEnded).toHaveBeenCalledWith('gone');
     expect(mockCleanupUnreferencedConversationAttachments).toHaveBeenCalledTimes(1);

--- a/src/dashboard/server/services/__tests__/pending-respawn.test.ts
+++ b/src/dashboard/server/services/__tests__/pending-respawn.test.ts
@@ -1,26 +1,28 @@
+import { Effect } from 'effect';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock tmux.sessionExistsAsync — pending-respawn polls it. Each test resets
+// Mock tmux.sessionExistsAsyncEffect — pending-respawn polls it. Each test resets
 // the mock's implementation so cases are independent.
 vi.mock('../../../../lib/tmux.js', () => ({
-  sessionExistsAsync: vi.fn(),
+  sessionExistsAsyncEffect: vi.fn(),
 }));
 
-import { sessionExistsAsync } from '../../../../lib/tmux.js';
+import { sessionExistsAsyncEffect } from '../../../../lib/tmux.js';
 import {
   isRespawnPending,
   markRespawnPending,
   waitForSessionRespawn,
 } from '../pending-respawn.js';
 
-const mockedSessionExistsAsync = vi.mocked(sessionExistsAsync);
+const mockedSessionExistsEffect = vi.mocked(sessionExistsAsyncEffect);
 
 describe('pending-respawn registry', () => {
   beforeEach(() => {
-    mockedSessionExistsAsync.mockReset();
+    mockedSessionExistsEffect.mockReset();
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     // Defensive: nothing should be left marked between tests.
     expect(isRespawnPending('test-session')).toBe(false);
     expect(isRespawnPending('other-session')).toBe(false);
@@ -42,58 +44,62 @@ describe('pending-respawn registry', () => {
   });
 
   it('waitForSessionRespawn resolves true once the session appears', async () => {
-    mockedSessionExistsAsync
-      .mockResolvedValueOnce(false)
-      .mockResolvedValueOnce(false)
-      .mockResolvedValueOnce(true);
+    vi.useFakeTimers();
+    mockedSessionExistsEffect
+      .mockReturnValueOnce(Effect.succeed(false))
+      .mockReturnValueOnce(Effect.succeed(false))
+      .mockReturnValueOnce(Effect.succeed(true));
 
     const respawn = markRespawnPending('test-session');
-    const result = await waitForSessionRespawn('test-session', 5000);
-    expect(result).toBe(true);
+    const resultPromise = waitForSessionRespawn('test-session', 5000);
+    await vi.advanceTimersByTimeAsync(400);
+
+    await expect(resultPromise).resolves.toBe(true);
     respawn.done();
   });
 
   it('bails early once the marker clears and the session still does not exist', async () => {
-    mockedSessionExistsAsync.mockResolvedValue(false);
-
+    vi.useFakeTimers();
+    let calls = 0;
     const respawn = markRespawnPending('test-session');
-    // Clear the marker after the first poll round so the next iteration
-    // takes the early-exit path. The bail check itself does one more
-    // sessionExistsAsync to handle "respawn just cleared and may have
-    // succeeded" — we want the final result here to be false (no session).
-    setTimeout(() => respawn.done(), 50);
+    mockedSessionExistsEffect.mockImplementation(() => Effect.sync(() => {
+      calls += 1;
+      if (calls === 2) respawn.done();
+      return false;
+    }));
 
-    const result = await waitForSessionRespawn('test-session', 5000);
-    expect(result).toBe(false);
-    // Bail path performs at least one initial check and one final check.
-    expect(mockedSessionExistsAsync.mock.calls.length).toBeGreaterThanOrEqual(2);
+    const resultPromise = waitForSessionRespawn('test-session', 5000);
+    await vi.advanceTimersByTimeAsync(200);
+
+    await expect(resultPromise).resolves.toBe(false);
+    expect(mockedSessionExistsEffect.mock.calls.length).toBeGreaterThanOrEqual(3);
   });
 
   it('honors the timeout when the session never appears', async () => {
-    mockedSessionExistsAsync.mockResolvedValue(false);
+    vi.useFakeTimers();
+    mockedSessionExistsEffect.mockReturnValue(Effect.succeed(false));
     const respawn = markRespawnPending('test-session');
-    const start = Date.now();
-    const result = await waitForSessionRespawn('test-session', 300);
-    const elapsed = Date.now() - start;
-    expect(result).toBe(false);
-    expect(elapsed).toBeGreaterThanOrEqual(250);
-    expect(elapsed).toBeLessThan(1500);
+    const resultPromise = waitForSessionRespawn('test-session', 300);
+
+    await vi.advanceTimersByTimeAsync(400);
+
+    await expect(resultPromise).resolves.toBe(false);
     respawn.done();
   });
 
   it('returns true immediately if the session already exists when called', async () => {
-    mockedSessionExistsAsync.mockResolvedValueOnce(true);
+    mockedSessionExistsEffect.mockReturnValueOnce(Effect.succeed(true));
     const respawn = markRespawnPending('test-session');
     const result = await waitForSessionRespawn('test-session', 5000);
     expect(result).toBe(true);
-    expect(mockedSessionExistsAsync).toHaveBeenCalledTimes(1);
+    expect(mockedSessionExistsEffect).toHaveBeenCalledTimes(1);
     respawn.done();
   });
 
-  it('checks sessionExistsAsync even when no marker is set', async () => {
-    mockedSessionExistsAsync.mockResolvedValueOnce(true);
+  it('checks sessionExistsAsyncEffect even when no marker is set', async () => {
+    mockedSessionExistsEffect.mockReturnValueOnce(Effect.succeed(true));
     const result = await waitForSessionRespawn('test-session', 5000);
     expect(result).toBe(true);
-    expect(mockedSessionExistsAsync).toHaveBeenCalledTimes(1);
+    expect(mockedSessionExistsEffect).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/dashboard/server/services/agent-spawner.ts
+++ b/src/dashboard/server/services/agent-spawner.ts
@@ -153,12 +153,12 @@ export const AgentSpawnerLive = Layer.effect(
           }
 
           // Guard: no agent already running
-          const { getAgentStateAsync, spawnAgent, normalizeAgentId } = await import(
+          const { getAgentStateEffect, spawnAgent, normalizeAgentId } = await import(
             '../../../lib/agents.js'
           ) as any;
           const normalizedId = normalizeAgentId(issueId);
 
-          const existing = await getAgentStateAsync(normalizedId);
+          const existing = await Effect.runPromise(getAgentStateEffect(normalizedId));
           if (existing?.status === 'running') {
             throw new AgentAlreadyRunning({ id: issueId });
           }
@@ -241,8 +241,8 @@ export const AgentSpawnerLive = Layer.effect(
     kill: (agentId) =>
       Effect.tryPromise({
         try: async () => {
-          const { stopAgentAsync } = await import('../../../lib/agents.js') as any;
-          await stopAgentAsync(agentId);
+          const { stopAgentEffect } = await import('../../../lib/agents.js') as any;
+          await Effect.runPromise(stopAgentEffect(agentId));
         },
         catch: () => undefined,
       }).pipe(Effect.ignore),

--- a/src/dashboard/server/services/conversation-lifecycle.ts
+++ b/src/dashboard/server/services/conversation-lifecycle.ts
@@ -18,13 +18,14 @@ import { readFile, readdir, stat } from 'fs/promises';
 import { existsSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
+import { Effect } from 'effect';
 import {
   createConversation,
   getConversationByName,
   listActiveConversations,
   markConversationEnded,
 } from '../../../lib/database/conversations-db.js';
-import { listSessionNamesAsync } from '../../../lib/tmux.js';
+import { listSessionNamesAsyncEffect } from '../../../lib/tmux.js';
 import { encodeClaudeProjectDir, sessionFilePath } from '../../../lib/paths.js';
 import { cleanupUnreferencedConversationAttachments, runInBatches } from './conversation-attachments.js';
 
@@ -63,7 +64,7 @@ export async function pollConversations(): Promise<void> {
     const conversations = listActiveConversations();
     if (conversations.length === 0) return;
 
-    const aliveSessions = new Set(await listSessionNamesAsync());
+    const aliveSessions = new Set(await Effect.runPromise(listSessionNamesAsyncEffect()));
 
     const endedConversations: typeof conversations = [];
     const now = Date.now();

--- a/src/dashboard/server/services/pending-respawn.ts
+++ b/src/dashboard/server/services/pending-respawn.ts
@@ -12,7 +12,7 @@
  *
  * The terminal frontend (`XTerminal.tsx`) reconnects on close 1000 with
  * exponential backoff (1s, 2s, 4s, 8s, 16s). Every reconnect re-enters
- * `ws-terminal.ts`, which checks `listSessionNamesAsync()` upfront and
+ * `ws-terminal.ts`, which checks the tmux session list upfront and
  * `close(4404, 'session-not-found')` if the name isn't there yet.
  * 4404 is treated as fatal on the client (no retry — the session is
  * presumed gone), so the panel sticks on "Could not reconnect" even
@@ -26,7 +26,8 @@
  * `isRespawnPending()` is true.
  */
 
-import { sessionExistsAsync } from '../../../lib/tmux.js';
+import { Effect } from 'effect';
+import { sessionExistsAsyncEffect } from '../../../lib/tmux.js';
 
 const pendingRespawns = new Set<string>();
 
@@ -66,11 +67,11 @@ export async function waitForSessionRespawn(
 ): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (await sessionExistsAsync(sessionName)) return true;
+    if (await Effect.runPromise(sessionExistsAsyncEffect(sessionName))) return true;
     if (!pendingRespawns.has(sessionName)) {
-      return sessionExistsAsync(sessionName);
+      return Effect.runPromise(sessionExistsAsyncEffect(sessionName));
     }
     await new Promise<void>((r) => setTimeout(r, POLL_INTERVAL_MS));
   }
-  return sessionExistsAsync(sessionName);
+  return Effect.runPromise(sessionExistsAsyncEffect(sessionName));
 }


### PR DESCRIPTION
## Summary
- Migrates conversation lifecycle and pending respawn tmux checks to Effect helpers.
- Migrates agent-spawner dynamic agent-state and stop calls to Effect siblings.
- Updates colocated tests and pending-respawn timer tests for Effect-based mocks.

## Test plan
- [x] `bunx vitest run src/dashboard/server/services/__tests__/conversation-lifecycle.test.ts src/dashboard/server/services/__tests__/pending-respawn.test.ts src/dashboard/server/services/__tests__/agent-spawner.test.ts src/dashboard/server/services/__tests__/agent-spawner.unit.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)