### PR TITLE
Migrate cloister review helpers to Effect

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - feature-pan-1312-slot-6  (2026-05-22)
 
 ## Corpus Check
-- 1878 files · ~2,476,563 words
+- 1878 files · ~2,476,605 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 26658 nodes · 41387 edges · 1254 communities (1204 shown, 50 thin omitted)
-- Extraction: 99% EXTRACTED · 1% INFERRED · 0% AMBIGUOUS · INFERRED: 502 edges (avg confidence: 0.8)
+- 26661 nodes · 41414 edges · 1258 communities (1208 shown, 50 thin omitted)
+- Extraction: 99% EXTRACTED · 1% INFERRED · 0% AMBIGUOUS · INFERRED: 505 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `ff800465`
+- Built from commit: `e6c4ff8b`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -1204,18 +1204,18 @@
 - [[_COMMUNITY_Community 1186|Community 1186]]
 - [[_COMMUNITY_Community 1187|Community 1187]]
 - [[_COMMUNITY_Community 1188|Community 1188]]
+- [[_COMMUNITY_Community 1189|Community 1189]]
+- [[_COMMUNITY_Community 1190|Community 1190]]
 - [[_COMMUNITY_Community 1191|Community 1191]]
 - [[_COMMUNITY_Community 1192|Community 1192]]
-- [[_COMMUNITY_Community 1194|Community 1194]]
 - [[_COMMUNITY_Community 1195|Community 1195]]
 - [[_COMMUNITY_Community 1196|Community 1196]]
-- [[_COMMUNITY_Community 1197|Community 1197]]
 - [[_COMMUNITY_Community 1198|Community 1198]]
+- [[_COMMUNITY_Community 1199|Community 1199]]
 - [[_COMMUNITY_Community 1200|Community 1200]]
+- [[_COMMUNITY_Community 1201|Community 1201]]
 - [[_COMMUNITY_Community 1202|Community 1202]]
-- [[_COMMUNITY_Community 1203|Community 1203]]
 - [[_COMMUNITY_Community 1204|Community 1204]]
-- [[_COMMUNITY_Community 1205|Community 1205]]
 - [[_COMMUNITY_Community 1206|Community 1206]]
 - [[_COMMUNITY_Community 1207|Community 1207]]
 - [[_COMMUNITY_Community 1208|Community 1208]]
@@ -1227,6 +1227,10 @@
 - [[_COMMUNITY_Community 1214|Community 1214]]
 - [[_COMMUNITY_Community 1215|Community 1215]]
 - [[_COMMUNITY_Community 1216|Community 1216]]
+- [[_COMMUNITY_Community 1217|Community 1217]]
+- [[_COMMUNITY_Community 1218|Community 1218]]
+- [[_COMMUNITY_Community 1219|Community 1219]]
+- [[_COMMUNITY_Community 1220|Community 1220]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `fetch` - 199 edges
@@ -1247,520 +1251,520 @@
   src/lib/work-agent-lifecycle.ts → docs/god-view.md
 - `fileExists()` --calls--> `Access`  [INFERRED]
   src/lib/cloister/config.ts → docs/god-view.md
-- `pathExists()` --calls--> `Access`  [INFERRED]
-  src/dashboard/server/routes/command-deck.ts → docs/god-view.md
 - `getIndexStats()` --calls--> `Access`  [INFERRED]
   src/dashboard/server/routes/misc.ts → docs/god-view.md
+- `pathExists()` --calls--> `Access`  [INFERRED]
+  src/dashboard/server/routes/projects.ts → docs/god-view.md
 
-## Communities (1254 total, 50 thin omitted)
+## Communities (1258 total, 50 thin omitted)
 
 ### Community 0 - "Community 0"
-Cohesion: 0.03
-Nodes (168): performKillAndSpawn(), spawnInspectAgent(), renderPrompt(), buildSpecialistBaseCommand(), pauseCommand(), PauseOptions, recoverCommand(), RecoverOptions (+160 more)
+Cohesion: 0.01
+Nodes (169): ConversationList(), fetchConversations(), GeneralConversation, GeneralSectionProps, CommandDeck(), CommandDeckProps, ContainerStats, fetchAllSessionTrees() (+161 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.01
-Nodes (152): fetchConversations(), GeneralConversation, GeneralSectionProps, archiveConversation(), ConversationMutations, favoriteConversation(), stopConversation(), summaryForkConversation() (+144 more)
+Cohesion: 0.03
+Nodes (171): monitorReviewConvoySignals(), nudgeIdleWorkAgentsWithOpenBeads(), buildHandoffPrompt(), detectHandoffMethod(), HandoffError, HandoffMethod, HandoffOptions, HandoffResult (+163 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.02
-Nodes (143): ActivitySparkline(), ActivitySparklineProps, CATEGORY_COLORS, SparklineCategory, SparklineEvent, PlanningState, useZoneAActions(), ZoneAActionsState (+135 more)
+Nodes (127): ActivitySection, ActivityView(), ActivityViewProps, CostByStage, fetchActivity(), ActivityFeedSidebar(), ActivityFeedSidebarProps, BUCKET_LABELS (+119 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.02
-Nodes (161): ACTIVE_STATUS_PATTERNS, addLog(), API_ERROR_PATTERNS, apiErrorRecoveryState, autoCloseOut(), autoCloseOutCache, autoResumeStoppedWorkAgents(), checkAndSuspendIdleAgents() (+153 more)
+Nodes (140): ActivitySparkline(), ActivitySparklineProps, CATEGORY_COLORS, SparklineCategory, SparklineEvent, ZoneA(), ZoneAProps, ALL_TABS (+132 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.02
-Nodes (125): loadCloisterConfig(), cleanupStaleAgentState(), captureTmuxOutput(), isMergeAgentRunning(), agentStatusCommand(), AgentStatusOptions, analyzeSession(), detectStatus() (+117 more)
+Nodes (145): ACTIVE_STATUS_PATTERNS, addLog(), API_ERROR_PATTERNS, apiErrorRecoveryState, autoCloseOut(), autoCloseOutCache, autoResumeStoppedWorkAgents(), checkAndSuspendIdleAgents() (+137 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.02
-Nodes (114): ActivityView(), AgentOutputPanel(), AgentOutputPanelProps, deriveAgentIssueId(), fetchAgentConversation(), parseSpecialistSession(), AwaitingMergePage(), AwaitingMergeRow() (+106 more)
+Nodes (119): DiffPanel(), DiffPanelProps, DiffThemeType, readDiffParamsFromUrl(), RenderablePatch, ToggleButton(), DiffPanelLoadingState(), DiffPanelMode (+111 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.03
-Nodes (125): TurnDiffFileChange, forkCommand(), ForkOptions, normalize(), unarchiveConversationCommand(), buildCorrelationMap(), CorrelationResult, copySessionFromCompactBoundary() (+117 more)
+Nodes (126): buildHostOverrideConfirmation(), confirmDropRecovery(), confirmHostOverride(), DASHBOARD_URL, difficultyColor(), dryRun(), isSwarmRecoverAction(), parseFiniteInteger() (+118 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.03
-Nodes (121): buildHostOverrideConfirmation(), confirmDropRecovery(), confirmHostOverride(), DASHBOARD_URL, difficultyColor(), dryRun(), isSwarmRecoverAction(), parseFiniteInteger() (+113 more)
+Cohesion: 0.02
+Nodes (111): checkPostReviewCommits(), pendingCommand(), after, before, blockers, result, statuses, after (+103 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.03
-Nodes (123): embedAction(), confirmCost(), enrichAction(), formatCost(), scanAction(), collectJsonlFiles(), discoverJsonlFiles(), filterByMode() (+115 more)
+Cohesion: 0.02
+Nodes (116): checkMissingReviewStatuses(), cleanupSpawnAndOrphanedStashes(), listFeatureWorkspaces(), logNonCanonicalStashesOnStartup(), dropLingeringPreMergeStashes(), buildConvoyPrompt(), buildReviewRolePrompt(), cleanupReviewTempStash() (+108 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.02
-Nodes (110): checkMissingReviewStatuses(), logNonCanonicalStashesOnStartup(), dropLingeringPreMergeStashes(), buildConvoyPrompt(), buildReviewRolePrompt(), cleanupReviewTempStash(), ensureReviewTempStash(), execAsync (+102 more)
+Cohesion: 0.03
+Nodes (97): isRunningAgent(), useZoneAActions(), ZoneActionStrip(), ZoneActionStripProps, ZoneBActionStrip(), ZoneBActionStripProps, ArtifactLinksProps, CloseOutIssueButton() (+89 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.02
-Nodes (98): BulkAgentWarningDialogProps, CommandPalette(), CommandPaletteProps, EMPTY_AGENTS, EMPTY_ISSUES, PaletteAction, { onNavigate }, user (+90 more)
+Nodes (106): transitionIssueToVerifyingOnMain(), HttpServerResponse, AgentSpawner, AgentSpawnerLive, AgentSpawnerShape, DeepWipeOptions, SpawnedAgent, StartPlanningOptions (+98 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.02
-Nodes (102): setAgentStatusChangedNotifier(), setAgentStoppedNotifier(), ActivityLevel, ActivitySource, emitActivityDetailed(), emitActivityEntry(), EmitActivityOptions, emitActivityTts() (+94 more)
+Cohesion: 0.03
+Nodes (110): approveCommand(), cancelCommand(), collectInFlightRows(), collectLifecycleRows(), completeCommand(), dedupeRows(), formatTransition(), getProjectPath() (+102 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.02
-Nodes (98): EDITOR_LABELS, PanOpenInPickerProps, buildFilterParams(), ConversationRpcFilter, ConversationsPage(), CostResponse, countCostFacets(), countFacetValues() (+90 more)
+Nodes (102): BulkActionBar(), BulkActionBarProps, BulkAgentWarningDialog(), BulkAgentWarningDialogProps, BulkCloseOutProgress(), BulkCloseOutProgressProps, BulkCloseResult, BulkCloseStatus (+94 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.02
-Nodes (88): agentPhase(), AgentPhaseFilter, agentRole(), AgentsFilterState, AgentsViewMode, DropdownFilter(), FilterOption, filterSummary() (+80 more)
+Cohesion: 0.03
+Nodes (105): forkCommand(), ForkOptions, normalize(), unarchiveConversationCommand(), buildCorrelationMap(), CorrelationResult, copySessionFromCompactBoundary(), createSummaryFork() (+97 more)
 
 ### Community 14 - "Community 14"
-Cohesion: 0.02
-Nodes (97): BulkActionBar(), BulkActionBarProps, BulkAgentWarningDialog(), BulkCloseOutProgress(), BulkCloseOutProgressProps, BulkCloseResult, BulkCloseStatus, AgentWarningDialogProps (+89 more)
+Cohesion: 0.03
+Nodes (98): getUnblockedItems(), getUnblockedItemsEffect(), isTaskReady(), isTaskReadyEffect(), TERMINAL_STATUSES, buildACLookupByTitle(), readWorkspacePlanAsync(), writeStoryFeatureContext() (+90 more)
 
 ### Community 15 - "Community 15"
-Cohesion: 0.02
-Nodes (102): adminRouteLayer, getAdminTldrRoute, agentsRouteLayer, agentStopRoute(), createAgentStopHandler(), invalidateAgentsCache(), cloisterRouteLayer, getCloisterAgentsHealthRoute (+94 more)
+Cohesion: 0.03
+Nodes (101): setAgentStatusChangedNotifier(), setAgentStoppedNotifier(), announceMerge(), agentStatusCommand(), AgentStatusOptions, analyzeSession(), detectStatus(), extractCost() (+93 more)
 
 ### Community 16 - "Community 16"
-Cohesion: 0.03
-Nodes (94): monitorReviewConvoySignals(), pendingCommand(), after, row, status, clearWorkspaceStuck(), DatabaseError, DbReviewStatusRow (+86 more)
+Cohesion: 0.02
+Nodes (95): CodexAuthBanner(), SensitiveText(), SensitiveTextProps, CodexAuthStatus, fetchCodexAuthStatus(), useCodexAuthStatus(), DEFAULTS, UIPreferences (+87 more)
 
 ### Community 17 - "Community 17"
 Cohesion: 0.03
-Nodes (81): resolveProjectConfig(), workspaceRenderDevcontainerCommand(), WorkspaceRenderDevcontainerOptions, createHumeConfig(), deleteHumeConfig(), HumeApiError, humeFetch(), HumeResult (+73 more)
+Nodes (99): ContainerDetailPanel(), ContainerDetailPanelProps, ContainerDetails, DetailTab, fetchContainerDetails(), formatBytes(), getBarColor(), ResourceBar() (+91 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.03
-Nodes (78): ZoneActionStripProps, ZoneBActionStrip(), ZoneBActionStripProps, ArtifactLinksProps, CloseOutIssueButton(), CloseOutIssueButtonProps, AlertOptions, ConfirmOptions (+70 more)
+Cohesion: 0.02
+Nodes (97): detectMergedSwarmSlots(), reconcileAndCheckIfMerged(), buildShipPreparationPrompt(), buildShipSyncMainPrompt(), _completedPostMerge, defaultWorkspaceForIssue(), __dirname, execAsync (+89 more)
 
 ### Community 19 - "Community 19"
-Cohesion: 0.04
-Nodes (92): deriveProjectRoot(), queueAutoCommit(), deleteContinueFile(), getContinueFilePath(), getContinuesDir(), hasContinueFile(), listContinueFiles(), readContinueFile() (+84 more)
+Cohesion: 0.02
+Nodes (85): agentPhase(), AgentPhaseFilter, agentRole(), AgentsFilterState, AgentsViewMode, DropdownFilter(), FilterOption, filterSummary() (+77 more)
 
 ### Community 20 - "Community 20"
+Cohesion: 0.03
+Nodes (93): createMemoryCommand(), queryCostEvents(), buildDailySummaryMarkdown(), createResetMarker(), DailySummaryResult, DailySummaryStatus, dedupeResetMarkers(), generateDailySummary() (+85 more)
+
+### Community 21 - "Community 21"
 Cohesion: 0.02
 Nodes (83): DeaconLogEntry, DeaconStatus(), DeaconStatusData, fetchDeaconLogs(), fetchDeaconStatus(), LOG_LEVEL_COLORS, LOG_LEVEL_LABELS, SpecialistHealthState (+75 more)
 
-### Community 21 - "Community 21"
-Cohesion: 0.04
-Nodes (88): createMemoryCommand(), buildDailySummaryMarkdown(), createResetMarker(), DailySummaryResult, DailySummaryStatus, dedupeResetMarkers(), generateDailySummary(), getMemoryStatus() (+80 more)
-
 ### Community 22 - "Community 22"
 Cohesion: 0.02
-Nodes (80): ActivityFeedSidebar(), ActivityFeedSidebarProps, BUCKET_LABELS, BUCKET_ORDER, createActionStatusObservationSelector(), EMPTY_OBSERVATIONS, bucket, first (+72 more)
+Nodes (93): db, makeTestLayer(), makeTestService(), received, runWithService(), store, svc, unsubscribe (+85 more)
 
 ### Community 23 - "Community 23"
 Cohesion: 0.03
-Nodes (82): backup, bundledFrontendIndex, bundledServer, child, composeFile, config, configContent, configFile (+74 more)
+Nodes (83): renderPrompt(), inferMemoryProjectId(), retrieveSpawnTimeMemoryContext(), BLANKED_PROVIDER_ENV, buildChildEnv(), buildChildEnvWithoutTmux(), LEAKED_ENV_KEYS, PROVIDER_ENV_KEYS (+75 more)
 
 ### Community 24 - "Community 24"
-Cohesion: 0.03
-Nodes (78): conversationsTab, firstLens, lens, overview, tablist, ConversationList(), CommandDeck(), CommandDeckProps (+70 more)
+Cohesion: 0.04
+Nodes (85): buildPolyrepoContext(), projectListCommand(), projectShowCommand(), listTestsCommand(), runCommand(), RunOptions, addRepoCommand(), AddRepoOptions (+77 more)
 
 ### Community 25 - "Community 25"
 Cohesion: 0.03
-Nodes (70): criteria, doc, result, { projectPath, workspacePath }, promoted, specFiles, fsHooks, path (+62 more)
+Nodes (67): createHumeConfig(), deleteHumeConfig(), HumeApiError, humeFetch(), HumeResult, addTunnelIngress(), cfFetch(), CloudflareCredentials (+59 more)
 
 ### Community 26 - "Community 26"
-Cohesion: 0.03
-Nodes (73): ComposerFooter(), ComposerFooterProps, deleteConversationImage(), PendingImage, sendConversationMessage(), switchModel(), uploadConversationImage(), ensureDefaultConversationModel() (+65 more)
+Cohesion: 0.04
+Nodes (69): ProcessSpawnError, TmuxError, CLAUDE_PROJECTS_DIR, createClaudeCodeRuntime(), SessionIndexEntry, getGlobalRegistry(), getRuntime(), getRuntimeForAgent() (+61 more)
 
 ### Community 27 - "Community 27"
-Cohesion: 0.03
-Nodes (87): execFile(), kCustom, mockExecFile, after, body, result, { saveAgentRuntimeStateMock, getAgentRuntimeStateMock }, ActivityEntry (+79 more)
+Cohesion: 0.05
+Nodes (87): embedAction(), confirmCost(), enrichAction(), formatCost(), scan(), ScanOptions, normalizeFilter(), SearchMode (+79 more)
 
 ### Community 28 - "Community 28"
-Cohesion: 0.04
-Nodes (77): transitionIssueToVerifyingOnMain(), HttpServerResponse, AgentSpawner, AgentSpawnerLive, AgentSpawnerShape, DeepWipeOptions, SpawnedAgent, StartPlanningOptions (+69 more)
+Cohesion: 0.03
+Nodes (77): AutoResumeConfig, normalizeAutoResumeConfig(), positiveNumber(), resolveAutoResumeConfigForIssue(), validBackoffSchedule(), checkFailedMergeRetry(), checkOrphanedReviewStatuses(), checkPendingTestDispatch() (+69 more)
 
 ### Community 29 - "Community 29"
 Cohesion: 0.04
-Nodes (77): buildPolyrepoContext(), closeOutCommand(), CloseOutOptions, execFileAsync, getGitHubConfig(), readGitHubCanonicalState(), addRepoCommand(), AddRepoOptions (+69 more)
+Nodes (79): readCavemanVariant(), checkStuckReviewing(), exec(), execMock, execResponses, kCustom, mockIsRunning, mockResolve (+71 more)
 
 ### Community 30 - "Community 30"
-Cohesion: 0.04
-Nodes (76): getUnblockedItems(), getUnblockedItemsEffect(), isTaskReady(), isTaskReadyEffect(), TERMINAL_STATUSES, writeStoryFeatureContext(), findWorkspaceRoot(), planFinalizeCommand() (+68 more)
+Cohesion: 0.03
+Nodes (85): defaults, first, { models }, second, ModelRef, RoleConfig, RolesConfig, TtsDaemonConfig (+77 more)
 
 ### Community 31 - "Community 31"
 Cohesion: 0.04
-Nodes (82): claimTranscriptRangeAsync(), commitTranscriptRangeAsync(), getTranscriptCheckpointAsync(), listTranscriptCheckpointsAsync(), pendingRequests, postWorkerRequest(), releaseTranscriptRangeAsync(), runInline() (+74 more)
+Nodes (63): DrawerTabPlaceholder(), tabLabel(), PanSpecListOptions, ProjectPanPaths, { projectPath, workspacePath }, promoted, specFiles, fsHooks (+55 more)
 
 ### Community 32 - "Community 32"
 Cohesion: 0.03
-Nodes (79): runCostSync(), buildSessionIndex(), decodeClaudeDirName(), extractCostEvents(), extractSessionId(), getAgentsDir(), getClaudeProjectsDir(), getSessionOffset() (+71 more)
+Nodes (81): dequeueMerge(), ActivityEntry, activityLog, ApprovePushResult, buildRichPRBody(), checkProjectGitSafeState(), ContainerPortBinding, ContainerServiceHealth (+73 more)
 
 ### Community 33 - "Community 33"
-Cohesion: 0.03
-Nodes (68): BUNDLED_GIT_HOOKS_DIR, checkCommand(), __dirname, __filename, syncCommand(), SyncOptions, getCurrentVersion(), getLatestVersion() (+60 more)
-
-### Community 34 - "Community 34"
-Cohesion: 0.03
-Nodes (66): classifyStreamLine(), DrawerActiveAgent(), formatSpend(), STREAM_LINE_COLOR_CLASS, StreamLineKind, stuckHours(), verbBadgeForAgent(), DrawerActivityRail() (+58 more)
-
-### Community 35 - "Community 35"
-Cohesion: 0.03
-Nodes (76): computeAgentEnrichment(), execAsync, getActiveSessionPath(), getAgentJsonlMtime(), getAgentJsonlPath(), getAgentPendingQuestions(), getAgentWorkspace(), getClaudeProjectDir() (+68 more)
-
-### Community 36 - "Community 36"
-Cohesion: 0.04
-Nodes (81): ModelRef, RoleConfig, RolesConfig, TtsDaemonConfig, WorkhorsesConfig, WorkhorseSlot, MODEL_DEPRECATIONS, deprecatedIds (+73 more)
-
-### Community 37 - "Community 37"
-Cohesion: 0.03
-Nodes (77): agentDir, dir1, dir2, marker, missing, nested, cb, cmdArgs (+69 more)
-
-### Community 38 - "Community 38"
 Cohesion: 0.05
 Nodes (77): activeSwarmIssueIds, assertPathInside(), autoAdvanceInFlight, buildSlotPrompt(), buildStructuredSlotTaskInput(), canonicalIssueId(), clearAutoAdvanceFailureFields(), continueDirForWorkspace() (+69 more)
 
-### Community 39 - "Community 39"
+### Community 34 - "Community 34"
 Cohesion: 0.03
-Nodes (73): announceMerge(), buildShipPreparationPrompt(), buildShipSyncMainPrompt(), _completedPostMerge, defaultWorkspaceForIssue(), __dirname, execAsync, __filename (+65 more)
+Nodes (74): agentDir, dir1, dir2, marker, missing, nested, cb, cmdArgs (+66 more)
 
-### Community 40 - "Community 40"
-Cohesion: 0.03
-Nodes (69): db, makeTestLayer(), makeTestService(), received, runWithService(), store, svc, unsubscribe (+61 more)
-
-### Community 41 - "Community 41"
+### Community 35 - "Community 35"
 Cohesion: 0.04
-Nodes (73): AwaitingInputReason, compactPrompt(), detectAwaitingInputForAgent(), detectAwaitingInputFromPane(), findPermissionMenuEndIndex(), getPaneDetectionCacheKey(), isCurrentPromptIndex(), isRecentPromptIndex() (+65 more)
+Nodes (61): BUNDLED_GIT_HOOKS_DIR, checkCommand(), __dirname, __filename, syncCommand(), SyncOptions, getCurrentVersion(), getLatestVersion() (+53 more)
 
-### Community 42 - "Community 42"
+### Community 36 - "Community 36"
 Cohesion: 0.04
-Nodes (75): updateTtsConfig(), { config }, Role, applyEnvironmentFallbacks(), applyMigrations(), backupGlobalConfig(), CavemanConfig, CavemanMode (+67 more)
+Nodes (76): updateTtsConfig(), { config }, Role, applyEnvironmentFallbacks(), applyMigrations(), backupGlobalConfig(), CavemanConfig, CavemanMode (+68 more)
 
-### Community 43 - "Community 43"
-Cohesion: 0.04
-Nodes (68): readCavemanVariant(), buildSpecialistCavemanExports(), countContextTokens(), DEFAULT_SPECIALISTS, disableSpecialist(), enableSpecialist(), ensureProjectSpecialistDir(), execAsync (+60 more)
-
-### Community 44 - "Community 44"
-Cohesion: 0.04
-Nodes (63): ChatMessage, CompactBoundary, ConversationEvent, ProposedPlan, TurnDiffSummary, WorkLogEntry, ChatMarkdown, ConversationPanel() (+55 more)
-
-### Community 45 - "Community 45"
-Cohesion: 0.03
-Nodes (67): checkUndispatchedShip(), DeaconLogEntry, getDeaconLogs(), getLastPatrolResult(), PatrolResult, stopDeacon(), activeRoleRunExists(), AgentCrashTracker (+59 more)
-
-### Community 46 - "Community 46"
-Cohesion: 0.05
-Nodes (71): boundedAutoPresoElements(), jsonByteLength(), readElementLikes(), validateAutoPresoCanvasElements(), AutoPresoSession, ExcalidrawElementLike, postAgentMessageLikeRoute(), validateAgentDeliveryMethodOrigin() (+63 more)
-
-### Community 47 - "Community 47"
+### Community 37 - "Community 37"
 Cohesion: 0.02
 Nodes (80): ActivityDetailedEvent, ActivityEntryEvent, ActivityTtsEvent, ActivityUpdatedEvent, AgentActivityChangedEvent, AgentChannelReplyEvent, AgentCompletedEvent, AgentCreatedEvent (+72 more)
 
-### Community 48 - "Community 48"
+### Community 38 - "Community 38"
+Cohesion: 0.03
+Nodes (68): AgentRuntimeState, clearAgentPausedEffect(), clearAgentTroubledEffect(), getAgentStateEffect(), listRunningAgentsEffect(), recordAgentFailureEffect(), saveAgentStateEffect(), setAgentPausedEffect() (+60 more)
+
+### Community 39 - "Community 39"
+Cohesion: 0.03
+Nodes (56): DrawerActivityRail(), DrawerBeadsList(), DrawerReviewSpecialists(), DRAWER_TABS, DrawerTabs(), DrawerVerificationGates(), IssueDrawer(), createQueryClient() (+48 more)
+
+### Community 40 - "Community 40"
 Cohesion: 0.04
 Nodes (54): createCostCommand(), formatIssueCostAggregate(), aggregate, output, IssueAggregate, BUDGETS_FILE, calculateCost(), checkBudget() (+46 more)
 
+### Community 41 - "Community 41"
+Cohesion: 0.05
+Nodes (62): buildWorkAgentPrompt(), extractStitchDesigns(), inferIssueIdFromWorkspace(), matchBeadToAC(), readBeadsTasks(), readFeatureContext(), readPendingFeedback(), readPlanningContext() (+54 more)
+
+### Community 42 - "Community 42"
+Cohesion: 0.03
+Nodes (63): backup, bundledFrontendIndex, bundledServer, child, composeFile, config, configContent, configFile (+55 more)
+
+### Community 43 - "Community 43"
+Cohesion: 0.04
+Nodes (66): cosineSimilarity(), arrayIndexCondition(), ArrayIndexTarget, CosineSearchResult, cosineSimilarity(), countFts(), countFtsInSet(), findEnrichedSessionsMissingEmbedding() (+58 more)
+
+### Community 44 - "Community 44"
+Cohesion: 0.05
+Nodes (54): acquireStartLock(), buildManagedProcessIdentity(), buildTtsDaemonEnv(), clearState(), clearTtsDaemonManualStopGate(), defaultAllowedOrigins(), execFileAsync, fetchDaemonHealth() (+46 more)
+
+### Community 45 - "Community 45"
+Cohesion: 0.04
+Nodes (52): ChangedFilesTree, EMPTY_DIRECTORY_OVERRIDES, ChatMessage, CompactBoundary, ConversationEvent, ProposedPlan, TurnDiffFileChange, TurnDiffSummary (+44 more)
+
+### Community 46 - "Community 46"
+Cohesion: 0.04
+Nodes (56): sentinel, eightDaysAgo, events, payload, r1, r2, received, recent (+48 more)
+
+### Community 47 - "Community 47"
+Cohesion: 0.04
+Nodes (63): resetDb(), resetDb(), closeDatabase(), DatabaseError, getDatabasePath(), isBunRuntime(), _require, resetDatabase() (+55 more)
+
+### Community 48 - "Community 48"
+Cohesion: 0.06
+Nodes (55): githubTracker, linearTracker, longBody, mockCreateTrackerFromConfig, mockExistsSync, mockLoadConfig, mockStatSync, STATE_MTIME (+47 more)
+
 ### Community 49 - "Community 49"
 Cohesion: 0.03
-Nodes (55): existingSkillDir, existsInTarget, mockClaudeSkills, mockPanopticonSkills, nonSkillDir, skillDir, skills, skillsToSync (+47 more)
+Nodes (50): AC_STATUS_ICONS, BeadsResponse, BeadsTasksPanel(), BeadsTasksPanelProps, BeadTask, PlanItemDetailProps, AC_STATUS_COLORS, AC_STATUS_SYMBOL (+42 more)
 
 ### Community 50 - "Community 50"
 Cohesion: 0.03
-Nodes (66): resetDb(), resetDb(), closeDatabase(), getDatabasePath(), isBunRuntime(), _require, resetDatabase(), ExtractedPayload (+58 more)
+Nodes (57): loadCloisterConfig(), cleanupStaleAgentState(), { activeSessions }, agentDir, fortyMinutesAgo, twentyMinutesAgo, result, checkAgentHealthAsync() (+49 more)
 
 ### Community 51 - "Community 51"
-Cohesion: 0.04
-Nodes (65): getTrackerContext(), addGitHubComment(), fetchGitHubIssue(), fetchIssueWithComments(), findLocalWorkspace(), formatComments(), getGitHubToken(), GitHubIssueResult (+57 more)
+Cohesion: 0.05
+Nodes (50): BeadsTask, captureBeadsTasks(), captureFiles(), captureGitState(), captureHandoffContext(), execAsync, HandoffContextError, serializeHandoffContext() (+42 more)
 
 ### Community 52 - "Community 52"
 Cohesion: 0.04
-Nodes (59): VoiceMode, VoiceWidget(), Conversation, ConversationListProps, fetchConversations(), getSortKey(), ListTab, SORT_LABELS (+51 more)
+Nodes (48): ComposerFooter(), ComposerFooterProps, deleteConversationImage(), PendingImage, sendConversationMessage(), switchModel(), uploadConversationImage(), ensureDefaultConversationModel() (+40 more)
 
 ### Community 53 - "Community 53"
 Cohesion: 0.05
-Nodes (52): acquireStartLock(), buildManagedProcessIdentity(), buildTtsDaemonEnv(), clearState(), clearTtsDaemonManualStopGate(), defaultAllowedOrigins(), execFileAsync, fetchDaemonHealth() (+44 more)
+Nodes (50): buildManifestFromDirectory(), collectSourceFiles(), compareFileToManifest(), createEmptyManifest(), FileStatus, hashFile(), Manifest, ManifestEntry (+42 more)
 
 ### Community 54 - "Community 54"
-Cohesion: 0.04
-Nodes (13): createFlyApiClient(), FlyApiClient, FlyApiError, FlyExecResult, FlyMachine, FlyMachineConfig, client, fetchMock (+5 more)
+Cohesion: 0.05
+Nodes (52): checkUndispatchedShip(), DeaconLogEntry, getDeaconLogs(), getLastPatrolResult(), PatrolResult, startDeacon(), activeRoleRunExists(), AgentCrashTracker (+44 more)
 
 ### Community 55 - "Community 55"
-Cohesion: 0.04
-Nodes (55): cleanupOldEntries(), dequeueMerge(), enqueueMerge(), getCurrentMerge(), getQueueForProject(), markMergeProcessing(), MergeQueueEntry, removeMerge() (+47 more)
-
-### Community 56 - "Community 56"
-Cohesion: 0.06
-Nodes (50): killCommand(), KillOptions, destroyRemoteWorkspace(), buildClaudeUserSettings(), ClaudeUserSettings, getClaudePermissionFlags(), readYoloEnv(), resolvePermissionMode() (+42 more)
-
-### Community 57 - "Community 57"
-Cohesion: 0.05
-Nodes (35): buildObservation(), buildObservationPrompt(), ExtractedObservationPayload, ExtractedResultMetadata, ExtractObservationCall, extractObservationFromTurn(), ExtractObservationInput, ExtractObservationResult (+27 more)
-
-### Community 58 - "Community 58"
-Cohesion: 0.05
-Nodes (51): cn(), Button, ButtonLink, SharedButtonBaseProps, SharedButtonLinkProps, SharedButtonProps, SharedButtonSize, SharedButtonVariant (+43 more)
-
-### Community 59 - "Community 59"
-Cohesion: 0.03
-Nodes (48): AC_STATUS_ICONS, BeadsResponse, BeadsTasksPanel(), BeadsTasksPanelProps, BeadTask, PlanItemDetailProps, AC_STATUS_COLORS, AC_STATUS_SYMBOL (+40 more)
-
-### Community 60 - "Community 60"
-Cohesion: 0.04
-Nodes (51): buildContextMenu(), buildMenuTemplate(), buildTooltip(), callServerApi(), configureApplicationMenu(), createTerminalWindow(), createTray(), createTrayIcon() (+43 more)
-
-### Community 61 - "Community 61"
-Cohesion: 0.05
-Nodes (53): getReviewerSessionName(), parseReviewerSessionName(), REVIEWER_ROLES, ReviewerRole, Access, result, getIndexStats(), ActivityContext (+45 more)
-
-### Community 62 - "Community 62"
-Cohesion: 0.05
-Nodes (50): updateCommand(), buildManifestFromDirectory(), collectSourceFiles(), compareFileToManifest(), createEmptyManifest(), hashFile(), Manifest, ManifestEntry (+42 more)
-
-### Community 63 - "Community 63"
 Cohesion: 0.07
 Nodes (53): dashboardBundleMtimeMs(), parseHealthTimeout(), recordReloadStatus(), reloadCommand(), ReloadOptions, runBuild(), UsageError, DashboardBundleCandidate (+45 more)
 
-### Community 64 - "Community 64"
+### Community 56 - "Community 56"
 Cohesion: 0.04
-Nodes (49): BASE_TIME, exitSpy, loadDeaconWithResumeMock(), loadStartCommand(), mailDir, mailFiles, state, stderrSpy (+41 more)
+Nodes (44): abortReviewCommand(), DASHBOARD_URL, CompletePlanningResponse, DASHBOARD_URL, planDoneCommand(), DASHBOARD_URL, requestReviewCommand(), RequestReviewOptions (+36 more)
 
-### Community 65 - "Community 65"
+### Community 57 - "Community 57"
+Cohesion: 0.04
+Nodes (55): TranscriptClaimTrigger, buildObservation(), buildObservationPrompt(), ExtractedObservationPayload, ExtractedResultMetadata, ExtractObservationCall, extractObservationFromTurn(), ExtractObservationInput (+47 more)
+
+### Community 58 - "Community 58"
+Cohesion: 0.05
+Nodes (48): format(), LiveCounter(), LiveCounterProps, ACTIVE_AGENT_STATUSES, agentForFeature(), BucketedFeature, bucketFeaturePhase(), classifierAgent() (+40 more)
+
+### Community 59 - "Community 59"
 Cohesion: 0.05
 Nodes (47): AggregateActivityState, AggregateBadge, buildActivitySummary(), computeDominantStatus(), FeatureContextMenuProps, FeatureItem(), FeatureItemProps, formatCost() (+39 more)
 
-### Community 66 - "Community 66"
+### Community 60 - "Community 60"
+Cohesion: 0.04
+Nodes (48): BASE_TIME, exitSpy, loadDeaconWithResumeMock(), loadStartCommand(), mailDir, mailFiles, state, stderrSpy (+40 more)
+
+### Community 61 - "Community 61"
 Cohesion: 0.06
-Nodes (28): issues, result, importTrackerConfig(), findProjectsByRallyProject(), computeBeadCounts(), getCachedPlanningState(), getCanonicalStatus(), IssueDataService (+20 more)
+Nodes (54): claimTranscriptRangeAsync(), commitTranscriptRangeAsync(), getTranscriptCheckpointAsync(), listTranscriptCheckpointsAsync(), pendingRequests, postWorkerRequest(), releaseTranscriptRangeAsync(), runInline() (+46 more)
+
+### Community 62 - "Community 62"
+Cohesion: 0.05
+Nodes (44): calls, { mockExecAsync }, opts, CloseIssueOptions, compactBeads(), compactBeadsImpl(), CompactBeadsOptions, execAsync (+36 more)
+
+### Community 63 - "Community 63"
+Cohesion: 0.05
+Nodes (47): buildContextMenu(), buildMenuTemplate(), buildTooltip(), callServerApi(), configureApplicationMenu(), createTray(), createTrayIcon(), currentStatus (+39 more)
+
+### Community 64 - "Community 64"
+Cohesion: 0.06
+Nodes (46): conversationsTab, firstLens, lens, overview, tablist, ComposerMode, IssueComposer(), IssueComposerProps (+38 more)
+
+### Community 65 - "Community 65"
+Cohesion: 0.04
+Nodes (49): ClaudeMessageWithCwd, ClaudeUsage, ContentBlock, FILE_TOOLS, parseSessionJsonl(), SessionMetadata, scanAction(), collectJsonlFiles() (+41 more)
+
+### Community 66 - "Community 66"
+Cohesion: 0.05
+Nodes (25): CLAUDE_PROJECTS_DIR, ClaudeMessage, getActiveSessionModel(), getProjectDirs(), getRecentSessions(), getSessionFiles(), importSessionToCostLog(), normalizeModelName() (+17 more)
 
 ### Community 67 - "Community 67"
-Cohesion: 0.04
-Nodes (53): SensitiveText(), SensitiveTextProps, DEFAULTS, UIPreferences, useUIPreferences(), Capability, ModelDef, MODELS_BY_PROVIDER (+45 more)
+Cohesion: 0.06
+Nodes (49): getReviewerSessionName(), parseReviewerSessionName(), REVIEWER_ROLES, ReviewerRole, result, ActivityContext, awaitingInputFromProjection(), buildIssueTitleMap() (+41 more)
 
 ### Community 68 - "Community 68"
-Cohesion: 0.07
-Nodes (35): parsePiSession(), ProcessSpawnError, TmuxError, CLAUDE_PROJECTS_DIR, SessionIndexEntry, agentDirFor(), agentsDir(), cleanupPiTransientFiles() (+27 more)
+Cohesion: 0.05
+Nodes (48): HealthCheck, systemHealthCommand(), mockExistsSync, mockFetch, mockGetDashboardApiUrl, mockIsCliproxyRunning, mockIsSmeeProcessRunning, output (+40 more)
 
 ### Community 69 - "Community 69"
-Cohesion: 0.04
-Nodes (45): createCall, createCalls, dbError, deleteCalls, doc, doctorCalls, existingBeads, expectedPrefix (+37 more)
-
-### Community 70 - "Community 70"
-Cohesion: 0.05
-Nodes (41): DatabaseError, DbMergeSetRepoRow, DbMergeSetRow, deleteMergeSet(), getAllMergeSetsFromDb(), getMergeSetFromDb(), getReposFromDb(), rowToMergeSet() (+33 more)
-
-### Community 71 - "Community 71"
-Cohesion: 0.05
-Nodes (47): format(), LiveCounter(), LiveCounterProps, ACTIVE_AGENT_STATUSES, agentForFeature(), BucketedFeature, bucketFeaturePhase(), classifierAgent() (+39 more)
-
-### Community 72 - "Community 72"
-Cohesion: 0.07
-Nodes (46): assertSafeAgentId(), assertSafeAgentIdEffect(), captureCheckpoint(), captureCheckpointEffect(), CheckpointGitResult, checkpointRef(), checkpointSpawnerLayer, deleteAllCheckpoints() (+38 more)
-
-### Community 73 - "Community 73"
-Cohesion: 0.04
-Nodes (43): BeadsTask, buildHandoffPrompt(), captureBeadsTasks(), captureFiles(), captureGitState(), captureHandoffContext(), execAsync, HandoffContextError (+35 more)
-
-### Community 74 - "Community 74"
-Cohesion: 0.06
-Nodes (44): addEventToCache(), CostCache, createEmptyCache(), getCacheFile(), getCacheStatus(), getCostsByIssue(), getCostsDir(), getCostsForIssue() (+36 more)
-
-### Community 75 - "Community 75"
 Cohesion: 0.06
 Nodes (50): BYTE_UNITS, cachedContainerLifecycleSnapshot, ContainerHistory, ContainerStats, DockerContainerLifecycle, DockerNetwork, DockerPsRaw, DockerStatsCollector (+42 more)
 
-### Community 76 - "Community 76"
-Cohesion: 0.09
-Nodes (51): bridgeCodexAuthToCliproxy(), bridgeCodexAuthToCliproxyAsync(), bridgeGeminiAuthToCliproxyAsync(), buildCliproxyConfig(), checkCliproxyPortAsync(), cliproxyCatch(), CliproxyCodexCredentials, CliproxyError (+43 more)
+### Community 70 - "Community 70"
+Cohesion: 0.06
+Nodes (52): assertExistingPathInsideRoot(), commitFlywheelStateChanges(), createInitialFlywheelStatus(), dashboardBaseUrl(), decodeFlywheelStatus, emitStatusCommand(), EmitStatusOptions, execAsync (+44 more)
 
-### Community 77 - "Community 77"
+### Community 71 - "Community 71"
+Cohesion: 0.06
+Nodes (44): doneCommand(), DoneOptions, execAsync, getGitHubConfig(), isMergeSetMergedIntoTargets(), updateGitHubToInReview(), updateLinearToInReview(), findLinearStateByName() (+36 more)
+
+### Community 72 - "Community 72"
+Cohesion: 0.05
+Nodes (51): AgentRollup, CavemanExperimentRow, dailySpendCache, dailySpendCacheKey(), DailyTrend, DatabaseError, DbCostRow, DbIssueSummaryRow (+43 more)
+
+### Community 73 - "Community 73"
+Cohesion: 0.05
+Nodes (43): ActivityFeed(), ActivityFeedProps, EVENT_COLORS, EVENT_ICONS, fetchActivityREST(), selectIssueActivityFeed(), CostDonut(), CostDonutProps (+35 more)
+
+### Community 74 - "Community 74"
+Cohesion: 0.06
+Nodes (24): importTrackerConfig(), findProjectsByRallyProject(), loadReviewStatusesForIssues(), computeBeadCounts(), getCachedPlanningState(), IssueDataService, issuesChanged(), mapRallyStateToCanonical() (+16 more)
+
+### Community 75 - "Community 75"
 Cohesion: 0.08
 Nodes (44): getReviewStatusAsync(), setReviewStatusAsync(), addFailingSource(), getFailingChecksBlocker(), getRepoFromPrUrl(), getTrackedRepos(), handleCheckRun(), handleCheckSuite() (+36 more)
 
+### Community 76 - "Community 76"
+Cohesion: 0.05
+Nodes (53): Access, getIssueDataService(), ActivityContext, awaitingInputFromProjection(), closedIssuesCache, commandDeckRouteLayer, costCache, execAsync (+45 more)
+
+### Community 77 - "Community 77"
+Cohesion: 0.09
+Nodes (54): extractNumber(), extractPrefix(), archiveWorkspaceArtifactsImpl(), applyClosedOutLabel(), applyLabelGitHub(), applyLabelGitHubImpl(), applyLabelLinear(), applyLabelLinearImpl() (+46 more)
+
 ### Community 78 - "Community 78"
-Cohesion: 0.04
-Nodes (49): cosineSimilarity(), getFtsRow(), replaceDiscoveredSessionArrayIndexes(), replaceFtsRow(), replaceSessionArrayIndex(), updateEnrichment(), upsertDiscoveredSession(), chalk (+41 more)
-
-### Community 79 - "Community 79"
-Cohesion: 0.07
-Nodes (48): checkCommand(), checkComposeLabelDrift(), checkDirectory(), checkPi(), CheckResult, compareSemver(), ComposeDriftEntry, countItems() (+40 more)
-
-### Community 80 - "Community 80"
 Cohesion: 0.06
 Nodes (52): buildDefaultTtsTestVoice(), buildTtsSpeakPayload(), deleteTtsVoiceByName(), findVoiceByNameOrReport(), formatMegabytes(), formatSeconds(), formatTtsDaemonStatus(), formatVoiceDetails() (+44 more)
 
-### Community 81 - "Community 81"
+### Community 79 - "Community 79"
+Cohesion: 0.06
+Nodes (34): refreshCommand(), refreshFromLinear(), RefreshOptions, shadowCommand(), CanonicalState, getDisplayStatus(), getShadowState(), getShadowStatePath() (+26 more)
+
+### Community 80 - "Community 80"
 Cohesion: 0.05
 Nodes (37): categorizeToolUse(), CompressedTranscriptDelta, compressEntry(), compressJsonlBuffer(), compressTranscriptDelta(), CompressTranscriptDeltaInput, extractBashCommand(), extractText() (+29 more)
 
-### Community 82 - "Community 82"
+### Community 81 - "Community 81"
 Cohesion: 0.05
-Nodes (33): DiffPanel(), DiffPanelProps, DiffThemeType, getRenderablePatch(), readDiffParamsFromUrl(), RenderablePatch, ToggleButton(), DiffPanelLoadingState() (+25 more)
+Nodes (43): VoiceMode, VoiceWidget(), Conversation, ConversationListProps, fetchConversations(), getSortKey(), ListTab, SORT_LABELS (+35 more)
+
+### Community 82 - "Community 82"
+Cohesion: 0.06
+Nodes (51): generateFallbackSummary(), buildConversationResponse(), getCachedMessages(), isPiSessionFile(), activeCompactions, buildContinuationSummary(), compactConversationNative(), doCompact() (+43 more)
 
 ### Community 83 - "Community 83"
 Cohesion: 0.06
-Nodes (48): cleanFile(), configCommand(), execAsync, ExtendedProjectConfig, findFullProjectByTeam(), loadFullProjects(), seedCommand(), snapshotCommand() (+40 more)
+Nodes (38): rebuildCache(), appendCostEvent(), CostEvent, deduplicateEvents(), ensureEventsFile(), EventMetadata, getCostsDir(), getEventsFile() (+30 more)
 
 ### Community 84 - "Community 84"
 Cohesion: 0.05
 Nodes (45): runMemoryFtsTransaction(), EMPTY_HEALTH, getMemoryHealthPath(), MemoryHealthChangedPayload, MemoryHealthSnapshot, MemoryHealthStatus, MemoryHealthUpdate, MemoryHealthUpdateOptions (+37 more)
 
 ### Community 85 - "Community 85"
-Cohesion: 0.04
-Nodes (49): result, clearCacheRoute, ConfirmationRequest, deletePlanningSessionRoute, execAsync, getCacheStatusRoute, getConfirmationsRoute, getDeaconLogsRoute (+41 more)
+Cohesion: 0.05
+Nodes (39): DEACON_PAUSE_QUERY_KEY, DeaconPauseBanner(), DeaconPauseToggle(), useDeaconPause(), useDeaconPauseMutation(), getRenderablePatch(), DiffWorkerPoolProvider(), Tab (+31 more)
 
 ### Community 86 - "Community 86"
-Cohesion: 0.06
-Nodes (34): getHealthThresholdsMs(), evaluateHealthState(), formatDuration(), generateHealthSummary(), getAgentHealth(), getAgentsNeedingAttention(), getAgentsToKill(), getAgentsToPoke() (+26 more)
+Cohesion: 0.08
+Nodes (41): cvCommand(), CVOptions, healthCommand(), HealthOptions, relativeTime(), showCommand(), ShowOptions, calls (+33 more)
 
 ### Community 87 - "Community 87"
-Cohesion: 0.06
-Nodes (44): parseContainerServiceName(), parseIssueIdFromText(), fetchProjectTree(), isBenchmarkMode, startedAt, computeResourceAllocatedIssues(), discoverResourceAllocatedIssues(), discoverResourceAllocatedIssuesFresh() (+36 more)
+Cohesion: 0.04
+Nodes (50): buildEmbeddingText(), embed(), EmbeddingProviderName, EmbeddingResult, EmbedHttpError, embedOllama(), embedOpenAI(), EmbedOptions (+42 more)
 
 ### Community 88 - "Community 88"
-Cohesion: 0.04
-Nodes (50): buildEmbeddingText(), embed(), EmbeddingResult, EmbedHttpError, embedOllama(), embedOpenAI(), EmbedOptions, embedVoyage() (+42 more)
+Cohesion: 0.06
+Nodes (43): ConversationPanel(), ConversationPanelProps, ConversationView(), ConversationViewProps, FailedMessage, fetchMessages(), FORK_STEPS, MessagesResponse (+35 more)
 
 ### Community 89 - "Community 89"
+Cohesion: 0.06
+Nodes (43): parseContainerServiceName(), parseIssueIdFromText(), fetchProjectTree(), isBenchmarkMode, startedAt, computeResourceAllocatedIssues(), discoverResourceAllocatedIssues(), discoverResourceAllocatedIssuesFresh() (+35 more)
+
+### Community 90 - "Community 90"
 Cohesion: 0.04
 Nodes (52): EDITOR_IDS, EditorEntry, EditorId, EditorIdSchema, EDITORS, OpenInEditorInput, AgentOutput, ChatMessage (+44 more)
 
-### Community 90 - "Community 90"
-Cohesion: 0.06
-Nodes (31): refreshCommand(), refreshFromLinear(), RefreshOptions, shadowCommand(), CanonicalState, getDisplayStatus(), getShadowState(), getUnsyncedHistory() (+23 more)
-
 ### Community 91 - "Community 91"
-Cohesion: 0.07
-Nodes (49): flywheelAbortCommand(), flywheelReportOpenCommand(), loadReportFlywheelStatus(), openFlywheelRunReport(), resolveReportOpenRunId(), getFlywheelRunPayload(), getFlywheelRunsPayload(), openFlywheelRunReportForDashboard() (+41 more)
+Cohesion: 0.04
+Nodes (34): SETTINGS_FILE, generateRouterConfigFromWorkTypes(), Provider, ROUTER_CONFIG_DIR, ROUTER_CONFIG_FILE, RouterConfig, RouterRule, config (+26 more)
 
 ### Community 92 - "Community 92"
+Cohesion: 0.04
+Nodes (36): CostEvent, CostStreamResponse, fetchCostStream(), useCostStream(), UseCostStreamOptions, UseCostStreamResult, comparePipelineIssues(), filterMatchesShipModifier() (+28 more)
+
+### Community 93 - "Community 93"
+Cohesion: 0.08
+Nodes (45): checkCommand(), checkComposeLabelDrift(), checkDirectory(), checkPi(), CheckResult, compareSemver(), ComposeDriftEntry, countItems() (+37 more)
+
+### Community 94 - "Community 94"
 Cohesion: 0.08
 Nodes (43): devCommand(), __dirname, ensureDashboardBundle(), killPort(), readConfig(), resolveNode22(), sleep(), waitForHealth() (+35 more)
 
-### Community 93 - "Community 93"
-Cohesion: 0.07
-Nodes (46): assertExistingPathInsideRoot(), commitFlywheelStateChanges(), createInitialFlywheelStatus(), dashboardBaseUrl(), decodeFlywheelStatus, emitStatusCommand(), EmitStatusOptions, execAsync (+38 more)
+### Community 95 - "Community 95"
+Cohesion: 0.06
+Nodes (39): buildInspectPrompt(), __dirname, execAsync, __filename, getBeadDescription(), InspectContext, InspectResult, onInspectComplete() (+31 more)
 
-### Community 94 - "Community 94"
+### Community 96 - "Community 96"
+Cohesion: 0.05
+Nodes (39): markEnrichmentFailed(), searchFts(), buildConversationExcerpt(), buildL1Prompt(), buildL2Prompt(), buildL3Prompt(), callClaudeApi(), callClaudeApiWithConfig() (+31 more)
+
+### Community 97 - "Community 97"
 Cohesion: 0.07
 Nodes (42): AutoPresoAgentSettings, createModel(), createTools(), DEFAULT_SETTINGS, readCodexBearerToken(), runWhiteboardAgent(), runWhiteboardWarmupOnce(), systemPrompt() (+34 more)
 
-### Community 95 - "Community 95"
-Cohesion: 0.06
-Nodes (47): appendJsonl(), readTranscriptSlice(), buildConversationResponse(), getCachedMessages(), isPiSessionFile(), analyze_session(), find_sessions(), main() (+39 more)
-
-### Community 96 - "Community 96"
-Cohesion: 0.06
-Nodes (40): computeRestartDelay(), getSmeeBinaryPath(), getSmeeUrl(), getWebhookTarget(), isProcessAlive(), isSmeeProcessRunning(), isSmeeRunning(), errorSpy (+32 more)
-
-### Community 97 - "Community 97"
-Cohesion: 0.06
-Nodes (38): buildACLookupByTitle(), buildActiveSliceContext(), buildWorkAgentPrompt(), extractStitchDesigns(), inferIssueIdFromWorkspace(), matchBeadToAC(), readBeadsTasks(), readFeatureContext() (+30 more)
-
 ### Community 98 - "Community 98"
+Cohesion: 0.05
+Nodes (41): entry, { issueId }, { limit }, old, op, ops, recent, result (+33 more)
+
+### Community 99 - "Community 99"
 Cohesion: 0.06
 Nodes (43): detectPlatform(), Platform, evaluateAgentStartGate(), evaluateSpawnGuardrails(), formatLeakedSpecialistSummary(), hasActiveAgentGateOrRetry(), resolveAgentCountEnv(), buildLeakedSpecialists() (+35 more)
 
-### Community 99 - "Community 99"
-Cohesion: 0.05
-Nodes (43): AvailableModel, AvailableModelsResponse, ClaudeAuthStatus, DEFAULT_FLYWHEEL_CONFIG, DEFAULT_WORKHORSES, displayModelRef(), Effort, fetchAvailableModels() (+35 more)
-
 ### Community 100 - "Community 100"
 Cohesion: 0.05
-Nodes (41): entry, { issueId }, { limit }, old, op, ops, recent, result (+33 more)
+Nodes (43): AvailableModel, AvailableModelsResponse, ClaudeAuthStatus, DEFAULT_FLYWHEEL_CONFIG, DEFAULT_WORKHORSES, displayModelRef(), Effort, fetchAvailableModels() (+35 more)
 
 ### Community 101 - "Community 101"
 Cohesion: 0.05
 Nodes (44): CappedBodyReadResult, CheckTtsHealthOptions, clearTtsVoices(), createTtsVoice(), CreateTtsVoiceInput, deleteTtsVoiceRoute, deleteTtsVoicesRoute, ExtractEmbeddingDeps (+36 more)
 
 ### Community 102 - "Community 102"
-Cohesion: 0.06
-Nodes (36): showCommand(), runtime, state, next, path, read, state, activeContinueWriters (+28 more)
-
-### Community 103 - "Community 103"
 Cohesion: 0.07
 Nodes (39): appendToRunLog(), checkLogSizeLimit(), cleanupAllLogs(), cleanupOldLogs(), createRunLog(), ensureRunsDirectory(), finalizeRunLog(), generateRunId() (+31 more)
 
-### Community 104 - "Community 104"
+### Community 103 - "Community 103"
 Cohesion: 0.04
 Nodes (48): 10. UX Requirements, 11. Implementation Notes, 12. Acceptance Criteria, 13. Success Criteria, 1. New Dashboard Surface, 2.1 By Issue, 2.2 By Workspace, 2.3 By Agent Type (+40 more)
 
-### Community 105 - "Community 105"
+### Community 104 - "Community 104"
 Cohesion: 0.04
 Nodes (48): 1.1 What We Have Today, 1.2 Tool-by-Tool Analysis, 1.3 Comparative Matrix, 2.1 Design Principles, 2.2 Proposed Enhancements (Prioritized), 2.3 Implementation Roadmap, 2.4 What We're NOT Adopting (and Why), 2.5 Success Metrics (+40 more)
 
-### Community 106 - "Community 106"
+### Community 105 - "Community 105"
 Cohesion: 0.04
 Nodes (48): 10. God View: Keep But Integrate, 1. Rename: Mission Control → Command Deck, 2. Navigation: Horizontal Bar → Grouped Sidebar, 3. Color System: Semantic Token Architecture, 4. Typography Update, 5. Fractal Noise Texture Overlay, 6. Component Unification, 7. Scrollbar Styling (+40 more)
 
+### Community 106 - "Community 106"
+Cohesion: 0.05
+Nodes (27): estimateCost(), getModelCapability(), MODEL_CAPABILITIES, ModelCapability, SkillDimension, ModelId, calculateSkillScore(), formatSelectionResults() (+19 more)
+
 ### Community 107 - "Community 107"
+Cohesion: 0.09
+Nodes (44): clearFlywheelRunGate(), flywheelAbortCommand(), getFlywheelActiveRunId(), getFlywheelRunPayload(), getFlywheelRunsPayload(), abortFlywheelRun(), clearFlywheelGate(), decodeFlywheelRunId (+36 more)
+
+### Community 108 - "Community 108"
+Cohesion: 0.06
+Nodes (32): appendJsonl(), ExtractFromTranscriptDeltaResult, countCompleteLines(), defaultTranscriptPoller, isSuccessfulExtractionResult(), readTranscriptSlice(), RegisteredTranscript, registerTranscriptForPolling() (+24 more)
+
+### Community 109 - "Community 109"
 Cohesion: 0.06
 Nodes (39): REVIEWER_STYLE, ReviewerRole, RoleBadge(), RoleBadgeProps, RoleBadgeSize, RoleStyle, SESSION_STYLE, SIZE_PX (+31 more)
 
-### Community 108 - "Community 108"
-Cohesion: 0.05
-Nodes (27): estimateCost(), getModelCapability(), MODEL_CAPABILITIES, ModelCapability, SkillDimension, calculateSkillScore(), formatSelectionResults(), getSimpleModelMapping() (+19 more)
-
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.04
 Nodes (47): 1. **work-agent**, 2. **planning-agent**, 3. **review-agent**, 4. **test-agent**, 5. **merge-agent**, 6. **inspect-agent** ⚠️ PARTIAL CONFIGURATION, 7. **uat-agent** ⚠️ CRITICAL GAPS, Action Items (Prioritized) (+39 more)
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.04
 Nodes (46): 1. Dashboard UI Integration (from PAN-225), 2. FTS5 as Phase 1 Search (from PAN-225, PAN-179), 3. Session-Oriented Learning Types (from PAN-225, PAN-184), 4. Specific Thinking-Block Perception Signals (from PAN-184), 5. Explicit Deduplication Threshold (from PAN-225), Acceptance Criteria, Architecture, code:block1 (Source of truth (git-tracked):) (+38 more)
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.04
 Nodes (47): 1. Agent Discovery, 1. Monitor Regularly, 2. Activity Detection, 2. Establish Baselines, 3. Automate Alerts, 3. Log Analysis, 4. Log Everything, 4. Resource Usage (+39 more)
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.04
 Nodes (47): 1. Start Traefik, 2. Add DNS Entry, 3. Verify, "502 Bad Gateway", Add a New Route, Architecture, "Certificate Error", Certificate Management (+39 more)
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
+Cohesion: 0.06
+Nodes (26): configShadowCommand(), ShadowOptions, ENV_KEYS, EnvSnapshot, PanopticonConfig, ENV_FILE_PATH, getShadowModeFromEnv(), loadPanopticonEnv() (+18 more)
+
+### Community 115 - "Community 115"
 Cohesion: 0.08
 Nodes (29): hookCommand(), HookOptions, generateRecoveryPrompt(), checkHook(), clearHook(), collectMail(), generateFixedPointPrompt(), getHook() (+21 more)
 
-### Community 114 - "Community 114"
-Cohesion: 0.08
-Nodes (41): confirmHostOverride(), countBeadsTasks(), determineWorkspaceLocation(), ensureRemoteWorkspace(), execAsync, execFileAsync, failPostCreateValidation(), fetchIssueForAutoStart() (+33 more)
-
-### Community 115 - "Community 115"
-Cohesion: 0.07
-Nodes (42): deletePRDDraft(), deletePRDDraftEffect(), getPRDDraftInfo(), getPRDDraftInfoEffect(), getPRDDraftPath(), getPRDDraftPathEffect(), hasPRDDraft(), hasPRDDraftEffect() (+34 more)
-
 ### Community 116 - "Community 116"
+Cohesion: 0.08
+Nodes (34): FsError, writeWorkspaceContext(), ensureWorkspacePanDir(), getWorkspacePanPaths(), readWorkspaceContinue(), workspacePanPaths(), clearFeedback(), readFeedback() (+26 more)
+
+### Community 117 - "Community 117"
 Cohesion: 0.07
 Nodes (37): BadgeBarProps, fetchPlanning(), PlanningData, MarkdownModal(), MarkdownModalProps, TranscriptUpload(), TranscriptUploadProps, ActionKey (+29 more)
 
-### Community 117 - "Community 117"
-Cohesion: 0.04
-Nodes (46): 1. Issue lifecycle, 2. Observation, 3. Things you manage, 4. System / daemon, 5. Releases, 6. First-run & maintenance, 7. `pan admin` — plumbing, code:bash (pan issues                       # what can I work on?) (+38 more)
-
 ### Community 118 - "Community 118"
-Cohesion: 0.04
-Nodes (46): 1.1 Kanban Card Cost Badge, 1.2 Issue Detail Panel Cost Section, 1. Per-Issue Cost Display, 2.1 Session File Location, 2.2 JSONL Message Format, 2.3 Parser Implementation, 2. Claude Code JSONL Parsing, 3.1 Linking Mechanism (+38 more)
+Cohesion: 0.08
+Nodes (43): postAgentMessageLikeRoute(), validateAgentDeliveryMethodOrigin(), validateAgentMessageOrigin(), constantTimeTokenEqual(), cookieValue(), dashboardCsrfToken(), dashboardSessionCookieHeader(), getDashboardSessionToken() (+35 more)
 
 ### Community 119 - "Community 119"
 Cohesion: 0.04
-Nodes (46): 10. Compose right pane for project-selected mode, 11. CSS for session tree, issue header, session panel, 1. Add `SessionNode`, `FeatureNode`, `ProjectSessionTree` types to contracts, 2. Extend `fetchActivityData` to include reviewer sub-agents, presence, and JSONL paths, 3. New endpoint `GET /api/projects/:projectKey/session-tree`, 4. RPC subscription `subscribeProjectSessionTree`, 5. `SessionNode.tsx` component, 6. Extend `FeatureItem.tsx` to be expandable (+38 more)
+Nodes (46): 1. Issue lifecycle, 2. Observation, 3. Things you manage, 4. System / daemon, 5. Releases, 6. First-run & maintenance, 7. `pan admin` — plumbing, code:bash (pan issues                       # what can I work on?) (+38 more)
 
 ### Community 120 - "Community 120"
-Cohesion: 0.07
-Nodes (35): AutoResumeConfig, normalizeAutoResumeConfig(), positiveNumber(), resolveAutoResumeConfigForIssue(), validBackoffSchedule(), checkPendingTestDispatch(), buildTestRolePrompt(), dashboardApiUrl() (+27 more)
+Cohesion: 0.04
+Nodes (46): 1.1 Kanban Card Cost Badge, 1.2 Issue Detail Panel Cost Section, 1. Per-Issue Cost Display, 2.1 Session File Location, 2.2 JSONL Message Format, 2.3 Parser Implementation, 2. Claude Code JSONL Parsing, 3.1 Linking Mechanism (+38 more)
 
 ### Community 121 - "Community 121"
 Cohesion: 0.04
-Nodes (45): 1. Overview, 2.1 What It Is, 2.2 Implementation, 2. Ralph Wiggum Self-Assessment Loop, 3.1 What It Is, 3.2 Current State, 3.3 Proposed State, 3.4 Implementation (+37 more)
+Nodes (46): 10. Compose right pane for project-selected mode, 11. CSS for session tree, issue header, session panel, 1. Add `SessionNode`, `FeatureNode`, `ProjectSessionTree` types to contracts, 2. Extend `fetchActivityData` to include reviewer sub-agents, presence, and JSONL paths, 3. New endpoint `GET /api/projects/:projectKey/session-tree`, 4. RPC subscription `subscribeProjectSessionTree`, 5. `SessionNode.tsx` component, 6. Extend `FeatureItem.tsx` to be expandable (+38 more)
 
 ### Community 122 - "Community 122"
-Cohesion: 0.04
-Nodes (45): Automated Installation, code:bash (pan doctor), code:bash (# Option 1: Install globally), code:bash (# Add user to docker group), code:bash (# Using nvm (recommended)), code:bash (# Ubuntu/Debian), code:bash (# Ubuntu/Debian (Docker Compose v2)), code:bash (# Clear npm cache) (+37 more)
+Cohesion: 0.06
+Nodes (37): createSpecialistHandoff(), ensureLogDir(), getLiveQueueDepth(), getSpecialistHandoffLogFile(), getSpecialistHandoffStats(), getTodaySpecialistHandoffs(), logSpecialistHandoff(), readIssueSpecialistHandoffs() (+29 more)
 
 ### Community 123 - "Community 123"
 Cohesion: 0.04
-Nodes (45): 1. Creation, 2. Usage, 3. Cleanup, Architecture, Best Practices, code:block1 (project/), code:bash (pan workspace create MIN-123), code:bash (pan workspace create MIN-123 --docker) (+37 more)
+Nodes (45): 1. Overview, 2.1 What It Is, 2.2 Implementation, 2. Ralph Wiggum Self-Assessment Loop, 3.1 What It Is, 3.2 Current State, 3.3 Proposed State, 3.4 Implementation (+37 more)
 
 ### Community 124 - "Community 124"
-Cohesion: 0.08
-Nodes (35): buildInspectPrompt(), __dirname, execAsync, __filename, getBeadDescription(), InspectContext, InspectResult, onInspectComplete() (+27 more)
+Cohesion: 0.04
+Nodes (45): Automated Installation, code:bash (pan doctor), code:bash (# Option 1: Install globally), code:bash (# Add user to docker group), code:bash (# Using nvm (recommended)), code:bash (# Ubuntu/Debian), code:bash (# Ubuntu/Debian (Docker Compose v2)), code:bash (# Clear npm cache) (+37 more)
 
 ### Community 125 - "Community 125"
-Cohesion: 0.06
-Nodes (40): DEFAULT_AUTO_RESUME_CONFIG, applyEnvironmentOverrides(), AutoActions, AutoRestartConfig, CLOISTER_CONFIG_FILE, CloisterConfig, CloseOutConfig, CostTrackingConfig (+32 more)
+Cohesion: 0.04
+Nodes (45): 1. Creation, 2. Usage, 3. Cleanup, Architecture, Best Practices, code:block1 (project/), code:bash (pan workspace create MIN-123), code:bash (pan workspace create MIN-123 --docker) (+37 more)
 
 ### Community 126 - "Community 126"
-Cohesion: 0.07
-Nodes (24): chunks, emitter, googleMocks, stream, emitter, onTurn, queue, subscribeVoiceSettings() (+16 more)
+Cohesion: 0.06
+Nodes (40): DEFAULT_AUTO_RESUME_CONFIG, applyEnvironmentOverrides(), AutoActions, AutoRestartConfig, CLOISTER_CONFIG_FILE, CloisterConfig, CloseOutConfig, CostTrackingConfig (+32 more)
 
 ### Community 127 - "Community 127"
 Cohesion: 0.06
@@ -1768,7 +1772,7 @@ Nodes (37): mockLoadProjectsConfig, mockRunQualityGates, PASSING_GATE_RESULT, ru
 
 ### Community 128 - "Community 128"
 Cohesion: 0.06
-Nodes (26): SETTINGS_FILE, getKimiAnthropicBaseUrl(), getProviderEnv(), ProviderAuthType, ProviderName, PROVIDERS, AnthropicModel, ApiKeysConfig (+18 more)
+Nodes (32): ActivitySection, AgentSection(), AgentSectionProps, formatCost(), formatDuration(), formatModel(), formatTime(), getPreviewLine() (+24 more)
 
 ### Community 129 - "Community 129"
 Cohesion: 0.04
@@ -1779,52 +1783,52 @@ Cohesion: 0.05
 Nodes (43): 1. Concise is Key, 1. Source Locations, 2. Degrees of Freedom, 2. Installation Flow, 3. Progressive Disclosure, Bundled Resources, code:block1 (pan install (first time)), code:bash (# For public skills) (+35 more)
 
 ### Community 131 - "Community 131"
-Cohesion: 0.05
-Nodes (42): execAsync, execFileAsync, firePostMergeLifecycle(), getModelsResolveRoute, getProjectPathForIssue(), getProjectSpecialistContextRoute, getProjectSpecialistGraceRoute, getProjectSpecialistLatestLogRoute (+34 more)
+Cohesion: 0.06
+Nodes (31): applyTierAwareFallback(), detectEnabledProviders(), ENRICHMENT_TIER_MAX_MESSAGES, EnrichmentTier, EnrichmentTierConfig, FALLBACK_MAP, filterAvailableModels(), getAvailableModels() (+23 more)
 
 ### Community 132 - "Community 132"
-Cohesion: 0.08
-Nodes (35): resolveWorkTypeKey(), useResolvedModels(), activityToStatus(), capitalize(), deriveDotStatus(), deriveSessionLabel(), deriveSessionModel(), describePresence() (+27 more)
-
-### Community 133 - "Community 133"
 Cohesion: 0.06
 Nodes (39): assertExistingPathInsideRoot(), assertWritePathInsideRoot(), BriefRequestBody, decodeFlywheelRunId, decodeFlywheelStatus, FlywheelActionDeps, flywheelRouteLayer, FlywheelStatusResponse (+31 more)
 
-### Community 134 - "Community 134"
+### Community 133 - "Community 133"
 Cohesion: 0.05
-Nodes (43): After Adding Custom Skills, After Updating Panopticon, Auto-Sync, Available Targets, Backup Location, Backup Only, Backups, code:block1 (~/.panopticon/skills/          (Panopticon skills - source)) (+35 more)
+Nodes (42): execAsync, execFileAsync, firePostMergeLifecycle(), getModelsResolveRoute, getProjectPathForIssue(), getProjectSpecialistContextRoute, getProjectSpecialistGraceRoute, getProjectSpecialistLatestLogRoute (+34 more)
+
+### Community 134 - "Community 134"
+Cohesion: 0.07
+Nodes (32): InlineSparkline(), InlineSparklineProps, STATUS_ANIM_CLASS, STATUS_COLOR, STATUS_GLOW, StatusDot(), StatusDotProps, StatusDotSize (+24 more)
 
 ### Community 135 - "Community 135"
-Cohesion: 0.05
-Nodes (43): Anatomy of a Resumable Issue, Anti-Patterns, code:markdown (Description: What needs to be built and why), code:block10, code:block11, code:block12, code:markdown (Title: Fix typo in README), code:markdown (Acceptance:) (+35 more)
+Cohesion: 0.08
+Nodes (35): resolveWorkTypeKey(), useResolvedModels(), activityToStatus(), capitalize(), deriveDotStatus(), deriveSessionLabel(), deriveSessionModel(), describePresence() (+27 more)
 
 ### Community 136 - "Community 136"
 Cohesion: 0.05
-Nodes (43): Boundaries: When to Use bd vs TodoWrite, code:block1 (bd issue: "Implement user authentication" (epic)), code:block2 (Session start:), code:block3 (1. Create bd issue with current TodoWrite content), code:block4 (1. Keep bd issue for historical record), code:block5 (db-epic: "Migrate production database to PostgreSQL"), code:block6 (- [ ] Import logging library), code:block7 (- [ ] Reproduce bug) (+35 more)
+Nodes (43): After Adding Custom Skills, After Updating Panopticon, Auto-Sync, Available Targets, Backup Location, Backup Only, Backups, code:block1 (~/.panopticon/skills/          (Panopticon skills - source)) (+35 more)
 
 ### Community 137 - "Community 137"
 Cohesion: 0.05
-Nodes (43): Architectural Smells (High Confidence), Available Categories, code:bash (# If project has override skill, this skill is permanently d), code:bash (# AI will add this section if it doesn't exist, or append to), code:bash (# Edit directly), code:bash (# Remove the AI Suggestion Preferences section), code:bash (rm -rf .claude/skills/refactor-radar/), code:markdown (## Refactoring Proposal: Standardize User Entity Naming) (+35 more)
+Nodes (43): Anatomy of a Resumable Issue, Anti-Patterns, code:markdown (Description: What needs to be built and why), code:block10, code:block11, code:block12, code:markdown (Title: Fix typo in README), code:markdown (Acceptance:) (+35 more)
 
 ### Community 138 - "Community 138"
-Cohesion: 0.08
-Nodes (40): EnqueueStatusRollup, findExistingPendingTurn(), inFlightRollups, loadThreshold(), maybeTriggerStatusRollup(), pendingTurnFileName(), pendingTurnRangeKey(), readPendingTurns() (+32 more)
+Cohesion: 0.05
+Nodes (43): Boundaries: When to Use bd vs TodoWrite, code:block1 (bd issue: "Implement user authentication" (epic)), code:block2 (Session start:), code:block3 (1. Create bd issue with current TodoWrite content), code:block4 (1. Keep bd issue for historical record), code:block5 (db-epic: "Migrate production database to PostgreSQL"), code:block6 (- [ ] Import logging library), code:block7 (- [ ] Reproduce bug) (+35 more)
 
 ### Community 139 - "Community 139"
-Cohesion: 0.1
-Nodes (32): insertCostEvent(), AnthropicExtractionProvider, AnthropicCompatibleResponse, CliproxyExtractionProvider, FetchFn, extractWithProviderPolicy(), getTodayMemoryExtractionSpendUsd(), MemoryExtractionPolicyDeps (+24 more)
+Cohesion: 0.05
+Nodes (43): Architectural Smells (High Confidence), Available Categories, code:bash (# If project has override skill, this skill is permanently d), code:bash (# AI will add this section if it doesn't exist, or append to), code:bash (# Edit directly), code:bash (# Remove the AI Suggestion Preferences section), code:bash (rm -rf .claude/skills/refactor-radar/), code:markdown (## Refactoring Proposal: Standardize User Entity Naming) (+35 more)
 
 ### Community 140 - "Community 140"
-Cohesion: 0.06
-Nodes (33): markEnrichmentFailed(), buildConversationExcerpt(), buildL1Prompt(), buildL2Prompt(), buildL3Prompt(), callClaudeApi(), callClaudeApiWithConfig(), EnrichmentApiConfig (+25 more)
+Cohesion: 0.08
+Nodes (35): getHealthThresholdsMs(), AgentHealth, evaluateHealthState(), formatDuration(), generateHealthSummary(), getAgentHealth(), getAgentsNeedingAttention(), getAgentsToKill() (+27 more)
 
 ### Community 141 - "Community 141"
-Cohesion: 0.07
-Nodes (31): addCandidateRoot(), collectCandidatePaths(), extractHashFromJsonlPath(), HashResolver, projectCandidateRoots(), ResolvedWorkspace, ReverseMapCache, detectDriveType (+23 more)
+Cohesion: 0.11
+Nodes (35): destroyRemoteWorkspace(), createFlyProvider(), FlyProviderConfig, { execAsyncMock, spawnMock, mockApi }, fly, p, getRemoteProvider(), ProviderType (+27 more)
 
 ### Community 142 - "Community 142"
-Cohesion: 0.05
-Nodes (40): decode, decodeCandidate(), ev, bodyToEvent(), decodeDomainEvent, Activity, AgentChannelReply, AgentId (+32 more)
+Cohesion: 0.1
+Nodes (32): insertCostEvent(), AnthropicExtractionProvider, AnthropicCompatibleResponse, CliproxyExtractionProvider, FetchFn, extractWithProviderPolicy(), getTodayMemoryExtractionSpendUsd(), MemoryExtractionPolicyDeps (+24 more)
 
 ### Community 143 - "Community 143"
 Cohesion: 0.05
@@ -1855,11 +1859,11 @@ Cohesion: 0.07
 Nodes (30): execAsync, gatherArtifacts(), generateBasicInference(), generateMonitoringPrompt(), InferenceDocument, MonitoringAgentConfig, MonitoringAgentError, readInferenceDocument() (+22 more)
 
 ### Community 150 - "Community 150"
-Cohesion: 0.07
-Nodes (29): CloseIssueOptions, approve(), buildResult(), cancelIssueWorkflow(), clearReviewStatusStep(), close(), closeOut(), deepWipe() (+21 more)
+Cohesion: 0.09
+Nodes (39): resolvePendingDir(), EnqueueStatusRollup, findExistingPendingTurn(), inFlightRollups, loadThreshold(), maybeTriggerStatusRollup(), pendingTurnFileName(), pendingTurnRangeKey() (+31 more)
 
 ### Community 151 - "Community 151"
-Cohesion: 0.09
+Cohesion: 0.08
 Nodes (39): isRecord(), isSubagentHookPayload(), SubagentHookPayload, enqueuePipeline, getTranscriptSize, registerTranscript, response, statTranscript (+31 more)
 
 ### Community 152 - "Community 152"
@@ -1867,460 +1871,464 @@ Cohesion: 0.06
 Nodes (37): SearchFilters, SearchResult, useSearch(), UseSearchOptions, fetchIssues(), SearchModal(), SearchModalProps, mockPrefetchQuery (+29 more)
 
 ### Community 153 - "Community 153"
-Cohesion: 0.07
-Nodes (29): applyTierAwareFallback(), detectEnabledProviders(), ENRICHMENT_TIER_MAX_MESSAGES, FALLBACK_MAP, filterAvailableModels(), getAvailableModels(), getBestAnthropicAtTier(), getFallbackModel() (+21 more)
-
-### Community 154 - "Community 154"
-Cohesion: 0.07
-Nodes (35): createSpecialistHandoff(), ensureLogDir(), getLiveQueueDepth(), getSpecialistHandoffLogFile(), getSpecialistHandoffStats(), getTodaySpecialistHandoffs(), logSpecialistHandoff(), readIssueSpecialistHandoffs() (+27 more)
-
-### Community 155 - "Community 155"
 Cohesion: 0.05
 Nodes (41): Agentic, All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, Coding, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer` (+33 more)
 
-### Community 156 - "Community 156"
+### Community 154 - "Community 154"
 Cohesion: 0.05
 Nodes (41): 1. Run Diagnostics, 2. Check Configuration, 3. Check Running Services, 4. Check Skills, 5. Check Dependencies, Agents, Clean Up Old Workspaces, code:bash (pan doctor) (+33 more)
 
-### Community 157 - "Community 157"
-Cohesion: 0.06
-Nodes (35): ActivityEntry, ActivityItem(), ActivityPanel(), ActivityPanelProps, ActivityStream, applyPinWarnings(), CategoryFilter, fetchActivityREST() (+27 more)
+### Community 155 - "Community 155"
+Cohesion: 0.07
+Nodes (28): buildAnthropicMessagesUrl(), cache, CacheEntry, cacheKey(), classifyError(), classifyFetchError(), doProbe(), formatProbeError() (+20 more)
 
-### Community 158 - "Community 158"
+### Community 156 - "Community 156"
 Cohesion: 0.06
 Nodes (31): migrateConfigCommand(), MigrateConfigOptions, BACKUP_SETTINGS_PATH, convertToYamlConfig(), detectEnabledProviders(), getMigrationStatus(), hasLegacySettings(), LEGACY_SETTINGS_PATH (+23 more)
 
+### Community 157 - "Community 157"
+Cohesion: 0.09
+Nodes (33): isNoResumeValueEnabled(), formatGatingReason(), formatRestartAge(), formatRestartDuration(), formatTldrAge(), formatTldrRow(), isBootNoResumeModeActive(), issueKey() (+25 more)
+
+### Community 158 - "Community 158"
+Cohesion: 0.09
+Nodes (33): getTrackerContext(), addGitHubComment(), fetchGitHubIssue(), fetchIssueWithComments(), findLocalWorkspace(), formatComments(), getGitHubToken(), GitHubIssueResult (+25 more)
+
 ### Community 159 - "Community 159"
-Cohesion: 0.05
-Nodes (40): Automatic Setup (Recommended), Certificate Errors in Browser, code:bash (pan install), code:bash (# Install dnsmasq), code:bash (# Install dnsmasq), code:bash (cat /etc/hosts | grep pan.localhost), code:bash (# macOS), code:bash (curl -k https://pan.localhost) (+32 more)
+Cohesion: 0.07
+Nodes (26): DbMergeSetRepoRow, DbMergeSetRow, deleteMergeSet(), getAllMergeSetsFromDb(), getMergeSetFromDb(), getReposFromDb(), rowToMergeSet(), repos (+18 more)
 
 ### Community 160 - "Community 160"
-Cohesion: 0.05
-Nodes (40): 10. References, 1. Problem, 2. Goal, 3. Non-Goals, 4.1 Information Architecture, 4.2 Five Surfaces (canonical mockups), 4.3 Shared Primitives, 4.4 Verb Badges (+32 more)
+Cohesion: 0.06
+Nodes (35): ActivityEntry, ActivityItem(), ActivityPanel(), ActivityPanelProps, ActivityStream, applyPinWarnings(), CategoryFilter, fetchActivityREST() (+27 more)
 
 ### Community 161 - "Community 161"
-Cohesion: 0.05
-Nodes (40): 1. Copy Template Files, 2. Create Environment File, 3. Start Containers, 4. Verify, Add a Service, Add Environment Variables, Available Templates, By Database Needs (+32 more)
+Cohesion: 0.08
+Nodes (34): boundedAutoPresoElements(), jsonByteLength(), readElementLikes(), validateAutoPresoCanvasElements(), AutoPresoSession, ExcalidrawElementLike, autopresoRouteLayer, backToStagingRoute (+26 more)
 
 ### Community 162 - "Community 162"
-Cohesion: 0.05
-Nodes (39): AC-Driven Specialist Pipeline, Artifact Lifecycle, Automatic Beads Conversion, Can agents produce valid vBRIEF JSON reliably?, code:block1 (PRD (human, markdown)              ← requirements & intent), code:block2 (docs/prds/), code:json ({), code:json ({) (+31 more)
+Cohesion: 0.07
+Nodes (31): execAsync, getActiveSessionPath(), getAgentJsonlMtime(), getAgentJsonlPath(), getAgentPendingQuestions(), getAgentWorkspace(), getClaudeProjectDir(), getPendingQuestions() (+23 more)
 
 ### Community 163 - "Community 163"
 Cohesion: 0.05
-Nodes (37): 1. record-cost-event.js esbuild bundle broken, 2. Deacon patrolWorkAgentResolutions — getEnabledSpecialists not defined, 3. Issue ID regex missing prefixes, Bugs Found and Fixed (2026-03-20), Build Requirements, code:block1 (~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl), code:block2 (cwd: /home/eltmon/Projects/krux/workspaces/feature-krux-4), code:block5 (Claude Code Agent (tmux session)) (+29 more)
+Nodes (40): Automatic Setup (Recommended), Certificate Errors in Browser, code:bash (pan install), code:bash (# Install dnsmasq), code:bash (# Install dnsmasq), code:bash (cat /etc/hosts | grep pan.localhost), code:bash (# macOS), code:bash (curl -k https://pan.localhost) (+32 more)
 
 ### Community 164 - "Community 164"
 Cohesion: 0.05
-Nodes (39): Acceptance Criteria, API Changes, API Server, Architecture, Beads Tasks, CLI, code:block1 (~/.panopticon/specialists/), code:block2 (~/.panopticon/specialists/) (+31 more)
+Nodes (40): 10. References, 1. Problem, 2. Goal, 3. Non-Goals, 4.1 Information Architecture, 4.2 Five Surfaces (canonical mockups), 4.3 Shared Primitives, 4.4 Verb Badges (+32 more)
 
 ### Community 165 - "Community 165"
 Cohesion: 0.05
-Nodes (39): Action Items, Agentic, All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, Coding, Community Reception `[K2.6]`, Confirmed Improvements `[K2.6]`, `convoy:correctness-reviewer` (+31 more)
+Nodes (40): 1. Copy Template Files, 2. Create Environment File, 3. Start Containers, 4. Verify, Add a Service, Add Environment Variables, Available Templates, By Database Needs (+32 more)
 
 ### Community 166 - "Community 166"
-Cohesion: 0.05
-Nodes (39): 1. Create a `dev` Script, 1. Register the Project, 2. Create CLAUDE.md (Recommended), 2. Create docker-compose.yml, 3. Panopticon Integration, 3. Set Up Tracker Mapping, 4. Verify Setup, Add a Project (+31 more)
+Cohesion: 0.09
+Nodes (34): closeMemoryFtsDatabases(), createDatabase(), databases, deferSqliteWork(), getMemoryFtsDatabase(), getMemoryFtsWorker(), initializeMemoryFtsSchema(), isBunRuntime() (+26 more)
 
 ### Community 167 - "Community 167"
 Cohesion: 0.05
-Nodes (39): 1. Isolate High-Volume Operations, 2. Parallel Research, 3. Cost Optimization, 4. Security Boundaries, Built-in Subagents, CLI-Defined Subagents, code:markdown (---), code:markdown (---) (+31 more)
+Nodes (39): AC-Driven Specialist Pipeline, Artifact Lifecycle, Automatic Beads Conversion, Can agents produce valid vBRIEF JSON reliably?, code:block1 (PRD (human, markdown)              ← requirements & intent), code:block2 (docs/prds/), code:json ({), code:json ({) (+31 more)
 
 ### Community 168 - "Community 168"
-Cohesion: 0.08
-Nodes (24): showHelp(), startCommand(), statusCommand(), stopCommand(), tldrCommand(), TldrOptions, warmCommand(), captureTldrMetrics() (+16 more)
+Cohesion: 0.05
+Nodes (37): 1. record-cost-event.js esbuild bundle broken, 2. Deacon patrolWorkAgentResolutions — getEnabledSpecialists not defined, 3. Issue ID regex missing prefixes, Bugs Found and Fixed (2026-03-20), Build Requirements, code:block1 (~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl), code:block2 (cwd: /home/eltmon/Projects/krux/workspaces/feature-krux-4), code:block5 (Claude Code Agent (tmux session)) (+29 more)
 
 ### Community 169 - "Community 169"
-Cohesion: 0.07
-Nodes (27): createClaudeCodeRuntime(), getGlobalRegistry(), getRuntime(), getRuntimeForAgent(), RuntimeRegistry, setGlobalRegistry(), createPiRuntime(), PiSpawnTimeout (+19 more)
+Cohesion: 0.05
+Nodes (39): Acceptance Criteria, API Changes, API Server, Architecture, Beads Tasks, CLI, code:block1 (~/.panopticon/specialists/), code:block2 (~/.panopticon/specialists/) (+31 more)
 
 ### Community 170 - "Community 170"
 Cohesion: 0.05
-Nodes (30): defect, defectQuery, feature, featureQuery, featureWithEmptyState, featureWithObjectState, featureWithPartialState, mockCreate (+22 more)
+Nodes (39): Action Items, Agentic, All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, Coding, Community Reception `[K2.6]`, Confirmed Improvements `[K2.6]`, `convoy:correctness-reviewer` (+31 more)
 
 ### Community 171 - "Community 171"
-Cohesion: 0.06
-Nodes (26): StandaloneTerminal(), StandaloneTerminalProps, ContextMenuState, isMac, TERMINAL_PROFILE_ENABLED, TerminalSizeMessage, TerminalSnapshotMessage, checkbox (+18 more)
+Cohesion: 0.05
+Nodes (39): 1. Create a `dev` Script, 1. Register the Project, 2. Create CLAUDE.md (Recommended), 2. Create docker-compose.yml, 3. Panopticon Integration, 3. Set Up Tracker Mapping, 4. Verify Setup, Add a Project (+31 more)
 
 ### Community 172 - "Community 172"
 Cohesion: 0.05
-Nodes (38): 1. Read Enforcer (`PreToolUse` on `Read`), 2. Post-Edit Notify (`PostToolUse` on `Edit|Write`), 3. MCP Server, Architecture, Build Triggers, CLI Commands, code:block1 (PROJECT ROOT (main branch)), code:block2 (┌─────────────────────────┐) (+30 more)
+Nodes (39): 1. Isolate High-Volume Operations, 2. Parallel Research, 3. Cost Optimization, 4. Security Boundaries, Built-in Subagents, CLI-Defined Subagents, code:markdown (---), code:markdown (---) (+31 more)
 
 ### Community 173 - "Community 173"
-Cohesion: 0.05
-Nodes (38): Before Production, code:typescript (cache.lastEventLine += events.length;), code:block2 (events.jsonl has lines 0-104 (105 total lines)), code:javascript (const agentId = process.env.PANOPTICON_AGENT_ID ||), code:typescript (const content = events.map(e => JSON.stringify(e)).join('\n'), code:typescript (const content = events.length > 0), code:block6 (Process A writes: {"ts":"2026...), Critical Bugs Found in PAN-81 Implementation (+30 more)
+Cohesion: 0.08
+Nodes (24): showHelp(), startCommand(), statusCommand(), stopCommand(), tldrCommand(), TldrOptions, warmCommand(), captureTldrMetrics() (+16 more)
 
 ### Community 174 - "Community 174"
 Cohesion: 0.05
-Nodes (38): 10. JSONL Session File Format & Access, #10 — JSONL Session File Format & Access, 11. Specialist Event File Protocol, #11 — Specialist Event File Protocol, 12. Heartbeat File Deprecation Plan, #12 — Heartbeat File Deprecation Plan, 13. Backwards Compatibility During Migration, #13 — Backwards Compatibility During Migration (+30 more)
+Nodes (30): defect, defectQuery, feature, featureQuery, featureWithEmptyState, featureWithObjectState, featureWithPartialState, mockCreate (+22 more)
 
 ### Community 175 - "Community 175"
-Cohesion: 0.05
-Nodes (38): Agentic, All subagents (`explore`, `plan`, `bash`, `general-purpose`), Benchmark Credibility Note, `cli:interactive` and `cli:quick-command`, Coding, Composite, `convoy:correctness-reviewer`, `convoy:performance-reviewer` (+30 more)
+Cohesion: 0.06
+Nodes (26): StandaloneTerminal(), StandaloneTerminalProps, ContextMenuState, isMac, TERMINAL_PROFILE_ENABLED, TerminalSizeMessage, TerminalSnapshotMessage, checkbox (+18 more)
 
 ### Community 176 - "Community 176"
-Cohesion: 0.05
-Nodes (38): code:block1 ([completed] Implement login endpoint), code:bash (bd update oauth-5 --notes "COMPLETED: Token refresh endpoint), code:bash (bd create "Q4 strategic planning document" -t task -p 0), code:bash (bd update strat-1 --notes "COMPLETED: Research phase (review), code:block13 (- [ ] Draft recommendation 1: Market expansion), code:bash (bd create "Refactor auth system to use JWT" -t epic -p 0), code:block15 (Current: login-1), code:bash (bd close login-1 --reason "Updated to JWT. Tests passing. Ba) (+30 more)
+Cohesion: 0.08
+Nodes (28): CloseOutContext, CloseOutError, CloseOutResult, CloseOutStep, execAsync, executeCloseOut(), findWorkspacePath(), isBranchMerged() (+20 more)
 
 ### Community 177 - "Community 177"
-Cohesion: 0.09
-Nodes (33): createDatabase(), databases, deferSqliteWork(), getMemoryFtsDatabase(), getMemoryFtsWorker(), initializeMemoryFtsSchema(), isBunRuntime(), MemoryFtsStatement (+25 more)
+Cohesion: 0.05
+Nodes (38): 1. Read Enforcer (`PreToolUse` on `Read`), 2. Post-Edit Notify (`PostToolUse` on `Edit|Write`), 3. MCP Server, Architecture, Build Triggers, CLI Commands, code:block1 (PROJECT ROOT (main branch)), code:block2 (┌─────────────────────────┐) (+30 more)
 
 ### Community 178 - "Community 178"
 Cohesion: 0.05
-Nodes (37): 1. ChatMarkdown, 2. MessagesTimeline, 3. JSONL Parser (server-side), 4. ComposerPromptEditor, 5. ModelPicker, 6. EffortPicker, 7. SendButton + Message Submission, 8. ConversationPanel (wrapper) (+29 more)
+Nodes (38): Before Production, code:typescript (cache.lastEventLine += events.length;), code:block2 (events.jsonl has lines 0-104 (105 total lines)), code:javascript (const agentId = process.env.PANOPTICON_AGENT_ID ||), code:typescript (const content = events.map(e => JSON.stringify(e)).join('\n'), code:typescript (const content = events.length > 0), code:block6 (Process A writes: {"ts":"2026...), Critical Bugs Found in PAN-81 Implementation (+30 more)
 
 ### Community 179 - "Community 179"
 Cohesion: 0.05
-Nodes (36): 1. CommentMediator Service, 2. Author Filtering, 3. Content Classifier, 4. Summarizer, 5. Retrofit `getTrackerContext()`, 6. Quarantine Storage & Dashboard, 7. Gated Full-Text Tool, 8. Configuration (+28 more)
+Nodes (38): 10. JSONL Session File Format & Access, #10 — JSONL Session File Format & Access, 11. Specialist Event File Protocol, #11 — Specialist Event File Protocol, 12. Heartbeat File Deprecation Plan, #12 — Heartbeat File Deprecation Plan, 13. Backwards Compatibility During Migration, #13 — Backwards Compatibility During Migration (+30 more)
 
 ### Community 180 - "Community 180"
 Cohesion: 0.05
-Nodes (37): Audit Completeness, Category: Agent Lifecycle, Category: Delivery Confirmation, Category: Git Pattern Scanning (Merge Agent), Category: Health Checks (No Pattern Scanning), Category: Health & Stuck Detection (Deacon), Category: Model & Metadata Extraction, Category: Readiness Detection (+29 more)
+Nodes (38): Agentic, All subagents (`explore`, `plan`, `bash`, `general-purpose`), Benchmark Credibility Note, `cli:interactive` and `cli:quick-command`, Coding, Composite, `convoy:correctness-reviewer`, `convoy:performance-reviewer` (+30 more)
 
 ### Community 181 - "Community 181"
 Cohesion: 0.05
-Nodes (37): 1. Triggered After Test Pass, 2. UAT Specialist Receives Context, 3. UAT Specialist Runs Verification, 4. UAT Specialist Reports, Auth Flow, code:block1 (Agent → Inspect (per-bead) → Review (full MR) → Test (suite)), code:typescript (// After test passes, queue UAT), code:block11 (Agent finishes bead → Inspect (bead diff)    → PASS → next b) (+29 more)
+Nodes (38): code:block1 ([completed] Implement login endpoint), code:bash (bd update oauth-5 --notes "COMPLETED: Token refresh endpoint), code:bash (bd create "Q4 strategic planning document" -t task -p 0), code:bash (bd update strat-1 --notes "COMPLETED: Research phase (review), code:block13 (- [ ] Draft recommendation 1: Market expansion), code:bash (bd create "Refactor auth system to use JWT" -t epic -p 0), code:block15 (Current: login-1), code:bash (bd close login-1 --reason "Updated to JWT. Tests passing. Ba) (+30 more)
 
 ### Community 182 - "Community 182"
-Cohesion: 0.05
-Nodes (37): Advanced Features, bd vs TodoWrite, Beads - Persistent Task Memory for AI Agents, CLI Reference, Close & Reopen, code:bash (# Link beads issue to GitHub issue PAN-84), code:bash (bd label add <id> <label> --json), code:bash (bd show <id> --json              # Full issue details) (+29 more)
+Cohesion: 0.08
+Nodes (33): eventsFileExists(), AgentContext, findSessionDirsByIssue(), getAgentsDir(), getClaudeProjectsDir(), getProjectPaths(), getProjectsYamlPath(), getSessionDir() (+25 more)
 
 ### Community 183 - "Community 183"
 Cohesion: 0.05
-Nodes (37): Arguments, Auto-Detection (when no wrapper config), code:block1 (1. Check: Does ~/.panopticon/skills/spec-readiness-*/config.), code:block10 (## Bug Analysis), code:block11 (Read spec-readiness-{identifier}.json), code:block12 (spec readiness MIN-704), code:yaml (# ~/.panopticon/skills/spec-readiness-mycompany/config.yaml), code:block3 (get_issue         → mcp__linear__get_issue(id, includeRelati) (+29 more)
+Nodes (37): 1. ChatMarkdown, 2. MessagesTimeline, 3. JSONL Parser (server-side), 4. ComposerPromptEditor, 5. ModelPicker, 6. EffortPicker, 7. SendButton + Message Submission, 8. ConversationPanel (wrapper) (+29 more)
 
 ### Community 184 - "Community 184"
-Cohesion: 0.09
-Nodes (25): BeadsTask, COMPLEXITY_KEYWORDS, COMPLEXITY_LABELS, ComplexityDetectionResult, ComplexityLevel, complexityToModel(), detectComplexity(), detectComplexityFromEstimate() (+17 more)
+Cohesion: 0.05
+Nodes (36): 1. CommentMediator Service, 2. Author Filtering, 3. Content Classifier, 4. Summarizer, 5. Retrofit `getTrackerContext()`, 6. Quarantine Storage & Dashboard, 7. Gated Full-Text Tool, 8. Configuration (+28 more)
 
 ### Community 185 - "Community 185"
-Cohesion: 0.09
-Nodes (35): BudgetKey, buildContext(), CandidateContext, countHits(), emptyAllocations(), emptyHitCounts(), escapeJsonForPrompt(), estimateTokens() (+27 more)
+Cohesion: 0.05
+Nodes (37): Audit Completeness, Category: Agent Lifecycle, Category: Delivery Confirmation, Category: Git Pattern Scanning (Merge Agent), Category: Health Checks (No Pattern Scanning), Category: Health & Stuck Detection (Deacon), Category: Model & Metadata Extraction, Category: Readiness Detection (+29 more)
 
 ### Community 186 - "Community 186"
-Cohesion: 0.07
-Nodes (33): registerFlywheelCommands(), getFlywheelConversationPayload(), postFlywheelPausePayload(), postFlywheelResumePayload(), postFlywheelStartPayload(), subscribeLatestFlywheelStatus(), abort, aborted (+25 more)
+Cohesion: 0.05
+Nodes (37): 1. Triggered After Test Pass, 2. UAT Specialist Receives Context, 3. UAT Specialist Runs Verification, 4. UAT Specialist Reports, Auth Flow, code:block1 (Agent → Inspect (per-bead) → Review (full MR) → Test (suite)), code:typescript (// After test passes, queue UAT), code:block11 (Agent finishes bead → Inspect (bead diff)    → PASS → next b) (+29 more)
 
 ### Community 187 - "Community 187"
-Cohesion: 0.11
-Nodes (36): reconcileClosedPrReadyForMerge(), reconcileFalseMerged(), apiCatch(), APP_DIR, configureWorkspaceForBot(), execAsync, generateInstallationToken(), generateInstallationTokenEffect() (+28 more)
+Cohesion: 0.05
+Nodes (37): Advanced Features, bd vs TodoWrite, Beads - Persistent Task Memory for AI Agents, CLI Reference, Close & Reopen, code:bash (# Link beads issue to GitHub issue PAN-84), code:bash (bd label add <id> <label> --json), code:bash (bd show <id> --json              # Full issue details) (+29 more)
 
 ### Community 188 - "Community 188"
 Cohesion: 0.05
-Nodes (36): 1. All-Up Skill, 2. Awaiting Merge Page, 3. Workflow Orchestration Visibility, Acceptance Criteria, Architecture, Awaiting Merge Page Spec, Behavior, Benefits (+28 more)
+Nodes (37): Arguments, Auto-Detection (when no wrapper config), code:block1 (1. Check: Does ~/.panopticon/skills/spec-readiness-*/config.), code:block10 (## Bug Analysis), code:block11 (Read spec-readiness-{identifier}.json), code:block12 (spec readiness MIN-704), code:yaml (# ~/.panopticon/skills/spec-readiness-mycompany/config.yaml), code:block3 (get_issue         → mcp__linear__get_issue(id, includeRelati) (+29 more)
 
 ### Community 189 - "Community 189"
+Cohesion: 0.07
+Nodes (33): registerFlywheelCommands(), getFlywheelConversationPayload(), postFlywheelPausePayload(), postFlywheelResumePayload(), postFlywheelStartPayload(), subscribeLatestFlywheelStatus(), abort, aborted (+25 more)
+
+### Community 190 - "Community 190"
+Cohesion: 0.09
+Nodes (25): BeadsTask, COMPLEXITY_KEYWORDS, COMPLEXITY_LABELS, ComplexityDetectionResult, ComplexityLevel, complexityToModel(), detectComplexity(), detectComplexityFromEstimate() (+17 more)
+
+### Community 191 - "Community 191"
+Cohesion: 0.11
+Nodes (36): reconcileClosedPrReadyForMerge(), reconcileFalseMerged(), apiCatch(), APP_DIR, configureWorkspaceForBot(), execAsync, generateInstallationToken(), generateInstallationTokenEffect() (+28 more)
+
+### Community 192 - "Community 192"
+Cohesion: 0.08
+Nodes (31): closeOutCommand(), CloseOutOptions, execFileAsync, getGitHubConfig(), readGitHubCanonicalState(), AutoCreateStateConfig, CANONICAL_STATES, CanonicalState (+23 more)
+
+### Community 193 - "Community 193"
+Cohesion: 0.06
+Nodes (10): ConfigError, FlyApiClient, FlyApiError, FlyExecResult, FlyMachine, FlyMachineConfig, client, fetchMock (+2 more)
+
+### Community 194 - "Community 194"
+Cohesion: 0.08
+Nodes (26): execAsync, rebaseFeatureBranch(), RebaseResult, openBrowser(), runCommand(), ClaudeAuthStatus, getClaudeAuthStatusImpl, parseOAuthPayload() (+18 more)
+
+### Community 195 - "Community 195"
+Cohesion: 0.09
+Nodes (35): BudgetKey, buildContext(), CandidateContext, countHits(), emptyAllocations(), emptyHitCounts(), escapeJsonForPrompt(), estimateTokens() (+27 more)
+
+### Community 196 - "Community 196"
+Cohesion: 0.06
+Nodes (26): RoundMarker, ZoneCConversation(), ZoneCConversationProps, deriveRoundMarkers(), TimestampedItem, getViewKey(), PanelView, readView() (+18 more)
+
+### Community 197 - "Community 197"
+Cohesion: 0.06
+Nodes (36): Activity, AgentChannelReply, AgentId, AgentResolution, AgentStatus, CHANNEL_REPLY_KIND_VALUES, ChannelReplyArtifactRef, ChannelReplyKind (+28 more)
+
+### Community 198 - "Community 198"
+Cohesion: 0.05
+Nodes (36): 1. All-Up Skill, 2. Awaiting Merge Page, 3. Workflow Orchestration Visibility, Acceptance Criteria, Architecture, Awaiting Merge Page Spec, Behavior, Benefits (+28 more)
+
+### Community 199 - "Community 199"
 Cohesion: 0.05
 Nodes (35): 1. Identity key and registry shape, 1. Per-project singleton baked in at three places, 2. Inverted model priority — hidden Sonnet default, 2. Model resolution — authoritative chain + resolution trace, 3. PAN-540 convoy reviewers in the registry, 3. PAN-540 convoy reviewers invisible, 4. Duplicate-tab risk on shared worktree, 4. Single-writer-per-worktree enforcement (+27 more)
 
-### Community 190 - "Community 190"
+### Community 200 - "Community 200"
 Cohesion: 0.05
 Nodes (36): Closure Checklist, Closure Pattern, code:bash ($ bd ready), code:bash (bd list --status in_progress), code:bash (bd show issue-id), code:block12 ("From bd notes: [summary of COMPLETED]. Currently [IN PROGRE), code:block13 (Issue: bd-42 "OAuth refresh token implementation"), code:block14 (- [ ] Implement rate limiting on refresh endpoint) (+28 more)
 
-### Community 191 - "Community 191"
+### Community 201 - "Community 201"
 Cohesion: 0.05
 Nodes (35): API Commands, code:bash (gh issue list --state open --limit 50), code:bash (gh pr merge 456 --squash --delete-branch), code:bash (gh pr close 456), code:bash (gh pr checkout 456), code:bash (# Get PR comments), code:bash (gh issue list -R eltmon/panopticon-cli), code:bash (gh issue view 123) (+27 more)
 
-### Community 192 - "Community 192"
-Cohesion: 0.1
-Nodes (29): isNoResumeValueEnabled(), NO_RESUME_MODE_ACTIVE, TRUTHY_NO_RESUME_VALUES, formatGatingReason(), formatRestartAge(), formatRestartDuration(), formatTldrAge(), formatTldrRow() (+21 more)
-
-### Community 193 - "Community 193"
-Cohesion: 0.08
-Nodes (21): configShadowCommand(), ShadowOptions, PanopticonConfig, ENV_FILE_PATH, getShadowModeFromEnv(), loadPanopticonEnv(), parseEnvFile(), getShadowModeStatus() (+13 more)
-
-### Community 194 - "Community 194"
+### Community 202 - "Community 202"
 Cohesion: 0.1
 Nodes (28): acquireRestartLock(), acquireStaleBreaker(), isErrnoException(), isProcessAlive(), isStale(), readHolderFromPath(), readRestartLockHolder(), RestartLockError (+20 more)
 
-### Community 195 - "Community 195"
-Cohesion: 0.08
-Nodes (23): execAsync, rebaseFeatureBranch(), RebaseResult, openBrowser(), runCommand(), ClaudeAuthStatus, getClaudeAuthStatusImpl, parseOAuthPayload() (+15 more)
+### Community 203 - "Community 203"
+Cohesion: 0.1
+Nodes (3): stopDeacon(), CloisterService, writeStateFile()
 
-### Community 196 - "Community 196"
+### Community 204 - "Community 204"
 Cohesion: 0.07
-Nodes (22): countCompleteLines(), defaultTranscriptPoller, isSuccessfulExtractionResult(), RegisteredTranscript, registerTranscriptForPolling(), startTranscriptPoller(), syncTranscriptPollerRegistry(), activeA (+14 more)
+Nodes (18): SessionUsage, emptyUsage(), isAssistantMessage(), isMessage(), KNOWN_TYPES, parsePiSession(), parsePiSessionContent(), ParseResult (+10 more)
 
-### Community 197 - "Community 197"
-Cohesion: 0.07
-Nodes (30): fetchSettings(), isIssueTtsMuted(), normalizeIssueId(), putSettings(), setIssueTtsMuted(), fetchMock, muted, putCall (+22 more)
+### Community 205 - "Community 205"
+Cohesion: 0.1
+Nodes (26): addEventToCache(), CostCache, createEmptyCache(), getCacheFile(), getCacheStatus(), getCostsByIssue(), getCostsDir(), getCostsForIssue() (+18 more)
 
-### Community 198 - "Community 198"
+### Community 206 - "Community 206"
 Cohesion: 0.12
 Nodes (35): buildReleaseNotesMarkdown(), contractsPackageJsonPath, desktopPackageJsonPath, __dirname, ensureCleanTree(), ensureMainBranch(), ensureTagDoesNotExist(), __filename (+27 more)
 
-### Community 199 - "Community 199"
-Cohesion: 0.08
-Nodes (31): agentDir, missing, snapshot, status, discoverNewAgentIds(), Jsonish, ReadModelServiceShape, ReviewStatusSnapshotInput (+23 more)
-
-### Community 200 - "Community 200"
+### Community 207 - "Community 207"
 Cohesion: 0.06
 Nodes (35): Adding Repos Mid-Work, Agent Skill: `/workspace-add-repo`, Architecture, code:typescript (export interface WorkspaceConfig {), code:block10, code:block11 (## Readonly Repos), code:typescript (// CURRENT: create worktree for every repo), code:typescript (// NEW: respect progressive mode) (+27 more)
 
-### Community 201 - "Community 201"
+### Community 208 - "Community 208"
 Cohesion: 0.06
 Nodes (35): Bug Tracking During Oversight, code:block1 (/pan-oversee PAN-129), code:bash (# Manually trigger review), code:bash (# Check specialist status), code:bash (# Wake it manually), code:bash (# Check if work agent received feedback), code:bash (# Check test status), code:bash (# Final status check) (+27 more)
 
-### Community 202 - "Community 202"
-Cohesion: 0.11
-Nodes (32): sshCommand(), CHUNK_BUDGET_CHARS_BY_MODEL, chunkEntriesByBudget(), CompactionOptions, CompactionResult, computeFileLists(), createFileOps(), CutPointResult (+24 more)
-
-### Community 204 - "Community 204"
-Cohesion: 0.09
-Nodes (31): HandoffContext, createHandoffEvent(), ensureLogDir(), ensureLogDirAsync(), getHandoffStats(), getPendingVerificationHandoffs(), getPendingVerificationHandoffsEffect(), HANDOFF_LOG_FILE (+23 more)
-
-### Community 205 - "Community 205"
-Cohesion: 0.07
-Nodes (29): AgentDetailView(), AgentDetailViewProps, AgentHealthHistory, fetchHealthHistory(), fetchSpecialists(), formatDuration(), formatTokens(), HEALTH_STATE_EMOJI (+21 more)
-
-### Community 206 - "Community 206"
-Cohesion: 0.08
-Nodes (27): InlineSparkline(), InlineSparklineProps, STATUS_ANIM_CLASS, STATUS_COLOR, STATUS_GLOW, StatusDot(), StatusDotProps, StatusDotSize (+19 more)
-
-### Community 207 - "Community 207"
-Cohesion: 0.12
-Nodes (32): decodeFlywheelRunId, defaultFlywheelPrompt(), defaultFlywheelRunId(), FlywheelLifecycleOptions, FlywheelPauseResult, FlywheelResumeResult, getLocalFlywheelRunDir(), isFlywheelDevcontainerRuntime() (+24 more)
-
-### Community 208 - "Community 208"
-Cohesion: 0.06
-Nodes (34): Authentication failure, Build and push, Building the pan-workspace Image, code:bash (curl -L https://fly.io/install.sh | sh), code:bash (pan workspace delete PAN-42), code:bash (# Tunnel remote port 4173 to local port 4173), code:bash (pan workspace sync-auth PAN-42), code:bash (# Via the dashboard UI (Costs tab)) (+26 more)
-
 ### Community 209 - "Community 209"
-Cohesion: 0.06
-Nodes (34): 1. Filesystem: `.claude/agents/<name>.md`, 2. CLI JSON: `--agents '{"name":{...}}'`, 3. Hybrid: Filesystem base + CLI `--model` override, Agent Definition Format (Full Spec), Agent Teams: Out of Scope, Architecture: Three Injection Paths, `claude agents` Has No JSON Output, code:yaml (---) (+26 more)
+Cohesion: 0.07
+Nodes (32): cleanupOldHealthEvents(), DatabaseError, deleteAgentHealthHistory(), getAgentsWithHistory(), getAllHealthHistory(), getHealthHistory(), getLatestHealthEvent(), getRecentHealthHistory() (+24 more)
 
 ### Community 210 - "Community 210"
 Cohesion: 0.06
-Nodes (34): 1. Agent Triggers Inspection (Only When Flagged), 2. Inspect Specialist Runs, 3. Inspect Specialist Reports, 4. Checkpoint System, Agent Workflow Integration, Check 1: Spec Fidelity, Check 2: Constraint Compliance, Check 3: Compile + Smoke (+26 more)
+Nodes (32): cb, completedState, dispatched, featureWorkspace, ghArgs, ghExecFileMock, { handler, dispose }, implSlot (+24 more)
 
 ### Community 211 - "Community 211"
-Cohesion: 0.06
-Nodes (34): 1. Configuration Ownership, 2. Implementation Scope, 3. API Key Storage, 4. Complexity Routing, Acceptance Criteria Checklist, Agent Spawning Changes, Architecture, code:block1 (~/.panopticon/) (+26 more)
-
-### Community 212 - "Community 212"
-Cohesion: 0.06
-Nodes (34): `cli:interactive` and `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit, Gemini 3 Flash Preview Work Type Fit Analysis (+26 more)
-
-### Community 213 - "Community 213"
-Cohesion: 0.06
-Nodes (34): `cli:interactive`, `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit (+26 more)
-
-### Community 214 - "Community 214"
-Cohesion: 0.06
-Nodes (34): Agent States, code:bash (# List recent boots — the previous boot (-1) is the crashed ), code:bash (# Check .pan/continue.json for each workspace), code:bash (# Current memory usage), code:markdown (## Crash Summary), code:typescript (pool: 'forks',), code:bash (# All OOM events from the crashed boot), code:bash (# Find the process table dump from the first OOM event) (+26 more)
-
-### Community 215 - "Community 215"
 Cohesion: 0.09
 Nodes (31): activeViolations, checkAgentForViolations(), clearOldViolations(), clearOldViolationsEffect(), DEFAULT_FPP_CONFIG, FPPViolation, FPPViolationConfig, FPPViolationType (+23 more)
 
-### Community 216 - "Community 216"
+### Community 212 - "Community 212"
 Cohesion: 0.07
-Nodes (27): AVATAR_TONE_CLASSES, avatarInitials(), hashString(), IssueRow(), IssueRowAgent, IssueRowAssignee, IssueRowLedger, IssueRowPriority (+19 more)
+Nodes (29): AgentDetailView(), AgentDetailViewProps, AgentHealthHistory, fetchHealthHistory(), fetchSpecialists(), formatDuration(), formatTokens(), HEALTH_STATE_EMOJI (+21 more)
+
+### Community 213 - "Community 213"
+Cohesion: 0.06
+Nodes (34): Authentication failure, Build and push, Building the pan-workspace Image, code:bash (curl -L https://fly.io/install.sh | sh), code:bash (pan workspace delete PAN-42), code:bash (# Tunnel remote port 4173 to local port 4173), code:bash (pan workspace sync-auth PAN-42), code:bash (# Via the dashboard UI (Costs tab)) (+26 more)
+
+### Community 214 - "Community 214"
+Cohesion: 0.06
+Nodes (34): 1. Filesystem: `.claude/agents/<name>.md`, 2. CLI JSON: `--agents '{"name":{...}}'`, 3. Hybrid: Filesystem base + CLI `--model` override, Agent Definition Format (Full Spec), Agent Teams: Out of Scope, Architecture: Three Injection Paths, `claude agents` Has No JSON Output, code:yaml (---) (+26 more)
+
+### Community 215 - "Community 215"
+Cohesion: 0.06
+Nodes (34): 1. Agent Triggers Inspection (Only When Flagged), 2. Inspect Specialist Runs, 3. Inspect Specialist Reports, 4. Checkpoint System, Agent Workflow Integration, Check 1: Spec Fidelity, Check 2: Constraint Compliance, Check 3: Compile + Smoke (+26 more)
+
+### Community 216 - "Community 216"
+Cohesion: 0.06
+Nodes (34): 1. Configuration Ownership, 2. Implementation Scope, 3. API Key Storage, 4. Complexity Routing, Acceptance Criteria Checklist, Agent Spawning Changes, Architecture, code:block1 (~/.panopticon/) (+26 more)
 
 ### Community 217 - "Community 217"
 Cohesion: 0.06
-Nodes (29): ClaudeMessageWithCwd, ClaudeUsage, ContentBlock, FILE_TOOLS, parseSessionJsonl(), SessionMetadata, corruptLines, file (+21 more)
+Nodes (34): `cli:interactive` and `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit, Gemini 3 Flash Preview Work Type Fit Analysis (+26 more)
 
 ### Community 218 - "Community 218"
-Cohesion: 0.1
-Nodes (31): doneCommand(), DoneOptions, execAsync, getGitHubConfig(), isMergeSetMergedIntoTargets(), updateGitHubToInReview(), updateLinearToInReview(), AutoCreateStateConfig (+23 more)
+Cohesion: 0.06
+Nodes (34): `cli:interactive`, `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit (+26 more)
 
 ### Community 219 - "Community 219"
 Cohesion: 0.06
-Nodes (33): 1. Upgrade CanonicalState to 9-State vBRIEF Lifecycle, 2. vBRIEF Lifecycle Folders, 3. `pan install` Bootstraps Deft, 4. Layered Rule Hierarchy for Agent Prompts, 5. Deterministic Gates in Cloister Pipeline, 6. Structured Planning Strategies, 7. Swarm Integration, 8. Issue Ingestion and Reconciliation (+25 more)
+Nodes (34): Agent States, code:bash (# List recent boots — the previous boot (-1) is the crashed ), code:bash (# Check .pan/continue.json for each workspace), code:bash (# Current memory usage), code:markdown (## Crash Summary), code:typescript (pool: 'forks',), code:bash (# All OOM events from the crashed boot), code:bash (# Find the process table dump from the first OOM event) (+26 more)
 
 ### Community 220 - "Community 220"
-Cohesion: 0.06
-Nodes (31): `AgentStateService` — the single interface, Architectural principle, Backpressure, code:block1 (writers                          canonical state            ), code:typescript (// in AgentSnapshot Schema.Struct, add:), code:typescript (export const AgentActivityChanged = Schema.Struct({), code:typescript (export const AgentStateRestored = Schema.Struct({), code:typescript (// inside applyEvent switch, representative case:) (+23 more)
+Cohesion: 0.07
+Nodes (23): SearchResult, DiscoveredSession, AgentIssueLookup, AgentIssueRecord, buildAgentIssueLookup(), buildEnrichSessionsJobPayload(), EnrichSessionsRpcInput, filterDomainEventForIssue() (+15 more)
 
 ### Community 221 - "Community 221"
 Cohesion: 0.06
-Nodes (33): 10. Preserve power-user trust, 1. Replace the current page shell with a coherent settings shell, 2. Introduce reusable settings primitives, 3. Reorganize the settings information architecture, 4. Add explicit local settings navigation, 5. Redesign Providers into summary-first expandable management panels, 6. Redesign Model Routing around presets + overrides, not a wall of tiles, 7. Normalize Conversations, Terminal, Tracker Keys, Appearance, Maintenance, and Desktop sections into the shared system (+25 more)
+Nodes (33): 1. Upgrade CanonicalState to 9-State vBRIEF Lifecycle, 2. vBRIEF Lifecycle Folders, 3. `pan install` Bootstraps Deft, 4. Layered Rule Hierarchy for Agent Prompts, 5. Deterministic Gates in Cloister Pipeline, 6. Structured Planning Strategies, 7. Swarm Integration, 8. Issue Ingestion and Reconciliation (+25 more)
 
 ### Community 222 - "Community 222"
 Cohesion: 0.06
-Nodes (32): 1. mem0 Overview, 2. Architecture, 3. Key Technical Details, 4. Managed Platform vs Open Source, 5. Performance Claims, 6. Panopticon Adoption Analysis, 7. References, AI Memory Layer Research: mem0 and Adoption Strategy for Panopticon (+24 more)
+Nodes (31): `AgentStateService` — the single interface, Architectural principle, Backpressure, code:block1 (writers                          canonical state            ), code:typescript (// in AgentSnapshot Schema.Struct, add:), code:typescript (export const AgentActivityChanged = Schema.Struct({), code:typescript (export const AgentStateRestored = Schema.Struct({), code:typescript (// inside applyEvent switch, representative case:) (+23 more)
 
 ### Community 223 - "Community 223"
 Cohesion: 0.06
-Nodes (33): 1. Public bootstrap/health/config endpoints, 2. Inspect the deployed frontend bundle, 3. SSH and inspect runtime directly, code:bash (pan remote setup), code:bash (fly auth whoami), code:bash (pan remote status), code:bash (fly proxy 4173:4173 -a <app>), code:bash (fly status -a <app>) (+25 more)
+Nodes (33): 10. Preserve power-user trust, 1. Replace the current page shell with a coherent settings shell, 2. Introduce reusable settings primitives, 3. Reorganize the settings information architecture, 4. Add explicit local settings navigation, 5. Redesign Providers into summary-first expandable management panels, 6. Redesign Model Routing around presets + overrides, not a wall of tiles, 7. Normalize Conversations, Terminal, Tracker Keys, Appearance, Maintenance, and Desktop sections into the shared system (+25 more)
 
 ### Community 224 - "Community 224"
 Cohesion: 0.06
-Nodes (33): 1. Find the Agent Session, 2. Check Current Agent Status, 3. Send Your Message, 4. Verify Message Was Received, Change Priorities, code:bash (# ALWAYS use pan tell - it handles Enter correctly), code:bash (pan tell ISSUE-123 "Looks good! Please commit your changes a), code:bash (# List all sessions to find the correct name) (+25 more)
+Nodes (32): 1. mem0 Overview, 2. Architecture, 3. Key Technical Details, 4. Managed Platform vs Open Source, 5. Performance Claims, 6. Panopticon Adoption Analysis, 7. References, AI Memory Layer Research: mem0 and Adoption Strategy for Panopticon (+24 more)
 
 ### Community 225 - "Community 225"
 Cohesion: 0.06
-Nodes (33): Backend Frameworks, code:yaml (projects:), code:bash (# Rebuild one workspace Docker stack from the configured com), code:bash (# Create workspace (uses configuration from projects.yaml)), code:yaml (services:), code:yaml (projects:), code:yaml (projects:), code:yaml (projects:) (+25 more)
+Nodes (33): 1. Public bootstrap/health/config endpoints, 2. Inspect the deployed frontend bundle, 3. SSH and inspect runtime directly, code:bash (pan remote setup), code:bash (fly auth whoami), code:bash (pan remote status), code:bash (fly proxy 4173:4173 -a <app>), code:bash (fly status -a <app>) (+25 more)
 
 ### Community 226 - "Community 226"
 Cohesion: 0.06
-Nodes (33): code:block1 (myproject/), code:block10 (your-project/), code:yaml (# ~/.panopticon/projects.yaml), code:yaml (# WRONG - causes Maven startup failure), code:yaml (projects:), code:yaml (projects:), code:yaml (services:), code:block4 (your-project/) (+25 more)
+Nodes (33): 1. Find the Agent Session, 2. Check Current Agent Status, 3. Send Your Message, 4. Verify Message Was Received, Change Priorities, code:bash (# ALWAYS use pan tell - it handles Enter correctly), code:bash (pan tell ISSUE-123 "Looks good! Please commit your changes a), code:bash (# List all sessions to find the correct name) (+25 more)
 
 ### Community 227 - "Community 227"
 Cohesion: 0.06
-Nodes (33): Agent Self-Requeue (Circuit Breaker), Automatic Handoffs, Cloister: AI Lifecycle Manager, code:block1 (┌───────────────────────────────────────────────────────────), code:json ({), code:javascript ({), code:json ({), code:bash (# Via dashboard - click "Start" in the Cloister status bar) (+25 more)
+Nodes (33): Backend Frameworks, code:yaml (projects:), code:bash (# Rebuild one workspace Docker stack from the configured com), code:bash (# Create workspace (uses configuration from projects.yaml)), code:yaml (services:), code:yaml (projects:), code:yaml (projects:), code:yaml (projects:) (+25 more)
 
 ### Community 228 - "Community 228"
-Cohesion: 0.07
-Nodes (21): CLAUDE_PROJECTS_DIR, ClaudeMessage, getActiveSessionModel(), getRecentSessions(), importSessionToCostLog(), normalizeModelName(), parseAllSessions(), parseClaudeSession() (+13 more)
+Cohesion: 0.06
+Nodes (33): code:block1 (myproject/), code:block10 (your-project/), code:yaml (# ~/.panopticon/projects.yaml), code:yaml (# WRONG - causes Maven startup failure), code:yaml (projects:), code:yaml (projects:), code:yaml (services:), code:block4 (your-project/) (+25 more)
 
 ### Community 229 - "Community 229"
-Cohesion: 0.09
-Nodes (21): appendCostEvent(), deduplicateEvents(), ensureEventsFile(), EventMetadata, eventsFileExists(), getCostsDir(), getEventsFile(), getEventsFilePath() (+13 more)
+Cohesion: 0.06
+Nodes (33): Agent Self-Requeue (Circuit Breaker), Automatic Handoffs, Cloister: AI Lifecycle Manager, code:block1 (┌───────────────────────────────────────────────────────────), code:json ({), code:javascript ({), code:json ({), code:bash (# Via dashboard - click "Start" in the Cloister status bar) (+25 more)
 
 ### Community 230 - "Community 230"
-Cohesion: 0.07
-Nodes (22): SearchResult, AgentIssueLookup, AgentIssueRecord, buildAgentIssueLookup(), buildEnrichSessionsJobPayload(), EnrichSessionsRpcInput, filterDomainEventForIssue(), mapEventToDelta() (+14 more)
+Cohesion: 0.08
+Nodes (22): FetchFn, InternalState, LogFn, parsePositiveIntEnv(), readWatchdogConfig(), readWatchdogPersistentState(), SpawnRestart, SpawnRestartResult (+14 more)
 
 ### Community 231 - "Community 231"
+Cohesion: 0.12
+Nodes (32): runDashboardDbJob(), WorkerLane, abortFlywheelRunForDashboard(), assertExistingPathInsideRoot(), createInitialFlywheelStatus(), dashboardSetting(), execAsync, FlywheelGateSnapshot (+24 more)
+
+### Community 232 - "Community 232"
+Cohesion: 0.11
+Nodes (4): createFlyApiClient(), effFromPromise(), execAsync, FlyProvider
+
+### Community 233 - "Community 233"
 Cohesion: 0.11
 Nodes (28): drainPendingEvents(), envFor(), getDashboardUrl(), handlePanDone(), handleSessionStart(), handleToolExecutionEnd(), handleTurnEnd(), HookEnv (+20 more)
 
-### Community 232 - "Community 232"
+### Community 234 - "Community 234"
 Cohesion: 0.06
 Nodes (32): 1. Installation Test, 2. DNS Setup Test, 3. Startup Test (pan up), 4. Port-based Fallback Test, 5. Traefik Routing Test, 6. Shutdown Test (pan down), 7. Minimal Mode Test, Automated Test Script (+24 more)
 
-### Community 233 - "Community 233"
+### Community 235 - "Community 235"
 Cohesion: 0.06
 Nodes (32): 1.1 vBRIEF (Adopted), 1.2 Deft, 1.3 Superpowers, 1.4 Spec Kit (GitHub), 1.5 Taskmaster (eyaltoledano/claude-task-master), 1.6 OpenAI Agents SDK ("Agent OS" candidate), 1.7 Not Found / Need Clarification, 1. The Frameworks (+24 more)
 
-### Community 234 - "Community 234"
+### Community 236 - "Community 236"
 Cohesion: 0.06
 Nodes (31): 1. FizzyApiClient (`src/lib/tracker/fizzy-client.ts`), 2. FizzyCardMapping (SQLite), 3. FizzySyncService (`src/lib/fizzy/sync-service.ts`), 4. FizzyWebhookReceiver (`src/dashboard/server/routes/fizzy-webhooks.ts`), 5. FizzyColumnResolver (`src/lib/fizzy/column-resolver.ts`), Architecture, code:block1 (GitHub Issues (source of truth)), code:yaml (fizzy:) (+23 more)
 
-### Community 235 - "Community 235"
+### Community 237 - "Community 237"
 Cohesion: 0.06
 Nodes (32): Automated Synthesis, Best Practices, Code Conflicts, code:bash (# Get convoy status and results), code:typescript (// Agent 1 added field:), code:bash (# Generate synthesis prompt), code:bash (# Convoy management), code:bash (# Check each workspace for changes) (+24 more)
 
-### Community 236 - "Community 236"
+### Community 238 - "Community 238"
 Cohesion: 0.06
 Nodes (32): code:bash (pan setup), code:yaml (# template.yaml), code:block11 (team-meta/), code:bash (# Setup Agent prompt includes:), code:block2 ($ pan setup), code:block3 (Step 2: Project Type Detection), code:block4 (Step 3: Template Selection), code:block5 (Step 4: Repository Configuration) (+24 more)
 
-### Community 237 - "Community 237"
+### Community 239 - "Community 239"
 Cohesion: 0.06
 Nodes (32): Available TLDR Tools, Beads Tasks, code:block1 (1. Agent needs to understand auth.ts), code:bash (node -e "const fs=require('fs'); const p='.pan/spec.vbrief.j), code:bash (git fetch origin main && git rebase origin/main), code:bash (pan done {{ISSUE_ID}} -c "Work already complete from previou), code:json ({), code:bash (npm test                                         # Run tests) (+24 more)
 
-### Community 238 - "Community 238"
+### Community 240 - "Community 240"
 Cohesion: 0.09
 Nodes (26): AlsoSyncTool, collectSkillDirs(), extractSkillName(), MultiToolSyncResult, readSkillContent(), stripFrontmatter(), syncSkillsToTools(), syncToAider() (+18 more)
 
-### Community 239 - "Community 239"
-Cohesion: 0.08
-Nodes (25): githubTracker, linearTracker, longBody, mockCreateTrackerFromConfig, mockExistsSync, mockLoadConfig, mockStatSync, STATE_MTIME (+17 more)
-
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.08
 Nodes (24): approveReviewArtifactEffect(), ApproveReviewArtifactInput, buildRepositoryFlag(), commentOnArtifactEffect(), CommentOnArtifactInput, createReviewArtifactEffect(), CreateReviewArtifactInput, CreateReviewArtifactResult (+16 more)
 
-### Community 241 - "Community 241"
-Cohesion: 0.06
-Nodes (30): 1. JWT Expiry (Primary), 2. CLIProxy Log Tailing (Secondary), Automatic Retry, Bridging to CLIProxy, code:block1 (~/.panopticon/cliproxy/auth/codex-primary.json), code:bash (curl http://localhost:3000/api/settings/codex-auth), code:bash (pan config get issue-agent:implementation), code:block2 (~/.codex/) (+22 more)
-
 ### Community 242 - "Community 242"
-Cohesion: 0.06
-Nodes (31): All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Critical Issue: Tool Behavior Bug (+23 more)
+Cohesion: 0.09
+Nodes (28): snapshot, status, Jsonish, ReadModelServiceShape, ReviewStatusSnapshotInput, SpecialistAgentName, SpecialistLifecycleState, toAgentResolution() (+20 more)
 
 ### Community 243 - "Community 243"
-Cohesion: 0.06
-Nodes (31): All subagents (except general-purpose), Claude Sonnet 4.6 Work Type Fit Analysis, `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent` (+23 more)
+Cohesion: 0.11
+Nodes (24): checkCliproxyPortAsync(), cliproxyCatch(), CliproxyCodexCredentials, CliproxyError, CliproxyGeminiCredentials, CodexAuthFile, execAsync, getCliproxyPidPath() (+16 more)
 
 ### Community 244 - "Community 244"
-Cohesion: 0.06
-Nodes (31): 1. Be Specific, 2. Explain Why, 3. Order Steps Logically, 4. Consider Edge Cases, 5. Be Realistic, code:typescript (// Find authentication code), code:typescript (AskUserQuestion({), code:markdown (# [ISSUE-ID]: [Issue Title]) (+23 more)
+Cohesion: 0.09
+Nodes (23): activePtyHubs, addClientToHub(), broadcastToHub(), hubFlushTimer, hubOutputBuffer, PtyHub, removeClientFromHub(), setClientReady() (+15 more)
 
 ### Community 245 - "Community 245"
-Cohesion: 0.06
-Nodes (31): Available Commands, Available Skills, Code Review, code:bash (# 1. Initialize Panopticon), code:bash (# 1. Optionally create a plan first), code:bash (# List all workspaces), Configuration, Configuration Files (+23 more)
+Cohesion: 0.1
+Nodes (22): chunks, emitter, googleMocks, stream, emitter, onTurn, queue, subscribeVoiceSettings() (+14 more)
 
 ### Community 246 - "Community 246"
 Cohesion: 0.06
-Nodes (31): Best Practices, Built-in Convoy Templates, code-review Template, code:bash (# Run a parallel code review), code:block10 (1. Start command received), code:bash (# Watch convoy progress), code:bash (# Check individual agent status), code:block2 (pan convoy start code-review --files "src/**/*.ts") (+23 more)
+Nodes (30): 1. JWT Expiry (Primary), 2. CLIProxy Log Tailing (Secondary), Automatic Retry, Bridging to CLIProxy, code:block1 (~/.panopticon/cliproxy/auth/codex-primary.json), code:bash (curl http://localhost:3000/api/settings/codex-auth), code:bash (pan config get issue-agent:implementation), code:block2 (~/.codex/) (+22 more)
 
 ### Community 247 - "Community 247"
+Cohesion: 0.06
+Nodes (31): All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Critical Issue: Tool Behavior Bug (+23 more)
+
+### Community 248 - "Community 248"
+Cohesion: 0.06
+Nodes (31): All subagents (except general-purpose), Claude Sonnet 4.6 Work Type Fit Analysis, `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent` (+23 more)
+
+### Community 249 - "Community 249"
+Cohesion: 0.06
+Nodes (31): 1. Be Specific, 2. Explain Why, 3. Order Steps Logically, 4. Consider Edge Cases, 5. Be Realistic, code:typescript (// Find authentication code), code:typescript (AskUserQuestion({), code:markdown (# [ISSUE-ID]: [Issue Title]) (+23 more)
+
+### Community 250 - "Community 250"
+Cohesion: 0.06
+Nodes (31): Available Commands, Available Skills, Code Review, code:bash (# 1. Initialize Panopticon), code:bash (# 1. Optionally create a plan first), code:bash (# List all workspaces), Configuration, Configuration Files (+23 more)
+
+### Community 251 - "Community 251"
+Cohesion: 0.06
+Nodes (31): Best Practices, Built-in Convoy Templates, code-review Template, code:bash (# Run a parallel code review), code:block10 (1. Start command received), code:bash (# Watch convoy progress), code:bash (# Check individual agent status), code:block2 (pan convoy start code-review --files "src/**/*.ts") (+23 more)
+
+### Community 252 - "Community 252"
 Cohesion: 0.09
 Nodes (29): ACCEPTANCE_CRITERIA_TEMPLATE, ALREADY_MIGRATED, AnalysisGraph, AnalysisOutput, assignWaves(), buildGraph(), buildPerFileItem(), buildSharedErrorsItem() (+21 more)
 
-### Community 248 - "Community 248"
-Cohesion: 0.09
-Nodes (23): callServerApi(), buildMenuTemplate(), configureApplicationMenu(), fetchActiveWorkspaces(), rebuildMenu(), WorkspaceSummary, checkForUpdates(), currentStatus (+15 more)
-
-### Community 249 - "Community 249"
-Cohesion: 0.12
-Nodes (21): cvCommand(), CVOptions, relativeTime(), showCommand(), ShowOptions, calls, logSpy, now (+13 more)
-
-### Community 250 - "Community 250"
-Cohesion: 0.09
-Nodes (20): FetchFn, InternalState, LogFn, readWatchdogPersistentState(), SpawnRestart, SpawnRestartResult, SupervisorWatchdog, SupervisorWatchdogConfig (+12 more)
-
-### Community 251 - "Community 251"
-Cohesion: 0.16
-Nodes (30): movePrdImpl(), applyLabelGitHubImpl(), applyLabelLinearImpl(), closeGitHubDirectImpl(), closeGitHubPrImpl(), closeLinearDirectImpl(), closeRallyDirectImpl(), execAsync (+22 more)
-
-### Community 252 - "Community 252"
-Cohesion: 0.08
-Nodes (26): adaptFlywheelAgent(), AGENT_STATUS_MAP, AgentRole, AgentStatus, BUG_STATUS_CLASS, FlywheelStatusDetails(), FlywheelStatusDetailsProps, formatMemory() (+18 more)
-
 ### Community 253 - "Community 253"
-Cohesion: 0.06
-Nodes (30): 1. Template File Resolution, 2. Config File Integration, 3. Docker Compose Integration, 4. Certificate Integration, code:bash (pan install), code:bash (node -e "import('./dist/chunk-*.js').then(m => console.log(m), code:bash (ls -la templates/traefik/), code:bash (ls -la ~/.panopticon/traefik/) (+22 more)
+Cohesion: 0.13
+Nodes (28): decodeFlywheelRunId, defaultFlywheelPrompt(), defaultFlywheelRunId(), FlywheelLifecycleOptions, FlywheelPauseResult, FlywheelResumeResult, getLocalFlywheelRunDir(), isFlywheelDevcontainerRuntime() (+20 more)
 
 ### Community 254 - "Community 254"
-Cohesion: 0.06
-Nodes (30): 1. Review Artifact Creation at `pan done`, 1. The work agent owns all code-changing git operations, 2. Merge-Set Data Model, 2. Review artifacts are created at work completion, 3. Merge agent is the coordinator for merge sets, 3. Work-Agent-Owned Rebase Flow, 4. Non-Mutating Post-Rebase Verification, 4. Verification runs twice (+22 more)
+Cohesion: 0.1
+Nodes (27): buildReviewContext(), BuildReviewContextOpts, ChangedFile, execAsync, extractAcceptanceCriteria(), flattenAC(), getChangedFiles(), getCurrentBranch() (+19 more)
 
 ### Community 255 - "Community 255"
-Cohesion: 0.06
-Nodes (30): 1. Extend XTerminal Component, 3. Smart Ctrl+C Logic, 4. Context Menu (Embedded in XTerminal), 5. Auto-Copy on Selection, 6. Configuration UI, Breakdown into Sub-Tasks, code:typescript (interface XTerminalProps {), code:typescript (// Pseudo-code) (+22 more)
+Cohesion: 0.09
+Nodes (26): buildFilterParams(), ConversationRpcFilter, ConversationsPage(), CostResponse, countCostFacets(), countFacetValues(), countTimeFacets(), DiscoveredSession (+18 more)
 
 ### Community 256 - "Community 256"
 Cohesion: 0.06
-Nodes (30): All subagents, `cli:interactive` and `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit (+22 more)
+Nodes (31): code:yaml (# Your original docker-compose.yml), code:bash (pan workspace create my-feature --template node-fullstack), code:block102 (~/.panopticon/templates/), code:toml ([template]), code:block109 (~/.panopticon/), code:yaml (# ~/.panopticon/traefik/dynamic/feature-min-648.yml), code:toml ([panopticon]), code:toml ([project]) (+23 more)
 
 ### Community 257 - "Community 257"
 Cohesion: 0.06
-Nodes (30): Agent State Management, Architecture, code:block1 (┌───────────────────────────────────────────────────────────), code:bash (# Check what will be synced (including dev-skills)), code:block2 (~/.panopticon/), code:json ({), code:bash (pan remote init        # Initialize Fly.io provider), code:bash (pan work wipe MIN-123           # Basic cleanup) (+22 more)
+Nodes (30): 1. Template File Resolution, 2. Config File Integration, 3. Docker Compose Integration, 4. Certificate Integration, code:bash (pan install), code:bash (node -e "import('./dist/chunk-*.js').then(m => console.log(m), code:bash (ls -la templates/traefik/), code:bash (ls -la ~/.panopticon/traefik/) (+22 more)
 
 ### Community 258 - "Community 258"
 Cohesion: 0.06
-Nodes (30): 1. Planning Phase, 2. Implementation Phase, 3. Iteration, "API not enabled" errors, Available MCP Tools, Best Practices, Bidirectional Sync, Code Quality (+22 more)
+Nodes (30): 1. Review Artifact Creation at `pan done`, 1. The work agent owns all code-changing git operations, 2. Merge-Set Data Model, 2. Review artifacts are created at work completion, 3. Merge agent is the coordinator for merge sets, 3. Work-Agent-Owned Rebase Flow, 4. Non-Mutating Post-Rebase Verification, 4. Verification runs twice (+22 more)
 
 ### Community 259 - "Community 259"
 Cohesion: 0.06
-Nodes (30): Agent Commands, code:bash (# Spawn an agent for a Linear issue), code:bash (pan work request-review min-123 -m "Fixed: added tests and r), code:bash (# Clean up agents, state, Linear status), code:bash (# Recover a specific agent), code:bash (# Check status of all specialists), code:bash (# Initialize Fly.io provider), code:bash (pan work status) (+22 more)
+Nodes (30): 1. Extend XTerminal Component, 3. Smart Ctrl+C Logic, 4. Context Menu (Embedded in XTerminal), 5. Auto-Copy on Selection, 6. Configuration UI, Breakdown into Sub-Tasks, code:typescript (interface XTerminalProps {), code:typescript (// Pseudo-code) (+22 more)
 
 ### Community 260 - "Community 260"
-Cohesion: 0.1
-Nodes (18): cleanupOldEvents(), CLOISTER_DB_PATH, CloisterDatabaseError, deleteAgentHistory(), getAgentsWithHistory(), getAllHealthHistory(), getDatabaseStats(), getHealthDatabase() (+10 more)
+Cohesion: 0.06
+Nodes (30): All subagents, `cli:interactive` and `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit (+22 more)
 
 ### Community 261 - "Community 261"
+Cohesion: 0.06
+Nodes (30): Agent State Management, Architecture, code:block1 (┌───────────────────────────────────────────────────────────), code:bash (# Check what will be synced (including dev-skills)), code:block2 (~/.panopticon/), code:json ({), code:bash (pan remote init        # Initialize Fly.io provider), code:bash (pan work wipe MIN-123           # Basic cleanup) (+22 more)
+
+### Community 262 - "Community 262"
+Cohesion: 0.06
+Nodes (30): 1. Planning Phase, 2. Implementation Phase, 3. Iteration, "API not enabled" errors, Available MCP Tools, Best Practices, Bidirectional Sync, Code Quality (+22 more)
+
+### Community 263 - "Community 263"
+Cohesion: 0.06
+Nodes (30): Agent Commands, code:bash (# Spawn an agent for a Linear issue), code:bash (pan work request-review min-123 -m "Fixed: added tests and r), code:bash (# Clean up agents, state, Linear status), code:bash (# Recover a specific agent), code:bash (# Check status of all specialists), code:bash (# Initialize Fly.io provider), code:bash (pan work status) (+22 more)
+
+### Community 264 - "Community 264"
+Cohesion: 0.1
+Nodes (22): buildMenuTemplate(), configureApplicationMenu(), fetchActiveWorkspaces(), rebuildMenu(), WorkspaceSummary, checkForUpdates(), currentStatus, downloadUpdate() (+14 more)
+
+### Community 265 - "Community 265"
+Cohesion: 0.09
+Nodes (25): getTtsDaemonAuthHeaders(), buildDirectTtsSpeakPayload(), buildTtsSpeakPayload(), FetchLike, postSpeakPayload(), renderTemplate(), resolveAndSpeak(), ResolveAndSpeakDeps (+17 more)
+
+### Community 266 - "Community 266"
 Cohesion: 0.13
 Nodes (19): workspaceDeepCleanCommand(), WorkspaceDeepCleanOptions, dangerBanner(), DangerousGitOpError, DangerousOp, DangerousOpBlockedError, dryRunGitClean(), execAsync (+11 more)
 
-### Community 262 - "Community 262"
-Cohesion: 0.12
-Nodes (17): contextCommand(), ContextOptions, appendSummary(), checkContextBudget(), ContextBudget, estimateTokens(), generateSummaryEntry(), getHistoryDir() (+9 more)
-
-### Community 263 - "Community 263"
-Cohesion: 0.09
-Nodes (20): CapabilityStats, clearMetrics(), DailyStats, DEFAULT_METRICS, getAggregatedMetrics(), getAllRuntimeMetrics(), getIssueTasks(), getRecentTasks() (+12 more)
-
-### Community 264 - "Community 264"
-Cohesion: 0.17
-Nodes (24): GitHubApiError, LinearApiError, AnyTrackerError, Comment, Issue, IssueFilters, IssueNotFoundError, IssueState (+16 more)
-
-### Community 265 - "Community 265"
-Cohesion: 0.11
-Nodes (25): main(), print_usage(), build_compress_prompt(), build_fix_prompt(), call_claude(), compress_file(), Strip outer ```markdown ... ``` fence when it wraps the entire output., strip_llm_wrapper() (+17 more)
-
-### Community 266 - "Community 266"
-Cohesion: 0.14
-Nodes (29): saveResumeSessionId(), runDashboardDbJob(), WorkerLane, abortFlywheelRunForDashboard(), assertExistingPathInsideRoot(), createInitialFlywheelStatus(), dashboardSetting(), execAsync (+21 more)
-
 ### Community 267 - "Community 267"
-Cohesion: 0.09
-Nodes (22): scanForConflictMarkers(), err, exec(), execFile(), execMock, kCustom, prompt, spawnRunMock (+14 more)
+Cohesion: 0.1
+Nodes (18): cleanupOldEvents(), CLOISTER_DB_PATH, CloisterDatabaseError, deleteAgentHistory(), getAgentsWithHistory(), getAllHealthHistory(), getDatabaseStats(), getHealthDatabase() (+10 more)
 
 ### Community 268 - "Community 268"
 Cohesion: 0.13
@@ -2328,767 +2336,767 @@ Nodes (26): buildDigestPrompt(), deleteContextDigest(), ensureContextDirectory()
 
 ### Community 269 - "Community 269"
 Cohesion: 0.09
-Nodes (29): shouldSkipCheckpointReconciliation(), applyEvent(), bumpRuntimeSnapshotSequence(), DashboardLifecycleState, defaultRuntimeSnapshot(), getMaxMemoryObservationsPerIssue(), getMaxTurnDiffSummariesPerAgent(), isTerminalTurnDiffSummaryStatus() (+21 more)
+Nodes (20): CapabilityStats, clearMetrics(), DailyStats, DEFAULT_METRICS, getAggregatedMetrics(), getAllRuntimeMetrics(), getIssueTasks(), getRecentTasks() (+12 more)
 
 ### Community 270 - "Community 270"
+Cohesion: 0.12
+Nodes (17): contextCommand(), ContextOptions, appendSummary(), checkContextBudget(), ContextBudget, estimateTokens(), generateSummaryEntry(), getHistoryDir() (+9 more)
+
+### Community 271 - "Community 271"
+Cohesion: 0.11
+Nodes (25): main(), print_usage(), build_compress_prompt(), build_fix_prompt(), call_claude(), compress_file(), Strip outer ```markdown ... ``` fence when it wraps the entire output., strip_llm_wrapper() (+17 more)
+
+### Community 272 - "Community 272"
+Cohesion: 0.1
+Nodes (11): issues, result, CACHE_DB_PATH, CacheEntry, CacheService, DEFAULT_TTLS, L1Entry, openSqliteDb() (+3 more)
+
+### Community 273 - "Community 273"
+Cohesion: 0.1
+Nodes (24): AwaitingInputReason, compactPrompt(), detectAwaitingInputForAgent(), detectAwaitingInputFromPane(), findPermissionMenuEndIndex(), getPaneDetectionCacheKey(), isCurrentPromptIndex(), isRecentPromptIndex() (+16 more)
+
+### Community 274 - "Community 274"
+Cohesion: 0.13
+Nodes (27): CHUNK_BUDGET_CHARS_BY_MODEL, chunkEntriesByBudget(), CompactionOptions, CompactionResult, computeFileLists(), createFileOps(), CutPointResult, estimateContextTokens() (+19 more)
+
+### Community 275 - "Community 275"
 Cohesion: 0.07
 Nodes (29): Agent Enrichment Service, API, Auto-Resume Gates, Bulk apply, code:yaml (cloister:), code:yaml (autoResume:), code:bash (tsx scripts/deacon-ignore-bulk.ts --prefix MIN --states "in ), Configuration (+21 more)
 
-### Community 271 - "Community 271"
+### Community 276 - "Community 276"
 Cohesion: 0.07
 Nodes (29): code:typescript (interface VBriefReference {), code:typescript (export interface VBriefInfo {), code:json ({), code:block4 (## vBRIEF Plan Format), code:markdown (| **vBRIEF Plan Format** | Machine-readable work plans using), code:typescript (// Scan for PRDs matching this issue), code:block7 (VBriefViewer), code:block8 (tests/vbrief/full-spec.test.ts) (+21 more)
 
-### Community 272 - "Community 272"
+### Community 277 - "Community 277"
 Cohesion: 0.07
 Nodes (29): 1. Be Realistic, 2. Verify with Code, 3. Consider Context, 4. Communicate Uncertainty, 5. Update Estimates, Best Practices, Bug Triage, code:bash (# Find related code) (+21 more)
 
-### Community 273 - "Community 273"
+### Community 278 - "Community 278"
 Cohesion: 0.07
 Nodes (29): Access Points, Alternative Backend Frameworks, API Communication, Backend CORS, Backend Development, code:block1 (project/), code:javascript (const cors = require('cors')), code:bash (docker compose exec backend npx prisma migrate dev) (+21 more)
 
-### Community 274 - "Community 274"
-Cohesion: 0.11
-Nodes (25): buildReviewContext(), BuildReviewContextOpts, ChangedFile, execAsync, extractAcceptanceCriteria(), flattenAC(), getChangedFiles(), getCurrentBranch() (+17 more)
-
-### Community 275 - "Community 275"
-Cohesion: 0.1
-Nodes (24): getTtsDaemonAuthHeaders(), buildDirectTtsSpeakPayload(), buildTtsSpeakPayload(), FetchLike, postSpeakPayload(), renderTemplate(), resolveAndSpeak(), ResolveAndSpeakDeps (+16 more)
-
-### Community 276 - "Community 276"
+### Community 279 - "Community 279"
 Cohesion: 0.1
 Nodes (25): AnthropicContentBlock, AnthropicInputBlock, AnthropicMessage, AnthropicMessageResponse, AnthropicMessagesRequest, emptyBlock(), ensureOpenAICompatibleProxyRunning(), getOpenAICompatibleProxyBaseUrl() (+17 more)
 
-### Community 277 - "Community 277"
-Cohesion: 0.07
-Nodes (28): API Endpoints, Architecture Overview, Backoff Strategy, CacheService (`src/dashboard/server/services/cache-service.ts`), code:block1 (Frontend (TanStack Query)), code:typescript (await issueDataService.invalidateTracker('github'); // or 'l), code:json ({), Dashboard API Caching & Real-Time Push Architecture (+20 more)
-
-### Community 278 - "Community 278"
-Cohesion: 0.07
-Nodes (28): 1. Interactive CLI Wizard (`pan setup`), 2. Project Templates, 3. Setup Agent, Architecture, code:block1 ($ pan setup), code:typescript (interface SetupState {), code:typescript (async function detectRepos(projectPath: string): Promise<Det), code:block4 (templates/project-types/) (+20 more)
-
-### Community 279 - "Community 279"
-Cohesion: 0.07
-Nodes (28): 1. `ensureManagedTmuxConfig*` thrash on every tmux invocation, 2. 5000-line escape-coded snapshot on every attach, 3. `sendKeysAsync` per-line buffer + 50 ms sleep, Acceptance Criteria, Add, Code Changes Summary, code:typescript (// Lines 84-88 (sync) and 90-94 (async):), code:typescript (async function captureSnapshot(sessionName: string, cols: nu) (+20 more)
-
 ### Community 280 - "Community 280"
-Cohesion: 0.07
-Nodes (28): 1. Keep or Remove Runtime Parameter?, 1. Remove Sync Targets and Runtime Adapters, 2. Config Migration Strategy, 2. Consolidate Cloister Runtime System, 3. Remove CLI Runtime Selection, 3. Symlink Cleanup Approach, 4. Cloister Runtime Consolidation, 4. Config Migration (+20 more)
+Cohesion: 0.12
+Nodes (5): enqueueMemoryExtractionJob(), enqueueReconciledMemoryExtractionJobs(), MemoryExtractionWorkerPool, MemoryPipelineWorkerPool, normalizeQueueLimit()
 
 ### Community 281 - "Community 281"
-Cohesion: 0.07
-Nodes (28): 1. Cleanup Strategy: **Delete Permanently**, 2. Age Threshold: **7 Days (Configurable)**, 3. Directory Types to Clean, 4. Cleanup Triggers: **Both Auto + Manual**, 5. Status Marking: **Add 'completed' Status**, 6. Cost Endpoint Migration: **Yes, Include It**, Acceptance Criteria, Blocker Status: RESOLVED ✓ (+20 more)
+Cohesion: 0.08
+Nodes (21): ALLOWED, AuthMode, AvailableModelsState, FALLBACK_GROUPS, getProviderForPickerModel(), Harness, HARNESS_OPTIONS, HarnessDecision (+13 more)
 
 ### Community 282 - "Community 282"
 Cohesion: 0.07
-Nodes (28): All subagents, inspect agent, merge agent, CLI modes, API Migration from Opus 4.6, Breaking Changes, Claude Opus 4.7 Work Type Fit Analysis, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer` (+20 more)
+Nodes (28): API Endpoints, Architecture Overview, Backoff Strategy, CacheService (`src/dashboard/server/services/cache-service.ts`), code:block1 (Frontend (TanStack Query)), code:typescript (await issueDataService.invalidateTracker('github'); // or 'l), code:json ({), Dashboard API Caching & Real-Time Push Architecture (+20 more)
 
 ### Community 283 - "Community 283"
 Cohesion: 0.07
-Nodes (28): All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, `convoy:performance-reviewer` and `convoy:correctness-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit, GLM-5.1 Work Type Fit Analysis (+20 more)
+Nodes (28): 1. Interactive CLI Wizard (`pan setup`), 2. Project Templates, 3. Setup Agent, Architecture, code:block1 ($ pan setup), code:typescript (interface SetupState {), code:typescript (async function detectRepos(projectPath: string): Promise<Det), code:block4 (templates/project-types/) (+20 more)
 
 ### Community 284 - "Community 284"
 Cohesion: 0.07
-Nodes (28): code:bash (# PAN-XXX -> /home/eltmon/projects/panopticon (GitHub)), code:block10 (Items:), code:block11 (Items:), code:json ({), code:json ({), code:bash (# Materialize beads and mark the workspace spec proposed), code:bash (# Load Stitch tools), code:bash (gh label create "planned" --color "0E8A16" 2>/dev/null || tr) (+20 more)
+Nodes (28): 1. `ensureManagedTmuxConfig*` thrash on every tmux invocation, 2. 5000-line escape-coded snapshot on every attach, 3. `sendKeysAsync` per-line buffer + 50 ms sleep, Acceptance Criteria, Add, Code Changes Summary, code:typescript (// Lines 84-88 (sync) and 90-94 (async):), code:typescript (async function captureSnapshot(sessionName: string, cols: nu) (+20 more)
 
 ### Community 285 - "Community 285"
 Cohesion: 0.07
-Nodes (28): code:bash (# Check dashboard is running), code:bash (# Check for uncommitted changes), code:bash (# Create GitHub issue), code:bash (# Create test fixture), code:bash (# Trigger the approval - this kicks off review-agent), code:bash (# Watch review-agent (should complete review and hand off)), code:bash (# Check if branch was merged to main), code:bash (# Close the GitHub issue) (+20 more)
+Nodes (28): 1. Keep or Remove Runtime Parameter?, 1. Remove Sync Targets and Runtime Adapters, 2. Config Migration Strategy, 2. Consolidate Cloister Runtime System, 3. Remove CLI Runtime Selection, 3. Symlink Cleanup Approach, 4. Cloister Runtime Consolidation, 4. Config Migration (+20 more)
 
 ### Community 286 - "Community 286"
-Cohesion: 0.11
-Nodes (4): getProjectDirs(), getSessionFiles(), ClaudeCodeRuntime, ClaudeCodeRuntimeEffect
+Cohesion: 0.07
+Nodes (28): 1. Cleanup Strategy: **Delete Permanently**, 2. Age Threshold: **7 Days (Configurable)**, 3. Directory Types to Clean, 4. Cleanup Triggers: **Both Auto + Manual**, 5. Status Marking: **Add 'completed' Status**, 6. Cost Endpoint Migration: **Yes, Include It**, Acceptance Criteria, Blocker Status: RESOLVED ✓ (+20 more)
 
 ### Community 287 - "Community 287"
-Cohesion: 0.12
-Nodes (21): FsError, CLAUDE_DIR, createClaudeAdapter(), createClaudeAdapterEffect(), createRuntimeRegistry(), getInstalledRuntimes(), getRuntimeAdapter(), getSupportedRuntimes() (+13 more)
+Cohesion: 0.07
+Nodes (28): All subagents, inspect agent, merge agent, CLI modes, API Migration from Opus 4.6, Breaking Changes, Claude Opus 4.7 Work Type Fit Analysis, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer` (+20 more)
 
 ### Community 288 - "Community 288"
-Cohesion: 0.09
-Nodes (23): ComposerPlugin(), ComposerPromptEditor(), ComposerPromptEditorProps, EditorRefPluginProps, filterCommands(), getDraftKey(), InnerPluginProps, loadDraft() (+15 more)
+Cohesion: 0.07
+Nodes (28): All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, `convoy:performance-reviewer` and `convoy:correctness-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit, GLM-5.1 Work Type Fit Analysis (+20 more)
 
 ### Community 289 - "Community 289"
-Cohesion: 0.09
-Nodes (16): ALLOWED_CSS_PROPERTIES, ALLOWED_SHIKI_ATTRS, ALLOWED_SHIKI_TAGS, cacheKey(), ChatMarkdownErrorBoundary, ChatMarkdownProps, CodeBlockProps, ErrorBoundaryState (+8 more)
+Cohesion: 0.07
+Nodes (28): code:bash (# PAN-XXX -> /home/eltmon/projects/panopticon (GitHub)), code:block10 (Items:), code:block11 (Items:), code:json ({), code:json ({), code:bash (# Materialize beads and mark the workspace spec proposed), code:bash (# Load Stitch tools), code:bash (gh label create "planned" --color "0E8A16" 2>/dev/null || tr) (+20 more)
 
 ### Community 290 - "Community 290"
+Cohesion: 0.07
+Nodes (28): code:bash (# Check dashboard is running), code:bash (# Check for uncommitted changes), code:bash (# Create GitHub issue), code:bash (# Create test fixture), code:bash (# Trigger the approval - this kicks off review-agent), code:bash (# Watch review-agent (should complete review and hand off)), code:bash (# Check if branch was merged to main), code:bash (# Close the GitHub issue) (+20 more)
+
+### Community 291 - "Community 291"
 Cohesion: 0.13
 Nodes (19): execFileAsync, gitFetch(), gitForcePush(), gitMerge(), gitPush(), gitRevParse(), MainDivergedError, appendGitOperation() (+11 more)
 
-### Community 291 - "Community 291"
-Cohesion: 0.07
-Nodes (27): 1.1 vBRIEF (Adopted), 1.2 Deft, 1.3 Superpowers, 1.4 Spec Kit (GitHub), 1.5 Not Found / Unavailable, 1. The Frameworks, 2.1 Ralph Wiggum Self-Assessment Loop, 2.2 Two-Stage Specialist Review Gate (+19 more)
-
 ### Community 292 - "Community 292"
-Cohesion: 0.07
-Nodes (28): Auto-Sync, `ccr` Utility Script, code:bash (# Direct execution (recommended)), code:bash (# Make executable (if needed)), code:block61 (~/.panopticon/skills/*     →  ~/.claude/skills/           # ), code:toml ([sync]), code:typescript (type SyncTargetState =), code:bash ($ pan sync) (+20 more)
+Cohesion: 0.13
+Nodes (24): registerAdminCommands(), archiveCustomState(), CleanupOptions, cleanupStatesCommand(), LinearState, ListOptions, listStatesCommand(), listTeamStates() (+16 more)
 
 ### Community 293 - "Community 293"
-Cohesion: 0.07
-Nodes (28): CLI Distribution Strategy, code:yaml (# Your original docker-compose.yml), code:block109 (~/.panopticon/), code:yaml (# ~/.panopticon/traefik/dynamic/feature-min-648.yml), code:bash (# First time - zero install), code:bash (# pan init adds to ~/.bashrc or ~/.zshrc:), code:bash (npm install -g panopticon), code:bash (brew install panopticon      # macOS) (+20 more)
+Cohesion: 0.09
+Nodes (12): linearCall(), LinearTracker, constructorTracker, createdIssue, mockAssignee, mockClient, mockComment, mockIssue (+4 more)
 
 ### Community 294 - "Community 294"
-Cohesion: 0.07
-Nodes (27): 1. State of LLM Evals in 2026, 2.1 Compaction (`src/lib/conversations/smart-compaction.ts`), 2.2 Observability / Activity Feed (PAN-1052), 2.3 Other Panopticon surfaces (out of scope now, in scope soon), 2. What to evaluate in Panopticon, 3.1 Choice of base library: **`evalite` + `autoevals`** (both MIT, TS-native), in-tree under `evals/`., 3.2 Repo layout, 3.3 The `pan evals` CLI surface (+19 more)
+Cohesion: 0.09
+Nodes (19): backfillDiscoveredSessionArrayIndexes(), initDiscoveredSessionsSchema(), initSchema(), base, cols, colsAfter, colsBefore, correctedPath (+11 more)
 
 ### Community 295 - "Community 295"
-Cohesion: 0.07
-Nodes (27): Async Gates for Workflow Coordination, Best Practices, Can't find gate ID, CI run ID detection fails, code:bash (bd config set types.custom '["gate"]'), code:bash (bd gate list | grep "spec-myfeature"), code:bash (# Check gate details), code:bash (# List all gates (including closed)) (+19 more)
+Cohesion: 0.1
+Nodes (16): assertSafeAgentIdEffect(), captureCheckpointEffect(), CheckpointGitResult, checkpointSpawnerLayer, deleteAllCheckpointsEffect(), deleteCheckpointEffect(), diffCheckpointFilesEffect(), diffCheckpointsEffect() (+8 more)
 
 ### Community 296 - "Community 296"
-Cohesion: 0.07
-Nodes (27): code:block1 (User invokes /pan-code-review), code:typescript (// Read the synthesis report), code:bash (# Review all uncommitted changes (git diff)), code:bash (# Review specific files), code:bash (# Review all changes in current branch vs main), code:bash (# Focus on security only), code:typescript (// Default: review uncommitted changes), code:typescript (// Create reviews directory) (+19 more)
+Cohesion: 0.09
+Nodes (23): ComposerPlugin(), ComposerPromptEditor(), ComposerPromptEditorProps, EditorRefPluginProps, filterCommands(), getDraftKey(), InnerPluginProps, loadDraft() (+15 more)
 
 ### Community 297 - "Community 297"
 Cohesion: 0.07
-Nodes (27): Case 1 — Expected Score: ~42 (Partial / Risky), Case 2 — Expected Score: ~35 (Not Ready), code:json ({), Deduction Examples, Deduction Examples, Deduction Examples, Deduction Examples, Deduction Examples (+19 more)
+Nodes (27): 1.1 vBRIEF (Adopted), 1.2 Deft, 1.3 Superpowers, 1.4 Spec Kit (GitHub), 1.5 Not Found / Unavailable, 1. The Frameworks, 2.1 Ralph Wiggum Self-Assessment Loop, 2.2 Two-Stage Specialist Review Gate (+19 more)
 
 ### Community 298 - "Community 298"
 Cohesion: 0.07
-Nodes (27): code:bash (pan project add <path> --name <name>), code:block10 (## New Project Setup Complete: <NAME>), code:yaml (<project-key>:), code:yaml (<project-key>:), code:bash (# Format: owner/repo:PREFIX (comma-separated)), code:bash (cd <project-path>), code:bash (mkdir -p <project-path>/workspaces), code:bash (grep -q '^workspaces/' <project-path>/.gitignore 2>/dev/null) (+19 more)
+Nodes (28): Auto-Sync, `ccr` Utility Script, code:bash (# Direct execution (recommended)), code:bash (# Make executable (if needed)), code:block61 (~/.panopticon/skills/*     →  ~/.claude/skills/           # ), code:toml ([sync]), code:typescript (type SyncTargetState =), code:bash ($ pan sync) (+20 more)
 
 ### Community 299 - "Community 299"
 Cohesion: 0.07
-Nodes (27): `.agent-template/`, code:block1 (team-meta/), code:bash (#!/bin/bash), code:yaml (groups:), code:block3 (Step 6: Meta Repo), code:bash (mkdir -p team-meta/{.agent-template/.claude,panopticon,docs/), code:bash (git clone git@github.com:yourorg/team-meta.git), code:bash (cd team-meta/docs/onboarding) (+19 more)
+Nodes (27): 1. State of LLM Evals in 2026, 2.1 Compaction (`src/lib/conversations/smart-compaction.ts`), 2.2 Observability / Activity Feed (PAN-1052), 2.3 Other Panopticon surfaces (out of scope now, in scope soon), 2. What to evaluate in Panopticon, 3.1 Choice of base library: **`evalite` + `autoevals`** (both MIT, TS-native), in-tree under `evals/`., 3.2 Repo layout, 3.3 The `pan evals` CLI surface (+19 more)
 
 ### Community 300 - "Community 300"
 Cohesion: 0.07
-Nodes (27): 1. Test Coverage, 2. No Blocking Operations, 3. No Dead Code, 4. Error Handling, 5. Type Safety, 6. Temporal Dead Zone (TDZ), Acceptance Criteria (from vBRIEF plan) — MANDATORY GATE, APPROVED (rare — only for PERFECT code) (+19 more)
+Nodes (27): Async Gates for Workflow Coordination, Best Practices, Can't find gate ID, CI run ID detection fails, code:bash (bd config set types.custom '["gate"]'), code:bash (bd gate list | grep "spec-myfeature"), code:bash (# Check gate details), code:bash (# List all gates (including closed)) (+19 more)
 
 ### Community 301 - "Community 301"
-Cohesion: 0.13
-Nodes (25): appendJsonl(), buildQueryExpansionCacheKey(), buildQueryExpansionPrompt(), CachedQueryExpansionResult, clearQueryExpansionCache(), expandMemoryQuery(), expansionCache, fallback() (+17 more)
+Cohesion: 0.07
+Nodes (27): code:block1 (User invokes /pan-code-review), code:typescript (// Read the synthesis report), code:bash (# Review all uncommitted changes (git diff)), code:bash (# Review specific files), code:bash (# Review all changes in current branch vs main), code:bash (# Focus on security only), code:typescript (// Default: review uncommitted changes), code:typescript (// Create reviews directory) (+19 more)
 
 ### Community 302 - "Community 302"
-Cohesion: 0.16
-Nodes (26): handleConversationImageUpload(), safeUploadExtension(), validateCwdContainment(), validateImageMagicBytes(), assertSafeName(), cleanupConversationAttachments(), cleanupOrphanedConversationAttachments(), cleanupUnreferencedConversationAttachments() (+18 more)
+Cohesion: 0.07
+Nodes (27): Case 1 — Expected Score: ~42 (Partial / Risky), Case 2 — Expected Score: ~35 (Not Ready), code:json ({), Deduction Examples, Deduction Examples, Deduction Examples, Deduction Examples, Deduction Examples (+19 more)
 
 ### Community 303 - "Community 303"
 Cohesion: 0.07
-Nodes (26): A. Provider Billing & Observability → #730, Already Fixed / Shipped (14), B. Metrics Page v2 → #750, Biggest backlog themes, C. Documentation Overhaul → #634, Critical (5 issues) — 1.0 blockers or active pipeline corruption, D. Cost Display Polish → new umbrella or #77, Duplicates (10) (+18 more)
+Nodes (27): code:bash (pan project add <path> --name <name>), code:block10 (## New Project Setup Complete: <NAME>), code:yaml (<project-key>:), code:yaml (<project-key>:), code:bash (# Format: owner/repo:PREFIX (comma-separated)), code:bash (cd <project-path>), code:bash (mkdir -p <project-path>/workspaces), code:bash (grep -q '^workspaces/' <project-path>/.gitignore 2>/dev/null) (+19 more)
 
 ### Community 304 - "Community 304"
 Cohesion: 0.07
-Nodes (26): 1. Check release readiness, 2. Create the release commit and tag, 3. Push intentionally, Branch and channel policy, Build or tests fail during preflight, Canary, Canary tags, code:bash (pan release check) (+18 more)
+Nodes (27): `.agent-template/`, code:block1 (team-meta/), code:bash (#!/bin/bash), code:yaml (groups:), code:block3 (Step 6: Meta Repo), code:bash (mkdir -p team-meta/{.agent-template/.claude,panopticon,docs/), code:bash (git clone git@github.com:yourorg/team-meta.git), code:bash (cd team-meta/docs/onboarding) (+19 more)
 
 ### Community 305 - "Community 305"
 Cohesion: 0.07
-Nodes (26): Advanced: Work Type Table, Available Providers, Bulk Reset, Canonical Sources, Changing a Model Assignment, code:yaml (models:), code:yaml (openrouter:), Configuration File (+18 more)
+Nodes (27): 1. Test Coverage, 2. No Blocking Operations, 3. No Dead Code, 4. Error Handling, 5. Type Safety, 6. Temporal Dead Zone (TDZ), Acceptance Criteria (from vBRIEF plan) — MANDATORY GATE, APPROVED (rare — only for PERFECT code) (+19 more)
 
 ### Community 306 - "Community 306"
 Cohesion: 0.07
-Nodes (26): Anthropic-heavy reviews, cheaper helpers, Choosing What to Override, CLI Modes, code:yaml (models:), code:yaml (models:), code:yaml (models:), code:yaml (models:), code:yaml (models:) (+18 more)
+Nodes (21): createCall, createCalls, dbError, deleteCalls, doc, doctorCalls, existingBeads, expectedPrefix (+13 more)
 
 ### Community 307 - "Community 307"
-Cohesion: 0.07
-Nodes (25): 1. The breaker logic and the reset logic do not match, 2. `manual_retry` does not fit the current history type, 3. The `markWorkspaceStuck()` sample call is type-wrong, 4. The new retry endpoint overlaps heavily with the existing unstick flow, 5. `checkStuckReviewing()` may become too aggressive if tmux output pauses, 6. The PRD should call out interaction with stale-session cleanup in `runParallelReview()`, 7. The frontend copy and state model are good, but the PRD under-specifies how `stuckReason` should drive copy, 8. Minor path/documentation mismatch (+17 more)
+Cohesion: 0.16
+Nodes (26): handleConversationImageUpload(), safeUploadExtension(), validateCwdContainment(), validateImageMagicBytes(), assertSafeName(), cleanupConversationAttachments(), cleanupOrphanedConversationAttachments(), cleanupUnreferencedConversationAttachments() (+18 more)
 
 ### Community 308 - "Community 308"
-Cohesion: 0.07
-Nodes (26): Acceptance Criteria, Architecture, Claude Code, CLI Surface, code:markdown (# Project Rules), code:block2 ([WARN] sync.devroot is deprecated. Run `pan context migrate`), code:block3 (pan context list                    # Show all three layers'), code:bash (claude --append-system-prompt-file "$WORKSPACE/.panopticon/c) (+18 more)
+Cohesion: 0.13
+Nodes (25): appendJsonl(), buildQueryExpansionCacheKey(), buildQueryExpansionPrompt(), CachedQueryExpansionResult, clearQueryExpansionCache(), expandMemoryQuery(), expansionCache, fallback() (+17 more)
 
 ### Community 309 - "Community 309"
-Cohesion: 0.07
-Nodes (26): A/B Infrastructure, code:markdown (## Simplicity First), code:markdown ({{#KARPATHY_GUIDELINES}}), code:markdown ({{#KARPATHY_GUIDELINES}}), code:markdown ({{#KARPATHY_GUIDELINES}}), code:yaml (# ~/.panopticon/config.yaml), Config Schema, Design (+18 more)
+Cohesion: 0.1
+Nodes (26): applyEvent(), bumpRuntimeSnapshotSequence(), DashboardLifecycleState, defaultRuntimeSnapshot(), getMaxMemoryObservationsPerIssue(), getMaxTurnDiffSummariesPerAgent(), MemoryHealthSnapshot, MemoryReadModelState (+18 more)
 
 ### Community 310 - "Community 310"
 Cohesion: 0.07
-Nodes (26): 1. Infrastructure Model: Self-Contained Machines, 2. Command Execution: Hybrid Approach, 3. Exe Provider: Delete and Reimplement, 4. Docker Image: Full Pipeline, 5. Workspace Flow: Full Parity (minus shared infra), 6. Cost Tracking: Existing JSONL System, 7. Agent Management: Fly Machine Exec API, Architecture (+18 more)
+Nodes (26): A. Provider Billing & Observability → #730, Already Fixed / Shipped (14), B. Metrics Page v2 → #750, Biggest backlog themes, C. Documentation Overhaul → #634, Critical (5 issues) — 1.0 blockers or active pipeline corruption, D. Cost Display Polish → new umbrella or #77, Duplicates (10) (+18 more)
 
 ### Community 311 - "Community 311"
 Cohesion: 0.07
-Nodes (26): All implementation work types, All specialist agents (except review), All subagents, Claude Opus 4.6 Work Type Fit Analysis, CLI modes, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer` (+18 more)
+Nodes (26): 1. Check release readiness, 2. Create the release commit and tag, 3. Push intentionally, Branch and channel policy, Build or tests fail during preflight, Canary, Canary tags, code:bash (pan release check) (+18 more)
 
 ### Community 312 - "Community 312"
 Cohesion: 0.07
-Nodes (26): All convoy reviewers, All implementation work types, All specialist agents (except inspect), `cli:interactive`, `cli:quick-command`, Excellent Fit, Good Fit — Worth Benchmarking, GPT-5.4 Nano Work Type Fit Analysis (+18 more)
+Nodes (26): Advanced: Work Type Table, Available Providers, Bulk Reset, Canonical Sources, Changing a Model Assignment, code:yaml (models:), code:yaml (openrouter:), Configuration File (+18 more)
 
 ### Community 313 - "Community 313"
 Cohesion: 0.07
-Nodes (26): 1. Check Agent Status First, 2. Graceful Shutdown (Recommended), 3. Immediate Stop (If Needed), 4. Verify Stopped, 5. Clean Up (Optional), After Killing, code:bash (# Using pan CLI), code:bash (# List all matching sessions) (+18 more)
+Nodes (26): Anthropic-heavy reviews, cheaper helpers, Choosing What to Override, CLI Modes, code:yaml (models:), code:yaml (models:), code:yaml (models:), code:yaml (models:), code:yaml (models:) (+18 more)
 
 ### Community 314 - "Community 314"
 Cohesion: 0.07
-Nodes (26): code:bash (python3 scripts/conv-find.py <id>), code:text (Conversation #108), code:bash (python3 scripts/conv-find.py --jsonl 108), code:bash (python3 scripts/conv-find.py --summary 108), code:bash (python3 scripts/conv-find.py --json 108), code:bash (python3 scripts/conv-find.py --recent 20   # default 20), code:bash (python3 scripts/conv-find.py --search lexerra), code:python (import json, pathlib) (+18 more)
+Nodes (25): 1. The breaker logic and the reset logic do not match, 2. `manual_retry` does not fit the current history type, 3. The `markWorkspaceStuck()` sample call is type-wrong, 4. The new retry endpoint overlaps heavily with the existing unstick flow, 5. `checkStuckReviewing()` may become too aggressive if tmux output pauses, 6. The PRD should call out interaction with stale-session cleanup in `runParallelReview()`, 7. The frontend copy and state model are good, but the PRD under-specifies how `stuckReason` should drive copy, 8. Minor path/documentation mismatch (+17 more)
 
 ### Community 315 - "Community 315"
 Cohesion: 0.07
-Nodes (26): 1. Visual Theme & Atmosphere, 2. Color Palette & Roles, 3. Typography Rules, 4. Component Stylings, 5. Layout Principles, 6. Design System Notes for Stitch Generation, Accent & Interactive, Alignment & Visual Balance (+18 more)
+Nodes (26): Acceptance Criteria, Architecture, Claude Code, CLI Surface, code:markdown (# Project Rules), code:block2 ([WARN] sync.devroot is deprecated. Run `pan context migrate`), code:block3 (pan context list                    # Show all three layers'), code:bash (claude --append-system-prompt-file "$WORKSPACE/.panopticon/c) (+18 more)
 
 ### Community 316 - "Community 316"
 Cohesion: 0.07
-Nodes (26): Adding Repos Mid-Work, CLI Command, code:yaml (# ~/.panopticon/projects.yaml), code:yaml (# Old config — still works, all repos checked out), code:yaml (# team-meta/panopticon/repo-groups.yaml), code:bash (# Add specific repos), code:bash (# Add specific repos), code:block5 (/workspace-add-repo) (+18 more)
+Nodes (26): A/B Infrastructure, code:markdown (## Simplicity First), code:markdown ({{#KARPATHY_GUIDELINES}}), code:markdown ({{#KARPATHY_GUIDELINES}}), code:markdown ({{#KARPATHY_GUIDELINES}}), code:yaml (# ~/.panopticon/config.yaml), Config Schema, Design (+18 more)
 
 ### Community 317 - "Community 317"
 Cohesion: 0.07
-Nodes (26): Agent Self-Requeue (Circuit Breaker), code:block1 (Human clicks "Review"), code:bash (# All specialists with their current state), code:bash (# Via dashboard: click "Review" on an issue card), code:yaml (projects:), code:yaml (projects:), code:yaml (projects:), code:bash (# Via dashboard: click "Approve & Merge" on an issue card) (+18 more)
+Nodes (26): 1. Infrastructure Model: Self-Contained Machines, 2. Command Execution: Hybrid Approach, 3. Exe Provider: Delete and Reimplement, 4. Docker Image: Full Pipeline, 5. Workspace Flow: Full Parity (minus shared infra), 6. Cost Tracking: Existing JSONL System, 7. Agent Management: Fly Machine Exec API, Architecture (+18 more)
 
 ### Community 318 - "Community 318"
-Cohesion: 0.11
-Nodes (19): childEnv, expectedExits, killChildTree(), port, requiredFiles, restartQueue, shutdown(), startApp() (+11 more)
+Cohesion: 0.07
+Nodes (26): All implementation work types, All specialist agents (except review), All subagents, Claude Opus 4.6 Work Type Fit Analysis, CLI modes, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer` (+18 more)
 
 ### Community 319 - "Community 319"
-Cohesion: 0.13
-Nodes (21): checkTtsHealth(), speakTts(), startTtsDaemonFromDashboard(), StoredEvent, ActivityTtsPayload, drainQueue(), dropIndexForFullQueue(), enqueueActivityTts() (+13 more)
+Cohesion: 0.07
+Nodes (26): All convoy reviewers, All implementation work types, All specialist agents (except inspect), `cli:interactive`, `cli:quick-command`, Excellent Fit, Good Fit — Worth Benchmarking, GPT-5.4 Nano Work Type Fit Analysis (+18 more)
 
 ### Community 320 - "Community 320"
-Cohesion: 0.08
-Nodes (23): CloisterEvent, setCloisterService(), capturedEvents, consoleSpy, customService, emergencyEvent, health, healths (+15 more)
+Cohesion: 0.07
+Nodes (26): 1. Check Agent Status First, 2. Graceful Shutdown (Recommended), 3. Immediate Stop (If Needed), 4. Verify Stopped, 5. Clean Up (Optional), After Killing, code:bash (# Using pan CLI), code:bash (# List all matching sessions) (+18 more)
 
 ### Community 321 - "Community 321"
-Cohesion: 0.08
-Nodes (22): body, bytes, claudeProjectDir, conv, created, deliverMock, encodedCwd, getTrustedOrigins() (+14 more)
+Cohesion: 0.07
+Nodes (26): code:bash (python3 scripts/conv-find.py <id>), code:text (Conversation #108), code:bash (python3 scripts/conv-find.py --jsonl 108), code:bash (python3 scripts/conv-find.py --summary 108), code:bash (python3 scripts/conv-find.py --json 108), code:bash (python3 scripts/conv-find.py --recent 20   # default 20), code:bash (python3 scripts/conv-find.py --search lexerra), code:python (import json, pathlib) (+18 more)
 
 ### Community 322 - "Community 322"
-Cohesion: 0.12
-Nodes (14): wipeCommand(), WipeOptions, extractNumber(), extractPrefix(), extractStandardNumber(), extractStandardPrefix(), normalizeIssueId(), ParsedIssueId (+6 more)
+Cohesion: 0.07
+Nodes (26): 1. Visual Theme & Atmosphere, 2. Color Palette & Roles, 3. Typography Rules, 4. Component Stylings, 5. Layout Principles, 6. Design System Notes for Stitch Generation, Accent & Interactive, Alignment & Visual Balance (+18 more)
 
 ### Community 323 - "Community 323"
-Cohesion: 0.09
-Nodes (15): MessagesTimeline, derivePlanningIssueId(), fetchOutput(), TerminalPanel(), TerminalPanelProps, agent, queryClient, { rerender } (+7 more)
+Cohesion: 0.07
+Nodes (26): Adding Repos Mid-Work, CLI Command, code:yaml (# ~/.panopticon/projects.yaml), code:yaml (# Old config — still works, all repos checked out), code:yaml (# team-meta/panopticon/repo-groups.yaml), code:bash (# Add specific repos), code:bash (# Add specific repos), code:block5 (/workspace-add-repo) (+18 more)
 
 ### Community 324 - "Community 324"
-Cohesion: 0.1
-Nodes (21): ActivitySection, AgentSection(), AgentSectionProps, formatCost(), formatDuration(), formatModel(), formatTime(), getPreviewLine() (+13 more)
+Cohesion: 0.07
+Nodes (26): Agent Self-Requeue (Circuit Breaker), code:block1 (Human clicks "Review"), code:bash (# All specialists with their current state), code:bash (# Via dashboard: click "Review" on an issue card), code:yaml (projects:), code:yaml (projects:), code:yaml (projects:), code:bash (# Via dashboard: click "Approve & Merge" on an issue card) (+18 more)
 
 ### Community 325 - "Community 325"
 Cohesion: 0.08
-Nodes (25): BRANCH_NOT_FOUND, Check Merged, code:bash (# Standard naming convention), code:bash (# Get repo list from project config), code:bash (# Check local branches), code:bash (# Check for unmerged commits), code:bash (git -C "$PROJECT_PATH" fetch origin "$BRANCH" 2>/dev/null), code:bash (# Check if any commit in main references the issue ID) (+17 more)
+Nodes (23): CloisterEvent, setCloisterService(), capturedEvents, consoleSpy, customService, emergencyEvent, health, healths (+15 more)
 
 ### Community 326 - "Community 326"
+Cohesion: 0.15
+Nodes (24): deletePRDDraft(), deletePRDDraftEffect(), getPRDDraftInfo(), getPRDDraftInfoEffect(), getPRDDraftPathEffect(), hasPRDDraftEffect(), listPRDDrafts(), listPRDDraftsEffect() (+16 more)
+
+### Community 327 - "Community 327"
+Cohesion: 0.13
+Nodes (21): runCostSync(), buildSessionIndex(), decodeClaudeDirName(), extractCostEvents(), extractSessionId(), getAgentsDir(), getClaudeProjectsDir(), getSessionOffset() (+13 more)
+
+### Community 328 - "Community 328"
+Cohesion: 0.09
+Nodes (15): MessagesTimeline, derivePlanningIssueId(), fetchOutput(), TerminalPanel(), TerminalPanelProps, agent, queryClient, { rerender } (+7 more)
+
+### Community 329 - "Community 329"
+Cohesion: 0.08
+Nodes (22): body, bytes, claudeProjectDir, conv, created, deliverMock, encodedCwd, getTrustedOrigins() (+14 more)
+
+### Community 330 - "Community 330"
+Cohesion: 0.11
+Nodes (19): childEnv, expectedExits, killChildTree(), port, requiredFiles, restartQueue, shutdown(), startApp() (+11 more)
+
+### Community 331 - "Community 331"
+Cohesion: 0.08
+Nodes (25): BRANCH_NOT_FOUND, Check Merged, code:bash (# Standard naming convention), code:bash (# Get repo list from project config), code:bash (# Check local branches), code:bash (# Check for unmerged commits), code:bash (git -C "$PROJECT_PATH" fetch origin "$BRANCH" 2>/dev/null), code:bash (# Check if any commit in main references the issue ID) (+17 more)
+
+### Community 332 - "Community 332"
 Cohesion: 0.08
 Nodes (25): 10. Footer, 1. Brand Stripe (4px), 2. Header Block (primary_color background), 3. Issue Info Row (Light Gray background, #F5F5F5), 4. Score Dashboard — 5 metric cards in a row/grid, 5. Overall Score Bar, 6. Top Blockers (Amber/warning callout box), 7. Dimension Details — One section per dimension (+17 more)
 
-### Community 327 - "Community 327"
+### Community 333 - "Community 333"
 Cohesion: 0.08
 Nodes (20): assistantIssues, assistantText, CLAUDE_PROJECTS, contextIssues, cost, db, DB_PATH, entries (+12 more)
 
-### Community 328 - "Community 328"
-Cohesion: 0.12
-Nodes (20): clearFeedbackFiles(), FeedbackWriteError, getNextSequenceNumber(), resolveWorkspacePath(), writeFeedbackFile(), WriteFeedbackOptions, WriteFeedbackResult, buildReviewFeedbackBody() (+12 more)
+### Community 334 - "Community 334"
+Cohesion: 0.08
+Nodes (18): AgentState, __testInternals, createSessionAsync, dir, emitActivityEntry, legacyDir, rawState, state (+10 more)
 
-### Community 329 - "Community 329"
-Cohesion: 0.12
-Nodes (15): completeSession(), DEFAULT_DATA, findSessionById(), getAllIssuesWithCosts(), getIssueCostSummary(), getIssueSessions(), IssueSessionMap, linkSessionToIssue() (+7 more)
-
-### Community 330 - "Community 330"
-Cohesion: 0.12
-Nodes (10): defectQuery, hrQuery, mockCreate, mockQuery, mockUpdate, tracker, escapeQueryValue(), RallyTracker (+2 more)
-
-### Community 331 - "Community 331"
-Cohesion: 0.13
-Nodes (8): CACHE_DB_PATH, CacheEntry, CacheService, DEFAULT_TTLS, L1Entry, openSqliteDb(), RateLimitInfo, _require
-
-### Community 332 - "Community 332"
+### Community 335 - "Community 335"
 Cohesion: 0.12
 Nodes (16): ForgeType, buildMergeSetForIssue(), getRepoForge(), inferProjectForge(), normalizeForge(), resolveConfiguredRepos(), ResolvedProjectRepo, resolveProjectReposForIssue() (+8 more)
 
-### Community 333 - "Community 333"
-Cohesion: 0.08
-Nodes (18): generateRouterConfigFromWorkTypes(), Provider, ROUTER_CONFIG_DIR, ROUTER_CONFIG_FILE, RouterConfig, RouterRule, config, config1 (+10 more)
-
-### Community 334 - "Community 334"
-Cohesion: 0.08
-Nodes (24): Agent Auto-Resume Gates, Beads Enforcement, Claude Code Channels (experimental), Commit and Push When Working on Main, CRITICAL: Deep-Wipe Destroys Everything — NEVER Run Without Explicit User Confirmation, CRITICAL: Deliver Complete Features — No Partial Implementations, CRITICAL: JSONL Session Files Are Sacred — NEVER Delete, CRITICAL: Never Do Agent Work — Fix the System (+16 more)
-
-### Community 335 - "Community 335"
-Cohesion: 0.08
-Nodes (24): Architecture, Auto-Start, Auto-Updater Channels, Available Actions, Building the Desktop App, Cmd+K Command Palette, code:bash (chmod +x Panopticon-*.AppImage), code:bash (npx panopticon serve) (+16 more)
-
 ### Community 336 - "Community 336"
-Cohesion: 0.08
-Nodes (24): Backlog (hidden), Canonical States (Internal), Classification Labels (all trackers), Close-Out Ceremony, code:block1 (┌─────────────────────────────────────────┐), code:block2 (docs/prds/), code:block3 (backlog      -- Hidden from board, separate view), Columns (+16 more)
+Cohesion: 0.12
+Nodes (10): defectQuery, hrQuery, mockCreate, mockQuery, mockUpdate, tracker, escapeQueryValue(), RallyTracker (+2 more)
 
 ### Community 337 - "Community 337"
-Cohesion: 0.08
-Nodes (24): code:block1 (project-repo/), code:block2 (project-repo/), code:yaml (models:), code:yaml (# ~/.panopticon/config.yaml), code:yaml (# .pan.yaml (per-project, merges with global — never replace), code:block6 (project-repo/  (main branch)), code:block7 (project-repo/  (feature branch workspace)), code:block8 (.pan/events/) (+16 more)
+Cohesion: 0.12
+Nodes (15): completeSession(), DEFAULT_DATA, findSessionById(), getAllIssuesWithCosts(), getIssueCostSummary(), getIssueSessions(), IssueSessionMap, linkSessionToIssue() (+7 more)
 
 ### Community 338 - "Community 338"
-Cohesion: 0.08
-Nodes (24): Authentication & Network Exposure, Backpressure, Bash / curl, code:block1 (GET /events/stream), code:block2 (event: activity.entry), code:bash (curl -N -H "Accept: text/event-stream" \), code:python (import sseclient, requests, json), code:ts (import { EventSource } from 'eventsource';) (+16 more)
+Cohesion: 0.17
+Nodes (18): costAction(), CostRow, formatTokens(), GroupBy, resolveGroupKey(), formatBrief(), formatDate(), formatIds() (+10 more)
 
 ### Community 339 - "Community 339"
 Cohesion: 0.08
-Nodes (25): Automatic Complexity Detection, Beads Integration, code:block10 (┌───────────────────────────────────────────────────────────), code:typescript (// Example: Task completion triggers handoff), code:yaml (# ~/.panopticon/cloister.yaml), code:typescript (interface HandoffContext {), code:block18 (┌───────────────────────────────────────────────────────────), code:typescript (interface HandoffEvent {) (+17 more)
+Nodes (24): Agent Auto-Resume Gates, Beads Enforcement, Claude Code Channels (experimental), Commit and Push When Working on Main, CRITICAL: Deep-Wipe Destroys Everything — NEVER Run Without Explicit User Confirmation, CRITICAL: Deliver Complete Features — No Partial Implementations, CRITICAL: JSONL Session Files Are Sacred — NEVER Delete, CRITICAL: Never Do Agent Work — Fix the System (+16 more)
 
 ### Community 340 - "Community 340"
 Cohesion: 0.08
-Nodes (24): Adding New Assets, Build Commands, Build Commands, Build Pipeline, Build Tools, code:javascript (// Injected by tsdown shims), code:typescript (import { renderPrompt } from './prompts.js';), code:block3 (src/lib/cloister/prompts/*.md → dist/dashboard/prompts/) (+16 more)
+Nodes (24): Architecture, Auto-Start, Auto-Updater Channels, Available Actions, Building the Desktop App, Cmd+K Command Palette, code:bash (chmod +x Panopticon-*.AppImage), code:bash (npx panopticon serve) (+16 more)
 
 ### Community 341 - "Community 341"
 Cohesion: 0.08
-Nodes (23): Acceptance Criteria, Architecture, Budget Controls, Build Pipeline, CLI, code:bash (# scripts/build-docs-index.ts), code:block3 (pan docs query "<text>" [--top 5] [--kind docs|skill|rule|pr), code:markdown (## docs/HARNESSES.md → Installing Pi) (+15 more)
+Nodes (24): Backlog (hidden), Canonical States (Internal), Classification Labels (all trackers), Close-Out Ceremony, code:block1 (┌─────────────────────────────────────────┐), code:block2 (docs/prds/), code:block3 (backlog      -- Hidden from board, separate view), Columns (+16 more)
 
 ### Community 342 - "Community 342"
 Cohesion: 0.08
-Nodes (24): Acceptance Criteria, Architecture, code:block1 (┌─────────────────────────────────────────────────────┐), code:typescript (// packages/contracts/src/editor.ts), code:typescript (// In WS_METHODS:), code:typescript ([WS_METHODS.shellOpenInEditor]: (input) => panOpen.openInEdi), code:block5 (┌─ Inspector: MIN-846 ─────────────────────────────────┐), Design Goals (+16 more)
+Nodes (24): code:block1 (project-repo/), code:block2 (project-repo/), code:yaml (models:), code:yaml (# ~/.panopticon/config.yaml), code:yaml (# .pan.yaml (per-project, merges with global — never replace), code:block6 (project-repo/  (main branch)), code:block7 (project-repo/  (feature branch workspace)), code:block8 (.pan/events/) (+16 more)
 
 ### Community 343 - "Community 343"
 Cohesion: 0.08
-Nodes (24): Architecture, code:block1 (MissionControl (index.tsx)), code:block2 (JSONL file (append-only)), code:block3 (@pierre/diffs, react-markdown, remark-gfm, lexical, @lexical), Data Flow, Decisions, Frontend Changes, Full Lexical Editor (+16 more)
+Nodes (24): Authentication & Network Exposure, Backpressure, Bash / curl, code:block1 (GET /events/stream), code:block2 (event: activity.entry), code:bash (curl -N -H "Accept: text/event-stream" \), code:python (import sseclient, requests, json), code:ts (import { EventSource } from 'eventsource';) (+16 more)
 
 ### Community 344 - "Community 344"
 Cohesion: 0.08
-Nodes (24): code:yaml (projects:), code:bash (# Run all tests for a workspace), code:yaml (tests:), code:yaml (tests:), code:yaml (tests:), code:yaml (tests:), code:block7 (reports/), code:markdown (# Test Run Report - feature-min-123) (+16 more)
+Nodes (25): Automatic Complexity Detection, Beads Integration, code:block10 (┌───────────────────────────────────────────────────────────), code:typescript (// Example: Task completion triggers handoff), code:yaml (# ~/.panopticon/cloister.yaml), code:typescript (interface HandoffContext {), code:block18 (┌───────────────────────────────────────────────────────────), code:typescript (interface HandoffEvent {) (+17 more)
 
 ### Community 345 - "Community 345"
 Cohesion: 0.08
-Nodes (24): Adding DNS Entries, Automatic (Recommended), Checking Status, code:bash (pan doctor --fix), code:powershell (powershell -ExecutionPolicy Bypass -File "$env:USERPROFILE\.), code:powershell (cd \\wsl$\Ubuntu-20.04\home\eltmon\projects\panopticon\infra), code:powershell (# Copy sync script), code:bash (echo "myapp.localhost" >> ~/.wsl2hosts) (+16 more)
+Nodes (24): Adding New Assets, Build Commands, Build Commands, Build Pipeline, Build Tools, code:javascript (// Injected by tsdown shims), code:typescript (import { renderPrompt } from './prompts.js';), code:block3 (src/lib/cloister/prompts/*.md → dist/dashboard/prompts/) (+16 more)
 
 ### Community 346 - "Community 346"
 Cohesion: 0.08
-Nodes (24): 1. Provider Configuration, 2. Cost Tracking, 3. Model Routing, 4. Dashboard Visibility, 5. CLI Visibility, API Contract, Chat Completions, code:block1 (POST /v1/chat/completions) (+16 more)
+Nodes (23): Acceptance Criteria, Architecture, Budget Controls, Build Pipeline, CLI, code:bash (# scripts/build-docs-index.ts), code:block3 (pan docs query "<text>" [--top 5] [--kind docs|skill|rule|pr), code:markdown (## docs/HARNESSES.md → Installing Pi) (+15 more)
 
 ### Community 347 - "Community 347"
-Cohesion: 0.13
-Nodes (17): createTerminalWindow(), createWindow(), dispatchMenuAction(), iconPath, IPC, isDevelopment, resolveResourcePath(), resolveServerStaticDir() (+9 more)
+Cohesion: 0.08
+Nodes (24): Acceptance Criteria, Architecture, code:block1 (┌─────────────────────────────────────────────────────┐), code:typescript (// packages/contracts/src/editor.ts), code:typescript (// In WS_METHODS:), code:typescript ([WS_METHODS.shellOpenInEditor]: (input) => panOpen.openInEdi), code:block5 (┌─ Inspector: MIN-846 ─────────────────────────────────┐), Design Goals (+16 more)
 
 ### Community 348 - "Community 348"
-Cohesion: 0.16
-Nodes (21): CostLimitsConfig, checkCostLimits(), checkDailyReset(), COST_DATA_FILE, CostAlert, CostAlertLevel, CostData, CostDataPersisted (+13 more)
+Cohesion: 0.08
+Nodes (24): Architecture, code:block1 (MissionControl (index.tsx)), code:block2 (JSONL file (append-only)), code:block3 (@pierre/diffs, react-markdown, remark-gfm, lexical, @lexical), Data Flow, Decisions, Frontend Changes, Full Lexical Editor (+16 more)
 
 ### Community 349 - "Community 349"
-Cohesion: 0.11
-Nodes (14): fmtCost(), fmtDuration(), ReviewSummary(), ReviewSummaryProps, ROLE_META, getViewKey(), PanelView, readView() (+6 more)
+Cohesion: 0.08
+Nodes (24): code:yaml (projects:), code:bash (# Run all tests for a workspace), code:yaml (tests:), code:yaml (tests:), code:yaml (tests:), code:yaml (tests:), code:block7 (reports/), code:markdown (# Test Run Report - feature-min-123) (+16 more)
 
 ### Community 350 - "Community 350"
-Cohesion: 0.13
-Nodes (18): buildAnthropicMessagesUrl(), cache, CacheEntry, cacheKey(), classifyError(), classifyFetchError(), doProbe(), formatProbeError() (+10 more)
+Cohesion: 0.08
+Nodes (24): Adding DNS Entries, Automatic (Recommended), Checking Status, code:bash (pan doctor --fix), code:powershell (powershell -ExecutionPolicy Bypass -File "$env:USERPROFILE\.), code:powershell (cd \\wsl$\Ubuntu-20.04\home\eltmon\projects\panopticon\infra), code:powershell (# Copy sync script), code:bash (echo "myapp.localhost" >> ~/.wsl2hosts) (+16 more)
 
 ### Community 351 - "Community 351"
 Cohesion: 0.08
-Nodes (23): Activity View, Adding Projects, Badge Bar, code:block1 (feature-pan-XXX/.planning/), Concept, Configuration, Conversation List, Conversations (+15 more)
+Nodes (24): 1. Provider Configuration, 2. Cost Tracking, 3. Model Routing, 4. Dashboard Visibility, 5. CLI Visibility, API Contract, Chat Completions, code:block1 (POST /v1/chat/completions) (+16 more)
 
 ### Community 352 - "Community 352"
-Cohesion: 0.08
-Nodes (23): Agent Guidance, Agent System, Architecture & Design, Build & Development, Configuration, Configuration & Models, Development, Documentation Maintenance (+15 more)
+Cohesion: 0.14
+Nodes (19): startTtsDaemonFromDashboard(), StoredEvent, ActivityTtsPayload, drainQueue(), dropIndexForFullQueue(), enqueueActivityTts(), eventPriority(), onEvent() (+11 more)
 
 ### Community 353 - "Community 353"
-Cohesion: 0.08
-Nodes (23): code:block1 (Session 1: AI queries users.created_at → Error (column is "c), code:block2 (myproject/), code:markdown (# In ~/.claude/CLAUDE.md (developer's personal config)), code:bash (pan start MIN-123 --shadow), code:yaml (# In <project>/.panopticon.yaml), code:yaml (# In ~/.panopticon/config.yaml), code:bash (SHADOW_MODE=true pan start MIN-123), code:yaml (# In .panopticon.yaml — only shadow Linear, not GitHub) (+15 more)
+Cohesion: 0.16
+Nodes (21): CostLimitsConfig, checkCostLimits(), checkDailyReset(), COST_DATA_FILE, CostAlert, CostAlertLevel, CostData, CostDataPersisted (+13 more)
 
 ### Community 354 - "Community 354"
-Cohesion: 0.08
-Nodes (23): Auth: Internal Token, CLI, code:bash (pan swarm <id>                       # Spawn dispatchable it), code:bash (pan swarm <id> --task next                        # List dis), code:ts (interface SwarmRuntime {), code:block4 (plan dispatch), `continue-state.ts` — async helpers, Continue vBRIEF (Runtime State) (+15 more)
+Cohesion: 0.09
+Nodes (20): existingSkillDir, existsInTarget, mockClaudeSkills, mockPanopticonSkills, nonSkillDir, skillDir, skills, skillsToSync (+12 more)
 
 ### Community 355 - "Community 355"
-Cohesion: 0.08
-Nodes (23): Architecture, code:block1 (Main repo (host)), code:yaml (projects:), code:yaml (volumes:), code:yaml (# ✗ WRONG — causes two hard failures:), code:sh (bun install &&), code:json ("overrides": {), Container Image (+15 more)
+Cohesion: 0.12
+Nodes (7): clientMock, octokitMock, result, states, GitHubTracker, octokitToEffect(), parseIssueNumber()
 
 ### Community 356 - "Community 356"
 Cohesion: 0.08
-Nodes (23): Architecture Decisions, Build Verification, code:bash (pan install), code:bash (pan up), code:bash (pan down), code:bash (pan install --minimal), Documentation, Files Created/Modified (+15 more)
+Nodes (22): content, createTestDb(), db, event, goodLine, history, ids, latest (+14 more)
 
 ### Community 357 - "Community 357"
 Cohesion: 0.08
-Nodes (22): Acceptance Criteria, Architecture, CLI Surface, code:markdown (# Working Inside Panopticon), code:bash (claude --append-system-prompt-file "$HOME/.panopticon/sessio), code:bash (# dist/hooks/briefing-refresh.sh), code:markdown (## Knowledge Registry), code:typescript (// src/lib/hooks/compliance-audit.ts) (+14 more)
+Nodes (23): Activity View, Adding Projects, Badge Bar, code:block1 (feature-pan-XXX/.planning/), Concept, Configuration, Conversation List, Conversations (+15 more)
 
 ### Community 358 - "Community 358"
 Cohesion: 0.08
-Nodes (23): Click Behavior Split on ProjectNode, code:block1 (selectedConversation → ConversationView), code:typescript (export type PipelineStage =), code:typescript (interface ProjectOverviewProps {), Command Deck — Project Overview Panel (PAN-1044), Component Design, Data Sources, Files (+15 more)
+Nodes (23): Agent Guidance, Agent System, Architecture & Design, Build & Development, Configuration, Configuration & Models, Development, Documentation Maintenance (+15 more)
 
 ### Community 359 - "Community 359"
 Cohesion: 0.08
-Nodes (22): Acceptance Criteria, Architecture, CLI, CLI Examples, code:block1 (pan artifacts validate <file>              # validate, no pu), code:yaml (http:), code:bash (# Agent writes the file), Dashboard Integration (+14 more)
+Nodes (23): code:block1 (Session 1: AI queries users.created_at → Error (column is "c), code:block2 (myproject/), code:markdown (# In ~/.claude/CLAUDE.md (developer's personal config)), code:bash (pan start MIN-123 --shadow), code:yaml (# In <project>/.panopticon.yaml), code:yaml (# In ~/.panopticon/config.yaml), code:bash (SHADOW_MODE=true pan start MIN-123), code:yaml (# In .panopticon.yaml — only shadow Linear, not GitHub) (+15 more)
 
 ### Community 360 - "Community 360"
 Cohesion: 0.08
-Nodes (23): Agent Slots, AgentSnapshot extensions, Architecture (3 sentences), CLI Command, Cloister as Monitor, code:block1 (Wave 1: [items with no unmet blocks dependencies]  → spawn N), code:block2 (PAN-970), code:bash (pan swarm <issueId>          # Analyze DAG, show wave plan, ) (+15 more)
+Nodes (23): Auth: Internal Token, CLI, code:bash (pan swarm <id>                       # Spawn dispatchable it), code:bash (pan swarm <id> --task next                        # List dis), code:ts (interface SwarmRuntime {), code:block4 (plan dispatch), `continue-state.ts` — async helpers, Continue vBRIEF (Runtime State) (+15 more)
 
 ### Community 361 - "Community 361"
 Cohesion: 0.08
-Nodes (23): Acceptance Criteria, code:block1 (click + → DraftConversationPanel mounts → user types first m), code:block2 (click + → POST /api/conversations { model, effort }), Compact-boundary offset, Design, Duplicate-id audit (#696), Goals, Implementation Notes (+15 more)
+Nodes (23): Architecture, code:block1 (Main repo (host)), code:yaml (projects:), code:yaml (volumes:), code:yaml (# ✗ WRONG — causes two hard failures:), code:sh (bun install &&), code:json ("overrides": {), Container Image (+15 more)
 
 ### Community 362 - "Community 362"
 Cohesion: 0.08
-Nodes (23): A/B Testing, caveman-compress (manual only), caveman-review for Review Agent, code:json ({), code:yaml (# ~/.panopticon/config.yaml), code:block3 (## Panopticon Overrides (non-negotiable)), code:block4 (Format: L<line>: <problem>. <fix>.), Config Schema (+15 more)
+Nodes (23): Architecture Decisions, Build Verification, code:bash (pan install), code:bash (pan up), code:bash (pan down), code:bash (pan install --minimal), Documentation, Files Created/Modified (+15 more)
 
 ### Community 363 - "Community 363"
 Cohesion: 0.08
-Nodes (23): Animations, Architecture, Charts (visx), code:block1 (GodViewPage (new tab component)), code:block2 (Server:), Data Flow, Decisions Made, Design System (God View scope) (+15 more)
+Nodes (22): Acceptance Criteria, Architecture, CLI Surface, code:markdown (# Working Inside Panopticon), code:bash (claude --append-system-prompt-file "$HOME/.panopticon/sessio), code:bash (# dist/hooks/briefing-refresh.sh), code:markdown (## Knowledge Registry), code:typescript (// src/lib/hooks/compliance-audit.ts) (+14 more)
 
 ### Community 364 - "Community 364"
 Cohesion: 0.08
-Nodes (23): 1a. Verification Gate Enhancement, 1b. Review Convoy Enhancement, Architecture, Attribution, code:typescript (async function checkForStubs(workspacePath: string): Promise), code:block2 (## Stub Detection), code:markdown (## Locked Decisions), code:block4 (## Decision Protocol) (+15 more)
+Nodes (23): Click Behavior Split on ProjectNode, code:block1 (selectedConversation → ConversationView), code:typescript (export type PipelineStage =), code:typescript (interface ProjectOverviewProps {), Command Deck — Project Overview Panel (PAN-1044), Component Design, Data Sources, Files (+15 more)
 
 ### Community 365 - "Community 365"
 Cohesion: 0.08
-Nodes (23): Architecture Decisions, D1: Extend existing command, not create new, D2: Transition to "In Progress", not Backlog, D3: Keep .planning-complete marker, D4: Reset specialist states to pending (preserve history), D5: Append-only STATE.md updates, D6: Core reopen logic in a shared function, D7: Remove issue from specialist queues on reopen (+15 more)
+Nodes (22): Acceptance Criteria, Architecture, CLI, CLI Examples, code:block1 (pan artifacts validate <file>              # validate, no pu), code:yaml (http:), code:bash (# Agent writes the file), Dashboard Integration (+14 more)
 
 ### Community 366 - "Community 366"
 Cohesion: 0.08
-Nodes (22): Architecture, code:block1 (main.ts: await startSharedIssueService()     ← BLOCKS until ), code:block2 (main.ts: startSharedIssueService()           ← NO await, fir), Current Flow (Slow), Decisions, Edge Cases, EventRouter Changes, Files Changed (Summary) (+14 more)
+Nodes (23): Agent Slots, AgentSnapshot extensions, Architecture (3 sentences), CLI Command, Cloister as Monitor, code:block1 (Wave 1: [items with no unmet blocks dependencies]  → spawn N), code:block2 (PAN-970), code:bash (pan swarm <issueId>          # Analyze DAG, show wave plan, ) (+15 more)
 
 ### Community 367 - "Community 367"
 Cohesion: 0.08
-Nodes (23): 1. God View: Token foundation only, 2. API rename: Full rename, 3. Chat components: Included in rebrand, 4. Sidebar: Custom component, Architecture Overview, Decisions Made, Design References, In Scope (+15 more)
+Nodes (23): Acceptance Criteria, code:block1 (click + → DraftConversationPanel mounts → user types first m), code:block2 (click + → POST /api/conversations { model, effort }), Compact-boundary offset, Design, Duplicate-id audit (#696), Goals, Implementation Notes (+15 more)
 
 ### Community 368 - "Community 368"
 Cohesion: 0.08
-Nodes (23): By Gemini 3 Flash (for subagent:explore), By GPT-5.4 Nano (for subagent/CLI work), Claude Haiku 4.5 Work Type Fit Analysis, `cli:interactive`, `cli:quick-command`, Good Fit (Current Defaults), Integration Notes, Keep Haiku for: (+15 more)
+Nodes (23): A/B Testing, caveman-compress (manual only), caveman-review for Review Agent, code:json ({), code:yaml (# ~/.panopticon/config.yaml), code:block3 (## Panopticon Overrides (non-negotiable)), code:block4 (Format: L<line>: <problem>. <fix>.), Config Schema (+15 more)
 
 ### Community 369 - "Community 369"
 Cohesion: 0.08
-Nodes (23): Anti-Patterns, Chemistry Patterns, code:block1 (┌───────────────────────────────────────────────────────────), code:block2 (Will this work be referenced later?), code:bash (# Start grooming), code:bash (# Start review), code:bash (# Start spike (2 hour timebox)), code:bash (# Persistent mol (solid → liquid)) (+15 more)
+Nodes (23): Animations, Architecture, Charts (visx), code:block1 (GodViewPage (new tab component)), code:block2 (Server:), Data Flow, Decisions Made, Design System (God View scope) (+15 more)
 
 ### Community 370 - "Community 370"
 Cohesion: 0.08
-Nodes (23): code:block1 (~/.panopticon/skills/spec-readiness-{name}/), code:bash (mkdir -p ~/.panopticon/skills/spec-readiness-{name}), code:block11 (Created spec-readiness wrapper: spec-readiness-{name}), code:block12 (User: setup spec readiness), code:yaml (tracker:), code:yaml (tracker:), code:yaml (tracker:), code:yaml (tracker:) (+15 more)
+Nodes (23): 1a. Verification Gate Enhancement, 1b. Review Convoy Enhancement, Architecture, Attribution, code:typescript (async function checkForStubs(workspacePath: string): Promise), code:block2 (## Stub Detection), code:markdown (## Locked Decisions), code:block4 (## Decision Protocol) (+15 more)
 
 ### Community 371 - "Community 371"
-Cohesion: 0.13
-Nodes (17): handleAutoStartNag(), showFirstLaunchDialog(), deepClone(), DEFAULTS, DesktopSettings, getDesktopSettings(), loadDesktopSettings(), NotificationEventType (+9 more)
+Cohesion: 0.08
+Nodes (23): Architecture Decisions, D1: Extend existing command, not create new, D2: Transition to "In Progress", not Backlog, D3: Keep .planning-complete marker, D4: Reset specialist states to pending (preserve history), D5: Append-only STATE.md updates, D6: Core reopen logic in a shared function, D7: Remove issue from specialist queues on reopen (+15 more)
 
 ### Community 372 - "Community 372"
-Cohesion: 0.19
-Nodes (20): healthCommand(), HealthOptions, AgentHealth, formatHealthStatus(), getAgentHealth(), getAgentOutput(), getHealthFile(), handleStuckAgent() (+12 more)
+Cohesion: 0.08
+Nodes (22): Architecture, code:block1 (main.ts: await startSharedIssueService()     ← BLOCKS until ), code:block2 (main.ts: startSharedIssueService()           ← NO await, fir), Current Flow (Slow), Decisions, Edge Cases, EventRouter Changes, Files Changed (Summary) (+14 more)
 
 ### Community 373 - "Community 373"
-Cohesion: 0.12
-Nodes (6): clientMock, octokitMock, result, states, linearCall(), LinearTracker
+Cohesion: 0.08
+Nodes (23): 1. God View: Token foundation only, 2. API rename: Full rename, 3. Chat components: Included in rebrand, 4. Sidebar: Custom component, Architecture Overview, Decisions Made, Design References, In Scope (+15 more)
 
 ### Community 374 - "Community 374"
-Cohesion: 0.13
-Nodes (9): DEFAULT_STORE, formatIssueRef(), LinkDirection, LinkManager, LinkStore, parseIssueRef(), pathExists(), newManager (+1 more)
+Cohesion: 0.08
+Nodes (23): By Gemini 3 Flash (for subagent:explore), By GPT-5.4 Nano (for subagent/CLI work), Claude Haiku 4.5 Work Type Fit Analysis, `cli:interactive`, `cli:quick-command`, Good Fit (Current Defaults), Integration Notes, Keep Haiku for: (+15 more)
 
 ### Community 375 - "Community 375"
-Cohesion: 0.13
-Nodes (20): markAgentStopped(), markAgentStoppedState(), applyClosedOutLabel(), applyLabelGitHub(), applyLabelLinear(), applyLabelViaTracker(), closeGitHubDirect(), closeGitHubPr() (+12 more)
+Cohesion: 0.08
+Nodes (23): Anti-Patterns, Chemistry Patterns, code:block1 (┌───────────────────────────────────────────────────────────), code:block2 (Will this work be referenced later?), code:bash (# Start grooming), code:bash (# Start review), code:bash (# Start spike (2 hour timebox)), code:bash (# Persistent mol (solid → liquid)) (+15 more)
 
 ### Community 376 - "Community 376"
-Cohesion: 0.13
-Nodes (18): workspaceRebuildCommand(), StepResult, tempDirs, workspace, DevcontainerRenderResult, ensureDevcontainer(), EnsureDevcontainerInput, EnsureDevcontainerResult (+10 more)
+Cohesion: 0.08
+Nodes (23): code:block1 (~/.panopticon/skills/spec-readiness-{name}/), code:bash (mkdir -p ~/.panopticon/skills/spec-readiness-{name}), code:block11 (Created spec-readiness wrapper: spec-readiness-{name}), code:block12 (User: setup spec readiness), code:yaml (tracker:), code:yaml (tracker:), code:yaml (tracker:), code:yaml (tracker:) (+15 more)
 
 ### Community 377 - "Community 377"
-Cohesion: 0.1
-Nodes (19): AvailableModel, AvailableModelsResponse, ClaudeAuthStatus, fetchAvailableModels(), fetchClaudeAuth(), fetchSettings(), PROVIDER_LABELS, providerForModel() (+11 more)
-
-### Community 378 - "Community 378"
-Cohesion: 0.09
-Nodes (22): all, backing, cheap, enriched, expensive, fetched, inserted, malformed (+14 more)
-
-### Community 379 - "Community 379"
-Cohesion: 0.19
-Nodes (17): costAction(), CostRow, formatTokens(), GroupBy, resolveGroupKey(), formatBrief(), formatDate(), formatIds() (+9 more)
-
-### Community 380 - "Community 380"
-Cohesion: 0.11
-Nodes (16): buildSyncFailureFeedback(), execAsync, getSyncTargetBranch(), resolveGitDirs(), runVerificationForIssue(), SyncResult, syncSingleRepo(), commands (+8 more)
-
-### Community 381 - "Community 381"
 Cohesion: 0.16
 Nodes (21): ACTIVE_AGENT_STATUSES, CandidateGroup, collectActiveAgentIssueIds(), collectWorkspaceReapCandidatesFromInspect(), composeDown(), confirmApply(), DockerInspectContainer, execFileAsync (+13 more)
 
-### Community 382 - "Community 382"
+### Community 378 - "Community 378"
+Cohesion: 0.14
+Nodes (16): handleAutoStartNag(), showFirstLaunchDialog(), createTerminalWindow(), createWindow(), dispatchMenuAction(), iconPath, IPC, isDevelopment (+8 more)
+
+### Community 379 - "Community 379"
+Cohesion: 0.11
+Nodes (16): buildSyncFailureFeedback(), execAsync, getSyncTargetBranch(), resolveGitDirs(), runVerificationForIssue(), SyncResult, syncSingleRepo(), commands (+8 more)
+
+### Community 380 - "Community 380"
+Cohesion: 0.13
+Nodes (9): DEFAULT_STORE, formatIssueRef(), LinkDirection, LinkManager, LinkStore, parseIssueRef(), pathExists(), newManager (+1 more)
+
+### Community 381 - "Community 381"
 Cohesion: 0.09
-Nodes (23): code:typescript (interface IssueTracker {), code:block78 (┌───────────────────────────────────────────────────────────), code:toml (# ~/.panopticon/projects.toml), code:block80 (┌──────────┐    ┌──────────┐    ┌──────────┐    ┌───────────), code:yaml (# ~/.panopticon/state-mappings.yaml), code:typescript (// ~/.panopticon/issue-states.json), code:typescript (interface StateManager {), code:block84 ($ pan project add ~/projects/myn --tracker linear --team MIN) (+15 more)
+Nodes (22): all, backing, cheap, enriched, expensive, fetched, inserted, malformed (+14 more)
+
+### Community 382 - "Community 382"
+Cohesion: 0.1
+Nodes (19): AvailableModel, AvailableModelsResponse, ClaudeAuthStatus, fetchAvailableModels(), fetchClaudeAuth(), fetchSettings(), PROVIDER_LABELS, providerForModel() (+11 more)
 
 ### Community 383 - "Community 383"
 Cohesion: 0.09
-Nodes (23): 10. `onboard-codebase` - Understanding New Code, All Questions Resolved ✅, Appendix A: Key Concepts Reference, Appendix C: References, Appendix D: Open Questions, code:block141 (workspaces/feature-min-648/), code:bash (# 1. Mayor spawns convoy), code:block37 (+15 more)
+Nodes (23): code:block126 (┌─────────────────┐    ┌─────────────────┐    ┌─────────────), code:block127 (┌──────────────────────────────────────────────────────────┐), code:yaml (permissions:), code:json ({), code:bash (# 1. Login to npm (one-time)), code:bash (# Bump version (follows semver)), code:bash (# One-shot (no global install needed)), code:bash (# Tag beta releases) (+15 more)
 
 ### Community 384 - "Community 384"
 Cohesion: 0.09
-Nodes (23): code:block126 (┌─────────────────┐    ┌─────────────────┐    ┌─────────────), code:block127 (┌──────────────────────────────────────────────────────────┐), code:yaml (permissions:), code:json ({), code:bash (# 1. Login to npm (one-time)), code:bash (# Bump version (follows semver)), code:bash (# One-shot (no global install needed)), code:bash (# Tag beta releases) (+15 more)
+Nodes (23): 10. `onboard-codebase` - Understanding New Code, All Questions Resolved ✅, Appendix A: Key Concepts Reference, Appendix C: References, Appendix D: Open Questions, code:block141 (workspaces/feature-min-648/), code:bash (# 1. Mayor spawns convoy), code:block37 (+15 more)
 
 ### Community 385 - "Community 385"
 Cohesion: 0.09
-Nodes (22): A. Per-issue allow-list at plan time, Acceptance Criteria, Approach (Option 5 — combination), Architecture, Awaiting-input extension, Awaiting-input indicator (Section C), B. Outbound-write suppression during prompt display, C. Awaiting-input indicator + inspector deep link (+14 more)
+Nodes (23): code:typescript (interface IssueTracker {), code:block78 (┌───────────────────────────────────────────────────────────), code:toml (# ~/.panopticon/projects.toml), code:block80 (┌──────────┐    ┌──────────┐    ┌──────────┐    ┌───────────), code:yaml (# ~/.panopticon/state-mappings.yaml), code:typescript (// ~/.panopticon/issue-states.json), code:typescript (interface StateManager {), code:block84 ($ pan project add ~/projects/myn --tracker linear --team MIN) (+15 more)
 
 ### Community 386 - "Community 386"
 Cohesion: 0.09
-Nodes (22): 1. Root policy: what stays at root, 2. Root artifacts to relocate, 3. Destination policy, 4. Reference update pass, 5. Professionalism rule for future additions, Audits / investigations / findings, Constraints, Design (+14 more)
+Nodes (22): A. Per-issue allow-list at plan time, Acceptance Criteria, Approach (Option 5 — combination), Architecture, Awaiting-input extension, Awaiting-input indicator (Section C), B. Outbound-write suppression during prompt display, C. Awaiting-input indicator + inspector deep link (+14 more)
 
 ### Community 387 - "Community 387"
 Cohesion: 0.09
-Nodes (22): 1. Viewer in scope, 2. Model injection for plan.author, 3. vBRIEFInfo.author from package.json, 4. Artifact copy: skip if exists, 5. Testing approach, Architecture, Artifact auto-copy (issues.ts — complete-planning), Beads sync (beads.ts) (+14 more)
+Nodes (22): 1. Root policy: what stays at root, 2. Root artifacts to relocate, 3. Destination policy, 4. Reference update pass, 5. Professionalism rule for future additions, Audits / investigations / findings, Constraints, Design (+14 more)
 
 ### Community 388 - "Community 388"
 Cohesion: 0.09
-Nodes (21): 1. KanbanBoard.tsx — `CycleFilter` type (line 678), 2. KanbanBoard.tsx — `groupByStatus()` (lines 191-193), 3. KanbanBoard.tsx — Filter bar UI (around line 1042), 4. KanbanBoard.tsx — Canceled list view, 5. issue-data-service.ts — `getIssues()` (around line 223), Acceptance Criteria, Architecture, code:typescript (// Before:) (+13 more)
+Nodes (22): 1. Viewer in scope, 2. Model injection for plan.author, 3. vBRIEFInfo.author from package.json, 4. Artifact copy: skip if exists, 5. Testing approach, Architecture, Artifact auto-copy (issues.ts — complete-planning), Beads sync (beads.ts) (+14 more)
 
 ### Community 389 - "Community 389"
 Cohesion: 0.09
-Nodes (22): 1. Scope — all 5 phases in this issue, 2. Table model — new `discovered_sessions` table, separate from `conversations`, 3. Hash→path resolution — JSONL cwd primary, reverse-map fallback, 4. Adaptive parallelism — full probe as spec'd, 5. Embeddings — all three providers (OpenAI, Voyage, Ollama), 6. Enrichment execution — reuse `model-fallback.ts` routing, 7. Re-scanning — manual only in v1, 8. Blocking FS calls — must use async everywhere in server code (+14 more)
+Nodes (21): 1. KanbanBoard.tsx — `CycleFilter` type (line 678), 2. KanbanBoard.tsx — `groupByStatus()` (lines 191-193), 3. KanbanBoard.tsx — Filter bar UI (around line 1042), 4. KanbanBoard.tsx — Canceled list view, 5. issue-data-service.ts — `getIssues()` (around line 223), Acceptance Criteria, Architecture, code:typescript (// Before:) (+13 more)
 
 ### Community 390 - "Community 390"
 Cohesion: 0.09
-Nodes (22): Acceptance criteria, Command Taxonomy Reorganization, Decision, Design principles, Implementation plan, Out of scope, Phase 1 — Scaffolding (non-breaking), Phase 2 — Collapse commands (+14 more)
+Nodes (22): 1. Scope — all 5 phases in this issue, 2. Table model — new `discovered_sessions` table, separate from `conversations`, 3. Hash→path resolution — JSONL cwd primary, reverse-map fallback, 4. Adaptive parallelism — full probe as spec'd, 5. Embeddings — all three providers (OpenAI, Voyage, Ollama), 6. Enrichment execution — reuse `model-fallback.ts` routing, 7. Re-scanning — manual only in v1, 8. Blocking FS calls — must use async everywhere in server code (+14 more)
 
 ### Community 391 - "Community 391"
 Cohesion: 0.09
-Nodes (22): 1. Auth Configuration, 2. CCR Command, 3. claudish Installation, 4. Model Prefixes, 5. Dashboard Model Display, 6. OpenAI Model Registry, 7. Token Usage Tracking, Architecture (+14 more)
+Nodes (22): Acceptance criteria, Command Taxonomy Reorganization, Decision, Design principles, Implementation plan, Out of scope, Phase 1 — Scaffolding (non-breaking), Phase 2 — Collapse commands (+14 more)
 
 ### Community 392 - "Community 392"
 Cohesion: 0.09
-Nodes (22): 10. Not yet decided, 1.1 PAN-722 (queue removal) left a per-project singleton, 1.2 Inverted model priority — Sonnet lurking under every config, 1.3 PAN-540 parallel review — invisible sibling tmux sessions, 1.4 Cross-cutting: duplicate-tab failure mode, 1. Problem inventory, 2. Root cause, 3. The DAG reframe (+14 more)
+Nodes (22): 1. Auth Configuration, 2. CCR Command, 3. claudish Installation, 4. Model Prefixes, 5. Dashboard Model Display, 6. OpenAI Model Registry, 7. Token Usage Tracking, Architecture (+14 more)
 
 ### Community 393 - "Community 393"
 Cohesion: 0.09
-Nodes (22): ACCEPTANCE CRITERIA (WHAT SUCCESS LOOKS LIKE):, Ask the user before creating when:, code:markdown (bd update issue-9 --notes "IMPLEMENTATION GUIDE:), code:block2 (Two-phase Docs API approach:), code:block3 (- [ ] Markdown formatting renders in Doc (bold, italic, head), code:block4 (- [ ] Use two-phase batchUpdate approach), Contents, Create directly when: (+14 more)
+Nodes (22): 10. Not yet decided, 1.1 PAN-722 (queue removal) left a per-project singleton, 1.2 Inverted model priority — Sonnet lurking under every config, 1.3 PAN-540 parallel review — invisible sibling tmux sessions, 1.4 Cross-cutting: duplicate-tab failure mode, 1. Problem inventory, 2. Root cause, 3. The DAG reframe (+14 more)
 
 ### Community 394 - "Community 394"
 Cohesion: 0.09
-Nodes (22): 1. Confirm scope before destroying anything, 2. Kill work agents via the CLI (preferred), 3. Kill review coordinators and test specialists, 4. Verify only conversations and the server remain, 5. (Optional) Stop the dashboard, 6. Verify, code:bash (# List live tmux sessions, classified), code:bash (# Loop over agent sessions and kill each via pan) (+14 more)
+Nodes (22): ACCEPTANCE CRITERIA (WHAT SUCCESS LOOKS LIKE):, Ask the user before creating when:, code:markdown (bd update issue-9 --notes "IMPLEMENTATION GUIDE:), code:block2 (Two-phase Docs API approach:), code:block3 (- [ ] Markdown formatting renders in Doc (bold, italic, head), code:block4 (- [ ] Use two-phase batchUpdate approach), Contents, Create directly when: (+14 more)
 
 ### Community 395 - "Community 395"
 Cohesion: 0.09
-Nodes (22): Bead ID vs Issue ID, Beads Quick Reference for Panopticon Agents, code:bash (bd list --issue PAN-116), code:bash (# Option 1: Search in title (most common)), code:bash (# Find ALL beads for PAN-116 (including closed)), code:bash (# By status), code:bash (# Start work on a bead), code:bash (# ❌ WRONG) (+14 more)
+Nodes (22): 1. Confirm scope before destroying anything, 2. Kill work agents via the CLI (preferred), 3. Kill review coordinators and test specialists, 4. Verify only conversations and the server remain, 5. (Optional) Stop the dashboard, 6. Verify, code:bash (# List live tmux sessions, classified), code:bash (# Loop over agent sessions and kill each via pan) (+14 more)
 
 ### Community 396 - "Community 396"
 Cohesion: 0.09
-Nodes (23): 7. Components, Alerts, Badges, Buttons, Cards, code:block11 (Container:), code:block12 (Base:), code:block13 (Base:) (+15 more)
+Nodes (22): Bead ID vs Issue ID, Beads Quick Reference for Panopticon Agents, code:bash (bd list --issue PAN-116), code:bash (# Option 1: Search in title (most common)), code:bash (# Find ALL beads for PAN-116 (including closed)), code:bash (# By status), code:bash (# Start work on a bead), code:bash (# ❌ WRONG) (+14 more)
 
 ### Community 397 - "Community 397"
 Cohesion: 0.09
-Nodes (22): AI Self-Monitoring, Best Practices, Built-In Skills, Code Review Subagents, code:block1 (# In Claude Code, Cursor, Windsurf, etc:), code:bash (# Use the guided skill creator), code:markdown (# Skill Title), code:bash (# Sync all skills to AI tools (Claude Code, Cursor, etc.)) (+14 more)
+Nodes (23): 7. Components, Alerts, Badges, Buttons, Cards, code:block11 (Container:), code:block12 (Base:), code:block13 (Base:) (+15 more)
 
 ### Community 398 - "Community 398"
 Cohesion: 0.09
-Nodes (22): Claude Code subagents (NOT Panopticon roles), code:block1 (pan plan finalize), code:json ({), code:json ({), continue.vbrief.json Format, CRITICAL: PLANNING ONLY - NO IMPLEMENTATION, Description, Difficulty Estimation (+14 more)
+Nodes (22): AI Self-Monitoring, Best Practices, Built-In Skills, Code Review Subagents, code:block1 (# In Claude Code, Cursor, Windsurf, etc:), code:bash (# Use the guided skill creator), code:markdown (# Skill Title), code:bash (# Sync all skills to AI tools (Claude Code, Cursor, etc.)) (+14 more)
 
 ### Community 399 - "Community 399"
 Cohesion: 0.09
-Nodes (22): Anthropic, Benchmark Leaderboards, code:json ({), Coding Benchmarks, Community Sources, Deliverables, Google, Important Notes (+14 more)
+Nodes (22): Claude Code subagents (NOT Panopticon roles), code:block1 (pan plan finalize), code:json ({), code:json ({), continue.vbrief.json Format, CRITICAL: PLANNING ONLY - NO IMPLEMENTATION, Description, Difficulty Estimation (+14 more)
 
 ### Community 400 - "Community 400"
 Cohesion: 0.09
-Nodes (21): consoleSpy, mirrorLog, mockCleanupLegacyRuntimeSymlinks, mockCreateBackup, mockEnsurePlaywrightIsolation, mockExecuteSync, mockGetDevrootPath, mockListProjects (+13 more)
+Nodes (22): Anthropic, Benchmark Leaderboards, code:json ({), Coding Benchmarks, Community Sources, Deliverables, Google, Important Notes (+14 more)
 
 ### Community 401 - "Community 401"
 Cohesion: 0.09
-Nodes (16): CLAUDE_PROJECTS, cost, db, DB_PATH, entry, insert, issueStats, lines (+8 more)
+Nodes (20): companionInTarget, contentAfterFirst, dstScript, gitCwd, gitManifestDir, manifest, manifestAfterFirst, result (+12 more)
 
 ### Community 402 - "Community 402"
-Cohesion: 0.09
-Nodes (21): TldrSessionMetrics, branch, branchMatch, buffer, cavemanVariant, cost, entry, input (+13 more)
-
-### Community 403 - "Community 403"
 Cohesion: 0.15
 Nodes (15): BUNDLED_AGENTS_DIR, BUNDLED_SKILLS_DIR, copyBundledAgents(), copyBundledSkills(), __dirname, __filename, initCommand(), PACKAGE_ROOT (+7 more)
 
+### Community 403 - "Community 403"
+Cohesion: 0.09
+Nodes (21): consoleSpy, mirrorLog, mockCleanupLegacyRuntimeSymlinks, mockCreateBackup, mockEnsurePlaywrightIsolation, mockExecuteSync, mockGetDevrootPath, mockListProjects (+13 more)
+
 ### Community 404 - "Community 404"
 Cohesion: 0.09
-Nodes (20): companionInTarget, contentAfterFirst, dstScript, gitCwd, gitManifestDir, manifest, manifestAfterFirst, result (+12 more)
+Nodes (16): CLAUDE_PROJECTS, cost, db, DB_PATH, entry, insert, issueStats, lines (+8 more)
 
 ### Community 405 - "Community 405"
-Cohesion: 0.13
-Nodes (12): NormalizedTtsDaemonConfig, isTtsDaemonManuallyStopped(), parseTtsWatchdogIntEnv(), readTtsWatchdogConfig(), TtsWatchdog, TtsWatchdogConfig, TtsWatchdogStatus, parsePositiveIntEnv() (+4 more)
+Cohesion: 0.09
+Nodes (21): TldrSessionMetrics, branch, branchMatch, buffer, cavemanVariant, cost, entry, input (+13 more)
 
 ### Community 406 - "Community 406"
-Cohesion: 0.15
-Nodes (18): validateAndCleanStateFile(), readWorkspaceContext(), writeWorkspaceContext(), ensureWorkspacePanDir(), getWorkspacePanPaths(), readWorkspaceContinue(), uniqueTmpPath(), workspacePanPaths() (+10 more)
+Cohesion: 0.09
+Nodes (18): dir, event, eventsDir1, eventsDir2, line, lines, parsed, repo1 (+10 more)
 
 ### Community 407 - "Community 407"
-Cohesion: 0.12
-Nodes (15): CloseOutContext, CloseOutError, CloseOutResult, CloseOutStep, findWorkspacePath(), canonicalPrdSubdir(), findDraftPrd(), findPrdAnywhere() (+7 more)
-
-### Community 408 - "Community 408"
-Cohesion: 0.11
-Nodes (18): MetricStrip(), MetricStripProps, MetricDeltaDirection, MetricSignal, MetricTile(), MetricTileDelta, MetricTileProps, MetricTileVariant (+10 more)
-
-### Community 409 - "Community 409"
 Cohesion: 0.17
 Nodes (20): checkCommand(), execAsync, getMissingToolsForFeature(), INSTALLABLE_TOOLS, installBeads(), installMkcert(), installOx(), InstallResult (+12 more)
 
-### Community 410 - "Community 410"
-Cohesion: 0.09
-Nodes (18): fail, failLayer, githubLayer, layer, mockGitHubAddLabel, mockGitHubCloseIssue, mockGitHubEnsureLabel, mockGitHubRemoveLabel (+10 more)
+### Community 408 - "Community 408"
+Cohesion: 0.13
+Nodes (20): appendBridgeLog(), BunGlobal, ChannelPermissionRequest, ChannelPermissionRequestNotification, ChannelPushPayload, ChannelPushResult, constantTimeHeaderMatch(), forwardPermissionRequestToDashboard() (+12 more)
 
-### Community 411 - "Community 411"
+### Community 409 - "Community 409"
 Cohesion: 0.09
 Nodes (19): assistantLine, content, existingFiles, firstLine, fixture, fixturePath, ids, lines (+11 more)
 
-### Community 412 - "Community 412"
+### Community 410 - "Community 410"
 Cohesion: 0.09
 Nodes (18): agent2, baseAgent, bigOutput, events, existing, issues, next, planningAgent (+10 more)
 
-### Community 413 - "Community 413"
+### Community 411 - "Community 411"
 Cohesion: 0.09
 Nodes (21): 13 Dashboard Views, Agent Auto-Resume Controls, Architecture at a Glance, code:bash (npx @panctl/cli), code:block2 (Issue         PRD           Agent         Review        Test), Command Deck, Contributing, Documentation (+13 more)
 
-### Community 414 - "Community 414"
+### Community 412 - "Community 412"
 Cohesion: 0.09
 Nodes (21): 1. Batch Processing, 2. Cascade Approach, 3. Parallel Processing, Alternative Models, Claude Family (USD per million tokens), Cost Analysis, Detailed Recommendations, For Cost-Sensitive Deployments (+13 more)
 
-### Community 415 - "Community 415"
+### Community 413 - "Community 413"
 Cohesion: 0.09
 Nodes (21): 1. Supported harnesses, 2. Installing Pi, 3. Where you pick the harness, 4. ToS rules, 5. Troubleshooting, 6. Tradeoffs, Auth mode is exclusive, Claude Code (default) (+13 more)
 
-### Community 416 - "Community 416"
+### Community 414 - "Community 414"
 Cohesion: 0.09
 Nodes (20): Architecture, Backward Compatibility, code:typescript (/**), code:typescript (export interface ProjectConfig {), code:typescript (export function resolveTrackerType(issueId: string): Tracker), code:yaml (# Rally-tracked project with multiple artifact type prefixes), Configuration Example, Decision (+12 more)
 
-### Community 417 - "Community 417"
+### Community 415 - "Community 415"
 Cohesion: 0.09
 Nodes (21): 1. Event Bus & Real-Time Broadcast, 2. Webhook System, 3. Claude Session Introspection, 4. Alert Rules Engine, 5. Standup / Daily Reports, 6. Workflow Templates & Pipelines, 7. Quality Review Gate Improvements, 8. RBAC & Authentication (+13 more)
 
-### Community 418 - "Community 418"
+### Community 416 - "Community 416"
 Cohesion: 0.09
 Nodes (21): 1. Extract Project Identity (JSON), 2. Define the Atmosphere (Image/HTML), 3. Map the Color Palette (Tailwind Config/JSON), 4. Translate Geometry & Shape (CSS/Tailwind), 5. Describe Depth & Elevation, Analysis & Synthesis Instructions, Best Practices, code:markdown (# Design System: [Project Title]) (+13 more)
 
-### Community 419 - "Community 419"
+### Community 417 - "Community 417"
 Cohesion: 0.09
 Nodes (21): Bead Description (What Was Asked), BLOCKED — Any check fails, Check 1: Spec Fidelity, Check 2: Constraint Compliance, code:bash (cd {{workspacePath}}), code:bash (# Check workspace CLAUDE.md), code:bash (# Example: check for prohibited imports), code:bash (pan tell {{issueId}} "INSPECTION PASSED for bead {{beadId}}.) (+13 more)
 
-### Community 420 - "Community 420"
+### Community 418 - "Community 418"
 Cohesion: 0.09
 Nodes (21): code:bash (pan workspace create MIN-123), code:bash (pan workspace create MIN-123 --docker), code:javascript (// Disable Docker by default), code:bash (# From dashboard: click "Start Planning" (Docker enabled by ), code:bash (pan workspace list), code:bash (pan workspace destroy MIN-123), code:bash (export PANOPTICON_AUTO_REVERT_CHECKOUT=1  # Add to .bashrc/.), code:bash (./scripts/install-git-hooks.sh /path/to/your/project) (+13 more)
 
-### Community 421 - "Community 421"
-Cohesion: 0.1
-Nodes (20): agents, count, deleted, end, events, futureEnd, futureStart, id (+12 more)
-
-### Community 422 - "Community 422"
+### Community 419 - "Community 419"
 Cohesion: 0.1
 Nodes (16): CLAUDE_PROJECTS, cost, db, DB_PATH, entry, insert, issueId, issueStats (+8 more)
 
-### Community 423 - "Community 423"
+### Community 420 - "Community 420"
 Cohesion: 0.17
 Nodes (17): buildChannelsArgs(), buildCommand(), buildNonConversationCommand(), buildPiCommand(), buildReviewSubRoleCommand(), generateLauncherWrapper(), LauncherConfig, LauncherHarness (+9 more)
 
-### Community 424 - "Community 424"
-Cohesion: 0.17
-Nodes (17): AgentContext, findSessionDirsByIssue(), getAgentsDir(), getClaudeProjectsDir(), getProjectPaths(), getProjectsYamlPath(), getSessionDir(), inferIssueId() (+9 more)
+### Community 421 - "Community 421"
+Cohesion: 0.16
+Nodes (20): HandoffContext, createHandoffEvent(), ensureLogDir(), ensureLogDirAsync(), getHandoffStats(), getPendingVerificationHandoffs(), getPendingVerificationHandoffsEffect(), HANDOFF_LOG_FILE (+12 more)
 
-### Community 425 - "Community 425"
-Cohesion: 0.19
-Nodes (20): approveCommand(), cancelCommand(), collectInFlightRows(), collectLifecycleRows(), completeCommand(), dedupeRows(), formatTransition(), getProjectPath() (+12 more)
-
-### Community 426 - "Community 426"
-Cohesion: 0.12
-Nodes (15): calls, { mockExecAsync }, opts, compactBeads(), compactBeadsImpl(), CompactBeadsOptions, execAsync, { mockExecAsync } (+7 more)
-
-### Community 427 - "Community 427"
-Cohesion: 0.13
-Nodes (15): ChangedFilesTree, EMPTY_DIRECTORY_OVERRIDES, TurnDiffFileChange, DiffStatLabel, hasNonZeroStat(), buildTurnDiffTree(), MutableDirectoryNode, normalizePathSegments() (+7 more)
-
-### Community 428 - "Community 428"
+### Community 422 - "Community 422"
 Cohesion: 0.13
 Nodes (19): parseLogMetadata(), execAsync, listLogsCommand(), logsCommand(), LogsOptions, tailLogCommand(), actual, allLogs (+11 more)
 
-### Community 429 - "Community 429"
+### Community 423 - "Community 423"
+Cohesion: 0.14
+Nodes (17): displayIssues(), getConfiguredTrackers(), getTrackerConfig(), listCommand(), ListOptions, PRIORITY_LABELS, { loadConfigMock, isShadowedMock, getPendingSyncCountMock, createTrackerMock, loadProjectsConfigMock }, mockIssues (+9 more)
+
+### Community 424 - "Community 424"
+Cohesion: 0.1
+Nodes (15): ExtractedPayload, fallback, identity, primary, provider, recordHealth, result, TestProvider (+7 more)
+
+### Community 425 - "Community 425"
+Cohesion: 0.18
+Nodes (20): findAllWorkspacePaths(), findWorkspacePath(), buildPlaceholders(), clearLegacyPlanningDir(), clearProjectBeads(), clearShadowState(), deleteBranches(), isDockerContainerProcess() (+12 more)
+
+### Community 426 - "Community 426"
 Cohesion: 0.1
 Nodes (19): FlywheelAgent, FlywheelAgentStatus, FlywheelEffort, FlywheelHarness, FlywheelHeadline, FlywheelHttpUrl, FlywheelOrchestrator, FlywheelParkedItem (+11 more)
 
-### Community 430 - "Community 430"
-Cohesion: 0.1
-Nodes (21): 6. Agreed End-State, Agent Startup Context, code:yaml (devroot: ~/Projects        # where you launch Claude Code fr), code:bash (pan workspace update MIN-678    # explicit command, only whe), code:block16 (pan workspace create MIN-678), code:block17 (Agent starts on MIN-678 workspace), code:block18 (~/.panopticon/                          PANOPTICON'S PRIVATE), code:block19 (~/.claude/skills/my-override/               ← WINS (personal) (+13 more)
-
-### Community 431 - "Community 431"
+### Community 427 - "Community 427"
 Cohesion: 0.1
 Nodes (20): 10. B20 does not fully account for the current terminal surface area, 11. The resources event model is too narrow for the current resources UI, 12. The dependency DAG has one sequencing problem, 1. The current dashboard already has a real data layer; the problem is inconsistency, not total absence, 2. "Wrap existing libs in Effect" does not fix the blocking-call problem, 3. The storage plan should not introduce a third SQLite story without justification, 4. The toolchain/runtime section is not fully aligned with the repo as it exists today, 5. The dist/output migration has more blast radius than the PRD currently captures (+12 more)
 
-### Community 432 - "Community 432"
+### Community 428 - "Community 428"
 Cohesion: 0.1
 Nodes (20): Code Changes Required in Panopticon, code:block1 (┌─────────────────────────────────────────────────────────┐), code:yaml (myn:), Critical Constraint: exe.dev Single Port, Current State, Goals, Implementation Checklist, Manual Fixes Still Required Per-Project (+12 more)
 
-### Community 433 - "Community 433"
+### Community 429 - "Community 429"
 Cohesion: 0.1
 Nodes (20): Agent Navigation, Architecture, Backend (Server), code:block1 (docker stats (5s poll)), Container Detail View, Data Flow, Decisions, Files to Create/Modify (+12 more)
 
-### Community 434 - "Community 434"
+### Community 430 - "Community 430"
 Cohesion: 0.1
 Nodes (20): Architecture, btca CLI Skill, code:block1 (Browser (React + Vite)), code:json ({ "key": "mod+j", "command": "terminal.toggle" },), code:bash (btca ask -r codex -q "What is the return format for Codex Ap), Comparison to Panopticon, Feature Inventory, High priority (+12 more)
 
-### Community 435 - "Community 435"
+### Community 431 - "Community 431"
 Cohesion: 0.1
 Nodes (21): 10. Configuration, 1. High-Level Structure, 2. Entry Points, 3. Architecture Patterns, 4. Code Organization, 5. Feature Location, 6. Dependencies Analysis, 7. Data Models (+13 more)
 
-### Community 436 - "Community 436"
+### Community 432 - "Community 432"
 Cohesion: 0.1
 Nodes (20): Ad-Hoc Speak and CLI Smoke Test, Architecture, code:block1 (pan dashboard                  qwen-tts daemon            au), code:bash (pan install                # creates packages/qwen-tts-linux), code:yaml (endpoint: http://127.0.0.1:3000/events/stream), code:bash (# one-shot foreground run (smoke test)), code:bash (pan tts test), code:bash (./scripts/say.sh "Build is green, ready for review.") (+12 more)
 
-### Community 437 - "Community 437"
+### Community 433 - "Community 433"
 Cohesion: 0.1
 Nodes (20): code:block1 (skill-name/), code:yaml (---), code:bash (python scripts/init_skill.py <skill-name> --path <output-dir), code:bash (python scripts/package_skill.py <path/to/skill-folder> [outp), Concise is Key, Core Principles, Creation Process, Degrees of Freedom (+12 more)
 
-### Community 438 - "Community 438"
+### Community 434 - "Community 434"
 Cohesion: 0.1
 Nodes (20): Activity View, Adding Projects, Badge Bar, code:block1 (feature-pan-XXX/.planning/), Concept, Configuration, How It Works, Layout (+12 more)
 
-### Community 439 - "Community 439"
+### Community 435 - "Community 435"
 Cohesion: 0.11
 Nodes (19): activeIssues, date1, date2, expectedOrder, filtered, filteredIds, filterRecentCompletedIssues(), getOneDayAgo() (+11 more)
 
-### Community 440 - "Community 440"
-Cohesion: 0.12
-Nodes (18): NormalizedChannelPermissionRequestFields, buildPermissionActivityDetails(), buildPermissionWaitingMessage(), normalizePermissionRequestBody(), parsePermissionResponseBehavior(), permissionResolutionVerb(), processPermissionResponse(), ProcessPermissionResponseDeps (+10 more)
-
-### Community 441 - "Community 441"
-Cohesion: 0.15
-Nodes (16): CavemanVariant, determineCavemanVariant(), HookEntry, injectCavemanSettings(), injectMemoryHookSettings(), installTrustedMemoryHookScript(), memoryHookScript(), readWorkspaceSettings() (+8 more)
-
-### Community 442 - "Community 442"
+### Community 436 - "Community 436"
 Cohesion: 0.1
 Nodes (19): agentDir, body, commit, dir, files, launcher, LEGACY_FIELDS, legacyFields (+11 more)
 
+### Community 437 - "Community 437"
+Cohesion: 0.13
+Nodes (18): AddOptions, BUNDLED_HOOKS_DIR, __dirname, __filename, installGitHooks(), ListOptions, projectAddCommand(), projectInitCommand() (+10 more)
+
+### Community 438 - "Community 438"
+Cohesion: 0.09
+Nodes (18): columns, db, divergedRows, id, indexes, indexNames, names, pushRows (+10 more)
+
+### Community 439 - "Community 439"
+Cohesion: 0.19
+Nodes (20): assertSafeAgentId(), captureCheckpoint(), checkpointRef(), deleteAllCheckpoints(), deleteCheckpoint(), deleteLegacyCheckpointRefs(), diffCheckpointFiles(), diffCheckpoints() (+12 more)
+
+### Community 440 - "Community 440"
+Cohesion: 0.15
+Nodes (16): CavemanVariant, determineCavemanVariant(), HookEntry, injectCavemanSettings(), injectMemoryHookSettings(), installTrustedMemoryHookScript(), memoryHookScript(), readWorkspaceSettings() (+8 more)
+
+### Community 441 - "Community 441"
+Cohesion: 0.14
+Nodes (17): findVendoredDir(), getCavemanHooksDir(), getCavemanSkillsDir(), setupCavemanCompressScripts(), setupCavemanHooks(), compressSrc, destDir, dir (+9 more)
+
+### Community 442 - "Community 442"
+Cohesion: 0.15
+Nodes (13): consumeDashboardBootstrapToken(), createPanRpcProtocolLayer(), dashboardMutationJsonHeaders(), dashboardSessionUrl(), DEFAULT_RETRY_DELAY, ensureDashboardSession(), makePanRpcClient, resetTransport() (+5 more)
+
 ### Community 443 - "Community 443"
-Cohesion: 0.1
-Nodes (20): 10 High-Value Skills, 1. `feature-work` - Standard Feature Development, 2. `bug-fix` - Bug Investigation and Fix, 3. `code-review` - Code Review Focus Areas, 4. `code-review-security` - Security-Focused Review, 5. `code-review-performance` - Performance-Focused Review, 6. `refactor` - Safe Refactoring, 7. `release` - Release Process (+12 more)
+Cohesion: 0.12
+Nodes (17): CostThresholdDetails, embedSession(), EnrichRequest, enrichSession(), fetchSession(), formatDate(), fromRpcSession(), Props (+9 more)
 
 ### Community 444 - "Community 444"
-Cohesion: 0.1
-Nodes (19): Appendix: exe.dev CLI Reference, CLI Reference, code:bash (# Authentication), Documentation Updates, Future Enhancements, Goals, Modified Commands, New Commands (+11 more)
+Cohesion: 0.12
+Nodes (16): fetchFlywheelState(), FlywheelStatePane(), FlywheelStatePayload, formatLastModified(), fetchCurrentFlywheelStatus(), FlywheelLeftTab, FlywheelPage(), FlywheelPageProps (+8 more)
 
 ### Community 445 - "Community 445"
-Cohesion: 0.1
-Nodes (19): Canonical reviewer naming, code:block2 (┌───────────────────────────────────────────────────────────), code:typescript (// src/lib/cloister/specialists.ts), code:block3 (╔═══════════════════════════════════════════════════════════), code:typescript (// pseudocode for review-agent.ts after PAN-830), code:block31 (┌───────────────────────────────────────────────────────────), code:typescript (async function resolveJsonlPath(session: SessionDescriptor):), Goal (+11 more)
+Cohesion: 0.13
+Nodes (8): wipeCommand(), WipeOptions, extractStandardNumber(), extractStandardPrefix(), normalizeIssueId(), ParsedIssueId, parseIssueId(), result
 
 ### Community 446 - "Community 446"
 Cohesion: 0.1
-Nodes (19): Architecture (3 sentences), code:block1 ([work items DAG] ──→ VERIFY ──→ REVIEW ──→ TEST ──→ MERGE ──), Data Sources, Depends On, Design, Escape State Overlays, Inline Diff Toggle, Motivation (+11 more)
+Nodes (20): 10 High-Value Skills, 1. `feature-work` - Standard Feature Development, 2. `bug-fix` - Bug Investigation and Fix, 3. `code-review` - Code Review Focus Areas, 4. `code-review-security` - Security-Focused Review, 5. `code-review-performance` - Performance-Focused Review, 6. `refactor` - Safe Refactoring, 7. `release` - Release Process (+12 more)
 
 ### Community 447 - "Community 447"
 Cohesion: 0.1
-Nodes (19): 10. Cleanup, 1. `.panopticon/` → `.pan/` (project-level only), 2. `.panopticon.yaml` → `.pan.yaml`, 3. Archive structure: flat → per-issue subdirectory, 4. `findWorkspacePath` numeric suffix fix, 5. `.pan/skills/` as sync source, 6. Multi-tool sync (all 6 tools), 7. `.gitignore` injection (+11 more)
+Nodes (20): 6. Agreed End-State, Agent Startup Context, code:block10 (pan sync), code:block11 (pan sync), code:yaml (devroot: ~/Projects        # where you launch Claude Code fr), code:bash (pan workspace update MIN-678    # explicit command, only whe), code:block16 (pan workspace create MIN-678), code:block17 (Agent starts on MIN-678 workspace) (+12 more)
 
 ### Community 448 - "Community 448"
 Cohesion: 0.1
-Nodes (19): 9 items flagged for Epic D recovery review, Bug locations (as of HEAD), code:block1 (feature/pan-698@{2026-04-22 15:30:09}: reset: moving to e0ce), code:block2 (Epic D  →  Epic A  →  Epic B  →  Epic C), Context, Decisions (resolved 2026-04-23), Epic A — Labels as display, internal state as source of truth, Epic B — Work agent doesn't touch git (+11 more)
+Nodes (19): Appendix: exe.dev CLI Reference, CLI Reference, code:bash (# Authentication), Documentation Updates, Future Enhancements, Goals, Modified Commands, New Commands (+11 more)
 
 ### Community 449 - "Community 449"
 Cohesion: 0.1
-Nodes (19): 10. Cleanup, 1. `.panopticon/` → `.pan/` (project-level only), 2. `.panopticon.yaml` → `.pan.yaml`, 3. Archive structure: flat → per-issue subdirectory, 4. `findWorkspacePath` numeric suffix fix, 5. `.pan/skills/` as sync source, 6. Multi-tool sync (all 6 tools), 7. `.gitignore` injection (+11 more)
+Nodes (19): Canonical reviewer naming, code:block2 (┌───────────────────────────────────────────────────────────), code:typescript (// src/lib/cloister/specialists.ts), code:block3 (╔═══════════════════════════════════════════════════════════), code:typescript (// pseudocode for review-agent.ts after PAN-830), code:block31 (┌───────────────────────────────────────────────────────────), code:typescript (async function resolveJsonlPath(session: SessionDescriptor):), Goal (+11 more)
 
 ### Community 450 - "Community 450"
 Cohesion: 0.1
-Nodes (19): API Endpoints, Auth Token Refresh, Check Recent Logs, CLIProxy — Check and Restart, code:bash (# Is it running?), code:bash (# Kill any existing instance), code:bash (# Last 30 lines of cliproxy log), code:yaml (host: "127.0.0.1") (+11 more)
+Nodes (19): Architecture (3 sentences), code:block1 ([work items DAG] ──→ VERIFY ──→ REVIEW ──→ TEST ──→ MERGE ──), Data Sources, Depends On, Design, Escape State Overlays, Inline Diff Toggle, Motivation (+11 more)
 
 ### Community 451 - "Community 451"
 Cohesion: 0.1
-Nodes (17): code:bash (grep -E "FAIL|✗|Error|failed|BUILD FAILURE" /tmp/test-featur), code:bash (curl -s -X POST {{API_URL}}/api/review/{{ISSUE_ID}}/status \), code:bash (curl -s -X POST {{API_URL}}/api/review/{{ISSUE_ID}}/status \), code:bash (# Check if containers are running for this workspace), CRITICAL: Bash Timeout for Test Commands, CRITICAL: Context Management — Output Redirection, Memory Context, Never Close GitHub Issues (+9 more)
+Nodes (19): 10. Cleanup, 1. `.panopticon/` → `.pan/` (project-level only), 2. `.panopticon.yaml` → `.pan.yaml`, 3. Archive structure: flat → per-issue subdirectory, 4. `findWorkspacePath` numeric suffix fix, 5. `.pan/skills/` as sync source, 6. Multi-tool sync (all 6 tools), 7. `.gitignore` injection (+11 more)
 
 ### Community 452 - "Community 452"
 Cohesion: 0.1
-Nodes (19): CLI Overview, code:bash (# Install Panopticon globally), code:bash (pan work issue MIN-123      # Spawn agent), code:bash (pan workspace create MIN-123         # Create workspace), code:bash (pan up    # Start dashboard at localhost:3011), code:bash (# General help), Command Structure, Common Options (+11 more)
+Nodes (19): 9 items flagged for Epic D recovery review, Bug locations (as of HEAD), code:block1 (feature/pan-698@{2026-04-22 15:30:09}: reset: moving to e0ce), code:block2 (Epic D  →  Epic A  →  Epic B  →  Epic C), Context, Decisions (resolved 2026-04-23), Epic A — Labels as display, internal state as source of truth, Epic B — Work agent doesn't touch git (+11 more)
 
 ### Community 453 - "Community 453"
-Cohesion: 0.13
-Nodes (16): SessionUsage, emptyUsage(), isAssistantMessage(), isMessage(), KNOWN_TYPES, parsePiSessionContent(), ParseResult, PiEntry (+8 more)
+Cohesion: 0.1
+Nodes (19): 10. Cleanup, 1. `.panopticon/` → `.pan/` (project-level only), 2. `.panopticon.yaml` → `.pan.yaml`, 3. Archive structure: flat → per-issue subdirectory, 4. `findWorkspacePath` numeric suffix fix, 5. `.pan/skills/` as sync source, 6. Multi-tool sync (all 6 tools), 7. `.gitignore` injection (+11 more)
 
 ### Community 454 - "Community 454"
-Cohesion: 0.13
-Nodes (10): createPiFifo(), execAsync, PiFifoError, PiNotReady, shellQuote(), chunks, paths, reader (+2 more)
+Cohesion: 0.1
+Nodes (19): API Endpoints, Auth Token Refresh, Check Recent Logs, CLIProxy — Check and Restart, code:bash (# Is it running?), code:bash (# Kill any existing instance), code:bash (# Last 30 lines of cliproxy log), code:yaml (host: "127.0.0.1") (+11 more)
 
 ### Community 455 - "Community 455"
-Cohesion: 0.17
-Nodes (12): after, before, blockers, result, statuses, clearReviewStatus(), DEFAULT_STATUS_FILE, getReviewStatus() (+4 more)
+Cohesion: 0.1
+Nodes (17): code:bash (grep -E "FAIL|✗|Error|failed|BUILD FAILURE" /tmp/test-featur), code:bash (curl -s -X POST {{API_URL}}/api/review/{{ISSUE_ID}}/status \), code:bash (curl -s -X POST {{API_URL}}/api/review/{{ISSUE_ID}}/status \), code:bash (# Check if containers are running for this workspace), CRITICAL: Bash Timeout for Test Commands, CRITICAL: Context Management — Output Redirection, Memory Context, Never Close GitHub Issues (+9 more)
 
 ### Community 456 - "Community 456"
-Cohesion: 0.13
-Nodes (17): BunGlobal, ChannelPermissionRequest, ChannelPermissionRequestNotification, ChannelPushPayload, ChannelPushResult, constantTimeHeaderMatch(), forwardPermissionRequestToDashboard(), getDashboardBaseUrl() (+9 more)
+Cohesion: 0.1
+Nodes (19): CLI Overview, code:bash (# Install Panopticon globally), code:bash (pan work issue MIN-123      # Spawn agent), code:bash (pan workspace create MIN-123         # Create workspace), code:bash (pan up    # Start dashboard at localhost:3011), code:bash (# General help), Command Structure, Common Options (+11 more)
 
 ### Community 457 - "Community 457"
-Cohesion: 0.2
-Nodes (18): buildPlaceholders(), clearLegacyPlanningDir(), clearProjectBeads(), clearShadowState(), deleteBranches(), isDockerContainerProcess(), killOrphanedProcesses(), killTmuxSessions() (+10 more)
+Cohesion: 0.12
+Nodes (16): doCommit(), flushAutoCommits(), flushInner(), flushPromise(), FlushResult, GitResult, pending, QueuedCommit (+8 more)
 
 ### Community 458 - "Community 458"
-Cohesion: 0.14
-Nodes (16): findVendoredDir(), getCavemanHooksDir(), getCavemanSkillsDir(), setupCavemanHooks(), compressSrc, destDir, dir, hookFiles (+8 more)
+Cohesion: 0.15
+Nodes (13): addCandidateRoot(), collectCandidatePaths(), extractHashFromJsonlPath(), HashResolver, projectCandidateRoots(), ResolvedWorkspace, ReverseMapCache, a (+5 more)
 
 ### Community 459 - "Community 459"
-Cohesion: 0.11
-Nodes (15): RoundMarker, deriveRoundMarkers(), TimestampedItem, markers, MESSAGES, meta, divider, dividers (+7 more)
+Cohesion: 0.19
+Nodes (17): bridgeCodexAuthToCliproxy(), bridgeCodexAuthToCliproxyAsync(), decodeJwtPayload(), getCliproxyCodexCredPath(), getCodexAuthPath(), buildStatus(), decodeBase64Url(), decodeJwtPayload() (+9 more)
 
 ### Community 460 - "Community 460"
 Cohesion: 0.11
@@ -3123,128 +3131,128 @@ Cohesion: 0.11
 Nodes (16): capturedCmds, mockCreateReviewArtifactsForIssue, mockEnsureMergeSetForIssue, mockExecFileFn, mockExecFn, mockGetAgentState, mockGetDashboardApiUrl, mockGetReviewStatus (+8 more)
 
 ### Community 468 - "Community 468"
-Cohesion: 0.18
-Nodes (16): buildReport(), categorizeProcesses(), ClaudeProcess, detectRole(), formatGb(), formatMb(), getClaudeProcesses(), getHeavyProcesses() (+8 more)
+Cohesion: 0.11
+Nodes (15): agentState, callOrder, checkFn, killed, mockGetAgentState, mockGetRuntimeForAgent, mockKillAgent, mockKillSession (+7 more)
 
 ### Community 469 - "Community 469"
-Cohesion: 0.19
-Nodes (12): startPostLaunchSidecars(), startSidecars(), getSupervisorPort(), getSupervisorUrl(), isProcessAlive(), isSupervisorRunning(), readSupervisorPid(), resolveSupervisorBundle() (+4 more)
-
-### Community 470 - "Community 470"
 Cohesion: 0.23
 Nodes (9): addVoice(), clearVoices(), deleteVoice(), findVoiceById(), findVoiceByName(), getTtsVoicesPath(), loadVoices(), saveVoices() (+1 more)
 
-### Community 471 - "Community 471"
+### Community 470 - "Community 470"
 Cohesion: 0.14
-Nodes (15): __dirname, __filename, isStringArray(), loadPromptFrontmatter(), ParsedPrompt, parsePrompt(), PromptError, PromptFrontmatter (+7 more)
+Nodes (9): NormalizedTtsDaemonConfig, parseTtsWatchdogIntEnv(), readTtsWatchdogConfig(), TtsWatchdog, TtsWatchdogConfig, TtsWatchdogStatus, log, mocks (+1 more)
 
-### Community 472 - "Community 472"
-Cohesion: 0.16
-Nodes (14): ARCHIVES_DIR, archivePlanning(), archiveWorkspaceArtifacts(), archiveWorkspaceArtifactsImpl(), execAsync, findAllWorkspacePaths(), findWorkspacePath(), movePrd() (+6 more)
-
-### Community 473 - "Community 473"
-Cohesion: 0.2
-Nodes (15): setupCavemanCompressScripts(), addPanopticonHookIfMissing(), checkJqInstalled(), HookConfig, installJq(), isHookConfigured(), McpServer, setupHooksCommand() (+7 more)
-
-### Community 474 - "Community 474"
-Cohesion: 0.11
-Nodes (17): firstSelect, openaiKeyInput, openaiProvider, PANOPTICON_HOME, reviewAgentLabel, reviewAgentSelect, ROUTER_CONFIG, routerConfig (+9 more)
-
-### Community 475 - "Community 475"
-Cohesion: 0.18
-Nodes (13): AutoPresoControls(), warmupIcon(), AutoPresoView(), Excalidraw, ExcalidrawApiLike, TranscriptPanel(), AutoPresoMessage, AutoPresoMode (+5 more)
-
-### Community 476 - "Community 476"
-Cohesion: 0.11
-Nodes (14): ensuredLabels, makeTestLayer(), mockGitHubAddLabel, mockGitHubCloseIssue, mockGitHubEnsureLabel, mockGitHubRemoveLabel, mockGitHubReopenIssue, mockLinearGetIssue (+6 more)
-
-### Community 477 - "Community 477"
-Cohesion: 0.11
-Nodes (17): cb, cmdArgs, cmdStr, inline, issueCommentsJson, linearGetComments, linearGetIssueId, mockExec (+9 more)
-
-### Community 478 - "Community 478"
+### Community 471 - "Community 471"
 Cohesion: 0.16
 Nodes (14): atomicWrite(), backupIfNeeded(), detectProviderEnvConflicts(), findNewestBackup(), injectPanopticonInfraDeny(), injectProviderEnvOverlay(), INVALID_LEGACY_PATTERNS, OverlayResult (+6 more)
 
-### Community 479 - "Community 479"
+### Community 472 - "Community 472"
+Cohesion: 0.14
+Nodes (13): GPT_5_5_API_KEY_BLOCK, HarnessPolicyDecision, PI_ANTHROPIC_SUBSCRIPTION_BLOCK, SUBSCRIPTION_ONLY_OPENAI_MODELS, AuthMode, SubscriptionPlan, RuntimeName, AUTH_MODES (+5 more)
+
+### Community 473 - "Community 473"
+Cohesion: 0.19
+Nodes (12): startPostLaunchSidecars(), startSidecars(), getSupervisorPort(), getSupervisorUrl(), isProcessAlive(), isSupervisorRunning(), readSupervisorPid(), resolveSupervisorBundle() (+4 more)
+
+### Community 474 - "Community 474"
+Cohesion: 0.14
+Nodes (15): __dirname, __filename, isStringArray(), loadPromptFrontmatter(), ParsedPrompt, parsePrompt(), PromptError, PromptFrontmatter (+7 more)
+
+### Community 475 - "Community 475"
+Cohesion: 0.18
+Nodes (16): buildReport(), categorizeProcesses(), ClaudeProcess, detectRole(), formatGb(), formatMb(), getClaudeProcesses(), getHeavyProcesses() (+8 more)
+
+### Community 476 - "Community 476"
 Cohesion: 0.11
-Nodes (18): Approach 1: Passive Detection (MVP), Approach 2: Active Heartbeats (via Claude Code Hooks), Approach 3: Hybrid (Recommended), code:typescript (interface PassiveHeartbeat {), code:json ({), code:bash (#!/bin/bash), code:json ({), code:typescript (function getHeartbeat(agentId: string): Heartbeat {) (+10 more)
+Nodes (17): firstSelect, openaiKeyInput, openaiProvider, PANOPTICON_HOME, reviewAgentLabel, reviewAgentSelect, ROUTER_CONFIG, routerConfig (+9 more)
+
+### Community 477 - "Community 477"
+Cohesion: 0.18
+Nodes (13): AutoPresoControls(), warmupIcon(), AutoPresoView(), Excalidraw, ExcalidrawApiLike, TranscriptPanel(), AutoPresoMessage, AutoPresoMode (+5 more)
+
+### Community 478 - "Community 478"
+Cohesion: 0.11
+Nodes (17): cb, cmdArgs, cmdStr, inline, issueCommentsJson, linearGetComments, linearGetIssueId, mockExec (+9 more)
+
+### Community 479 - "Community 479"
+Cohesion: 0.13
+Nodes (16): buildPermissionActivityDetails(), buildPermissionWaitingMessage(), parsePermissionResponseBehavior(), permissionResolutionVerb(), processPermissionResponse(), ProcessPermissionResponseDeps, ProcessPermissionResponseResult, redactPermissionInputPreview() (+8 more)
 
 ### Community 480 - "Community 480"
 Cohesion: 0.11
-Nodes (18): `<ActivitySparkline events={Event[]} windowMinutes={60} buckets={12} />`, Animation-timing reference, code:typescript (// Renders a 6×6 (small) or 8×8 (medium) circle with the rig), code:typescript (// Animates the number on change (vertical scroll fade, 250m), code:typescript (// Inline SVG, ~120×16px.), code:typescript (// 140-wide mini card with verdict, finding count, duration,), code:typescript (// Cross-fades the tool name on change (200ms each, with → b), code:typescript (// Wraps a lucide icon with the right ring color and avatar ) (+10 more)
+Nodes (18): Approach 1: Passive Detection (MVP), Approach 2: Active Heartbeats (via Claude Code Hooks), Approach 3: Hybrid (Recommended), code:typescript (interface PassiveHeartbeat {), code:json ({), code:bash (#!/bin/bash), code:json ({), code:typescript (function getHeartbeat(agentId: string): Heartbeat {) (+10 more)
 
 ### Community 481 - "Community 481"
 Cohesion: 0.11
-Nodes (17): Architecture Decisions, code:block1 (wire-converter ──blocks──> remove-bd-prompts), Decisions, Dependency Graph (text), Key Files to Modify, Out of Scope, PAN-388: vBRIEF Integration — Structured Plans, Programmatic Beads, DAG Visualization, Phase 2 (+9 more)
+Nodes (18): `<ActivitySparkline events={Event[]} windowMinutes={60} buckets={12} />`, Animation-timing reference, code:typescript (// Renders a 6×6 (small) or 8×8 (medium) circle with the rig), code:typescript (// Animates the number on change (vertical scroll fade, 250m), code:typescript (// Inline SVG, ~120×16px.), code:typescript (// 140-wide mini card with verdict, finding count, duration,), code:typescript (// Cross-fades the tool name on change (200ms each, with → b), code:typescript (// Wraps a lucide icon with the right ring color and avatar ) (+10 more)
 
 ### Community 482 - "Community 482"
 Cohesion: 0.11
-Nodes (17): Access Points, Add Dependencies, Add Services, Change Java Version, code:bash (# Copy template to your project), code:bash (# Application), code:bash (# Connect to PostgreSQL), code:bash (docker compose restart app) (+9 more)
+Nodes (17): Architecture Decisions, code:block1 (wire-converter ──blocks──> remove-bd-prompts), Decisions, Dependency Graph (text), Key Files to Modify, Out of Scope, PAN-388: vBRIEF Integration — Structured Plans, Programmatic Beads, DAG Visualization, Phase 2 (+9 more)
 
 ### Community 483 - "Community 483"
 Cohesion: 0.11
-Nodes (17): Access Points, Adding Dependencies, Alembic Migrations, code:bash (# Copy template to your project), code:bash (APP_PORT=8000), code:python (# database.py), code:bash (# Install alembic), code:bash (# Connect to PostgreSQL) (+9 more)
+Nodes (17): Access Points, Add Dependencies, Add Services, Change Java Version, code:bash (# Copy template to your project), code:bash (# Application), code:bash (# Connect to PostgreSQL), code:bash (docker compose restart app) (+9 more)
 
 ### Community 484 - "Community 484"
 Cohesion: 0.11
-Nodes (17): Adding Workspace Routes, code:block1 (~/.panopticon/traefik/), code:bash (mkcert "*.pan.localhost" "*.localhost" localhost 127.0.0.1 :), code:bash (cd ~/.panopticon/traefik), code:bash (cd ~/.panopticon/traefik), code:bash (docker logs -f panopticon-traefik), code:yaml (# dynamic/feature-pan-4.yml), Directory Structure (+9 more)
+Nodes (17): Access Points, Adding Dependencies, Alembic Migrations, code:bash (# Copy template to your project), code:bash (APP_PORT=8000), code:python (# database.py), code:bash (# Install alembic), code:bash (# Connect to PostgreSQL) (+9 more)
 
 ### Community 485 - "Community 485"
 Cohesion: 0.11
-Nodes (17): bd vs TodoWrite, Beads Skill for Claude Code, code:bash (# Global installation), code:block2 (beads/), code:bash (# Want: "Setup must complete before Implementation"), code:bash (bd update issue-123 --notes "COMPLETED: JWT auth with RS256), Contributing, File Structure (+9 more)
+Nodes (17): Adding Workspace Routes, code:block1 (~/.panopticon/traefik/), code:bash (mkcert "*.pan.localhost" "*.localhost" localhost 127.0.0.1 :), code:bash (cd ~/.panopticon/traefik), code:bash (cd ~/.panopticon/traefik), code:bash (docker logs -f panopticon-traefik), code:yaml (# dynamic/feature-pan-4.yml), Directory Structure (+9 more)
 
 ### Community 486 - "Community 486"
 Cohesion: 0.11
-Nodes (17): code:block1 (Session Start (when bd is available):), code:block13 (Side Quest Workflow:), code:block14 (Main task: Adding user profiles), code:block15 (Resume Workflow:), code:block25 (Hybrid Workflow:), code:block5 (Discovery Workflow:), code:block6 (Issue Lifecycle:), Contents (+9 more)
+Nodes (17): bd vs TodoWrite, Beads Skill for Claude Code, code:bash (# Global installation), code:block2 (beads/), code:bash (# Want: "Setup must complete before Implementation"), code:bash (bd update issue-123 --notes "COMPLETED: JWT auth with RS256), Contributing, File Structure (+9 more)
 
 ### Community 487 - "Community 487"
 Cohesion: 0.11
-Nodes (17): Benchmark: QuantumLlama Provider Integration, code:block1 (/benchmark <scenario description>), code:bash (cat /home/eltmon/Projects/panopticon-cli/benchmarks/template), code:bash (cd /home/eltmon/Projects/panopticon-cli && gh label create b), code:bash (cd /home/eltmon/Projects/panopticon-cli && gh issue create \), code:block5 (Created PAN-XXX: Benchmark: QuantumLlama — <scenario>), Execution Steps, Important Notes (+9 more)
+Nodes (17): code:block1 (Session Start (when bd is available):), code:block13 (Side Quest Workflow:), code:block14 (Main task: Adding user profiles), code:block15 (Resume Workflow:), code:block25 (Hybrid Workflow:), code:block5 (Discovery Workflow:), code:block6 (Issue Lifecycle:), Contents (+9 more)
 
 ### Community 488 - "Community 488"
 Cohesion: 0.11
-Nodes (17): API Documentation, Checklist Output, Code Generation, code:markdown (## Analysis Report), code:markdown (## Review Checklist), code:markdown (## Generated Code), code:markdown (## Changes Made), code:markdown (## Option Analysis) (+9 more)
+Nodes (17): Benchmark: QuantumLlama Provider Integration, code:block1 (/benchmark <scenario description>), code:bash (cat /home/eltmon/Projects/panopticon-cli/benchmarks/template), code:bash (cd /home/eltmon/Projects/panopticon-cli && gh label create b), code:bash (cd /home/eltmon/Projects/panopticon-cli && gh issue create \), code:block5 (Created PAN-XXX: Benchmark: QuantumLlama — <scenario>), Execution Steps, Important Notes (+9 more)
 
 ### Community 489 - "Community 489"
 Cohesion: 0.11
-Nodes (17): code:bash (# Register a project), code:yaml (projects:), code:json ([), code:yaml (projects:), code:bash (#!/bin/bash), code:yaml (projects:), Configuration Fields, Custom Workspace Commands (Legacy) (+9 more)
+Nodes (17): API Documentation, Checklist Output, Code Generation, code:markdown (## Analysis Report), code:markdown (## Review Checklist), code:markdown (## Generated Code), code:markdown (## Changes Made), code:markdown (## Option Analysis) (+9 more)
 
 ### Community 490 - "Community 490"
 Cohesion: 0.11
-Nodes (17): 1. Review the shared context first, 2. Wait for convoy signals, 3. Read available reviewer reports, 4. Determine the cycle number and the diff scope to evaluate, 5. Synthesize the verdict, 6. Write the synthesis report, 7. Signal review status, Boundaries (+9 more)
+Nodes (17): code:bash (# Register a project), code:yaml (projects:), code:json ([), code:yaml (projects:), code:bash (#!/bin/bash), code:yaml (projects:), Configuration Fields, Custom Workspace Commands (Legacy) (+9 more)
 
 ### Community 491 - "Community 491"
-Cohesion: 0.12
-Nodes (15): activeAgent, address, agent, feature, frontendRoot, issue, newContext(), openRoute() (+7 more)
+Cohesion: 0.11
+Nodes (17): 1. Review the shared context first, 2. Wait for convoy signals, 3. Read available reviewer reports, 4. Determine the cycle number and the diff scope to evaluate, 5. Synthesize the verdict, 6. Write the synthesis report, 7. Signal review status, Boundaries (+9 more)
 
 ### Community 492 - "Community 492"
 Cohesion: 0.12
-Nodes (15): CI_FAILED_STATUS, ciBlockedStatus, feedbackDir, mockGetAgentRuntimeState, mockLoadReviewStatuses, mockResolveProjectFromIssue, mockSendKeysAsync, mockSessionExists (+7 more)
+Nodes (15): activeAgent, address, agent, feature, frontendRoot, issue, newContext(), openRoute() (+7 more)
 
 ### Community 493 - "Community 493"
-Cohesion: 0.29
-Nodes (16): display_title(), extract_text_fragments(), extract_tool_names(), find_by_id(), format_cost(), get_db(), get_session_summary(), iter_session_messages() (+8 more)
-
-### Community 494 - "Community 494"
-Cohesion: 0.15
-Nodes (12): GPT_5_5_API_KEY_BLOCK, HarnessPolicyDecision, PI_ANTHROPIC_SUBSCRIPTION_BLOCK, SUBSCRIPTION_ONLY_OPENAI_MODELS, AuthMode, RuntimeName, AUTH_MODES, cells (+4 more)
-
-### Community 495 - "Community 495"
-Cohesion: 0.19
-Nodes (15): registerAdminCommands(), archiveCustomState(), CleanupOptions, cleanupStatesCommand(), LinearState, ListOptions, listStatesCommand(), listTeamStates() (+7 more)
-
-### Community 496 - "Community 496"
 Cohesion: 0.12
 Nodes (15): agentDir, agentResult, beadsDir, branchResult, clearResult, content, legacyDir, legacyResult (+7 more)
 
+### Community 494 - "Community 494"
+Cohesion: 0.12
+Nodes (15): CI_FAILED_STATUS, ciBlockedStatus, feedbackDir, mockGetAgentRuntimeState, mockLoadReviewStatuses, mockResolveProjectFromIssue, mockSendKeysAsync, mockSessionExists (+7 more)
+
+### Community 495 - "Community 495"
+Cohesion: 0.29
+Nodes (16): display_title(), extract_text_fragments(), extract_tool_names(), find_by_id(), format_cost(), get_db(), get_session_summary(), iter_session_messages() (+8 more)
+
+### Community 496 - "Community 496"
+Cohesion: 0.17
+Nodes (14): deepClone(), DEFAULTS, DesktopSettings, loadDesktopSettings(), NotificationEventType, saveDesktopSettings(), settings, settingsPath() (+6 more)
+
 ### Community 497 - "Community 497"
-Cohesion: 0.14
-Nodes (10): TtsVoiceListItem, playVoice(), requireTtsSpoken(), TtsSystemVoicePicker(), TtsSystemVoicePickerProps, VoiceChoiceSectionProps, onSetStatusVoice, onSetSystemVoice (+2 more)
+Cohesion: 0.19
+Nodes (10): backupCleanCommand(), backupListCommand(), restoreCommand(), BackupInfo, cleanOldBackups(), createBackup(), createBackupTimestamp(), listBackups() (+2 more)
 
 ### Community 498 - "Community 498"
-Cohesion: 0.14
-Nodes (14): cleanupExpiredReauthSessions(), codexAuthRouteLayer, consumeReauthTerminalToken(), getCodexAuthRoute, getExistingLiveReauthSession(), getLiveReauthSession(), postCodexReauthRoute, postCodexReauthStatusRoute (+6 more)
+Cohesion: 0.13
+Nodes (14): getBridgeLogPath(), getPanopticonHome(), getSocketPath(), BRIDGE_ENTRY, entry, exitPromise, lines, logPath (+6 more)
 
 ### Community 499 - "Community 499"
 Cohesion: 0.12
@@ -3268,175 +3276,175 @@ Nodes (17): code:block21 (- discovers all sessions in target dir), code:block22 
 
 ### Community 504 - "Community 504"
 Cohesion: 0.12
-Nodes (17): Action cluster, code:block10 ($0.04/min currently · projecting $1.20 for this session at t), code:block11 (+47 lines), code:block12 (○ idle for 4m 12s — needs nudge?    [Send Message] [Stop]), code:block6 (phase: review-response · tool: Grep), code:block7 (🧠 thinking · since 14:32:42 · last tool was Grep 8s ago), code:block8 (⏸ waiting · {reason} — {message}                    [Resolve), code:block9 (┌──────────────┐  ┌──────────────┐  ┌──────────────┐) (+9 more)
+Nodes (16): Architecture, CLI Interface (full surface), code:block1 (┌──────────────────────────────────────────┐), code:bash (pan conversations embed                      # all enriched,), code:yaml (# config.yaml), code:bash (# Discovery), code:block20 (GET  /api/archived-conversations), Dependencies (+8 more)
 
 ### Community 505 - "Community 505"
 Cohesion: 0.12
-Nodes (16): Additional Gaps, code:json ({), code:block2 (For each running work agent:), code:typescript ({), Files to Change, Non-Goals, PAN-309: Evidence-Based Completion Detection & Lifecycle Badges, Phase 1: Evidence-Based Completion Detection (stop-hook) (+8 more)
+Nodes (17): Action cluster, code:block10 ($0.04/min currently · projecting $1.20 for this session at t), code:block11 (+47 lines), code:block12 (○ idle for 4m 12s — needs nudge?    [Send Message] [Stop]), code:block6 (phase: review-response · tool: Grep), code:block7 (🧠 thinking · since 14:32:42 · last tool was Grep 8s ago), code:block8 (⏸ waiting · {reason} — {message}                    [Resolve), code:block9 (┌──────────────┐  ┌──────────────┐  ┌──────────────┐) (+9 more)
 
 ### Community 506 - "Community 506"
 Cohesion: 0.12
-Nodes (15): Approach: Pre-fetch in callers, pass to prompt builder, Architecture, code:block1 ([issueCommand() / server endpoint]), Data Flow, Data to include, Decisions, Error handling: Warn in prompt, Files to Modify (+7 more)
+Nodes (16): Additional Gaps, code:json ({), code:block2 (For each running work agent:), code:typescript ({), Files to Change, Non-Goals, PAN-309: Evidence-Based Completion Detection & Lifecycle Badges, Phase 1: Evidence-Based Completion Detection (stop-hook) (+8 more)
 
 ### Community 507 - "Community 507"
 Cohesion: 0.12
-Nodes (16): Constraints, Design, Draft-mode parity, Explicit reconciliation, Local outbox model, Must Have, Open Questions, Out of Scope (+8 more)
+Nodes (15): Approach: Pre-fetch in callers, pass to prompt builder, Architecture, code:block1 ([issueCommand() / server endpoint]), Data Flow, Data to include, Decisions, Error handling: Warn in prompt, Files to Modify (+7 more)
 
 ### Community 508 - "Community 508"
 Cohesion: 0.12
-Nodes (16): Architecture, Bootstrap, code:block1 (AgentEnrichmentService (3s poll)), Contracts Package (`packages/contracts/src/`), Data Flow, Decisions, Files to Modify, Frontend (verify only) (+8 more)
+Nodes (16): Constraints, Design, Draft-mode parity, Explicit reconciliation, Local outbox model, Must Have, Open Questions, Out of Scope (+8 more)
 
 ### Community 509 - "Community 509"
 Cohesion: 0.12
-Nodes (16): Access Points, code:bash (# Copy template to your project), code:bash (APP_PORT=5000), code:block3 (Server=sqlserver;Database=${DB_NAME};User Id=sa;Password=${D), code:json ({), code:bash (# Run migrations), code:bash (# Connect via sqlcmd), Connection String (+8 more)
+Nodes (16): Architecture, Bootstrap, code:block1 (AgentEnrichmentService (3s poll)), Contracts Package (`packages/contracts/src/`), Data Flow, Decisions, Files to Modify, Frontend (verify only) (+8 more)
 
 ### Community 510 - "Community 510"
 Cohesion: 0.12
-Nodes (16): Authentication Issues, code:bash (npx @_davideast/stitch-mcp init), code:json ({), code:bash (npx @_davideast/stitch-mcp doctor), code:bash (export STITCH_USE_SYSTEM_GCLOUD=1), Environment Detection, Manual Configuration, Prerequisites (+8 more)
+Nodes (16): Access Points, code:bash (# Copy template to your project), code:bash (APP_PORT=5000), code:block3 (Server=sqlserver;Database=${DB_NAME};User Id=sa;Password=${D), code:json ({), code:bash (# Run migrations), code:bash (# Connect via sqlcmd), Connection String (+8 more)
 
 ### Community 511 - "Community 511"
 Cohesion: 0.12
-Nodes (16): 1. Generate the table, 2. Add an Awaiting Merge summary line, 3. (Optional) Defer to other status skills if user wants more detail, Cell semantics, code:block1 (ISSUE      TITLE                                            ), code:bash (python3 - <<'PY'), code:bash (curl -s http://localhost:3011/api/issues | python3 -c "), code:block4 (For deeper detail beyond the pipeline view:) (+8 more)
+Nodes (16): Authentication Issues, code:bash (npx @_davideast/stitch-mcp init), code:json ({), code:bash (npx @_davideast/stitch-mcp doctor), code:bash (export STITCH_USE_SYSTEM_GCLOUD=1), Environment Detection, Manual Configuration, Prerequisites (+8 more)
 
 ### Community 512 - "Community 512"
 Cohesion: 0.12
-Nodes (16): Basic Usage, Cleanup After Shutdown, code:bash (# Stop all Panopticon services), code:bash (# Method 1: Separate commands), code:bash (# Clean up log files), code:env (# Graceful shutdown timeout (seconds)), Configuration Options, More Information (+8 more)
+Nodes (16): 1. Generate the table, 2. Add an Awaiting Merge summary line, 3. (Optional) Defer to other status skills if user wants more detail, Cell semantics, code:block1 (ISSUE      TITLE                                            ), code:bash (python3 - <<'PY'), code:bash (curl -s http://localhost:3011/api/issues | python3 -c "), code:block4 (For deeper detail beyond the pipeline view:) (+8 more)
 
 ### Community 513 - "Community 513"
 Cohesion: 0.12
-Nodes (16): 10. Scrollbars, 16. File Organization, 17. Quick Reference Card, 1. Design Philosophy, 5. Border Radius Scale, 6. Spacing & Sizing, 9. Fractal Noise Texture, code:css (--radius: 0.625rem;  /* 10px */) (+8 more)
+Nodes (16): Basic Usage, Cleanup After Shutdown, code:bash (# Stop all Panopticon services), code:bash (# Clean up log files), code:bash (# Monitor in one terminal), code:env (# Graceful shutdown timeout (seconds)), Configuration Options, Monitoring Shutdown (+8 more)
 
 ### Community 514 - "Community 514"
 Cohesion: 0.12
-Nodes (16): code:bash (curl {{API_URL}}/api/health), code:bash (# Get test token (server-side, before opening browser)), code:javascript (// Launch browser), code:block4 (## UAT Results), Context, Critical Notes, Examples of BLOCKED vs PASS, Handling Playwright (Browser Automation) (+8 more)
+Nodes (16): 10. Scrollbars, 16. File Organization, 17. Quick Reference Card, 1. Design Philosophy, 5. Border Radius Scale, 6. Spacing & Sizing, 9. Fractal Noise Texture, code:css (--radius: 0.625rem;  /* 10px */) (+8 more)
 
 ### Community 515 - "Community 515"
 Cohesion: 0.12
-Nodes (16): Best Value by Tier, Budget Tasks, Changes from Baseline, Code Review & Security, Conclusion, Cost-Effectiveness Analysis, Debugging, Executive Summary (+8 more)
+Nodes (16): code:bash (curl {{API_URL}}/api/health), code:bash (# Get test token (server-side, before opening browser)), code:javascript (// Launch browser), code:block4 (## UAT Results), Context, Critical Notes, Examples of BLOCKED vs PASS, Handling Playwright (Browser Automation) (+8 more)
 
 ### Community 516 - "Community 516"
 Cohesion: 0.12
-Nodes (16): code:bash (# Full install (includes Traefik + mkcert for HTTPS)), code:bash (pan sync), code:bash (pan doctor), code:bash (# Start with default settings), code:bash (pan down), code:bash (pan restart), code:bash (pan health), Core Commands (+8 more)
+Nodes (16): Best Value by Tier, Budget Tasks, Changes from Baseline, Code Review & Security, Conclusion, Cost-Effectiveness Analysis, Debugging, Executive Summary (+8 more)
 
 ### Community 517 - "Community 517"
+Cohesion: 0.12
+Nodes (16): code:bash (# Full install (includes Traefik + mkcert for HTTPS)), code:bash (pan sync), code:bash (pan doctor), code:bash (# Start with default settings), code:bash (pan down), code:bash (pan restart), code:bash (pan health), Core Commands (+8 more)
+
+### Community 518 - "Community 518"
 Cohesion: 0.15
 Nodes (6): MockRallyArtifact, RallyApiMock, compoundQueries, mock, sampleArtifacts, typeQueries
 
-### Community 518 - "Community 518"
-Cohesion: 0.12
-Nodes (15): agentDir, cache1, cache2, events1, events2, eventsFile, sessionDir, stats (+7 more)
-
 ### Community 519 - "Community 519"
-Cohesion: 0.2
-Nodes (3): GitHubTracker, octokitToEffect(), parseIssueNumber()
-
-### Community 520 - "Community 520"
-Cohesion: 0.13
-Nodes (13): getBridgeLogPath(), getPanopticonHome(), BRIDGE_ENTRY, entry, exitPromise, lines, logPath, params (+5 more)
-
-### Community 521 - "Community 521"
-Cohesion: 0.16
-Nodes (14): CategoryFilter, formatContextLength(), formatCost(), ModelCard(), OpenRouterModel, OpenRouterModelBrowser(), OpenRouterModelBrowserProps, { container } (+6 more)
-
-### Community 522 - "Community 522"
 Cohesion: 0.23
 Nodes (14): getDefaultTtsDaemonConfig(), getGlobalConfigPath(), mergeTtsConfig(), mergeTtsDaemonConfigs(), cloneTtsConfig(), currentConfig, findProjectRootAsync(), pathExists() (+6 more)
 
-### Community 523 - "Community 523"
+### Community 520 - "Community 520"
 Cohesion: 0.19
 Nodes (12): getAllSpecialistStatus(), LegacySpecialistRuntimeStatus, displaySpecialist(), getRelativeTime(), getStatusColor(), getStatusIcon(), listCommand(), ListOptions (+4 more)
 
-### Community 524 - "Community 524"
-Cohesion: 0.12
-Nodes (15): Architecture, CLI Commands, code:bash (# 1. Implement feature), code:bash (# List all specialists with status), code:toml ([specialists.review_agent]), code:typescript (type Priority = 'urgent' | 'high' | 'normal' | 'low';), Configuration, Deacon Health Monitor (+7 more)
-
-### Community 525 - "Community 525"
-Cohesion: 0.12
-Nodes (16): Baseline-Aware Test Validation, code:block1 (┌───────────────────────────────────────────────────────────), code:bash (# In validate-merge.sh), code:typescript (// validation.ts — autoRevertMerge always uses ORIG_HEAD), code:typescript (const { stdout: statusOut } = await execAsync('git status --), code:typescript (if (stashCreated) {), code:block6 (┌──────────┐     ┌──────────┐     ┌──────────┐     ┌────────), code:typescript (POST /api/specialists/done) (+8 more)
-
-### Community 526 - "Community 526"
-Cohesion: 0.12
-Nodes (15): code:block1 (tests/), code:typescript (// Mock execAsync for git command tests), code:typescript (// Preferred: testid), Conventions, Dashboard UI Testing, `data-testid` Convention, Mocking, Playwright MCP (+7 more)
-
-### Community 527 - "Community 527"
-Cohesion: 0.12
-Nodes (15): API Integration, Component Structure, Core Layout, Design 1: Collapsed State, Design 2: Expanded State, Next Steps, Overrides (6 components), Overview (+7 more)
-
-### Community 528 - "Community 528"
-Cohesion: 0.12
-Nodes (16): 10. Autonomous flywheel daemon, 11. Public flywheel dashboard page, 12. Updated `all-up` skill, 13. Updated `CLAUDE.md` (repo-level), 1. `retro-agent` — New agent type, 2. Retro storage, 3. Synthesis step — new Step 8 in `all-up` skill, 4. `docs/FLYWHEEL-REPORT.md` — user-facing living doc (+8 more)
-
-### Community 529 - "Community 529"
-Cohesion: 0.12
-Nodes (15): Acceptance Criteria, Code to Preserve (Merge Queue), code:block1 (if (specialist busy) → submitToSpecialistQueue()), code:block2 (if (workspace already has running specialist) → no-op (dupli), Current Architecture, Goal, Key Files to Remove/Modify, New Dispatch Pattern (+7 more)
-
-### Community 530 - "Community 530"
-Cohesion: 0.12
-Nodes (15): Approach, D1: Full scope — all 6 problem areas, D2: Typed error-to-HTTP mapping via `httpHandler` wrapper, D3: Convert ALL sync FS calls including `existsSync`, D4: Keep existing route composition pattern, Decisions, Out of Scope, PAN-470: Rewrite route handlers to idiomatic Effect (+7 more)
-
-### Community 531 - "Community 531"
-Cohesion: 0.12
-Nodes (15): 1. Eliminating Waterfalls (CRITICAL), 2. Bundle Size Optimization (CRITICAL), 3. Server-Side Performance (HIGH), 4. Client-Side Data Fetching (MEDIUM-HIGH), 5. Re-render Optimization (MEDIUM), 6. Rendering Performance (MEDIUM), 7. JavaScript Performance (LOW-MEDIUM), 8. Advanced Patterns (LOW) (+7 more)
-
-### Community 532 - "Community 532"
-Cohesion: 0.12
-Nodes (15): Auto-Fix Critical Issues, Check Specific Workspace, code:bash (python ~/.claude/skills/session-health/scripts/check_session), code:bash (python ~/.claude/skills/session-health/scripts/check_session), code:bash (# Replace with your actual project path), code:bash (tmux kill-session -t agent-proj-123), code:python (import os, glob), code:bash (pan start PROJ-123) (+7 more)
-
-### Community 533 - "Community 533"
-Cohesion: 0.12
-Nodes (15): Beads Completion Check, BLOCKED - Open Beads Found, code:bash (# Check for open beads), code:block2 (BEADS CHECK: PASS), code:block3 (BEADS CHECK: BLOCKED), code:block4 (Task(subagent_type='beads-completion-check', prompt='Check i), code:json ({), Error Handling (+7 more)
-
-### Community 534 - "Community 534"
-Cohesion: 0.12
-Nodes (15): Code Review Agent, code:markdown (---), code:markdown (---), code:markdown (---), code:markdown (---), code:markdown (---), code:markdown (---), code:markdown (---) (+7 more)
-
-### Community 535 - "Community 535"
-Cohesion: 0.12
-Nodes (15): code:markdown (## Process), code:markdown (## Decision Tree), code:markdown (## Data Transformation), code:markdown (## Investigation Flow), code:markdown (## Setup Wizard), code:markdown (## Multi-Source Research), code:markdown (## Robust Execution), Conditional Branching (+7 more)
-
-### Community 536 - "Community 536"
-Cohesion: 0.12
-Nodes (15): 1. Inspect commit context, 2. Choose the narrowest fitting scope, 3. Draft the commit message, 4. Commit safely, 5. If commitlint rejects the message, code:bash (git status --short --branch), code:text (feat(cli): add pan-commit skill), code:text (fix(dashboard): rehydrate snapshot after reconnect) (+7 more)
-
-### Community 537 - "Community 537"
-Cohesion: 0.12
-Nodes (15): code:bash (cd {{projectPath}}), code:bash (git diff --check), code:bash (git commit --no-edit), code:block4 (MERGE_RESULT: SUCCESS), code:block5 (MERGE_RESULT: FAILURE), code:bash (git merge --abort), Conflict Files, Critical Rules (+7 more)
-
-### Community 538 - "Community 538"
-Cohesion: 0.13
-Nodes (13): cleanupOldHealthEvents(), DatabaseError, deleteAgentHealthHistory(), getAgentsWithHistory(), getAllHealthHistory(), getHealthHistory(), getLatestHealthEvent(), getRecentHealthHistory() (+5 more)
-
-### Community 539 - "Community 539"
-Cohesion: 0.13
-Nodes (14): backup, backup1, backup2, backupDir, backups, dir1, dir2, removed (+6 more)
-
-### Community 540 - "Community 540"
-Cohesion: 0.16
-Nodes (10): TrackerError, RallyApiConfig, RallyCreateConfig, RallyCreateResult, RallyQueryConfig, RallyQueryResult, RallyRestApi, RallyUpdateConfig (+2 more)
-
-### Community 542 - "Community 542"
-Cohesion: 0.13
-Nodes (13): after, backupPath, backups, calls, errSpy, exitSpy, original, out (+5 more)
-
-### Community 543 - "Community 543"
-Cohesion: 0.16
-Nodes (11): isStale(), PHASE_CONFIG, recentActionObservations(), issue, list, onOpenWorkspaceHome, status, summary (+3 more)
-
-### Community 544 - "Community 544"
+### Community 521 - "Community 521"
 Cohesion: 0.18
-Nodes (13): bucketByTime(), classifyTimeBucket(), isSameLocalDay(), TimeBucketed, TimeBucketKey, toDate(), buckets, Item (+5 more)
+Nodes (9): buildClaudeUserSettings(), ClaudeUserSettings, getClaudePermissionFlags(), readYoloEnv(), resolvePermissionMode(), YOLO_FALSE, YOLO_TRUE, ClaudePermissionMode (+1 more)
 
-### Community 545 - "Community 545"
+### Community 522 - "Community 522"
+Cohesion: 0.18
+Nodes (13): fetchSettings(), isIssueTtsMuted(), normalizeIssueId(), putSettings(), setIssueTtsMuted(), fetchMock, muted, putCall (+5 more)
+
+### Community 523 - "Community 523"
+Cohesion: 0.16
+Nodes (14): CategoryFilter, formatContextLength(), formatCost(), ModelCard(), OpenRouterModel, OpenRouterModelBrowser(), OpenRouterModelBrowserProps, { container } (+6 more)
+
+### Community 524 - "Community 524"
 Cohesion: 0.2
 Nodes (12): createRecoveryCoordinator(), EventClassification, RecoveryCoordinator, RecoveryPhase, RecoveryPhaseKind, RecoveryReason, RecoveryState, bootstrapped() (+4 more)
 
-### Community 546 - "Community 546"
-Cohesion: 0.13
-Nodes (12): mockDeepWipe, mockExistsSync, mockGetAgentState, mockGetAgentStateAsync, mockMessageAgent, mockMkdir, mockSpawnAgent, mockSpawnPlanningSession (+4 more)
+### Community 525 - "Community 525"
+Cohesion: 0.15
+Nodes (13): cleanupExpiredReauthSessions(), codexAuthRouteLayer, consumeReauthTerminalToken(), getCodexAuthRoute, getExistingLiveReauthSession(), getLiveReauthSession(), postCodexReauthRoute, postCodexReauthStatusRoute (+5 more)
 
-### Community 547 - "Community 547"
+### Community 526 - "Community 526"
+Cohesion: 0.12
+Nodes (15): Architecture, CLI Commands, code:bash (# 1. Implement feature), code:bash (# List all specialists with status), code:toml ([specialists.review_agent]), code:typescript (type Priority = 'urgent' | 'high' | 'normal' | 'low';), Configuration, Deacon Health Monitor (+7 more)
+
+### Community 527 - "Community 527"
+Cohesion: 0.12
+Nodes (16): Baseline-Aware Test Validation, code:block1 (┌───────────────────────────────────────────────────────────), code:bash (# In validate-merge.sh), code:typescript (// validation.ts — autoRevertMerge always uses ORIG_HEAD), code:typescript (const { stdout: statusOut } = await execAsync('git status --), code:typescript (if (stashCreated) {), code:block6 (┌──────────┐     ┌──────────┐     ┌──────────┐     ┌────────), code:typescript (POST /api/specialists/done) (+8 more)
+
+### Community 528 - "Community 528"
+Cohesion: 0.12
+Nodes (15): code:block1 (tests/), code:typescript (// Mock execAsync for git command tests), code:typescript (// Preferred: testid), Conventions, Dashboard UI Testing, `data-testid` Convention, Mocking, Playwright MCP (+7 more)
+
+### Community 529 - "Community 529"
+Cohesion: 0.12
+Nodes (15): API Integration, Component Structure, Core Layout, Design 1: Collapsed State, Design 2: Expanded State, Next Steps, Overrides (6 components), Overview (+7 more)
+
+### Community 530 - "Community 530"
+Cohesion: 0.12
+Nodes (16): 10. Autonomous flywheel daemon, 11. Public flywheel dashboard page, 12. Updated `all-up` skill, 13. Updated `CLAUDE.md` (repo-level), 1. `retro-agent` — New agent type, 2. Retro storage, 3. Synthesis step — new Step 8 in `all-up` skill, 4. `docs/FLYWHEEL-REPORT.md` — user-facing living doc (+8 more)
+
+### Community 531 - "Community 531"
+Cohesion: 0.12
+Nodes (15): Acceptance Criteria, Code to Preserve (Merge Queue), code:block1 (if (specialist busy) → submitToSpecialistQueue()), code:block2 (if (workspace already has running specialist) → no-op (dupli), Current Architecture, Goal, Key Files to Remove/Modify, New Dispatch Pattern (+7 more)
+
+### Community 532 - "Community 532"
+Cohesion: 0.12
+Nodes (15): Approach, D1: Full scope — all 6 problem areas, D2: Typed error-to-HTTP mapping via `httpHandler` wrapper, D3: Convert ALL sync FS calls including `existsSync`, D4: Keep existing route composition pattern, Decisions, Out of Scope, PAN-470: Rewrite route handlers to idiomatic Effect (+7 more)
+
+### Community 533 - "Community 533"
+Cohesion: 0.12
+Nodes (15): 1. Eliminating Waterfalls (CRITICAL), 2. Bundle Size Optimization (CRITICAL), 3. Server-Side Performance (HIGH), 4. Client-Side Data Fetching (MEDIUM-HIGH), 5. Re-render Optimization (MEDIUM), 6. Rendering Performance (MEDIUM), 7. JavaScript Performance (LOW-MEDIUM), 8. Advanced Patterns (LOW) (+7 more)
+
+### Community 534 - "Community 534"
+Cohesion: 0.12
+Nodes (15): Auto-Fix Critical Issues, Check Specific Workspace, code:bash (python ~/.claude/skills/session-health/scripts/check_session), code:bash (python ~/.claude/skills/session-health/scripts/check_session), code:bash (# Replace with your actual project path), code:bash (tmux kill-session -t agent-proj-123), code:python (import os, glob), code:bash (pan start PROJ-123) (+7 more)
+
+### Community 535 - "Community 535"
+Cohesion: 0.12
+Nodes (15): Beads Completion Check, BLOCKED - Open Beads Found, code:bash (# Check for open beads), code:block2 (BEADS CHECK: PASS), code:block3 (BEADS CHECK: BLOCKED), code:block4 (Task(subagent_type='beads-completion-check', prompt='Check i), code:json ({), Error Handling (+7 more)
+
+### Community 536 - "Community 536"
+Cohesion: 0.12
+Nodes (15): Code Review Agent, code:markdown (---), code:markdown (---), code:markdown (---), code:markdown (---), code:markdown (---), code:markdown (---), code:markdown (---) (+7 more)
+
+### Community 537 - "Community 537"
+Cohesion: 0.12
+Nodes (15): code:markdown (## Process), code:markdown (## Decision Tree), code:markdown (## Data Transformation), code:markdown (## Investigation Flow), code:markdown (## Setup Wizard), code:markdown (## Multi-Source Research), code:markdown (## Robust Execution), Conditional Branching (+7 more)
+
+### Community 538 - "Community 538"
+Cohesion: 0.12
+Nodes (15): 1. Inspect commit context, 2. Choose the narrowest fitting scope, 3. Draft the commit message, 4. Commit safely, 5. If commitlint rejects the message, code:bash (git status --short --branch), code:text (feat(cli): add pan-commit skill), code:text (fix(dashboard): rehydrate snapshot after reconnect) (+7 more)
+
+### Community 539 - "Community 539"
+Cohesion: 0.12
+Nodes (15): code:bash (cd {{projectPath}}), code:bash (git diff --check), code:bash (git commit --no-edit), code:block4 (MERGE_RESULT: SUCCESS), code:block5 (MERGE_RESULT: FAILURE), code:bash (git merge --abort), Conflict Files, Critical Rules (+7 more)
+
+### Community 540 - "Community 540"
+Cohesion: 0.13
+Nodes (14): backup, backup1, backup2, backupDir, backups, dir1, dir2, removed (+6 more)
+
+### Community 541 - "Community 541"
 Cohesion: 0.17
 Nodes (10): ApiKeyValidationResult, classifyModel(), detectThinkingSupport(), ModelCache, OpenRouterModel, OpenRouterService, OpenRouterServiceLive, OpenRouterServiceShape (+2 more)
+
+### Community 542 - "Community 542"
+Cohesion: 0.2
+Nodes (12): workspaceRebuildCommand(), tempDirs, workspace, COMPOSE_FILES, composeProjectNameForWorkspace(), declaredComposeProjectName(), dockerCompose(), execFileAsync (+4 more)
+
+### Community 544 - "Community 544"
+Cohesion: 0.13
+Nodes (13): after, backupPath, backups, calls, errSpy, exitSpy, original, out (+5 more)
+
+### Community 545 - "Community 545"
+Cohesion: 0.26
+Nodes (12): checkJqInstalled(), HookConfig, installJq(), McpServer, setupHooksCommand(), SetupHooksOptions, atomicWriteJsonSync(), backupSettingsSync() (+4 more)
+
+### Community 546 - "Community 546"
+Cohesion: 0.16
+Nodes (11): isStale(), PHASE_CONFIG, recentActionObservations(), issue, list, onOpenWorkspaceHome, status, summary (+3 more)
+
+### Community 547 - "Community 547"
+Cohesion: 0.13
+Nodes (12): mockDeepWipe, mockExistsSync, mockGetAgentState, mockGetAgentStateAsync, mockMessageAgent, mockMkdir, mockSpawnAgent, mockSpawnPlanningSession (+4 more)
 
 ### Community 548 - "Community 548"
 Cohesion: 0.13
@@ -3519,132 +3527,132 @@ Cohesion: 0.25
 Nodes (4): execAsync, getPidFilePath(), readDaemonState(), TldrDaemonService
 
 ### Community 568 - "Community 568"
-Cohesion: 0.16
-Nodes (12): applyBurnedTokenOverride(), CheckCodexAuthOptions, checkCodexAuthStatus(), CliproxyCodexCredentials, CodexAuthBurned, CodexAuthCheckError, CodexAuthExpired, CodexAuthMissing (+4 more)
+Cohesion: 0.18
+Nodes (9): RallyApiConfig, RallyCreateConfig, RallyCreateResult, RallyQueryConfig, RallyQueryResult, RallyRestApi, RallyUpdateConfig, RallyUpdateResult (+1 more)
 
 ### Community 569 - "Community 569"
 Cohesion: 0.14
-Nodes (12): closedWorkspaceIcon, issueId, pan777Row, pan862Row, ProjectData, projectHeader, RESOURCE_DETAIL_IDENTIFIERS, RESOURCE_ISSUES (+4 more)
+Nodes (13): shouldSkipCheckpointReconciliation(), isTerminalTurnDiffSummaryStatus(), agentIds, baseTimestamp, checkpoints, deleteLegacyCheckpointRefs, diffCheckpointFiles, encoder (+5 more)
 
 ### Community 570 - "Community 570"
 Cohesion: 0.14
-Nodes (13): conversationButton, CONVERSATIONS_RESPONSE, conversationsTab, COSTS_RESPONSE, featureRow, ISSUES_RESPONSE, pipelineTab, projectHeader (+5 more)
+Nodes (12): closedWorkspaceIcon, issueId, pan777Row, pan862Row, ProjectData, projectHeader, RESOURCE_DETAIL_IDENTIFIERS, RESOURCE_ISSUES (+4 more)
 
 ### Community 571 - "Community 571"
 Cohesion: 0.14
-Nodes (13): Agent Grid, code:block1 (┌────────────────────────────────────────────────────┐), code:css (--gv-bg: #0a0e1a          /* Dark navy background */), Components, Dependencies, Design System, Focus View, God View — Real-time Agent Activity Command Center (+5 more)
+Nodes (13): conversationButton, CONVERSATIONS_RESPONSE, conversationsTab, COSTS_RESPONSE, featureRow, ISSUES_RESPONSE, pipelineTab, projectHeader (+5 more)
+
+### Community 572 - "Community 572"
+Cohesion: 0.16
+Nodes (12): applyBurnedTokenOverride(), CheckCodexAuthOptions, checkCodexAuthStatus(), CliproxyCodexCredentials, CodexAuthBurned, CodexAuthCheckError, CodexAuthExpired, CodexAuthMissing (+4 more)
 
 ### Community 573 - "Community 573"
 Cohesion: 0.14
-Nodes (11): mockDeepWipe, mockExistsSync, mockGetAgentState, mockGetAgentStateAsync, mockMessageAgent, mockMkdir, mockSpawnAgent, mockSpawnPlanningSession (+3 more)
-
-### Community 574 - "Community 574"
-Cohesion: 0.14
-Nodes (10): mockGetLinearApiKey, mockSdkCreateComment, mockSdkCreateIssueLabel, mockSdkIssue, mockSdkIssueLabels, mockSdkSearchIssues, mockSdkTeam, mockSdkUpdateIssue (+2 more)
+Nodes (13): Agent Grid, code:block1 (┌────────────────────────────────────────────────────┐), code:css (--gv-bg: #0a0e1a          /* Dark navy background */), Components, Dependencies, Design System, Focus View, God View — Real-time Agent Activity Command Center (+5 more)
 
 ### Community 575 - "Community 575"
 Cohesion: 0.14
-Nodes (13): code:bash (npx @panctl/cli), code:mermaid (flowchart LR), code:bash (npx @panctl/cli), Command Deck, Dashboard Views, How It Works, Key Features, Learn More (+5 more)
+Nodes (11): mockDeepWipe, mockExistsSync, mockGetAgentState, mockGetAgentStateAsync, mockMessageAgent, mockMkdir, mockSpawnAgent, mockSpawnPlanningSession (+3 more)
 
 ### Community 576 - "Community 576"
 Cohesion: 0.14
-Nodes (13): code:block1 (Claude Code fires hook), Global `~/.claude/settings.json`, Hook Execution Flow, Hook Scripts Inventory, Migration Pruning, Panopticon Hook System, Per-Agent Frontmatter (`agents/pan-*.md`), Pi Event Channel (PAN-1134) (+5 more)
+Nodes (10): mockGetLinearApiKey, mockSdkCreateComment, mockSdkCreateIssueLabel, mockSdkIssue, mockSdkIssueLabels, mockSdkSearchIssues, mockSdkTeam, mockSdkUpdateIssue (+2 more)
 
 ### Community 577 - "Community 577"
 Cohesion: 0.14
-Nodes (13): 1. Browser / app shell, 2. Panopticon terminal wrapper (`XTerminal.tsx`), 3. xterm.js, 4. Remote PTY app (`tmux` + attached TUI), Debugging checklist, Managed tmux policy, Ownership rules, Right-click / context menu (+5 more)
+Nodes (13): code:bash (npx @panctl/cli), code:mermaid (flowchart LR), code:bash (npx @panctl/cli), Command Deck, Dashboard Views, How It Works, Key Features, Learn More (+5 more)
 
 ### Community 578 - "Community 578"
 Cohesion: 0.14
-Nodes (13): code:bash (pan up), code:bash (pan dev), code:bash (npm run build), code:bash (pan reload), code:bash (pan status), code:bash (less ~/.panopticon/logs/supervisor.log), code:bash (less ~/.panopticon/logs/dashboard.log), Failure triage (+5 more)
+Nodes (13): code:block1 (Claude Code fires hook), Global `~/.claude/settings.json`, Hook Execution Flow, Hook Scripts Inventory, Migration Pruning, Panopticon Hook System, Per-Agent Frontmatter (`agents/pan-*.md`), Pi Event Channel (PAN-1134) (+5 more)
 
 ### Community 579 - "Community 579"
 Cohesion: 0.14
-Nodes (14): Agent Attribution, Agent CVs (Work History), Beads Flow with Panopticon, Beyond Issue Tracking, code:block13 (┌───────────────────────────────────────────────────────────), code:bash (# Hook structure), code:json ({), code:bash (bd stats --actor=panopticon/agent-min-648) (+6 more)
+Nodes (13): 1. Browser / app shell, 2. Panopticon terminal wrapper (`XTerminal.tsx`), 3. xterm.js, 4. Remote PTY app (`tmux` + attached TUI), Debugging checklist, Managed tmux policy, Ownership rules, Right-click / context menu (+5 more)
 
 ### Community 580 - "Community 580"
 Cohesion: 0.14
-Nodes (14): Built-in Variables, CLAUDE.md Templating System, code:block104 (┌───────────────────────────────────────────────────────────), code:toml (# .panopticon/project.toml), code:markdown (<!-- ~/.panopticon/templates/claude-md/sections/workspace-in), code:markdown (<!-- .panopticon/claude-md/sections/principles.md -->), code:bash (pan workspace create min-648), Example: Panopticon-Provided Section (+6 more)
+Nodes (13): code:bash (pan up), code:bash (pan dev), code:bash (npm run build), code:bash (pan reload), code:bash (pan status), code:bash (less ~/.panopticon/logs/supervisor.log), code:bash (less ~/.panopticon/logs/dashboard.log), Failure triage (+5 more)
 
 ### Community 581 - "Community 581"
 Cohesion: 0.14
-Nodes (14): Available Hook Points, code:toml (# .panopticon/project.toml), code:toml ([hooks.pre_commit]), code:block122 (workspace_aware = false (default):), code:toml (# /home/eltmon/projects/myn/.panopticon/project.toml), code:toml ([hooks.post_agent_complete]), code:toml ([hooks.pre_commit]), Hook Configuration (+6 more)
+Nodes (14): Agent Attribution, Agent CVs (Work History), Beads Flow with Panopticon, Beyond Issue Tracking, code:block13 (┌───────────────────────────────────────────────────────────), code:bash (# Hook structure), code:json ({), code:bash (bd stats --actor=panopticon/agent-min-648) (+6 more)
 
 ### Community 582 - "Community 582"
 Cohesion: 0.14
-Nodes (13): code:block1 (skills/pan-<verb>/SKILL.md            (canonical, committed)), Creating a new wrapper skill, For CLI-wrapper skills, For workflow / reference / topical skills, How skills are distributed, Linting, Panopticon Skills ↔ CLI Convention, Related (+5 more)
+Nodes (14): Available Hook Points, code:toml (# .panopticon/project.toml), code:toml ([hooks.pre_commit]), code:block122 (workspace_aware = false (default):), code:toml (# /home/eltmon/projects/myn/.panopticon/project.toml), code:toml ([hooks.post_agent_complete]), code:toml ([hooks.pre_commit]), Hook Configuration (+6 more)
 
 ### Community 583 - "Community 583"
 Cohesion: 0.14
-Nodes (14): Claude Code Bypass Permissions (Automatic), code:block26 (https://github.com/owner/repo.git  → git@github.com:owner/re), code:bash (mkdir -p ~/.panopticon/ssh), code:bash (cat ~/.panopticon/ssh/exe-dev-key.pub | pbcopy  # Copy to cl), code:bash (# For GitHub:), code:bash (ssh exe.dev help), code:json ({), code:bash (ssh <vm-name>.exe.xyz 'echo "{\"bypassPermissionsModeAccepte) (+6 more)
+Nodes (14): Built-in Variables, CLAUDE.md Templating System, code:block104 (┌───────────────────────────────────────────────────────────), code:toml (# .panopticon/project.toml), code:markdown (<!-- ~/.panopticon/templates/claude-md/sections/workspace-in), code:markdown (<!-- .panopticon/claude-md/sections/principles.md -->), code:bash (pan workspace create min-648), Example: Panopticon-Provided Section (+6 more)
 
 ### Community 584 - "Community 584"
 Cohesion: 0.14
-Nodes (14): 1.1 Add exe.dev Provider, 1.2 New Commands, 2.2 Modified docker-compose for Remote, 5.1 Workspace List View, 5.2 Agent Terminal View, code:yaml (# .devcontainer/docker-compose.remote.yml), code:block21 (┌───────────────────────────────────────────────────────────), code:typescript (// Server-side: bridge WebSocket to SSH) (+6 more)
+Nodes (13): code:block1 (skills/pan-<verb>/SKILL.md            (canonical, committed)), Creating a new wrapper skill, For CLI-wrapper skills, For workflow / reference / topical skills, How skills are distributed, Linting, Panopticon Skills ↔ CLI Convention, Related (+5 more)
 
 ### Community 585 - "Community 585"
 Cohesion: 0.14
-Nodes (13): 12. Responsive Behavior, 14. File Structure, 15. Acceptance Criteria, 16. Risks & Mitigations, 17. Open Questions, 1. Problem Statement, 2. Design Philosophy, 6. Cloister Banner (+5 more)
+Nodes (14): Claude Code Bypass Permissions (Automatic), code:block26 (https://github.com/owner/repo.git  → git@github.com:owner/re), code:bash (mkdir -p ~/.panopticon/ssh), code:bash (cat ~/.panopticon/ssh/exe-dev-key.pub | pbcopy  # Copy to cl), code:bash (# For GitHub:), code:bash (ssh exe.dev help), code:json ({), code:bash (ssh <vm-name>.exe.xyz 'echo "{\"bypassPermissionsModeAccepte) (+6 more)
 
 ### Community 586 - "Community 586"
 Cohesion: 0.14
-Nodes (13): Acceptance Criteria, Design Goals, Files Likely Touched, Goal, Host Role & Handoff, Implementation Phases (sequencing within PAN-658), Input Model, Open question — concurrent direct-submit ordering (+5 more)
+Nodes (14): 1.1 Add exe.dev Provider, 1.2 New Commands, 2.2 Modified docker-compose for Remote, 5.1 Workspace List View, 5.2 Agent Terminal View, code:yaml (# .devcontainer/docker-compose.remote.yml), code:block21 (┌───────────────────────────────────────────────────────────), code:typescript (// Server-side: bridge WebSocket to SSH) (+6 more)
 
 ### Community 587 - "Community 587"
 Cohesion: 0.14
-Nodes (13): Architecture, CLI Interface (full surface), code:block1 (┌──────────────────────────────────────────┐), code:bash (# Discovery), code:block20 (GET  /api/archived-conversations), Dependencies, Files Changed (planning estimate), Out of Scope (this issue) (+5 more)
+Nodes (13): 12. Responsive Behavior, 14. File Structure, 15. Acceptance Criteria, 16. Risks & Mitigations, 17. Open Questions, 1. Problem Statement, 2. Design Philosophy, 6. Cloister Banner (+5 more)
 
 ### Community 588 - "Community 588"
 Cohesion: 0.14
-Nodes (14): A.1 Add `isInfrastructureFailure` helper, A.2 Enhance `checkStuckReviewing` to detect dead parallel sessions, A.3 Add infrastructure-failure circuit breaker, A.4 Honor `stuck` flag in re-dispatch path, A.5 Detect verification/review contradiction, A.6 Partial results from incomplete parallel reviews, A. `src/lib/cloister/deacon.ts`, code:typescript (function isInfrastructureFailure(notes?: string): boolean {) (+6 more)
+Nodes (13): Acceptance Criteria, code:block3 ({ iss: "panopticon-cli.com", sub: "<github-user-id>", login,), Design Goals, Files Likely Touched, Goal, Host Role & Handoff, Identity & GitHub OAuth, Implementation Phases (sequencing within PAN-658) (+5 more)
 
 ### Community 589 - "Community 589"
 Cohesion: 0.14
-Nodes (14): B0: Toolchain Setup, B18: Integration + Build, B19: Frontend Component Migration, B1: Contracts Package, B20: Terminal Streaming RPC (Dual-Runtime), B21: Cleanup + Verification, B2: Event Store, B3: ServerConfig Service (+6 more)
+Nodes (14): A.1 Add `isInfrastructureFailure` helper, A.2 Enhance `checkStuckReviewing` to detect dead parallel sessions, A.3 Add infrastructure-failure circuit breaker, A.4 Honor `stuck` flag in re-dispatch path, A.5 Detect verification/review contradiction, A.6 Partial results from incomplete parallel reviews, A. `src/lib/cloister/deacon.ts`, code:typescript (function isInfrastructureFailure(notes?: string): boolean {) (+6 more)
 
 ### Community 590 - "Community 590"
 Cohesion: 0.14
-Nodes (13): Acceptance Criteria, code:typescript (export async function buildAgentLaunchConfig(opts: {), code:block2 (POST /api/agents/:id/restart), code:typescript (export async function resumeAgent(agentId: string, message?:), Design, Files to Modify, Motivation, PAN-980: Agent Restart Refactor — Shared Launch Config, Model Override, Graceful Shutdown (+5 more)
+Nodes (14): B0: Toolchain Setup, B18: Integration + Build, B19: Frontend Component Migration, B1: Contracts Package, B20: Terminal Streaming RPC (Dual-Runtime), B21: Cleanup + Verification, B2: Event Store, B3: ServerConfig Service (+6 more)
 
 ### Community 591 - "Community 591"
 Cohesion: 0.14
-Nodes (13): Acceptance Criteria for the Epic, Architecture Overview, Children, code:block1 (┌───────────────────────────────────────────────────────────), Differentiation vs Prior Art, Files Likely Touched, Open Questions, PAN-1200 — Universal Context System (Epic) (+5 more)
+Nodes (13): Acceptance Criteria, code:typescript (export async function buildAgentLaunchConfig(opts: {), code:block2 (POST /api/agents/:id/restart), code:typescript (export async function resumeAgent(agentId: string, message?:), Design, Files to Modify, Motivation, PAN-980: Agent Restart Refactor — Shared Launch Config, Model Override, Graceful Shutdown (+5 more)
 
 ### Community 592 - "Community 592"
 Cohesion: 0.14
-Nodes (13): 1. PAN-685 model-override frontend (`stash@{34}` + `d81260d0e`), 2. Material Symbols (`stash@{38}`), 3. PAN-TTS + model-routing README (`stash@{35}`), 4. Model-override work (`stash@{39}` + `df0982bcb`), 5. "Other changes to restore later" (`7b12b85990`), 6. Inspector panel (`stash@{18}`) — **NEEDS USER DECISION**, Flagged items — 9 total, 6 unique (3 duplicates), Follow-up tickets to file (if user agrees with recommendation) (+5 more)
+Nodes (13): Acceptance Criteria for the Epic, Architecture Overview, Children, code:block1 (┌───────────────────────────────────────────────────────────), Differentiation vs Prior Art, Files Likely Touched, Open Questions, PAN-1200 — Universal Context System (Epic) (+5 more)
 
 ### Community 593 - "Community 593"
 Cohesion: 0.14
-Nodes (13): Decisions, Files Modified, Implementation Plan, Out of Scope, PAN-290: Fix 9 Pre-existing Test Failures, Problem, Root Cause Analysis, Session-rotation (3 failures) (+5 more)
+Nodes (13): 1. PAN-685 model-override frontend (`stash@{34}` + `d81260d0e`), 2. Material Symbols (`stash@{38}`), 3. PAN-TTS + model-routing README (`stash@{35}`), 4. Model-override work (`stash@{39}` + `df0982bcb`), 5. "Other changes to restore later" (`7b12b85990`), 6. Inspector panel (`stash@{18}`) — **NEEDS USER DECISION**, Flagged items — 9 total, 6 unique (3 duplicates), Follow-up tickets to file (if user agrees with recommendation) (+5 more)
 
 ### Community 594 - "Community 594"
 Cohesion: 0.14
-Nodes (13): 1. Programmatic cleanup in `postMergeLifecycle()`, 2. Belt-and-suspenders: .gitignore, 3. Update planning code to use `git add -f`, 4. Ordering in postMergeLifecycle(), code:block1 (.planning/STATE.md), code:block2 (1. Move PRD (existing)), Decisions, Files to Modify (+5 more)
+Nodes (13): Decisions, Files Modified, Implementation Plan, Out of Scope, PAN-290: Fix 9 Pre-existing Test Failures, Problem, Root Cause Analysis, Session-rotation (3 failures) (+5 more)
 
 ### Community 595 - "Community 595"
 Cohesion: 0.14
-Nodes (13): Approach, Architecture Notes, Endpoint location: conversations.ts, NOT agents.ts, Files Changed, Image storage: OS temp dir, Key Decisions, PAN-539: Image Paste Support in Activity View Conversation, Paste interception: wrapper div, not Lexical plugin (+5 more)
+Nodes (13): 1. Programmatic cleanup in `postMergeLifecycle()`, 2. Belt-and-suspenders: .gitignore, 3. Update planning code to use `git add -f`, 4. Ordering in postMergeLifecycle(), code:block1 (.planning/STATE.md), code:block2 (1. Move PRD (existing)), Decisions, Files to Modify (+5 more)
 
 ### Community 596 - "Community 596"
 Cohesion: 0.14
-Nodes (13): Do Not Route, Exception: One-Shot High-Stakes Analysis, GPT-5.4 Pro Work Type Fit Analysis, Integration Notes, Key Benchmarks, Known Weaknesses, Model Profile, Sources (+5 more)
+Nodes (13): Approach, Architecture Notes, Endpoint location: conversations.ts, NOT agents.ts, Files Changed, Image storage: OS temp dir, Key Decisions, PAN-539: Image Paste Support in Activity View Conversation, Paste interception: wrapper div, not Lexical plugin (+5 more)
 
 ### Community 597 - "Community 597"
 Cohesion: 0.14
-Nodes (13): Access Points, Adding Dependencies, code:bash (# Copy template to your project), code:bash (APP_PORT=5173), code:typescript (export default defineConfig({), code:bash (# Install inside container), Development Workflow, Environment Variables (+5 more)
+Nodes (13): Do Not Route, Exception: One-Shot High-Stakes Analysis, GPT-5.4 Pro Work Type Fit Analysis, Integration Notes, Key Benchmarks, Known Weaknesses, Model Profile, Sources (+5 more)
 
 ### Community 598 - "Community 598"
 Cohesion: 0.14
-Nodes (13): After Reopening, code:bash (pan reopen PAN-123), code:bash (curl -X POST http://localhost:3011/api/issues/PAN-123/reopen), Do NOT Use `pan done` Until Re-Work Is Complete, How to Reopen, Preflight Guard, Reopen a Closed/Completed Issue for Re-Work, Via CLI (recommended for agents/supervisors) (+5 more)
+Nodes (13): Access Points, Adding Dependencies, code:bash (# Copy template to your project), code:bash (APP_PORT=5173), code:typescript (export default defineConfig({), code:bash (# Install inside container), Development Workflow, Environment Variables (+5 more)
 
 ### Community 599 - "Community 599"
 Cohesion: 0.14
-Nodes (14): code:block15 (oauth-epic: "Implement OAuth integration" (epic)), code:block16 (research-epic: "Investigate caching strategies" (epic)), code:bash (bd dep add child-task-id parent-epic-id --type parent-child), code:block18 (auth-epic (parent of all)), code:block19 (Epic with no ordering between children:), code:block20 (Epic with blocks dependencies between children:), code:block21 (major-epic), Combining with blocks (+6 more)
+Nodes (13): After Reopening, code:bash (pan reopen PAN-123), code:bash (curl -X POST http://localhost:3011/api/issues/PAN-123/reopen), Do NOT Use `pan done` Until Re-Work Is Complete, How to Reopen, Preflight Guard, Reopen a Closed/Completed Issue for Re-Work, Via CLI (recommended for agents/supervisors) (+5 more)
 
 ### Community 600 - "Community 600"
 Cohesion: 0.14
-Nodes (14): code:bash (# Check if pan command exists), code:bash (# Check for running services), code:bash (pan down), code:bash (pan up), code:block6 (✓ API server started on port 3002), code:bash (# Check all services are running), code:block8 (http://localhost:3001), code:bash (# View dashboard logs) (+6 more)
+Nodes (14): code:block15 (oauth-epic: "Implement OAuth integration" (epic)), code:block16 (research-epic: "Investigate caching strategies" (epic)), code:bash (bd dep add child-task-id parent-epic-id --type parent-child), code:block18 (auth-epic (parent of all)), code:block19 (Epic with no ordering between children:), code:block20 (Epic with blocks dependencies between children:), code:block21 (major-epic), Combining with blocks (+6 more)
 
 ### Community 601 - "Community 601"
 Cohesion: 0.14
@@ -3652,703 +3660,695 @@ Nodes (13): Basic Usage, code:bash (# Start all services), code:env (# Dashboard
 
 ### Community 602 - "Community 602"
 Cohesion: 0.14
-Nodes (13): Auto-planning, Available commands, code:bash (pan plan <id> [--auto] [--model <model>] [--harness claude-c), code:bash (pan plan PAN-1071), code:bash (pan plan PAN-1071 --auto), code:bash (pan plan finalize), code:bash (pan plan done PAN-1071), Completing planning (`pan plan done`) (+5 more)
+Nodes (14): code:bash (# Check if pan command exists), code:bash (# Check for running services), code:bash (pan down), code:bash (pan up), code:block6 (✓ API server started on port 3002), code:bash (# Check all services are running), code:block8 (http://localhost:3001), code:bash (# View dashboard logs) (+6 more)
 
 ### Community 603 - "Community 603"
 Cohesion: 0.14
-Nodes (13): 1. Identify the Issue, 2. Gather Context, 3. Research (Interactive), 4. Write the Spec, 5. Confirm File Location, code:markdown (# {Issue ID}: {Title}), code:block2 (Spec written: docs/prds/active/{filename}-spec.md), Execution Steps (+5 more)
+Nodes (13): Auto-planning, Available commands, code:bash (pan plan <id> [--auto] [--model <model>] [--harness claude-c), code:bash (pan plan PAN-1071), code:bash (pan plan PAN-1071 --auto), code:bash (pan plan finalize), code:bash (pan plan done PAN-1071), Completing planning (`pan plan done`) (+5 more)
 
 ### Community 604 - "Community 604"
 Cohesion: 0.14
-Nodes (13): code:block1 (Session 1: AI queries users.created_at → Error (column is "c), code:block2 (myproject/), code:markdown (# In ~/.claude/CLAUDE.md (developer's personal config)), Configurable Per Team and Per Developer, For Executives, For Technical Leaders, How It Works, Legacy Codebase Support (+5 more)
+Nodes (13): 1. Identify the Issue, 2. Gather Context, 3. Research (Interactive), 4. Write the Spec, 5. Confirm File Location, code:markdown (# {Issue ID}: {Title}), code:block2 (Spec written: docs/prds/active/{filename}-spec.md), Execution Steps (+5 more)
 
 ### Community 605 - "Community 605"
 Cohesion: 0.14
-Nodes (14): 2. Typography, code:html (<!-- index.html -->), code:js (fontFamily: {), code:css (body {), Conversation Typography, CRITICAL: The Four Canonical Typography Rules (PAN-698), CSS Default, Deprecated Patterns (DO NOT USE) (+6 more)
+Nodes (13): code:block1 (Session 1: AI queries users.created_at → Error (column is "c), code:block2 (myproject/), code:markdown (# In ~/.claude/CLAUDE.md (developer's personal config)), Configurable Per Team and Per Developer, For Executives, For Technical Leaders, How It Works, Legacy Codebase Support (+5 more)
 
 ### Community 606 - "Community 606"
 Cohesion: 0.14
-Nodes (13): CLI, code:bash (pan swarm <id>                       # Spawn dispatchable it), code:bash (pan swarm <id> --task next                              # Li), code:ts (interface SwarmRuntime {), HTTP Surface, Inspect and Mutate Items, Mental Model, Plan Authoring: `files_scope` and Synthesis (+5 more)
+Nodes (14): 2. Typography, code:html (<!-- index.html -->), code:js (fontFamily: {), code:css (body {), Conversation Typography, CRITICAL: The Four Canonical Typography Rules (PAN-698), CSS Default, Deprecated Patterns (DO NOT USE) (+6 more)
 
 ### Community 607 - "Community 607"
-Cohesion: 0.18
-Nodes (11): build, cliPromptsDir, copyCavemanAssets(), copyCloisterPrompts(), copyMatching(), dashboardDir, distDir, preservedDashboardDir (+3 more)
+Cohesion: 0.14
+Nodes (13): CLI, code:bash (pan swarm <id>                       # Spawn dispatchable it), code:bash (pan swarm <id> --task next                              # Li), code:ts (interface SwarmRuntime {), HTTP Surface, Inspect and Mutate Items, Mental Model, Plan Authoring: `files_scope` and Synthesis (+5 more)
 
 ### Community 608 - "Community 608"
 Cohesion: 0.24
-Nodes (11): AgentRuntimeFetchError, emitActivity(), emitAgentEvent(), emitChannelReply(), emitMessageReceived(), emitModelSet(), emitResolution(), emitWaitingClear() (+3 more)
+Nodes (11): execAsync, formatDuration(), generateReport(), parseTestOutput(), runTests(), RunTestsOptions, runTestSuite(), sendNotification() (+3 more)
 
 ### Community 609 - "Community 609"
-Cohesion: 0.15
-Nodes (12): agentDir, mockGetAgentRuntimeState, mockGetAgentState, mockGetTmuxSessionName, mockGetWorkspaceStackHealth, mockLoadReviewStatuses, mockRebuildWorkspaceStack, mockResolveProjectFromIssue (+4 more)
+Cohesion: 0.18
+Nodes (11): build, cliPromptsDir, copyCavemanAssets(), copyCloisterPrompts(), copyMatching(), dashboardDir, distDir, preservedDashboardDir (+3 more)
 
 ### Community 610 - "Community 610"
 Cohesion: 0.15
-Nodes (11): dir, event, eventsDir1, eventsDir2, line, lines, parsed, repo1 (+3 more)
+Nodes (9): createTerminalWindow(), createWindow(), dispatchMenuAction(), resolveWindowUrl(), showOrCreateWindow(), consoleErrors, flywheelStatus, MockWebSocket (+1 more)
 
 ### Community 611 - "Community 611"
 Cohesion: 0.24
-Nodes (11): buildStatus(), decodeBase64Url(), decodeJwtPayload(), getCodexAuthPath(), getJwtExpiry(), getOpenAIAuthStatusSync(), hasApiKey(), OpenAIAuthStatus (+3 more)
+Nodes (11): AgentRuntimeFetchError, emitActivity(), emitAgentEvent(), emitChannelReply(), emitMessageReceived(), emitModelSet(), emitResolution(), emitWaitingClear() (+3 more)
 
 ### Community 612 - "Community 612"
-Cohesion: 0.15
-Nodes (10): constructorTracker, createdIssue, mockAssignee, mockClient, mockComment, mockIssue, mockLabels, mockState (+2 more)
-
-### Community 613 - "Community 613"
 Cohesion: 0.15
 Nodes (8): PendingCompletion, _pendingCompletions, ResumeCallback, SpecialistCancelledError, SpecialistCompletionError, SpecialistCompletionResult, SpecialistCompletionTimeoutError, SpecialistSupersededError
 
 ### Community 614 - "Community 614"
-Cohesion: 0.15
-Nodes (10): cleanupMergedLabels(), calls, ctx, mockClientCreateIssueLabel, mockClientIssueLabels, mockClientIssues, { mockExecAsync, mockGetLinearApiKey }, mockIssueLabels (+2 more)
+Cohesion: 0.21
+Nodes (10): checkAllTriggers(), checkStuckEscalation(), checkTaskCompletion(), checkTestFailure(), detectTestFailure(), execAsync, taskCompletionCache, TaskCompletionCacheEntry (+2 more)
 
 ### Community 615 - "Community 615"
-Cohesion: 0.15
-Nodes (12): ACTIVITY_RESPONSE, AGENTS_RESPONSE, COSTS_RESPONSE, DISCUSSIONS_RESPONSE, ISSUES_RESPONSE, PLANNING_RESPONSE, PR_DIFF_RESPONSE, PR_RESPONSE (+4 more)
-
-### Community 616 - "Community 616"
-Cohesion: 0.21
-Nodes (10): CapabilityStats, DailyStats, fetchRuntimeMetrics(), formatCost(), formatDuration(), formatPercent(), getSuccessColor(), MetricsResponse (+2 more)
-
-### Community 617 - "Community 617"
 Cohesion: 0.24
 Nodes (11): buildContinuation(), convertConversationTranscript(), ConvertOptions, ConvertResult, extractClaudeTranscript(), extractContentText(), extractPiTranscript(), renderTranscript() (+3 more)
 
+### Community 616 - "Community 616"
+Cohesion: 0.15
+Nodes (12): ACTIVITY_RESPONSE, AGENTS_RESPONSE, COSTS_RESPONSE, DISCUSSIONS_RESPONSE, ISSUES_RESPONSE, PLANNING_RESPONSE, PR_DIFF_RESPONSE, PR_RESPONSE (+4 more)
+
+### Community 617 - "Community 617"
+Cohesion: 0.21
+Nodes (10): CapabilityStats, DailyStats, fetchRuntimeMetrics(), formatCost(), formatDuration(), formatPercent(), getSuccessColor(), MetricsResponse (+2 more)
+
 ### Community 618 - "Community 618"
 Cohesion: 0.15
-Nodes (13): code:block53 (~/.panopticon/), code:block54 (~/projects/myn/.panopticon/), code:toml ([panopticon]), code:toml ([[projects]]), code:toml ([project]), code:toml (# panopticon/.panopticon/project.toml), Example: Open Source Project Config, Global Config (`~/.panopticon/config.toml`) (+5 more)
+Nodes (10): COST_RESPONSE, filterBtn, FilterOnChange, input, LIST_RESPONSE, rpcMocks, SEARCH_RESPONSE, SESSION_STUB (+2 more)
 
 ### Community 619 - "Community 619"
 Cohesion: 0.15
-Nodes (12): 1. Role file — `roles/*.md`, 2. Panopticon pipeline agent — `agents/pan-*-agent.md`, 3. Claude Code subagent — `.claude/agents/*.md`, Adding a new role or sub-role, code:block1 (Cloister decides to spawn (role, subRole?)), File shapes you will see, How a run actually gets the right instructions, Roles: Panopticon's Agent Definition Primitive (+4 more)
+Nodes (10): cleanupMergedLabels(), calls, ctx, mockClientCreateIssueLabel, mockClientIssueLabels, mockClientIssues, { mockExecAsync, mockGetLinearApiKey }, mockIssueLabels (+2 more)
 
 ### Community 620 - "Community 620"
 Cohesion: 0.15
-Nodes (12): Agent Taxonomy, Architecture, CLI Commands, Cloister: Agent Watchdog Framework, code:block23 (┌───────────────────────────────────────────────────────────), code:bash (# Cloister control), Goals, Issue Agents (Ephemeral) (+4 more)
+Nodes (13): code:block53 (~/.panopticon/), code:block54 (~/projects/myn/.panopticon/), code:toml ([panopticon]), code:toml ([[projects]]), code:toml ([project]), code:toml (# panopticon/.panopticon/project.toml), Example: Open Source Project Config, Global Config (`~/.panopticon/config.toml`) (+5 more)
 
 ### Community 621 - "Community 621"
 Cohesion: 0.15
-Nodes (12): Dependencies, Design Principles, Implementation Notes, Key files, Non-goals, Phase 1: Interactive FeatureCard (Dashboard UI), Phase 2: Feature Planning Pipeline (Backend), Phase 3: Integration Testing (+4 more)
+Nodes (12): 1. Role file — `roles/*.md`, 2. Panopticon pipeline agent — `agents/pan-*-agent.md`, 3. Claude Code subagent — `.claude/agents/*.md`, Adding a new role or sub-role, code:block1 (Cloister decides to spawn (role, subRole?)), File shapes you will see, How a run actually gets the right instructions, Roles: Panopticon's Agent Definition Primitive (+4 more)
 
 ### Community 622 - "Community 622"
 Cohesion: 0.15
-Nodes (13): Actions vs Roles, code:block1 (User Action          Cloister spawns       Role (.md)       ), code:block2 (Run = (role, model, harness)), code:block3 (Tracker (GitHub Issue)          Cloister (Scheduler)        ), code:yaml (# ~/.panopticon/config.yaml — defaults), code:block5 (model), Convoy Reviewers, Eval Grid (+5 more)
+Nodes (12): Agent Taxonomy, Architecture, CLI Commands, Cloister: Agent Watchdog Framework, code:block23 (┌───────────────────────────────────────────────────────────), code:bash (# Cloister control), Goals, Issue Agents (Ephemeral) (+4 more)
 
 ### Community 623 - "Community 623"
 Cohesion: 0.15
-Nodes (12): code:typescript (export function isReviewPipelineStuck(status?: PipelineState), code:typescript (// PAN-794: Recovery state indicators), code:typescript (const recoveryBorderClass = isReviewRecoveryInProgress), code:typescript (className={`relative ... bg-gradient-to-br ${cardTone} ${rec), code:typescript (const phaseLabel =), E.1 Update `isReviewPipelineStuck` in `src/dashboard/frontend/src/lib/pipeline-state.ts`, E.2 Add recovery indicator helpers to `KanbanBoard.tsx`, E.3 Add recovery border and badges to the card (+4 more)
+Nodes (12): Dependencies, Design Principles, Implementation Notes, Key files, Non-goals, Phase 1: Interactive FeatureCard (Dashboard UI), Phase 2: Feature Planning Pipeline (Backend), Phase 3: Integration Testing (+4 more)
 
 ### Community 624 - "Community 624"
 Cohesion: 0.15
-Nodes (12): C.1 Update `isReviewPipelineStuck` in `src/dashboard/frontend/src/lib/pipeline-state.ts`, C.2 Add recovery indicator helpers to `KanbanBoard.tsx`, C.3 Add pulsing border and recovery badge to the card, C.4 Add recovery badge in the card header, C.6 Style compliance, C. Frontend: Kanban Card Recovery Indicators, code:typescript (export function isReviewPipelineStuck(status?: PipelineState), code:typescript (export function isReviewPipelineStuck(status?: PipelineState) (+4 more)
+Nodes (13): Actions vs Roles, code:block1 (User Action          Cloister spawns       Role (.md)       ), code:block2 (Run = (role, model, harness)), code:block3 (Tracker (GitHub Issue)          Cloister (Scheduler)        ), code:yaml (# ~/.panopticon/config.yaml — defaults), code:block5 (model), Convoy Reviewers, Eval Grid (+5 more)
 
 ### Community 625 - "Community 625"
 Cohesion: 0.15
-Nodes (13): code:typescript (// POST /api/rally/validate - Test Rally connection and conf), code:typescript (describe('Rally Integration', () => {), code:markdown (### Rally Troubleshooting), code:block15, code:block16 (This will log the actual WSAPI queries being sent.), code:typescript (const mock = new RallyApiMock();), Task 1: Fix Query String Builder (CRITICAL), Task 2: Add Comprehensive Unit Tests (+5 more)
+Nodes (12): code:typescript (export function isReviewPipelineStuck(status?: PipelineState), code:typescript (// PAN-794: Recovery state indicators), code:typescript (const recoveryBorderClass = isReviewRecoveryInProgress), code:typescript (className={`relative ... bg-gradient-to-br ${cardTone} ${rec), code:typescript (const phaseLabel =), E.1 Update `isReviewPipelineStuck` in `src/dashboard/frontend/src/lib/pipeline-state.ts`, E.2 Add recovery indicator helpers to `KanbanBoard.tsx`, E.3 Add recovery border and badges to the card (+4 more)
 
 ### Community 626 - "Community 626"
 Cohesion: 0.15
-Nodes (12): Affected Components, Architecture, code:block1 (App.tsx), Decision, Difficulty: medium, Files to Create, Files to Modify, Key Decisions (+4 more)
+Nodes (12): C.1 Update `isReviewPipelineStuck` in `src/dashboard/frontend/src/lib/pipeline-state.ts`, C.2 Add recovery indicator helpers to `KanbanBoard.tsx`, C.3 Add pulsing border and recovery badge to the card, C.4 Add recovery badge in the card header, C.6 Style compliance, C. Frontend: Kanban Card Recovery Indicators, code:typescript (export function isReviewPipelineStuck(status?: PipelineState), code:typescript (export function isReviewPipelineStuck(status?: PipelineState) (+4 more)
 
 ### Community 627 - "Community 627"
 Cohesion: 0.15
-Nodes (12): Acceptance (feature-level), Approach, Decisions, Destination directories (none exist yet), Discovery Findings, Goal, PAN-697 Planning — Root Artifact Cleanup, Problem (+4 more)
+Nodes (13): code:typescript (// POST /api/rally/validate - Test Rally connection and conf), code:typescript (describe('Rally Integration', () => {), code:typescript (const mock = new RallyApiMock();), code:typescript (// Before error throw:), code:typescript (// Add debug logging:), code:typescript (// Improve error logging:), Task 1: Fix Query String Builder (CRITICAL), Task 2: Add Comprehensive Unit Tests (+5 more)
 
 ### Community 628 - "Community 628"
 Cohesion: 0.15
-Nodes (12): Architecture, Difficulty Estimates, Discovery Summary, Files to Modify, Items NOT in scope for v1, Menu Integration, npx latest version, Package Distribution (+4 more)
+Nodes (12): Affected Components, Architecture, code:block1 (App.tsx), Decision, Difficulty: medium, Files to Create, Files to Modify, Key Decisions (+4 more)
 
 ### Community 629 - "Community 629"
 Cohesion: 0.15
-Nodes (12): Approach, Conversation list titles → DM Sans prose, Decomposition, Documentation, Out of scope, PAN-698: Dashboard Typography Cleanup — Planning State, Playwright isolation, Policy (final, to be encoded everywhere) (+4 more)
+Nodes (12): Acceptance (feature-level), Approach, Decisions, Destination directories (none exist yet), Discovery Findings, Goal, PAN-697 Planning — Root Artifact Cleanup, Problem (+4 more)
 
 ### Community 630 - "Community 630"
 Cohesion: 0.15
-Nodes (13): code:bash (# If project has override skill, this skill is permanently d), code:bash (cat .panopticon/knowledge-capture.json 2>/dev/null || echo "), code:json ({), code:javascript (// Pseudocode for decision), code:bash (mkdir -p .claude/skills/knowledge-capture), code:bash (# Ensure directory exists), Invocation Protocol, Step 0: Check for Permanent Override (+5 more)
+Nodes (12): Architecture, Difficulty Estimates, Discovery Summary, Files to Modify, Items NOT in scope for v1, Menu Integration, npx latest version, Package Distribution (+4 more)
 
 ### Community 631 - "Community 631"
 Cohesion: 0.15
-Nodes (13): code:bash (bd dep add issue-2 issue-1 --type blocks), code:bash (bd version), code:bash (# Via Homebrew (macOS/Linux)), code:bash (pkill -f "bd daemon"  # Kill old daemon), code:bash (bd create "Test A" -t task), code:bash (ps aux | grep "bd daemon"), code:bash (# Instead of: bd --no-daemon dep add ...), code:bash (cat .beads/issues.jsonl | jq '.dependencies') (+5 more)
+Nodes (12): Approach, Conversation list titles → DM Sans prose, Decomposition, Documentation, Out of scope, PAN-698: Dashboard Typography Cleanup — Planning State, Playwright isolation, Policy (final, to be encoded everywhere) (+4 more)
 
 ### Community 632 - "Community 632"
 Cohesion: 0.15
-Nodes (12): `bd rules audit`, `bd rules compact`, Best Practices, code:bash (bd rules audit                    # Default scan), code:bash (bd rules compact --dry-run        # Preview merges without a), code:bash ($ bd rules audit), code:bash (# In pan sync workflow), Commands (+4 more)
+Nodes (13): code:bash (# If project has override skill, this skill is permanently d), code:bash (cat .panopticon/knowledge-capture.json 2>/dev/null || echo "), code:json ({), code:javascript (// Pseudocode for decision), code:bash (mkdir -p .claude/skills/knowledge-capture), code:bash (# Ensure directory exists), Invocation Protocol, Step 0: Check for Permanent Override (+5 more)
 
 ### Community 633 - "Community 633"
 Cohesion: 0.15
-Nodes (13): At Session End (Claude prompts user), At Session Start (Claude's responsibility), code:block16 (Session Start with in_progress issues:), code:block17 (Session End Handoff:), code:block18 (Good handoff note (current state):), code:block19 (Session End Checklist:), code:block20 (User Tips:), code:bash (bd update workspace-mcp-server-2 --notes "COMPLETED: Set up ) (+5 more)
+Nodes (12): `bd rules audit`, `bd rules compact`, Best Practices, code:bash (bd rules audit                    # Default scan), code:bash (bd rules compact --dry-run        # Preview merges without a), code:bash ($ bd rules audit), code:bash (# In pan sync workflow), Commands (+4 more)
 
 ### Community 634 - "Community 634"
 Cohesion: 0.15
-Nodes (13): code:block10 (Start: "What's the final deliverable?"), code:block11 (Ready Front 1:  gt-buffer (foundation)), code:bash (# Create epic (the goal)), code:block7 (Ready Front = Issues where all dependencies are closed), code:block8 (⚠️ COGNITIVE TRAP:), code:block9 (Epic Planning with Ready Fronts:), Epic Planning {#epic-planning}, Epic Planning Workflow (+5 more)
+Nodes (13): At Session End (Claude prompts user), At Session Start (Claude's responsibility), code:block16 (Session Start with in_progress issues:), code:block17 (Session End Handoff:), code:block18 (Good handoff note (current state):), code:block19 (Session End Checklist:), code:block20 (User Tips:), code:bash (bd update workspace-mcp-server-2 --notes "COMPLETED: Set up ) (+5 more)
 
 ### Community 635 - "Community 635"
 Cohesion: 0.15
-Nodes (12): API Function, Categories, code:bash (pan tell ISSUE-123 "Your feedback message here"), code:block2 (Sending feedback to agent-pan-45:), code:block3 (Sending feedback to agent-pan-45:), Example: Merge Success, Example: Test Failure, Feedback Types (+4 more)
+Nodes (13): code:block10 (Start: "What's the final deliverable?"), code:block11 (Ready Front 1:  gt-buffer (foundation)), code:bash (# Create epic (the goal)), code:block7 (Ready Front = Issues where all dependencies are closed), code:block8 (⚠️ COGNITIVE TRAP:), code:block9 (Epic Planning with Ready Fronts:), Epic Planning {#epic-planning}, Epic Planning Workflow (+5 more)
 
 ### Community 636 - "Community 636"
 Cohesion: 0.15
-Nodes (12): code:bash (#!/bin/bash), code:bash (# Check system health), Complete Quick Start Script, Feedback and Support, Overview, Panopticon Quick Start, Related Skills, Success Checklist (+4 more)
+Nodes (12): API Function, Categories, code:bash (pan tell ISSUE-123 "Your feedback message here"), code:block2 (Sending feedback to agent-pan-45:), code:block3 (Sending feedback to agent-pan-45:), Example: Merge Success, Example: Test Failure, Feedback Types (+4 more)
 
 ### Community 637 - "Community 637"
+Cohesion: 0.15
+Nodes (12): code:bash (#!/bin/bash), code:bash (# Check system health), Complete Quick Start Script, Feedback and Support, Overview, Panopticon Quick Start, Related Skills, Success Checklist (+4 more)
+
+### Community 638 - "Community 638"
+Cohesion: 0.15
+Nodes (13): "Certificate not trusted" warnings, code:bash (docker ps | grep traefik), code:bash (docker logs panopticon-traefik), code:bash (ls ~/.panopticon/traefik/certs/), code:bash (mkcert -install), code:bash (docker network inspect panopticon), code:bash (docker inspect <container> | grep -A 20 Labels), code:bash (# Find what's using the ports) (+5 more)
+
+### Community 639 - "Community 639"
 Cohesion: 0.17
 Nodes (11): available, content, defaults, defaults1, defaults2, error, invalidSettings, loaded (+3 more)
 
-### Community 638 - "Community 638"
-Cohesion: 0.17
-Nodes (10): bin, binPath, content, desktopDir, devDeps, engines, files, p (+2 more)
-
-### Community 639 - "Community 639"
+### Community 640 - "Community 640"
 Cohesion: 0.29
 Nodes (8): cleanupAgentDirectories(), CleanupResult, findOrphanedAgentDirs(), getPlanningIssueId(), isLegacyConversationDirectory(), isValidAgentDirectoryName(), OrphanedAgentDir, names
 
-### Community 640 - "Community 640"
-Cohesion: 0.21
-Nodes (6): ENV_KEYS, EnvSnapshot, ServerConfig, ServerConfigError, ServerConfigLayer, ServerConfigShape
-
-### Community 643 - "Community 643"
+### Community 641 - "Community 641"
 Cohesion: 0.17
-Nodes (10): allOps, divergedOp, execAsync, execFileMock, execMock, ops, opTypes, status (+2 more)
+Nodes (10): bin, binPath, content, desktopDir, devDeps, engines, files, p (+2 more)
 
-### Community 644 - "Community 644"
+### Community 642 - "Community 642"
 Cohesion: 0.17
 Nodes (10): mockClearConfigCache, mockLoadConfig, mockMergeConfigs, mockReadFile, mockResolveModelId, mockWriteFile, result, settings (+2 more)
 
-### Community 645 - "Community 645"
+### Community 644 - "Community 644"
 Cohesion: 0.17
-Nodes (11): agentIds, baseTimestamp, checkpoints, deleteLegacyCheckpointRefs, diffCheckpointFiles, encoder, getCheckpointTimestamp, listCheckpoints (+3 more)
+Nodes (10): allOps, divergedOp, execAsync, execFileMock, execMock, ops, opTypes, status (+2 more)
 
 ### Community 646 - "Community 646"
-Cohesion: 0.17
-Nodes (12): Before starting any work, Build before deploy, code:bash (# 1. Rebase onto latest main (always — even if STATE.md alre), code:bash (npm run build), code:bash (# WRONG — may stage .beads/, dist/, secrets), code:bash (bd ready -l pan-xxx          # Next unblocked bead for THIS ), code:bash (npm test                                         # Must pass), Completing work (+4 more)
+Cohesion: 0.23
+Nodes (9): CacheEntry, clearSnapshotCache(), loadSnapshotFromCache(), saveSnapshotToCache(), serialize(), bigSnapshot, err, loaded (+1 more)
 
 ### Community 647 - "Community 647"
-Cohesion: 0.17
-Nodes (12): Always pre-trust directories before spawning agents, Architecture Rules, code:typescript (// WRONG), code:bash (# CORRECT), code:typescript (// WRONG), code:typescript (let running = false;), code:typescript (import { preTrustDirectory } from '../workspace-manager.js';), Idempotency guards on background services (+4 more)
+Cohesion: 0.48
+Nodes (12): detectPlatformAsset(), ensureConfigFile(), ensureDirs(), getCliproxyBinary(), getCliproxyConfigPath(), getCliproxyDir(), getCliproxyLogPath(), installCliproxy() (+4 more)
 
 ### Community 648 - "Community 648"
-Cohesion: 0.17
-Nodes (11): Agent Instructions, Beads Issue Tracker, code:bash (bd ready              # Find available work), code:bash (git pull --rebase), code:bash (bd ready              # Find available work), code:bash (git pull --rebase), Landing the Plane (Session Completion), Quick Reference (+3 more)
+Cohesion: 0.2
+Nodes (9): authorized(), eventsRouteLayer, getEventStreamRoute, getEventVersionRoute, getHeader(), isPublicEventType(), matchesFilter(), PUBLIC_CATALOG (+1 more)
 
 ### Community 649 - "Community 649"
-Cohesion: 0.17
-Nodes (11): Architecture at a Glance, code:bash (npx @panctl/cli), code:bash (npm install -g @panctl/cli), code:bash (npm install -g @panctl/cli), Direct Desktop Downloads, Headless / CI, One Command, Power-User Path: Install Everything Up Front (+3 more)
+Cohesion: 0.21
+Nodes (11): handlePermissionRequestNotification(), normalizePermissionRequest(), parsePermissionRequestNotification(), CHANNEL_PERMISSION_LIMITS, normalizeChannelPermissionRequestFields(), NormalizedChannelPermissionRequestFields, normalizePermissionInputPreview(), PermissionPayloadValidationError (+3 more)
 
 ### Community 650 - "Community 650"
 Cohesion: 0.17
-Nodes (11): code:typescript (interface ContextBudget {), Context Budget Manager, ⚠️ DECOUPLING FROM MYN (CRITICAL), DO NOT rely on MYN infrastructure:, If tests pass, commit, Migration checklist (from MYN):, Panopticon: Multi-Agent Orchestration for Claude Code, Panopticon MUST be self-contained: (+3 more)
+Nodes (12): Always pre-trust directories before spawning agents, Architecture Rules, code:typescript (// WRONG), code:bash (# CORRECT), code:typescript (// WRONG), code:typescript (let running = false;), code:typescript (import { preTrustDirectory } from '../workspace-manager.js';), Idempotency guards on background services (+4 more)
 
 ### Community 651 - "Community 651"
 Cohesion: 0.17
-Nodes (12): code:bash (# 1. Install Panopticon), code:bash (# Start the day), code:bash (# Create detailed plan before spawning agent), code:bash (# Update Panopticon itself), code:toml (# In projects.toml), code:bash (pan sync), Daily Development, Initial Setup (+4 more)
+Nodes (12): Before starting any work, Build before deploy, code:bash (# 1. Rebase onto latest main (always — even if STATE.md alre), code:bash (npm run build), code:bash (# WRONG — may stage .beads/, dist/, secrets), code:bash (bd ready -l pan-xxx          # Next unblocked bead for THIS ), code:bash (npm test                                         # Must pass), Completing work (+4 more)
 
 ### Community 652 - "Community 652"
 Cohesion: 0.17
-Nodes (12): Agent Integration, Canonical PRD Sections, CLI Commands, code:block143 ({project}/), code:block144 (┌───────────────────────────────────────────────────────────), code:bash (# Initialize/regenerate canonical PRD), Feature PRDs Live in Workspaces, Naming Convention (+4 more)
+Nodes (11): Agent Instructions, Beads Issue Tracker, code:bash (bd ready              # Find available work), code:bash (git pull --rebase), code:bash (bd ready              # Find available work), code:bash (git pull --rebase), Landing the Plane (Session Completion), Quick Reference (+3 more)
 
 ### Community 653 - "Community 653"
 Cohesion: 0.17
-Nodes (12): code:bash (pan workspace create MIN-667 --remote    # Create on exe.dev), code:toml (# ~/.panopticon/config.toml), code:block38 ($ pan workspace create MIN-667), code:block39 (┌───────────────────────────────────────────────────────────), code:block40 (┌─────────────────────┐), code:block41 (┌─────────────────────────────┐), code:block42 (┌────────────────────────────────────────────────────────┐), code:block43 (┌────────────────────────────────────────────────────────┐) (+4 more)
+Nodes (11): Architecture at a Glance, code:bash (npx @panctl/cli), code:bash (npm install -g @panctl/cli), code:bash (npm install -g @panctl/cli), Direct Desktop Downloads, Headless / CI, One Command, Power-User Path: Install Everything Up Front (+3 more)
 
 ### Community 654 - "Community 654"
 Cohesion: 0.17
-Nodes (11): code:yaml (models:), code:env (ANTHROPIC_API_KEY=sk-ant-...), code:yaml (models:), code:yaml (models:), Configuration Guide, Example Resolution, Getting Help, Precedence Rules (+3 more)
+Nodes (11): code:typescript (interface ContextBudget {), Context Budget Manager, ⚠️ DECOUPLING FROM MYN (CRITICAL), DO NOT rely on MYN infrastructure:, If tests pass, commit, Migration checklist (from MYN):, Panopticon: Multi-Agent Orchestration for Claude Code, Panopticon MUST be self-contained: (+3 more)
 
 ### Community 655 - "Community 655"
 Cohesion: 0.17
-Nodes (12): code:yaml (# Deprecated → Current), code:yaml (models:), code:yaml (models:), code:block24 (✓ Backed up config.yaml → config.yaml.bak), code:bash (cp ~/.panopticon/config.yaml.bak ~/.panopticon/config.yaml), Current Deprecations, Dashboard Behavior, Example Migration (+4 more)
+Nodes (12): code:bash (# 1. Install Panopticon), code:bash (# Start the day), code:bash (# Create detailed plan before spawning agent), code:bash (# Update Panopticon itself), code:toml (# In projects.toml), code:bash (pan sync), Daily Development, Initial Setup (+4 more)
 
 ### Community 656 - "Community 656"
 Cohesion: 0.17
-Nodes (12): Branch node layout, code:block2 (├── MIN-846  [$12.40]  In Review  [📁 🔀 📻 📋 🐛 🔀 🐳]     ← reso), code:block3 (┌──────────────────────────────────────────────────────────┐), code:block4 (┌──────────────────────────────────────────────────────────┐), code:block5 (┌──────────────────────────────────────────────────────────┐), code:block6 (┌──────────────────────────────────────────────────────────┐), Container node context menu (right-click), Container node layout (single row) (+4 more)
+Nodes (12): Agent Integration, Canonical PRD Sections, CLI Commands, code:block143 ({project}/), code:block144 (┌───────────────────────────────────────────────────────────), code:bash (# Initialize/regenerate canonical PRD), Feature PRDs Live in Workspaces, Naming Convention (+4 more)
 
 ### Community 657 - "Community 657"
 Cohesion: 0.17
-Nodes (11): code:typescript (// In src/dashboard/server/routes/resources.ts), code:typescript (HttpRouter.post('/api/resources/docker/container/:id/start',), code:typescript (// In src/dashboard/server/services/resource-discovery.ts (o), code:typescript (// New field on the response), Container name parsing utility (new), Extend `ResourceDetailIdentifiers` response, `GET /api/resources/docker/container/:id/logs`, New API endpoints (+3 more)
+Nodes (12): code:bash (pan workspace create MIN-667 --remote    # Create on exe.dev), code:toml (# ~/.panopticon/config.toml), code:block38 ($ pan workspace create MIN-667), code:block39 (┌───────────────────────────────────────────────────────────), code:block40 (┌─────────────────────┐), code:block41 (┌─────────────────────────────┐), code:block42 (┌────────────────────────────────────────────────────────┐), code:block43 (┌────────────────────────────────────────────────────────┐) (+4 more)
 
 ### Community 658 - "Community 658"
 Cohesion: 0.17
-Nodes (12): 1. Status billboard, 2. Reviewer summary (when in review), 3. Test summary (when test has run), 4. PR summary (when PR exists), 5. Cost breakdown sparkline, 6. Recent activity feed (combined across all sessions), 7. Quick links, code:block17 (┌───────────────────────────────────────────────────────────) (+4 more)
+Nodes (11): code:yaml (models:), code:env (ANTHROPIC_API_KEY=sk-ant-...), code:yaml (models:), code:yaml (models:), Configuration Guide, Example Resolution, Getting Help, Precedence Rules (+3 more)
 
 ### Community 659 - "Community 659"
 Cohesion: 0.17
-Nodes (11): Architecture Notes, code:typescript (const confirmed = await confirm({), code:typescript (catch (labelErr) {), Decisions, Implementation Plan, Out of Scope, PAN-445: Planning Abort button uses native JS confirm() instead of styled dialog, Problem (+3 more)
+Nodes (12): code:yaml (# Deprecated → Current), code:yaml (models:), code:yaml (models:), code:block24 (✓ Backed up config.yaml → config.yaml.bak), code:bash (cp ~/.panopticon/config.yaml.bak ~/.panopticon/config.yaml), Current Deprecations, Dashboard Behavior, Example Migration (+4 more)
 
 ### Community 660 - "Community 660"
 Cohesion: 0.17
-Nodes (11): Architecture, Backend Changes, code:block1 (Backend /api/agents → includes planning-* agents with agentP), Data Flow, Decisions, Edge Cases, Files to Modify, Frontend Changes (+3 more)
+Nodes (12): Branch node layout, code:block2 (├── MIN-846  [$12.40]  In Review  [📁 🔀 📻 📋 🐛 🔀 🐳]     ← reso), code:block3 (┌──────────────────────────────────────────────────────────┐), code:block4 (┌──────────────────────────────────────────────────────────┐), code:block5 (┌──────────────────────────────────────────────────────────┐), code:block6 (┌──────────────────────────────────────────────────────────┐), Container node context menu (right-click), Container node layout (single row) (+4 more)
 
 ### Community 661 - "Community 661"
 Cohesion: 0.17
-Nodes (11): code:json ({ "HEAD": "abc1234", "branch": "feature/PAN-333" }), Decision: Implement the missing function, Difficulty: simple, Files to modify, Implementation approach, No changes needed, PAN-342: getWorkspaceCommitHashes is not a function, Problem (+3 more)
+Nodes (11): code:typescript (// In src/dashboard/server/routes/resources.ts), code:typescript (HttpRouter.post('/api/resources/docker/container/:id/start',), code:typescript (// In src/dashboard/server/services/resource-discovery.ts (o), code:typescript (// New field on the response), Container name parsing utility (new), Extend `ResourceDetailIdentifiers` response, `GET /api/resources/docker/container/:id/logs`, New API endpoints (+3 more)
 
 ### Community 662 - "Community 662"
 Cohesion: 0.17
-Nodes (11): Affected Files, code:typescript (const inInput = ['INPUT', 'TEXTAREA'].includes(target.tagNam), code:typescript (const inInput = target.tagName === 'INPUT' || target.tagName), Complexity, Out of Scope, Part 1: Fix global search hotkey (App.tsx), Part 2: Add slash command menu (ComposerPromptEditor.tsx), Problem (+3 more)
+Nodes (12): 1. Status billboard, 2. Reviewer summary (when in review), 3. Test summary (when test has run), 4. PR summary (when PR exists), 5. Cost breakdown sparkline, 6. Recent activity feed (combined across all sessions), 7. Quick links, code:block17 (┌───────────────────────────────────────────────────────────) (+4 more)
 
 ### Community 663 - "Community 663"
 Cohesion: 0.17
-Nodes (11): 1. Eliminate Extended Token Layer, 2. Replace `text-white` with Semantic Foreground Tokens, 3. Rename Mission Control → Command Deck, 4. Delete Isolated Codex Theme, 5. Upgrade DialogProvider, 6. Align `index.css` with T3Code Formulas, Acceptance Criteria, Objective (+3 more)
+Nodes (11): Architecture Notes, code:typescript (const confirmed = await confirm({), code:typescript (catch (labelErr) {), Decisions, Implementation Plan, Out of Scope, PAN-445: Planning Abort button uses native JS confirm() instead of styled dialog, Problem (+3 more)
 
 ### Community 664 - "Community 664"
 Cohesion: 0.17
-Nodes (11): Approach, Backend status: already done, Difficulty, Edit state, Empty/whitespace, Files touched, Out of scope, PAN-596: Allow editing a conversation title (+3 more)
+Nodes (11): Architecture, Backend Changes, code:block1 (Backend /api/agents → includes planning-* agents with agentP), Data Flow, Decisions, Edge Cases, Files to Modify, Frontend Changes (+3 more)
 
 ### Community 665 - "Community 665"
 Cohesion: 0.17
-Nodes (11): Current architecture (observed), Decision summary, Difficulty, Files to change, Goal, Out of scope (explicit), PAN-509 — Inspector: Phase-Aware Terminal, Phase → session mapping (+3 more)
+Nodes (11): code:json ({ "HEAD": "abc1234", "branch": "feature/PAN-333" }), Decision: Implement the missing function, Difficulty: simple, Files to modify, Implementation approach, No changes needed, PAN-342: getWorkspaceCommitHashes is not a function, Problem (+3 more)
 
 ### Community 666 - "Community 666"
 Cohesion: 0.17
-Nodes (11): Approach, Decisions, Files to Modify, Layer 1: Frontend (toast + better messaging), Layer 2: Backend — complete-planning, Layer 3: Backend — POST /api/agents, Layer 4: beads.ts — robust initialization, Out of Scope (+3 more)
+Nodes (11): Affected Files, code:typescript (const inInput = ['INPUT', 'TEXTAREA'].includes(target.tagNam), code:typescript (const inInput = target.tagName === 'INPUT' || target.tagName), Complexity, Out of Scope, Part 1: Fix global search hotkey (App.tsx), Part 2: Add slash command menu (ComposerPromptEditor.tsx), Problem (+3 more)
 
 ### Community 667 - "Community 667"
 Cohesion: 0.17
-Nodes (12): code:block10 (feature-1: "Add OAuth login"), code:block11 (perf-1: "Investigate Redis caching"), code:bash (bd dep add issue-1 issue-2 --type related), code:block13 (api-redesign related to:), code:block14 (security-audit related to:), code:block9 (refactor-1: "Extract validation logic"), Common Patterns, Creating related Dependencies (+4 more)
+Nodes (11): 1. Eliminate Extended Token Layer, 2. Replace `text-white` with Semantic Foreground Tokens, 3. Rename Mission Control → Command Deck, 4. Delete Isolated Codex Theme, 5. Upgrade DialogProvider, 6. Align `index.css` with T3Code Formulas, Acceptance Criteria, Objective (+3 more)
 
 ### Community 668 - "Community 668"
 Cohesion: 0.17
-Nodes (11): Basic Usage, code:block1 (Invoke first: pipeline-status), code:bash (# Check all running agents (shorthand for work status)), Lead with the pipeline-status table, More Information, Next Steps, Overview, Panopticon Status Overview (+3 more)
+Nodes (11): Approach, Backend status: already done, Difficulty, Edit state, Empty/whitespace, Files touched, Out of scope, PAN-596: Allow editing a conversation title (+3 more)
 
 ### Community 669 - "Community 669"
 Cohesion: 0.17
-Nodes (12): Agent shows as crashed, code:bash (# Check tmux sessions directly), code:bash (# Check agent logs), code:bash (# Check Docker containers directly), code:bash (nvm install 18), code:bash (sudo systemctl start docker  # Linux), code:bash (pan up), code:bash (# Check API key in config) (+4 more)
+Nodes (11): Current architecture (observed), Decision summary, Difficulty, Files to change, Goal, Out of scope (explicit), PAN-509 — Inspector: Phase-Aware Terminal, Phase → session mapping (+3 more)
 
 ### Community 670 - "Community 670"
 Cohesion: 0.17
-Nodes (11): Canary, code:bash (pan release check), code:bash (pan release stable --version 0.7.1), code:bash (git push origin main), Core policy, Notes, Panopticon Release Workflow, Preferred operator flow (+3 more)
+Nodes (11): Approach, Decisions, Files to Modify, Layer 1: Frontend (toast + better messaging), Layer 2: Backend — complete-planning, Layer 3: Backend — POST /api/agents, Layer 4: beads.ts — robust initialization, Out of Scope (+3 more)
 
 ### Community 671 - "Community 671"
 Cohesion: 0.17
-Nodes (12): 3. Color System, Architecture, code:css (:root {), code:css (@variant dark {), code:block6 (NEVER: bg-gray-800, bg-gray-900, bg-gray-700), Color Restraint (Data-Dense Views), Column Semantic Colors (Kanban Pipeline), Dark Mode Tokens (+4 more)
+Nodes (12): code:block10 (feature-1: "Add OAuth login"), code:block11 (perf-1: "Investigate Redis caching"), code:bash (bd dep add issue-1 issue-2 --type related), code:block13 (api-redesign related to:), code:block14 (security-audit related to:), code:block9 (refactor-1: "Extract validation logic"), Common Patterns, Creating related Dependencies (+4 more)
 
 ### Community 672 - "Community 672"
 Cohesion: 0.17
-Nodes (11): Boundaries, code:bash (npm test), Completion, Deep depth: `inspect-deep`, Fast depth: `inspect`, Hardcoding it here would override the user's config and force everyone onto a, Jidoka Inspection Gates, No `model:` pin — Cloister resolves the model from config.yaml (roles.work.model). (+3 more)
+Nodes (11): Basic Usage, code:block1 (Invoke first: pipeline-status), code:bash (# Check all running agents (shorthand for work status)), Lead with the pipeline-status table, More Information, Next Steps, Overview, Panopticon Status Overview (+3 more)
 
 ### Community 673 - "Community 673"
 Cohesion: 0.17
-Nodes (11): Boundaries, code:bash (npm run typecheck), Hardcoding it here would override the user's config and force everyone onto a, Human-Merge Invariant, Inputs, No `model:` pin — Cloister resolves the model from config.yaml (roles.ship.model)., Panopticon Ship Role, Shipping Workflow (+3 more)
+Nodes (12): Agent shows as crashed, code:bash (# Check tmux sessions directly), code:bash (# Check agent logs), code:bash (# Check Docker containers directly), code:bash (nvm install 18), code:bash (sudo systemctl start docker  # Linux), code:bash (pan up), code:bash (# Check API key in config) (+4 more)
 
 ### Community 674 - "Community 674"
 Cohesion: 0.17
-Nodes (11): code:bash (curl -s -X POST {{API_URL}}/api/specialists/done \), code:bash (curl -s -X POST {{API_URL}}/api/specialists/done \), Hard Rules, Memory Context, Merge Task — {{ISSUE_ID}}, PHASE 1 — SYNC & BASELINE (before merge), PHASE 2 — MERGE, PHASE 3 — VERIFY (+3 more)
+Nodes (11): Canary, code:bash (pan release check), code:bash (pan release stable --version 0.7.1), code:bash (git push origin main), Core policy, Notes, Panopticon Release Workflow, Preferred operator flow (+3 more)
 
 ### Community 675 - "Community 675"
-Cohesion: 0.18
-Nodes (6): configFixture, __dirname, issueFixture, mockGitHubResponses, mockLinearResponses, skillFixture
+Cohesion: 0.17
+Nodes (12): 3. Color System, Architecture, code:css (:root {), code:css (@variant dark {), code:block6 (NEVER: bg-gray-800, bg-gray-900, bg-gray-700), Color Restraint (Data-Dense Views), Column Semantic Colors (Kanban Pipeline), Dark Mode Tokens (+4 more)
 
 ### Community 676 - "Community 676"
-Cohesion: 0.18
-Nodes (9): decode, events, identity, marker, next, observation, observationEvents, pendingTurn (+1 more)
+Cohesion: 0.17
+Nodes (11): Boundaries, code:bash (npm test), Completion, Deep depth: `inspect-deep`, Fast depth: `inspect`, Hardcoding it here would override the user's config and force everyone onto a, Jidoka Inspection Gates, No `model:` pin — Cloister resolves the model from config.yaml (roles.work.model). (+3 more)
 
 ### Community 677 - "Community 677"
-Cohesion: 0.18
-Nodes (6): ACTIVE_STATUS_PATTERNS, agentDir, LAZY_PATTERNS, lazySamples, oldTime, stateFile
+Cohesion: 0.17
+Nodes (11): Boundaries, code:bash (npm run typecheck), Hardcoding it here would override the user's config and force everyone onto a, Human-Merge Invariant, Inputs, No `model:` pin — Cloister resolves the model from config.yaml (roles.ship.model)., Panopticon Ship Role, Shipping Workflow (+3 more)
 
 ### Community 678 - "Community 678"
-Cohesion: 0.25
-Nodes (9): create_skill(), init_skill(), main(), Validate skill name follows conventions., Convert skill-name to Skill Name., Create a new skill directory structure., Initialize a new skill directory structure., to_title() (+1 more)
+Cohesion: 0.17
+Nodes (11): code:bash (curl -s -X POST {{API_URL}}/api/specialists/done \), code:bash (curl -s -X POST {{API_URL}}/api/specialists/done \), Hard Rules, Memory Context, Merge Task — {{ISSUE_ID}}, PHASE 1 — SYNC & BASELINE (before merge), PHASE 2 — MERGE, PHASE 3 — VERIFY (+3 more)
 
 ### Community 679 - "Community 679"
 Cohesion: 0.18
-Nodes (10): desktopDir, __dirname, pkg, pkgPath, publicDest, publicSrc, repoRoot, serverDest (+2 more)
+Nodes (6): configFixture, __dirname, issueFixture, mockGitHubResponses, mockLinearResponses, skillFixture
 
 ### Community 680 - "Community 680"
 Cohesion: 0.18
-Nodes (8): error, mockComment, mockComments, mockIssue, mockIssues, mockOctokit, stateTests, tracker
+Nodes (9): decode, events, identity, marker, next, observation, observationEvents, pendingTurn (+1 more)
 
 ### Community 681 - "Community 681"
-Cohesion: 0.22
-Nodes (9): EditorLaunch, execAsync, getFileManagerCommand(), isCommandAvailable(), launchDetached(), PanOpen, PanOpenLive, PanOpenShape (+1 more)
+Cohesion: 0.18
+Nodes (6): ACTIVE_STATUS_PATTERNS, agentDir, LAZY_PATTERNS, lazySamples, oldTime, stateFile
 
 ### Community 682 - "Community 682"
-Cohesion: 0.18
-Nodes (7): mockAddComment, mockGetChildIssues, mockGetIssue, mockGetRallyConfig, mockTransitionIssue, program, RALLY_CONFIG
+Cohesion: 0.25
+Nodes (9): create_skill(), init_skill(), main(), Validate skill name follows conventions., Convert skill-name to Skill Name., Create a new skill directory structure., Initialize a new skill directory structure., to_title() (+1 more)
 
 ### Community 683 - "Community 683"
 Cohesion: 0.18
-Nodes (8): MOCK_PROJECT, mockCreateWorkspace, mockExistsSync, mockLoadProjectsConfig, mockRemoveWorkspace, mockResolveProjectFromIssue, mockStopWorkspaceDocker, program
+Nodes (10): desktopDir, __dirname, pkg, pkgPath, publicDest, publicSrc, repoRoot, serverDest (+2 more)
 
 ### Community 684 - "Community 684"
-Cohesion: 0.18
-Nodes (8): MOCK_PROJECT, mockCreateWorkspace, mockExistsSync, mockLoadProjectsConfig, mockRemoveWorkspace, mockResolveProjectFromIssue, mockStopWorkspaceDocker, program
+Cohesion: 0.29
+Nodes (10): callServerApi(), AgentStatus, buildContextMenu(), buildTooltip(), createTray(), createTrayIcon(), destroyTray(), HealthResponse (+2 more)
 
 ### Community 685 - "Community 685"
 Cohesion: 0.18
-Nodes (11): Acceptance Criteria Pipeline, Agent Environment Variables, Beads Prerequisite, code:block4 (1. Planning agent writes:), DAG-Aware Task Scheduling, Handling Pre-Existing PRDs, Lifecycle, Planning → Implementation Transition (+3 more)
+Nodes (9): diffAgainstMain(), diffAgainstMainFiles(), diffsRouteLayer, getDiffsRoute, getFullDiffRoute, getTurnDiffRoute, getVsMainDiffRoute, postTestCheckpointRoute (+1 more)
 
 ### Community 686 - "Community 686"
 Cohesion: 0.18
-Nodes (11): 1. Tool Response Materialization, 2. Chat History as Queryable Files, 3. Skills as Discoverable Definitions, 4. MCP Tool Discovery, 5. Terminal Output Integration, code:block10 (~/.panopticon/mcp/), code:block11 (~/.panopticon/terminals/), code:typescript (// Before) (+3 more)
+Nodes (10): ghCliIssue, githubApiIssue, githubOpenIssue, issueWithCompletedAt, issueWithoutCompletedAt, linearIssue, linearOpenIssue, mappedIssue (+2 more)
 
 ### Community 687 - "Community 687"
-Cohesion: 0.18
-Nodes (11): code:json ({), code:bash (# Cost for a specific issue), code:bash (bd show MIN-123), Cost Calculation, Data Sources, Implementation Notes, Part 15: Per-Feature Cost Tracking, Related Tools (+3 more)
+Cohesion: 0.27
+Nodes (11): bridgeGeminiAuthToCliproxyAsync(), buildCliproxyConfig(), ensureConfigFileAsync(), ensureDirsAsync(), getCliproxyAuthDir(), getCliproxyGeminiCredPath(), parseBridgedGeminiApiKey(), readBridgedGeminiApiKey() (+3 more)
 
 ### Community 688 - "Community 688"
-Cohesion: 0.18
-Nodes (11): Adopting GSD Patterns for Panopticon, code:markdown (# Workspace Context: MIN-648), code:markdown (# Agent State: MIN-648), code:markdown (# Work Summary: Research Phase), code:block43 (┌───────────────────────────────────────────────────────────), Context File Lifecycle, Part 5: Context Engineering from GSD-Plus, PROJECT.md → Workspace Context (+3 more)
-
-### Community 689 - "Community 689"
-Cohesion: 0.18
-Nodes (11): code:typescript (interface Runtime {), code:toml (# ~/.panopticon/runtimes/claude.toml), code:toml (# ~/.panopticon/runtimes/codex.toml), code:bash (# Default: use project runtime), code:typescript (interface RuntimeMetrics {), Part 6: Multi-Runtime Architecture, Per-Agent Runtime Selection, Runtime Abstraction Layer (+3 more)
+Cohesion: 0.22
+Nodes (9): EditorLaunch, execAsync, getFileManagerCommand(), isCommandAvailable(), launchDetached(), PanOpen, PanOpenLive, PanOpenShape (+1 more)
 
 ### Community 690 - "Community 690"
 Cohesion: 0.18
-Nodes (10): Conversation Forks, Developer Notes, Fork Modes, Fork Options, Model Switching, Plain Fork, Summary Fork (Default), Thinking Block Behavior (+2 more)
+Nodes (7): mockAddComment, mockGetChildIssues, mockGetIssue, mockGetRallyConfig, mockTransitionIssue, program, RALLY_CONFIG
 
 ### Community 691 - "Community 691"
 Cohesion: 0.18
-Nodes (11): 1. Claude Code's Native Hierarchy, Additional Loading Behavior, CLAUDE.md Precedence (team wins over personal), code:block1 (HIGHEST PRIORITY), code:block2 (HIGHEST PRIORITY), code:yaml (---), code:bash (export CLAUDE_CODE_DISABLE_AUTO_MEMORY=0  # Force ON), Rules vs. Skills vs. Agents (+3 more)
+Nodes (8): MOCK_PROJECT, mockCreateWorkspace, mockExistsSync, mockLoadProjectsConfig, mockRemoveWorkspace, mockResolveProjectFromIssue, mockStopWorkspaceDocker, program
 
 ### Community 692 - "Community 692"
 Cohesion: 0.18
-Nodes (10): Autonomous planning auto-promote (commit 861cf8baa, 2026-05-20, RUN-1), Deacon orphan-detection races new agent spawn (observed RUN-1 tick 2), Flywheel State, GitHub App credential config fails ENOTDIR in worktrees (observed RUN-3), Open questions for the human, Orphan-test recovery loops on an unhealthy docker stack (commit ebb7f1387, 2026-05-20, RUN-3), Parked items, Recurring patterns to watch (+2 more)
+Nodes (8): MOCK_PROJECT, mockCreateWorkspace, mockExistsSync, mockLoadProjectsConfig, mockRemoveWorkspace, mockResolveProjectFromIssue, mockStopWorkspaceDocker, program
 
 ### Community 693 - "Community 693"
 Cohesion: 0.18
-Nodes (10): Author allowlist (hard filter), End of run, Flywheel Brief, Human input invariant, Parked labels, Read first, Scope, Status vs State (+2 more)
+Nodes (11): Acceptance Criteria Pipeline, Agent Environment Variables, Beads Prerequisite, code:block4 (1. Planning agent writes:), DAG-Aware Task Scheduling, Handling Pre-Existing PRDs, Lifecycle, Planning → Implementation Transition (+3 more)
 
 ### Community 694 - "Community 694"
 Cohesion: 0.18
-Nodes (10): Acceptance criteria, Architecture Overview, code:block1 (┌───────────────────────────────────────────────────────────), Decision, Implementation notes, Non-goals, Open questions, PAN-709: Self-Improving Flywheel — Retro Agent, Skill-Change Pipeline, and Autonomous Daemon (+2 more)
+Nodes (11): 1. Tool Response Materialization, 2. Chat History as Queryable Files, 3. Skills as Discoverable Definitions, 4. MCP Tool Discovery, 5. Terminal Output Integration, code:block10 (~/.panopticon/mcp/), code:block11 (~/.panopticon/terminals/), code:typescript (// Before) (+3 more)
 
 ### Community 695 - "Community 695"
 Cohesion: 0.18
-Nodes (11): code:typescript (const isPlanningAgent = agent?.agentPhase === 'planning' || ), code:typescript (const isPlanningAgent = agent?.role === 'plan';), code:typescript (const label = specialist), code:typescript (const label = agent?.role), Dashboard Component Changes, Issue card phase label (`KanbanBoard.tsx`), PlanDialog (`PlanDialog.tsx:94-104`), Planning detection (`AgentOutputPanel.tsx:88`) (+3 more)
+Nodes (11): code:typescript (interface Runtime {), code:toml (# ~/.panopticon/runtimes/claude.toml), code:toml (# ~/.panopticon/runtimes/codex.toml), code:bash (# Default: use project runtime), code:typescript (interface RuntimeMetrics {), Part 6: Multi-Runtime Architecture, Per-Agent Runtime Selection, Runtime Abstraction Layer (+3 more)
 
 ### Community 696 - "Community 696"
 Cohesion: 0.18
-Nodes (10): 1. `InlineSparkline.tsx`, 2. `ContainerNode.tsx`, 3. `ResourcesGroup.tsx`, 4. `FeatureItem.tsx` modifications, 5. Container stats polling in `CommandDeck/index.tsx`, code:typescript (interface InlineSparklineProps {), code:typescript (interface ContainerNodeProps {), code:typescript (interface ResourcesGroupProps {) (+2 more)
+Nodes (11): code:json ({), code:bash (# Cost for a specific issue), code:bash (bd show MIN-123), Cost Calculation, Data Sources, Implementation Notes, Part 15: Per-Feature Cost Tracking, Related Tools (+3 more)
 
 ### Community 697 - "Community 697"
 Cohesion: 0.18
-Nodes (10): Acceptance criteria, code:css (.resourcesGroup {), CSS additions, Goal, Non-goals, PAN-965: Command Deck — Hierarchical Resource Tree Under Issues, Relationship to existing work, Status (+2 more)
+Nodes (11): Adopting GSD Patterns for Panopticon, code:markdown (# Workspace Context: MIN-648), code:markdown (# Agent State: MIN-648), code:markdown (# Work Summary: Research Phase), code:block43 (┌───────────────────────────────────────────────────────────), Context File Lifecycle, Part 5: Context Engineering from GSD-Plus, PROJECT.md → Workspace Context (+3 more)
 
 ### Community 698 - "Community 698"
 Cohesion: 0.18
-Nodes (10): Acceptance Criteria, code:typescript (import { HttpRouter, HttpServer, HttpServerRequest, HttpServ), code:block8 (┌──────────────────┐), Decision, PAN-428: Full Effect.js Migration — Dashboard Server + Data Layer, Problem, Reference Implementation, Risk Assessment (Post-Investigation) (+2 more)
+Nodes (10): Conversation Forks, Developer Notes, Fork Modes, Fork Options, Model Switching, Plain Fork, Summary Fork (Default), Thinking Block Behavior (+2 more)
 
 ### Community 699 - "Community 699"
 Cohesion: 0.18
-Nodes (11): Activity sparkline (NEW, Zone A enrichment), code:block4 (⚠ Stuck — {reason}              [View details] [Mark unstuck), code:block5 (⚠ Salvageable user work in stash — recover before destructiv), Contextual actions row, Identity row (visual spec), Live cost ticker, Quality gates rollup (right side of stage row), Salvageable stash warning (+3 more)
+Nodes (11): 1. Claude Code's Native Hierarchy, Additional Loading Behavior, CLAUDE.md Precedence (team wins over personal), code:block1 (HIGHEST PRIORITY), code:block2 (HIGHEST PRIORITY), code:yaml (---), code:bash (export CLAUDE_CODE_DISABLE_AUTO_MEMORY=0  # Force ON), Rules vs. Skills vs. Agents (+3 more)
 
 ### Community 700 - "Community 700"
 Cohesion: 0.18
-Nodes (11): P0 — Remove the worst offenders, P3 — Dashboard transcripts (stream from JSONL), P4 — WebSocket terminal (in-memory buffer), Per-Consumer Migration Plan, `src/dashboard/server/routes/agents.ts:526` — agent output endpoint, `src/dashboard/server/routes/mission-control.ts:161` — ActivityView agent transcript, `src/dashboard/server/routes/mission-control.ts:297` — specialist live output filter, `src/dashboard/server/routes/workspaces.ts:931` — model extraction (+3 more)
+Nodes (10): Autonomous planning auto-promote (commit 861cf8baa, 2026-05-20, RUN-1), Deacon orphan-detection races new agent spawn (observed RUN-1 tick 2), Flywheel State, GitHub App credential config fails ENOTDIR in worktrees (observed RUN-3), Open questions for the human, Orphan-test recovery loops on an unhealthy docker stack (commit ebb7f1387, 2026-05-20, RUN-3), Parked items, Recurring patterns to watch (+2 more)
 
 ### Community 701 - "Community 701"
 Cohesion: 0.18
-Nodes (10): Approach, Constraints, Decisions, PAN-410: DAG Visualization — Match vBRIEF Studio Quality, Problem, Risks, Status: Planning Complete, Task 1: Node Enhancements (PlanDAG.tsx) (+2 more)
+Nodes (10): Author allowlist (hard filter), End of run, Flywheel Brief, Human input invariant, Parked labels, Read first, Scope, Status vs State (+2 more)
 
 ### Community 702 - "Community 702"
 Cohesion: 0.18
-Nodes (10): Approach, Decisions Made, Files Modified, Investigation: `scrollback: 0` History, Out of Scope, PAN-209: Mouse scroll in planning dialog scrolls chat input instead of agent output, Problem, Risk Assessment (+2 more)
+Nodes (10): Acceptance criteria, Architecture Overview, code:block1 (┌───────────────────────────────────────────────────────────), Decision, Implementation notes, Non-goals, Open questions, PAN-709: Self-Improving Flywheel — Retro Agent, Skill-Change Pipeline, and Autonomous Daemon (+2 more)
 
 ### Community 703 - "Community 703"
 Cohesion: 0.18
-Nodes (10): code:block1 (specialists.review_agent = 'claude-opus-4-6'), Decisions, Failure Group 1: settings.test.ts (4 failures), Failure Group 2: tracker/factory.test.ts (2 failures), Files to Modify, PAN-136: Fix Pre-existing Test Failures, Problem, Root Cause Analysis (+2 more)
+Nodes (11): code:typescript (const isPlanningAgent = agent?.agentPhase === 'planning' || ), code:typescript (const isPlanningAgent = agent?.role === 'plan';), code:typescript (const label = specialist), code:typescript (const label = agent?.role), Dashboard Component Changes, Issue card phase label (`KanbanBoard.tsx`), PlanDialog (`PlanDialog.tsx:94-104`), Planning detection (`AgentOutputPanel.tsx:88`) (+3 more)
 
 ### Community 704 - "Community 704"
 Cohesion: 0.18
-Nodes (10): Architecture — new parallel-review runner, code:ts (async function runParallelReview(ctx: ReviewContext, agents:), Decisions, Out of scope, PAN-540: Remove convoy abstraction, inline parallel review into review-agent, Problem, Proposal, Quality gates (per bead, enforced by pipeline) (+2 more)
+Nodes (10): Acceptance criteria, code:css (.resourcesGroup {), CSS additions, Goal, Non-goals, PAN-965: Command Deck — Hierarchical Resource Tree Under Issues, Relationship to existing work, Status (+2 more)
 
 ### Community 705 - "Community 705"
 Cohesion: 0.18
-Nodes (10): 1. `.claude/skills/test-specialist-workflow/SKILL.md` (4 refs), 2. `.claude/skills/update-panopticon-docs/resources/EXAMPLES.md` (1 ref), Approach, Audit findings, Current taxonomy (verified against `pan --help` on feature/pan-712), Decomposition, Out of scope, PAN-712: Fix stale pan work/cloister/specialists refs in .claude/skills/ (+2 more)
+Nodes (10): 1. `InlineSparkline.tsx`, 2. `ContainerNode.tsx`, 3. `ResourcesGroup.tsx`, 4. `FeatureItem.tsx` modifications, 5. Container stats polling in `CommandDeck/index.tsx`, code:typescript (interface InlineSparklineProps {), code:typescript (interface ContainerNodeProps {), code:typescript (interface ResourcesGroupProps {) (+2 more)
 
 ### Community 706 - "Community 706"
 Cohesion: 0.18
-Nodes (10): Architecture outline, Data flow (divergence case), Decisions, Modified files, New files, Out of scope, PAN-653 — Hotfix commits on main get silently lost, Problem (+2 more)
+Nodes (10): Acceptance Criteria, code:typescript (import { HttpRouter, HttpServer, HttpServerRequest, HttpServ), code:block8 (┌──────────────────┐), Decision, PAN-428: Full Effect.js Migration — Dashboard Server + Data Layer, Problem, Reference Implementation, Risk Assessment (Post-Investigation) (+2 more)
 
 ### Community 707 - "Community 707"
 Cohesion: 0.18
-Nodes (10): Architecture Decisions, Decision Summary, Feature Decisions, Framework: Electron, Out of Scope, PAN-442: Electron Desktop App for Panopticon Dashboard, Reference Architecture, Status: Planning Complete (+2 more)
+Nodes (11): Activity sparkline (NEW, Zone A enrichment), code:block4 (⚠ Stuck — {reason}              [View details] [Mark unstuck), code:block5 (⚠ Salvageable user work in stash — recover before destructiv), Contextual actions row, Identity row (visual spec), Live cost ticker, Quality gates rollup (right side of stage row), Salvageable stash warning (+3 more)
 
 ### Community 708 - "Community 708"
 Cohesion: 0.18
-Nodes (9): Acceptance Criteria, Affected File, code:typescript (return yield* RallyClient.pipe(Effect.provide(RallyClientLiv), code:block2 (Error: Fiber.runLoop: Not a valid effect: { "_id": "Service"), Difficulty: Simple, Fix, Issue, Root Cause (+1 more)
+Nodes (11): P0 — Remove the worst offenders, P3 — Dashboard transcripts (stream from JSONL), P4 — WebSocket terminal (in-memory buffer), Per-Consumer Migration Plan, `src/dashboard/server/routes/agents.ts:526` — agent output endpoint, `src/dashboard/server/routes/mission-control.ts:161` — ActivityView agent transcript, `src/dashboard/server/routes/mission-control.ts:297` — specialist live output filter, `src/dashboard/server/routes/workspaces.ts:931` — model extraction (+3 more)
 
 ### Community 709 - "Community 709"
 Cohesion: 0.18
-Nodes (11): A Mustache section renders when it shouldn't, A template renders the literal `{{VAR}}` instead of a value, code:block13 (Prompt "merge" (.../prompts/merge.md) requires variables tha), code:block14 (Prompt "review" (.../prompts/review.md) was passed unknown v), code:block15 (Prompt template "<name>" at .../<name>.md is missing YAML fr), code:block16 (Failed to load prompt template "work" from .../prompts/work.), "Failed to load prompt template", "missing YAML frontmatter" (+3 more)
+Nodes (10): Approach, Constraints, Decisions, PAN-410: DAG Visualization — Match vBRIEF Studio Quality, Problem, Risks, Status: Planning Complete, Task 1: Node Enhancements (PlanDAG.tsx) (+2 more)
 
 ### Community 710 - "Community 710"
 Cohesion: 0.18
-Nodes (10): ADR-0001: Use bd prime as CLI Reference Source of Truth, Consequences, Context, Date, Decision, Implementation, Negative, Positive (+2 more)
+Nodes (10): Approach, Decisions Made, Files Modified, Investigation: `scrollback: 0` History, Out of Scope, PAN-209: Mouse scroll in planning dialog scrolls chat input instead of agent output, Problem, Risk Assessment (+2 more)
 
 ### Community 711 - "Community 711"
 Cohesion: 0.18
-Nodes (10): CLI Quick Reference, code:bash (bd mol distill bd-o5xe --as "Release Workflow"), code:bash (--var branch=feature-auth      # variable=value (recommended), Distilling Protos, Molecules and Wisps Reference, The Chemistry Metaphor, Troubleshooting, Use Protos/Mols When: (+2 more)
+Nodes (10): code:block1 (specialists.review_agent = 'claude-opus-4-6'), Decisions, Failure Group 1: settings.test.ts (4 failures), Failure Group 2: tracker/factory.test.ts (2 failures), Files to Modify, PAN-136: Fix Pre-existing Test Failures, Problem, Root Cause Analysis (+2 more)
 
 ### Community 712 - "Community 712"
 Cohesion: 0.18
-Nodes (10): code:block30 (Does Issue A prevent Issue B from starting?), code:block40 (Issue: feature-10), Contents, Decision Guide, Decision Tree, Dependency Types Guide, Overview, Quick Reference by Situation (+2 more)
+Nodes (10): Architecture — new parallel-review runner, code:ts (async function runParallelReview(ctx: ReviewContext, agents:), Decisions, Out of scope, PAN-540: Remove convoy abstraction, inline parallel review into review-agent, Problem, Proposal, Quality gates (per bead, enforced by pipeline) (+2 more)
 
 ### Community 713 - "Community 713"
 Cohesion: 0.18
-Nodes (11): code:block31 (docs-1: "Update documentation"), code:block32 (epic-1: "OAuth integration"), code:block33 (Everything blocks everything else in strict sequential order), code:bash (bd dep add api-endpoint database-schema), code:bash (bd dep add database-schema api-endpoint), Common Mistakes, Mistake 1: Using blocks for Preferences, Mistake 2: Using discovered-from for Planning (+3 more)
+Nodes (10): 1. `.claude/skills/test-specialist-workflow/SKILL.md` (4 refs), 2. `.claude/skills/update-panopticon-docs/resources/EXAMPLES.md` (1 ref), Approach, Audit findings, Current taxonomy (verified against `pan --help` on feature/pan-712), Decomposition, Out of scope, PAN-712: Fix stale pan work/cloister/specialists refs in .claude/skills/ (+2 more)
 
 ### Community 714 - "Community 714"
 Cohesion: 0.18
-Nodes (11): Add Your First Project, code:bash (pan init), code:bash (# Edit ~/.panopticon.env and add:), code:bash (# Edit ~/.panopticon.env and add:), code:bash (# Edit ~/.panopticon.env and add:), code:bash (# Add the project you want to work on), code:bash (# Check system health), Configure Issue Tracker (+3 more)
+Nodes (10): Architecture outline, Data flow (divergence case), Decisions, Modified files, New files, Out of scope, PAN-653 — Hotfix commits on main get silently lost, Problem (+2 more)
 
 ### Community 715 - "Community 715"
 Cohesion: 0.18
-Nodes (10): code:bash (# CLI command), code:bash (# Sync PAN-123 workspace with latest main), Dashboard, Design Decisions, Examples, Outcomes, Related Commands, Sync with Main (+2 more)
+Nodes (10): Architecture Decisions, Decision Summary, Feature Decisions, Framework: Electron, Out of Scope, PAN-442: Electron Desktop App for Panopticon Dashboard, Reference Architecture, Status: Planning Complete (+2 more)
 
 ### Community 716 - "Community 716"
 Cohesion: 0.18
-Nodes (11): code:bash (# Find what's using the port), code:bash (# Check if frontend built correctly), code:bash (# Check what's using port 80/443), code:bash (# Check browser console for errors), code:bash (# Run in foreground to see errors), Dashboard shows blank page, Port already in use, Services don't stay running (+3 more)
+Nodes (9): Acceptance Criteria, Affected File, code:typescript (return yield* RallyClient.pipe(Effect.provide(RallyClientLiv), code:block2 (Error: Fiber.runLoop: Not a valid effect: { "_id": "Service"), Difficulty: Simple, Fix, Issue, Root Cause (+1 more)
 
 ### Community 717 - "Community 717"
 Cohesion: 0.18
-Nodes (11): Buttons, Cards, code:tsx (// Blue gradient background), code:tsx (// Variants: default, destructive, success, error, warning, ), code:tsx (// Input), code:tsx (// Primary), code:tsx (// Main card (primary, higher elevation)), Component Patterns (+3 more)
+Nodes (11): A Mustache section renders when it shouldn't, A template renders the literal `{{VAR}}` instead of a value, code:block13 (Prompt "merge" (.../prompts/merge.md) requires variables tha), code:block14 (Prompt "review" (.../prompts/review.md) was passed unknown v), code:block15 (Prompt template "<name>" at .../<name>.md is missing YAML fr), code:block16 (Failed to load prompt template "work" from .../prompts/work.), "Failed to load prompt template", "missing YAML frontmatter" (+3 more)
 
 ### Community 718 - "Community 718"
 Cohesion: 0.18
-Nodes (11): Agent sessions remain after shutdown, Can't stop Traefik, code:bash (# Check for orphaned processes), code:bash (# Find what's using the port), code:bash (# Check Traefik status), code:bash (# List tmux sessions), code:bash (# Remove stale PID files), PID file exists but process doesn't (+3 more)
+Nodes (10): ADR-0001: Use bd prime as CLI Reference Source of Truth, Consequences, Context, Date, Decision, Implementation, Negative, Positive (+2 more)
 
 ### Community 719 - "Community 719"
 Cohesion: 0.18
-Nodes (10): Code Review: Requirements Coverage, code:markdown (# Requirements Coverage Review - <timestamp>), Inputs from your spawn prompt, Method, Output format, Per-AC scope classification (REQUIRED), Scope, Severity and evidence (+2 more)
+Nodes (10): CLI Quick Reference, code:bash (bd mol distill bd-o5xe --as "Release Workflow"), code:bash (--var branch=feature-auth      # variable=value (recommended), Distilling Protos, Molecules and Wisps Reference, The Chemistry Metaphor, Troubleshooting, Use Protos/Mols When: (+2 more)
 
 ### Community 720 - "Community 720"
 Cohesion: 0.18
-Nodes (10): Claude Code Channels — Manual Smoke Test (PAN-985), code:block1 ([agent-pan-XXX] channels:eligible), code:block2 ({"ts":"2026-05-07T...","agentId":"agent-pan-XXX","contentLen), code:block3 ({"ts":"2026-...","agentId":"agent-pan-XXX","path":"channel",), code:block4 ({"ts":"2026-...","agentId":"agent-pan-XXX","path":"tmux","re), Expected log signatures, Failure modes & where to look, Prerequisites (+2 more)
+Nodes (11): code:block31 (docs-1: "Update documentation"), code:block32 (epic-1: "OAuth integration"), code:block33 (Everything blocks everything else in strict sequential order), code:bash (bd dep add api-endpoint database-schema), code:bash (bd dep add database-schema api-endpoint), Common Mistakes, Mistake 1: Using blocks for Preferences, Mistake 2: Using discovered-from for Planning (+3 more)
 
 ### Community 721 - "Community 721"
+Cohesion: 0.18
+Nodes (10): code:block30 (Does Issue A prevent Issue B from starting?), code:block40 (Issue: feature-10), Contents, Decision Guide, Decision Tree, Dependency Types Guide, Overview, Quick Reference by Situation (+2 more)
+
+### Community 722 - "Community 722"
+Cohesion: 0.18
+Nodes (11): Add Your First Project, code:bash (pan init), code:bash (# Edit ~/.panopticon.env and add:), code:bash (# Edit ~/.panopticon.env and add:), code:bash (# Edit ~/.panopticon.env and add:), code:bash (# Add the project you want to work on), code:bash (# Check system health), Configure Issue Tracker (+3 more)
+
+### Community 723 - "Community 723"
+Cohesion: 0.18
+Nodes (10): code:bash (# CLI command), code:bash (# Sync PAN-123 workspace with latest main), Dashboard, Design Decisions, Examples, Outcomes, Related Commands, Sync with Main (+2 more)
+
+### Community 724 - "Community 724"
+Cohesion: 0.18
+Nodes (11): code:bash (# Find what's using the port), code:bash (# Check if frontend built correctly), code:bash (# Check what's using port 80/443), code:bash (# Check browser console for errors), code:bash (# Run in foreground to see errors), Dashboard shows blank page, Port already in use, Services don't stay running (+3 more)
+
+### Community 725 - "Community 725"
+Cohesion: 0.18
+Nodes (11): Buttons, Cards, code:tsx (// Blue gradient background), code:tsx (// Variants: default, destructive, success, error, warning, ), code:tsx (// Input), code:tsx (// Primary), code:tsx (// Main card (primary, higher elevation)), Component Patterns (+3 more)
+
+### Community 726 - "Community 726"
+Cohesion: 0.18
+Nodes (11): Agent sessions remain after shutdown, Can't stop Traefik, code:bash (# Check for orphaned processes), code:bash (# Find what's using the port), code:bash (# Check Traefik status), code:bash (# List tmux sessions), code:bash (# Remove stale PID files), PID file exists but process doesn't (+3 more)
+
+### Community 727 - "Community 727"
+Cohesion: 0.18
+Nodes (10): Code Review: Requirements Coverage, code:markdown (# Requirements Coverage Review - <timestamp>), Inputs from your spawn prompt, Method, Output format, Per-AC scope classification (REQUIRED), Scope, Severity and evidence (+2 more)
+
+### Community 728 - "Community 728"
+Cohesion: 0.18
+Nodes (10): Claude Code Channels — Manual Smoke Test (PAN-985), code:block1 ([agent-pan-XXX] channels:eligible), code:block2 ({"ts":"2026-05-07T...","agentId":"agent-pan-XXX","contentLen), code:block3 ({"ts":"2026-...","agentId":"agent-pan-XXX","path":"channel",), code:block4 ({"ts":"2026-...","agentId":"agent-pan-XXX","path":"tmux","re), Expected log signatures, Failure modes & where to look, Prerequisites (+2 more)
+
+### Community 729 - "Community 729"
 Cohesion: 0.29
 Nodes (9): AGENTS_DIR, AgentState, APPLY, dirExists(), execFileAsync, issueIsClosed(), loadState(), main() (+1 more)
 
-### Community 722 - "Community 722"
-Cohesion: 0.33
-Nodes (9): AgentStatus, buildContextMenu(), buildTooltip(), createTray(), createTrayIcon(), destroyTray(), HealthResponse, refreshTrayStatus() (+1 more)
-
-### Community 723 - "Community 723"
-Cohesion: 0.44
-Nodes (9): compactCommand(), CompactOptions, detectPlatform(), doctorCommand(), execAsync, getOldClosedCount(), isBdAvailable(), statsCommand() (+1 more)
-
-### Community 724 - "Community 724"
-Cohesion: 0.2
-Nodes (8): CONFIG, hadPackageDir, hadPython, hadVenvDir, killSpy, packageDir, python, scriptPath
-
-### Community 725 - "Community 725"
-Cohesion: 0.22
-Nodes (8): HealthCheck, systemHealthCommand(), mockExistsSync, mockFetch, mockGetDashboardApiUrl, mockIsCliproxyRunning, mockIsSmeeProcessRunning, output
-
-### Community 726 - "Community 726"
+### Community 730 - "Community 730"
 Cohesion: 0.31
 Nodes (8): analyzeIssue(), sortByPriority(), issues, options, results, triageMultiple(), TriageOptions, TriageResult
 
-### Community 727 - "Community 727"
-Cohesion: 0.27
-Nodes (9): handlePermissionRequestNotification(), normalizePermissionRequest(), parsePermissionRequestNotification(), CHANNEL_PERMISSION_LIMITS, normalizeChannelPermissionRequestFields(), normalizePermissionInputPreview(), PermissionPayloadValidationError, utf8ByteLength() (+1 more)
-
-### Community 728 - "Community 728"
-Cohesion: 0.24
-Nodes (8): CostBreakdownData, CostBreakdownModal(), CostBreakdownModalProps, formatCost(), formatTokens(), ModelBreakdown, STAGE_CONFIG, StageBreakdown
-
-### Community 729 - "Community 729"
-Cohesion: 0.27
-Nodes (7): ConversationRow(), ConversationRowProps, PHASE_ICONS, useNow(), initial, { result }, { result, unmount }
-
-### Community 730 - "Community 730"
-Cohesion: 0.2
-Nodes (9): ArcProps, GroupProps, HTMLMotionProps, MotionComponent, PanopticonBridge, PanopticonBridgeDesktopSettings, Transition, Variants (+1 more)
-
 ### Community 731 - "Community 731"
-Cohesion: 0.2
-Nodes (10): 1. TypeScript typecheck, 2. Lint, 3. Tests, 4. No ephemeral files staged, code:bash (npm run typecheck    # npx tsc --noEmit), code:bash (npm run lint), code:bash (npm test), code:typescript (// vitest.config.ts) (+2 more)
+Cohesion: 0.44
+Nodes (9): compactCommand(), CompactOptions, detectPlatform(), doctorCommand(), execAsync, getOldClosedCount(), isBdAvailable(), statsCommand() (+1 more)
 
 ### Community 732 - "Community 732"
 Cohesion: 0.2
-Nodes (10): code:bash (npx @panctl/cli), code:bash (npm install -g @panctl/cli && pan install && pan up), code:bash (npm install -g @panctl/cli), code:bash (pan install), code:bash (pan sync), code:bash (cd /path/to/your-project), code:bash (pan up), Installation (+2 more)
+Nodes (9): ArcProps, GroupProps, HTMLMotionProps, MotionComponent, PanopticonBridge, PanopticonBridgeDesktopSettings, Transition, Variants (+1 more)
 
 ### Community 733 - "Community 733"
-Cohesion: 0.2
-Nodes (9): Agent Types Index, code:ts (export type Role = 'plan' | 'work' | 'review' | 'test' | 'sh), Important distinction: roles vs helper subagents, Related docs, Runtime role inventory, Sub-roles, The big picture, Typical workflow (+1 more)
+Cohesion: 0.27
+Nodes (8): isRespawnPending(), markRespawnPending(), pendingRespawns, waitForSessionRespawn(), a, mockedSessionExistsAsync, respawn, start
 
 ### Community 734 - "Community 734"
 Cohesion: 0.2
-Nodes (10): Caveats, code:json ({), code:yaml (claude:), code:bash (pan up                     # uses config (default: auto)), code:bash (pan --yolo=false up        # before subcommand), Permission Mode, Precedence, Prereq for `auto` mode (+2 more)
+Nodes (8): CONFIG, hadPackageDir, hadPython, hadVenvDir, killSpy, packageDir, python, scriptPath
 
 ### Community 735 - "Community 735"
 Cohesion: 0.2
-Nodes (10): code:yaml (fpp_violation:), code:typescript (interface FPPViolation {), FPP (Fixed Point Principle) Violation Detection, Implementation Phases, Phase 1: Core Watchdog (MVP), Phase 2: Agent Management UI, Phase 3: Active Heartbeats & Hooks, Phase 4: Model Routing & Handoffs (+2 more)
+Nodes (10): 1. TypeScript typecheck, 2. Lint, 3. Tests, 4. No ephemeral files staged, code:bash (npm run typecheck    # npx tsc --noEmit), code:bash (npm run lint), code:bash (npm test), code:typescript (// vitest.config.ts) (+2 more)
 
 ### Community 736 - "Community 736"
 Cohesion: 0.2
-Nodes (10): Agent state — new `waiting-on-human` state, code:yaml (---), code:yaml (---), code:yaml (flywheel:), Dashboard schema — new kanban badge + Awaiting Merge sub-tab, Data model changes, `docs/FLYWHEEL-REPORT.md` (new), `docs/flywheel/retros/<issue-id>-<timestamp>.md` (new) (+2 more)
+Nodes (10): code:bash (npx @panctl/cli), code:bash (npm install -g @panctl/cli && pan install && pan up), code:bash (npm install -g @panctl/cli), code:bash (pan install), code:bash (pan sync), code:bash (cd /path/to/your-project), code:bash (pan up), Installation (+2 more)
 
 ### Community 737 - "Community 737"
 Cohesion: 0.2
-Nodes (10): code:bash (pan conversations enrich), code:bash (pan conversations enrich --deep), code:bash (pan conversations enrich --with claude-opus-4-6 <session-id>), code:block15 (Session abc123 — 847 messages, ~125K tokens), L1 — Quick enrich (cheap, batch), L2 — Deep enrich (mid-tier model), L3 — Custom enrich (user-selected model), Re-enrichment rules (+2 more)
+Nodes (9): Agent Types Index, code:ts (export type Role = 'plan' | 'work' | 'review' | 'test' | 'sh), Important distinction: roles vs helper subagents, Related docs, Runtime role inventory, Sub-roles, The big picture, Typical workflow (+1 more)
 
 ### Community 738 - "Community 738"
 Cohesion: 0.2
-Nodes (7): code:sql (CREATE VIEW archived_conversations_v AS), Data Model, Existing — `conversations` table, New — `discovered_sessions` table, New — FTS5 mirror, New — vector embeddings (optional), Unified view — `archived_conversations_v`
+Nodes (10): Caveats, code:json ({), code:yaml (claude:), code:bash (pan up                     # uses config (default: auto)), code:bash (pan --yolo=false up        # before subcommand), Permission Mode, Precedence, Prereq for `auto` mode (+2 more)
 
 ### Community 739 - "Community 739"
 Cohesion: 0.2
-Nodes (10): Architecture, Backend extraction, code:block1 (┌──────────────────────────┐         ┌──────────────────────), code:block2 (src/lib/setup/), code:typescript (// src/dashboard/frontend/src/stores/wizardStore.ts), Dashboard surfaces, High-level shape, Setup Agent as a first-class agent (+2 more)
+Nodes (10): code:yaml (fpp_violation:), code:typescript (interface FPPViolation {), FPP (Fixed Point Principle) Violation Detection, Implementation Phases, Phase 1: Core Watchdog (MVP), Phase 2: Agent Management UI, Phase 3: Active Heartbeats & Hooks, Phase 4: Model Routing & Handoffs (+2 more)
 
 ### Community 740 - "Community 740"
 Cohesion: 0.2
-Nodes (9): Files to Create, Files to Modify, Goals, Non-goals, Open Questions, Problem, Project Setup Wizard — Dashboard UI, Risks (+1 more)
+Nodes (10): Agent state — new `waiting-on-human` state, code:yaml (---), code:yaml (---), code:yaml (flywheel:), Dashboard schema — new kanban badge + Awaiting Merge sub-tab, Data model changes, `docs/FLYWHEEL-REPORT.md` (new), `docs/flywheel/retros/<issue-id>-<timestamp>.md` (new) (+2 more)
 
 ### Community 741 - "Community 741"
 Cohesion: 0.2
-Nodes (10): code:typescript (export interface ReviewStatusSnapshot {), code:typescript (describe('isInfrastructureFailure', () => {), D.1 Add new fields to `ReviewStatusSnapshot`, D. `packages/contracts/src/types.ts`, Detailed Changes, E.1 Unit test: `isInfrastructureFailure`, E.2 Unit test: circuit breaker in `checkOrphanedReviewStatuses`, E.3 Unit test: `checkStuckReviewing` with dead parallel sessions (+2 more)
+Nodes (10): code:bash (pan conversations enrich), code:bash (pan conversations enrich --deep), code:bash (pan conversations enrich --with claude-opus-4-6 <session-id>), code:block15 (Session abc123 — 847 messages, ~125K tokens), L1 — Quick enrich (cheap, batch), L2 — Deep enrich (mid-tier model), L3 — Custom enrich (user-selected model), Re-enrichment rules (+2 more)
 
 ### Community 742 - "Community 742"
 Cohesion: 0.2
-Nodes (9): 1. Do NOT rewrite `src/lib/*` modules, 2. Do NOT modify `server.ts` from route modules, 3. Preserve exact API contracts, 4. Socket.io → EventStore mapping, 5. Background processes become Effect fibers, 6. Effect service pattern for existing modules, code:typescript (// services/agent-manager.ts), code:typescript (// CORRECT — wrap existing async code in Effect) (+1 more)
+Nodes (7): code:sql (CREATE VIEW archived_conversations_v AS), Data Model, Existing — `conversations` table, New — `discovered_sessions` table, New — FTS5 mirror, New — vector embeddings (optional), Unified view — `archived_conversations_v`
 
 ### Community 743 - "Community 743"
 Cohesion: 0.2
-Nodes (9): Architecture, code:typescript ({), Data Flow, Decisions, Files to Modify, Key Implementation Details, PAN-426: Tasks Panel and DAG — AC Subtask Toggle, Scope (+1 more)
+Nodes (10): Architecture, Backend extraction, code:block1 (┌──────────────────────────┐         ┌──────────────────────), code:block2 (src/lib/setup/), code:typescript (// src/dashboard/frontend/src/stores/wizardStore.ts), Dashboard surfaces, High-level shape, Setup Agent as a first-class agent (+2 more)
 
 ### Community 744 - "Community 744"
 Cohesion: 0.2
-Nodes (9): Approach, Architecture, code:block1 (DetailPanelLayout), Decision Record, Files Modified, Key Decisions, PAN-406: Workspace detail — replace polling logs with live interactive terminal, Problem (+1 more)
+Nodes (9): Files to Create, Files to Modify, Goals, Non-goals, Open Questions, Problem, Project Setup Wizard — Dashboard UI, Risks (+1 more)
 
 ### Community 745 - "Community 745"
 Cohesion: 0.2
-Nodes (9): Architecture, Decisions, Edge Cases, Files to Modify, Flow After Fix, Out of Scope, PAN-208: Stale planning state causes premature 'Planning Complete' on restart, Problem (+1 more)
+Nodes (10): code:typescript (export interface ReviewStatusSnapshot {), code:typescript (describe('isInfrastructureFailure', () => {), D.1 Add new fields to `ReviewStatusSnapshot`, D. `packages/contracts/src/types.ts`, Detailed Changes, E.1 Unit test: `isInfrastructureFailure`, E.2 Unit test: circuit breaker in `checkOrphanedReviewStatuses`, E.3 Unit test: `checkStuckReviewing` with dead parallel sessions (+2 more)
 
 ### Community 746 - "Community 746"
 Cohesion: 0.2
-Nodes (9): 1. Deep Link URL Format, 2. Deep Link Navigation Behavior, 3. Copy Button Feedback, Affected Files, Context, Decisions, Implementation Plan, Out of Scope (+1 more)
+Nodes (9): 1. Do NOT rewrite `src/lib/*` modules, 2. Do NOT modify `server.ts` from route modules, 3. Preserve exact API contracts, 4. Socket.io → EventStore mapping, 5. Background processes become Effect fibers, 6. Effect service pattern for existing modules, code:typescript (// services/agent-manager.ts), code:typescript (// CORRECT — wrap existing async code in Effect) (+1 more)
 
 ### Community 747 - "Community 747"
 Cohesion: 0.2
-Nodes (9): Context, Decision: Add unit tests for createBeadsFromVBrief, Difficulty, Files affected, PAN-507: beads db not initialized on fresh install, Status: Planning Complete, Test approach, What NOT to test (+1 more)
+Nodes (9): Architecture, code:typescript ({), Data Flow, Decisions, Files to Modify, Key Implementation Details, PAN-426: Tasks Panel and DAG — AC Subtask Toggle, Scope (+1 more)
 
 ### Community 748 - "Community 748"
 Cohesion: 0.2
-Nodes (10): Boolean flags, code:mustache (Issue: {{ISSUE_ID}}), code:mustache ({{#USER_MESSAGE}}), code:mustache ({{^DO_PUSH}}), code:typescript (renderPrompt({), Inverted sections, Mustache syntax reference, No partials, no lambdas, no custom helpers (+2 more)
+Nodes (9): Approach, Architecture, code:block1 (DetailPanelLayout), Decision Record, Files Modified, Key Decisions, PAN-406: Workspace detail — replace polling logs with live interactive terminal, Problem (+1 more)
 
 ### Community 749 - "Community 749"
 Cohesion: 0.2
-Nodes (9): Codebase Explorer, Deliverables, Exploration Strategies, For Architecture Understanding, For New Codebases, For Specific Questions, Performance Tips, Remember (+1 more)
+Nodes (9): Architecture, Decisions, Edge Cases, Files to Modify, Flow After Fix, Out of Scope, PAN-208: Stale planning state causes premature 'Planning Complete' on restart, Problem (+1 more)
 
 ### Community 750 - "Community 750"
 Cohesion: 0.2
-Nodes (9): code:bash (tmux -L panopticon list-sessions), code:block2 ({{WORKSPACE_PATH}}), code:bash (# 1. Run tests), Completion Requirements (CRITICAL), CRITICAL: Workspace Isolation, Investigation First — NEVER Fix Inline, NEVER Defer Work (CRITICAL), tmux Socket — CRITICAL (+1 more)
+Nodes (9): 1. Deep Link URL Format, 2. Deep Link Navigation Behavior, 3. Copy Button Feedback, Affected Files, Context, Decisions, Implementation Plan, Out of Scope (+1 more)
 
 ### Community 751 - "Community 751"
 Cohesion: 0.2
-Nodes (9): AI Writing Patterns to Avoid, Bottom Line, Clear Writing, Composition Rules, Limited Context Strategy, Overview, Reference Files, Rules (+1 more)
+Nodes (9): Context, Decision: Add unit tests for createBeadsFromVBrief, Difficulty, Files affected, PAN-507: beads db not initialized on fresh install, Status: Planning Complete, Test approach, What NOT to test (+1 more)
 
 ### Community 752 - "Community 752"
 Cohesion: 0.2
-Nodes (10): code:bash (# In directory: /Users/name/Google Drive/...), code:bash (# Wrong location (cloud sync)), code:bash (mv ~/Google\ Drive/project ~/Repos/project), code:bash (bd init myproject), code:bash (bd import < issues-backup.jsonl), code:bash (# Don't initialize bd in cloud-synced directory), Database Errors on Cloud Storage, Resolution (+2 more)
+Nodes (10): Boolean flags, code:mustache (Issue: {{ISSUE_ID}}), code:mustache ({{#USER_MESSAGE}}), code:mustache ({{^DO_PUSH}}), code:typescript (renderPrompt({), Inverted sections, Mustache syntax reference, No partials, no lambdas, no custom helpers (+2 more)
 
 ### Community 753 - "Community 753"
 Cohesion: 0.2
-Nodes (10): code:bash (bd mol wisp mol-patrol                       # From proto), code:bash (bd mol wisp list                     # List all wisps), code:bash (bd mol squash wisp-abc123                              # Aut), code:bash (bd mol burn wisp-abc123                    # Delete wisp, no), code:bash (bd mol wisp gc                       # Clean up orphaned wis), Creating Wisps, Ending Wisps, Garbage Collection (+2 more)
+Nodes (9): Codebase Explorer, Deliverables, Exploration Strategies, For Architecture Understanding, For New Codebases, For Specific Questions, Performance Tips, Remember (+1 more)
 
 ### Community 754 - "Community 754"
 Cohesion: 0.2
-Nodes (9): 1. Verify Implementation, 2. Self-Review Your Changes, 3. Commit Your Work (BLOCKING - DO THIS FIRST), 4. Signal Completion, 5. Wait for User Response, code:bash (git diff origin/main...HEAD), code:bash (# Check for uncommitted changes), code:block3 (✅ WORK COMPLETE - Ready for Review) (+1 more)
+Nodes (9): code:bash (tmux -L panopticon list-sessions), code:block2 ({{WORKSPACE_PATH}}), code:bash (# 1. Run tests), Completion Requirements (CRITICAL), CRITICAL: Workspace Isolation, Investigation First — NEVER Fix Inline, NEVER Defer Work (CRITICAL), tmux Socket — CRITICAL (+1 more)
 
 ### Community 755 - "Community 755"
 Cohesion: 0.2
-Nodes (10): Approve and Merge, Check Pending Work, code:bash (# Start dashboard and services), code:bash (# See completed work awaiting review), code:bash (# Approve work, merge MR, update tracker), Quick Start Workflow, Review in Dashboard, Step 1: Prerequisites Check (+2 more)
+Nodes (9): AI Writing Patterns to Avoid, Bottom Line, Clear Writing, Composition Rules, Limited Context Strategy, Overview, Reference Files, Rules (+1 more)
 
 ### Community 756 - "Community 756"
 Cohesion: 0.2
-Nodes (10): Agent Status, code:bash (pan status), code:block4 (Running Agents (3):), code:bash (pan workspace list), code:block6 (Workspaces (5):), code:bash (pan doctor), code:block8 (Panopticon System Health), System Health (+2 more)
+Nodes (10): code:bash (# In directory: /Users/name/Google Drive/...), code:bash (# Wrong location (cloud sync)), code:bash (mv ~/Google\ Drive/project ~/Repos/project), code:bash (bd init myproject), code:bash (bd import < issues-backup.jsonl), code:bash (# Don't initialize bd in cloud-synced directory), Database Errors on Cloud Storage, Resolution (+2 more)
 
 ### Community 757 - "Community 757"
 Cohesion: 0.2
-Nodes (10): code:bash (# Check Panopticon status), code:bash (# Check for agents), code:bash (pan down), code:block5 (✓ Stopping API server (PID 12345)), code:bash (# Check nothing is listening on ports), Step 1: Check What's Running, Step 2: Save Any Pending Work, Step 3: Stop Services (+2 more)
+Nodes (10): code:bash (bd mol wisp mol-patrol                       # From proto), code:bash (bd mol wisp list                     # List all wisps), code:bash (bd mol squash wisp-abc123                              # Aut), code:bash (bd mol burn wisp-abc123                    # Delete wisp, no), code:bash (bd mol wisp gc                       # Clean up orphaned wis), Creating Wisps, Ending Wisps, Garbage Collection (+2 more)
 
 ### Community 758 - "Community 758"
 Cohesion: 0.2
-Nodes (9): Code Review: Performance, code:markdown (# Performance Review - <timestamp>), Inputs from your spawn prompt, Method, Output format, Scope, Severity and evidence, TLDR: prefer code summaries over full reads (+1 more)
+Nodes (9): 1. Verify Implementation, 2. Self-Review Your Changes, 3. Commit Your Work (BLOCKING - DO THIS FIRST), 4. Signal Completion, 5. Wait for User Response, code:bash (git diff origin/main...HEAD), code:bash (# Check for uncommitted changes), code:block3 (✅ WORK COMPLETE - Ready for Review) (+1 more)
 
 ### Community 759 - "Community 759"
 Cohesion: 0.2
-Nodes (9): Code Review: Security, code:markdown (# Security Review - <timestamp>), Inputs from your spawn prompt, Method, Output format, Scope, Severity and evidence, TLDR: prefer code summaries over full reads (+1 more)
+Nodes (10): Approve and Merge, Check Pending Work, code:bash (# Start dashboard and services), code:bash (# See completed work awaiting review), code:bash (# Approve work, merge MR, update tracker), Quick Start Workflow, Review in Dashboard, Step 1: Prerequisites Check (+2 more)
 
 ### Community 760 - "Community 760"
 Cohesion: 0.2
-Nodes (9): Code Review: Correctness, code:markdown (# Correctness Review - <timestamp>), Inputs from your spawn prompt, Method, Output format, Scope, Severity and evidence, TLDR: prefer code summaries over full reads (+1 more)
+Nodes (10): Agent Status, code:bash (pan status), code:block4 (Running Agents (3):), code:bash (pan workspace list), code:block6 (Workspaces (5):), code:bash (pan doctor), code:block8 (Panopticon System Health), System Health (+2 more)
 
 ### Community 761 - "Community 761"
 Cohesion: 0.2
-Nodes (9): Boundaries, Browser UAT Contract, Hardcoding it here would override the user's config and force everyone onto a, Inputs, No `model:` pin — Cloister resolves the model from config.yaml (roles.test.model)., Panopticon Test Role, single model, defeating the per-role model configurability the dashboard exposes., TLDR: prefer code summaries over full reads (+1 more)
+Nodes (10): code:bash (# Check Panopticon status), code:bash (# Check for agents), code:bash (pan down), code:block5 (✓ Stopping API server (PID 12345)), code:bash (# Check nothing is listening on ports), Step 1: Check What's Running, Step 2: Save Any Pending Work, Step 3: Stop Services (+2 more)
 
 ### Community 762 - "Community 762"
 Cohesion: 0.2
-Nodes (9): Boundaries, Hardcoding it here would override the user's config and force everyone onto a, No `model:` pin — Cloister resolves the model from config.yaml (roles.plan.model)., Outputs, Panopticon Planning Agent, Process, single model, defeating the per-role model configurability the dashboard exposes., State model (+1 more)
+Nodes (9): Code Review: Performance, code:markdown (# Performance Review - <timestamp>), Inputs from your spawn prompt, Method, Output format, Scope, Severity and evidence, TLDR: prefer code summaries over full reads (+1 more)
 
 ### Community 763 - "Community 763"
-Cohesion: 0.22
-Nodes (7): activeBeadsIgnore, activePlanningBeadsIgnore, content, gitignorePath, lines, ROOT, tracked
+Cohesion: 0.2
+Nodes (9): Code Review: Security, code:markdown (# Security Review - <timestamp>), Inputs from your spawn prompt, Method, Output format, Scope, Severity and evidence, TLDR: prefer code summaries over full reads (+1 more)
 
 ### Community 764 - "Community 764"
-Cohesion: 0.31
-Nodes (8): continuesDir, ensureContinuesDir(), legacyLifecycles, lifecycleDir, log(), migrateFile(), parseIssueId(), projectRoot
+Cohesion: 0.2
+Nodes (9): Code Review: Correctness, code:markdown (# Correctness Review - <timestamp>), Inputs from your spawn prompt, Method, Output format, Scope, Severity and evidence, TLDR: prefer code summaries over full reads (+1 more)
 
 ### Community 765 - "Community 765"
-Cohesion: 0.22
-Nodes (5): dispatchMenuAction(), consoleErrors, flywheelStatus, MockWebSocket, statusPane
+Cohesion: 0.2
+Nodes (9): Boundaries, Browser UAT Contract, Hardcoding it here would override the user's config and force everyone onto a, Inputs, No `model:` pin — Cloister resolves the model from config.yaml (roles.test.model)., Panopticon Test Role, single model, defeating the per-role model configurability the dashboard exposes., TLDR: prefer code summaries over full reads (+1 more)
 
 ### Community 766 - "Community 766"
-Cohesion: 0.31
-Nodes (6): resolveServerEntry(), randomHex(), resolvePort(), spawnServer(), startServer(), stopServer()
+Cohesion: 0.2
+Nodes (9): Boundaries, Hardcoding it here would override the user's config and force everyone onto a, No `model:` pin — Cloister resolves the model from config.yaml (roles.plan.model)., Outputs, Panopticon Planning Agent, Process, single model, defeating the per-role model configurability the dashboard exposes., State model (+1 more)
 
 ### Community 767 - "Community 767"
 Cohesion: 0.22
-Nodes (5): execFileMock, postMergeLifecycleMock, readContinueStateAsyncMock, readdirSyncMock, resolveGitHubIssueMock
+Nodes (7): activeBeadsIgnore, activePlanningBeadsIgnore, content, gitignorePath, lines, ROOT, tracked
 
 ### Community 768 - "Community 768"
+Cohesion: 0.31
+Nodes (8): continuesDir, ensureContinuesDir(), legacyLifecycles, lifecycleDir, log(), migrateFile(), parseIssueId(), projectRoot
+
+### Community 769 - "Community 769"
+Cohesion: 0.31
+Nodes (6): resolveServerEntry(), randomHex(), resolvePort(), spawnServer(), startServer(), stopServer()
+
+### Community 770 - "Community 770"
 Cohesion: 0.36
 Nodes (7): consolidateSpeakerCues(), decodeHtmlEntities(), formatTimestamp(), ParsedCue, parseTimestamp(), result, vttToMarkdown()
 
-### Community 769 - "Community 769"
-Cohesion: 0.22
-Nodes (7): colNames, cols, db, disabledRow, enabledRow, [row], rows
-
-### Community 770 - "Community 770"
+### Community 771 - "Community 771"
 Cohesion: 0.28
 Nodes (7): formatDuration(), fiveMinAgo, now, recent, threeDaysAgo, twoHoursAgo, timeAgo()
 
-### Community 771 - "Community 771"
+### Community 772 - "Community 772"
 Cohesion: 0.28
 Nodes (7): detectTestCommand(), detectTestCommandEffect(), fileExists(), command, jestConfig, packageJson, testDir
 
-### Community 772 - "Community 772"
-Cohesion: 0.28
-Nodes (6): BYTE_UNITS, hist, parseBytes(), parseMemUsage(), parseNetIO(), result
-
 ### Community 773 - "Community 773"
-Cohesion: 0.22
-Nodes (8): MOCK_HEALTH_RESPONSE, MOCK_PROJECT_SPECIALISTS_RESPONSE, MOCK_SPECIALISTS_RESPONSE, panBadge, perProjectHeader, sectionHeader, sessionCard, statusBar
-
-### Community 774 - "Community 774"
-Cohesion: 0.25
-Nodes (5): PersistedState, useConversationUiState(), parsed, raw, { result }
-
-### Community 775 - "Community 775"
-Cohesion: 0.22
-Nodes (6): chalk, exitSpy, logs, MockCostThresholdError, mockEnrichSessions, output
-
-### Community 776 - "Community 776"
 Cohesion: 0.22
 Nodes (8): cb, cmdArgs, { MainDivergedErrorClass }, mockExec, mockGitPush, mockMarkWorkspaceStuck, result, pushApproveMain()
 
-### Community 777 - "Community 777"
+### Community 774 - "Community 774"
 Cohesion: 0.28
 Nodes (7): restoreTrackedBeadsExport(), runGit(), spawnerLayer, after, before, content, notGit
 
+### Community 775 - "Community 775"
+Cohesion: 0.28
+Nodes (6): BYTE_UNITS, hist, parseBytes(), parseMemUsage(), parseNetIO(), result
+
+### Community 776 - "Community 776"
+Cohesion: 0.22
+Nodes (6): chalk, exitSpy, logs, MockCostThresholdError, mockEnrichSessions, output
+
+### Community 777 - "Community 777"
+Cohesion: 0.22
+Nodes (8): MOCK_HEALTH_RESPONSE, MOCK_PROJECT_SPECIALISTS_RESPONSE, MOCK_SPECIALISTS_RESPONSE, panBadge, perProjectHeader, sectionHeader, sessionCard, statusBar
+
 ### Community 778 - "Community 778"
 Cohesion: 0.22
-Nodes (8): code:markdown (## Summary), code:block5 (panopticon-cli/), Contributing to Panopticon CLI, Filing Bugs, Issue Tracking, Key Invariants, Repository Layout, Table of Contents
+Nodes (9): After making changes, Building and Running, code:bash (npm run build           # Compiles TypeScript to dist/ via t), code:bash (npm run dev             # Dashboard with hot reload (Vite fr), code:bash (# ALWAYS use the explicit Node 22 path), code:bash (npm run build && npm link   # Rebuild + re-link `pan` global), Development mode, Full build (+1 more)
 
 ### Community 779 - "Community 779"
 Cohesion: 0.22
@@ -4356,7 +4356,7 @@ Nodes (9): code:bash (# Activate Node 22 (always required)), code:bash (cp .env.
 
 ### Community 780 - "Community 780"
 Cohesion: 0.22
-Nodes (9): After making changes, Building and Running, code:bash (npm run build           # Compiles TypeScript to dist/ via t), code:bash (npm run dev             # Dashboard with hot reload (Vite fr), code:bash (# ALWAYS use the explicit Node 22 path), code:bash (npm run build && npm link   # Rebuild + re-link `pan` global), Development mode, Full build (+1 more)
+Nodes (8): code:markdown (## Summary), code:block5 (panopticon-cli/), Contributing to Panopticon CLI, Filing Bugs, Issue Tracking, Key Invariants, Repository Layout, Table of Contents
 
 ### Community 781 - "Community 781"
 Cohesion: 0.22
@@ -4400,11 +4400,11 @@ Nodes (8): Acceptance Criteria, code:block24 (Foundation), Implementation — Si
 
 ### Community 791 - "Community 791"
 Cohesion: 0.22
-Nodes (9): Problem 1: Dead/stuck parallel review sessions are invisible to deacon, Problem 2: No circuit breaker for infrastructure-failure cycling, Problem 3: Verification passed but review blocks the pipeline forever, Problem 4: Incomplete parallel reviews waste completed findings, Problem 5: `stuck` flag is never checked in re-dispatch path, Problem 6: No cycle boundary for the circuit breaker, Problem 7: No UI indication that recovery is happening, Problem 8: Multiple actors can manipulate the same review tmux sessions (+1 more)
+Nodes (9): C.1 Add migration in `schema.ts`, C.2 Update `upsertReviewStatus` in `review-status-db.ts`, C.3 Update `rowToReviewStatus` in `review-status-db.ts`, C. Database schema changes (`src/lib/database/schema.ts` + `src/lib/database/review-status-db.ts`), code:typescript (// v24 → v25: add review_retry_count and recovery_started_at), code:typescript (export const ReviewStatusSnapshot = Schema.Struct({), D.1 Add new fields to `ReviewStatusSnapshot`, D. `packages/contracts/src/types.ts` (+1 more)
 
 ### Community 792 - "Community 792"
 Cohesion: 0.22
-Nodes (9): C.1 Add migration in `schema.ts`, C.2 Update `upsertReviewStatus` in `review-status-db.ts`, C.3 Update `rowToReviewStatus` in `review-status-db.ts`, C. Database schema changes (`src/lib/database/schema.ts` + `src/lib/database/review-status-db.ts`), code:typescript (// v24 → v25: add review_retry_count and recovery_started_at), code:typescript (export const ReviewStatusSnapshot = Schema.Struct({), D.1 Add new fields to `ReviewStatusSnapshot`, D. `packages/contracts/src/types.ts` (+1 more)
+Nodes (9): Problem 1: Dead/stuck parallel review sessions are invisible to deacon, Problem 2: No circuit breaker for infrastructure-failure cycling, Problem 3: Verification passed but review blocks the pipeline forever, Problem 4: Incomplete parallel reviews waste completed findings, Problem 5: `stuck` flag is never checked in re-dispatch path, Problem 6: No cycle boundary for the circuit breaker, Problem 7: No UI indication that recovery is happening, Problem 8: Multiple actors can manipulate the same review tmux sessions (+1 more)
 
 ### Community 793 - "Community 793"
 Cohesion: 0.22
@@ -4416,11 +4416,11 @@ Nodes (8): Acceptance Criteria, Backend: Deacon stuck detection, Background, Fil
 
 ### Community 795 - "Community 795"
 Cohesion: 0.22
-Nodes (9): US-1 — First project (zero state), US-2 — Second project (existing user), US-3 — Watch the Setup Agent work, US-4 — Review generated docs, US-5 — Edit an existing project's config, US-6 — Re-run setup after adding repos, US-7 — Remove a project, US-8 — Dogfood through the dashboard (+1 more)
+Nodes (9): code:block4 (┌───────────────────────────────────────────────────────────), code:block5 (┌──────────────────────────────────────────────────────────┐), First-run welcome, Project detail page (`/projects/:projectKey`), Project list page (`/projects`), Setup Agent in the agent list, Steps, UX Specification (+1 more)
 
 ### Community 796 - "Community 796"
 Cohesion: 0.22
-Nodes (9): code:block4 (┌───────────────────────────────────────────────────────────), code:block5 (┌──────────────────────────────────────────────────────────┐), First-run welcome, Project detail page (`/projects/:projectKey`), Project list page (`/projects`), Setup Agent in the agent list, Steps, UX Specification (+1 more)
+Nodes (9): US-1 — First project (zero state), US-2 — Second project (existing user), US-3 — Watch the Setup Agent work, US-4 — Review generated docs, US-5 — Edit an existing project's config, US-6 — Re-run setup after adding repos, US-7 — Remove a project, US-8 — Dogfood through the dashboard (+1 more)
 
 ### Community 797 - "Community 797"
 Cohesion: 0.22
@@ -4528,19 +4528,19 @@ Nodes (8): Agent Beads, Bead Types, CLI Reference, code:block1 (idle → spawnin
 
 ### Community 823 - "Community 823"
 Cohesion: 0.22
-Nodes (9): code:bash (# Explicitly enable sandbox mode), code:bash (# Skip staleness check (emergency escape hatch)), code:bash (# Force metadata update even when DB appears synced), code:bash (# JSON output for programmatic use), Force Import, Global Flags, Other Global Flags, Sandbox Mode (+1 more)
+Nodes (9): Batch Operations, Claim and Complete Work, code:bash (# 1. Find available work), code:bash (# While working on bd-100, discover a bug), code:bash (# Update multiple issues at once), code:bash (# Start of session), Common Patterns for AI Agents, Discover and Link Work (+1 more)
 
 ### Community 824 - "Community 824"
 Cohesion: 0.22
-Nodes (9): code:bash (# Import issues from JSONL), code:bash (# Migrate databases after version upgrade), code:bash (# List all running daemons), code:bash (# Commit pending local Dolt changes), Daemon Management, Database Management, Import/Export, Migration (+1 more)
+Nodes (9): code:bash (# Explicitly enable sandbox mode), code:bash (# Skip staleness check (emergency escape hatch)), code:bash (# Force metadata update even when DB appears synced), code:bash (# JSON output for programmatic use), Force Import, Global Flags, Other Global Flags, Sandbox Mode (+1 more)
 
 ### Community 825 - "Community 825"
 Cohesion: 0.22
-Nodes (9): Batch Operations, Claim and Complete Work, code:bash (# 1. Find available work), code:bash (# While working on bd-100, discover a bug), code:bash (# Update multiple issues at once), code:bash (# Start of session), Common Patterns for AI Agents, Discover and Link Work (+1 more)
+Nodes (9): Advanced Operations, Cleanup, code:bash (# Clean up closed issues (bulk deletion)), code:bash (# Find and merge duplicate issues), code:bash (# Agent-driven compaction), code:bash (# Rename issue prefix (e.g., from 'knowledge-work-' to 'kw-'), Compaction (Memory Decay), Duplicate Detection & Merging (+1 more)
 
 ### Community 826 - "Community 826"
 Cohesion: 0.22
-Nodes (9): Advanced Operations, Cleanup, code:bash (# Clean up closed issues (bulk deletion)), code:bash (# Find and merge duplicate issues), code:bash (# Agent-driven compaction), code:bash (# Rename issue prefix (e.g., from 'knowledge-work-' to 'kw-'), Compaction (Memory Decay), Duplicate Detection & Merging (+1 more)
+Nodes (9): code:bash (# Import issues from JSONL), code:bash (# Migrate databases after version upgrade), code:bash (# List all running daemons), code:bash (# Commit pending local Dolt changes), Daemon Management, Database Management, Import/Export, Migration (+1 more)
 
 ### Community 827 - "Community 827"
 Cohesion: 0.22
@@ -4556,11 +4556,11 @@ Nodes (9): Checklist Templates, code:block30 (- [ ] Check for .beads/ directory)
 
 ### Community 830 - "Community 830"
 Cohesion: 0.22
-Nodes (9): Agent session not starting, code:bash (# Start Docker daemon), code:bash (# Find what's using the port), code:bash (# Verify API key is set), code:bash (# Check tmux is installed), Common First-Time Issues, Docker not running, Issue tracker not configured (+1 more)
+Nodes (9): code:bash (# See issues from your tracker), code:bash (# Replace PAN-3 with your issue ID), code:bash (# Check agent status), code:bash (# Send message to agent), Create Workspace and Spawn Agent, Interact with Agent, List Available Issues, Monitor Agent Progress (+1 more)
 
 ### Community 831 - "Community 831"
 Cohesion: 0.22
-Nodes (9): code:bash (# See issues from your tracker), code:bash (# Replace PAN-3 with your issue ID), code:bash (# Check agent status), code:bash (# Send message to agent), Create Workspace and Spawn Agent, Interact with Agent, List Available Issues, Monitor Agent Progress (+1 more)
+Nodes (9): Agent session not starting, code:bash (# Start Docker daemon), code:bash (# Find what's using the port), code:bash (# Verify API key is set), code:bash (# Check tmux is installed), Common First-Time Issues, Docker not running, Issue tracker not configured (+1 more)
 
 ### Community 832 - "Community 832"
 Cohesion: 0.22
@@ -4595,12 +4595,12 @@ Cohesion: 0.22
 Nodes (9): code:bash (RALLY_API_KEY=_xxxxx), code:yaml (# ~/.panopticon/projects.yaml), code:yaml (issue_prefixes: [F, US, DE, TA, TC]), code:yaml (projects:), Configuration, Rally ID Formats, Rally Integration, Setup (+1 more)
 
 ### Community 840 - "Community 840"
-Cohesion: 0.22
-Nodes (9): "Certificate not trusted" warnings, code:bash (mkcert -install), code:bash (docker network inspect panopticon), code:bash (docker inspect <container> | grep -A 20 Labels), code:bash (# Find what's using the ports), Port conflicts, Troubleshooting, Workspace containers not routable (+1 more)
+Cohesion: 0.25
+Nodes (7): composeCall, globalSettings, hookPath, { mockExecAsync }, result, validHookPath, workspaceSettings
 
 ### Community 841 - "Community 841"
 Cohesion: 0.25
-Nodes (7): composeCall, globalSettings, hookPath, { mockExecAsync }, result, validHookPath, workspaceSettings
+Nodes (6): execSyncMock, first, parsed, result, second, settingsPath
 
 ### Community 842 - "Community 842"
 Cohesion: 0.25
@@ -4619,1308 +4619,1328 @@ Cohesion: 0.32
 Nodes (7): BASE_TIME, loadAgents(), loadDeaconWithResumeMock(), saveStoppedAgent(), state, updated, workspaceFor()
 
 ### Community 846 - "Community 846"
-Cohesion: 0.32
-Nodes (6): agentDir(), AGENTS_DIR, cleanup(), ctxFile(), id, ids
-
-### Community 847 - "Community 847"
-Cohesion: 0.25
-Nodes (7): baseSettings, exp, method, section, sections, settingsBtn, toggle
-
-### Community 848 - "Community 848"
 Cohesion: 0.39
 Nodes (6): getAllActiveQueues(), MergeTriggerHandler, resumeQueuedMerges(), setMergeQueueTriggerHandler(), { getAllActiveQueuesMock }, triggerHandler
 
-### Community 849 - "Community 849"
+### Community 847 - "Community 847"
 Cohesion: 0.25
-Nodes (8): Activity Log, code:block17 (Agent runs `pan done` (Bash command)), Full Review Flow, Human Intervention, Key API Endpoints, Review Cycle Circuit Breaker, verificationStatus semantics, What Happens at the Limit
+Nodes (7): addPanopticonHookIfMissing(), ClaudeSettings, isHookConfigured(), added, first, second, settings
+
+### Community 848 - "Community 848"
+Cohesion: 0.25
+Nodes (7): baseSettings, exp, method, section, sections, settingsBtn, toggle
+
+### Community 849 - "Community 849"
+Cohesion: 0.29
+Nodes (6): Props, ScanButton(), ScanProgress, ScanResult, lastResult, onScan
 
 ### Community 850 - "Community 850"
-Cohesion: 0.25
-Nodes (7): code:bash (pan workspace rebuild <issue-id>), Compose contract, Health surfaces, Recovery commands, Single-deacon invariant, Spawn gate and break-glass, Workspace Containers
+Cohesion: 0.32
+Nodes (5): EDITOR_LABELS, PanOpenInPickerProps, PanRpcProtocolClient, getPreferredEditor(), setPreferredEditor()
 
 ### Community 851 - "Community 851"
 Cohesion: 0.25
-Nodes (7): code:block24 (Worker Agent completes work), Getting Help, Panopticon Usage Guide, Specialist Types, Specialist Workflow, Specialists, Table of Contents
+Nodes (6): closeResult, command, ctx, editCalls, labelResult, prResult
 
 ### Community 852 - "Community 852"
 Cohesion: 0.25
-Nodes (8): Appendix B: Comparisons (FAQ), Can Panopticon and Gastown work together?, Can Panopticon and Vibe Kanban work together?, code:block140 (┌─────────────┐     ┌─────────────┐     ┌─────────────┐), How does Panopticon compare to Gastown?, How does Panopticon compare to Vibe Kanban?, Should I use Panopticon, Gastown, or Vibe Kanban?, Why build Panopticon when these tools exist?
+Nodes (8): Activity Log, code:block17 (Agent runs `pan done` (Bash command)), Full Review Flow, Human Intervention, Key API Endpoints, Review Cycle Circuit Breaker, verificationStatus semantics, What Happens at the Limit
 
 ### Community 853 - "Community 853"
 Cohesion: 0.25
-Nodes (8): 2. Panopticon's Current Distribution (Broken), code:block5 (TIER 1: REPO SOURCE), code:typescript (if (!existsSync(destPath)) {), Current Inventory, Problem 1: Stale Copies, Problem 2: Known Symlink Bug, Problem 3: Wrong Priority Level, The Three-Tier Flow
+Nodes (7): code:bash (pan workspace rebuild <issue-id>), Compose contract, Health surfaces, Recovery commands, Single-deacon invariant, Spawn gate and break-glass, Workspace Containers
 
 ### Community 854 - "Community 854"
 Cohesion: 0.25
-Nodes (8): 3.1 Agent Spawning, 3.2 Agent Monitoring, 3.3 Agent Lifecycle Events, code:bash (pan agent start MIN-667 --remote), code:bash (# SSH to workspace VM and start agent in tmux), code:bash (# Get agent output), code:typescript (// Agent events forwarded to dashboard via SSH polling or We), Phase 3: Remote Agent Execution
+Nodes (7): code:block24 (Worker Agent completes work), Getting Help, Panopticon Usage Guide, Specialist Types, Specialist Workflow, Specialists, Table of Contents
 
 ### Community 855 - "Community 855"
 Cohesion: 0.25
-Nodes (8): Agent Detail View, Agents Page Layout, Cloister Control Bar, code:block35 (┌───────────────────────────────────────────────────────────), code:block36 (┌───────────────────────────────────────────────────────────), code:block37 (┌───────────────────────────────────────────────────────────), code:block38 (┌───────────────────────────────────────────────────────────), Dashboard UI
+Nodes (8): CLI Distribution Strategy, code:bash (# First time - zero install), code:bash (# pan init adds to ~/.bashrc or ~/.zshrc:), code:bash (npm install -g panopticon), code:bash (brew install panopticon      # macOS), Future: Homebrew/apt (v2), Primary: npx + Auto-Aliasing, Secondary: Global npm Install
 
 ### Community 856 - "Community 856"
 Cohesion: 0.25
-Nodes (8): Risk 1: Retros produce too much noise (every issue triggers a "proposal"), Risk 2: Retro-agent cost escalates, Risk 3: The skill-change pipeline introduces new failure modes, Risk 4: Autonomous daemon runs during user's active work and causes unwanted side effects, Risk 5: Q&A detection false positives (agent gets marked `waiting-on-human` when it's actually stuck), Risk 6: Proposed skill changes by the retro-agent are low-quality or hallucinated, Risk 7: Existing skills break when we add the audience field, Risks and mitigations
+Nodes (8): Appendix B: Comparisons (FAQ), Can Panopticon and Gastown work together?, Can Panopticon and Vibe Kanban work together?, code:block140 (┌─────────────┐     ┌─────────────┐     ┌─────────────┐), How does Panopticon compare to Gastown?, How does Panopticon compare to Vibe Kanban?, Should I use Panopticon, Gastown, or Vibe Kanban?, Why build Panopticon when these tools exist?
 
 ### Community 857 - "Community 857"
 Cohesion: 0.25
-Nodes (8): 9.1 Header, 9.2 Tabs, 9.3 Terminal Tab, 9.4 Info Tab, 9.5 Actions Footer, 9. Agent Detail Panel (Slide-out), code:block8 (agent-pan-505                                [X]), code:block9 (+---------------+---------------+)
+Nodes (8): 2. Panopticon's Current Distribution (Broken), code:block5 (TIER 1: REPO SOURCE), code:typescript (if (!existsSync(destPath)) {), Current Inventory, Problem 1: Stale Copies, Problem 2: Known Symlink Bug, Problem 3: Wrong Priority Level, The Three-Tier Flow
 
 ### Community 858 - "Community 858"
 Cohesion: 0.25
-Nodes (8): Acceptance Criteria, CLI parity, Discovery, Embeddings, Enrichment, Page, Search, Settings UI
+Nodes (8): 3.1 Agent Spawning, 3.2 Agent Monitoring, 3.3 Agent Lifecycle Events, code:bash (pan agent start MIN-667 --remote), code:bash (# SSH to workspace VM and start agent in tmux), code:bash (# Get agent output), code:typescript (// Agent events forwarded to dashboard via SSH polling or We), Phase 3: Remote Agent Execution
 
 ### Community 859 - "Community 859"
 Cohesion: 0.25
-Nodes (8): code:block18 (┌───────────────────────────────────────────────────────────), Conversation viewer reuse (PAN-451 dependency), Dashboard: Archived Conversations Page, Page layout, Real-time updates, Route + navigation, Row badges (`source` field), Settings panel additions — "Conversations & Search"
+Nodes (8): Agent Detail View, Agents Page Layout, Cloister Control Bar, code:block35 (┌───────────────────────────────────────────────────────────), code:block36 (┌───────────────────────────────────────────────────────────), code:block37 (┌───────────────────────────────────────────────────────────), code:block38 (┌───────────────────────────────────────────────────────────), Dashboard UI
 
 ### Community 860 - "Community 860"
 Cohesion: 0.25
-Nodes (8): code:bash (pan conversations scan <dir> [<dir>...]   # Targeted directo), code:typescript (interface SystemCapabilities {), code:block8 (Scanning ~/.claude/projects/...), Discovery Subsystem, MUST NOT delete or modify JSONL files, Performance-adaptive parallelism (system scan), Scripted extraction (zero LLM), Three discovery modes
+Nodes (8): Risk 1: Retros produce too much noise (every issue triggers a "proposal"), Risk 2: Retro-agent cost escalates, Risk 3: The skill-change pipeline introduces new failure modes, Risk 4: Autonomous daemon runs during user's active work and causes unwanted side effects, Risk 5: Q&A detection false positives (agent gets marked `waiting-on-human` when it's actually stuck), Risk 6: Proposed skill changes by the retro-agent are low-quality or hallucinated, Risk 7: Existing skills break when we add the audience field, Risks and mitigations
 
 ### Community 861 - "Community 861"
 Cohesion: 0.25
-Nodes (8): B.1 Add new fields to `ReviewStatus` interface, B.2 Increment `reviewRetryCount` on each deacon re-dispatch, B.3 Reset recovery window on clean completion and on new commits, B. `src/lib/review-status.ts`, code:typescript (const { dispatchParallelReview } = await import('./review-ag), code:typescript (.then(result => {), code:typescript (setReviewStatus(issueId, {), code:typescript (export interface ReviewStatus {)
+Nodes (8): 9.1 Header, 9.2 Tabs, 9.3 Terminal Tab, 9.4 Info Tab, 9.5 Actions Footer, 9. Agent Detail Panel (Slide-out), code:block8 (agent-pan-505                                [X]), code:block9 (+---------------+---------------+)
 
 ### Community 862 - "Community 862"
 Cohesion: 0.25
-Nodes (8): code:block4 (panopticon-cli/), code:block5 (panopticon-cli/), code:json ({), code:json ({), Current Layout, Monorepo Structure, Target Layout, Workspace Configuration
+Nodes (8): Acceptance Criteria, CLI parity, Discovery, Embeddings, Enrichment, Page, Search, Settings UI
 
 ### Community 863 - "Community 863"
 Cohesion: 0.25
-Nodes (8): code:block16 (8 sessions · 1 alive · 7 ended · last activity 2m ago · idle), code:block21 (Select a session in the tree to send a message …), Composer behavior in issue-selected mode, Issue-selected mode, Selection rules, Why have this mode, Zone B in issue-selected mode, Zone C tab strip (NEW)
+Nodes (8): code:bash (pan conversations scan <dir> [<dir>...]   # Targeted directo), code:typescript (interface SystemCapabilities {), code:block8 (Scanning ~/.claude/projects/...), Discovery Subsystem, MUST NOT delete or modify JSONL files, Performance-adaptive parallelism (system scan), Scripted extraction (zero LLM), Three discovery modes
 
 ### Community 864 - "Community 864"
 Cohesion: 0.25
-Nodes (7): code:block1 ([IssueDataService] Rally poll error: Rally API query failed:), Dependencies, Follow-up Work, PAN-166: Rally WSAPI Query Parse Error Fix, Problem Statement, Risk Assessment, Success Criteria
+Nodes (8): code:block18 (┌───────────────────────────────────────────────────────────), Conversation viewer reuse (PAN-451 dependency), Dashboard: Archived Conversations Page, Page layout, Real-time updates, Route + navigation, Row badges (`source` field), Settings panel additions — "Conversations & Search"
 
 ### Community 865 - "Community 865"
 Cohesion: 0.25
-Nodes (7): Acceptance Criteria, Decision, Out of Scope, PAN-448: Start Agent confirmation timeout too short, Problem, Scope, Status: Planning Complete
+Nodes (8): B.1 Add new fields to `ReviewStatus` interface, B.2 Increment `reviewRetryCount` on each deacon re-dispatch, B.3 Reset recovery window on clean completion and on new commits, B. `src/lib/review-status.ts`, code:typescript (const { dispatchParallelReview } = await import('./review-ag), code:typescript (.then(result => {), code:typescript (setReviewStatus(issueId, {), code:typescript (export interface ReviewStatus {)
 
 ### Community 866 - "Community 866"
 Cohesion: 0.25
-Nodes (8): Can't reach workspace URLs, code:bash (ls ~/.panopticon/traefik/certs/), code:bash (cd ~/.panopticon/traefik/certs), code:bash (mkcert -install), code:bash (docker ps | grep traefik), code:bash (ping feature-min-123.localhost), HTTPS not working, Network Issues
+Nodes (8): code:block4 (panopticon-cli/), code:block5 (panopticon-cli/), code:json ({), code:json ({), Current Layout, Monorepo Structure, Target Layout, Workspace Configuration
 
 ### Community 867 - "Community 867"
 Cohesion: 0.25
-Nodes (8): Additional Windows 10 Workarounds, code:ini ([wsl2]), code:powershell (wsl --shutdown), code:bash (# Check resources), code:powershell (# 1. Update WSL to latest version), Recommended Configuration, Windows 10 Limitations, WSL2 Stability Issues (Windows Users)
+Nodes (8): code:block16 (8 sessions · 1 alive · 7 ended · last activity 2m ago · idle), code:block21 (Select a session in the tree to send a message …), Composer behavior in issue-selected mode, Issue-selected mode, Selection rules, Why have this mode, Zone B in issue-selected mode, Zone C tab strip (NEW)
 
 ### Community 868 - "Community 868"
 Cohesion: 0.25
-Nodes (8): Bootstrap templates, Deleted (replaced by the loader), Legacy (ad-hoc) templates, Legacy templates, Planning agent templates, Specialist agent templates, Template catalogue, Work agent templates
+Nodes (7): code:block1 ([IssueDataService] Rally poll error: Rally API query failed:), Dependencies, Follow-up Work, PAN-166: Rally WSAPI Query Parse Error Fix, Problem Statement, Risk Assessment, Success Criteria
 
 ### Community 869 - "Community 869"
 Cohesion: 0.25
-Nodes (8): Architecture Map, code:markdown (# Codebase Architecture), code:block12, code:markdown (# Feature: User Authentication), code:markdown (# Dependencies), Dependency Report, Feature Location Report, Output Formats
+Nodes (7): Acceptance Criteria, Decision, Out of Scope, PAN-448: Start Agent confirmation timeout too short, Problem, Scope, Status: Planning Complete
 
 ### Community 870 - "Community 870"
 Cohesion: 0.25
-Nodes (7): code:bash (# View agent output), Log Levels, Overview, Quick Commands, Related Skills, View Logs, When to Use
+Nodes (8): Additional Windows 10 Workarounds, code:ini ([wsl2]), code:powershell (wsl --shutdown), code:bash (# Check resources), code:powershell (# 1. Update WSL to latest version), Recommended Configuration, Windows 10 Limitations, WSL2 Stability Issues (Windows Users)
 
 ### Community 871 - "Community 871"
 Cohesion: 0.25
-Nodes (8): Available Categories, code:bash (# AI will add this section if it doesn't exist), code:bash (# Edit directly), code:bash (# Remove the AI Suggestion Preferences section), code:markdown (## AI Suggestion Preferences), Updating Preferences, User Preferences in ~/.claude/CLAUDE.md, Why Skip Categories?
+Nodes (8): Can't reach workspace URLs, code:bash (ls ~/.panopticon/traefik/certs/), code:bash (cd ~/.panopticon/traefik/certs), code:bash (mkcert -install), code:bash (docker ps | grep traefik), code:bash (ping feature-min-123.localhost), HTTPS not working, Network Issues
 
 ### Community 872 - "Community 872"
 Cohesion: 0.25
-Nodes (7): code:bash (pan pause <issue-id>), code:bash (pan pause PAN-123), pan pause, See Also, Usage, What It Does, When to Use
+Nodes (8): Bootstrap templates, Deleted (replaced by the loader), Legacy (ad-hoc) templates, Legacy templates, Planning agent templates, Specialist agent templates, Template catalogue, Work agent templates
 
 ### Community 873 - "Community 873"
 Cohesion: 0.25
-Nodes (8): Bond Types, Bonding Molecules, code:bash (# Found bug during wisp patrol? Persist it:), code:bash (bd mol bond mol-feature mol-deploy --as "Feature with Deploy), code:bash (bd mol bond A B                    # Sequential: B runs afte), Custom Compound Names, Operand Combinations, Phase Control in Bonds
+Nodes (8): Architecture Map, code:markdown (# Codebase Architecture), code:block12, code:markdown (# Feature: User Authentication), code:markdown (# Dependencies), Dependency Report, Feature Location Report, Output Formats
 
 ### Community 874 - "Community 874"
 Cohesion: 0.25
-Nodes (7): code:bash (pan untroubled <issue-id>), code:bash (pan untroubled PAN-123), pan untroubled, See Also, Usage, What It Does, When to Use
+Nodes (7): code:bash (# View agent output), Log Levels, Overview, Quick Commands, Related Skills, View Logs, When to Use
 
 ### Community 875 - "Community 875"
 Cohesion: 0.25
-Nodes (7): 1. Audit Current State, 2. Update Strategy, 3. For Each Update, 4. Verify, code:bash (npm outdated          # See what's outdated), code:bash (npm install package@version), Dependency Update
+Nodes (8): Available Categories, code:bash (# AI will add this section if it doesn't exist), code:bash (# Edit directly), code:bash (# Remove the AI Suggestion Preferences section), code:markdown (## AI Suggestion Preferences), Updating Preferences, User Preferences in ~/.claude/CLAUDE.md, Why Skip Categories?
 
 ### Community 876 - "Community 876"
 Cohesion: 0.25
-Nodes (7): code:bash (pan unpause <issue-id>), code:bash (pan unpause PAN-123), pan unpause, See Also, Usage, What It Does, When to Use
+Nodes (7): code:bash (pan pause <issue-id>), code:bash (pan pause PAN-123), pan pause, See Also, Usage, What It Does, When to Use
 
 ### Community 877 - "Community 877"
 Cohesion: 0.25
-Nodes (7): Add Repos to Workspace, After adding repos, code:bash (pan workspace add-repo <workspace-id> <repo-name> [repo-name), code:bash (# Add specific repos), How to decide which repos you need, Notes, Usage
+Nodes (8): code:bash (bd dep add issue-2 issue-1 --type blocks), code:bash (ps aux | grep "bd daemon"), code:bash (# Instead of: bd --no-daemon dep add ...), code:bash (cat .beads/issues.jsonl | jq '.dependencies'), Dependencies Not Persisting, Root Cause (Fixed in v0.15.0+), Still Not Working?, Symptom
 
 ### Community 878 - "Community 878"
 Cohesion: 0.25
-Nodes (7): code:bash (pan VERB <args>), code:block2 (pan VERB <id>           # Primary usage), pan VERB, See Also, Usage, What It Does, When to Use
+Nodes (8): Bond Types, Bonding Molecules, code:bash (# Found bug during wisp patrol? Persist it:), code:bash (bd mol bond mol-feature mol-deploy --as "Feature with Deploy), code:bash (bd mol bond A B                    # Sequential: B runs afte), Custom Compound Names, Operand Combinations, Phase Control in Bonds
 
 ### Community 879 - "Community 879"
 Cohesion: 0.25
-Nodes (7): code:bash (pan admin config <subcommand>), code:block2 (pan admin config shadow --status), pan admin config, See Also, Usage, What It Does, When to Use
+Nodes (7): code:bash (pan untroubled <issue-id>), code:bash (pan untroubled PAN-123), pan untroubled, See Also, Usage, What It Does, When to Use
 
 ### Community 880 - "Community 880"
 Cohesion: 0.25
-Nodes (7): code:bash (pan start <issue-id>), code:block2 (pan start PAN-123          # Spawn agent for issue PAN-123), pan start, See Also, Usage, What It Does, When to Use
+Nodes (7): 1. Audit Current State, 2. Update Strategy, 3. For Each Update, 4. Verify, code:bash (npm outdated          # See what's outdated), code:bash (npm install package@version), Dependency Update
 
 ### Community 881 - "Community 881"
 Cohesion: 0.25
-Nodes (7): code:bash (pan admin tracker <subcommand>), code:block2 (pan admin tracker linear-states    # List Linear workflow st), pan admin tracker, See Also, Usage, What It Does, When to Use
+Nodes (7): code:bash (pan unpause <issue-id>), code:bash (pan unpause PAN-123), pan unpause, See Also, Usage, What It Does, When to Use
 
 ### Community 882 - "Community 882"
 Cohesion: 0.25
-Nodes (7): 1. Understand Requirements, 2. Design Approach, 3. Implement, 4. Test, 5. Self-Review, 6. Submit, Feature Work
+Nodes (7): Add Repos to Workspace, After adding repos, code:bash (pan workspace add-repo <workspace-id> <repo-name> [repo-name), code:bash (# Add specific repos), How to decide which repos you need, Notes, Usage
 
 ### Community 883 - "Community 883"
 Cohesion: 0.25
-Nodes (7): code:block1 (pan review pending                                 # List co), Merging is NOT here, pan review, See also, Usage, What each subcommand does, When to use each
+Nodes (7): code:bash (pan VERB <args>), code:block2 (pan VERB <id>           # Primary usage), pan VERB, See Also, Usage, What It Does, When to Use
 
 ### Community 884 - "Community 884"
 Cohesion: 0.25
-Nodes (7): code:bash (pan show <issue-id>), code:block2 (pan show PAN-123           # Summary: shadow state + CV + he), pan show, See Also, Usage, What It Does, When to Use
+Nodes (7): code:bash (pan admin config <subcommand>), code:block2 (pan admin config shadow --status), pan admin config, See Also, Usage, What It Does, When to Use
 
 ### Community 885 - "Community 885"
 Cohesion: 0.25
-Nodes (7): Available MCP tools, Cost comparison, See also, The workflow, Troubleshooting, Use TLDR for code exploration, When TLDR is NOT a good fit
+Nodes (7): code:bash (pan start <issue-id>), code:block2 (pan start PAN-123          # Spawn agent for issue PAN-123), pan start, See Also, Usage, What It Does, When to Use
 
 ### Community 886 - "Community 886"
 Cohesion: 0.25
-Nodes (7): code:bash (pan admin tldr <subcommand>), code:block2 (pan admin tldr status              # Show TLDR daemon state), pan admin tldr, See Also, Usage, What It Does, When to Use
+Nodes (7): code:bash (pan admin tracker <subcommand>), code:block2 (pan admin tracker linear-states    # List Linear workflow st), pan admin tracker, See Also, Usage, What It Does, When to Use
 
 ### Community 887 - "Community 887"
 Cohesion: 0.25
-Nodes (8): code:bash (# Authenticate with GitHub CLI (recommended)), code:block4 (PAN-45       # GitHub issue #45 on the panopticon-cli projec), code:yaml (projects:), code:bash (# Via CLI), Creating Issues, GitHub Issues, Issue Prefix, Setup
+Nodes (7): 1. Understand Requirements, 2. Design Approach, 3. Implement, 4. Test, 5. Self-Review, 6. Submit, Feature Work
 
 ### Community 888 - "Community 888"
 Cohesion: 0.25
-Nodes (8): 4. Surfaces & Depth, code:block7 (Level 0 (Page):     bg-background     — the deepest surface), code:css (shadow-xs/5    — buttons, inputs (barely visible)), code:css (/* Light mode: top edge highlight */), Inner Shadows (Cards), Shadow Scale, Tonal Layering (not shadows), When to Use Shadows
+Nodes (7): code:block1 (pan review pending                                 # List co), Merging is NOT here, pan review, See also, Usage, What each subcommand does, When to use each
 
 ### Community 889 - "Community 889"
 Cohesion: 0.25
-Nodes (7): End of run, Entrypoint, No `model:` pin — Cloister resolves it from config.yaml roles.flywheel., Panopticon Flywheel Role, Status vs State, Substrate bug policy, Tick loop
+Nodes (7): code:bash (pan show <issue-id>), code:block2 (pan show PAN-123           # Summary: shadow state + CV + he), pan show, See Also, Usage, What It Does, When to Use
 
 ### Community 890 - "Community 890"
+Cohesion: 0.25
+Nodes (7): Available MCP tools, Cost comparison, See also, The workflow, Troubleshooting, Use TLDR for code exploration, When TLDR is NOT a good fit
+
+### Community 891 - "Community 891"
+Cohesion: 0.25
+Nodes (7): code:bash (pan admin tldr <subcommand>), code:block2 (pan admin tldr status              # Show TLDR daemon state), pan admin tldr, See Also, Usage, What It Does, When to Use
+
+### Community 892 - "Community 892"
+Cohesion: 0.25
+Nodes (8): code:bash (# Authenticate with GitHub CLI (recommended)), code:block4 (PAN-45       # GitHub issue #45 on the panopticon-cli projec), code:yaml (projects:), code:bash (# Via CLI), Creating Issues, GitHub Issues, Issue Prefix, Setup
+
+### Community 893 - "Community 893"
+Cohesion: 0.25
+Nodes (8): 4. Surfaces & Depth, code:block7 (Level 0 (Page):     bg-background     — the deepest surface), code:css (shadow-xs/5    — buttons, inputs (barely visible)), code:css (/* Light mode: top edge highlight */), Inner Shadows (Cards), Shadow Scale, Tonal Layering (not shadows), When to Use Shadows
+
+### Community 894 - "Community 894"
+Cohesion: 0.25
+Nodes (7): End of run, Entrypoint, No `model:` pin — Cloister resolves it from config.yaml roles.flywheel., Panopticon Flywheel Role, Status vs State, Substrate bug policy, Tick loop
+
+### Community 895 - "Community 895"
 Cohesion: 0.33
 Nodes (5): createTerminalWindow(), MockWindow, openTerminalWindow(), terminalWindows, win
 
-### Community 891 - "Community 891"
+### Community 896 - "Community 896"
 Cohesion: 0.33
 Nodes (5): execFileAsync, hooksLog, runHook(), runtimeRequests, SCRIPT_PATH
 
-### Community 892 - "Community 892"
+### Community 897 - "Community 897"
 Cohesion: 0.29
 Nodes (5): actual, CLI_PATH, __dirname, expected, FIXTURE_PATH
 
-### Community 893 - "Community 893"
+### Community 898 - "Community 898"
 Cohesion: 0.29
 Nodes (5): actual, __dirname, expected, FIXTURE_PATH, SKILLS_SOURCE_DIR
 
-### Community 894 - "Community 894"
+### Community 899 - "Community 899"
 Cohesion: 0.29
 Nodes (5): CLI_PATH, __dirname, { stdout }, { stdout, status }, { stdout, stderr }
 
-### Community 895 - "Community 895"
+### Community 900 - "Community 900"
 Cohesion: 0.29
 Nodes (5): next, restored, s, start, withAgent
 
-### Community 896 - "Community 896"
+### Community 901 - "Community 901"
 Cohesion: 0.29
 Nodes (6): alicePos, bobPos, longBody, result, subDir, wsPath
 
-### Community 897 - "Community 897"
+### Community 902 - "Community 902"
 Cohesion: 0.29
 Nodes (4): BIN_DIR, __dirname, NATIVE_MODULES, PACKAGE_ROOT
 
-### Community 898 - "Community 898"
-Cohesion: 0.29
-Nodes (6): bridge, DesktopSettings, IPC, NotificationEventType, PanopticonBridge, Window
-
-### Community 899 - "Community 899"
-Cohesion: 0.43
-Nodes (6): checkNodeVersion(), checkServerBundle(), __dirname, launch(), packageDir, resolveElectron()
-
-### Community 900 - "Community 900"
-Cohesion: 0.33
-Nodes (6): OpenRouterPage(), input, makeQueryClient(), mockFetch, onApiKeyChange, renderPage()
-
-### Community 901 - "Community 901"
-Cohesion: 0.33
-Nodes (5): DesktopSettings, DesktopSettingsSection(), isDesktopApp(), NOTIFICATION_LABELS, NotificationEventType
-
-### Community 902 - "Community 902"
-Cohesion: 0.29
-Nodes (5): bead, beads, plan, specsDir, ws123
-
 ### Community 903 - "Community 903"
-Cohesion: 0.29
-Nodes (3): mockFetch, mockGetGitHubConfig, program
+Cohesion: 0.33
+Nodes (4): resolveServerStaticDir(), registerDesktopProtocol(), resolveStaticPath(), result
 
 ### Community 904 - "Community 904"
 Cohesion: 0.29
-Nodes (7): Auto (non-interactive), Auto-Start (skip planning), code:bash (pan plan <id>), code:bash (pan plan <id> --auto), code:bash (pan start <id> --auto), Interactive (default), Planning Modes
+Nodes (6): bridge, DesktopSettings, IPC, NotificationEventType, PanopticonBridge, Window
 
 ### Community 905 - "Community 905"
 Cohesion: 0.29
-Nodes (7): Auto-Behaviors, code:block7 (draft (in .pan/drafts/*.md) ──► proposed ──► approved ──► ac), Dashboard Viewer, Legacy paths, Status is a JSON field, not a directory, The four-artifact model (PAN-1124: single-spec-on-main), vBRIEF Plans & Lifecycle
+Nodes (5): bead, beads, plan, specsDir, ws123
 
 ### Community 906 - "Community 906"
-Cohesion: 0.29
-Nodes (7): code:block13 (<type>(<scope>): <short description> (PAN-<number>)), code:block14 (feat(cloister): add preTrustDirectory to initializeSpecialis), Commit Message Convention, Examples, Issue references, Scope (optional but encouraged), Types
+Cohesion: 0.43
+Nodes (6): checkNodeVersion(), checkServerBundle(), __dirname, launch(), packageDir, resolveElectron()
 
 ### Community 907 - "Community 907"
-Cohesion: 0.29
-Nodes (7): Branch and PR Workflow, Branch naming, code:block10 (feature/pan-<number>), code:bash (git checkout -b feature/pan-<number>), code:block12 (1. Create feature branch from latest main), PR checklist, The flow
+Cohesion: 0.38
+Nodes (6): sshCommand(), runModelSummary(), runPiModelSummary(), buildSpawnEnvForModel(), spawn, resolveSidecarBinary()
 
 ### Community 908 - "Community 908"
 Cohesion: 0.29
-Nodes (7): code:bash (# Check if specialist is running), code:toml ([specialists.test_agent]), code:bash (cat ~/.panopticon/specialists/merge-agent/history.jsonl | ta), Merge agent conflict resolution failed, Review agent not dispatching, Test agent not detecting test runner, Troubleshooting
+Nodes (3): mockFetch, mockGetGitHubConfig, program
 
 ### Community 909 - "Community 909"
-Cohesion: 0.29
-Nodes (7): Adding a New Template, Available Templates, code:yaml (---), Frontmatter Contract, Prompt Templates, Template Location, Template Syntax
+Cohesion: 0.38
+Nodes (5): decode, decodeCandidate(), ev, bodyToEvent(), decodeDomainEvent
 
 ### Community 910 - "Community 910"
 Cohesion: 0.29
-Nodes (7): Agent Workflow, Checkpoint System, CLI Reference, code:bash (# After closing a bead), code:bash (pan inspect <issueId> --bead <beadId>           # Fast inspe), Inspect Specialist (PAN-382), What Inspect Checks
+Nodes (7): Auto (non-interactive), Auto-Start (skip planning), code:bash (pan plan <id>), code:bash (pan plan <id> --auto), code:bash (pan start <id> --auto), Interactive (default), Planning Modes
 
 ### Community 911 - "Community 911"
 Cohesion: 0.29
-Nodes (7): code:typescript (interface MergeResult {), code:typescript (interface ReviewResult {), code:typescript (interface TestResult {), Merge Agent Results, Result Monitoring, Review Agent Results, Test Agent Results
+Nodes (7): Auto-Behaviors, code:block7 (draft (in .pan/drafts/*.md) ──► proposed ──► approved ──► ac), Dashboard Viewer, Legacy paths, Status is a JSON field, not a directory, The four-artifact model (PAN-1124: single-spec-on-main), vBRIEF Plans & Lifecycle
 
 ### Community 912 - "Community 912"
 Cohesion: 0.29
-Nodes (7): API, CLI, code:block21 (POST /api/issues/:issueId/sync-main), code:bash (pan sync-main PAN-143), Design Decisions, How It Works, Sync with Main (PAN-242)
+Nodes (7): Branch and PR Workflow, Branch naming, code:block10 (feature/pan-<number>), code:bash (git checkout -b feature/pan-<number>), code:block12 (1. Create feature branch from latest main), PR checklist, The flow
 
 ### Community 913 - "Community 913"
 Cohesion: 0.29
-Nodes (7): code:typescript (// Worker agent creates PR using gh CLI), code:bash (# Worker signals done — triggers verification gate → review-), Step 1: Complete Implementation, Step 2: Create Pull Request, Step 3: Signal Completion, Step 4: Specialist Pipeline Takes Over, Worker Agent Integration
+Nodes (7): code:block13 (<type>(<scope>): <short description> (PAN-<number>)), code:block14 (feat(cloister): add preTrustDirectory to initializeSpecialis), Commit Message Convention, Examples, Issue references, Scope (optional but encouraged), Types
 
 ### Community 914 - "Community 914"
 Cohesion: 0.29
-Nodes (7): code:bash (# From Linear issue), code:block22 (~/.panopticon/workspaces/), code:block23 (https://feature-pan-123.localhost:3000     # Frontend), Creating Workspaces, Workspace Structure, Workspace URLs, Workspaces
+Nodes (7): code:bash (# Check if specialist is running), code:toml ([specialists.test_agent]), code:bash (cat ~/.panopticon/specialists/merge-agent/history.jsonl | ta), Merge agent conflict resolution failed, Review agent not dispatching, Test agent not detecting test runner, Troubleshooting
 
 ### Community 915 - "Community 915"
 Cohesion: 0.29
-Nodes (7): code:bash (# ~/.panopticon.env), code:yaml (models:), code:bash (chmod 600 ~/.panopticon/config.yaml ~/.panopticon.env), Configuration via Dashboard, Multi-Model Support, Router Configuration, Supported Providers and Models
+Nodes (7): Agent Workflow, Checkpoint System, CLI Reference, code:bash (# After closing a bead), code:bash (pan inspect <issueId> --bead <beadId>           # Fast inspe), Inspect Specialist (PAN-382), What Inspect Checks
 
 ### Community 916 - "Community 916"
 Cohesion: 0.29
-Nodes (7): code:markdown (---), code:bash (# Create skill directory), code:block27 (/my-skill), Creating Skills, Skill Structure, Skills, Using Skills
+Nodes (7): code:typescript (interface MergeResult {), code:typescript (interface ReviewResult {), code:typescript (interface TestResult {), Merge Agent Results, Result Monitoring, Review Agent Results, Test Agent Results
 
 ### Community 917 - "Community 917"
 Cohesion: 0.29
-Nodes (7): Advanced Topics, code:bash (# Create remote workspace), code:yaml (# ~/.panopticon/work-types.yaml), code:json (// ~/.claude/hooks.json), Custom Work Types, Heartbeat Monitoring, Remote Workspaces
+Nodes (7): Adding a New Template, Available Templates, code:yaml (---), Frontmatter Contract, Prompt Templates, Template Location, Template Syntax
 
 ### Community 918 - "Community 918"
 Cohesion: 0.29
-Nodes (7): About the Name, Core Insight, Executive Summary, Industry Convergence, Key Insights, Opinionated Decisions, Skills over Molecules
+Nodes (7): API, CLI, code:block21 (POST /api/issues/:issueId/sync-main), code:bash (pan sync-main PAN-143), Design Decisions, How It Works, Sync with Main (PAN-242)
 
 ### Community 919 - "Community 919"
 Cohesion: 0.29
-Nodes (7): code:bash (# Expose port on VM), code:yaml (# pan-infra:/etc/traefik/docker-compose.yml), code:bash (# Tunnel remote services to local ports), Option A: exe.dev Native HTTPS Proxy, Option B: Traefik on Infra VM, Option C: Local SSH Tunnels (Fallback), Phase 4: URL Routing & Access
+Nodes (7): code:typescript (// Worker agent creates PR using gh CLI), code:bash (# Worker signals done — triggers verification gate → review-), Step 1: Complete Implementation, Step 2: Create Pull Request, Step 3: Signal Completion, Step 4: Specialist Pipeline Takes Over, Worker Agent Integration
 
 ### Community 920 - "Community 920"
 Cohesion: 0.29
-Nodes (7): Architecture, code:block1 (┌───────────────────────────────────────────────────────────), code:block2 (Shared infra:     0.5 GB), High-Level Design, Memory Budget (16GB Plan), Per-Workspace VMs, Shared Infrastructure VM
+Nodes (7): code:markdown (---), code:bash (# Create skill directory), code:block27 (/my-skill), Creating Skills, Skill Structure, Skills, Using Skills
 
 ### Community 921 - "Community 921"
 Cohesion: 0.29
-Nodes (7): 6.1 Workspace Hibernation, 6.2 Workspace Cleanup, 6.3 Resource Monitoring, code:bash (pan workspace stop MIN-667), code:bash (pan workspace delete MIN-667), code:bash (pan remote resources), Phase 6: Lifecycle Management
+Nodes (7): code:bash (# From Linear issue), code:block22 (~/.panopticon/workspaces/), code:block23 (https://feature-pan-123.localhost:3000     # Frontend), Creating Workspaces, Workspace Structure, Workspace URLs, Workspaces
 
 ### Community 922 - "Community 922"
 Cohesion: 0.29
-Nodes (6): Agent Directory Structure, Cleanup, code:bash (# Preview orphaned directories), Legacy Directories, Standard Directory Contents, Valid Directory Naming Patterns
+Nodes (7): code:bash (# ~/.panopticon.env), code:yaml (models:), code:bash (chmod 600 ~/.panopticon/config.yaml ~/.panopticon.env), Configuration via Dashboard, Multi-Model Support, Router Configuration, Supported Providers and Models
 
 ### Community 923 - "Community 923"
 Cohesion: 0.29
-Nodes (7): Adding New Integrations, Cloudflare Tunnels, code:yaml (workspace:), code:yaml (workspace:), code:yaml (env_file:), External Service Integrations, Hume EVI (Voice AI)
+Nodes (7): Advanced Topics, code:bash (# Create remote workspace), code:yaml (# ~/.panopticon/work-types.yaml), code:json (// ~/.claude/hooks.json), Custom Work Types, Heartbeat Monitoring, Remote Workspaces
 
 ### Community 924 - "Community 924"
 Cohesion: 0.29
-Nodes (7): code:toml (# Each entry controls one parallel reviewer.), code:yaml (models:), Configuration Schema, Default Reviewers, Fields, Parallel Review Agents, Per-Reviewer Model Overrides
+Nodes (7): About the Name, Core Insight, Executive Summary, Industry Convergence, Key Insights, Opinionated Decisions, Skills over Molecules
 
 ### Community 925 - "Community 925"
 Cohesion: 0.29
-Nodes (7): Balanced Preset (Recommended), Budget Preset, code:yaml (models:), code:yaml (models:), code:yaml (models:), Premium Preset, Presets
+Nodes (7): 6.1 Workspace Hibernation, 6.2 Workspace Cleanup, 6.3 Resource Monitoring, code:bash (pan workspace stop MIN-667), code:bash (pan workspace delete MIN-667), code:bash (pan remote resources), Phase 6: Lifecycle Management
 
 ### Community 926 - "Community 926"
 Cohesion: 0.29
-Nodes (7): Available Work Types, code:yaml (models:), code:yaml (models:), code:yaml (models:), code:yaml (models:), Override Examples, Per-Work-Type Overrides
+Nodes (7): code:bash (# Expose port on VM), code:yaml (# pan-infra:/etc/traefik/docker-compose.yml), code:bash (# Tunnel remote services to local ports), Option A: exe.dev Native HTTPS Proxy, Option B: Traefik on Infra VM, Option C: Local SSH Tunnels (Fallback), Phase 4: URL Routing & Access
 
 ### Community 927 - "Community 927"
 Cohesion: 0.29
-Nodes (7): API Keys: `~/.panopticon.env`, code:yaml (models:), code:yaml (models:), code:env (# Anthropic (required)), Configuration Files, Global Configuration: `~/.panopticon/config.yaml`, Per-Project Configuration: `.panopticon.yaml`
+Nodes (7): Architecture, code:block1 (┌───────────────────────────────────────────────────────────), code:block2 (Shared infra:     0.5 GB), High-Level Design, Memory Budget (16GB Plan), Per-Workspace VMs, Shared Infrastructure VM
 
 ### Community 928 - "Community 928"
 Cohesion: 0.29
-Nodes (7): Agent Management, API Endpoints, Cloister Control, code:typescript (// Get Cloister status), code:typescript (// List all agents (specialists + issue agents)), code:typescript (// Initialize a specialist agent), Specialist Management
+Nodes (6): Agent Directory Structure, Cleanup, code:bash (# Preview orphaned directories), Legacy Directories, Standard Directory Contents, Valid Directory Naming Patterns
 
 ### Community 929 - "Community 929"
 Cohesion: 0.29
-Nodes (5): code:block12 (┌─────────────┐     ┌─────────────┐     ┌─────────────┐), code:block14 (┌─────────────┐     ┌─────────────┐     ┌─────────────┐), Handoff Mechanics, Method 1: Kill & Spawn (Issue Agents), Method 2: Specialist Wake (--resume)
+Nodes (7): code:toml (# Each entry controls one parallel reviewer.), code:yaml (models:), Configuration Schema, Default Reviewers, Fields, Parallel Review Agents, Per-Reviewer Model Overrides
 
 ### Community 930 - "Community 930"
 Cohesion: 0.29
-Nodes (6): 1. Context Budget Manager (PRD Phase 12.8), 2. Runtime Metrics (PRD Phase 13.6), 3. Multi-Runtime Dashboard (PRD Phase 13), Critical Gaps (Missing Functionality), Panopticon Implementation Gaps, Summary
+Nodes (7): Balanced Preset (Recommended), Budget Preset, code:yaml (models:), code:yaml (models:), code:yaml (models:), Premium Preset, Presets
 
 ### Community 931 - "Community 931"
 Cohesion: 0.29
-Nodes (6): AgentList and GodView/AgentGrid deletion notes, Cleanup decision, Deletion gate, Inspector sub-file inventory, InspectorPanel feature inventory, InspectorPanel parity checklist
+Nodes (7): Adding New Integrations, Cloudflare Tunnels, code:yaml (workspace:), code:yaml (workspace:), code:yaml (env_file:), External Service Integrations, Hume EVI (Voice AI)
 
 ### Community 932 - "Community 932"
 Cohesion: 0.29
-Nodes (7): 1. Operator skills are already renamed, 2. Skill naming — operator vs. agent split, 3. `pan sync` — two changes, one codebase, 4. Dashboard API routes follow PAN-705 conventions, 5. Audience backfill and skill renaming, 6. Operator-skill description format for any new operator skills PAN-709 adds, Dependencies — aligned with PAN-705 (Command Taxonomy Reorg)
+Nodes (7): Available Work Types, code:yaml (models:), code:yaml (models:), code:yaml (models:), code:yaml (models:), Override Examples, Per-Work-Type Overrides
 
 ### Community 933 - "Community 933"
 Cohesion: 0.29
-Nodes (7): 4.1 Color Palette (Obsidian Dark), 4.2 Signal Colors, 4.3 Typography, 4.4 Spacing & Radius, 4.5 Shadows & Elevation, 4.6 Animations, 4. Visual Design System
+Nodes (7): API Keys: `~/.panopticon.env`, code:yaml (models:), code:yaml (models:), code:env (# Anthropic (required)), Configuration Files, Global Configuration: `~/.panopticon/config.yaml`, Per-Project Configuration: `.panopticon.yaml`
 
 ### Community 934 - "Community 934"
 Cohesion: 0.29
-Nodes (7): 11.1 View Switching, 11.2 Agent Selection, 11.3 Filtering, 11.4 Filtering (Global), 11.5 Keyboard Shortcuts, 11.6 Empty States, 11. Interactions & Behaviors
+Nodes (7): Agent Management, API Endpoints, Cloister Control, code:typescript (// Get Cloister status), code:typescript (// List all agents (specialists + issue agents)), code:typescript (// Initialize a specialist agent), Specialist Management
 
 ### Community 935 - "Community 935"
 Cohesion: 0.29
-Nodes (7): 5.1 Live Grid (Default), 5.2 Command Table, 5.3 Timeline, 5.4 Topology, 5. View Modes (Detailed), code:block4 (+----------------------------------+), code:block5 (●  2m ago)
+Nodes (5): code:block12 (┌─────────────┐     ┌─────────────┐     ┌─────────────┐), code:block14 (┌─────────────┐     ┌─────────────┐     ┌─────────────┐), Handoff Mechanics, Method 1: Kill & Spawn (Issue Agents), Method 2: Specialist Wake (--resume)
 
 ### Community 936 - "Community 936"
 Cohesion: 0.29
-Nodes (7): 3.1 Page Layout, 3.2 Detail Panel (Slide-out), 3.3 Component Tree, 3. Architecture Overview, code:block1 (+-----------------------------------------------------------), code:block2 (+-----------------------------------+ +---------------------), code:block3 (AgentsPage (new, replaces AgentList + GodView agent display))
+Nodes (6): 1. Context Budget Manager (PRD Phase 12.8), 2. Runtime Metrics (PRD Phase 13.6), 3. Multi-Runtime Dashboard (PRD Phase 13), Critical Gaps (Missing Functionality), Panopticon Implementation Gaps, Summary
 
 ### Community 937 - "Community 937"
 Cohesion: 0.29
-Nodes (7): After — Workhorse panel + 5 role cards, Before — 17 agent cards in 4 groups (`AgentCardsPanel.tsx:8-114`), code:block13 (Issue Agent (5 phases: Exploration, Implementation, Testing,), code:block14 (┌─ Workhorse Models ────────────────────────────────────────), code:typescript (const ROLES = [), Implementation, Settings UI Changes
+Nodes (6): AgentList and GodView/AgentGrid deletion notes, Cleanup decision, Deletion gate, Inspector sub-file inventory, InspectorPanel feature inventory, InspectorPanel parity checklist
 
 ### Community 938 - "Community 938"
 Cohesion: 0.29
-Nodes (7): code:bash (pan conversations search "redis cache invalidation"), code:bash (pan conversations search --semantic "debugging a race condit), code:bash (pan conversations search --workspace ~/Projects/myn), Search, Tier 1: Structured filters (instant, no LLM), Tier 2: Full-text search (FTS5, no LLM), Tier 3: Semantic search (optional, requires embeddings)
+Nodes (7): 1. Operator skills are already renamed, 2. Skill naming — operator vs. agent split, 3. `pan sync` — two changes, one codebase, 4. Dashboard API routes follow PAN-705 conventions, 5. Audience backfill and skill renaming, 6. Operator-skill description format for any new operator skills PAN-709 adds, Dependencies — aligned with PAN-705 (Command Taxonomy Reorg)
 
 ### Community 939 - "Community 939"
 Cohesion: 0.29
-Nodes (7): Implementation Plan, Phase 1 — Backend extraction, Phase 2 — Project list & detail pages (no wizard yet), Phase 3 — Wizard UI (without Setup Agent), Phase 4 — Setup Agent integration, Phase 5 — First-run welcome, Phase 6 — Polish
+Nodes (7): 11.1 View Switching, 11.2 Agent Selection, 11.3 Filtering, 11.4 Filtering (Global), 11.5 Keyboard Shortcuts, 11.6 Empty States, 11. Interactions & Behaviors
 
 ### Community 940 - "Community 940"
 Cohesion: 0.29
-Nodes (7): B.1 Add `reviewRetryCount` to `ReviewStatus` interface, B.2 Increment `reviewRetryCount` on each deacon re-dispatch, B.3 Reset `reviewRetryCount` on successful review completion, B. `src/lib/review-status.ts`, code:typescript (setReviewStatus(opts.issueId, {), code:typescript (export interface ReviewStatus {), code:typescript (setReviewStatus(issueId, {)
+Nodes (7): 4.1 Color Palette (Obsidian Dark), 4.2 Signal Colors, 4.3 Typography, 4.4 Spacing & Radius, 4.5 Shadows & Elevation, 4.6 Animations, 4. Visual Design System
 
 ### Community 941 - "Community 941"
 Cohesion: 0.29
-Nodes (7): Problem 1: Dead/stuck parallel review sessions are invisible to deacon, Problem 2: No circuit breaker for infrastructure-failure cycling, Problem 3: Verification passed but review blocks the pipeline forever, Problem 4: Incomplete parallel reviews waste completed findings, Problem 5: `stuck` flag is never set, so re-dispatch never stops, Problem 6: No UI indication that recovery is happening, Problems Enumerated
+Nodes (7): 5.1 Live Grid (Default), 5.2 Command Table, 5.3 Timeline, 5.4 Topology, 5. View Modes (Detailed), code:block4 (+----------------------------------+), code:block5 (●  2m ago)
 
 ### Community 942 - "Community 942"
 Cohesion: 0.29
-Nodes (7): code:block7 (DockerStatsCollector (5s poll)), code:block8 (DockerStatsCollector.getHistory(containerId) (60 samples)), code:block9 (resource-discovery.ts (30s cache)), Container history path (new, lazy), Container stats path (new), Data flow, Resource detail identifiers path (existing)
+Nodes (7): 3.1 Page Layout, 3.2 Detail Panel (Slide-out), 3.3 Component Tree, 3. Architecture Overview, code:block1 (+-----------------------------------------------------------), code:block2 (+-----------------------------------+ +---------------------), code:block3 (AgentsPage (new, replaces AgentList + GodView agent display))
 
 ### Community 943 - "Community 943"
 Cohesion: 0.29
-Nodes (7): code:typescript ({), code:typescript ({), Commands (mutations), Key Type Definitions, RPC Methods, Streaming (server → client), Unary (request → response)
+Nodes (7): After — Workhorse panel + 5 role cards, Before — 17 agent cards in 4 groups (`AgentCardsPanel.tsx:8-114`), code:block13 (Issue Agent (5 phases: Exploration, Implementation, Testing,), code:block14 (┌─ Workhorse Models ────────────────────────────────────────), code:typescript (const ROLES = [), Implementation, Settings UI Changes
 
 ### Community 944 - "Community 944"
 Cohesion: 0.29
-Nodes (7): From `BadgeBar` modals, From `InspectorPanel` sections, From `IssueCard` (kanban card), From `StatusFlowControl`, From `WorkspacePane`, Parity smoke test, Reunified action layer (parity, additive)
+Nodes (7): code:bash (pan conversations search "redis cache invalidation"), code:bash (pan conversations search --semantic "debugging a race condit), code:bash (pan conversations search --workspace ~/Projects/myn), Search, Tier 1: Structured filters (instant, no LLM), Tier 2: Full-text search (FTS5, no LLM), Tier 3: Semantic search (optional, requires embeddings)
 
 ### Community 945 - "Community 945"
 Cohesion: 0.29
-Nodes (7): code:typescript (interface RoundMarker {), code:block14 (── Round 1 · 14:02 → 14:06 · passed · 8 findings ─────), code:block15 (addressing: specialist-panopticon-540-review-correctness    ), Composer addressing, Session-tab strip (NEW), What changes, Zone C — Conversation + composer (agent-selected)
+Nodes (7): Implementation Plan, Phase 1 — Backend extraction, Phase 2 — Project list & detail pages (no wizard yet), Phase 3 — Wizard UI (without Setup Agent), Phase 4 — Setup Agent integration, Phase 5 — First-run welcome, Phase 6 — Polish
 
 ### Community 946 - "Community 946"
 Cohesion: 0.29
-Nodes (7): P2 — Readiness and delivery (trust hooks, remove fallbacks), `src/dashboard/server/routes/conversations.ts:81` — `waitForClaudeReady()`, `src/lib/agents.ts:1041` — `startAgent` inline prompt-ready check, `src/lib/agents.ts:244` — `waitForReadySignal()`, `src/lib/cloister/specialists.ts:2484,2495` — specialist delivery confirmation, `src/lib/tmux.ts:527` — `waitForClaudePrompt()`, `src/lib/tmux.ts:559` — `confirmDelivery()`
+Nodes (7): Problem 1: Dead/stuck parallel review sessions are invisible to deacon, Problem 2: No circuit breaker for infrastructure-failure cycling, Problem 3: Verification passed but review blocks the pipeline forever, Problem 4: Incomplete parallel reviews waste completed findings, Problem 5: `stuck` flag is never set, so re-dispatch never stops, Problem 6: No UI indication that recovery is happening, Problems Enumerated
 
 ### Community 947 - "Community 947"
 Cohesion: 0.29
-Nodes (7): P1 — Deacon health/stuck detection (structured state), `src/dashboard/lib/health-filtering.ts:13` — `checkAgentHealthAsync()`, `src/lib/cloister/deacon.ts:651` — `checkLazyAgent()`, `src/lib/cloister/deacon.ts:849` — `isAgentActiveInTmux()`, `src/lib/cloister/deacon.ts:935` — `parseThinkingDuration()`, `src/lib/cloister/deacon.ts:955` — `checkStuckWorkAgents()`, `src/lib/health.ts:91` — `getAgentOutput()`
+Nodes (7): B.1 Add `reviewRetryCount` to `ReviewStatus` interface, B.2 Increment `reviewRetryCount` on each deacon re-dispatch, B.3 Reset `reviewRetryCount` on successful review completion, B. `src/lib/review-status.ts`, code:typescript (setReviewStatus(opts.issueId, {), code:typescript (export interface ReviewStatus {), code:typescript (setReviewStatus(issueId, {)
 
 ### Community 948 - "Community 948"
 Cohesion: 0.29
-Nodes (6): Approach, Decision, Difficulty: trivial, PAN-415: Test: trace what calls complete-planning after agent finishes, Scope, Status: Planning Complete
+Nodes (7): code:block7 (DockerStatsCollector (5s poll)), code:block8 (DockerStatsCollector.getHistory(containerId) (60 samples)), code:block9 (resource-discovery.ts (30s cache)), Container history path (new, lazy), Container stats path (new), Data flow, Resource detail identifiers path (existing)
 
 ### Community 949 - "Community 949"
 Cohesion: 0.29
-Nodes (7): 1. Core Fix (CRITICAL), 2. Comprehensive Testing, 3. Error Handling Improvements, 4. Configuration Validation, 5. Documentation, code:typescript (// Before:), Solution Design
+Nodes (7): code:typescript ({), code:typescript ({), Commands (mutations), Key Type Definitions, RPC Methods, Streaming (server → client), Unary (request → response)
 
 ### Community 950 - "Community 950"
 Cohesion: 0.29
-Nodes (6): Agent State: PAN-647, Blockers/Concerns, Current Position, Decisions Made During Planning, Notes, Planned Tasks
+Nodes (7): code:typescript (interface RoundMarker {), code:block14 (── Round 1 · 14:02 → 14:06 · passed · 8 findings ─────), code:block15 (addressing: specialist-panopticon-540-review-correctness    ), Composer addressing, Session-tab strip (NEW), What changes, Zone C — Conversation + composer (agent-selected)
 
 ### Community 951 - "Community 951"
 Cohesion: 0.29
-Nodes (6): Agent State: MIN-794, Blockers/Concerns, Current Position, Decisions Made During Planning, Notes, Planned Tasks
+Nodes (7): From `BadgeBar` modals, From `InspectorPanel` sections, From `IssueCard` (kanban card), From `StatusFlowControl`, From `WorkspacePane`, Parity smoke test, Reunified action layer (parity, additive)
 
 ### Community 952 - "Community 952"
 Cohesion: 0.29
-Nodes (6): Decision (per PRD), Out of scope (confirmed from PRD), PAN-705: Command Taxonomy Reorganization, Pipeline handoff notes for specialists, Problem, Scope anchors
+Nodes (7): P1 — Deacon health/stuck detection (structured state), `src/dashboard/lib/health-filtering.ts:13` — `checkAgentHealthAsync()`, `src/lib/cloister/deacon.ts:651` — `checkLazyAgent()`, `src/lib/cloister/deacon.ts:849` — `isAgentActiveInTmux()`, `src/lib/cloister/deacon.ts:935` — `parseThinkingDuration()`, `src/lib/cloister/deacon.ts:955` — `checkStuckWorkAgents()`, `src/lib/health.ts:91` — `getAgentOutput()`
 
 ### Community 953 - "Community 953"
 Cohesion: 0.29
-Nodes (7): code:bash (# Check container logs), code:bash (# Create the network), code:bash (# Use sudo to remove), Container won't start, Docker Issues, "No such network: panopticon", Permission denied on mounted volumes
+Nodes (7): P2 — Readiness and delivery (trust hooks, remove fallbacks), `src/dashboard/server/routes/conversations.ts:81` — `waitForClaudeReady()`, `src/lib/agents.ts:1041` — `startAgent` inline prompt-ready check, `src/lib/agents.ts:244` — `waitForReadySignal()`, `src/lib/cloister/specialists.ts:2484,2495` — specialist delivery confirmation, `src/lib/tmux.ts:527` — `waitForClaudePrompt()`, `src/lib/tmux.ts:559` — `confirmDelivery()`
 
 ### Community 954 - "Community 954"
 Cohesion: 0.29
-Nodes (7): Agent Issues, Agent keeps failing, Agent stuck / not responding, code:bash (# Check tmux session), code:bash (cat ~/.panopticon/agents/agent-min-123/state.json | jq .hand), code:bash (# Correct), Messages not reaching agent
+Nodes (6): Approach, Decision, Difficulty: trivial, PAN-415: Test: trace what calls complete-planning after agent finishes, Scope, Status: Planning Complete
 
 ### Community 955 - "Community 955"
 Cohesion: 0.29
-Nodes (7): Analyze Structure, code:bash (# By name), code:bash (# Function definitions), code:bash (# Directory tree (shallow)), Find Files, Quick Reference Commands, Search Code
+Nodes (7): 1. Core Fix (CRITICAL), 2. Comprehensive Testing, 3. Error Handling Improvements, 4. Configuration Validation, 5. Documentation, code:typescript (// Before:), Solution Design
 
 ### Community 956 - "Community 956"
 Cohesion: 0.29
-Nodes (7): code:bash (# Count errors per agent), code:bash (# If logs have timestamps, extract timeline), code:bash (# Count tool calls by type), Count Errors, Log Analysis, Timeline of Actions, Tool Usage Analysis
+Nodes (6): Agent State: PAN-647, Blockers/Concerns, Current Position, Decisions Made During Planning, Notes, Planned Tasks
 
 ### Community 957 - "Community 957"
 Cohesion: 0.29
-Nodes (7): code:bash (# Check if session exists), code:bash (# Truncate log file), code:bash (# Add timestamps when capturing), Logs Too Large, Missing Timestamps, No Output from Agent, Troubleshooting
+Nodes (6): Agent State: MIN-794, Blockers/Concerns, Current Position, Decisions Made During Planning, Notes, Planned Tasks
 
 ### Community 958 - "Community 958"
 Cohesion: 0.29
-Nodes (6): 1. Assess (First 5 minutes), 2. Mitigate (Stop the bleeding), 3. Investigate (Once stable), 4. Fix, 5. Postmortem, Incident Response
+Nodes (6): Decision (per PRD), Out of scope (confirmed from PRD), PAN-705: Command Taxonomy Reorganization, Pipeline handoff notes for specialists, Problem, Scope anchors
 
 ### Community 959 - "Community 959"
 Cohesion: 0.29
-Nodes (7): code:bash (bd init myproject), code:bash (bd daemon --global=false &), code:bash (#!/bin/bash), JSONL File Not Created, Resolution, Root Cause, Symptom
+Nodes (7): code:bash (# Check container logs), code:bash (# Create the network), code:bash (# Use sudo to remove), Container won't start, Docker Issues, "No such network: panopticon", Permission denied on mounted volumes
 
 ### Community 960 - "Community 960"
 Cohesion: 0.29
-Nodes (7): code:bash (bd daemon), code:bash (# In your project directory), code:bash (# If you don't want daemon to pull from remote), Daemon Won't Start, Resolution, Root Cause, Symptom
+Nodes (7): Agent Issues, Agent keeps failing, Agent stuck / not responding, code:bash (# Check tmux session), code:bash (cat ~/.panopticon/agents/agent-min-123/state.json | jq .hand), code:bash (# Correct), Messages not reaching agent
 
 ### Community 961 - "Community 961"
 Cohesion: 0.29
-Nodes (7): code:bash (# Project A ships a capability), code:bash (bd ship <capability>            # Ship capability (requires ), code:bash (bd dep add <issue> external:<project>:<capability>), Concept, Cross-Project Dependencies, Depending on External Capabilities, Shipping Capabilities
+Nodes (7): Analyze Structure, code:bash (# By name), code:bash (# Function definitions), code:bash (# Directory tree (shallow)), Find Files, Quick Reference Commands, Search Code
 
 ### Community 962 - "Community 962"
 Cohesion: 0.29
-Nodes (7): code:bash (# Manual creation), code:bash (bd formula list                 # List all formulas (protos)), code:bash (bd mol show mol-release         # Show template structure an), Creating a Proto, Listing Formulas, Proto Management, Viewing Proto Structure
+Nodes (7): code:bash (# Check if session exists), code:bash (# Truncate log file), code:bash (# Add timestamps when capturing), Logs Too Large, Missing Timestamps, No Output from Agent, Troubleshooting
 
 ### Community 963 - "Community 963"
 Cohesion: 0.29
-Nodes (6): CLI Command Reference, Dependency Types, Issue Types, Priorities, Quick Navigation, See Also
+Nodes (7): code:bash (# Count errors per agent), code:bash (# If logs have timestamps, extract timeline), code:bash (# Count tool calls by type), Count Errors, Log Analysis, Timeline of Actions, Tool Usage Analysis
 
 ### Community 964 - "Community 964"
 Cohesion: 0.29
-Nodes (6): code:bash (pan wipe <issue-id>), pan wipe, See Also, Warning, What It Does, When to Use
+Nodes (6): 1. Assess (First 5 minutes), 2. Mitigate (Stop the bleeding), 3. Investigate (Once stable), 4. Fix, 5. Postmortem, Incident Response
 
 ### Community 965 - "Community 965"
 Cohesion: 0.29
-Nodes (7): Check Current Status, code:bash (pan doctor), code:bash (# Clone the repository), code:bash (# Use automated installer), Install Panopticon, Install Prerequisites, Step 2: Installation (5 minutes)
+Nodes (7): code:bash (bd init myproject), code:bash (bd daemon --global=false &), code:bash (#!/bin/bash), JSONL File Not Created, Resolution, Root Cause, Symptom
 
 ### Community 966 - "Community 966"
 Cohesion: 0.29
-Nodes (6): code:block1 (pan admin cloister status [--json]   # Show watchdog service), Confirm before emergency-stop, pan admin cloister, See also, Usage, When to use each subcommand
+Nodes (7): code:bash (bd daemon), code:bash (# In your project directory), code:bash (# If you don't want daemon to pull from remote), Daemon Won't Start, Resolution, Root Cause, Symptom
 
 ### Community 967 - "Community 967"
 Cohesion: 0.29
-Nodes (7): Advanced Usage, code:bash (# Start with hot reload for development), code:bash (# Start only dashboard (no API)), code:bash (# Use environment variables), Custom Ports, Start in Development Mode, Start Specific Services
+Nodes (7): code:bash (# Project A ships a capability), code:bash (bd ship <capability>            # Ship capability (requires ), code:bash (bd dep add <issue> external:<project>:<capability>), Concept, Cross-Project Dependencies, Depending on External Capabilities, Shipping Capabilities
 
 ### Community 968 - "Community 968"
 Cohesion: 0.29
-Nodes (7): Auto-Start on Boot, code:ini ([Unit]), code:bash (sudo systemctl enable panopticon), code:xml (<?xml version="1.0" encoding="UTF-8"?>), code:bash (launchctl load ~/Library/LaunchAgents/com.panopticon.dashboa), Using launchd (macOS), Using systemd (Linux)
+Nodes (7): code:bash (# Manual creation), code:bash (bd formula list                 # List all formulas (protos)), code:bash (bd mol show mol-release         # Show template structure an), Creating a Proto, Listing Formulas, Proto Management, Viewing Proto Structure
 
 ### Community 969 - "Community 969"
 Cohesion: 0.29
-Nodes (7): Check Resource Usage, Check Service Status, Check Specific Agent, code:bash (# Check if dashboard is running), code:bash (# Verbose status with CPU/memory), code:bash (# Show detailed status for one agent), Detailed Status Checks
+Nodes (6): CLI Command Reference, Dependency Types, Issue Types, Priorities, Quick Navigation, See Also
 
 ### Community 970 - "Community 970"
 Cohesion: 0.29
-Nodes (7): Border Radius, Border & Shadow, code:block5 (rounded-md   (6px)  Buttons, inputs, small cards), code:block6 (shadow-sm   Sidebar cards, secondary), code:tsx (bg-muted/40         // Very subtle containers), Opacity Modifiers, Shadows
+Nodes (6): code:bash (pan wipe <issue-id>), pan wipe, See Also, Warning, What It Does, When to Use
 
 ### Community 971 - "Community 971"
 Cohesion: 0.29
-Nodes (6): code:block14 (src/), Design Principles, File Structure, Key Files, Mind Your Now Design System & Coding Standards, Tech Stack
+Nodes (7): Check Current Status, code:bash (pan doctor), code:bash (# Clone the repository), code:bash (# Use automated installer), Install Panopticon, Install Prerequisites, Step 2: Installation (5 minutes)
 
 ### Community 972 - "Community 972"
 Cohesion: 0.29
-Nodes (7): App Background, code:block2 (--background       Page background (white / slate-950)), Color System, MYN Task Type Colors (Methodology), Priority Colors, Semantic Colors, Shadcn/UI Semantic Tokens (CSS Variables)
+Nodes (6): code:block1 (pan admin cloister status [--json]   # Show watchdog service), Confirm before emergency-stop, pan admin cloister, See also, Usage, When to use each subcommand
 
 ### Community 973 - "Community 973"
 Cohesion: 0.29
-Nodes (6): Code Review, Correctness, Design, Output Format, Performance, Security
+Nodes (7): Auto-Start on Boot, code:ini ([Unit]), code:bash (sudo systemctl enable panopticon), code:xml (<?xml version="1.0" encoding="UTF-8"?>), code:bash (launchctl load ~/Library/LaunchAgents/com.panopticon.dashboa), Using launchd (macOS), Using systemd (Linux)
 
 ### Community 974 - "Community 974"
 Cohesion: 0.29
-Nodes (6): 1. Reproduce, 2. Investigate Root Cause, 3. Implement Fix, 4. Add Regression Test, 5. Verify, Bug Fix
+Nodes (7): Advanced Usage, code:bash (# Start with hot reload for development), code:bash (# Start only dashboard (no API)), code:bash (# Use environment variables), Custom Ports, Start in Development Mode, Start Specific Services
 
 ### Community 975 - "Community 975"
 Cohesion: 0.29
-Nodes (7): "Cannot find module" errors, code:bash (# Check if installed), code:bash (# Reinstall dependencies), code:bash (# Check version), Installation Issues, Node.js version issues, "pan: command not found"
+Nodes (7): Check Resource Usage, Check Service Status, Check Specific Agent, code:bash (# Check if dashboard is running), code:bash (# Verbose status with CPU/memory), code:bash (# Show detailed status for one agent), Detailed Status Checks
 
 ### Community 976 - "Community 976"
 Cohesion: 0.29
-Nodes (7): Can't reach Linear API, code:bash (# Test connectivity), code:bash (# Check Traefik is running), code:bash (# Get WSL2 IP), Network Issues, Traefik not routing, WSL2 networking
+Nodes (7): App Background, code:block2 (--background       Page background (white / slate-950)), Color System, MYN Task Type Colors (Methodology), Priority Colors, Semantic Colors, Shadcn/UI Semantic Tokens (CSS Variables)
 
 ### Community 977 - "Community 977"
 Cohesion: 0.29
-Nodes (6): code:bash (# System info), Collecting Diagnostics, Issue Categories, Overview, Related Skills, Troubleshooting Guide
+Nodes (6): code:block14 (src/), Design Principles, File Structure, Key Files, Mind Your Now Design System & Coding Standards, Tech Stack
 
 ### Community 978 - "Community 978"
 Cohesion: 0.29
-Nodes (7): code:bash (# Check sync status), code:bash (# Check what's there), code:bash (# Check trigger patterns in SKILL.md), "Skill already exists", Skill Issues, Skill not triggering, Skills not showing up
+Nodes (7): Border Radius, Border & Shadow, code:block5 (rounded-md   (6px)  Buttons, inputs, small cards), code:block6 (shadow-sm   Sidebar cards, secondary), code:tsx (bg-muted/40         // Very subtle containers), Opacity Modifiers, Shadows
 
 ### Community 979 - "Community 979"
 Cohesion: 0.29
-Nodes (6): code:block1 (LIFECYCLE VERBS (top-level)), code:bash (pan <args>), Command Taxonomy (0.7.0), Dispatch, Panopticon CLI Umbrella Skill, Usage
+Nodes (6): Code Review, Correctness, Design, Output Format, Performance, Security
 
 ### Community 980 - "Community 980"
 Cohesion: 0.29
-Nodes (6): 1. High-Level Structure, 2. Tech Stack, 3. Architecture Patterns, 4. Development Workflow, 5. Document Findings, Codebase Onboarding
+Nodes (6): 1. Reproduce, 2. Investigate Root Cause, 3. Implement Fix, 4. Add Regression Test, 5. Verify, Bug Fix
 
 ### Community 981 - "Community 981"
 Cohesion: 0.29
-Nodes (7): Advanced Usage, code:bash (# Force kill all processes), code:bash (# Stop only dashboard (keep API running)), code:bash (# Stop dashboard and Traefik), Force Stop, Stop and Clean Up Workspaces, Stop Specific Services
+Nodes (7): code:bash (# Check sync status), code:bash (# Check what's there), code:bash (# Check trigger patterns in SKILL.md), "Skill already exists", Skill Issues, Skill not triggering, Skills not showing up
 
 ### Community 982 - "Community 982"
 Cohesion: 0.29
-Nodes (6): code:bash (GITHUB_TOKEN=ghp_xxxxx     # For GitHub-tracked projects), Configuration, Issue Tracker Integration, Related Guides, Supported Trackers, Unified Dashboard
+Nodes (6): code:bash (# System info), Collecting Diagnostics, Issue Categories, Overview, Related Skills, Troubleshooting Guide
 
 ### Community 983 - "Community 983"
 Cohesion: 0.29
-Nodes (7): code:yaml (# In projects.yaml), code:bash (# Add manually or let Panopticon manage it), code:yaml (dns:), DNS Configuration, Option 1: .localhost (Recommended), Option 2: /etc/hosts, Option 3: WSL2 Hosts Sync (Windows)
+Nodes (7): "Cannot find module" errors, code:bash (# Check if installed), code:bash (# Reinstall dependencies), code:bash (# Check version), Installation Issues, Node.js version issues, "pan: command not found"
 
 ### Community 984 - "Community 984"
 Cohesion: 0.29
-Nodes (6): code:bash (# Install mkcert), Docker & HTTPS Setup, Overview, Prerequisites, Quick Setup, Related Guides
+Nodes (7): Can't reach Linear API, code:bash (# Test connectivity), code:bash (# Check Traefik is running), code:bash (# Get WSL2 IP), Network Issues, Traefik not routing, WSL2 networking
 
 ### Community 985 - "Community 985"
 Cohesion: 0.29
-Nodes (7): 11. Theme Toggle, code:html (<script>), code:css (.no-transitions,), code:typescript (function toggleTheme() {), Flash Prevention, Implementation, Transition Suppression
+Nodes (6): code:block1 (LIFECYCLE VERBS (top-level)), code:bash (pan <args>), Command Taxonomy (0.7.0), Dispatch, Panopticon CLI Umbrella Skill, Usage
 
 ### Community 986 - "Community 986"
 Cohesion: 0.29
-Nodes (6): code:bash (# Set up Kimi API), Files, Model Capability Research Framework, Overview, Research Workflow, Using Kimi 2.5 for Research
+Nodes (6): 1. High-Level Structure, 2. Tech Stack, 3. Architecture Patterns, 4. Development Workflow, 5. Document Findings, Codebase Onboarding
 
 ### Community 987 - "Community 987"
+Cohesion: 0.29
+Nodes (7): Advanced Usage, code:bash (# Force kill all processes), code:bash (# Stop only dashboard (keep API running)), code:bash (# Stop dashboard and Traefik), Force Stop, Stop and Clean Up Workspaces, Stop Specific Services
+
+### Community 988 - "Community 988"
+Cohesion: 0.29
+Nodes (6): code:bash (GITHUB_TOKEN=ghp_xxxxx     # For GitHub-tracked projects), Configuration, Issue Tracker Integration, Related Guides, Supported Trackers, Unified Dashboard
+
+### Community 989 - "Community 989"
+Cohesion: 0.29
+Nodes (7): code:yaml (# In projects.yaml), code:bash (# Add manually or let Panopticon manage it), code:yaml (dns:), DNS Configuration, Option 1: .localhost (Recommended), Option 2: /etc/hosts, Option 3: WSL2 Hosts Sync (Windows)
+
+### Community 990 - "Community 990"
+Cohesion: 0.29
+Nodes (6): code:bash (# Install mkcert), Docker & HTTPS Setup, Overview, Prerequisites, Quick Setup, Related Guides
+
+### Community 991 - "Community 991"
+Cohesion: 0.29
+Nodes (7): 11. Theme Toggle, code:html (<script>), code:css (.no-transitions,), code:typescript (function toggleTheme() {), Flash Prevention, Implementation, Transition Suppression
+
+### Community 992 - "Community 992"
+Cohesion: 0.29
+Nodes (6): code:bash (# Set up Kimi API), Files, Model Capability Research Framework, Overview, Research Workflow, Using Kimi 2.5 for Research
+
+### Community 993 - "Community 993"
 Cohesion: 0.33
 Nodes (4): CLI_DIST, CONTRACTS_DIST, __dirname, ROOT
 
-### Community 988 - "Community 988"
+### Community 994 - "Community 994"
 Cohesion: 0.33
 Nodes (5): cache, cacheKey, config, configRepos, keys
 
-### Community 989 - "Community 989"
+### Community 995 - "Community 995"
 Cohesion: 0.33
 Nodes (5): beads, capturedArgs, err, mockExecFileFn, mockExecFn
 
-### Community 990 - "Community 990"
+### Community 996 - "Community 996"
 Cohesion: 0.33
 Nodes (4): desktopVersion, __dirname, repoRoot, rootVersion
 
-### Community 991 - "Community 991"
+### Community 997 - "Community 997"
 Cohesion: 0.47
 Nodes (5): create_agent(), get_agent_path(), main(), Get the appropriate agent directory based on scope., Create a new subagent file.
 
-### Community 992 - "Community 992"
+### Community 998 - "Community 998"
 Cohesion: 0.47
 Nodes (5): main(), package_skill(), Validate skill structure and contents., Package a skill folder into a .skill file., validate_skill()
 
-### Community 993 - "Community 993"
+### Community 999 - "Community 999"
 Cohesion: 0.47
 Nodes (3): emit(), load_model(), main()
 
-### Community 994 - "Community 994"
-Cohesion: 0.33
-Nodes (3): body, content, { frontmatter, body }
-
-### Community 995 - "Community 995"
-Cohesion: 0.33
-Nodes (5): ClaudeSettings, added, first, second, settings
-
-### Community 996 - "Community 996"
-Cohesion: 0.33
-Nodes (5): mockConversation, mockMessages, raw, toggle, url
-
-### Community 997 - "Community 997"
-Cohesion: 0.33
-Nodes (5): baseSettings, flywheelCard, method, settings, settingsBtn
-
-### Community 999 - "Community 999"
-Cohesion: 0.4
-Nodes (3): LogViewerProps, SpecialistLogViewer(), SSEMessage
-
 ### Community 1000 - "Community 1000"
 Cohesion: 0.33
-Nodes (5): Audit Prompt: Distinct Data Captured from tmux Scrollback, Constraints, Instructions, Objective, Output Format
+Nodes (5): after, body, result, { saveAgentRuntimeStateMock, getAgentRuntimeStateMock }, processResetReviewPipeline()
 
 ### Community 1001 - "Community 1001"
 Cohesion: 0.33
-Nodes (6): Auth Flow, code:bash (pan specialists done uat <issueId> --status passed   # Signa), Four Verification Phases, Pipeline Trigger, UAT Specialist (PAN-383), Why UAT Exists
+Nodes (3): body, content, { frontmatter, body }
 
 ### Community 1002 - "Community 1002"
 Cohesion: 0.33
-Nodes (6): Agent Behavior After Reopen, Preserving History, Preventing Stale Dispatch, Reopening Issues for Re-Work, What Reopen Resets, Why "In Progress" and Not Backlog
+Nodes (5): mockConversation, mockMessages, raw, toggle, url
 
 ### Community 1003 - "Community 1003"
 Cohesion: 0.33
-Nodes (5): Central gate, CLI and dashboard break-glass, Non-agent tmux sessions, Spawn entrypoint audit, Spawn Gating
+Nodes (5): baseSettings, flywheelCard, method, settings, settingsBtn
 
 ### Community 1004 - "Community 1004"
-Cohesion: 0.33
-Nodes (6): Browser-Only Mode, code:bash (npx panopticon serve), Desktop App, Installation, Key Features, `pan up` Electron Detection
-
-### Community 1005 - "Community 1005"
-Cohesion: 0.33
-Nodes (6): code:block1 (┌───────────────────────────────────────────────────────────), code:block2 (┌───────────────────────────────────────────────────────────), Core Concept, Part 1: Architecture Vision, Success Metrics, Unified Architecture
+Cohesion: 0.4
+Nodes (3): LogViewerProps, SpecialistLogViewer(), SSEMessage
 
 ### Community 1006 - "Community 1006"
 Cohesion: 0.33
-Nodes (6): code:bash (pan workspace create my-feature --template node-fullstack), code:block102 (~/.panopticon/templates/), code:toml ([template]), Starter Templates (Optional), Template Metadata (template.toml), Template Structure
+Nodes (5): FacetPanel(), FacetValue, Filters, Props, SINCE_OPTIONS
 
 ### Community 1007 - "Community 1007"
 Cohesion: 0.33
-Nodes (6): 8. Complete Content Inventory, MYN Project Template Content, Panopticon Agents (8), Panopticon Dev-Skills (3), Panopticon Skills (64), Project-Scoped (Panopticon repo only)
+Nodes (5): Audit Prompt: Distinct Data Captured from tmux Scrollback, Constraints, Instructions, Objective, Output Format
 
 ### Community 1008 - "Community 1008"
 Cohesion: 0.33
-Nodes (6): 3. Real-World Conflict: Mind Your Now, code:block7 (pan workspace create MIN-678), code:yaml (agent:), MYN Project Configuration, Skill Audit (Feb 2026), The Override Problem
+Nodes (6): Agent Behavior After Reopen, Preserving History, Preventing Stale Dispatch, Reopening Issues for Re-Work, What Reopen Resets, Why "In Progress" and Not Backlog
 
 ### Community 1009 - "Community 1009"
 Cohesion: 0.33
-Nodes (6): Advanced Configuration, code:bash (# View effective configuration), code:bash (# Automatic migration (coming soon in PAN-118-6)), Debugging Model Resolution, Migration from settings.json, Validation
+Nodes (6): Auth Flow, code:bash (pan specialists done uat <issueId> --status passed   # Signa), Four Verification Phases, Pipeline Trigger, UAT Specialist (PAN-383), Why UAT Exists
 
 ### Community 1010 - "Community 1010"
 Cohesion: 0.33
-Nodes (6): code:yaml (models:), code:block27 (Warning: Model gpt-5.2-codex requires openai API key - falli), Example Scenario, Fallback Behavior, Fallback Mappings, Fallback Strategy
+Nodes (5): Central gate, CLI and dashboard break-glass, Non-agent tmux sessions, Spawn entrypoint audit, Spawn Gating
 
 ### Community 1011 - "Community 1011"
 Cohesion: 0.33
-Nodes (6): 10.1 Agent Object (Unified), 10.2 API Endpoints Needed, 10.3 Existing Endpoints to Reuse, 10.4 Real-time Updates, 10. Data Requirements, code:typescript (interface UnifiedAgent {)
+Nodes (6): Browser-Only Mode, code:bash (npx panopticon serve), Desktop App, Installation, Key Features, `pan up` Electron Detection
 
 ### Community 1012 - "Community 1012"
 Cohesion: 0.33
-Nodes (6): 13. Implementation Plan, Phase 1: Foundation, Phase 2: Live Grid, Phase 3: Detail Panel, Phase 4: Additional Views, Phase 5: Polish
+Nodes (6): code:block1 (┌───────────────────────────────────────────────────────────), code:block2 (┌───────────────────────────────────────────────────────────), Core Concept, Part 1: Architecture Vision, Success Metrics, Unified Architecture
 
 ### Community 1013 - "Community 1013"
 Cohesion: 0.33
-Nodes (6): code:ts (interface Room {), HTTP API, Room state (in-memory), The Signaling Service, WebSocket API — `WS /signal`, What the signaling service can and cannot see
+Nodes (6): 8. Complete Content Inventory, MYN Project Template Content, Panopticon Agents (8), Panopticon Dev-Skills (3), Panopticon Skills (64), Project-Scoped (Panopticon repo only)
 
 ### Community 1014 - "Community 1014"
 Cohesion: 0.33
-Nodes (6): Architecture, code:block1 (HOST machine                  panopticon-cli.com            ), Components, Reuse: the terminal-sharing primitive, Two-role decomposition of "host", Why the hub is the host's server, not the host's browser
+Nodes (6): 3. Real-World Conflict: Mind Your Now, code:block7 (pan workspace create MIN-678), code:yaml (agent:), MYN Project Configuration, Skill Audit (Feb 2026), The Override Problem
 
 ### Community 1015 - "Community 1015"
 Cohesion: 0.33
-Nodes (6): code:typescript (// workspaces.ts processUnstickRequest — skip git check for ), code:typescript (setReviewStatusBase(issueId, {), G.1 Reuse existing unstick route — do NOT add a new endpoint, G.2 Session ownership, G.3 Liveness-check caveats, G. Recovery flow, session ownership, liveness caveats
+Nodes (6): Advanced Configuration, code:bash (# View effective configuration), code:bash (# Automatic migration (coming soon in PAN-118-6)), Debugging Model Resolution, Migration from settings.json, Validation
 
 ### Community 1016 - "Community 1016"
 Cohesion: 0.33
-Nodes (6): Detailed flows, Flow A — First-run, Flow B — Adding a second project, Flow C — Editing branch config, Flow D — Re-detecting repos, Flow E — Killing a stuck Setup Agent
+Nodes (6): code:yaml (models:), code:block27 (Warning: Model gpt-5.2-codex requires openai API key - falli), Example Scenario, Fallback Behavior, Fallback Mappings, Fallback Strategy
 
 ### Community 1017 - "Community 1017"
 Cohesion: 0.33
-Nodes (6): Agent Instructions, Bead Assignments, code:typescript (// src/dashboard/server/routes/{category}.ts), Pattern, Route Conversion Cheat Sheet, Route Migration Details (B6–B17)
+Nodes (6): 13. Implementation Plan, Phase 1: Foundation, Phase 2: Live Grid, Phase 3: Detail Panel, Phase 4: Additional Views, Phase 5: Polish
 
 ### Community 1018 - "Community 1018"
 Cohesion: 0.33
-Nodes (6): 1. Reviewers fan out as fresh sessions on every round, 2. Conversation view never loads for agent sessions, 3. The Command Deck has no opinion on issue + agent + workflow as one surface, 4. The view doesn't feel alive, code:block1 (review                  ○ ended), Problem
+Nodes (6): 10.1 Agent Object (Unified), 10.2 API Endpoints Needed, 10.3 Existing Endpoints to Reuse, 10.4 Real-time Updates, 10. Data Requirements, code:typescript (interface UnifiedAgent {)
 
 ### Community 1019 - "Community 1019"
 Cohesion: 0.33
-Nodes (6): P3 — Merge/test/review structured events, `src/lib/cloister/merge-agent.ts:1071` — test failure baseline, `src/lib/cloister/merge-agent.ts:1744` — `resolveConflictsWithAgent()` sync-main polling, `src/lib/cloister/merge-agent.ts:412` — `parseAgentOutput()`, `src/lib/cloister/merge-agent.ts:684` — `scanGitPatterns()`, `src/lib/cloister/review-agent.ts:139` — `parseAgentOutput()`
+Nodes (6): Architecture, code:block1 (HOST machine                  panopticon-cli.com            ), Components, Reuse: the terminal-sharing primitive, Two-role decomposition of "host", Why the hub is the host's server, not the host's browser
 
 ### Community 1020 - "Community 1020"
 Cohesion: 0.33
-Nodes (5): Context, Decision, Difficulty: trivial, PAN-448: Start Agent confirmation timeout too short, Scope
+Nodes (6): code:ts (interface Room {), HTTP API, Room state (in-memory), The Signaling Service, WebSocket API — `WS /signal`, What the signaling service can and cannot see
 
 ### Community 1021 - "Community 1021"
 Cohesion: 0.33
-Nodes (6): code:bash (# Restart the dashboard), code:bash (# Check Docker memory), Dashboard slow to load, High CPU usage, High memory usage, Performance Issues
+Nodes (6): code:typescript (// workspaces.ts processUnstickRequest — skip git check for ), code:typescript (setReviewStatusBase(issueId, {), G.1 Reuse existing unstick route — do NOT add a new endpoint, G.2 Session ownership, G.3 Liveness-check caveats, G. Recovery flow, session ownership, liveness caveats
 
 ### Community 1022 - "Community 1022"
 Cohesion: 0.33
-Nodes (6): code:bash (# Option 1: Manual cleanup), Common Causes, Corrupted Workspaces, Prevention, Resolution, Symptoms
+Nodes (6): Detailed flows, Flow A — First-run, Flow B — Adding a second project, Flow C — Editing branch config, Flow D — Re-detecting repos, Flow E — Killing a stuck Setup Agent
 
 ### Community 1023 - "Community 1023"
 Cohesion: 0.33
-Nodes (5): code:block9 (<!-- panopticon:orchestration-context-start -->), Further reading, Orchestration markers, Prompt Templates, Why templates at all
+Nodes (6): Agent Instructions, Bead Assignments, code:typescript (// src/dashboard/server/routes/{category}.ts), Pattern, Route Conversion Cheat Sheet, Route Migration Details (B6–B17)
 
 ### Community 1024 - "Community 1024"
 Cohesion: 0.33
-Nodes (6): 1. Fail loud, fail early, 2. One template, one API, 3. Composition happens in TypeScript, 4. Variables are declared, not discovered, 5. Prompts are not docstrings, Core principles
+Nodes (6): 1. Reviewers fan out as fresh sessions on every round, 2. Conversation view never loads for agent sessions, 3. The Command Deck has no opinion on issue + agent + workflow as one surface, 4. The view doesn't feel alive, code:block1 (review                  ○ ended), Problem
 
 ### Community 1025 - "Community 1025"
 Cohesion: 0.33
-Nodes (5): Boundaries, Outputs, Panopticon Planning Agent, Process, State model
+Nodes (6): P3 — Merge/test/review structured events, `src/lib/cloister/merge-agent.ts:1071` — test failure baseline, `src/lib/cloister/merge-agent.ts:1744` — `resolveConflictsWithAgent()` sync-main polling, `src/lib/cloister/merge-agent.ts:412` — `parseAgentOutput()`, `src/lib/cloister/merge-agent.ts:684` — `scanGitPatterns()`, `src/lib/cloister/review-agent.ts:139` — `parseAgentOutput()`
 
 ### Community 1026 - "Community 1026"
 Cohesion: 0.33
-Nodes (5): Boundaries, code:bash (npm test), Completion, Panopticon Work Agent, Per-Bead Workflow
+Nodes (5): Context, Decision, Difficulty: trivial, PAN-448: Start Agent confirmation timeout too short, Scope
 
 ### Community 1027 - "Community 1027"
 Cohesion: 0.33
-Nodes (5): Additional Context (Optional), code:markdown (## Agent: {ISSUE_ID} - {ISSUE_TITLE}), Required Information Table, When to Apply This Format, Workspace Status Display Format
+Nodes (6): code:bash (# Option 1: Manual cleanup), Common Causes, Corrupted Workspaces, Prevention, Resolution, Symptoms
 
 ### Community 1028 - "Community 1028"
 Cohesion: 0.33
-Nodes (5): code:bash (pan done <issue-id>), pan done, See Also, What It Does, When to Use
+Nodes (6): code:bash (# Restart the dashboard), code:bash (# Check Docker memory), Dashboard slow to load, High CPU usage, High memory usage, Performance Issues
 
 ### Community 1029 - "Community 1029"
 Cohesion: 0.33
-Nodes (6): code:python (# Want: "task-2 depends on task-1" (task-1 blocks task-2)), code:python (# Correct: task-2 depends on task-1), code:bash (bd dep add task-2 task-1 --type blocks), code:bash (bd show task-2), Dependencies Created Backwards, MCP-Specific Issues
+Nodes (5): code:block9 (<!-- panopticon:orchestration-context-start -->), Further reading, Orchestration markers, Prompt Templates, Why templates at all
 
 ### Community 1030 - "Community 1030"
 Cohesion: 0.33
-Nodes (6): Claude Code Skill Issues, code:bash (# 1. Version), code:bash (ls -la ~/.claude/skills/bd-issue-tracking/), Debug Checklist, Getting Help, Report to beads GitHub
+Nodes (6): 1. Fail loud, fail early, 2. One template, one API, 3. Composition happens in TypeScript, 4. Variables are declared, not discovered, 5. Prompts are not docstrings, Core principles
 
 ### Community 1031 - "Community 1031"
 Cohesion: 0.33
-Nodes (5): Contents, Interface-Specific Troubleshooting, Quick Reference: Common Fixes, Related Documentation, Troubleshooting Guide
+Nodes (5): Boundaries, Outputs, Panopticon Planning Agent, Process, State model
 
 ### Community 1032 - "Community 1032"
 Cohesion: 0.33
-Nodes (5): Limitations, Reference Databases / Glossaries (Alternative Use), Using bd for Static Reference Data, When to Use This Pattern, Work Tracking (Primary Use Case)
+Nodes (5): Boundaries, code:bash (npm test), Completion, Panopticon Work Agent, Per-Bead Workflow
 
 ### Community 1033 - "Community 1033"
 Cohesion: 0.33
-Nodes (5): code:bash (pan resources), code:bash (pan resources --json), Interpreting results, JSON output, System Resource Inventory
+Nodes (5): Additional Context (Optional), code:markdown (## Agent: {ISSUE_ID} - {ISSUE_TITLE}), Required Information Table, When to Apply This Format, Workspace Status Display Format
 
 ### Community 1034 - "Community 1034"
 Cohesion: 0.33
-Nodes (5): code:bash (pan admin hooks install), pan admin hooks install, See Also, What It Does, When to Use
+Nodes (5): code:bash (pan done <issue-id>), pan done, See Also, What It Does, When to Use
 
 ### Community 1035 - "Community 1035"
 Cohesion: 0.33
-Nodes (5): code:block1 (https://raw.githubusercontent.com/vercel-labs/web-interface-), Guidelines Source, How It Works, Usage, Web Interface Guidelines
+Nodes (6): Claude Code Skill Issues, code:bash (# 1. Version), code:bash (ls -la ~/.claude/skills/bd-issue-tracking/), Debug Checklist, Getting Help, Report to beads GitHub
 
 ### Community 1036 - "Community 1036"
 Cohesion: 0.33
-Nodes (5): Canonical paths, code:bash (# Build first if dashboard server or CLI code changed), Execution, Important Notes, Restart Panopticon
+Nodes (5): Contents, Interface-Specific Troubleshooting, Quick Reference: Common Fixes, Related Documentation, Troubleshooting Guide
 
 ### Community 1037 - "Community 1037"
 Cohesion: 0.33
-Nodes (5): After Refactoring, Before Starting, During Refactoring, Refactoring, Refactoring Types
+Nodes (6): code:python (# Want: "task-2 depends on task-1" (task-1 blocks task-2)), code:python (# Correct: task-2 depends on task-1), code:bash (bd dep add task-2 task-1 --type blocks), code:bash (bd show task-2), Dependencies Created Backwards, MCP-Specific Issues
 
 ### Community 1038 - "Community 1038"
 Cohesion: 0.33
-Nodes (6): Alert on Agent Crash, code:bash (#!/bin/bash), code:bash (chmod +x ~/scripts/pan-dashboard.sh), code:bash (#!/bin/bash), Custom Status Dashboard, Status Scripts
+Nodes (5): Limitations, Reference Databases / Glossaries (Alternative Use), Using bd for Static Reference Data, When to Use This Pattern, Work Tracking (Primary Use Case)
 
 ### Community 1039 - "Community 1039"
 Cohesion: 0.33
-Nodes (6): code:bash (# One-liner to check everything), code:bash (# Watch agent status (updates every 2 seconds)), Continuous Monitoring, Dashboard Monitoring, Monitoring Workflows, Quick Health Check
+Nodes (5): code:bash (pan resources), code:bash (pan resources --json), Interpreting results, JSON output, System Resource Inventory
 
 ### Community 1040 - "Community 1040"
 Cohesion: 0.33
-Nodes (5): Architectural rules, Execution steps, Retrieval and networking, Stitch to React Components, Troubleshooting
+Nodes (5): code:bash (pan admin hooks install), pan admin hooks install, See Also, What It Does, When to Use
 
 ### Community 1041 - "Community 1041"
 Cohesion: 0.33
-Nodes (5): code:bash (pan reload), Command, Notes, Options, Pan Reload
+Nodes (5): code:block1 (https://raw.githubusercontent.com/vercel-labs/web-interface-), Guidelines Source, How It Works, Usage, Web Interface Guidelines
 
 ### Community 1042 - "Community 1042"
 Cohesion: 0.33
-Nodes (5): code:bash (pan issues), pan issues, See Also, What It Does, When to Use
+Nodes (5): Canonical paths, code:bash (# Build first if dashboard server or CLI code changed), Execution, Important Notes, Restart Panopticon
 
 ### Community 1043 - "Community 1043"
 Cohesion: 0.33
-Nodes (5): 1. Version Bump, 2. Final Verification, 3. Create Release, 4. Post-Release, Release Process
+Nodes (5): After Refactoring, Before Starting, During Refactoring, Refactoring, Refactoring Types
 
 ### Community 1044 - "Community 1044"
 Cohesion: 0.33
-Nodes (6): code:bash (LINEAR_API_KEY=lin_api_xxxxx), code:yaml (projects:), Issue States, Linear Integration, Setup, Team Mapping
+Nodes (6): code:bash (# One-liner to check everything), code:bash (# Watch agent status (updates every 2 seconds)), Continuous Monitoring, Dashboard Monitoring, Monitoring Workflows, Quick Health Check
 
 ### Community 1045 - "Community 1045"
 Cohesion: 0.33
-Nodes (6): code:bash (# In ~/.panopticon.env), code:bash (DEBUG=rally pan up), code:bash (curl -X POST http://localhost:3011/api/rally/validate \), Finding Workspace and Project IDs, Rally Troubleshooting, WSAPI Query Parse Errors
+Nodes (6): Alert on Agent Crash, code:bash (#!/bin/bash), code:bash (chmod +x ~/scripts/pan-dashboard.sh), code:bash (#!/bin/bash), Custom Status Dashboard, Status Scripts
 
 ### Community 1046 - "Community 1046"
 Cohesion: 0.33
-Nodes (6): code:block2 (~/.panopticon/traefik/), code:yaml (api:), code:yaml (http:), Dynamic Configuration, Static Configuration, Traefik Configuration
+Nodes (5): Architectural rules, Execution steps, Retrieval and networking, Stitch to React Components, Troubleshooting
 
 ### Community 1047 - "Community 1047"
 Cohesion: 0.33
-Nodes (6): 12. Animation & Motion, code:block29 (Duration: 200ms (default for all state transitions)), code:block30 (Hover highlight:   transition-colors duration-200), Patterns, Rules, Standard Timing
+Nodes (5): code:bash (pan reload), Command, Notes, Options, Pan Reload
 
 ### Community 1048 - "Community 1048"
 Cohesion: 0.33
-Nodes (6): 14. Accessibility, code:block33 (focus-visible:ring-[3px] focus-visible:ring-ring/24 focus-vi), Contrast Ratios, Focus Indicators, Keyboard Navigation, Touch Targets
+Nodes (5): code:bash (pan issues), pan issues, See Also, What It Does, When to Use
 
 ### Community 1049 - "Community 1049"
 Cohesion: 0.33
-Nodes (6): 15. Page-Specific Notes, Agents, Board (Kanban), Command Deck (formerly Mission Control), God View, Settings
+Nodes (5): 1. Version Bump, 2. Final Verification, 3. Create Release, 4. Post-Release, Release Process
 
 ### Community 1050 - "Community 1050"
 Cohesion: 0.33
-Nodes (5): Agent Resumed — {{ISSUE_ID}}, Last Known Status: {{STATE_STATUS}}, Operator Message, What To Do Now, Where You Left Off
+Nodes (6): code:bash (# In ~/.panopticon.env), code:bash (DEBUG=rally pan up), code:bash (curl -X POST http://localhost:3011/api/rally/validate \), Finding Workspace and Project IDs, Rally Troubleshooting, WSAPI Query Parse Errors
 
 ### Community 1051 - "Community 1051"
 Cohesion: 0.33
-Nodes (5): Auto-Clarity, Boundaries, Intensity, Persistence, Rules
+Nodes (6): code:bash (LINEAR_API_KEY=lin_api_xxxxx), code:yaml (projects:), Issue States, Linear Integration, Setup, Team Mapping
 
 ### Community 1052 - "Community 1052"
+Cohesion: 0.33
+Nodes (6): code:block2 (~/.panopticon/traefik/), code:yaml (api:), code:yaml (http:), Dynamic Configuration, Static Configuration, Traefik Configuration
+
+### Community 1053 - "Community 1053"
+Cohesion: 0.33
+Nodes (6): 15. Page-Specific Notes, Agents, Board (Kanban), Command Deck (formerly Mission Control), God View, Settings
+
+### Community 1054 - "Community 1054"
+Cohesion: 0.33
+Nodes (6): 14. Accessibility, code:block33 (focus-visible:ring-[3px] focus-visible:ring-ring/24 focus-vi), Contrast Ratios, Focus Indicators, Keyboard Navigation, Touch Targets
+
+### Community 1055 - "Community 1055"
+Cohesion: 0.33
+Nodes (6): 12. Animation & Motion, code:block29 (Duration: 200ms (default for all state transitions)), code:block30 (Hover highlight:   transition-colors duration-200), Patterns, Rules, Standard Timing
+
+### Community 1056 - "Community 1056"
+Cohesion: 0.33
+Nodes (5): Agent Resumed — {{ISSUE_ID}}, Last Known Status: {{STATE_STATUS}}, Operator Message, What To Do Now, Where You Left Off
+
+### Community 1057 - "Community 1057"
+Cohesion: 0.33
+Nodes (5): Auto-Clarity, Boundaries, Intensity, Persistence, Rules
+
+### Community 1058 - "Community 1058"
 Cohesion: 0.5
 Nodes (4): computeStaleResets(), hasSessionForSpecialist(), StatusSnapshot, updates
 
-### Community 1053 - "Community 1053"
+### Community 1059 - "Community 1059"
 Cohesion: 0.4
 Nodes (3): badge, { container }, DIFFICULTY_COLORS
 
-### Community 1054 - "Community 1054"
+### Community 1060 - "Community 1060"
 Cohesion: 0.4
 Nodes (4): consoleLogs, edges, mockGetStatus, output
 
-### Community 1055 - "Community 1055"
+### Community 1061 - "Community 1061"
 Cohesion: 0.4
 Nodes (4): hiddenDir, mockExecFn, subA, subB
 
-### Community 1056 - "Community 1056"
+### Community 1062 - "Community 1062"
 Cohesion: 0.4
 Nodes (3): content, LEGACY_TEMPLATE_FLAVORS, REVIEW_SUB_ROLES
 
-### Community 1057 - "Community 1057"
+### Community 1063 - "Community 1063"
 Cohesion: 0.4
 Nodes (4): REMOTE_PROVISIONERS, REPO_ROOT, src, stripped
 
-### Community 1058 - "Community 1058"
+### Community 1064 - "Community 1064"
 Cohesion: 0.4
 Nodes (3): entries, messages, workLog
 
-### Community 1061 - "Community 1061"
-Cohesion: 0.4
-Nodes (4): mockCleanupUnreferencedConversationAttachments, mockListActiveConversations, mockListSessionNamesAsync, mockMarkConversationEnded
-
-### Community 1062 - "Community 1062"
-Cohesion: 0.4
-Nodes (4): defaults, first, { models }, second
-
-### Community 1063 - "Community 1063"
-Cohesion: 0.4
-Nodes (5): code:block26 (Issue Created), code:block27 (mergeStatus:  pending → merging → merged), How the Agent Pipeline Works, Review status state machine, Specialist initialization
-
-### Community 1064 - "Community 1064"
-Cohesion: 0.4
-Nodes (5): Optional, Platform Support, Required, Requirements, Why CLI tools instead of API tokens?
-
-### Community 1065 - "Community 1065"
-Cohesion: 0.4
-Nodes (5): code:toml ([panopticon]), code:toml ([project]), Configuration Reference, Global Config (~/.panopticon/config.toml), Project Config (.panopticon/project.toml)
-
-### Community 1066 - "Community 1066"
-Cohesion: 0.4
-Nodes (5): code:block22 (Replace stale copies in ~/.panopticon/skills/ with fresh con), code:block23 (For each symlink in ~/.claude/skills/ pointing to ~/.panopti), code:block24 (Copy all skills, agents, rules from ~/.panopticon/ cache → <), code:block25 (Panopticon sync migration:), Migration Path
-
 ### Community 1067 - "Community 1067"
-Cohesion: 0.4
-Nodes (5): code:bash (# Existing local workspace), code:bash (pan workspace migrate MIN-667 --to local), From Local to Remote, Migration Path, Rollback to Local
+Cohesion: 0.5
+Nodes (4): APP_DIR, generateJWT(), main(), WEBHOOK_EVENTS
 
 ### Community 1068 - "Community 1068"
 Cohesion: 0.4
-Nodes (5): code:toml ([remote]), code:yaml (# Project-specific remote settings), Configuration, Project Config (`.panopticon/remote.yaml`), User Config (`~/.panopticon/config.toml`)
+Nodes (4): mockCleanupUnreferencedConversationAttachments, mockListActiveConversations, mockListSessionNamesAsync, mockMarkConversationEnded
 
 ### Community 1069 - "Community 1069"
 Cohesion: 0.4
-Nodes (5): code:yaml (models:), code:yaml (models:), Provider Configuration, Provider Management, When Providers are Disabled
+Nodes (5): code:block26 (Issue Created), code:block27 (mergeStatus:  pending → merging → merged), How the Agent Pipeline Works, Review status state machine, Specialist initialization
 
 ### Community 1070 - "Community 1070"
 Cohesion: 0.4
-Nodes (5): code:typescript (interface AgentRuntime {), code:yaml (# ~/.panopticon/cloister.yaml), Model Selection, Runtime Architecture, Runtime Interface
+Nodes (5): Optional, Platform Support, Required, Requirements, Why CLI tools instead of API tokens?
 
 ### Community 1071 - "Community 1071"
 Cohesion: 0.4
-Nodes (5): code:yaml (# ~/.panopticon/cloister.yaml), code:bash (# Override config file location), Configuration, Default Config File, Environment Variables
+Nodes (5): code:block22 (Replace stale copies in ~/.panopticon/skills/ with fresh con), code:block23 (For each symlink in ~/.claude/skills/ pointing to ~/.panopti), code:block24 (Copy all skills, agents, rules from ~/.panopticon/ cache → <), code:block25 (Panopticon sync migration:), Migration Path
 
 ### Community 1072 - "Community 1072"
 Cohesion: 0.4
-Nodes (4): Claude Code Skills Inventory, Duplicate names, Maintenance, Skills
+Nodes (5): code:toml ([remote]), code:yaml (# Project-specific remote settings), Configuration, Project Config (`.panopticon/remote.yaml`), User Config (`~/.panopticon/config.toml`)
 
 ### Community 1073 - "Community 1073"
 Cohesion: 0.4
-Nodes (5): 8.1 Activity Feed, 8.2 Phase Distribution (Donut Chart), 8.3 System Health Gauges, 8. Right Panel (Persistent), code:block7 (2m    ●  agent-pan-505 started)
+Nodes (5): code:bash (# Existing local workspace), code:bash (pan workspace migrate MIN-667 --to local), From Local to Remote, Migration Path, Rollback to Local
 
 ### Community 1074 - "Community 1074"
 Cohesion: 0.4
-Nodes (5): code:typescript (function readRole(state: any): Role {), Enum mapping table, Migration — Backward Compatibility, Old agent .md files, Reading old state.json files
+Nodes (5): code:yaml (models:), code:yaml (models:), Provider Configuration, Provider Management, When Providers are Disabled
 
 ### Community 1075 - "Community 1075"
 Cohesion: 0.4
-Nodes (5): Component, End-to-end (Playwright), Integration, Testing, Unit
+Nodes (5): code:typescript (interface AgentRuntime {), code:yaml (# ~/.panopticon/cloister.yaml), Model Selection, Runtime Architecture, Runtime Interface
 
 ### Community 1076 - "Community 1076"
 Cohesion: 0.4
-Nodes (5): Branch node (new), Container node (new), Data inventory, PR node (new), Resources group node (new)
+Nodes (5): code:yaml (# ~/.panopticon/cloister.yaml), code:bash (# Override config file location), Configuration, Default Config File, Environment Variables
 
 ### Community 1077 - "Community 1077"
 Cohesion: 0.4
-Nodes (5): Visual / data inventory by zone, Zone A — Issue header (always visible), Zone B — Agent context (selected session), Zone C — Conversation + composer (agent-selected), Zone C — Issue-selected mode (no agent selected)
+Nodes (4): Claude Code Skills Inventory, Duplicate names, Maintenance, Skills
 
 ### Community 1078 - "Community 1078"
 Cohesion: 0.4
-Nodes (5): `AgentRuntimeState` (`src/lib/agents.ts:359`), code:typescript (export interface AgentRuntimeState {), code:typescript (// review-results.json), Interface Changes, Specialist Result Files (new)
+Nodes (5): 8.1 Activity Feed, 8.2 Phase Distribution (Donut Chart), 8.3 System Health Gauges, 8. Right Panel (Persistent), code:block7 (2m    ●  agent-pan-505 started)
 
 ### Community 1079 - "Community 1079"
 Cohesion: 0.4
-Nodes (5): Hook Extensions Required, Hook reliability (PAN-759), PostToolUse hook, SessionStart hook, Specialist hooks (new)
+Nodes (5): code:typescript (function readRole(state: any): Role {), Enum mapping table, Migration — Backward Compatibility, Old agent .md files, Reading old state.json files
 
 ### Community 1080 - "Community 1080"
 Cohesion: 0.4
-Nodes (5): code:block1 (Agent → tmux pane → capture-pane → regex parsing → consumer), code:block2 (Agent → hooks → runtime.json ──┬──→ Dashboard (structured st), Data Flow: Today vs Target, Target (2 layers), Today (3 overlapping layers)
+Nodes (5): Component, End-to-end (Playwright), Integration, Testing, Unit
 
 ### Community 1081 - "Community 1081"
 Cohesion: 0.4
-Nodes (5): Implementation Sequence (4 Phases), Phase 1: Fix hooks (BLOCKS EVERYTHING), Phase 2: Structured event files + JSONL readers (can start after Phase 1), Phase 3: Remove high-risk tmux patterns (can start after Phase 1), Phase 4: Migrate remaining consumers (can start after Phase 1)
+Nodes (5): Branch node (new), Container node (new), Data inventory, PR node (new), Resources group node (new)
 
 ### Community 1082 - "Community 1082"
 Cohesion: 0.4
-Nodes (5): JSONL Session Files (use existing), `runtime.json` (extend existing schema), Specialist Event Files (new, lightweight), WebSocket Terminal (in-memory ring buffer), What Goes Where
+Nodes (5): Visual / data inventory by zone, Zone A — Issue header (always visible), Zone B — Agent context (selected session), Zone C — Conversation + composer (agent-selected), Zone C — Issue-selected mode (no agent selected)
 
 ### Community 1083 - "Community 1083"
 Cohesion: 0.4
-Nodes (5): Core Changes, Documentation, Error Handling & Validation, Files Modified, Testing
+Nodes (5): Implementation Sequence (4 Phases), Phase 1: Fix hooks (BLOCKS EVERYTHING), Phase 2: Structured event files + JSONL readers (can start after Phase 1), Phase 3: Remove high-risk tmux patterns (can start after Phase 1), Phase 4: Migrate remaining consumers (can start after Phase 1)
 
 ### Community 1084 - "Community 1084"
 Cohesion: 0.4
-Nodes (5): Can't delete workspace, code:bash (# Check for existing workspace), code:bash (# Via Panopticon (handles Docker cleanup)), Workspace creation fails, Workspace Issues
+Nodes (5): `AgentRuntimeState` (`src/lib/agents.ts:359`), code:typescript (export interface AgentRuntimeState {), code:typescript (// review-results.json), Interface Changes, Specialist Result Files (new)
 
 ### Community 1085 - "Community 1085"
 Cohesion: 0.4
-Nodes (4): code:javascript (server: {), Related Guides, Slow Vite/React Frontend with Multiple Workspaces, Troubleshooting
+Nodes (5): JSONL Session Files (use existing), `runtime.json` (extend existing schema), Specialist Event Files (new, lightweight), WebSocket Terminal (in-memory ring buffer), What Goes Where
 
 ### Community 1086 - "Community 1086"
 Cohesion: 0.4
-Nodes (5): 1. Loader contract tests, 2. Live-template smoke tests, 3. Caller-side tests, Testing prompts, Writing a new smoke test
+Nodes (5): Hook Extensions Required, Hook reliability (PAN-759), PostToolUse hook, SessionStart hook, Specialist hooks (new)
 
 ### Community 1087 - "Community 1087"
 Cohesion: 0.4
-Nodes (5): code:markdown (---), Fields, Frontmatter contract, `requires` vs `optional`, Unknown keys are an error
+Nodes (5): code:block1 (Agent → tmux pane → capture-pane → regex parsing → consumer), code:block2 (Agent → hooks → runtime.json ──┬──→ Dashboard (structured st), Data Flow: Today vs Target, Target (2 layers), Today (3 overlapping layers)
 
 ### Community 1088 - "Community 1088"
 Cohesion: 0.4
-Nodes (5): Adding a new template, Authoring workflow, code:typescript (import { renderPrompt } from './prompts.js';), Editing an existing template, Migrating a legacy ad-hoc prompt
+Nodes (5): Core Changes, Documentation, Error Handling & Validation, Files Modified, Testing
 
 ### Community 1089 - "Community 1089"
 Cohesion: 0.4
-Nodes (5): code:mustache ({{#PENDING_FEEDBACK_BLOCK}}), code:typescript (const pendingFeedbackBlock = ctx.pendingFeedback.length > 0), Composition pattern, Example: `resume-work.md`, When to use in-template conditionals vs pre-built blocks
+Nodes (5): Can't delete workspace, code:bash (# Check for existing workspace), code:bash (# Via Panopticon (handles Docker cleanup)), Workspace creation fails, Workspace Issues
 
 ### Community 1090 - "Community 1090"
 Cohesion: 0.4
-Nodes (5): code:bash (# Command history (if configured)), code:bash (# Traefik logs), Docker Logs (if using), Panopticon Commands, System Logs
+Nodes (4): code:javascript (server: {), Related Guides, Slow Vite/React Frontend with Multiple Workspaces, Troubleshooting
 
 ### Community 1091 - "Community 1091"
 Cohesion: 0.4
-Nodes (5): API Requests, code:bash (# If running in foreground, logs go to stdout), code:bash (# Filter API calls), Dashboard Logs, Server Logs
+Nodes (5): code:markdown (---), Fields, Frontmatter contract, `requires` vs `optional`, Unknown keys are an error
 
 ### Community 1092 - "Community 1092"
 Cohesion: 0.4
-Nodes (5): Clean Old Logs, code:bash (# Create log archive for an issue), code:bash (# Remove logs older than 7 days), Log Retention, Save Important Logs
+Nodes (5): Adding a new template, Authoring workflow, code:typescript (import { renderPrompt } from './prompts.js';), Editing an existing template, Migrating a legacy ad-hoc prompt
 
 ### Community 1093 - "Community 1093"
 Cohesion: 0.4
-Nodes (5): code:block15 (# Automatic logging), code:javascript (// Enable verbose logging), Configuring Log Output, Dashboard Logging, Enable tmux Logging
+Nodes (5): 1. Loader contract tests, 2. Live-template smoke tests, 3. Caller-side tests, Testing prompts, Writing a new smoke test
 
 ### Community 1094 - "Community 1094"
 Cohesion: 0.4
-Nodes (5): code:bash (rm .panopticon/knowledge-capture.json), code:bash (rm -rf .claude/skills/project-knowledge/), code:bash (rm -rf .claude/skills/knowledge-capture/), code:bash (# Edit ~/.claude/CLAUDE.md and remove the "AI Suggestion Pre), Reset / Clean Slate
+Nodes (5): code:mustache ({{#PENDING_FEEDBACK_BLOCK}}), code:typescript (const pendingFeedbackBlock = ctx.pendingFeedback.length > 0), Composition pattern, Example: `resume-work.md`, When to use in-template conditionals vs pre-built blocks
 
 ### Community 1095 - "Community 1095"
 Cohesion: 0.4
-Nodes (4): code:bash (pan memory search <query> [--project <id>] [--workspace <id>), Commands, Notes, Pan Memory
+Nodes (5): API Requests, code:bash (# If running in foreground, logs go to stdout), code:bash (# Filter API calls), Dashboard Logs, Server Logs
 
 ### Community 1096 - "Community 1096"
 Cohesion: 0.4
-Nodes (5): Breaking Changes, code:bash (bd version), code:bash (# Update Claude Code beads plugin), Minimum Version for Dependency Persistence, Version Requirements
+Nodes (5): Clean Old Logs, code:bash (# Create log archive for an issue), code:bash (# Remove logs older than 7 days), Log Retention, Save Important Logs
 
 ### Community 1097 - "Community 1097"
 Cohesion: 0.4
-Nodes (5): Basic Operations, Check Status, code:bash (# Check database path and daemon status), code:bash (# Find ready work (no blockers)), Find Work
+Nodes (5): code:block15 (# Automatic logging), code:javascript (// Enable verbose logging), Configuring Log Output, Dashboard Logging, Enable tmux Logging
 
 ### Community 1098 - "Community 1098"
 Cohesion: 0.4
-Nodes (5): code:bash (# Link discovered work (old way - two commands)), code:bash (# Label management (supports multiple IDs)), Dependencies, Dependencies & Labels, Labels
+Nodes (5): code:bash (# Command history (if configured)), code:bash (# Traefik logs), Docker Logs (if using), Panopticon Commands, System Logs
 
 ### Community 1099 - "Community 1099"
 Cohesion: 0.4
-Nodes (5): code:bash (# Single issue), code:bash (bd ready), Human-Readable Output, JSON Output (Recommended for Agents), Output Formats
+Nodes (5): code:bash (rm .panopticon/knowledge-capture.json), code:bash (rm -rf .claude/skills/project-knowledge/), code:bash (rm -rf .claude/skills/knowledge-capture/), code:bash (# Edit ~/.claude/CLAUDE.md and remove the "AI Suggestion Pre), Reset / Clean Slate
 
 ### Community 1100 - "Community 1100"
 Cohesion: 0.4
-Nodes (5): Background vs Foreground, Check Running Processes, code:bash (# Using pan), code:bash (# Foreground (default) - see logs in real time), Process Management
+Nodes (4): code:bash (pan memory search <query> [--project <id>] [--workspace <id>), Commands, Notes, Pan Memory
 
 ### Community 1101 - "Community 1101"
 Cohesion: 0.4
-Nodes (5): Brand Colors, Brand Identity, Brand Wordmark, code:tsx (<h1>), Logo
+Nodes (5): code:bash (bd version), code:bash (# Via Homebrew (macOS/Linux)), code:bash (pkill -f "bd daemon"  # Kill old daemon), code:bash (bd create "Test A" -t task), Resolution
 
 ### Community 1102 - "Community 1102"
 Cohesion: 0.4
-Nodes (5): Animation System, code:tsx (// Container: stagger children by 0.1s), Framer Motion (Auth/Splash), Tailwind Keyframes, Task Completion
+Nodes (5): Breaking Changes, code:bash (bd version), code:bash (# Update Claude Code beads plugin), Minimum Version for Dependency Persistence, Version Requirements
 
 ### Community 1103 - "Community 1103"
 Cohesion: 0.4
-Nodes (5): Breakpoints, code:tsx (// Page container), Common Patterns, Spacing & Layout, Spacing Scale
+Nodes (5): code:bash (# Single issue), code:bash (bd ready), Human-Readable Output, JSON Output (Recommended for Agents), Output Formats
 
 ### Community 1104 - "Community 1104"
 Cohesion: 0.4
-Nodes (5): code:block3 (text-foreground         Primary text), Font Stack, Text Colors, Type Scale, Typography
+Nodes (5): code:bash (# Link discovered work (old way - two commands)), code:bash (# Label management (supports multiple IDs)), Dependencies, Dependencies & Labels, Labels
 
 ### Community 1105 - "Community 1105"
 Cohesion: 0.4
-Nodes (4): Architecture Quality Gate, Structural integrity, Styling and theming, Type safety and syntax
+Nodes (5): Basic Operations, Check Status, code:bash (# Check database path and daemon status), code:bash (# Find ready work (no blockers)), Find Work
 
 ### Community 1106 - "Community 1106"
 Cohesion: 0.4
-Nodes (4): Additional Checks, Output Format, OWASP Top 10 Checklist, Security Review
+Nodes (5): Background vs Foreground, Check Running Processes, code:bash (# Using pan), code:bash (# Foreground (default) - see logs in real time), Process Management
 
 ### Community 1107 - "Community 1107"
 Cohesion: 0.4
-Nodes (5): code:block10 (myproject!23  # GitLab issue/MR), code:bash (# Authenticate with GitLab CLI), GitLab Issues, Issue Prefix, Setup
+Nodes (5): code:block3 (text-foreground         Primary text), Font Stack, Text Colors, Type Scale, Typography
 
 ### Community 1108 - "Community 1108"
 Cohesion: 0.4
-Nodes (5): code:yaml (projects:), code:markdown (<!-- In an agent's STATE.md -->), Mixed Tracker Pattern, Multi-Tracker Workflows, Syncing Between Trackers
+Nodes (5): Animation System, code:tsx (// Container: stagger children by 0.1s), Framer Motion (Auth/Splash), Tailwind Keyframes, Task Completion
 
 ### Community 1109 - "Community 1109"
 Cohesion: 0.4
-Nodes (5): code:yaml (projects:), Configuration Fields, Custom ID Patterns, Supported Formats, Unified Issue ID Parser
+Nodes (5): Brand Colors, Brand Identity, Brand Wordmark, code:tsx (<h1>), Logo
 
 ### Community 1110 - "Community 1110"
 Cohesion: 0.4
-Nodes (5): Certificate Generation, code:bash (# Generate certificates for localhost domains), code:bash (# Generate certificates for custom domain), For Custom Domains, Using mkcert
+Nodes (5): Breakpoints, code:tsx (// Page container), Common Patterns, Spacing & Layout, Spacing Scale
 
 ### Community 1111 - "Community 1111"
 Cohesion: 0.4
-Nodes (5): code:bash (pan up), code:bash (# Start Traefik container), Manually, Starting Traefik, Via Dashboard
+Nodes (4): Architecture Quality Gate, Structural integrity, Styling and theming, Type safety and syntax
 
 ### Community 1112 - "Community 1112"
 Cohesion: 0.4
-Nodes (5): code:yaml (# infra/.devcontainer-template/docker-compose.yml.template), code:bash (docker network create panopticon), Docker Compose Template, Network Setup, Workspace Container Setup
+Nodes (4): Additional Checks, Output Format, OWASP Top 10 Checklist, Security Review
 
 ### Community 1113 - "Community 1113"
 Cohesion: 0.4
-Nodes (5): 8. Navigation (Sidebar), code:block22 (Sidebar), code:block23 (Expanded width:  256px  (16rem)), Specs, Structure
+Nodes (5): code:block10 (myproject!23  # GitLab issue/MR), code:bash (# Authenticate with GitLab CLI), GitLab Issues, Issue Prefix, Setup
 
 ### Community 1114 - "Community 1114"
 Cohesion: 0.4
-Nodes (5): 13. Icons, code:block31 (Default:  18px (w-[18px] h-[18px])), code:block32 (Command Deck:  Compass), Nav Icons, Sizing
+Nodes (5): code:yaml (projects:), Configuration Fields, Custom ID Patterns, Supported Formats, Unified Issue ID Parser
 
 ### Community 1115 - "Community 1115"
 Cohesion: 0.4
-Nodes (4): Acceptance Criteria, Scope, Summary, What NOT to do
+Nodes (5): code:yaml (projects:), code:markdown (<!-- In an agent's STATE.md -->), Mixed Tracker Pattern, Multi-Tracker Workflows, Syncing Between Trackers
 
 ### Community 1116 - "Community 1116"
 Cohesion: 0.4
-Nodes (4): Auto-Clarity, Boundaries, Examples, Rules
+Nodes (5): Certificate Generation, code:bash (# Generate certificates for localhost domains), code:bash (# Generate certificates for custom domain), For Custom Domains, Using mkcert
 
 ### Community 1117 - "Community 1117"
+Cohesion: 0.4
+Nodes (5): code:yaml (# infra/.devcontainer-template/docker-compose.yml.template), code:bash (docker network create panopticon), Docker Compose Template, Network Setup, Workspace Container Setup
+
+### Community 1118 - "Community 1118"
+Cohesion: 0.4
+Nodes (5): code:bash (pan up), code:bash (# Start Traefik container), Manually, Starting Traefik, Via Dashboard
+
+### Community 1119 - "Community 1119"
+Cohesion: 0.4
+Nodes (5): 8. Navigation (Sidebar), code:block22 (Sidebar), code:block23 (Expanded width:  256px  (16rem)), Specs, Structure
+
+### Community 1120 - "Community 1120"
+Cohesion: 0.4
+Nodes (5): 13. Icons, code:block31 (Default:  18px (w-[18px] h-[18px])), code:block32 (Command Deck:  Compass), Nav Icons, Sizing
+
+### Community 1121 - "Community 1121"
+Cohesion: 0.4
+Nodes (4): Acceptance Criteria, Scope, Summary, What NOT to do
+
+### Community 1122 - "Community 1122"
+Cohesion: 0.4
+Nodes (4): Auto-Clarity, Boundaries, Examples, Rules
+
+### Community 1123 - "Community 1123"
 Cohesion: 0.5
 Nodes (3): client, content, mockExeca
 
-### Community 1118 - "Community 1118"
+### Community 1124 - "Community 1124"
 Cohesion: 0.5
 Nodes (3): mockGetVBriefACStatus, mockSyncBeadStatusToVBrief, result
 
-### Community 1119 - "Community 1119"
+### Community 1125 - "Community 1125"
 Cohesion: 0.5
 Nodes (3): { mockMessageAgent, mockResolveProjectFromIssue, mockGetReviewStatus, mockWriteFeedbackFile }, reviewDir, workspace
 
-### Community 1120 - "Community 1120"
+### Community 1126 - "Community 1126"
 Cohesion: 0.5
 Nodes (3): config, env, mockExistsSync
 
-### Community 1121 - "Community 1121"
+### Community 1127 - "Community 1127"
 Cohesion: 0.5
 Nodes (3): src, stripped, topLevelAwaits
 
-### Community 1123 - "Community 1123"
+### Community 1129 - "Community 1129"
 Cohesion: 0.67
-Nodes (4): appendBridgeLog(), handleUnixPost(), pushChannelNotification(), pushPermissionDecisionNotification()
-
-### Community 1126 - "Community 1126"
-Cohesion: 0.5
-Nodes (3): mockSystemHealth, pill, requests
-
-### Community 1127 - "Community 1127"
-Cohesion: 0.5
-Nodes (3): MOTION_CATALOG, MotionEntry, MotionEventType
-
-### Community 1128 - "Community 1128"
-Cohesion: 0.5
-Nodes (3): mockExecAsync, mockSpawn, program
+Nodes (3): execFile(), kCustom, mockExecFile
 
 ### Community 1130 - "Community 1130"
 Cohesion: 0.5
-Nodes (3): agentMocks, readlineMocks, written
-
-### Community 1131 - "Community 1131"
-Cohesion: 0.5
-Nodes (4): Beads Issue Tracker, code:bash (bd ready              # Find available work), Quick Reference, Rules
-
-### Community 1132 - "Community 1132"
-Cohesion: 0.5
-Nodes (4): Merge Agent Workflow, Review Agent Workflow, Specialist Agent Processing, Test Agent Workflow
+Nodes (3): agentDir, missing, discoverNewAgentIds()
 
 ### Community 1133 - "Community 1133"
 Cohesion: 0.5
-Nodes (4): Comparison, Cost Analysis, exe.dev Pricing, Recommended Setup
+Nodes (3): mockSystemHealth, pill, requests
 
 ### Community 1134 - "Community 1134"
 Cohesion: 0.5
-Nodes (4): Conversation Sharing, Default surface & terminal toggle, Host side, Viewer side
+Nodes (3): MOTION_CATALOG, MotionEntry, MotionEventType
 
 ### Community 1135 - "Community 1135"
 Cohesion: 0.5
-Nodes (4): code:ts (interface SharedEnvelope {), Peer connections and data channels, Scoped, versioned wire format, Transport & Wire Format
+Nodes (3): mockExecAsync, mockSpawn, program
 
 ### Community 1136 - "Community 1136"
 Cohesion: 0.5
-Nodes (3): Data Model, Host-side persistence, Signaling service
+Nodes (3): agentMocks, readlineMocks, written
 
 ### Community 1137 - "Community 1137"
 Cohesion: 0.5
-Nodes (4): CLI, Clients & Join Paths, Cold start, Dashboard
+Nodes (4): Beads Issue Tracker, code:bash (bd ready              # Find available work), Quick Reference, Rules
 
 ### Community 1138 - "Community 1138"
 Cohesion: 0.5
-Nodes (4): Access Control — Invite-Only, Controller actions, Defense in depth — the host gates content itself, The lobby
+Nodes (4): Merge Agent Workflow, Review Agent Workflow, Specialist Agent Processing, Test Agent Workflow
 
 ### Community 1139 - "Community 1139"
 Cohesion: 0.5
-Nodes (4): Component architecture, Existing components reused, Modified components, New components
+Nodes (4): code:block19 (~/.claude/skills/my-override/               ← WINS (personal), code:block20 (~/.claude/skills/my-override/               ← WINS (personal), code:block21 (workspace/.claude/skills/session-health/   ← MYN template ve), Precedence in Practice
 
 ### Community 1140 - "Community 1140"
 Cohesion: 0.5
-Nodes (4): Implementation phases, Phase 1: Core resource tree, Phase 2: Container actions, Phase 3: Data enrichment
+Nodes (4): Comparison, Cost Analysis, exe.dev Pricing, Recommended Setup
 
 ### Community 1141 - "Community 1141"
 Cohesion: 0.5
-Nodes (4): code:typescript (// Before error throw:), code:typescript (// Add debug logging:), code:typescript (// Improve error logging:), Task 4: Improve Error Context & Logging
+Nodes (4): Conversation Sharing, Default surface & terminal toggle, Host side, Viewer side
 
 ### Community 1142 - "Community 1142"
 Cohesion: 0.5
-Nodes (4): Integration Tests, Manual Testing, Testing Strategy, Unit Tests
+Nodes (4): CLI, Clients & Join Paths, Cold start, Dashboard
 
 ### Community 1143 - "Community 1143"
 Cohesion: 0.5
-Nodes (4): Phase 1: Core Fix (Immediate), Phase 2: Validation & Testing (Same PR), Phase 3: Integration & Documentation (Follow-up), Rollout Plan
+Nodes (4): Access Control — Invite-Only, Controller actions, Defense in depth — the host gates content itself, The lobby
 
 ### Community 1144 - "Community 1144"
 Cohesion: 0.5
-Nodes (4): code:typescript (return conditions.length > 0 ? conditions.join(' AND ') : ''), code:block3 (((ScheduleState != "Completed") AND (ScheduleState != "Accep), code:block4 ((((ScheduleState != "Completed") AND (ScheduleState != "Acce), Root Cause Analysis
+Nodes (3): Data Model, Host-side persistence, Signaling service
 
 ### Community 1145 - "Community 1145"
 Cohesion: 0.5
-Nodes (4): code:bash (# System info), Diagnostic Information, Getting Help, Resources
+Nodes (4): code:ts (interface SharedEnvelope {), Peer connections and data channels, Scoped, versioned wire format, Transport & Wire Format
 
 ### Community 1146 - "Community 1146"
 Cohesion: 0.5
-Nodes (3): Boundaries, Panopticon Review Agent, Responsibilities
+Nodes (4): Component architecture, Existing components reused, Modified components, New components
 
 ### Community 1147 - "Community 1147"
 Cohesion: 0.5
-Nodes (3): Boundaries, Panopticon Merge Agent, Responsibilities
+Nodes (4): Implementation phases, Phase 1: Core resource tree, Phase 2: Container actions, Phase 3: Data enrichment
 
 ### Community 1148 - "Community 1148"
 Cohesion: 0.5
-Nodes (3): Boundaries, Panopticon UAT Agent, Responsibilities
+Nodes (4): code:typescript (return conditions.length > 0 ? conditions.join(' AND ') : ''), code:block3 (((ScheduleState != "Completed") AND (ScheduleState != "Accep), code:block4 ((((ScheduleState != "Completed") AND (ScheduleState != "Acce), Root Cause Analysis
 
 ### Community 1149 - "Community 1149"
 Cohesion: 0.5
-Nodes (3): Boundaries, Panopticon Test Agent, Responsibilities
+Nodes (4): Phase 1: Core Fix (Immediate), Phase 2: Validation & Testing (Same PR), Phase 3: Integration & Documentation (Follow-up), Rollout Plan
 
 ### Community 1150 - "Community 1150"
 Cohesion: 0.5
-Nodes (3): Boundaries, Panopticon Inspect Agent, Responsibilities
+Nodes (4): Integration Tests, Manual Testing, Testing Strategy, Unit Tests
 
 ### Community 1151 - "Community 1151"
 Cohesion: 0.5
-Nodes (4): High-Confidence Triggers (Always Invoke), Low-Confidence Triggers (Check Config First), Medium-Confidence Triggers (Invoke After 2+ Occurrences), When to Trigger (Self-Assessment)
+Nodes (4): code:markdown (### Rally Troubleshooting), code:block15, code:block16 (This will log the actual WSAPI queries being sent.), Task 8: Update Documentation
 
 ### Community 1152 - "Community 1152"
 Cohesion: 0.5
-Nodes (3): pan approve — REMOVED, What to do instead, Why
+Nodes (4): code:bash (# System info), Diagnostic Information, Getting Help, Resources
 
 ### Community 1153 - "Community 1153"
 Cohesion: 0.5
-Nodes (4): code:block2 (After Compaction:), code:block3 (bd update issue-42 --notes "COMPLETED: User authentication -), code:block4 (bd update issue-42 --notes "Working on auth feature. Made so), Compaction Survival {#compaction-survival}
+Nodes (3): Boundaries, Panopticon Review Agent, Responsibilities
 
 ### Community 1154 - "Community 1154"
 Cohesion: 0.5
-Nodes (4): Advanced Features, Learn More, Next Steps, Productivity Tips
+Nodes (3): Boundaries, Panopticon Merge Agent, Responsibilities
 
 ### Community 1155 - "Community 1155"
 Cohesion: 0.5
-Nodes (4): Agent States, Service States, Status Interpretation, Workspace States
+Nodes (3): Boundaries, Panopticon UAT Agent, Responsibilities
 
 ### Community 1156 - "Community 1156"
 Cohesion: 0.5
-Nodes (4): Critical Issues, Healthy System, Needs Attention, Performance Indicators
+Nodes (3): Boundaries, Panopticon Test Agent, Responsibilities
 
 ### Community 1157 - "Community 1157"
 Cohesion: 0.5
-Nodes (3): Metadata schema, Stitch API reference, Technical mapping rules
+Nodes (3): Boundaries, Panopticon Inspect Agent, Responsibilities
 
 ### Community 1158 - "Community 1158"
 Cohesion: 0.5
-Nodes (4): Auto-Shutdown, code:bash (# Stop on user logout), Manual Triggers, On System Shutdown (systemd)
+Nodes (4): High-Confidence Triggers (Always Invoke), Low-Confidence Triggers (Check Config First), Medium-Confidence Triggers (Invoke After 2+ Occurrences), When to Trigger (Self-Assessment)
 
 ### Community 1159 - "Community 1159"
 Cohesion: 0.5
-Nodes (4): code:bash (pan down), Graceful Shutdown (default), Graceful vs Forceful Shutdown, Hung Shutdown
+Nodes (3): pan approve — REMOVED, What to do instead, Why
 
 ### Community 1160 - "Community 1160"
 Cohesion: 0.5
-Nodes (4): Best Practices, Performance, Resource Management, Security
+Nodes (4): code:block2 (After Compaction:), code:block3 (bd update issue-42 --notes "COMPLETED: User authentication -), code:block4 (bd update issue-42 --notes "Working on auth feature. Made so), Compaction Survival {#compaction-survival}
 
 ### Community 1161 - "Community 1161"
 Cohesion: 0.5
-Nodes (4): code:bash (docker ps | grep traefik), code:bash (docker logs panopticon-traefik), code:bash (ls ~/.panopticon/traefik/certs/), "Connection refused" on HTTPS
+Nodes (4): Advanced Features, Learn More, Next Steps, Productivity Tips
 
-### Community 1172 - "Community 1172"
-Cohesion: 0.67
-Nodes (3): Available MCP Tools, Recommended Workflow, TLDR: Token-Efficient Code Analysis
+### Community 1162 - "Community 1162"
+Cohesion: 0.5
+Nodes (4): Critical Issues, Healthy System, Needs Attention, Performance Indicators
 
-### Community 1173 - "Community 1173"
-Cohesion: 0.67
-Nodes (3): Best Practices, For Specialist Configuration, For Worker Agents
+### Community 1163 - "Community 1163"
+Cohesion: 0.5
+Nodes (4): Agent States, Service States, Status Interpretation, Workspace States
 
-### Community 1174 - "Community 1174"
-Cohesion: 0.67
-Nodes (3): code:block10 (pan sync), code:block11 (pan sync), What `pan sync` Does: Today vs End-State
+### Community 1164 - "Community 1164"
+Cohesion: 0.5
+Nodes (3): Metadata schema, Stitch API reference, Technical mapping rules
 
-### Community 1175 - "Community 1175"
-Cohesion: 0.67
-Nodes (3): code:json ({), code:json ({), Manifest Tracking
+### Community 1165 - "Community 1165"
+Cohesion: 0.5
+Nodes (4): code:bash (pan down), Graceful Shutdown (default), Graceful vs Forceful Shutdown, Hung Shutdown
 
-### Community 1176 - "Community 1176"
-Cohesion: 0.67
-Nodes (3): Dependencies & Sequencing, New native dependency, PAN-1249 — `src/lib/` Effect migration (in flight on `feature/pan-1249`)
+### Community 1166 - "Community 1166"
+Cohesion: 0.5
+Nodes (4): Auto-Shutdown, code:bash (# Stop on user logout), Manual Triggers, On System Shutdown (systemd)
 
-### Community 1177 - "Community 1177"
-Cohesion: 0.67
-Nodes (3): Host disconnect & reconnect, Link lifecycle, Link Lifecycle & Disconnect/Reconnect
+### Community 1167 - "Community 1167"
+Cohesion: 0.5
+Nodes (4): Best Practices, Performance, Resource Management, Security
 
 ### Community 1178 - "Community 1178"
 Cohesion: 0.67
-Nodes (3): code:bash (pan conversations embed                      # all enriched,), code:yaml (# config.yaml), Embeddings
+Nodes (3): Available MCP Tools, Recommended Workflow, TLDR: Token-Efficient Code Analysis
 
 ### Community 1179 - "Community 1179"
 Cohesion: 0.67
-Nodes (3): C.5 Update `phaseLabel` to show recovery state, code:typescript (const phaseLabel =), code:typescript (const phaseLabel =)
+Nodes (3): Best Practices, For Specialist Configuration, For Worker Agents
 
 ### Community 1180 - "Community 1180"
 Cohesion: 0.67
-Nodes (3): code:block1 (<Project: mind-your-now>), Problem, What the user wants
+Nodes (3): code:json ({), code:json ({), Manifest Tracking
 
 ### Community 1181 - "Community 1181"
 Cohesion: 0.67
-Nodes (3): code:typescript (export function validateRallyConfig(config: RallyConfig): {), code:typescript (private async pollRally(): Promise<void> {), Task 5: Add Configuration Validation
+Nodes (3): Host disconnect & reconnect, Link lifecycle, Link Lifecycle & Disconnect/Reconnect
+
+### Community 1182 - "Community 1182"
+Cohesion: 0.67
+Nodes (3): Dependencies & Sequencing, New native dependency, PAN-1249 — `src/lib/` Effect migration (in flight on `feature/pan-1249`)
+
+### Community 1183 - "Community 1183"
+Cohesion: 0.67
+Nodes (3): C.5 Update `phaseLabel` to show recovery state, code:typescript (const phaseLabel =), code:typescript (const phaseLabel =)
+
+### Community 1184 - "Community 1184"
+Cohesion: 0.67
+Nodes (3): code:block1 (<Project: mind-your-now>), Problem, What the user wants
 
 ### Community 1185 - "Community 1185"
 Cohesion: 0.67
+Nodes (3): code:typescript (export function validateRallyConfig(config: RallyConfig): {), code:typescript (private async pollRally(): Promise<void> {), Task 5: Add Configuration Validation
+
+### Community 1189 - "Community 1189"
+Cohesion: 0.67
 Nodes (3): code:bash (grep -A 20 "## AI Suggestion Preferences" ~/.claude/CLAUDE.m), code:markdown (## AI Suggestion Preferences), Step 0.5: Check User Preferences for Category Exclusions
 
-### Community 1186 - "Community 1186"
+### Community 1190 - "Community 1190"
 Cohesion: 0.67
 Nodes (3): code:block23 (Unblocking Workflow:), code:block24 (Situation: bd ready shows nothing), Unblocking Work {#unblocking}
 
 ## Knowledge Gaps
-- **13276 isolated node(s):** `__dirname`, `FIXTURES_DIR`, `TEMP_ROOT_DIR`, `__dirname`, `ROOT` (+13271 more)
+- **13279 isolated node(s):** `__dirname`, `FIXTURES_DIR`, `TEMP_ROOT_DIR`, `__dirname`, `ROOT` (+13274 more)
   These have ≤1 connection - possible missing edges or undocumented components.
 - **50 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `fetch` connect `Community 1` to `Community 2`, `Community 3`, `Community 5`, `Community 7`, `Community 11`, `Community 140`, `Community 12`, `Community 14`, `Community 13`, `Community 16`, `Community 17`, `Community 18`, `Community 276`, `Community 20`, `Community 22`, `Community 23`, `Community 24`, `Community 25`, `Community 152`, `Community 26`, `Community 157`, `Community 30`, `Community 44`, `Community 52`, `Community 53`, `Community 54`, `Community 187`, `Community 60`, `Community 63`, `Community 192`, `Community 66`, `Community 323`, `Community 324`, `Community 67`, `Community 197`, `Community 456`, `Community 205`, `Community 722`, `Community 725`, `Community 218`, `Community 92`, `Community 349`, `Community 350`, `Community 99`, `Community 231`, `Community 616`, `Community 497`, `Community 116`, `Community 248`, `Community 377`?**
-  _High betweenness centrality (0.056) - this node is a cross-community bridge._
-- **Why does `VBriefDocument` connect `Community 25` to `Community 97`, `Community 34`, `Community 66`, `Community 69`, `Community 38`, `Community 7`, `Community 425`, `Community 114`, `Community 19`, `Community 51`, `Community 150`, `Community 27`, `Community 30`?**
-  _High betweenness centrality (0.039) - this node is a cross-community bridge._
-- **Why does `FsError` connect `Community 287` to `Community 0`, `Community 128`, `Community 3`, `Community 262`, `Community 263`, `Community 6`, `Community 267`, `Community 140`, `Community 141`, `Community 17`, `Community 274`, `Community 403`, `Community 19`, `Community 406`, `Community 23`, `Community 29`, `Community 158`, `Community 30`, `Community 32`, `Community 33`, `Community 35`, `Community 168`, `Community 424`, `Community 48`, `Community 49`, `Community 53`, `Community 441`, `Community 187`, `Community 62`, `Community 193`, `Community 195`, `Community 68`, `Community 453`, `Community 455`, `Community 329`, `Community 202`, `Community 74`, `Community 76`, `Community 333`, `Community 204`, `Community 458`, `Community 470`, `Community 215`, `Community 90`, `Community 92`, `Community 348`, `Community 478`, `Community 98`, `Community 611`, `Community 228`, `Community 229`, `Community 238`, `Community 113`, `Community 114`, `Community 115`, `Community 374`, `Community 120`, `Community 249`, `Community 125`, `Community 639`?**
-  _High betweenness centrality (0.010) - this node is a cross-community bridge._
+- **Why does `fetch` connect `Community 0` to `Community 2`, `Community 3`, `Community 6`, `Community 7`, `Community 264`, `Community 9`, `Community 522`, `Community 12`, `Community 14`, `Community 16`, `Community 17`, `Community 18`, `Community 21`, `Community 279`, `Community 408`, `Community 25`, `Community 152`, `Community 155`, `Community 157`, `Community 31`, `Community 160`, `Community 42`, `Community 1067`, `Community 684`, `Community 44`, `Community 45`, `Community 46`, `Community 52`, `Community 55`, `Community 56`, `Community 442`, `Community 444`, `Community 191`, `Community 63`, `Community 193`, `Community 64`, `Community 196`, `Community 68`, `Community 71`, `Community 328`, `Community 73`, `Community 74`, `Community 81`, `Community 212`, `Community 88`, `Community 92`, `Community 94`, `Community 96`, `Community 100`, `Community 617`, `Community 233`, `Community 117`, `Community 382`?**
+  _High betweenness centrality (0.059) - this node is a cross-community bridge._
+- **Why does `VBriefDocument` connect `Community 31` to `Community 32`, `Community 33`, `Community 6`, `Community 41`, `Community 74`, `Community 11`, `Community 14`, `Community 306`, `Community 51`, `Community 210`, `Community 62`?**
+  _High betweenness centrality (0.038) - this node is a cross-community bridge._
+- **Why does `FsError` connect `Community 116` to `Community 640`, `Community 1`, `Community 4`, `Community 7`, `Community 11`, `Community 269`, `Community 270`, `Community 13`, `Community 14`, `Community 18`, `Community 402`, `Community 274`, `Community 24`, `Community 25`, `Community 26`, `Community 155`, `Community 156`, `Community 28`, `Community 162`, `Community 35`, `Community 421`, `Community 40`, `Community 41`, `Community 44`, `Community 173`, `Community 53`, `Community 182`, `Community 56`, `Community 441`, `Community 440`, `Community 191`, `Community 194`, `Community 66`, `Community 326`, `Community 327`, `Community 458`, `Community 459`, `Community 204`, `Community 205`, `Community 79`, `Community 337`, `Community 211`, `Community 83`, `Community 469`, `Community 86`, `Community 471`, `Community 91`, `Community 94`, `Community 96`, `Community 353`, `Community 99`, `Community 240`, `Community 497`, `Community 114`, `Community 115`, `Community 243`, `Community 126`, `Community 380`, `Community 254`?**
+  _High betweenness centrality (0.011) - this node is a cross-community bridge._
 - **Are the 198 inferred relationships involving `fetch` (e.g. with `main()` and `main()`) actually correct?**
   _`fetch` has 198 INFERRED edges - model-reasoned connections that need verification._
 - **What connects `__dirname`, `FIXTURES_DIR`, `TEMP_ROOT_DIR` to the rest of the system?**
-  _13276 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _13279 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.03 - nodes in this community are weakly interconnected._
-- **Should `Community 1` be split into smaller, more focused modules?**
   _Cohesion score 0.01 - nodes in this community are weakly interconnected._
+- **Should `Community 1` be split into smaller, more focused modules?**
+  _Cohesion score 0.03 - nodes in this community are weakly interconnected._

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1864,16 +1864,16 @@
     "hash": "830375906bcf28d3464e531dc45f1293"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-6/src/lib/cloister/review-monitor.ts": {
-    "mtime": 1779435519.8805175,
-    "hash": "09f5ca973a0e9b9990ec540b8a6645c3"
+    "mtime": 1779439452.4350717,
+    "hash": "e914c4a243b1053e352e8287ac46fe4e"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-6/src/lib/cloister/complexity.ts": {
     "mtime": 1779435519.875931,
     "hash": "de0836b619d4769cc1e545725b06de28"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-6/src/lib/cloister/review-agent.ts": {
-    "mtime": 1779435519.8797834,
-    "hash": "2e773ac85322f5189523ca80fe1afb49"
+    "mtime": 1779439452.3260682,
+    "hash": "955efe01614ab7342997687ebdfb6608"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-6/src/lib/cloister/specialist-logs.ts": {
     "mtime": 1779435519.881255,
@@ -1968,8 +1968,8 @@
     "hash": "5e4031125475e295cd5f9410da8ae536"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-6/src/lib/cloister/review-context.ts": {
-    "mtime": 1779435519.8805175,
-    "hash": "3062906ae8763ef2952ab352f87a8fb4"
+    "mtime": 1779439264.4776149,
+    "hash": "e1cd3a87bbf077f0b222ff39304bc02a"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-6/src/lib/cloister/session-rotation.ts": {
     "mtime": 1779435519.881046,
@@ -2016,8 +2016,8 @@
     "hash": "7106d633502680ae607749bdd636995a"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-6/src/lib/cloister/inspect-agent.ts": {
-    "mtime": 1779435519.878576,
-    "hash": "e73db0a7cd619a98ddd64b8ef1521327"
+    "mtime": 1779439294.3806407,
+    "hash": "73969939bf0a06f236c2fbd195a8da57"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-6/src/lib/cloister/__tests__/startup-recovery.test.ts": {
     "mtime": 1779435519.8750765,
@@ -2032,8 +2032,8 @@
     "hash": "f78ac855a3fffe403281c72c04d259fa"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-6/src/lib/cloister/__tests__/review-agent.test.ts": {
-    "mtime": 1779435519.8750765,
-    "hash": "3a6cdedfbb34f5d3447d195c63fc0d7a"
+    "mtime": 1779439319.304496,
+    "hash": "170b413421724e52c1b1cbe790118259"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-6/src/lib/cloister/__tests__/specialists-caveman.test.ts": {
     "mtime": 1779435519.8750765,
@@ -2044,12 +2044,12 @@
     "hash": "fa931ee4f0c823c9cfb534b87a2f0f24"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-6/src/lib/cloister/__tests__/review-monitor.test.ts": {
-    "mtime": 1779435519.8750765,
-    "hash": "dc71232e3438aebf69f4e813f6dbb8cb"
+    "mtime": 1779439413.3507276,
+    "hash": "c8db7faa2aeef4c756ea81844a0ad403"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-6/src/lib/cloister/__tests__/review-context.test.ts": {
-    "mtime": 1779435519.8750765,
-    "hash": "c760f56b3e2e58a14d91d3615e2a3134"
+    "mtime": 1779439343.5123274,
+    "hash": "88740bde7b44e965aa60618e576e22ad"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-6/src/lib/cloister/__tests__/deacon-stuck-skip.test.ts": {
     "mtime": 1779435519.8746493,
@@ -4672,8 +4672,8 @@
     "hash": "d870f476952205832caa54e7bb800618"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-6/src/dashboard/server/routes/agents.ts": {
-    "mtime": 1779435986.0210311,
-    "hash": "fa5cd1758070fe9fb5bd66fa726e72d2"
+    "mtime": 1779436214.3068392,
+    "hash": "1f7518266852e3144e3ac717b6ae25ca"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-6/src/dashboard/server/routes/events.ts": {
     "mtime": 1779435519.7742867,

--- a/src/lib/cloister/__tests__/review-agent.test.ts
+++ b/src/lib/cloister/__tests__/review-agent.test.ts
@@ -1,13 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Effect } from 'effect';
 
 const mocks = vi.hoisted(() => ({
   exec: vi.fn(),
   spawnRun: vi.fn(),
-  saveAgentStateAsync: vi.fn(),
-  getAgentStateAsync: vi.fn(),
-  listSessionNamesAsync: vi.fn(),
-  isPaneDeadAsync: vi.fn(),
-  killSessionAsync: vi.fn(),
+  saveAgentStateEffect: vi.fn(),
+  getAgentStateEffect: vi.fn(),
+  listSessionNamesAsyncEffect: vi.fn(),
+  isPaneDeadAsyncEffect: vi.fn(),
+  killSessionAsyncEffect: vi.fn(),
   emitActivityEntry: vi.fn(),
   getReviewStatus: vi.fn(),
   setReviewStatus: vi.fn(),
@@ -26,15 +27,15 @@ vi.mock('child_process', () => ({
 
 vi.mock('../../agents.js', () => ({
   spawnRun: mocks.spawnRun,
-  saveAgentStateAsync: mocks.saveAgentStateAsync,
-  getAgentStateAsync: mocks.getAgentStateAsync,
+  saveAgentStateEffect: mocks.saveAgentStateEffect,
+  getAgentStateEffect: mocks.getAgentStateEffect,
   messageAgent: vi.fn(),
 }));
 
 vi.mock('../../tmux.js', () => ({
-  listSessionNamesAsync: mocks.listSessionNamesAsync,
-  isPaneDeadAsync: mocks.isPaneDeadAsync,
-  killSessionAsync: mocks.killSessionAsync,
+  listSessionNamesAsyncEffect: mocks.listSessionNamesAsyncEffect,
+  isPaneDeadAsyncEffect: mocks.isPaneDeadAsyncEffect,
+  killSessionAsyncEffect: mocks.killSessionAsyncEffect,
 }));
 
 vi.mock('../../activity-logger.js', () => ({
@@ -97,9 +98,9 @@ describe('spawnReviewRoleForIssue', () => {
       status: 'running',
       startedAt: '2026-05-18T00:00:00.000Z',
     }));
-    mocks.saveAgentStateAsync.mockResolvedValue(undefined);
-    mocks.getAgentStateAsync.mockResolvedValue({ hostOverride: true });
-    mocks.listSessionNamesAsync.mockResolvedValue([]);
+    mocks.saveAgentStateEffect.mockReturnValue(Effect.void);
+    mocks.getAgentStateEffect.mockReturnValue(Effect.succeed({ hostOverride: true }));
+    mocks.listSessionNamesAsyncEffect.mockReturnValue(Effect.succeed([]));
     mocks.getReviewStatus.mockReturnValue(undefined);
     mocks.listStashes.mockResolvedValue([]);
     mocks.createNamedStash.mockResolvedValue(null);
@@ -116,7 +117,7 @@ describe('spawnReviewRoleForIssue', () => {
     });
 
     expect(result.success).toBe(true);
-    expect(mocks.getAgentStateAsync).toHaveBeenCalledWith('agent-pan-1194');
+    expect(mocks.getAgentStateEffect).toHaveBeenCalledWith('agent-pan-1194');
     expect(mocks.spawnRun).toHaveBeenCalledWith(
       'PAN-1194',
       'review',

--- a/src/lib/cloister/__tests__/review-context.test.ts
+++ b/src/lib/cloister/__tests__/review-context.test.ts
@@ -2,6 +2,7 @@
  * Tests for review-context.ts (PAN-1059)
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Effect } from 'effect';
 import { join } from 'path';
 
 // ── fs/promises mocks ──────────────────────────────────────────────────────
@@ -36,11 +37,10 @@ vi.mock('child_process', () => ({
 }));
 
 // ── vbrief / config mocks ──────────────────────────────────────────────────
+const mockReadPlanEffect = vi.hoisted(() => vi.fn());
 vi.mock('../../vbrief/io.js', () => ({
   findPlan: vi.fn(() => null),
-  readPlanAsync: vi.fn(async () => {
-    throw new Error('no plan');
-  }),
+  readPlanEffect: mockReadPlanEffect,
 }));
 vi.mock('../../vbrief/lifecycle-io.js', () => ({
   findVBriefByIssue: vi.fn(() => null),
@@ -69,6 +69,7 @@ describe('buildReviewContext', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockReadPlanEffect.mockReturnValue(Effect.fail(new Error('no plan')));
     mockExistsSync.mockImplementation((p: string) => p === workspace);
   });
 
@@ -168,6 +169,7 @@ describe('riskScore (via buildReviewContext file ranking)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockReadPlanEffect.mockReturnValue(Effect.fail(new Error('no plan')));
     mockExistsSync.mockImplementation((p: string) => p === workspace);
     mockExecAsync.mockRejectedValue(new Error('no git'));
   });

--- a/src/lib/cloister/__tests__/review-monitor.test.ts
+++ b/src/lib/cloister/__tests__/review-monitor.test.ts
@@ -2,6 +2,7 @@
  * Tests for review-monitor.ts (PAN-1059)
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Effect } from 'effect';
 import { join } from 'path';
 
 // ── fs/promises mock ───────────────────────────────────────────────────────
@@ -17,11 +18,11 @@ vi.mock('fs', () => ({
 }));
 
 // ── tmux mocks ─────────────────────────────────────────────────────────────
-const mockSessionExistsAsync = vi.fn(async () => false);
-const mockIsPaneDeadAsync = vi.fn(async () => true);
+const mockSessionExistsAsyncEffect = vi.fn();
+const mockIsPaneDeadAsyncEffect = vi.fn();
 vi.mock('../../tmux.js', () => ({
-  sessionExistsAsync: (...args: unknown[]) => mockSessionExistsAsync(...args),
-  isPaneDeadAsync: (...args: unknown[]) => mockIsPaneDeadAsync(...args),
+  sessionExistsAsyncEffect: (...args: unknown[]) => mockSessionExistsAsyncEffect(...args),
+  isPaneDeadAsyncEffect: (...args: unknown[]) => mockIsPaneDeadAsyncEffect(...args),
 }));
 
 import { waitForReviewerOutputs, reviewerOutputPath, REVIEW_SUB_ROLES } from '../review-monitor.js';
@@ -51,8 +52,8 @@ describe('waitForReviewerOutputs', () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     mockExistsSync.mockReturnValue(false);
-    mockSessionExistsAsync.mockResolvedValue(false);
-    mockIsPaneDeadAsync.mockResolvedValue(true);
+    mockSessionExistsAsyncEffect.mockReturnValue(Effect.succeed(false));
+    mockIsPaneDeadAsyncEffect.mockReturnValue(Effect.succeed(true));
   });
 
   afterEach(() => {
@@ -82,7 +83,7 @@ describe('waitForReviewerOutputs', () => {
 
   it('returns missing when session is dead and output file was never written', async () => {
     mockExistsSync.mockReturnValue(false);
-    mockIsPaneDeadAsync.mockResolvedValue(true);
+    mockIsPaneDeadAsyncEffect.mockReturnValue(Effect.succeed(true));
 
     const resultPromise = waitForReviewerOutputs({
       issueId: 'PAN-1059',
@@ -105,7 +106,7 @@ describe('waitForReviewerOutputs', () => {
     mockExistsSync.mockReturnValue(true);
     const oldMtime = Date.now() - 1000;
     mockStat.mockResolvedValue({ mtimeMs: oldMtime });
-    mockIsPaneDeadAsync.mockResolvedValue(true);
+    mockIsPaneDeadAsyncEffect.mockReturnValue(Effect.succeed(true));
 
     const resultPromise = waitForReviewerOutputs({
       issueId: 'PAN-1059',
@@ -136,7 +137,7 @@ describe('waitForReviewerOutputs', () => {
       // Return very old mtime on all calls so staleAfterMs is immediately exceeded
       return { mtimeMs: now - 20 * 60 * 1000 };
     });
-    mockIsPaneDeadAsync.mockResolvedValue(false); // sessions still alive
+    mockIsPaneDeadAsyncEffect.mockReturnValue(Effect.succeed(false)); // sessions still alive
 
     const resultPromise = waitForReviewerOutputs({
       issueId: 'PAN-1059',
@@ -167,7 +168,7 @@ describe('waitForReviewerOutputs', () => {
       if (path.endsWith('/performance.md')) return { mtimeMs: now - 1_000 };
       return { mtimeMs: now - 10 * 60 * 1000 };
     });
-    mockIsPaneDeadAsync.mockResolvedValue(true);
+    mockIsPaneDeadAsyncEffect.mockReturnValue(Effect.succeed(true));
 
     const resultPromise = waitForReviewerOutputs({
       issueId: 'PAN-1059',

--- a/src/lib/cloister/inspect-agent.ts
+++ b/src/lib/cloister/inspect-agent.ts
@@ -25,9 +25,9 @@ import { setReviewStatus } from '../review-status.js';
 import { withBdMutex } from '../bd-mutex.js';
 import { generateLauncherScript } from '../launcher-generator.js';
 import {
-  createSessionAsync,
-  killSessionAsync,
-  sessionExistsAsync,
+  createSessionAsyncEffect,
+  killSessionAsyncEffect,
+  sessionExistsAsyncEffect,
 } from '../tmux.js';
 import { loadConfig as loadYamlConfig, resolveModel } from '../config-yaml.js';
 import { bypassPrefixForAgentFlag } from '../claude-permissions.js';
@@ -164,9 +164,9 @@ export async function spawnInspectAgent(
   const tmuxSession = `inspect-${issueLower}-${beadSlug}`;
 
   try {
-    if (await sessionExistsAsync(tmuxSession)) {
+    if (await Effect.runPromise(sessionExistsAsyncEffect(tmuxSession))) {
       // Stale session left behind by a previous inspection run — clear it.
-      await killSessionAsync(tmuxSession).catch(() => {});
+      await Effect.runPromise(killSessionAsyncEffect(tmuxSession)).catch(() => {});
     }
 
     const prompt = await buildInspectPrompt(context);
@@ -231,12 +231,12 @@ export async function spawnInspectAgent(
       ...providerEnv,
     };
 
-    await createSessionAsync(
+    await Effect.runPromise(createSessionAsyncEffect(
       tmuxSession,
       context.workspace,
       `bash '${launcherScript}'`,
       { env: envForTmux },
-    );
+    ));
 
     saveAgentRuntimeState(tmuxSession, {
       state: 'active',

--- a/src/lib/cloister/review-agent.ts
+++ b/src/lib/cloister/review-agent.ts
@@ -44,7 +44,7 @@ import { mkdir, readFile, rm } from 'fs/promises';
 import { dirname, join } from 'path';
 import { promisify } from 'util';
 import { Effect } from 'effect';
-import { killSessionAsync, listSessionNamesAsync, isPaneDeadAsync } from '../tmux.js';
+import { killSessionAsyncEffect, listSessionNamesAsyncEffect, isPaneDeadAsyncEffect } from '../tmux.js';
 import { emitActivityEntry } from '../activity-logger.js';
 import { buildStashMessage, createNamedStash, dropStash, getNextReviewTempSequence, listStashes } from '../stashes.js';
 import { getReviewStatus, setReviewStatus } from '../review-status.js';
@@ -306,7 +306,7 @@ export async function spawnReviewSubRoleForIssue(opts: {
   allowHost?: boolean;
 }): Promise<{ success: boolean; message: string; error?: string; sessionId?: string }> {
   try {
-    const { saveAgentStateAsync, spawnRun } = await import('../agents.js');
+    const { saveAgentStateEffect, spawnRun } = await import('../agents.js');
     const cfg = loadYamlConfig().config;
     const outputPath = opts.outputPath ?? reviewerAgentOutputPath(opts.workspace, opts.runId, opts.subRole);
     const synthesisAgentId = opts.synthesisAgentId ?? `agent-${opts.issueId.toLowerCase()}-review`;
@@ -354,7 +354,7 @@ export async function spawnReviewSubRoleForIssue(opts: {
     run.reviewOutputPath = outputPath;
     run.reviewSynthesisAgentId = synthesisAgentId;
     run.reviewDeadlineAt = new Date(Date.now() + REVIEWER_TIMEOUT_MS).toISOString();
-    await saveAgentStateAsync(run);
+    await Effect.runPromise(saveAgentStateEffect(run));
     try {
       const { notifyPipeline } = await import('../pipeline-notifier.js');
       notifyPipeline({ type: 'reviewer_started', issueId: opts.issueId, role: opts.subRole, sessionName: run.id });
@@ -384,9 +384,9 @@ export async function spawnReviewRoleForIssue(
   // Force mode (human override from dashboard) kills the old session and
   // respawns so the review runs against current HEAD, not stale state.
   try {
-    const sessions = await listSessionNamesAsync();
+    const sessions = await Effect.runPromise(listSessionNamesAsyncEffect());
     if (sessions.includes(reviewSessionName)) {
-      const paneDead = await isPaneDeadAsync(reviewSessionName);
+      const paneDead = await Effect.runPromise(isPaneDeadAsyncEffect(reviewSessionName));
 
       // A synthesis agent that has finished its verdict does NOT terminate:
       // its role prompt tells it to "exit", but it runs `Bash(exit)` which
@@ -495,8 +495,8 @@ export async function spawnReviewRoleForIssue(
   }
 
   try {
-    const { spawnRun, saveAgentStateAsync, getAgentStateAsync } = await import('../agents.js');
-    const workAgentState = await getAgentStateAsync(`agent-${opts.issueId.toLowerCase()}`);
+    const { spawnRun, saveAgentStateEffect, getAgentStateEffect } = await import('../agents.js');
+    const workAgentState = await Effect.runPromise(getAgentStateEffect(`agent-${opts.issueId.toLowerCase()}`));
     const allowHost = opts.allowHost === true || workAgentState?.hostOverride === true;
 
     // Build the shared context manifest before spawning so all reviewers
@@ -543,7 +543,7 @@ export async function spawnReviewRoleForIssue(
     // PAN-1131. Sub-reviewers already persist this; the synthesis agent did not.
     run.reviewRunId = runId;
     try {
-      await saveAgentStateAsync(run);
+      await Effect.runPromise(saveAgentStateEffect(run));
     } catch (saveErr) {
       console.warn(`[review-agent] Could not persist reviewRunId on ${run.id}:`, saveErr);
     }
@@ -640,10 +640,10 @@ export async function killAllReviewerSessions(
 ): Promise<{ killed: string[]; failed: string[] }> {
   const killed: string[] = [];
   const failed: string[] = [];
-  let allSessions: string[];
+  let allSessions: readonly string[];
 
   try {
-    allSessions = await listSessionNamesAsync();
+    allSessions = await Effect.runPromise(listSessionNamesAsyncEffect());
   } catch (err) {
     console.warn('[review-agent] Failed to list tmux sessions during reviewer cleanup:', err instanceof Error ? err.message : String(err));
     return { killed, failed };
@@ -653,7 +653,7 @@ export async function killAllReviewerSessions(
   await Promise.all(
     sessionsToKill.map(async (sessionName) => {
       try {
-        await killSessionAsync(sessionName);
+        await Effect.runPromise(killSessionAsyncEffect(sessionName));
         console.log(`[review-agent] Killed reviewer session ${sessionName}`);
         killed.push(sessionName);
       } catch (err) {
@@ -685,9 +685,9 @@ export async function killAllReviewSessions(): Promise<{ killed: string[]; faile
   const killed: string[] = [];
   const failed: string[] = [];
 
-  let allSessions: string[];
+  let allSessions: readonly string[];
   try {
-    allSessions = await listSessionNamesAsync();
+    allSessions = await Effect.runPromise(listSessionNamesAsyncEffect());
   } catch (err) {
     console.warn('[review-agent] Failed to list tmux sessions during review cleanup:', err instanceof Error ? err.message : String(err));
     return { killed, failed };
@@ -710,7 +710,7 @@ export async function killAllReviewSessions(): Promise<{ killed: string[]; faile
   await Promise.all(
     sessionsToKill.map(async (sessionName) => {
       try {
-        await killSessionAsync(sessionName);
+        await Effect.runPromise(killSessionAsyncEffect(sessionName));
         console.log(`[review-agent] Killed review session ${sessionName}`);
         killed.push(sessionName);
       } catch (err) {

--- a/src/lib/cloister/review-context.ts
+++ b/src/lib/cloister/review-context.ts
@@ -14,7 +14,7 @@ import { join } from 'path';
 import { promisify } from 'util';
 import { Effect } from 'effect';
 import { PAN_DIRNAME } from '../pan-dir/types.js';
-import { findPlan, readPlanAsync } from '../vbrief/io.js';
+import { findPlan, readPlanEffect } from '../vbrief/io.js';
 import { findVBriefByIssue } from '../vbrief/lifecycle-io.js';
 import { getDevrootPath } from '../config.js';
 import { FsError } from '../errors.js';
@@ -191,7 +191,7 @@ async function extractAcceptanceCriteria(workspace: string, issueId: string): Pr
   const planPath = findPlan(workspace);
   if (planPath) {
     try {
-      const doc = await readPlanAsync(planPath);
+      const doc = await Effect.runPromise(readPlanEffect(planPath));
       return flattenAC(doc);
     } catch {
       // Fall through to lifecycle lookup

--- a/src/lib/cloister/review-monitor.ts
+++ b/src/lib/cloister/review-monitor.ts
@@ -17,7 +17,7 @@ import { stat } from 'fs/promises';
 import { join } from 'path';
 import { Effect, Schedule, Duration } from 'effect';
 import { PAN_DIRNAME } from '../pan-dir/types.js';
-import { sessionExistsAsync, isPaneDeadAsync } from '../tmux.js';
+import { sessionExistsAsyncEffect, isPaneDeadAsyncEffect } from '../tmux.js';
 
 export type ReviewSubRole = 'security' | 'correctness' | 'performance' | 'requirements';
 
@@ -119,7 +119,7 @@ export async function waitForReviewerOutputs(
 
       // Check if the tmux session is dead
       try {
-        const dead = await isPaneDeadAsync(s.sessionId);
+        const dead = await Effect.runPromise(isPaneDeadAsyncEffect(s.sessionId));
         if (dead) {
           s.settled = true;
           if (!existsSync(s.outputPath)) {
@@ -132,7 +132,7 @@ export async function waitForReviewerOutputs(
         }
       } catch {
         // Session may not exist
-        const exists = await sessionExistsAsync(s.sessionId);
+        const exists = await Effect.runPromise(sessionExistsAsyncEffect(s.sessionId));
         if (!exists) {
           s.settled = true;
           if (!existsSync(s.outputPath)) {
@@ -231,10 +231,10 @@ export const waitForReviewerOutputsEffect = (
           }
         }
 
-        const dead = yield* Effect.tryPromise({
-          try: () => isPaneDeadAsync(s.sessionId),
-          catch: () => null as boolean | null,
-        }).pipe(Effect.orElseSucceed(() => null));
+        const dead = yield* isPaneDeadAsyncEffect(s.sessionId).pipe(
+          Effect.map((value): boolean | null => value),
+          Effect.catch(() => Effect.succeed(null)),
+        );
 
         if (dead === true) {
           s.settled = true;
@@ -245,10 +245,9 @@ export const waitForReviewerOutputsEffect = (
           }
           continue;
         } else if (dead === null) {
-          const exists = yield* Effect.tryPromise({
-            try: () => sessionExistsAsync(s.sessionId),
-            catch: () => true,
-          }).pipe(Effect.orElseSucceed(() => true));
+          const exists = yield* sessionExistsAsyncEffect(s.sessionId).pipe(
+            Effect.catch(() => Effect.succeed(true)),
+          );
           if (!exists) {
             s.settled = true;
             if (!existsSync(s.outputPath)) s.stalledAt = now;


### PR DESCRIPTION
## Summary
- Replaces cloister review tmux, agent-state, and vBRIEF Promise helper calls with Effect siblings.
- Updates review-agent, review-context, and review-monitor tests to mock Effect-returning helpers.
- Refreshes graphify artifacts after the code migration.

## Test plan
- [x] npm run typecheck
- [x] npm run lint
- [x] npm test -- src/lib/cloister/__tests__/review-agent.test.ts src/lib/cloister/__tests__/review-context.test.ts src/lib/cloister/__tests__/review-monitor.test.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)