### PR TITLE
Migrate polling and review DB off Async

### DIFF
--- a/src/dashboard/server/services/__tests__/agent-output-service.test.ts
+++ b/src/dashboard/server/services/__tests__/agent-output-service.test.ts
@@ -7,6 +7,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Effect } from 'effect'
+import type { AgentState } from '../../../../lib/agents.js'
 
 // ─── Module mocks ─────────────────────────────────────────────────────────────
 
@@ -18,11 +20,11 @@ vi.mock('../../event-store.js', () => ({
 }))
 
 vi.mock('../../../../lib/tmux.js', () => ({
-  capturePaneAsync: vi.fn(),
+  capturePaneAsyncEffect: vi.fn(),
 }))
 
 vi.mock('../../../../lib/agents.js', () => ({
-  listRunningAgentsAsync: vi.fn(),
+  listRunningAgentsEffect: vi.fn(),
 }))
 
 vi.mock('node:fs/promises', () => ({
@@ -38,11 +40,13 @@ import {
   startAgentOutputService,
   stopAgentOutputService,
 } from '../agent-output-service.js'
-import { capturePaneAsync } from '../../../../lib/tmux.js'
-import { listRunningAgentsAsync } from '../../../../lib/agents.js'
+import { capturePaneAsyncEffect } from '../../../../lib/tmux.js'
+import { listRunningAgentsEffect } from '../../../../lib/agents.js'
 
-const mockCapturePaneAsync = vi.mocked(capturePaneAsync)
-const mockListRunningAgentsAsync = vi.mocked(listRunningAgentsAsync)
+type RunningAgent = AgentState & { tmuxActive: boolean }
+
+const mockCapturePaneEffect = vi.mocked(capturePaneAsyncEffect)
+const mockListRunningAgentsEffect = vi.mocked(listRunningAgentsEffect)
 
 // ─── diffLines tests ───────────────────────────────────────────────────────────
 
@@ -86,8 +90,8 @@ describe('AgentOutputService', () => {
   beforeEach(() => {
     stopAgentOutputService()
     mockAppendAsync.mockClear()
-    mockCapturePaneAsync.mockClear()
-    mockListRunningAgentsAsync.mockClear()
+    mockCapturePaneEffect.mockClear()
+    mockListRunningAgentsEffect.mockClear()
   })
 
   afterEach(() => {
@@ -95,12 +99,12 @@ describe('AgentOutputService', () => {
   })
 
   it('emits agent.output_received when a running agent produces new lines', async () => {
-    mockListRunningAgentsAsync.mockResolvedValue([
-      { id: 'agent-pan-test', issueId: 'PAN-TEST', tmuxActive: true } as unknown as Awaited<ReturnType<typeof listRunningAgentsAsync>>[number],
-    ])
-    mockCapturePaneAsync
-      .mockResolvedValueOnce('boot\nworking on PAN-TEST')
-      .mockResolvedValueOnce('boot\nworking on PAN-TEST\nnew line')
+    mockListRunningAgentsEffect.mockReturnValue(Effect.succeed([
+      { id: 'agent-pan-test', issueId: 'PAN-TEST', tmuxActive: true } as RunningAgent,
+    ]))
+    mockCapturePaneEffect
+      .mockReturnValueOnce(Effect.succeed('boot\nworking on PAN-TEST'))
+      .mockReturnValueOnce(Effect.succeed('boot\nworking on PAN-TEST\nnew line'))
 
     const state = { timer: null, lastOutput: new Map<string, string>() }
 
@@ -127,10 +131,10 @@ describe('AgentOutputService', () => {
   })
 
   it('does not emit when output is unchanged', async () => {
-    mockListRunningAgentsAsync.mockResolvedValue([
-      { id: 'agent-pan-test', issueId: 'PAN-TEST', tmuxActive: true } as unknown as Awaited<ReturnType<typeof listRunningAgentsAsync>>[number],
-    ])
-    mockCapturePaneAsync.mockResolvedValue('same output')
+    mockListRunningAgentsEffect.mockReturnValue(Effect.succeed([
+      { id: 'agent-pan-test', issueId: 'PAN-TEST', tmuxActive: true } as RunningAgent,
+    ]))
+    mockCapturePaneEffect.mockReturnValue(Effect.succeed('same output'))
 
     const state = { timer: null, lastOutput: new Map<string, string>() }
 
@@ -143,10 +147,10 @@ describe('AgentOutputService', () => {
   })
 
   it('does not emit for agents without tmuxActive', async () => {
-    mockListRunningAgentsAsync.mockResolvedValue([
-      { id: 'agent-pan-test', issueId: 'PAN-TEST', tmuxActive: false } as unknown as Awaited<ReturnType<typeof listRunningAgentsAsync>>[number],
-    ])
-    mockCapturePaneAsync.mockResolvedValue('some output')
+    mockListRunningAgentsEffect.mockReturnValue(Effect.succeed([
+      { id: 'agent-pan-test', issueId: 'PAN-TEST', tmuxActive: false } as RunningAgent,
+    ]))
+    mockCapturePaneEffect.mockReturnValue(Effect.succeed('some output'))
 
     const state = { timer: null, lastOutput: new Map<string, string>() }
 
@@ -155,13 +159,13 @@ describe('AgentOutputService', () => {
   })
 
   it('cleans up state for stopped agents', async () => {
-    mockListRunningAgentsAsync
-      .mockResolvedValueOnce([
-        { id: 'agent-pan-test', issueId: 'PAN-TEST', tmuxActive: true } as unknown as Awaited<ReturnType<typeof listRunningAgentsAsync>>[number],
-      ])
-      .mockResolvedValueOnce([])
+    mockListRunningAgentsEffect
+      .mockReturnValueOnce(Effect.succeed([
+        { id: 'agent-pan-test', issueId: 'PAN-TEST', tmuxActive: true } as RunningAgent,
+      ]))
+      .mockReturnValueOnce(Effect.succeed([]))
 
-    mockCapturePaneAsync.mockResolvedValue('output')
+    mockCapturePaneEffect.mockReturnValue(Effect.succeed('output'))
 
     const state = { timer: null, lastOutput: new Map<string, string>() }
 
@@ -173,15 +177,15 @@ describe('AgentOutputService', () => {
     await pollOnce(state)
     // Agent stopped, state cleaned up
     expect(state.lastOutput.has('agent-pan-test')).toBe(false)
-    expect(mockCapturePaneAsync).toHaveBeenCalledTimes(1)
+    expect(mockCapturePaneEffect).toHaveBeenCalledTimes(1)
     expect(mockAppendAsync).not.toHaveBeenCalled()
   })
 
   it('skips Session not found output', async () => {
-    mockListRunningAgentsAsync.mockResolvedValue([
-      { id: 'agent-pan-test', issueId: 'PAN-TEST', tmuxActive: true } as unknown as Awaited<ReturnType<typeof listRunningAgentsAsync>>[number],
-    ])
-    mockCapturePaneAsync.mockResolvedValue('Session not found')
+    mockListRunningAgentsEffect.mockReturnValue(Effect.succeed([
+      { id: 'agent-pan-test', issueId: 'PAN-TEST', tmuxActive: true } as RunningAgent,
+    ]))
+    mockCapturePaneEffect.mockReturnValue(Effect.succeed('Session not found'))
 
     const state = { timer: null, lastOutput: new Map<string, string>() }
 

--- a/src/dashboard/server/services/__tests__/running-agents-cache.test.ts
+++ b/src/dashboard/server/services/__tests__/running-agents-cache.test.ts
@@ -1,9 +1,11 @@
+import { Effect } from 'effect';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { clearRunningAgentsCache, getCachedRunningAgents } from '../running-agents-cache.js';
-import type { listRunningAgentsAsync } from '../../../../lib/agents.js';
+import type { AgentState } from '../../../../lib/agents.js';
 
-type ListAgentsFn = typeof listRunningAgentsAsync;
+type RunningAgent = AgentState & { tmuxActive: boolean };
+type ListAgentsFn = () => Effect.Effect<RunningAgent[], unknown>;
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -18,15 +20,15 @@ afterEach(() => {
 
 describe('running-agents-cache', () => {
   it('reuses the global cached agents list within the ttl', async () => {
-    const firstAgents = [{ id: 'agent-1', issueId: 'PAN-895' }];
-    const secondAgents = [{ id: 'agent-2', issueId: 'PAN-999' }];
+    const firstAgents = [{ id: 'agent-1', issueId: 'PAN-895' } as RunningAgent];
+    const secondAgents = [{ id: 'agent-2', issueId: 'PAN-999' } as RunningAgent];
     const listAgents = vi
-      .fn<() => Promise<Array<{ id: string; issueId: string }>>>()
-      .mockResolvedValueOnce(firstAgents)
-      .mockResolvedValueOnce(secondAgents);
+      .fn<ListAgentsFn>()
+      .mockReturnValueOnce(Effect.succeed(firstAgents))
+      .mockReturnValueOnce(Effect.succeed(secondAgents));
 
-    const first = await getCachedRunningAgents(listAgents as unknown as ListAgentsFn);
-    const second = await getCachedRunningAgents(listAgents as unknown as ListAgentsFn);
+    const first = await getCachedRunningAgents(listAgents);
+    const second = await getCachedRunningAgents(listAgents);
 
     expect(first).toBe(firstAgents);
     expect(second).toBe(firstAgents);
@@ -34,35 +36,33 @@ describe('running-agents-cache', () => {
   });
 
   it('refreshes the cache after the ttl expires', async () => {
-    const firstAgents = [{ id: 'agent-1', issueId: 'PAN-895' }];
-    const secondAgents = [{ id: 'agent-2', issueId: 'PAN-895' }];
+    const firstAgents = [{ id: 'agent-1', issueId: 'PAN-895' } as RunningAgent];
+    const secondAgents = [{ id: 'agent-2', issueId: 'PAN-895' } as RunningAgent];
     const listAgents = vi
-      .fn<() => Promise<Array<{ id: string; issueId: string }>>>()
-      .mockResolvedValueOnce(firstAgents)
-      .mockResolvedValueOnce(secondAgents);
+      .fn<ListAgentsFn>()
+      .mockReturnValueOnce(Effect.succeed(firstAgents))
+      .mockReturnValueOnce(Effect.succeed(secondAgents));
 
-    await getCachedRunningAgents(listAgents as unknown as ListAgentsFn);
+    await getCachedRunningAgents(listAgents);
     await vi.advanceTimersByTimeAsync(3_001);
-    const refreshed = await getCachedRunningAgents(listAgents as unknown as ListAgentsFn);
+    const refreshed = await getCachedRunningAgents(listAgents);
 
     expect(refreshed).toBe(secondAgents);
     expect(listAgents).toHaveBeenCalledTimes(2);
   });
 
   it('coalesces concurrent cache misses into one list call', async () => {
-    let resolveAgents: ((value: Array<{ id: string; issueId: string }>) => void) | undefined;
-    const listAgents = vi.fn(
-      () => new Promise<Array<{ id: string; issueId: string }>>((resolve) => {
-        resolveAgents = resolve;
-      }),
-    );
+    let resolveAgents: ((value: RunningAgent[]) => void) | undefined;
+    const listAgents = vi.fn<ListAgentsFn>(() => Effect.promise(() => new Promise<RunningAgent[]>((resolve) => {
+      resolveAgents = resolve;
+    })));
 
-    const firstPromise = getCachedRunningAgents(listAgents as unknown as ListAgentsFn);
-    const secondPromise = getCachedRunningAgents(listAgents as unknown as ListAgentsFn);
+    const firstPromise = getCachedRunningAgents(listAgents);
+    const secondPromise = getCachedRunningAgents(listAgents);
 
     expect(listAgents).toHaveBeenCalledTimes(1);
 
-    resolveAgents?.([{ id: 'agent-1', issueId: 'PAN-895' }]);
+    resolveAgents?.([{ id: 'agent-1', issueId: 'PAN-895' } as RunningAgent]);
 
     const [first, second] = await Promise.all([firstPromise, secondPromise]);
     expect(first).toEqual([{ id: 'agent-1', issueId: 'PAN-895' }]);

--- a/src/dashboard/server/services/agent-enrichment-service.ts
+++ b/src/dashboard/server/services/agent-enrichment-service.ts
@@ -12,15 +12,18 @@
  * restored here via the event-driven projection pipeline.
  */
 
-import { listRunningAgentsAsync } from '../../../lib/agents.js'
+import { listRunningAgentsEffect, type AgentState } from '../../../lib/agents.js'
 import { computeAgentEnrichment, getAgentJsonlMtime, type AgentEnrichment } from '../../../lib/agent-enrichment.js'
 import { getReviewStatus } from '../../../lib/review-status.js'
 import { withConcurrencyLimit } from '../../../lib/concurrency.js'
 import { getEventStore } from '../event-store.js'
 import type { AgentEnrichmentChangedEvent, AgentCreatedEvent, AgentStatusChangedEvent } from '@panctl/contracts'
+import { Effect } from 'effect'
 import { toAgentStatus, toRole, toAgentResolution } from '../read-model.js'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
+
+type RunningAgent = AgentState & { tmuxActive: boolean }
 
 interface EnrichmentServiceState {
   timer: ReturnType<typeof setInterval> | null
@@ -51,9 +54,9 @@ function enrichmentChanged(prev: AgentEnrichment | undefined, next: AgentEnrichm
 // ─── Poller ───────────────────────────────────────────────────────────────────
 
 async function pollOnce(state: EnrichmentServiceState): Promise<void> {
-  let runningAgents: Awaited<ReturnType<typeof listRunningAgentsAsync>>
+  let runningAgents: RunningAgent[]
   try {
-    runningAgents = await listRunningAgentsAsync()
+    runningAgents = await Effect.runPromise(listRunningAgentsEffect())
   } catch {
     return
   }

--- a/src/dashboard/server/services/agent-output-service.ts
+++ b/src/dashboard/server/services/agent-output-service.ts
@@ -10,16 +10,19 @@
  * server code was emitting the events.
  */
 
-import { listRunningAgentsAsync } from '../../../lib/agents.js'
-import { capturePaneAsync } from '../../../lib/tmux.js'
+import { listRunningAgentsEffect, type AgentState } from '../../../lib/agents.js'
+import { capturePaneAsyncEffect } from '../../../lib/tmux.js'
 import { withConcurrencyLimit } from '../../../lib/concurrency.js'
 import { getEventStore } from '../event-store.js'
 import type { AgentOutputReceivedEvent } from '@panctl/contracts'
+import { Effect } from 'effect'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
+
+type RunningAgent = AgentState & { tmuxActive: boolean }
 
 interface AgentOutputServiceState {
   timer: ReturnType<typeof setInterval> | null
@@ -64,9 +67,9 @@ export function diffLines(previous: string[], current: string[]): string[] {
 // ─── Poller ───────────────────────────────────────────────────────────────────
 
 export async function pollOnce(state: AgentOutputServiceState): Promise<void> {
-  let runningAgents: Awaited<ReturnType<typeof listRunningAgentsAsync>>
+  let runningAgents: RunningAgent[]
   try {
-    runningAgents = await listRunningAgentsAsync()
+    runningAgents = await Effect.runPromise(listRunningAgentsEffect())
   } catch {
     return
   }
@@ -90,10 +93,12 @@ export async function pollOnce(state: AgentOutputServiceState): Promise<void> {
           const { getRemoteAgentOutput } = await import('../../../lib/remote/remote-agents.js')
           stdout = await getRemoteAgentOutput(agentId, remoteState.vmName, 50)
         } else {
-          stdout = await capturePaneAsync(agentId, 50)
+          stdout = await Effect.runPromise(capturePaneAsyncEffect(agentId, 50))
         }
       } catch {
-        stdout = await capturePaneAsync(agentId, 50).catch(() => '')
+        stdout = await Effect.runPromise(
+          capturePaneAsyncEffect(agentId, 50).pipe(Effect.catchAll(() => Effect.succeed(''))),
+        )
       }
 
       if (!stdout || stdout.trim() === '' || stdout.trim() === 'Session not found') {

--- a/src/dashboard/server/services/running-agents-cache.ts
+++ b/src/dashboard/server/services/running-agents-cache.ts
@@ -1,14 +1,18 @@
-import { listRunningAgentsAsync } from '../../../lib/agents.js';
+import { Effect } from 'effect';
+import { listRunningAgentsEffect, type AgentState } from '../../../lib/agents.js';
+
+type RunningAgent = AgentState & { tmuxActive: boolean };
+type ListRunningAgentsEffect = () => Effect.Effect<RunningAgent[], unknown>;
 
 const RUNNING_AGENTS_CACHE_TTL_MS = 3_000;
 const GLOBAL_RUNNING_AGENTS_CACHE_KEY = '__all_agents__';
 
 const runningAgentsCache = new Map<string, {
   timestamp: number;
-  agents: Awaited<ReturnType<typeof listRunningAgentsAsync>>;
+  agents: RunningAgent[];
 }>();
 let inflightRunningAgents:
-  | Promise<Awaited<ReturnType<typeof listRunningAgentsAsync>>>
+  | Promise<RunningAgent[]>
   | null = null;
 
 function sweepExpired<T extends { timestamp: number }>(cache: Map<string, T>, ttlMs: number): void {
@@ -21,8 +25,8 @@ function sweepExpired<T extends { timestamp: number }>(cache: Map<string, T>, tt
 }
 
 export async function getCachedRunningAgents(
-  listAgents: typeof listRunningAgentsAsync = listRunningAgentsAsync,
-): Promise<Awaited<ReturnType<typeof listRunningAgentsAsync>>> {
+  listAgents: ListRunningAgentsEffect = listRunningAgentsEffect,
+): Promise<RunningAgent[]> {
   sweepExpired(runningAgentsCache, RUNNING_AGENTS_CACHE_TTL_MS);
   const cached = runningAgentsCache.get(GLOBAL_RUNNING_AGENTS_CACHE_KEY);
   if (cached && cached.timestamp > Date.now() - RUNNING_AGENTS_CACHE_TTL_MS) {
@@ -30,7 +34,7 @@ export async function getCachedRunningAgents(
   }
 
   if (!inflightRunningAgents) {
-    inflightRunningAgents = listAgents().then((agents) => {
+    inflightRunningAgents = Effect.runPromise(listAgents()).then((agents) => {
       runningAgentsCache.set(GLOBAL_RUNNING_AGENTS_CACHE_KEY, {
         timestamp: Date.now(),
         agents,

--- a/src/lib/database/review-status-db.ts
+++ b/src/lib/database/review-status-db.ts
@@ -13,7 +13,7 @@ import { normalizeReviewStatus } from '../review-status-normalize.js';
 
 /**
  * PAN-1249: Local typed error for SQLite failures against review_status.
- * Used by the *Async wrappers; sync functions still throw at the boundary.
+ * Used by the Effect wrappers; sync functions still throw at the boundary.
  * Full conversion to @effect/sql-sqlite-bun is deferred to PAN-447.
  */
 export class DatabaseError extends Data.TaggedError('DatabaseError')<{
@@ -151,16 +151,12 @@ export function deleteReviewStatus(issueId: string): void {
   db.prepare('DELETE FROM review_status WHERE issue_id = ?').run(issueId);
 }
 
-// ============== Async wrappers (dashboard-reachable code) ==============
+// ============== Effect wrappers (dashboard-reachable code) ==============
 // better-sqlite3 is synchronous. These wrappers defer execution via
 // setImmediate so the Node event loop can process other I/O (HTTP,
 // WebSocket, terminal) between SQLite operations. This satisfies the
 // "No Blocking Calls" dashboard rule (PAN-70 / PAN-446) for the
 // webhook ingestion path.
-//
-// PAN-1249: internally implemented with Effect.async/Effect.try so the
-// failure mode is typed (DatabaseError). The Promise return type is kept
-// to satisfy existing callers in src/lib/review-status.ts.
 
 export const upsertReviewStatusEffect = (
   status: ReviewStatus,
@@ -196,35 +192,6 @@ export const getReviewStatusFromDbEffect = (
       }),
     catch: (cause) => new DatabaseError({ operation: 'getReviewStatusFromDbEffect', cause }),
   });
-
-export function upsertReviewStatusAsync(status: ReviewStatus): Promise<void> {
-  const program = Effect.tryPromise({
-    try: () =>
-      new Promise<void>((resolve, reject) => {
-        setImmediate(() => {
-          try {
-            upsertReviewStatus(status);
-            resolve();
-          } catch (err) {
-            reject(err);
-          }
-        });
-      }),
-    catch: (cause) => new DatabaseError({ operation: 'upsertReviewStatusAsync', cause }),
-  });
-  return Effect.runPromise(program);
-}
-
-export function getReviewStatusFromDbAsync(issueId: string): Promise<ReviewStatus | null> {
-  const program = Effect.promise<ReviewStatus | null>(() =>
-    new Promise((resolve) => {
-      setImmediate(() => {
-        resolve(getReviewStatusFromDb(issueId));
-      });
-    }),
-  );
-  return Effect.runPromise(program);
-}
 
 // ============== Read operations ==============
 

--- a/src/lib/review-status.ts
+++ b/src/lib/review-status.ts
@@ -16,8 +16,7 @@ import {
   markWorkspaceStuck as dbMarkStuck,
   clearWorkspaceStuck as dbClearStuck,
   setDeaconIgnored as dbSetDeaconIgnored,
-  upsertReviewStatusAsync as dbUpsertAsync,
-  getReviewStatusFromDbAsync,
+  getReviewStatusFromDbEffect,
 } from './database/review-status-db.js';
 import { normalizeReviewStatus } from './review-status-normalize.js';
 
@@ -438,7 +437,7 @@ export async function setReviewStatusAsync(
 }
 
 export async function getReviewStatusAsync(issueId: string): Promise<ReviewStatus | null> {
-  return getReviewStatusFromDbAsync(issueId);
+  return Effect.runPromise(getReviewStatusFromDbEffect(issueId));
 }
 
 /**


### PR DESCRIPTION
## Summary
- Migrate agent enrichment/output pollers from Promise wrapper imports to Effect siblings.
- Update running-agents cache injection to consume Effect-returning list functions.
- Drop review-status DB Promise exports and switch the direct review-status caller to the Effect sibling.

## Test plan
- [x] npm test -- src/dashboard/server/services/__tests__/agent-output-service.test.ts src/dashboard/server/services/__tests__/running-agents-cache.test.ts
- [x] npm run typecheck
- [x] npm run lint
- [x] npm test
- [x] `! rg "upsertReviewStatusAsync|getReviewStatusFromDbAsync" "src"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)