### PR TITLE
Migrate infra routes to Effect APIs

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - feature-pan-1312-slot-10  (2026-05-22)
 
 ## Corpus Check
-- 1878 files · ~2,476,880 words
+- 1878 files · ~2,476,873 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 26665 nodes · 41403 edges · 1265 communities (1215 shown, 50 thin omitted)
+- 26666 nodes · 41420 edges · 1260 communities (1209 shown, 51 thin omitted)
 - Extraction: 99% EXTRACTED · 1% INFERRED · 0% AMBIGUOUS · INFERRED: 502 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `755191c0`
+- Built from commit: `49882c42`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -1210,19 +1210,19 @@
 - [[_COMMUNITY_Community 1192|Community 1192]]
 - [[_COMMUNITY_Community 1193|Community 1193]]
 - [[_COMMUNITY_Community 1194|Community 1194]]
-- [[_COMMUNITY_Community 1195|Community 1195]]
-- [[_COMMUNITY_Community 1196|Community 1196]]
 - [[_COMMUNITY_Community 1197|Community 1197]]
 - [[_COMMUNITY_Community 1198|Community 1198]]
-- [[_COMMUNITY_Community 1199|Community 1199]]
+- [[_COMMUNITY_Community 1200|Community 1200]]
+- [[_COMMUNITY_Community 1201|Community 1201]]
 - [[_COMMUNITY_Community 1202|Community 1202]]
 - [[_COMMUNITY_Community 1203|Community 1203]]
-- [[_COMMUNITY_Community 1205|Community 1205]]
+- [[_COMMUNITY_Community 1204|Community 1204]]
 - [[_COMMUNITY_Community 1206|Community 1206]]
-- [[_COMMUNITY_Community 1207|Community 1207]]
 - [[_COMMUNITY_Community 1208|Community 1208]]
 - [[_COMMUNITY_Community 1209|Community 1209]]
+- [[_COMMUNITY_Community 1210|Community 1210]]
 - [[_COMMUNITY_Community 1211|Community 1211]]
+- [[_COMMUNITY_Community 1212|Community 1212]]
 - [[_COMMUNITY_Community 1213|Community 1213]]
 - [[_COMMUNITY_Community 1214|Community 1214]]
 - [[_COMMUNITY_Community 1215|Community 1215]]
@@ -1233,11 +1233,6 @@
 - [[_COMMUNITY_Community 1220|Community 1220]]
 - [[_COMMUNITY_Community 1221|Community 1221]]
 - [[_COMMUNITY_Community 1222|Community 1222]]
-- [[_COMMUNITY_Community 1223|Community 1223]]
-- [[_COMMUNITY_Community 1224|Community 1224]]
-- [[_COMMUNITY_Community 1225|Community 1225]]
-- [[_COMMUNITY_Community 1226|Community 1226]]
-- [[_COMMUNITY_Community 1227|Community 1227]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `fetch` - 199 edges
@@ -1258,1692 +1253,1688 @@
   src/lib/work-agent-lifecycle.ts → docs/god-view.md
 - `fileExists()` --calls--> `Access`  [INFERRED]
   src/lib/cloister/config.ts → docs/god-view.md
+- `pathExists()` --calls--> `Access`  [INFERRED]
+  src/dashboard/server/routes/command-deck.ts → docs/god-view.md
 - `getIndexStats()` --calls--> `Access`  [INFERRED]
   src/dashboard/server/routes/misc.ts → docs/god-view.md
-- `getIndexStats()` --calls--> `Access`  [INFERRED]
-  src/dashboard/server/routes/workspaces.ts → docs/god-view.md
 
-## Communities (1265 total, 50 thin omitted)
+## Communities (1260 total, 51 thin omitted)
 
 ### Community 0 - "Community 0"
 Cohesion: 0.03
-Nodes (157): spawnInspectAgent(), buildSpecialistBaseCommand(), killCommand(), KillOptions, pauseCommand(), PauseOptions, recoverCommand(), RecoverOptions (+149 more)
+Nodes (170): monitorReviewConvoySignals(), spawnInspectAgent(), buildSpecialistBaseCommand(), recoverCommand(), RecoverOptions, tellCommand(), unpauseCommand(), untroubledCommand() (+162 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.02
-Nodes (153): ACTIVE_STATUS_PATTERNS, addLog(), API_ERROR_PATTERNS, apiErrorRecoveryState, autoCloseOut(), autoCloseOutCache, autoResumeStoppedWorkAgents(), checkAndSuspendIdleAgents() (+145 more)
+Nodes (154): ACTIVE_STATUS_PATTERNS, addLog(), API_ERROR_PATTERNS, apiErrorRecoveryState, autoCloseOut(), autoCloseOutCache, autoResumeStoppedWorkAgents(), checkAndSuspendIdleAgents() (+146 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.02
-Nodes (133): adaptFlywheelAgent(), AGENT_STATUS_MAP, AgentRole, AgentStatus, BUG_STATUS_CLASS, FlywheelStatusDetails(), FlywheelStatusDetailsProps, formatMemory() (+125 more)
+Nodes (113): DiffPanel(), DiffPanelProps, DiffThemeType, RenderablePatch, ToggleButton(), DiffPanelLoadingState(), DiffPanelMode, DiffPanelShell() (+105 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.02
-Nodes (125): ChatMarkdown, ActivitySparkline(), ActivitySparklineProps, CATEGORY_COLORS, SparklineCategory, SparklineEvent, ALL_TABS, OverviewTabSpec (+117 more)
+Nodes (116): ActivitySparkline(), ActivitySparklineProps, CATEGORY_COLORS, SparklineCategory, SparklineEvent, PlanningState, ZoneAActionsState, SwitchModelModal() (+108 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.03
-Nodes (121): buildHostOverrideConfirmation(), confirmDropRecovery(), confirmHostOverride(), DASHBOARD_URL, difficultyColor(), dryRun(), isSwarmRecoverAction(), parseFiniteInteger() (+113 more)
+Cohesion: 0.02
+Nodes (132): db, makeTestLayer(), makeTestService(), received, runWithService(), store, svc, unsubscribe (+124 more)
 
 ### Community 5 - "Community 5"
-Cohesion: 0.02
-Nodes (110): monitorReviewConvoySignals(), pendingCommand(), after, before, blockers, result, statuses, after (+102 more)
+Cohesion: 0.03
+Nodes (122): forkCommand(), ForkOptions, normalize(), unarchiveConversationCommand(), copySessionFromCompactBoundary(), createSummaryFork(), findLastCompactBoundaryOffset(), generateFallbackSummary() (+114 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.03
-Nodes (107): checkMissingReviewStatuses(), checkOrphanedReviewStatuses(), checkPendingTestDispatch(), checkUndispatchedShip(), cleanupOrphanedReviewSessions(), buildConvoyPrompt(), buildReviewRolePrompt(), cleanupReviewTempStash() (+99 more)
+Cohesion: 0.02
+Nodes (93): parsePiSession(), openBrowser(), runCommand(), ProcessSpawnError, ProcessTimeoutError, TmuxError, agentState, callOrder (+85 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.03
-Nodes (103): getReviewerSessionName(), parseReviewerSessionName(), REVIEWER_ROLES, ReviewerRole, Access, ActivityContext, awaitingInputFromProjection(), closedIssuesCache (+95 more)
+Nodes (120): buildHostOverrideConfirmation(), confirmDropRecovery(), confirmHostOverride(), DASHBOARD_URL, difficultyColor(), dryRun(), isSwarmRecoverAction(), parseFiniteInteger() (+112 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.04
-Nodes (93): buildPolyrepoContext(), runCommand(), addRepoCommand(), AddRepoOptions, convertToSshUrl(), createCommand(), CreateOptions, createRemoteWorkspace() (+85 more)
+Cohesion: 0.02
+Nodes (108): dropLingeringPreMergeStashes(), buildConvoyPrompt(), buildReviewRolePrompt(), cleanupReviewTempStash(), ensureReviewTempStash(), execAsync, isReviewSessionForIssue(), killAllReviewerSessions() (+100 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.03
-Nodes (95): transitionIssueToVerifyingOnMain(), HttpServerResponse, issuesRouteLayer, AgentSpawner, AgentSpawnerLive, AgentSpawnerShape, DeepWipeOptions, SpawnedAgent (+87 more)
+Cohesion: 0.02
+Nodes (91): AgentOutputPanel(), deriveAgentIssueId(), parseSpecialistSession(), AwaitingMergePage(), AwaitingMergeRow(), BlockedMergeRow(), BlockedRowProps, fetchWorkspace() (+83 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.02
-Nodes (93): BulkActionBar(), BulkActionBarProps, BulkCloseOutProgress(), BulkCloseOutProgressProps, BulkCloseResult, BulkCloseStatus, CostBreakdownData, CostBreakdownModal() (+85 more)
+Cohesion: 0.04
+Nodes (104): deriveProjectRoot(), queueAutoCommit(), deleteContinueFile(), getContinueFilePath(), getContinuesDir(), hasContinueFile(), listContinueFiles(), readContinueFile() (+96 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.04
-Nodes (109): decodeFlywheelRunId, defaultFlywheelPrompt(), defaultFlywheelRunId(), FlywheelLifecycleOptions, FlywheelPauseResult, FlywheelResumeResult, getLocalFlywheelRunDir(), isFlywheelDevcontainerRuntime() (+101 more)
+Cohesion: 0.02
+Nodes (98): EDITOR_LABELS, PanOpenInPickerProps, buildFilterParams(), ConversationRpcFilter, ConversationsPage(), CostResponse, countCostFacets(), countFacetValues() (+90 more)
 
 ### Community 12 - "Community 12"
-Cohesion: 0.04
-Nodes (96): deriveProjectRoot(), queueAutoCommit(), deleteContinueFile(), getContinueFilePath(), getContinuesDir(), hasContinueFile(), listContinueFiles(), readContinueFile() (+88 more)
+Cohesion: 0.02
+Nodes (96): BulkActionBar(), BulkActionBarProps, BulkCloseOutProgress(), BulkCloseOutProgressProps, BulkCloseResult, BulkCloseStatus, CostBreakdownData, CostBreakdownModal() (+88 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.02
-Nodes (78): agentPhase(), AgentPhaseFilter, agentRole(), AgentsFilterState, AgentsViewMode, DropdownFilter(), FilterOption, filterSummary() (+70 more)
+Nodes (95): ActivityFeedSidebar(), ActivityFeedSidebarProps, BUCKET_LABELS, BUCKET_ORDER, createActionStatusObservationSelector(), EMPTY_OBSERVATIONS, bucket, first (+87 more)
 
 ### Community 14 - "Community 14"
 Cohesion: 0.03
-Nodes (79): createHumeConfig(), deleteHumeConfig(), HumeApiError, humeFetch(), HumeResult, execAsync, formatDuration(), generateReport() (+71 more)
+Nodes (95): transitionIssueToVerifyingOnMain(), _resetDashboardSessionTokenForTests(), HttpServerResponse, issuesRouteLayer, AgentSpawner, AgentSpawnerLive, AgentSpawnerShape, DeepWipeOptions (+87 more)
 
 ### Community 15 - "Community 15"
 Cohesion: 0.03
-Nodes (81): changedFiles, errOutput, fetchMock, output, abortReviewCommand(), DASHBOARD_URL, configShadowCommand(), ShadowOptions (+73 more)
+Nodes (90): conversationsTab, firstLens, lens, overview, tablist, ConversationList(), CommandDeck(), CommandDeckProps (+82 more)
 
 ### Community 16 - "Community 16"
-Cohesion: 0.02
-Nodes (89): computeAgentEnrichment(), execAsync, getActiveSessionPath(), getAgentJsonlMtime(), getAgentJsonlPath(), getAgentPendingQuestions(), getAgentWorkspace(), getClaudeProjectDir() (+81 more)
+Cohesion: 0.03
+Nodes (95): ContainerDetailPanel(), ContainerDetailPanelProps, ContainerDetails, DetailTab, fetchContainerDetails(), formatBytes(), getBarColor(), ResourceBar() (+87 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.02
-Nodes (92): adminRouteLayer, getAdminTldrRoute, agentsRouteLayer, cliproxyRouteLayer, cloisterRouteLayer, getCloisterAgentsHealthRoute, getCloisterConfigRoute, getCloisterSpawnStatusRoute (+84 more)
+Cohesion: 0.03
+Nodes (78): resolveProjectConfig(), workspaceRenderDevcontainerCommand(), WorkspaceRenderDevcontainerOptions, createHumeConfig(), deleteHumeConfig(), HumeApiError, humeFetch(), HumeResult (+70 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.04
-Nodes (91): createMemoryCommand(), buildDailySummaryMarkdown(), createResetMarker(), DailySummaryResult, DailySummaryStatus, dedupeResetMarkers(), generateDailySummary(), getMemoryStatus() (+83 more)
+Cohesion: 0.02
+Nodes (93): captureTmuxOutput(), agentStatusCommand(), AgentStatusOptions, analyzeSession(), detectStatus(), extractCost(), extractModel(), MODEL_PATTERNS (+85 more)
 
 ### Community 19 - "Community 19"
 Cohesion: 0.03
-Nodes (76): activeAgent, cafSpy, client, onNavigateToIssues, rafSpy, scrollSpy, tiles, url (+68 more)
+Nodes (75): useZoneAActions(), ZoneActionStrip(), ZoneActionStripProps, ZoneBActionStrip(), ZoneBActionStripProps, ArtifactLinksProps, CloseOutIssueButton(), CloseOutIssueButtonProps (+67 more)
 
 ### Community 20 - "Community 20"
 Cohesion: 0.04
-Nodes (84): getUnblockedItems(), getUnblockedItemsEffect(), isTaskReady(), isTaskReadyEffect(), TERMINAL_STATUSES, buildACLookupByTitle(), writeStoryFeatureContext(), findWorkspaceRoot() (+76 more)
+Nodes (86): checkApiErrorAgents(), checkFailedMergeRetry(), killOrphanedWorkspaceProcesses(), killCommand(), KillOptions, pauseCommand(), PauseOptions, stopAgent() (+78 more)
 
 ### Community 21 - "Community 21"
 Cohesion: 0.03
-Nodes (82): setAgentStatusChangedNotifier(), setAgentStoppedNotifier(), ActivityLevel, ActivitySource, emitActivityDetailed(), emitActivityEntry(), EmitActivityOptions, emitActivityTts() (+74 more)
+Nodes (74): criteria, doc, result, { projectPath, workspacePath }, promoted, specFiles, doc, path (+66 more)
 
 ### Community 22 - "Community 22"
-Cohesion: 0.03
-Nodes (84): renderPrompt(), inferMemoryProjectId(), retrieveSpawnTimeMemoryContext(), BLANKED_PROVIDER_ENV, buildChildEnv(), buildChildEnvWithoutTmux(), LEAKED_ENV_KEYS, PROVIDER_ENV_KEYS (+76 more)
+Cohesion: 0.04
+Nodes (87): costAction(), CostRow, formatTokens(), GroupBy, resolveGroupKey(), confirmCost(), enrichAction(), formatCost() (+79 more)
 
 ### Community 23 - "Community 23"
 Cohesion: 0.04
-Nodes (84): embedAction(), scanAction(), collectJsonlFiles(), discoverJsonlFiles(), filterByMode(), normalizeDir(), projectDirMatchesAnyTarget(), scan() (+76 more)
+Nodes (87): createMemoryCommand(), buildDailySummaryMarkdown(), createResetMarker(), DailySummaryResult, DailySummaryStatus, dedupeResetMarkers(), generateDailySummary(), getMemoryStatus() (+79 more)
 
 ### Community 24 - "Community 24"
 Cohesion: 0.03
-Nodes (84): backup, bundledFrontendIndex, bundledServer, child, composeFile, config, configContent, configFile (+76 more)
+Nodes (69): ChangedFilesTree, EMPTY_DIRECTORY_OVERRIDES, ChatMessage, CompactBoundary, ConversationEvent, ProposedPlan, TurnDiffFileChange, TurnDiffSummary (+61 more)
 
 ### Community 25 - "Community 25"
-Cohesion: 0.04
-Nodes (67): isRunningAgent(), useZoneAActions(), ZoneActionStrip(), ZoneActionStripProps, ZoneBActionStrip(), ZoneBActionStripProps, ArtifactLinksProps, CloseOutIssueButton() (+59 more)
+Cohesion: 0.03
+Nodes (65): classifyStreamLine(), DrawerActiveAgent(), formatSpend(), STREAM_LINE_COLOR_CLASS, StreamLineKind, stuckHours(), verbBadgeForAgent(), DrawerActivityRail() (+57 more)
 
 ### Community 26 - "Community 26"
-Cohesion: 0.03
-Nodes (88): dequeueMerge(), execFile(), kCustom, mockExecFile, after, body, result, { saveAgentRuntimeStateMock, getAgentRuntimeStateMock } (+80 more)
+Cohesion: 0.04
+Nodes (78): getUnblockedItems(), getUnblockedItemsEffect(), isTaskReady(), isTaskReadyEffect(), TERMINAL_STATUSES, writeStoryFeatureContext(), findWorkspaceRoot(), planFinalizeCommand() (+70 more)
 
 ### Community 27 - "Community 27"
-Cohesion: 0.03
-Nodes (76): checkCommand(), checkComposeLabelDrift(), checkDirectory(), checkPi(), CheckResult, compareSemver(), ComposeDriftEntry, countItems() (+68 more)
-
-### Community 28 - "Community 28"
-Cohesion: 0.03
-Nodes (70): agent, queryClient, { rerender }, ActionBar(), ActionBarProps, ActivityFeed(), ActivityFeedProps, EVENT_COLORS (+62 more)
-
-### Community 29 - "Community 29"
-Cohesion: 0.03
-Nodes (70): AgentOutputPanel(), AgentOutputPanelProps, deriveAgentIssueId(), fetchAgentConversation(), parseSpecialistSession(), AwaitingMergePage(), AwaitingMergeRow(), BlockedMergeRow() (+62 more)
-
-### Community 30 - "Community 30"
-Cohesion: 0.03
-Nodes (77): db, makeTestLayer(), makeTestService(), received, runWithService(), store, svc, unsubscribe (+69 more)
-
-### Community 31 - "Community 31"
-Cohesion: 0.03
-Nodes (79): BulkAgentWarningDialog(), BulkAgentWarningDialogProps, DeepWipeDialogProps, DeepWipeProgress, STEP_ICONS, STEP_LABELS, WipeState, formatBytes() (+71 more)
-
-### Community 32 - "Community 32"
-Cohesion: 0.03
-Nodes (69): ComposerFooter(), ComposerFooterProps, deleteConversationImage(), PendingImage, sendConversationMessage(), switchModel(), uploadConversationImage(), ensureDefaultConversationModel() (+61 more)
-
-### Community 33 - "Community 33"
-Cohesion: 0.03
-Nodes (72): AutoResumeConfig, normalizeAutoResumeConfig(), positiveNumber(), resolveAutoResumeConfigForIssue(), validBackoffSchedule(), checkFailedMergeRetry(), cleanupAbandonedFeedback(), clearFeedbackFiles() (+64 more)
-
-### Community 34 - "Community 34"
-Cohesion: 0.04
-Nodes (63): computeBeadCounts(), { projectPath, workspacePath }, promoted, specFiles, fsHooks, doc, items, path (+55 more)
-
-### Community 35 - "Community 35"
 Cohesion: 0.04
 Nodes (81): isPaneDeadAsyncEffect(), listPaneValuesAsyncEffect(), listSessionNamesAsyncEffect(), activeSwarmIssueIds, assertPathInside(), autoAdvanceInFlight, buildSlotPrompt(), buildStructuredSlotTaskInput() (+73 more)
 
-### Community 36 - "Community 36"
+### Community 28 - "Community 28"
 Cohesion: 0.03
-Nodes (78): agentDir, dir1, dir2, marker, missing, nested, cb, cmdArgs (+70 more)
+Nodes (79): execFile(), kCustom, mockExecFile, ActivityEntry, activityLog, ApprovePushResult, checkProjectGitSafeState(), ContainerPortBinding (+71 more)
 
-### Community 37 - "Community 37"
+### Community 29 - "Community 29"
 Cohesion: 0.04
-Nodes (74): readCavemanVariant(), checkHeartbeat(), checkStuckReviewing(), buildSpecialistCavemanExports(), countContextTokens(), DEFAULT_SPECIALISTS, disableSpecialist(), enableSpecialist() (+66 more)
+Nodes (77): defaults, first, { models }, second, ModelRef, RoleConfig, RolesConfig, TtsDaemonConfig (+69 more)
 
-### Community 38 - "Community 38"
-Cohesion: 0.04
-Nodes (67): BUNDLED_GIT_HOOKS_DIR, checkCommand(), __dirname, __filename, syncCommand(), SyncOptions, getCurrentVersion(), getLatestVersion() (+59 more)
+### Community 30 - "Community 30"
+Cohesion: 0.03
+Nodes (76): agentDir, dir1, dir2, marker, missing, nested, cb, cmdArgs (+68 more)
 
-### Community 39 - "Community 39"
-Cohesion: 0.04
-Nodes (68): buildActiveSliceContext(), buildWorkAgentPrompt(), extractStitchDesigns(), inferIssueIdFromWorkspace(), matchBeadToAC(), readBeadsTasks(), readFeatureContext(), readPendingFeedback() (+60 more)
+### Community 31 - "Community 31"
+Cohesion: 0.03
+Nodes (73): issues, result, importTrackerConfig(), result, clearCacheRoute, ConfirmationRequest, deletePlanningSessionRoute, execAsync (+65 more)
 
-### Community 40 - "Community 40"
-Cohesion: 0.04
-Nodes (76): { config }, Role, applyEnvironmentFallbacks(), applyMigrations(), backupGlobalConfig(), CavemanConfig, CavemanMode, clearConfigCache() (+68 more)
-
-### Community 41 - "Community 41"
-Cohesion: 0.04
-Nodes (65): useAvailableModels(), AggregateActivityState, AggregateBadge, buildActivitySummary(), computeDominantStatus(), FeatureContextMenu(), FeatureContextMenuProps, FeatureItem() (+57 more)
-
-### Community 42 - "Community 42"
+### Community 32 - "Community 32"
 Cohesion: 0.05
-Nodes (71): boundedAutoPresoElements(), jsonByteLength(), readElementLikes(), validateAutoPresoCanvasElements(), AutoPresoSession, ExcalidrawElementLike, postAgentMessageLikeRoute(), validateAgentDeliveryMethodOrigin() (+63 more)
+Nodes (58): contextCommand(), ContextOptions, cvCommand(), CVOptions, healthCommand(), HealthOptions, relativeTime(), showCommand() (+50 more)
 
-### Community 43 - "Community 43"
+### Community 33 - "Community 33"
+Cohesion: 0.05
+Nodes (64): pendingCommand(), after, row, status, clearWorkspaceStuck(), DatabaseError, DbReviewStatusRow, deleteReviewStatus() (+56 more)
+
+### Community 34 - "Community 34"
+Cohesion: 0.05
+Nodes (72): claimTranscriptRangeAsync(), commitTranscriptRangeAsync(), getTranscriptCheckpointAsync(), listTranscriptCheckpointsAsync(), pendingRequests, postWorkerRequest(), releaseTranscriptRangeAsync(), runInline() (+64 more)
+
+### Community 35 - "Community 35"
+Cohesion: 0.04
+Nodes (75): updateTtsConfig(), { config }, applyEnvironmentFallbacks(), applyMigrations(), backupGlobalConfig(), CavemanConfig, CavemanMode, clearConfigCache() (+67 more)
+
+### Community 36 - "Community 36"
 Cohesion: 0.02
 Nodes (80): ActivityDetailedEvent, ActivityEntryEvent, ActivityTtsEvent, ActivityUpdatedEvent, AgentActivityChangedEvent, AgentChannelReplyEvent, AgentCompletedEvent, AgentCreatedEvent (+72 more)
 
-### Community 44 - "Community 44"
+### Community 37 - "Community 37"
+Cohesion: 0.04
+Nodes (56): BUNDLED_GIT_HOOKS_DIR, checkCommand(), __dirname, __filename, syncCommand(), SyncOptions, ensureExcalidrawMcp(), ensurePlaywrightIsolation() (+48 more)
+
+### Community 38 - "Community 38"
+Cohesion: 0.04
+Nodes (70): announceMerge(), buildShipPreparationPrompt(), buildShipSyncMainPrompt(), _completedPostMerge, defaultWorkspaceForIssue(), __dirname, execAsync, __filename (+62 more)
+
+### Community 39 - "Community 39"
 Cohesion: 0.03
-Nodes (69): cosineSimilarity(), arrayIndexCondition(), ArrayIndexTarget, buildFilterSql(), CosineSearchResult, cosineSimilarity(), countFts(), countFtsInSet() (+61 more)
+Nodes (69): resetDb(), resetDb(), closeDatabase(), getDatabasePath(), isBunRuntime(), _require, resetDatabase(), ExtractedPayload (+61 more)
+
+### Community 40 - "Community 40"
+Cohesion: 0.04
+Nodes (68): loadCloisterConfig(), checkUndispatchedShip(), cleanupStaleAgentState(), DeaconLogEntry, getDeaconLogs(), getLastPatrolResult(), PatrolResult, stopDeacon() (+60 more)
+
+### Community 41 - "Community 41"
+Cohesion: 0.04
+Nodes (60): boundedAutoPresoElements(), jsonByteLength(), readElementLikes(), validateAutoPresoCanvasElements(), AutoPresoSession, ExcalidrawElementLike, chunks, emitter (+52 more)
+
+### Community 42 - "Community 42"
+Cohesion: 0.03
+Nodes (65): backup, bundledFrontendIndex, bundledServer, child, composeFile, config, configContent, configFile (+57 more)
+
+### Community 43 - "Community 43"
+Cohesion: 0.04
+Nodes (65): archiveConversation(), ConversationMutations, favoriteConversation(), stopConversation(), summaryForkConversation(), unfavoriteConversation(), forgeApprove(), forgeMerge() (+57 more)
+
+### Community 44 - "Community 44"
+Cohesion: 0.04
+Nodes (65): cosineSimilarity(), arrayIndexCondition(), ArrayIndexTarget, CosineSearchResult, cosineSimilarity(), countFts(), countFtsInSet(), findEnrichedSessionsMissingEmbedding() (+57 more)
 
 ### Community 45 - "Community 45"
-Cohesion: 0.04
-Nodes (67): defaults, first, { models }, second, ModelRef, RoleConfig, RolesConfig, TtsDaemonConfig (+59 more)
+Cohesion: 0.05
+Nodes (58): getReviewerSessionName(), parseReviewerSessionName(), REVIEWER_ROLES, ReviewerRole, result, pathExists(), pickFreshestSessionId(), readOptional() (+50 more)
 
 ### Community 46 - "Community 46"
-Cohesion: 0.04
-Nodes (63): generateFallbackSummary(), generateSummaryForFork(), canReplaceTitle(), listConversations(), MessageDeliveryFailed, ALLOWED_UPLOAD_MIME_TYPES, backfillConversationModels(), deleteConversationFavoriteRoute (+55 more)
-
-### Community 47 - "Community 47"
-Cohesion: 0.03
-Nodes (60): CodexAuthBanner(), SensitiveText(), SensitiveTextProps, CodexAuthStatus, fetchCodexAuthStatus(), useCodexAuthStatus(), DEFAULTS, UIPreferences (+52 more)
-
-### Community 48 - "Community 48"
-Cohesion: 0.04
-Nodes (61): cleanupSpawnAndOrphanedStashes(), listFeatureWorkspaces(), logNonCanonicalStashesOnStartup(), dropLingeringPreMergeStashes(), ensureReviewTempStash(), execAsync, applyStash(), buildStashMessage() (+53 more)
-
-### Community 49 - "Community 49"
-Cohesion: 0.05
-Nodes (66): assertExistingPathInsideRoot(), commitFlywheelStateChanges(), createInitialFlywheelStatus(), dashboardBaseUrl(), decodeFlywheelStatus, emitStatusCommand(), EmitStatusOptions, execAsync (+58 more)
-
-### Community 50 - "Community 50"
-Cohesion: 0.04
-Nodes (51): ChangedFilesTree, EMPTY_DIRECTORY_OVERRIDES, CompactBoundary, ConversationEvent, ProposedPlan, TurnDiffFileChange, TurnDiffSummary, WorkLogEntry (+43 more)
-
-### Community 51 - "Community 51"
 Cohesion: 0.05
 Nodes (53): acquireStartLock(), buildManagedProcessIdentity(), buildTtsDaemonEnv(), clearState(), clearTtsDaemonManualStopGate(), defaultAllowedOrigins(), execFileAsync, fetchDaemonHealth() (+45 more)
 
-### Community 52 - "Community 52"
+### Community 47 - "Community 47"
+Cohesion: 0.05
+Nodes (59): countContextTokens(), DEFAULT_SPECIALISTS, disableSpecialist(), enableSpecialist(), ensureProjectSpecialistDir(), execAsync, exitGracePeriod(), FEEDBACK_DIR (+51 more)
+
+### Community 48 - "Community 48"
+Cohesion: 0.04
+Nodes (56): buildCorrelationMap(), CorrelationResult, ClaudeMessageWithCwd, ClaudeUsage, ContentBlock, FILE_TOOLS, parseSessionJsonl(), SessionMetadata (+48 more)
+
+### Community 49 - "Community 49"
+Cohesion: 0.04
+Nodes (52): ComposerFooter(), ComposerFooterProps, deleteConversationImage(), PendingImage, sendConversationMessage(), switchModel(), uploadConversationImage(), ensureDefaultConversationModel() (+44 more)
+
+### Community 50 - "Community 50"
 Cohesion: 0.04
 Nodes (58): AgentRollup, CavemanExperimentRow, dailySpendCache, dailySpendCacheKey(), DailyTrend, DatabaseError, DbCostRow, DbIssueSummaryRow (+50 more)
 
+### Community 51 - "Community 51"
+Cohesion: 0.05
+Nodes (57): appendToRunLog(), checkLogSizeLimit(), cleanupAllLogs(), cleanupOldLogs(), createRunLog(), ensureRunsDirectory(), finalizeRunLog(), generateRunId() (+49 more)
+
+### Community 52 - "Community 52"
+Cohesion: 0.04
+Nodes (47): beadsDir, doc, createCall, createCalls, dbError, deleteCalls, doc, doctorCalls (+39 more)
+
 ### Community 53 - "Community 53"
 Cohesion: 0.04
-Nodes (53): REVIEWER_STYLE, ReviewerRole, RoleBadge(), RoleBadgeProps, RoleBadgeSize, RoleStyle, SESSION_STYLE, SIZE_PX (+45 more)
+Nodes (57): CodexAuthBanner(), SensitiveText(), SensitiveTextProps, CodexAuthStatus, fetchCodexAuthStatus(), useCodexAuthStatus(), DEFAULTS, UIPreferences (+49 more)
 
 ### Community 54 - "Community 54"
-Cohesion: 0.05
-Nodes (58): announceMerge(), buildShipPreparationPrompt(), buildShipSyncMainPrompt(), _completedPostMerge, defaultWorkspaceForIssue(), __dirname, execAsync, __filename (+50 more)
+Cohesion: 0.04
+Nodes (53): mockLoadProjectsConfig, mockRunQualityGates, PASSING_GATE_RESULT, runProjectQualityGates(), autoRevertMerge(), DEFAULT_GATES, execAsync, parseValidationOutput() (+45 more)
 
 ### Community 55 - "Community 55"
 Cohesion: 0.04
-Nodes (52): buildContextMenu(), buildMenuTemplate(), buildTooltip(), callServerApi(), configureApplicationMenu(), createTerminalWindow(), createTray(), createTrayIcon() (+44 more)
+Nodes (53): BeadsTask, buildHandoffPrompt(), captureBeadsTasks(), captureFiles(), captureGitState(), captureHandoffContext(), execAsync, HandoffContext (+45 more)
 
 ### Community 56 - "Community 56"
-Cohesion: 0.07
-Nodes (54): dashboardBundleMtimeMs(), parseHealthTimeout(), recordReloadStatus(), reloadCommand(), ReloadOptions, runBuild(), UsageError, DashboardBundleCandidate (+46 more)
+Cohesion: 0.04
+Nodes (53): REVIEWER_STYLE, ReviewerRole, RoleBadge(), RoleBadgeProps, RoleBadgeSize, RoleStyle, SESSION_STYLE, SIZE_PX (+45 more)
 
 ### Community 57 - "Community 57"
-Cohesion: 0.05
-Nodes (49): conversationsTab, firstLens, lens, overview, tablist, ComposerMode, IssueComposer(), IssueComposerProps (+41 more)
+Cohesion: 0.04
+Nodes (48): agentPhase(), AgentPhaseFilter, agentRole(), AgentsFilterState, AgentsViewMode, DropdownFilter(), FilterOption, filterSummary() (+40 more)
 
 ### Community 58 - "Community 58"
 Cohesion: 0.05
-Nodes (49): format(), LiveCounter(), LiveCounterProps, ACTIVE_AGENT_STATUSES, agentForFeature(), BucketedFeature, bucketFeaturePhase(), classifierAgent() (+41 more)
+Nodes (49): markEnrichmentFailed(), buildConversationExcerpt(), buildL1Prompt(), buildL2Prompt(), buildL3Prompt(), callClaudeApi(), callClaudeApiWithConfig(), EnrichmentApiConfig (+41 more)
 
 ### Community 59 - "Community 59"
 Cohesion: 0.05
-Nodes (50): buildManifestFromDirectory(), collectSourceFiles(), compareFileToManifest(), createEmptyManifest(), hashFile(), Manifest, ManifestEntry, readManifest() (+42 more)
+Nodes (35): buildObservation(), buildObservationPrompt(), ExtractedObservationPayload, ExtractedResultMetadata, ExtractObservationCall, extractObservationFromTurn(), ExtractObservationInput, ExtractObservationResult (+27 more)
 
 ### Community 60 - "Community 60"
-Cohesion: 0.06
-Nodes (57): normalize(), unarchiveConversationCommand(), AGENT_CONVERSATION_PREFIXES, archiveConversation(), backfillConversationModel(), clearStuckForks(), createConversation(), FavoriteType (+49 more)
+Cohesion: 0.04
+Nodes (50): useAvailableModels(), AggregateActivityState, AggregateBadge, buildActivitySummary(), computeDominantStatus(), FeatureContextMenu(), FeatureContextMenuProps, FeatureItem() (+42 more)
 
 ### Community 61 - "Community 61"
-Cohesion: 0.05
-Nodes (42): DbMergeSetRepoRow, DbMergeSetRow, deleteMergeSet(), getAllMergeSetsFromDb(), getMergeSetFromDb(), getReposFromDb(), rowToMergeSet(), repos (+34 more)
+Cohesion: 0.04
+Nodes (49): ChannelPermissionDialog(), ChannelPermissionDialogProps, { container }, onAllow, onDeny, request, ConfirmationDialog(), ConfirmationDialogProps (+41 more)
 
 ### Community 62 - "Community 62"
-Cohesion: 0.06
-Nodes (54): claimTranscriptRangeAsync(), commitTranscriptRangeAsync(), getTranscriptCheckpointAsync(), listTranscriptCheckpointsAsync(), pendingRequests, postWorkerRequest(), releaseTranscriptRangeAsync(), runInline() (+46 more)
+Cohesion: 0.04
+Nodes (49): isRunningAgent(), isActiveAgent(), CostEvent, CostStreamResponse, fetchCostStream(), useCostStream(), UseCostStreamOptions, UseCostStreamResult (+41 more)
 
 ### Community 63 - "Community 63"
-Cohesion: 0.05
-Nodes (25): CLAUDE_PROJECTS_DIR, ClaudeMessage, getActiveSessionModel(), getProjectDirs(), getRecentSessions(), getSessionFiles(), importSessionToCostLog(), normalizeModelName() (+17 more)
+Cohesion: 0.04
+Nodes (51): buildContextMenu(), buildMenuTemplate(), buildTooltip(), callServerApi(), configureApplicationMenu(), createTerminalWindow(), createTray(), createTrayIcon() (+43 more)
 
 ### Community 64 - "Community 64"
-Cohesion: 0.05
-Nodes (51): TranscriptClaimTrigger, buildObservation(), buildObservationPrompt(), ExtractedObservationPayload, ExtractedResultMetadata, ExtractObservationCall, extractObservationFromTurn(), ExtractObservationInput (+43 more)
+Cohesion: 0.04
+Nodes (44): abortReviewCommand(), DASHBOARD_URL, CompletePlanningResponse, DASHBOARD_URL, planDoneCommand(), planCommand(), PlanOptions, DASHBOARD_URL (+36 more)
 
 ### Community 65 - "Community 65"
 Cohesion: 0.04
-Nodes (51): fetchConversations(), GeneralConversation, GeneralSectionProps, exitGracePeriod(), GraceCountdown(), GraceCountdownProps, GracePeriodState, pauseGracePeriod() (+43 more)
+Nodes (55): BulkAgentWarningDialog(), BulkAgentWarningDialogProps, DeepWipeDialogProps, DeepWipeProgress, STEP_ICONS, STEP_LABELS, WipeState, ghCliIssue (+47 more)
 
 ### Community 66 - "Community 66"
-Cohesion: 0.08
-Nodes (46): getReviewStatusFromDbAsync(), BlockerReason, getReviewStatusAsync(), setReviewStatusAsync(), addFailingSource(), getFailingChecksBlocker(), getRepoFromPrUrl(), getTrackedRepos() (+38 more)
+Cohesion: 0.07
+Nodes (53): dashboardBundleMtimeMs(), parseHealthTimeout(), recordReloadStatus(), reloadCommand(), ReloadOptions, runBuild(), UsageError, DashboardBundleCandidate (+45 more)
 
 ### Community 67 - "Community 67"
-Cohesion: 0.05
-Nodes (44): ChannelPermissionDialog(), ChannelPermissionDialogProps, { container }, onAllow, onDeny, request, ConfirmationDialog(), ConfirmationDialogProps (+36 more)
+Cohesion: 0.04
+Nodes (45): ActivitySection, AgentSection(), AgentSectionProps, formatCost(), formatDuration(), formatModel(), formatTime(), getPreviewLine() (+37 more)
 
 ### Community 68 - "Community 68"
-Cohesion: 0.07
-Nodes (44): destroyRemoteWorkspace(), buildClaudeUserSettings(), ClaudeUserSettings, getClaudePermissionFlags(), readYoloEnv(), resolvePermissionMode(), YOLO_FALSE, YOLO_TRUE (+36 more)
+Cohesion: 0.05
+Nodes (48): ConversationPanel(), ConversationPanelProps, ConversationView(), ConversationViewProps, FailedMessage, fetchMessages(), FORK_STEPS, MessagesResponse (+40 more)
 
 ### Community 69 - "Community 69"
-Cohesion: 0.07
-Nodes (45): assertSafeAgentId(), assertSafeAgentIdEffect(), captureCheckpoint(), captureCheckpointEffect(), CheckpointGitResult, checkpointRef(), checkpointSpawnerLayer, deleteAllCheckpoints() (+37 more)
+Cohesion: 0.05
+Nodes (46): getTrackerContext(), projectListCommand(), projectShowCommand(), addGitHubComment(), fetchGitHubIssue(), fetchIssueWithComments(), findLocalWorkspace(), formatComments() (+38 more)
 
 ### Community 70 - "Community 70"
 Cohesion: 0.05
-Nodes (45): VoiceMode, VoiceWidget(), Conversation, ConversationListProps, fetchConversations(), getSortKey(), ListTab, SORT_LABELS (+37 more)
+Nodes (40): DbMergeSetRepoRow, DbMergeSetRow, deleteMergeSet(), getAllMergeSetsFromDb(), getMergeSetFromDb(), getReposFromDb(), rowToMergeSet(), repos (+32 more)
 
 ### Community 71 - "Community 71"
-Cohesion: 0.04
-Nodes (50): BriefRequestBody, decodeFlywheelRunId, decodeFlywheelStatus, FlywheelActionDeps, flywheelRouteLayer, FlywheelStatusResponse, getFlywheelBriefRoute, getFlywheelConversationPayload() (+42 more)
+Cohesion: 0.08
+Nodes (46): getReviewStatusFromDbAsync(), BlockerReason, getReviewStatusAsync(), setReviewStatusAsync(), addFailingSource(), getFailingChecksBlocker(), getRepoFromPrUrl(), getTrackedRepos() (+38 more)
 
 ### Community 72 - "Community 72"
-Cohesion: 0.06
-Nodes (41): rebuildCache(), appendCostEvent(), CostEvent, deduplicateEvents(), ensureEventsFile(), EventMetadata, eventsFileExists(), getCostsDir() (+33 more)
+Cohesion: 0.05
+Nodes (46): execAsync, getActiveSessionPath(), getAgentJsonlMtime(), getAgentJsonlPath(), getAgentPendingQuestions(), getAgentWorkspace(), getClaudeProjectDir(), getPendingQuestions() (+38 more)
 
 ### Community 73 - "Community 73"
-Cohesion: 0.05
-Nodes (49): ContainerDetailPanel(), ContainerDetailPanelProps, ContainerDetails, DetailTab, fetchContainerDetails(), formatBytes(), getBarColor(), ResourceBar() (+41 more)
+Cohesion: 0.06
+Nodes (52): assertExistingPathInsideRoot(), commitFlywheelStateChanges(), createInitialFlywheelStatus(), dashboardBaseUrl(), decodeFlywheelStatus, emitStatusCommand(), EmitStatusOptions, execAsync (+44 more)
 
 ### Community 74 - "Community 74"
-Cohesion: 0.06
-Nodes (47): PlanningState, ZoneAActionsState, VerifyingOnMainBadge(), WorkspaceStatusOverviewProps, ActionKey, ActionLayout, derivePipelineState(), flattenActions() (+39 more)
+Cohesion: 0.05
+Nodes (45): format(), LiveCounter(), LiveCounterProps, ACTIVE_AGENT_STATUSES, agentForFeature(), BucketedFeature, bucketFeaturePhase(), classifierAgent() (+37 more)
 
 ### Community 75 - "Community 75"
-Cohesion: 0.06
-Nodes (24): issues, result, importTrackerConfig(), findProjectsByRallyProject(), loadReviewStatusesForIssues(), getCachedPlanningState(), getCanonicalStatus(), IssueDataService (+16 more)
+Cohesion: 0.07
+Nodes (44): assertSafeAgentId(), assertSafeAgentIdEffect(), captureCheckpoint(), captureCheckpointEffect(), CheckpointGitResult, checkpointRef(), checkpointSpawnerLayer, deleteAllCheckpoints() (+36 more)
 
 ### Community 76 - "Community 76"
-Cohesion: 0.09
-Nodes (49): bridgeCodexAuthToCliproxy(), bridgeCodexAuthToCliproxyAsync(), bridgeGeminiAuthToCliproxyAsync(), buildCliproxyConfig(), checkCliproxyPortAsync(), cliproxyCatch(), CliproxyCodexCredentials, CliproxyError (+41 more)
+Cohesion: 0.1
+Nodes (53): bridgeCodexAuthToCliproxy(), bridgeCodexAuthToCliproxyAsync(), bridgeGeminiAuthToCliproxyAsync(), buildCliproxyConfig(), checkCliproxyPortAsync(), cliproxyCatch(), CliproxyCodexCredentials, CliproxyError (+45 more)
 
 ### Community 77 - "Community 77"
-Cohesion: 0.05
-Nodes (34): DiffPanel(), DiffPanelProps, DiffThemeType, getRenderablePatch(), readDiffParamsFromUrl(), RenderablePatch, ToggleButton(), DiffPanelLoadingState() (+26 more)
+Cohesion: 0.07
+Nodes (44): updateCommand(), buildManifestFromDirectory(), collectSourceFiles(), compareFileToManifest(), createEmptyManifest(), FileStatus, hashFile(), Manifest (+36 more)
 
 ### Community 78 - "Community 78"
-Cohesion: 0.04
-Nodes (44): ViewMode, ConversationList(), CommandDeck(), CommandDeckProps, ContainerStats, fetchAllSessionTrees(), fetchConversations(), fetchCostsByIssue() (+36 more)
+Cohesion: 0.05
+Nodes (40): CLAUDE_DIR, createClaudeAdapter(), createClaudeAdapterEffect(), createRuntimeRegistry(), getInstalledRuntimes(), getRuntimeAdapter(), getSupportedRuntimes(), isRuntimeInstalled() (+32 more)
 
 ### Community 79 - "Community 79"
-Cohesion: 0.06
-Nodes (53): buildDefaultTtsTestVoice(), buildTtsSpeakPayload(), deleteTtsVoiceByName(), findVoiceByNameOrReport(), formatMegabytes(), formatSeconds(), formatTtsDaemonStatus(), formatVoiceDetails() (+45 more)
+Cohesion: 0.07
+Nodes (46): devCommand(), __dirname, ensureDashboardBundle(), killPort(), readConfig(), resolveNode22(), sleep(), waitForHealth() (+38 more)
 
 ### Community 80 - "Community 80"
 Cohesion: 0.04
-Nodes (51): result, createSessionAsyncEffect(), clearCacheRoute, ConfirmationRequest, deletePlanningSessionRoute, execAsync, getCacheStatusRoute, getConfirmationsRoute (+43 more)
+Nodes (53): UpsertDiscoveredSessionOpts, getConversationsConfigAsyncEffect(), updateConversationsConfigAsyncEffect(), ConfigResponseSchema, ConversationsConfigBodySchema, CostResponseSchema, DiscoveredSessionResponseSchema, discoveredSessionsRouteLayer (+45 more)
 
 ### Community 81 - "Community 81"
 Cohesion: 0.05
-Nodes (43): BASE_TIME, exitSpy, loadDeaconWithResumeMock(), loadStartCommand(), mailDir, mailFiles, state, stderrSpy (+35 more)
-
-### Community 82 - "Community 82"
-Cohesion: 0.07
-Nodes (46): devCommand(), __dirname, ensureDashboardBundle(), killPort(), readConfig(), resolveNode22(), sleep(), startSidecars() (+38 more)
-
-### Community 83 - "Community 83"
-Cohesion: 0.05
 Nodes (37): categorizeToolUse(), CompressedTranscriptDelta, compressEntry(), compressJsonlBuffer(), compressTranscriptDelta(), CompressTranscriptDeltaInput, extractBashCommand(), extractText() (+29 more)
 
+### Community 82 - "Community 82"
+Cohesion: 0.06
+Nodes (52): buildDefaultTtsTestVoice(), buildTtsSpeakPayload(), deleteTtsVoiceByName(), findVoiceByNameOrReport(), formatMegabytes(), formatSeconds(), formatTtsDaemonStatus(), formatVoiceDetails() (+44 more)
+
+### Community 83 - "Community 83"
+Cohesion: 0.06
+Nodes (34): refreshCommand(), refreshFromLinear(), RefreshOptions, shadowCommand(), CanonicalState, getDisplayStatus(), getShadowState(), getShadowStatePath() (+26 more)
+
 ### Community 84 - "Community 84"
-Cohesion: 0.04
-Nodes (42): CloisterStatus, CloisterStatusBar(), DashboardSettings, emergencyStop(), fetchCloisterStatus(), fetchConversations(), fetchDashboardSettings(), fetchTtsHealth() (+34 more)
+Cohesion: 0.05
+Nodes (41): BASE_TIME, exitSpy, loadDeaconWithResumeMock(), loadStartCommand(), mailDir, mailFiles, state, stderrSpy (+33 more)
 
 ### Community 85 - "Community 85"
 Cohesion: 0.05
-Nodes (40): BeadsTask, buildHandoffPrompt(), captureBeadsTasks(), captureFiles(), captureGitState(), captureHandoffContext(), execAsync, HandoffContext (+32 more)
+Nodes (45): runMemoryFtsTransaction(), EMPTY_HEALTH, getMemoryHealthPath(), MemoryHealthChangedPayload, MemoryHealthSnapshot, MemoryHealthStatus, MemoryHealthUpdate, MemoryHealthUpdateOptions (+37 more)
 
 ### Community 86 - "Community 86"
 Cohesion: 0.05
-Nodes (44): runMemoryFtsTransaction(), EMPTY_HEALTH, getMemoryHealthPath(), MemoryHealthChangedPayload, MemoryHealthSnapshot, MemoryHealthStatus, MemoryHealthUpdateOptions, readMemoryHealth() (+36 more)
+Nodes (39): DEACON_PAUSE_QUERY_KEY, DeaconPauseBanner(), DeaconPauseToggle(), useDeaconPause(), useDeaconPauseMutation(), getRenderablePatch(), DiffWorkerPoolProvider(), Tab (+31 more)
 
 ### Community 87 - "Community 87"
-Cohesion: 0.05
-Nodes (44): ActivityFeedSidebar(), ActivityFeedSidebarProps, BUCKET_LABELS, BUCKET_ORDER, createActionStatusObservationSelector(), EMPTY_OBSERVATIONS, bucket, first (+36 more)
+Cohesion: 0.04
+Nodes (35): SETTINGS_FILE, generateRouterConfigFromWorkTypes(), Provider, ROUTER_CONFIG_DIR, ROUTER_CONFIG_FILE, RouterConfig, RouterRule, config (+27 more)
 
 ### Community 88 - "Community 88"
 Cohesion: 0.04
 Nodes (52): EDITOR_IDS, EditorEntry, EditorId, EditorIdSchema, EDITORS, OpenInEditorInput, AgentOutput, ChatMessage (+44 more)
 
 ### Community 89 - "Community 89"
-Cohesion: 0.08
-Nodes (41): githubTracker, linearTracker, longBody, mockCreateTrackerFromConfig, mockExistsSync, mockLoadConfig, mockStatSync, STATE_MTIME (+33 more)
+Cohesion: 0.06
+Nodes (44): parseContainerServiceName(), parseIssueIdFromText(), fetchProjectTree(), isBenchmarkMode, startedAt, computeResourceAllocatedIssues(), discoverResourceAllocatedIssues(), discoverResourceAllocatedIssuesFresh() (+36 more)
 
 ### Community 90 - "Community 90"
-Cohesion: 0.04
-Nodes (50): UpsertDiscoveredSessionOpts, ConfigResponseSchema, ConversationsConfigBodySchema, CostResponseSchema, DiscoveredSessionResponseSchema, discoveredSessionsRouteLayer, EmbedBodySchema, EmbedResponseSchema (+42 more)
+Cohesion: 0.06
+Nodes (49): getIssueDataService(), ActivityContext, awaitingInputFromProjection(), closedIssuesCache, commandDeckRouteLayer, costCache, execAsync, execFileAsync (+41 more)
 
 ### Community 91 - "Community 91"
 Cohesion: 0.06
-Nodes (43): parseContainerServiceName(), parseIssueIdFromText(), fetchProjectTree(), isBenchmarkMode, startedAt, computeResourceAllocatedIssues(), discoverResourceAllocatedIssues(), discoverResourceAllocatedIssuesFresh() (+35 more)
+Nodes (41): cont, doc, projectRoot, specsDir, workspace, runtime, state, next (+33 more)
 
 ### Community 92 - "Community 92"
-Cohesion: 0.05
-Nodes (36): ActivitySection, AgentSection(), AgentSectionProps, formatCost(), formatDuration(), formatModel(), formatTime(), getPreviewLine() (+28 more)
+Cohesion: 0.08
+Nodes (45): checkCommand(), checkComposeLabelDrift(), checkDirectory(), checkPi(), CheckResult, compareSemver(), ComposeDriftEntry, countItems() (+37 more)
 
 ### Community 93 - "Community 93"
-Cohesion: 0.07
-Nodes (42): AutoPresoAgentSettings, createModel(), createTools(), DEFAULT_SETTINGS, readCodexBearerToken(), runWhiteboardAgent(), runWhiteboardWarmupOnce(), systemPrompt() (+34 more)
+Cohesion: 0.05
+Nodes (41): VoiceMode, VoiceWidget(), Conversation, ConversationListProps, fetchConversations(), getSortKey(), ListTab, SORT_LABELS (+33 more)
 
 ### Community 94 - "Community 94"
 Cohesion: 0.06
-Nodes (44): resetDb(), resetDb(), insertCostEvent(), closeDatabase(), getDatabasePath(), isBunRuntime(), _require, resetDatabase() (+36 more)
+Nodes (47): appendJsonl(), readTranscriptSlice(), buildConversationResponse(), getCachedMessages(), isPiSessionFile(), analyze_session(), find_sessions(), main() (+39 more)
 
 ### Community 95 - "Community 95"
-Cohesion: 0.05
-Nodes (41): entry, { issueId }, { limit }, old, op, ops, recent, result (+33 more)
+Cohesion: 0.07
+Nodes (41): InlineSparkline(), InlineSparklineProps, ContainerNode(), containerStatusColor(), containerStatusToDot(), formatMemory(), activityToStatus(), capitalize() (+33 more)
 
 ### Community 96 - "Community 96"
-Cohesion: 0.06
-Nodes (40): computeRestartDelay(), getSmeeBinaryPath(), getSmeeUrl(), getWebhookTarget(), isProcessAlive(), isSmeeProcessRunning(), isSmeeRunning(), errorSpy (+32 more)
+Cohesion: 0.07
+Nodes (42): AutoPresoAgentSettings, createModel(), createTools(), DEFAULT_SETTINGS, readCodexBearerToken(), runWhiteboardAgent(), runWhiteboardWarmupOnce(), systemPrompt() (+34 more)
 
 ### Community 97 - "Community 97"
-Cohesion: 0.05
-Nodes (28): estimateCost(), getModelCapability(), MODEL_CAPABILITIES, ModelCapability, SkillDimension, calculateSkillScore(), formatSelectionResults(), getSimpleModelMapping() (+20 more)
+Cohesion: 0.08
+Nodes (46): confirmHostOverride(), countBeadsTasks(), determineWorkspaceLocation(), ensureRemoteWorkspace(), execAsync, execFileAsync, failPostCreateValidation(), fetchIssueForAutoStart() (+38 more)
 
 ### Community 98 - "Community 98"
+Cohesion: 0.06
+Nodes (41): findVendoredDir(), getCavemanHooksDir(), getCavemanSkillsDir(), setupCavemanCompressScripts(), setupCavemanHooks(), CavemanVariant, determineCavemanVariant(), HookEntry (+33 more)
+
+### Community 99 - "Community 99"
+Cohesion: 0.07
+Nodes (37): buildInspectPrompt(), __dirname, execAsync, __filename, getBeadDescription(), InspectContext, InspectResult, onInspectComplete() (+29 more)
+
+### Community 100 - "Community 100"
 Cohesion: 0.07
 Nodes (28): createCostCommand(), formatIssueCostAggregate(), aggregate, output, IssueAggregate, BUDGETS_FILE, checkBudget(), CostBudget (+20 more)
 
-### Community 99 - "Community 99"
-Cohesion: 0.08
-Nodes (36): ExtractedPayload, fetchFn, provider, result, StubExtractionProvider, AnthropicExtractionProvider, AnthropicCompatibleResponse, CliproxyExtractionProvider (+28 more)
+### Community 101 - "Community 101"
+Cohesion: 0.07
+Nodes (35): rebuildCache(), appendCostEvent(), deduplicateEvents(), ensureEventsFile(), EventMetadata, getCostsDir(), getEventsFile(), getEventsFilePath() (+27 more)
 
-### Community 100 - "Community 100"
+### Community 102 - "Community 102"
+Cohesion: 0.05
+Nodes (44): agentDir, missing, snapshot, status, discoverNewAgentIds(), Jsonish, ReadModelServiceShape, ReviewStatusSnapshotInput (+36 more)
+
+### Community 103 - "Community 103"
 Cohesion: 0.05
 Nodes (43): AvailableModel, AvailableModelsResponse, ClaudeAuthStatus, DEFAULT_FLYWHEEL_CONFIG, DEFAULT_WORKHORSES, displayModelRef(), Effort, fetchAvailableModels() (+35 more)
 
-### Community 101 - "Community 101"
-Cohesion: 0.05
-Nodes (44): CappedBodyReadResult, CheckTtsHealthOptions, clearTtsVoices(), createTtsVoice(), CreateTtsVoiceInput, deleteTtsVoiceRoute, deleteTtsVoicesRoute, ExtractEmbeddingDeps (+36 more)
-
-### Community 102 - "Community 102"
-Cohesion: 0.04
-Nodes (48): 10. UX Requirements, 11. Implementation Notes, 12. Acceptance Criteria, 13. Success Criteria, 1. New Dashboard Surface, 2.1 By Issue, 2.2 By Workspace, 2.3 By Agent Type (+40 more)
-
-### Community 103 - "Community 103"
-Cohesion: 0.04
-Nodes (48): 1.1 What We Have Today, 1.2 Tool-by-Tool Analysis, 1.3 Comparative Matrix, 2.1 Design Principles, 2.2 Proposed Enhancements (Prioritized), 2.3 Implementation Roadmap, 2.4 What We're NOT Adopting (and Why), 2.5 Success Metrics (+40 more)
-
 ### Community 104 - "Community 104"
-Cohesion: 0.04
-Nodes (48): 10. God View: Keep But Integrate, 1. Rename: Mission Control → Command Deck, 2. Navigation: Horizontal Bar → Grouped Sidebar, 3. Color System: Semantic Token Architecture, 4. Typography Update, 5. Fractal Noise Texture Overlay, 6. Component Unification, 7. Scrollbar Styling (+40 more)
+Cohesion: 0.05
+Nodes (41): entry, { issueId }, { limit }, old, op, ops, recent, result (+33 more)
 
 ### Community 105 - "Community 105"
 Cohesion: 0.06
-Nodes (32): appendJsonl(), ExtractFromTranscriptDeltaResult, countCompleteLines(), defaultTranscriptPoller, isSuccessfulExtractionResult(), readTranscriptSlice(), RegisteredTranscript, registerTranscriptForPolling() (+24 more)
+Nodes (40): computeRestartDelay(), getSmeeBinaryPath(), getSmeeUrl(), getWebhookTarget(), isProcessAlive(), isSmeeProcessRunning(), isSmeeRunning(), errorSpy (+32 more)
 
 ### Community 106 - "Community 106"
-Cohesion: 0.07
-Nodes (38): appendToRunLog(), checkLogSizeLimit(), cleanupAllLogs(), cleanupOldLogs(), createRunLog(), ensureRunsDirectory(), finalizeRunLog(), generateRunId() (+30 more)
+Cohesion: 0.11
+Nodes (47): extractNumber(), extractPrefix(), archiveWorkspaceArtifactsImpl(), applyClosedOutLabel(), applyLabelGitHub(), applyLabelGitHubImpl(), applyLabelLinear(), applyLabelLinearImpl() (+39 more)
 
 ### Community 107 - "Community 107"
-Cohesion: 0.04
-Nodes (47): 1. **work-agent**, 2. **planning-agent**, 3. **review-agent**, 4. **test-agent**, 5. **merge-agent**, 6. **inspect-agent** ⚠️ PARTIAL CONFIGURATION, 7. **uat-agent** ⚠️ CRITICAL GAPS, Action Items (Prioritized) (+39 more)
+Cohesion: 0.05
+Nodes (44): CappedBodyReadResult, CheckTtsHealthOptions, clearTtsVoices(), createTtsVoice(), CreateTtsVoiceInput, deleteTtsVoiceRoute, deleteTtsVoicesRoute, ExtractEmbeddingDeps (+36 more)
 
 ### Community 108 - "Community 108"
 Cohesion: 0.04
-Nodes (46): 1. Dashboard UI Integration (from PAN-225), 2. FTS5 as Phase 1 Search (from PAN-225, PAN-179), 3. Session-Oriented Learning Types (from PAN-225, PAN-184), 4. Specific Thinking-Block Perception Signals (from PAN-184), 5. Explicit Deduplication Threshold (from PAN-225), Acceptance Criteria, Architecture, code:block1 (Source of truth (git-tracked):) (+38 more)
+Nodes (48): 10. UX Requirements, 11. Implementation Notes, 12. Acceptance Criteria, 13. Success Criteria, 1. New Dashboard Surface, 2.1 By Issue, 2.2 By Workspace, 2.3 By Agent Type (+40 more)
 
 ### Community 109 - "Community 109"
 Cohesion: 0.04
-Nodes (47): 1. Agent Discovery, 1. Monitor Regularly, 2. Activity Detection, 2. Establish Baselines, 3. Automate Alerts, 3. Log Analysis, 4. Log Everything, 4. Resource Usage (+39 more)
+Nodes (48): 1.1 What We Have Today, 1.2 Tool-by-Tool Analysis, 1.3 Comparative Matrix, 2.1 Design Principles, 2.2 Proposed Enhancements (Prioritized), 2.3 Implementation Roadmap, 2.4 What We're NOT Adopting (and Why), 2.5 Success Metrics (+40 more)
 
 ### Community 110 - "Community 110"
 Cohesion: 0.04
-Nodes (47): 1. Start Traefik, 2. Add DNS Entry, 3. Verify, "502 Bad Gateway", Add a New Route, Architecture, "Certificate Error", Certificate Management (+39 more)
+Nodes (48): 10. God View: Keep But Integrate, 1. Rename: Mission Control → Command Deck, 2. Navigation: Horizontal Bar → Grouped Sidebar, 3. Color System: Semantic Token Architecture, 4. Typography Update, 5. Fractal Noise Texture Overlay, 6. Component Unification, 7. Scrollbar Styling (+40 more)
 
 ### Community 111 - "Community 111"
-Cohesion: 0.07
-Nodes (39): closeOutCommand(), CloseOutOptions, execFileAsync, getGitHubConfig(), readGitHubCanonicalState(), doneCommand(), DoneOptions, execAsync (+31 more)
+Cohesion: 0.05
+Nodes (27): estimateCost(), getModelCapability(), MODEL_CAPABILITIES, ModelCapability, SkillDimension, calculateSkillScore(), formatSelectionResults(), getSimpleModelMapping() (+19 more)
 
 ### Community 112 - "Community 112"
-Cohesion: 0.08
-Nodes (29): hookCommand(), HookOptions, generateRecoveryPrompt(), checkHook(), clearHook(), collectMail(), generateFixedPointPrompt(), getHook() (+21 more)
+Cohesion: 0.06
+Nodes (40): setAgentStatusChangedNotifier(), setAgentStoppedNotifier(), AgentEnrichment, withConcurrencyLimit(), stopTranscriptPoller(), getEventStore(), attachmentCleanupTimer, buildAgentStatusChangedPayload() (+32 more)
 
 ### Community 113 - "Community 113"
-Cohesion: 0.06
-Nodes (41): DEFAULT_AUTO_RESUME_CONFIG, applyEnvironmentOverrides(), AutoActions, AutoRestartConfig, CLOISTER_CONFIG_FILE, CloisterConfig, CloseOutConfig, CostTrackingConfig (+33 more)
+Cohesion: 0.04
+Nodes (47): 1. **work-agent**, 2. **planning-agent**, 3. **review-agent**, 4. **test-agent**, 5. **merge-agent**, 6. **inspect-agent** ⚠️ PARTIAL CONFIGURATION, 7. **uat-agent** ⚠️ CRITICAL GAPS, Action Items (Prioritized) (+39 more)
 
 ### Community 114 - "Community 114"
-Cohesion: 0.07
-Nodes (36): runtime, state, next, path, read, state, activeContinueWriters, appendFeedbackEntry() (+28 more)
+Cohesion: 0.04
+Nodes (46): 1. Dashboard UI Integration (from PAN-225), 2. FTS5 as Phase 1 Search (from PAN-225, PAN-179), 3. Session-Oriented Learning Types (from PAN-225, PAN-184), 4. Specific Thinking-Block Perception Signals (from PAN-184), 5. Explicit Deduplication Threshold (from PAN-225), Acceptance Criteria, Architecture, code:block1 (Source of truth (git-tracked):) (+38 more)
 
 ### Community 115 - "Community 115"
-Cohesion: 0.07
-Nodes (28): refreshCommand(), refreshFromLinear(), RefreshOptions, shadowCommand(), CanonicalState, getDisplayStatus(), getShadowState(), getShadowStatePath() (+20 more)
+Cohesion: 0.04
+Nodes (47): 1. Agent Discovery, 1. Monitor Regularly, 2. Activity Detection, 2. Establish Baselines, 3. Automate Alerts, 3. Log Analysis, 4. Log Everything, 4. Resource Usage (+39 more)
 
 ### Community 116 - "Community 116"
 Cohesion: 0.04
-Nodes (46): 1. Issue lifecycle, 2. Observation, 3. Things you manage, 4. System / daemon, 5. Releases, 6. First-run & maintenance, 7. `pan admin` — plumbing, code:bash (pan issues                       # what can I work on?) (+38 more)
+Nodes (47): 1. Start Traefik, 2. Add DNS Entry, 3. Verify, "502 Bad Gateway", Add a New Route, Architecture, "Certificate Error", Certificate Management (+39 more)
 
 ### Community 117 - "Community 117"
 Cohesion: 0.04
-Nodes (46): 1.1 Kanban Card Cost Badge, 1.2 Issue Detail Panel Cost Section, 1. Per-Issue Cost Display, 2.1 Session File Location, 2.2 JSONL Message Format, 2.3 Parser Implementation, 2. Claude Code JSONL Parsing, 3.1 Linking Mechanism (+38 more)
+Nodes (46): 1. Issue lifecycle, 2. Observation, 3. Things you manage, 4. System / daemon, 5. Releases, 6. First-run & maintenance, 7. `pan admin` — plumbing, code:bash (pan issues                       # what can I work on?) (+38 more)
 
 ### Community 118 - "Community 118"
 Cohesion: 0.04
-Nodes (46): 10. Compose right pane for project-selected mode, 11. CSS for session tree, issue header, session panel, 1. Add `SessionNode`, `FeatureNode`, `ProjectSessionTree` types to contracts, 2. Extend `fetchActivityData` to include reviewer sub-agents, presence, and JSONL paths, 3. New endpoint `GET /api/projects/:projectKey/session-tree`, 4. RPC subscription `subscribeProjectSessionTree`, 5. `SessionNode.tsx` component, 6. Extend `FeatureItem.tsx` to be expandable (+38 more)
+Nodes (46): 1.1 Kanban Card Cost Badge, 1.2 Issue Detail Panel Cost Section, 1. Per-Issue Cost Display, 2.1 Session File Location, 2.2 JSONL Message Format, 2.3 Parser Implementation, 2. Claude Code JSONL Parsing, 3.1 Linking Mechanism (+38 more)
 
 ### Community 119 - "Community 119"
+Cohesion: 0.04
+Nodes (46): 10. Compose right pane for project-selected mode, 11. CSS for session tree, issue header, session panel, 1. Add `SessionNode`, `FeatureNode`, `ProjectSessionTree` types to contracts, 2. Extend `fetchActivityData` to include reviewer sub-agents, presence, and JSONL paths, 3. New endpoint `GET /api/projects/:projectKey/session-tree`, 4. RPC subscription `subscribeProjectSessionTree`, 5. `SessionNode.tsx` component, 6. Extend `FeatureItem.tsx` to be expandable (+38 more)
+
+### Community 120 - "Community 120"
 Cohesion: 0.06
 Nodes (37): createSpecialistHandoff(), ensureLogDir(), getLiveQueueDepth(), getSpecialistHandoffLogFile(), getSpecialistHandoffStats(), getTodaySpecialistHandoffs(), logSpecialistHandoff(), readIssueSpecialistHandoffs() (+29 more)
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
+Cohesion: 0.05
+Nodes (41): sessionExistsAsyncEffect(), assertExistingPathInsideRoot(), assertWritePathInsideRoot(), BriefRequestBody, decodeFlywheelRunId, decodeFlywheelStatus, FlywheelActionDeps, flywheelRouteLayer (+33 more)
+
+### Community 122 - "Community 122"
+Cohesion: 0.07
+Nodes (35): AutoResumeConfig, normalizeAutoResumeConfig(), positiveNumber(), resolveAutoResumeConfigForIssue(), validBackoffSchedule(), checkPendingTestDispatch(), buildTestRolePrompt(), dashboardApiUrl() (+27 more)
+
+### Community 123 - "Community 123"
+Cohesion: 0.07
+Nodes (39): closeOutCommand(), CloseOutOptions, execFileAsync, getGitHubConfig(), readGitHubCanonicalState(), doneCommand(), DoneOptions, execAsync (+31 more)
+
+### Community 124 - "Community 124"
+Cohesion: 0.08
+Nodes (32): buildPolyrepoContext(), listTestsCommand(), registerTestCommands(), runCommand(), RunOptions, workspaceDeepCleanCommand(), WorkspaceDeepCleanOptions, destroyCommand() (+24 more)
+
+### Community 125 - "Community 125"
 Cohesion: 0.04
 Nodes (45): 1. Overview, 2.1 What It Is, 2.2 Implementation, 2. Ralph Wiggum Self-Assessment Loop, 3.1 What It Is, 3.2 Current State, 3.3 Proposed State, 3.4 Implementation (+37 more)
 
-### Community 121 - "Community 121"
+### Community 126 - "Community 126"
 Cohesion: 0.04
 Nodes (45): Automated Installation, code:bash (pan doctor), code:bash (# Option 1: Install globally), code:bash (# Add user to docker group), code:bash (# Using nvm (recommended)), code:bash (# Ubuntu/Debian), code:bash (# Ubuntu/Debian (Docker Compose v2)), code:bash (# Clear npm cache) (+37 more)
 
-### Community 122 - "Community 122"
+### Community 127 - "Community 127"
 Cohesion: 0.04
 Nodes (45): 1. Creation, 2. Usage, 3. Cleanup, Architecture, Best Practices, code:block1 (project/), code:bash (pan workspace create MIN-123), code:bash (pan workspace create MIN-123 --docker) (+37 more)
 
-### Community 123 - "Community 123"
-Cohesion: 0.08
-Nodes (35): buildInspectPrompt(), __dirname, execAsync, __filename, getBeadDescription(), InspectContext, InspectResult, onInspectComplete() (+27 more)
-
-### Community 124 - "Community 124"
+### Community 128 - "Community 128"
 Cohesion: 0.06
-Nodes (26): SETTINGS_FILE, getKimiAnthropicBaseUrl(), getProviderEnv(), ProviderAuthType, ProviderName, PROVIDERS, AnthropicModel, ApiKeysConfig (+18 more)
+Nodes (40): DEFAULT_AUTO_RESUME_CONFIG, applyEnvironmentOverrides(), AutoActions, AutoRestartConfig, CLOISTER_CONFIG_FILE, CloisterConfig, CloseOutConfig, CostTrackingConfig (+32 more)
 
-### Community 125 - "Community 125"
-Cohesion: 0.07
-Nodes (24): chunks, emitter, googleMocks, stream, emitter, onTurn, queue, subscribeVoiceSettings() (+16 more)
-
-### Community 126 - "Community 126"
+### Community 129 - "Community 129"
 Cohesion: 0.04
 Nodes (44): After Frontend Code Changes, After Server Code Changes, Architecture, code:block1 (Browser → https://pan.localhost (Traefik)), code:bash (cd /home/eltmon/Projects/panopticon-cli && npm run build:das), code:bash (cd /home/eltmon/Projects/panopticon-cli && \), code:bash (for i in $(seq 1 15); do), code:bash (cd /home/eltmon/Projects/panopticon-cli/src/dashboard/fronte) (+36 more)
 
-### Community 127 - "Community 127"
+### Community 130 - "Community 130"
 Cohesion: 0.05
 Nodes (43): 1. Concise is Key, 1. Source Locations, 2. Degrees of Freedom, 2. Installation Flow, 3. Progressive Disclosure, Bundled Resources, code:block1 (pan install (first time)), code:bash (# For public skills) (+35 more)
 
-### Community 128 - "Community 128"
-Cohesion: 0.06
-Nodes (36): mockLoadProjectsConfig, mockRunQualityGates, PASSING_GATE_RESULT, runProjectQualityGates(), autoRevertMerge(), DEFAULT_GATES, execAsync, parseValidationOutput() (+28 more)
-
-### Community 129 - "Community 129"
-Cohesion: 0.06
-Nodes (31): RuntimeConversationsConfig, AgentIssueLookup, AgentIssueRecord, buildAgentIssueLookup(), buildEnrichSessionsJobPayload(), EnrichSessionsRpcInput, filterDomainEventForIssue(), mapEventToDelta() (+23 more)
-
-### Community 130 - "Community 130"
-Cohesion: 0.07
-Nodes (35): ConversationPanel(), ConversationPanelProps, ConversationView(), ConversationViewProps, FailedMessage, fetchMessages(), FORK_STEPS, MessagesResponse (+27 more)
-
 ### Community 131 - "Community 131"
-Cohesion: 0.05
-Nodes (42): execAsync, execFileAsync, firePostMergeLifecycle(), getModelsResolveRoute, getProjectPathForIssue(), getProjectSpecialistContextRoute, getProjectSpecialistGraceRoute, getProjectSpecialistLatestLogRoute (+34 more)
+Cohesion: 0.09
+Nodes (40): getFlywheelRunPayload(), getFlywheelRunsPayload(), decodeFlywheelRunId, decodeFlywheelStatus, decodeLaunchMetadata(), deriveRunStatus(), fileExists(), FlywheelCurrentStatusOptions (+32 more)
 
 ### Community 132 - "Community 132"
-Cohesion: 0.05
-Nodes (43): After Adding Custom Skills, After Updating Panopticon, Auto-Sync, Available Targets, Backup Location, Backup Only, Backups, code:block1 (~/.panopticon/skills/          (Panopticon skills - source)) (+35 more)
+Cohesion: 0.07
+Nodes (33): getWindowDimensionsAsync(), activePtyHubs, addClientToHub(), broadcastToHub(), hubFlushTimer, hubOutputBuffer, PtyHub, removeClientFromHub() (+25 more)
 
 ### Community 133 - "Community 133"
 Cohesion: 0.05
-Nodes (43): Anatomy of a Resumable Issue, Anti-Patterns, code:markdown (Description: What needs to be built and why), code:block10, code:block11, code:block12, code:markdown (Title: Fix typo in README), code:markdown (Acceptance:) (+35 more)
+Nodes (42): execAsync, execFileAsync, firePostMergeLifecycle(), getModelsResolveRoute, getProjectPathForIssue(), getProjectSpecialistContextRoute, getProjectSpecialistGraceRoute, getProjectSpecialistLatestLogRoute (+34 more)
 
 ### Community 134 - "Community 134"
-Cohesion: 0.05
-Nodes (43): Boundaries: When to Use bd vs TodoWrite, code:block1 (bd issue: "Implement user authentication" (epic)), code:block2 (Session start:), code:block3 (1. Create bd issue with current TodoWrite content), code:block4 (1. Keep bd issue for historical record), code:block5 (db-epic: "Migrate production database to PostgreSQL"), code:block6 (- [ ] Import logging library), code:block7 (- [ ] Reproduce bug) (+35 more)
+Cohesion: 0.07
+Nodes (29): isErrnoException(), readRestartStatus(), RestartStatus, RestartStatusError, restartStatusPath(), RestartTrigger, writeRestartStatus(), FetchFn (+21 more)
 
 ### Community 135 - "Community 135"
 Cohesion: 0.05
-Nodes (43): Architectural Smells (High Confidence), Available Categories, code:bash (# If project has override skill, this skill is permanently d), code:bash (# AI will add this section if it doesn't exist, or append to), code:bash (# Edit directly), code:bash (# Remove the AI Suggestion Preferences section), code:bash (rm -rf .claude/skills/refactor-radar/), code:markdown (## Refactoring Proposal: Standardize User Entity Naming) (+35 more)
+Nodes (43): After Adding Custom Skills, After Updating Panopticon, Auto-Sync, Available Targets, Backup Location, Backup Only, Backups, code:block1 (~/.panopticon/skills/          (Panopticon skills - source)) (+35 more)
 
 ### Community 136 - "Community 136"
-Cohesion: 0.07
-Nodes (32): getWindowDimensionsAsync(), activePtyHubs, addClientToHub(), broadcastToHub(), hubFlushTimer, hubOutputBuffer, PtyHub, removeClientFromHub() (+24 more)
+Cohesion: 0.05
+Nodes (43): Anatomy of a Resumable Issue, Anti-Patterns, code:markdown (Description: What needs to be built and why), code:block10, code:block11, code:block12, code:markdown (Title: Fix typo in README), code:markdown (Acceptance:) (+35 more)
 
 ### Community 137 - "Community 137"
-Cohesion: 0.08
-Nodes (40): EnqueueStatusRollup, findExistingPendingTurn(), inFlightRollups, loadThreshold(), maybeTriggerStatusRollup(), pendingTurnFileName(), pendingTurnRangeKey(), readPendingTurns() (+32 more)
+Cohesion: 0.05
+Nodes (43): Boundaries: When to Use bd vs TodoWrite, code:block1 (bd issue: "Implement user authentication" (epic)), code:block2 (Session start:), code:block3 (1. Create bd issue with current TodoWrite content), code:block4 (1. Keep bd issue for historical record), code:block5 (db-epic: "Migrate production database to PostgreSQL"), code:block6 (- [ ] Import logging library), code:block7 (- [ ] Reproduce bug) (+35 more)
 
 ### Community 138 - "Community 138"
 Cohesion: 0.05
-Nodes (28): ConversationTerminalProps, resumeConversation(), StandaloneTerminal(), StandaloneTerminalProps, ContextMenuState, isMac, TERMINAL_PROFILE_ENABLED, TerminalSizeMessage (+20 more)
+Nodes (43): Architectural Smells (High Confidence), Available Categories, code:bash (# If project has override skill, this skill is permanently d), code:bash (# AI will add this section if it doesn't exist, or append to), code:bash (# Edit directly), code:bash (# Remove the AI Suggestion Preferences section), code:bash (rm -rf .claude/skills/refactor-radar/), code:markdown (## Refactoring Proposal: Standardize User Entity Naming) (+35 more)
 
 ### Community 139 - "Community 139"
-Cohesion: 0.05
-Nodes (42): code:bash (# Create test settings), code:bash (pan start PAN-999 --model claude-sonnet-4-5), code:bash (# Configure settings.json with Kimi API key), code:bash (# Configure settings.json with GLM API key), code:bash (# Configure settings.json with OpenAI API key), code:bash (# Check if router is running), code:block15 ([ ] API key configured in settings.json), code:block16 ([ ] claude-code-router installed) (+34 more)
+Cohesion: 0.06
+Nodes (37): backfillDiscoveredSessionArrayIndexes(), initDiscoveredSessionsSchema(), initSchema(), base, cols, colsAfter, colsBefore, correctedPath (+29 more)
 
 ### Community 140 - "Community 140"
-Cohesion: 0.05
-Nodes (42): Backward Compatibility, code:block1 (.pan/), code:block2 (.pan/), code:block3 (draft ──► proposed ──► active ──► completed), code:json ({), code:json ({), code:json (// WRONG — missing vBRIEFInfo, plan wrapper), code:json (// WRONG — use plan.id, not these) (+34 more)
+Cohesion: 0.07
+Nodes (35): embedAction(), findEnrichedSessionIdsMissingEmbedding(), getDiscoveredStats(), searchFts(), buildEmbeddingText(), EmbedProgress, EmbedResult, embedSessions() (+27 more)
 
 ### Community 141 - "Community 141"
-Cohesion: 0.05
-Nodes (42): 1. Make the frontend typography contract explicit and centralized, 2. Remove the Mission Control / conversation typography island, 3. Normalize conversations end-to-end, 4. Restrict display-font usage to the exact approved boundary, 5. Preserve SF Mono only for semantically technical surfaces, 6. Sweep the rest of the non–God View dashboard for drift, 7. Update documentation so the codebase does not drift again, 8. Verification plan (+34 more)
+Cohesion: 0.08
+Nodes (40): EnqueueStatusRollup, findExistingPendingTurn(), inFlightRollups, loadThreshold(), maybeTriggerStatusRollup(), pendingTurnFileName(), pendingTurnRangeKey(), readPendingTurns() (+32 more)
 
 ### Community 142 - "Community 142"
-Cohesion: 0.05
-Nodes (42): 1. Navigation & Routing, 2. Planning Artifacts Scope, 3. Shadow Engineering Implementation, 4. UI/UX Design, 5. Data Architecture, 6. Out of Scope (Explicitly Deferred), Architecture, Backend APIs (+34 more)
+Cohesion: 0.1
+Nodes (32): insertCostEvent(), AnthropicExtractionProvider, AnthropicCompatibleResponse, CliproxyExtractionProvider, FetchFn, extractWithProviderPolicy(), getTodayMemoryExtractionSpendUsd(), MemoryExtractionPolicyDeps (+24 more)
 
 ### Community 143 - "Community 143"
-Cohesion: 0.05
-Nodes (42): 0.1 The breaking change, 0.2 Files affected in Panopticon, 0.3 Execution, 0.4 Risk, 0. Prerequisite: Effect beta.43 → beta.48 bump, 1.1 What t3code does, 1.2 What Panopticon does today, 1.3 Recommendation: migrate to single `/ws` with structured `TerminalEvent` (+34 more)
+Cohesion: 0.06
+Nodes (41): applyEvent(), bumpRuntimeSnapshotSequence(), DashboardLifecycleState, defaultRuntimeSnapshot(), getMaxMemoryObservationsPerIssue(), getMaxTurnDiffSummariesPerAgent(), MemoryHealthSnapshot, MemoryReadModelState (+33 more)
 
 ### Community 144 - "Community 144"
-Cohesion: 0.1
-Nodes (30): build_voice_clone_prompt(), _close_player(), _ensure_player(), _extract_audio(), extract_embedding(), _get_default_sink_state(), Handler, load_base_model() (+22 more)
+Cohesion: 0.07
+Nodes (38): appendBridgeLog(), BunGlobal, ChannelPermissionRequest, ChannelPermissionRequestNotification, ChannelPushPayload, ChannelPushResult, constantTimeHeaderMatch(), forwardPermissionRequestToDashboard() (+30 more)
 
 ### Community 145 - "Community 145"
 Cohesion: 0.09
-Nodes (34): getTrackerContext(), addGitHubComment(), fetchGitHubIssue(), fetchIssueWithComments(), findLocalWorkspace(), formatComments(), getGitHubToken(), GitHubIssueResult (+26 more)
+Nodes (33): cloneReposOnVm(), collectPanWorkspaceFiles(), convertToSshUrl(), copyPlanningStateFromRemote(), copyPlanningStateToRemote(), copyWorkspacePanStateFromRemote(), copyWorkspacePanStateToRemote(), detectWorkspaceLocation() (+25 more)
 
 ### Community 146 - "Community 146"
-Cohesion: 0.07
-Nodes (30): execAsync, gatherArtifacts(), generateBasicInference(), generateMonitoringPrompt(), InferenceDocument, MonitoringAgentConfig, MonitoringAgentError, readInferenceDocument() (+22 more)
+Cohesion: 0.11
+Nodes (35): destroyRemoteWorkspace(), createFlyProvider(), FlyProviderConfig, { execAsyncMock, spawnMock, mockApi }, fly, p, getRemoteProvider(), ProviderType (+27 more)
 
 ### Community 147 - "Community 147"
-Cohesion: 0.07
-Nodes (29): applyTierAwareFallback(), detectEnabledProviders(), ENRICHMENT_TIER_MAX_MESSAGES, FALLBACK_MAP, filterAvailableModels(), getAvailableModels(), getBestAnthropicAtTier(), getFallbackModel() (+21 more)
+Cohesion: 0.05
+Nodes (42): code:bash (# Create test settings), code:bash (pan start PAN-999 --model claude-sonnet-4-5), code:bash (# Configure settings.json with Kimi API key), code:bash (# Configure settings.json with GLM API key), code:bash (# Configure settings.json with OpenAI API key), code:bash (# Check if router is running), code:block15 ([ ] API key configured in settings.json), code:block16 ([ ] claude-code-router installed) (+34 more)
 
 ### Community 148 - "Community 148"
-Cohesion: 0.07
-Nodes (39): buildConversationResponse(), getCachedMessages(), isPiSessionFile(), activitySummaryCache, claudeProjectDir(), compactOffsetCache, ContentBlock, ConversationActivitySummary (+31 more)
+Cohesion: 0.05
+Nodes (42): Backward Compatibility, code:block1 (.pan/), code:block2 (.pan/), code:block3 (draft ──► proposed ──► active ──► completed), code:json ({), code:json ({), code:json (// WRONG — missing vBRIEFInfo, plan wrapper), code:json (// WRONG — use plan.id, not these) (+34 more)
 
 ### Community 149 - "Community 149"
-Cohesion: 0.08
-Nodes (39): isRecord(), isSubagentHookPayload(), SubagentHookPayload, enqueuePipeline, getTranscriptSize, registerTranscript, response, statTranscript (+31 more)
+Cohesion: 0.05
+Nodes (42): 1. Make the frontend typography contract explicit and centralized, 2. Remove the Mission Control / conversation typography island, 3. Normalize conversations end-to-end, 4. Restrict display-font usage to the exact approved boundary, 5. Preserve SF Mono only for semantically technical surfaces, 6. Sweep the rest of the non–God View dashboard for drift, 7. Update documentation so the codebase does not drift again, 8. Verification plan (+34 more)
 
 ### Community 150 - "Community 150"
 Cohesion: 0.05
-Nodes (41): Agentic, All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, Coding, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer` (+33 more)
+Nodes (42): 1. Navigation & Routing, 2. Planning Artifacts Scope, 3. Shadow Engineering Implementation, 4. UI/UX Design, 5. Data Architecture, 6. Out of Scope (Explicitly Deferred), Architecture, Backend APIs (+34 more)
 
 ### Community 151 - "Community 151"
 Cohesion: 0.05
-Nodes (41): 1. Run Diagnostics, 2. Check Configuration, 3. Check Running Services, 4. Check Skills, 5. Check Dependencies, Agents, Clean Up Old Workspaces, code:bash (pan doctor) (+33 more)
+Nodes (42): 0.1 The breaking change, 0.2 Files affected in Panopticon, 0.3 Execution, 0.4 Risk, 0. Prerequisite: Effect beta.43 → beta.48 bump, 1.1 What t3code does, 1.2 What Panopticon does today, 1.3 Recommendation: migrate to single `/ws` with structured `TerminalEvent` (+34 more)
 
 ### Community 152 - "Community 152"
-Cohesion: 0.07
-Nodes (28): approve(), buildResult(), cancelIssueWorkflow(), clearReviewStatusStep(), close(), closeOut(), deepWipe(), destructiveResetWorkflow() (+20 more)
+Cohesion: 0.1
+Nodes (30): build_voice_clone_prompt(), _close_player(), _ensure_player(), _extract_audio(), extract_embedding(), _get_default_sink_state(), Handler, load_base_model() (+22 more)
 
 ### Community 153 - "Community 153"
-Cohesion: 0.08
-Nodes (33): getHealthThresholdsMs(), evaluateHealthState(), formatDuration(), generateHealthSummary(), getAgentHealth(), getAgentsNeedingAttention(), getAgentsToKill(), getAgentsToPoke() (+25 more)
+Cohesion: 0.07
+Nodes (29): getOpenAICompatibleProxyBaseUrl(), buildAnthropicMessagesUrl(), cache, CacheEntry, cacheKey(), classifyError(), classifyFetchError(), doProbe() (+21 more)
 
 ### Community 154 - "Community 154"
-Cohesion: 0.06
-Nodes (35): ActivityEntry, ActivityItem(), ActivityPanel(), ActivityPanelProps, ActivityStream, applyPinWarnings(), CategoryFilter, fetchActivityREST() (+27 more)
+Cohesion: 0.07
+Nodes (30): execAsync, gatherArtifacts(), generateBasicInference(), generateMonitoringPrompt(), InferenceDocument, MonitoringAgentConfig, MonitoringAgentError, readInferenceDocument() (+22 more)
 
 ### Community 155 - "Community 155"
-Cohesion: 0.05
-Nodes (40): Automatic Setup (Recommended), Certificate Errors in Browser, code:bash (pan install), code:bash (# Install dnsmasq), code:bash (# Install dnsmasq), code:bash (cat /etc/hosts | grep pan.localhost), code:bash (# macOS), code:bash (curl -k https://pan.localhost) (+32 more)
+Cohesion: 0.08
+Nodes (39): isRecord(), isSubagentHookPayload(), SubagentHookPayload, enqueuePipeline, getTranscriptSize, registerTranscript, response, statTranscript (+31 more)
 
 ### Community 156 - "Community 156"
 Cohesion: 0.05
-Nodes (40): 10. References, 1. Problem, 2. Goal, 3. Non-Goals, 4.1 Information Architecture, 4.2 Five Surfaces (canonical mockups), 4.3 Shared Primitives, 4.4 Verb Badges (+32 more)
+Nodes (41): Agentic, All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, Coding, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer` (+33 more)
 
 ### Community 157 - "Community 157"
 Cohesion: 0.05
-Nodes (40): 1. Copy Template Files, 2. Create Environment File, 3. Start Containers, 4. Verify, Add a Service, Add Environment Variables, Available Templates, By Database Needs (+32 more)
+Nodes (41): 1. Run Diagnostics, 2. Check Configuration, 3. Check Running Services, 4. Check Skills, 5. Check Dependencies, Agents, Clean Up Old Workspaces, code:bash (pan doctor) (+33 more)
 
 ### Community 158 - "Community 158"
 Cohesion: 0.07
-Nodes (30): migrateConfigCommand(), MigrateConfigOptions, BACKUP_SETTINGS_PATH, convertToYamlConfig(), detectEnabledProviders(), getMigrationStatus(), hasLegacySettings(), LEGACY_SETTINGS_PATH (+22 more)
+Nodes (28): approve(), buildResult(), cancelIssueWorkflow(), clearReviewStatusStep(), close(), closeOut(), deepWipe(), destructiveResetWorkflow() (+20 more)
 
 ### Community 159 - "Community 159"
-Cohesion: 0.09
-Nodes (34): closeMemoryFtsDatabases(), createDatabase(), databases, deferSqliteWork(), getMemoryFtsDatabase(), getMemoryFtsWorker(), initializeMemoryFtsSchema(), isBunRuntime() (+26 more)
+Cohesion: 0.08
+Nodes (33): getHealthThresholdsMs(), evaluateHealthState(), formatDuration(), generateHealthSummary(), getAgentHealth(), getAgentsNeedingAttention(), getAgentsToKill(), getAgentsToPoke() (+25 more)
 
 ### Community 160 - "Community 160"
-Cohesion: 0.09
-Nodes (36): getCachedDockerContainerLifecycleObservedAt(), getCachedDockerContainerLifecycleSnapshot(), recordDockerContainerLifecycleSnapshot(), resetCachedDockerContainerLifecycleSnapshotForTests(), dockerProject, getWorkspaceStackHealth, health, now (+28 more)
+Cohesion: 0.06
+Nodes (35): ActivityEntry, ActivityItem(), ActivityPanel(), ActivityPanelProps, ActivityStream, applyPinWarnings(), CategoryFilter, fetchActivityREST() (+27 more)
 
 ### Community 161 - "Community 161"
-Cohesion: 0.05
-Nodes (39): AC-Driven Specialist Pipeline, Artifact Lifecycle, Automatic Beads Conversion, Can agents produce valid vBRIEF JSON reliably?, code:block1 (PRD (human, markdown)              ← requirements & intent), code:block2 (docs/prds/), code:json ({), code:json ({) (+31 more)
+Cohesion: 0.09
+Nodes (37): checkNodeVersion(), checkServerBundle(), __dirname, launch(), packageDir, resolveElectron(), CHUNK_BUDGET_CHARS_BY_MODEL, chunkEntriesByBudget() (+29 more)
 
 ### Community 162 - "Community 162"
 Cohesion: 0.05
-Nodes (37): 1. record-cost-event.js esbuild bundle broken, 2. Deacon patrolWorkAgentResolutions — getEnabledSpecialists not defined, 3. Issue ID regex missing prefixes, Bugs Found and Fixed (2026-03-20), Build Requirements, code:block1 (~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl), code:block2 (cwd: /home/eltmon/Projects/krux/workspaces/feature-krux-4), code:block5 (Claude Code Agent (tmux session)) (+29 more)
+Nodes (40): Automatic Setup (Recommended), Certificate Errors in Browser, code:bash (pan install), code:bash (# Install dnsmasq), code:bash (# Install dnsmasq), code:bash (cat /etc/hosts | grep pan.localhost), code:bash (# macOS), code:bash (curl -k https://pan.localhost) (+32 more)
 
 ### Community 163 - "Community 163"
 Cohesion: 0.05
-Nodes (39): Acceptance Criteria, API Changes, API Server, Architecture, Beads Tasks, CLI, code:block1 (~/.panopticon/specialists/), code:block2 (~/.panopticon/specialists/) (+31 more)
+Nodes (40): 10. References, 1. Problem, 2. Goal, 3. Non-Goals, 4.1 Information Architecture, 4.2 Five Surfaces (canonical mockups), 4.3 Shared Primitives, 4.4 Verb Badges (+32 more)
 
 ### Community 164 - "Community 164"
 Cohesion: 0.05
-Nodes (39): Action Items, Agentic, All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, Coding, Community Reception `[K2.6]`, Confirmed Improvements `[K2.6]`, `convoy:correctness-reviewer` (+31 more)
+Nodes (40): 1. Copy Template Files, 2. Create Environment File, 3. Start Containers, 4. Verify, Add a Service, Add Environment Variables, Available Templates, By Database Needs (+32 more)
 
 ### Community 165 - "Community 165"
-Cohesion: 0.05
-Nodes (39): 1. Create a `dev` Script, 1. Register the Project, 2. Create CLAUDE.md (Recommended), 2. Create docker-compose.yml, 3. Panopticon Integration, 3. Set Up Tracker Mapping, 4. Verify Setup, Add a Project (+31 more)
+Cohesion: 0.07
+Nodes (30): migrateConfigCommand(), MigrateConfigOptions, BACKUP_SETTINGS_PATH, convertToYamlConfig(), detectEnabledProviders(), getMigrationStatus(), hasLegacySettings(), LEGACY_SETTINGS_PATH (+22 more)
 
 ### Community 166 - "Community 166"
-Cohesion: 0.05
-Nodes (39): 1. Isolate High-Volume Operations, 2. Parallel Research, 3. Cost Optimization, 4. Security Boundaries, Built-in Subagents, CLI-Defined Subagents, code:markdown (---), code:markdown (---) (+31 more)
+Cohesion: 0.09
+Nodes (36): getCachedDockerContainerLifecycleObservedAt(), getCachedDockerContainerLifecycleSnapshot(), recordDockerContainerLifecycleSnapshot(), resetCachedDockerContainerLifecycleSnapshotForTests(), dockerProject, getWorkspaceStackHealth, health, now (+28 more)
 
 ### Community 167 - "Community 167"
 Cohesion: 0.07
-Nodes (27): createClaudeCodeRuntime(), getGlobalRegistry(), getRuntime(), getRuntimeForAgent(), RuntimeRegistry, setGlobalRegistry(), createPiRuntime(), PiSpawnTimeout (+19 more)
+Nodes (36): executeHandoff(), HandoffPanel(), HandoffPanelProps, MODEL_COLORS, ActivityEntry, AgentPauseFields, clearTroubledAgent(), CloisterHealth (+28 more)
 
 ### Community 168 - "Community 168"
 Cohesion: 0.05
-Nodes (30): defect, defectQuery, feature, featureQuery, featureWithEmptyState, featureWithObjectState, featureWithPartialState, mockCreate (+22 more)
+Nodes (39): AC-Driven Specialist Pipeline, Artifact Lifecycle, Automatic Beads Conversion, Can agents produce valid vBRIEF JSON reliably?, code:block1 (PRD (human, markdown)              ← requirements & intent), code:block2 (docs/prds/), code:json ({), code:json ({) (+31 more)
 
 ### Community 169 - "Community 169"
-Cohesion: 0.08
-Nodes (24): showHelp(), startCommand(), statusCommand(), stopCommand(), tldrCommand(), TldrOptions, warmCommand(), captureTldrMetrics() (+16 more)
+Cohesion: 0.05
+Nodes (37): 1. record-cost-event.js esbuild bundle broken, 2. Deacon patrolWorkAgentResolutions — getEnabledSpecialists not defined, 3. Issue ID regex missing prefixes, Bugs Found and Fixed (2026-03-20), Build Requirements, code:block1 (~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl), code:block2 (cwd: /home/eltmon/Projects/krux/workspaces/feature-krux-4), code:block5 (Claude Code Agent (tmux session)) (+29 more)
 
 ### Community 170 - "Community 170"
 Cohesion: 0.05
-Nodes (38): 1. Read Enforcer (`PreToolUse` on `Read`), 2. Post-Edit Notify (`PostToolUse` on `Edit|Write`), 3. MCP Server, Architecture, Build Triggers, CLI Commands, code:block1 (PROJECT ROOT (main branch)), code:block2 (┌─────────────────────────┐) (+30 more)
+Nodes (39): Acceptance Criteria, API Changes, API Server, Architecture, Beads Tasks, CLI, code:block1 (~/.panopticon/specialists/), code:block2 (~/.panopticon/specialists/) (+31 more)
 
 ### Community 171 - "Community 171"
 Cohesion: 0.05
-Nodes (38): Before Production, code:typescript (cache.lastEventLine += events.length;), code:block2 (events.jsonl has lines 0-104 (105 total lines)), code:javascript (const agentId = process.env.PANOPTICON_AGENT_ID ||), code:typescript (const content = events.map(e => JSON.stringify(e)).join('\n'), code:typescript (const content = events.length > 0), code:block6 (Process A writes: {"ts":"2026...), Critical Bugs Found in PAN-81 Implementation (+30 more)
+Nodes (39): Action Items, Agentic, All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, Coding, Community Reception `[K2.6]`, Confirmed Improvements `[K2.6]`, `convoy:correctness-reviewer` (+31 more)
 
 ### Community 172 - "Community 172"
 Cohesion: 0.05
-Nodes (38): 10. JSONL Session File Format & Access, #10 — JSONL Session File Format & Access, 11. Specialist Event File Protocol, #11 — Specialist Event File Protocol, 12. Heartbeat File Deprecation Plan, #12 — Heartbeat File Deprecation Plan, 13. Backwards Compatibility During Migration, #13 — Backwards Compatibility During Migration (+30 more)
+Nodes (39): 1. Create a `dev` Script, 1. Register the Project, 2. Create CLAUDE.md (Recommended), 2. Create docker-compose.yml, 3. Panopticon Integration, 3. Set Up Tracker Mapping, 4. Verify Setup, Add a Project (+31 more)
 
 ### Community 173 - "Community 173"
 Cohesion: 0.05
-Nodes (38): Agentic, All subagents (`explore`, `plan`, `bash`, `general-purpose`), Benchmark Credibility Note, `cli:interactive` and `cli:quick-command`, Coding, Composite, `convoy:correctness-reviewer`, `convoy:performance-reviewer` (+30 more)
+Nodes (39): 1. Isolate High-Volume Operations, 2. Parallel Research, 3. Cost Optimization, 4. Security Boundaries, Built-in Subagents, CLI-Defined Subagents, code:markdown (---), code:markdown (---) (+31 more)
 
 ### Community 174 - "Community 174"
 Cohesion: 0.05
-Nodes (38): code:block1 ([completed] Implement login endpoint), code:bash (bd update oauth-5 --notes "COMPLETED: Token refresh endpoint), code:bash (bd create "Q4 strategic planning document" -t task -p 0), code:bash (bd update strat-1 --notes "COMPLETED: Research phase (review), code:block13 (- [ ] Draft recommendation 1: Market expansion), code:bash (bd create "Refactor auth system to use JWT" -t epic -p 0), code:block15 (Current: login-1), code:bash (bd close login-1 --reason "Updated to JWT. Tests passing. Ba) (+30 more)
+Nodes (30): defect, defectQuery, feature, featureQuery, featureWithEmptyState, featureWithObjectState, featureWithPartialState, mockCreate (+22 more)
 
 ### Community 175 - "Community 175"
-Cohesion: 0.07
-Nodes (27): EventRouter(), error, replayPromise, request, snapshot, unsubscribe, createRecoveryCoordinator(), EventClassification (+19 more)
+Cohesion: 0.09
+Nodes (30): clearFeedbackFiles(), FeedbackWriteError, getNextSequenceNumber(), resolveWorkspacePath(), writeFeedbackFile(), WriteFeedbackOptions, WriteFeedbackResult, formatFeedbackForAgent() (+22 more)
 
 ### Community 176 - "Community 176"
-Cohesion: 0.06
-Nodes (29): AC_STATUS_ICONS, BeadsResponse, BeadsTasksPanelProps, BeadTask, PlanItemDetailProps, AC_STATUS_COLORS, AC_STATUS_SYMBOL, applyDagreLayout() (+21 more)
+Cohesion: 0.09
+Nodes (33): closeMemoryFtsDatabases(), createDatabase(), databases, deferSqliteWork(), getMemoryFtsDatabase(), getMemoryFtsWorker(), initializeMemoryFtsSchema(), isBunRuntime() (+25 more)
 
 ### Community 177 - "Community 177"
-Cohesion: 0.09
-Nodes (30): isNoResumeValueEnabled(), NO_RESUME_MODE_ACTIVE, TRUTHY_NO_RESUME_VALUES, formatGatingReason(), formatRestartAge(), formatRestartDuration(), formatTldrAge(), formatTldrRow() (+22 more)
+Cohesion: 0.05
+Nodes (38): 1. Read Enforcer (`PreToolUse` on `Read`), 2. Post-Edit Notify (`PostToolUse` on `Edit|Write`), 3. MCP Server, Architecture, Build Triggers, CLI Commands, code:block1 (PROJECT ROOT (main branch)), code:block2 (┌─────────────────────────┐) (+30 more)
 
 ### Community 178 - "Community 178"
 Cohesion: 0.05
-Nodes (37): 1. ChatMarkdown, 2. MessagesTimeline, 3. JSONL Parser (server-side), 4. ComposerPromptEditor, 5. ModelPicker, 6. EffortPicker, 7. SendButton + Message Submission, 8. ConversationPanel (wrapper) (+29 more)
+Nodes (38): Before Production, code:typescript (cache.lastEventLine += events.length;), code:block2 (events.jsonl has lines 0-104 (105 total lines)), code:javascript (const agentId = process.env.PANOPTICON_AGENT_ID ||), code:typescript (const content = events.map(e => JSON.stringify(e)).join('\n'), code:typescript (const content = events.length > 0), code:block6 (Process A writes: {"ts":"2026...), Critical Bugs Found in PAN-81 Implementation (+30 more)
 
 ### Community 179 - "Community 179"
 Cohesion: 0.05
-Nodes (36): 1. CommentMediator Service, 2. Author Filtering, 3. Content Classifier, 4. Summarizer, 5. Retrofit `getTrackerContext()`, 6. Quarantine Storage & Dashboard, 7. Gated Full-Text Tool, 8. Configuration (+28 more)
+Nodes (38): 10. JSONL Session File Format & Access, #10 — JSONL Session File Format & Access, 11. Specialist Event File Protocol, #11 — Specialist Event File Protocol, 12. Heartbeat File Deprecation Plan, #12 — Heartbeat File Deprecation Plan, 13. Backwards Compatibility During Migration, #13 — Backwards Compatibility During Migration (+30 more)
 
 ### Community 180 - "Community 180"
 Cohesion: 0.05
-Nodes (37): Audit Completeness, Category: Agent Lifecycle, Category: Delivery Confirmation, Category: Git Pattern Scanning (Merge Agent), Category: Health Checks (No Pattern Scanning), Category: Health & Stuck Detection (Deacon), Category: Model & Metadata Extraction, Category: Readiness Detection (+29 more)
+Nodes (38): Agentic, All subagents (`explore`, `plan`, `bash`, `general-purpose`), Benchmark Credibility Note, `cli:interactive` and `cli:quick-command`, Coding, Composite, `convoy:correctness-reviewer`, `convoy:performance-reviewer` (+30 more)
 
 ### Community 181 - "Community 181"
 Cohesion: 0.05
-Nodes (37): 1. Triggered After Test Pass, 2. UAT Specialist Receives Context, 3. UAT Specialist Runs Verification, 4. UAT Specialist Reports, Auth Flow, code:block1 (Agent → Inspect (per-bead) → Review (full MR) → Test (suite)), code:typescript (// After test passes, queue UAT), code:block11 (Agent finishes bead → Inspect (bead diff)    → PASS → next b) (+29 more)
+Nodes (38): code:block1 ([completed] Implement login endpoint), code:bash (bd update oauth-5 --notes "COMPLETED: Token refresh endpoint), code:bash (bd create "Q4 strategic planning document" -t task -p 0), code:bash (bd update strat-1 --notes "COMPLETED: Research phase (review), code:block13 (- [ ] Draft recommendation 1: Market expansion), code:bash (bd create "Refactor auth system to use JWT" -t epic -p 0), code:block15 (Current: login-1), code:bash (bd close login-1 --reason "Updated to JWT. Tests passing. Ba) (+30 more)
 
 ### Community 182 - "Community 182"
-Cohesion: 0.05
-Nodes (37): Advanced Features, bd vs TodoWrite, Beads - Persistent Task Memory for AI Agents, CLI Reference, Close & Reopen, code:bash (# Link beads issue to GitHub issue PAN-84), code:bash (bd label add <id> <label> --json), code:bash (bd show <id> --json              # Full issue details) (+29 more)
+Cohesion: 0.08
+Nodes (32): after, backupPath, backups, calls, errSpy, exitSpy, original, out (+24 more)
 
 ### Community 183 - "Community 183"
-Cohesion: 0.05
-Nodes (37): Arguments, Auto-Detection (when no wrapper config), code:block1 (1. Check: Does ~/.panopticon/skills/spec-readiness-*/config.), code:block10 (## Bug Analysis), code:block11 (Read spec-readiness-{identifier}.json), code:block12 (spec readiness MIN-704), code:yaml (# ~/.panopticon/skills/spec-readiness-mycompany/config.yaml), code:block3 (get_issue         → mcp__linear__get_issue(id, includeRelati) (+29 more)
+Cohesion: 0.08
+Nodes (33): eventsFileExists(), AgentContext, findSessionDirsByIssue(), getAgentsDir(), getClaudeProjectsDir(), getProjectPaths(), getProjectsYamlPath(), getSessionDir() (+25 more)
 
 ### Community 184 - "Community 184"
 Cohesion: 0.09
-Nodes (25): BeadsTask, COMPLEXITY_KEYWORDS, COMPLEXITY_LABELS, ComplexityDetectionResult, ComplexityLevel, complexityToModel(), detectComplexity(), detectComplexityFromEstimate() (+17 more)
+Nodes (36): BudgetKey, buildContext(), CandidateContext, countHits(), emptyAllocations(), emptyHitCounts(), escapeJsonForPrompt(), estimateTokens() (+28 more)
 
 ### Community 185 - "Community 185"
-Cohesion: 0.09
-Nodes (33): Platform, buildLeakedSpecialists(), buildTopConsumers(), bytesToGb(), collectAgentProcesses(), CpuSample, DEFAULT_RESOURCE_CONFIG, defaultThresholds() (+25 more)
+Cohesion: 0.07
+Nodes (32): fetchSettings(), isIssueTtsMuted(), normalizeIssueId(), putSettings(), setIssueTtsMuted(), fetchMock, muted, putCall (+24 more)
 
 ### Community 186 - "Community 186"
-Cohesion: 0.07
-Nodes (31): fetchSettings(), isIssueTtsMuted(), normalizeIssueId(), putSettings(), setIssueTtsMuted(), fetchMock, muted, putCall (+23 more)
+Cohesion: 0.06
+Nodes (29): AC_STATUS_ICONS, BeadsResponse, BeadsTasksPanelProps, BeadTask, PlanItemDetailProps, AC_STATUS_COLORS, AC_STATUS_SYMBOL, applyDagreLayout() (+21 more)
 
 ### Community 187 - "Community 187"
-Cohesion: 0.08
-Nodes (32): agentDir, missing, snapshot, status, discoverNewAgentIds(), Jsonish, ReadModelServiceLive, ReadModelServiceShape (+24 more)
+Cohesion: 0.07
+Nodes (27): EventRouter(), error, replayPromise, request, snapshot, unsubscribe, createRecoveryCoordinator(), EventClassification (+19 more)
 
 ### Community 188 - "Community 188"
 Cohesion: 0.05
-Nodes (36): 1. All-Up Skill, 2. Awaiting Merge Page, 3. Workflow Orchestration Visibility, Acceptance Criteria, Architecture, Awaiting Merge Page Spec, Behavior, Benefits (+28 more)
+Nodes (37): 1. ChatMarkdown, 2. MessagesTimeline, 3. JSONL Parser (server-side), 4. ComposerPromptEditor, 5. ModelPicker, 6. EffortPicker, 7. SendButton + Message Submission, 8. ConversationPanel (wrapper) (+29 more)
 
 ### Community 189 - "Community 189"
 Cohesion: 0.05
-Nodes (35): 1. Identity key and registry shape, 1. Per-project singleton baked in at three places, 2. Inverted model priority — hidden Sonnet default, 2. Model resolution — authoritative chain + resolution trace, 3. PAN-540 convoy reviewers in the registry, 3. PAN-540 convoy reviewers invisible, 4. Duplicate-tab risk on shared worktree, 4. Single-writer-per-worktree enforcement (+27 more)
+Nodes (36): 1. CommentMediator Service, 2. Author Filtering, 3. Content Classifier, 4. Summarizer, 5. Retrofit `getTrackerContext()`, 6. Quarantine Storage & Dashboard, 7. Gated Full-Text Tool, 8. Configuration (+28 more)
 
 ### Community 190 - "Community 190"
 Cohesion: 0.05
-Nodes (36): Closure Checklist, Closure Pattern, code:bash ($ bd ready), code:bash (bd list --status in_progress), code:bash (bd show issue-id), code:block12 ("From bd notes: [summary of COMPLETED]. Currently [IN PROGRE), code:block13 (Issue: bd-42 "OAuth refresh token implementation"), code:block14 (- [ ] Implement rate limiting on refresh endpoint) (+28 more)
+Nodes (37): Audit Completeness, Category: Agent Lifecycle, Category: Delivery Confirmation, Category: Git Pattern Scanning (Merge Agent), Category: Health Checks (No Pattern Scanning), Category: Health & Stuck Detection (Deacon), Category: Model & Metadata Extraction, Category: Readiness Detection (+29 more)
 
 ### Community 191 - "Community 191"
 Cohesion: 0.05
-Nodes (35): API Commands, code:bash (gh issue list --state open --limit 50), code:bash (gh pr merge 456 --squash --delete-branch), code:bash (gh pr close 456), code:bash (gh pr checkout 456), code:bash (# Get PR comments), code:bash (gh issue list -R eltmon/panopticon-cli), code:bash (gh issue view 123) (+27 more)
+Nodes (37): 1. Triggered After Test Pass, 2. UAT Specialist Receives Context, 3. UAT Specialist Runs Verification, 4. UAT Specialist Reports, Auth Flow, code:block1 (Agent → Inspect (per-bead) → Review (full MR) → Test (suite)), code:typescript (// After test passes, queue UAT), code:block11 (Agent finishes bead → Inspect (bead diff)    → PASS → next b) (+29 more)
 
 ### Community 192 - "Community 192"
-Cohesion: 0.12
-Nodes (35): reconcileClosedPrReadyForMerge(), reconcileFalseMerged(), apiCatch(), APP_DIR, configureWorkspaceForBot(), execAsync, generateInstallationToken(), generateInstallationTokenEffect() (+27 more)
+Cohesion: 0.05
+Nodes (37): Advanced Features, bd vs TodoWrite, Beads - Persistent Task Memory for AI Agents, CLI Reference, Close & Reopen, code:bash (# Link beads issue to GitHub issue PAN-84), code:bash (bd label add <id> <label> --json), code:bash (bd show <id> --json              # Full issue details) (+29 more)
 
 ### Community 193 - "Community 193"
-Cohesion: 0.06
-Nodes (9): FlyApiClient, FlyApiError, FlyExecResult, FlyMachine, FlyMachineConfig, client, fetchMock, machine (+1 more)
+Cohesion: 0.05
+Nodes (37): Arguments, Auto-Detection (when no wrapper config), code:block1 (1. Check: Does ~/.panopticon/skills/spec-readiness-*/config.), code:block10 (## Bug Analysis), code:block11 (Read spec-readiness-{identifier}.json), code:block12 (spec readiness MIN-704), code:yaml (# ~/.panopticon/skills/spec-readiness-mycompany/config.yaml), code:block3 (get_issue         → mcp__linear__get_issue(id, includeRelati) (+29 more)
 
 ### Community 194 - "Community 194"
-Cohesion: 0.1
-Nodes (28): acquireRestartLock(), acquireStaleBreaker(), isErrnoException(), isProcessAlive(), isStale(), readHolderFromPath(), readRestartLockHolder(), RestartLockError (+20 more)
+Cohesion: 0.07
+Nodes (32): atomicWrite(), backupIfNeeded(), detectProviderEnvConflicts(), findNewestBackup(), injectPanopticonInfraDeny(), injectProviderEnvOverlay(), INVALID_LEGACY_PATTERNS, OverlayResult (+24 more)
 
 ### Community 195 - "Community 195"
-Cohesion: 0.07
-Nodes (33): cleanupOldHealthEvents(), DatabaseError, deleteAgentHealthHistory(), getAgentsWithHistory(), getAllHealthHistory(), getHealthHistory(), getLatestHealthEvent(), getRecentHealthHistory() (+25 more)
+Cohesion: 0.09
+Nodes (25): BeadsTask, COMPLEXITY_KEYWORDS, COMPLEXITY_LABELS, ComplexityDetectionResult, ComplexityLevel, complexityToModel(), detectComplexity(), detectComplexityFromEstimate() (+17 more)
 
 ### Community 196 - "Community 196"
-Cohesion: 0.14
-Nodes (35): extractNumber(), archiveWorkspaceArtifactsImpl(), applyLabelGitHubImpl(), applyLabelLinearImpl(), closeGitHubDirectImpl(), closeGitHubPrImpl(), closeLinearDirectImpl(), closeRallyDirectImpl() (+27 more)
+Cohesion: 0.08
+Nodes (28): sentinel, initWorkspaceDiscoveredSessionsSchema(), emitReactiveLifecycleEvent(), emitResetMarkerCreated(), emitMemoryHealthChanged(), enqueueStatusRollupEvent(), emitMemoryObservationCreated(), emitStatusUpdatedEvent() (+20 more)
 
 ### Community 197 - "Community 197"
 Cohesion: 0.09
-Nodes (26): execAsync, rebaseFeatureBranch(), RebaseResult, ClaudeAuthStatus, getClaudeAuthStatusImpl, parseOAuthPayload(), readKeychainCredentials, CheckpointError (+18 more)
+Nodes (32): addRepoCommand(), AddRepoOptions, convertToSshUrl(), createCommand(), CreateOptions, createRemoteWorkspace(), DestroyOptions, encodeBeadsVersion() (+24 more)
 
 ### Community 198 - "Community 198"
-Cohesion: 0.07
-Nodes (16): clientMock, octokitMock, result, states, linearCall(), LinearTracker, constructorTracker, createdIssue (+8 more)
+Cohesion: 0.05
+Nodes (36): 1. All-Up Skill, 2. Awaiting Merge Page, 3. Workflow Orchestration Visibility, Acceptance Criteria, Architecture, Awaiting Merge Page Spec, Behavior, Benefits (+28 more)
 
 ### Community 199 - "Community 199"
-Cohesion: 0.09
-Nodes (34): BudgetKey, buildContext(), CandidateContext, countHits(), emptyAllocations(), emptyHitCounts(), escapeJsonForPrompt(), estimateTokens() (+26 more)
+Cohesion: 0.05
+Nodes (35): 1. Identity key and registry shape, 1. Per-project singleton baked in at three places, 2. Inverted model priority — hidden Sonnet default, 2. Model resolution — authoritative chain + resolution trace, 3. PAN-540 convoy reviewers in the registry, 3. PAN-540 convoy reviewers invisible, 4. Duplicate-tab risk on shared worktree, 4. Single-writer-per-worktree enforcement (+27 more)
 
 ### Community 200 - "Community 200"
-Cohesion: 0.07
-Nodes (33): ActivityEntry, AgentPauseFields, clearTroubledAgent(), CloisterHealth, fetchActivity(), formatDuration(), HEALTH_STATE_COLOR, HEALTH_STATE_EMOJI (+25 more)
+Cohesion: 0.05
+Nodes (36): Closure Checklist, Closure Pattern, code:bash ($ bd ready), code:bash (bd list --status in_progress), code:bash (bd show issue-id), code:block12 ("From bd notes: [summary of COMPLETED]. Currently [IN PROGRE), code:block13 (Issue: bd-42 "OAuth refresh token implementation"), code:block14 (- [ ] Implement rate limiting on refresh endpoint) (+28 more)
 
 ### Community 201 - "Community 201"
-Cohesion: 0.12
-Nodes (35): buildReleaseNotesMarkdown(), contractsPackageJsonPath, desktopPackageJsonPath, __dirname, ensureCleanTree(), ensureMainBranch(), ensureTagDoesNotExist(), __filename (+27 more)
+Cohesion: 0.05
+Nodes (35): API Commands, code:bash (gh issue list --state open --limit 50), code:bash (gh pr merge 456 --squash --delete-branch), code:bash (gh pr close 456), code:bash (gh pr checkout 456), code:bash (# Get PR comments), code:bash (gh issue list -R eltmon/panopticon-cli), code:bash (gh issue view 123) (+27 more)
 
 ### Community 202 - "Community 202"
-Cohesion: 0.06
-Nodes (35): Activity, AgentChannelReply, AgentId, AgentResolution, AgentStatus, CHANNEL_REPLY_KIND_VALUES, ChannelReplyArtifactRef, ChannelReplyKind (+27 more)
+Cohesion: 0.11
+Nodes (33): decodeFlywheelRunId, defaultFlywheelPrompt(), defaultFlywheelRunId(), FlywheelLifecycleOptions, FlywheelPauseResult, FlywheelResumeResult, isFlywheelDevcontainerRuntime(), parseRunId() (+25 more)
 
 ### Community 203 - "Community 203"
-Cohesion: 0.06
-Nodes (35): Adding Repos Mid-Work, Agent Skill: `/workspace-add-repo`, Architecture, code:typescript (export interface WorkspaceConfig {), code:block10, code:block11 (## Readonly Repos), code:typescript (// CURRENT: create worktree for every repo), code:typescript (// NEW: respect progressive mode) (+27 more)
+Cohesion: 0.07
+Nodes (32): registerFlywheelCommands(), postFlywheelPausePayload(), postFlywheelResumePayload(), postFlywheelStartPayload(), subscribeLatestFlywheelStatus(), abort, aborted, briefPath (+24 more)
 
 ### Community 204 - "Community 204"
-Cohesion: 0.06
-Nodes (35): Bug Tracking During Oversight, code:block1 (/pan-oversee PAN-129), code:bash (# Manually trigger review), code:bash (# Check specialist status), code:bash (# Wake it manually), code:bash (# Check if work agent received feedback), code:bash (# Check test status), code:bash (# Final status check) (+27 more)
+Cohesion: 0.1
+Nodes (26): addEventToCache(), CostCache, createEmptyCache(), getCacheFile(), getCacheStatus(), getCostsByIssue(), getCostsDir(), getCostsForIssue() (+18 more)
 
 ### Community 205 - "Community 205"
-Cohesion: 0.09
-Nodes (31): activeViolations, checkAgentForViolations(), clearOldViolations(), clearOldViolationsEffect(), DEFAULT_FPP_CONFIG, FPPViolation, FPPViolationConfig, FPPViolationType (+23 more)
+Cohesion: 0.06
+Nodes (9): FlyApiClient, FlyApiError, FlyExecResult, FlyMachine, FlyMachineConfig, client, fetchMock, machine (+1 more)
 
 ### Community 206 - "Community 206"
-Cohesion: 0.1
-Nodes (4): stopDeacon(), createHandoffEvent(), CloisterService, writeStateFile()
+Cohesion: 0.09
+Nodes (32): buildLeakedSpecialists(), buildTopConsumers(), bytesToGb(), collectAgentProcesses(), CpuSample, DEFAULT_RESOURCE_CONFIG, defaultThresholds(), ensureResourceConfigLoaded() (+24 more)
 
 ### Community 207 - "Community 207"
 Cohesion: 0.12
-Nodes (27): costAction(), CostRow, formatTokens(), GroupBy, resolveGroupKey(), confirmCost(), enrichAction(), formatCost() (+19 more)
+Nodes (23): hookCommand(), HookOptions, generateRecoveryPrompt(), checkHook(), clearHook(), collectMail(), generateFixedPointPrompt(), getHook() (+15 more)
 
 ### Community 208 - "Community 208"
-Cohesion: 0.06
-Nodes (32): cb, completedState, dispatched, featureWorkspace, ghArgs, ghExecFileMock, { handler, dispose }, implSlot (+24 more)
+Cohesion: 0.12
+Nodes (35): reconcileClosedPrReadyForMerge(), reconcileFalseMerged(), apiCatch(), APP_DIR, configureWorkspaceForBot(), execAsync, generateInstallationToken(), generateInstallationTokenEffect() (+27 more)
 
 ### Community 209 - "Community 209"
-Cohesion: 0.11
-Nodes (32): sshCommand(), CHUNK_BUDGET_CHARS_BY_MODEL, chunkEntriesByBudget(), CompactionOptions, CompactionResult, computeFileLists(), createFileOps(), CutPointResult (+24 more)
+Cohesion: 0.06
+Nodes (28): eightDaysAgo, events, payload, r1, r2, received, recent, remaining (+20 more)
 
 ### Community 210 - "Community 210"
-Cohesion: 0.09
-Nodes (24): forkCommand(), ForkOptions, buildCorrelationMap(), CorrelationResult, copySessionFromCompactBoundary(), createSummaryFork(), findLastCompactBoundaryOffset(), reserveSummaryForkSession() (+16 more)
+Cohesion: 0.07
+Nodes (22): countCompleteLines(), defaultTranscriptPoller, isSuccessfulExtractionResult(), RegisteredTranscript, registerTranscriptForPolling(), startTranscriptPoller(), syncTranscriptPollerRegistry(), activeA (+14 more)
 
 ### Community 211 - "Community 211"
-Cohesion: 0.1
-Nodes (25): addEventToCache(), CostCache, createEmptyCache(), getCacheFile(), getCacheStatus(), getCostsByIssue(), getCostsDir(), getCostsForIssue() (+17 more)
+Cohesion: 0.09
+Nodes (30): ActionKey, ActionLayout, derivePipelineState(), flattenActions(), getZoneAActions(), getZoneBActions(), normalizeCanonicalState(), PipelineState (+22 more)
 
 ### Community 212 - "Community 212"
-Cohesion: 0.07
-Nodes (29): AgentDetailView(), AgentDetailViewProps, AgentHealthHistory, fetchHealthHistory(), fetchSpecialists(), formatDuration(), formatTokens(), HEALTH_STATE_EMOJI (+21 more)
+Cohesion: 0.06
+Nodes (35): Activity, AgentChannelReply, AgentId, AgentResolution, AgentStatus, CHANNEL_REPLY_KIND_VALUES, ChannelReplyArtifactRef, ChannelReplyKind (+27 more)
 
 ### Community 213 - "Community 213"
-Cohesion: 0.06
-Nodes (34): Authentication failure, Build and push, Building the pan-workspace Image, code:bash (curl -L https://fly.io/install.sh | sh), code:bash (pan workspace delete PAN-42), code:bash (# Tunnel remote port 4173 to local port 4173), code:bash (pan workspace sync-auth PAN-42), code:bash (# Via the dashboard UI (Costs tab)) (+26 more)
+Cohesion: 0.12
+Nodes (35): buildReleaseNotesMarkdown(), contractsPackageJsonPath, desktopPackageJsonPath, __dirname, ensureCleanTree(), ensureMainBranch(), ensureTagDoesNotExist(), __filename (+27 more)
 
 ### Community 214 - "Community 214"
-Cohesion: 0.06
-Nodes (34): 1. Filesystem: `.claude/agents/<name>.md`, 2. CLI JSON: `--agents '{"name":{...}}'`, 3. Hybrid: Filesystem base + CLI `--model` override, Agent Definition Format (Full Spec), Agent Teams: Out of Scope, Architecture: Three Injection Paths, `claude agents` Has No JSON Output, code:yaml (---) (+26 more)
+Cohesion: 0.08
+Nodes (21): configShadowCommand(), ShadowOptions, PanopticonConfig, ENV_FILE_PATH, getShadowModeFromEnv(), loadPanopticonEnv(), parseEnvFile(), getShadowModeStatus() (+13 more)
 
 ### Community 215 - "Community 215"
-Cohesion: 0.06
-Nodes (34): 1. Agent Triggers Inspection (Only When Flagged), 2. Inspect Specialist Runs, 3. Inspect Specialist Reports, 4. Checkpoint System, Agent Workflow Integration, Check 1: Spec Fidelity, Check 2: Constraint Compliance, Check 3: Compile + Smoke (+26 more)
+Cohesion: 0.1
+Nodes (28): acquireRestartLock(), acquireStaleBreaker(), isErrnoException(), isProcessAlive(), isStale(), readHolderFromPath(), readRestartLockHolder(), RestartLockError (+20 more)
 
 ### Community 216 - "Community 216"
 Cohesion: 0.06
-Nodes (34): 1. Configuration Ownership, 2. Implementation Scope, 3. API Key Storage, 4. Complexity Routing, Acceptance Criteria Checklist, Agent Spawning Changes, Architecture, code:block1 (~/.panopticon/) (+26 more)
+Nodes (35): Adding Repos Mid-Work, Agent Skill: `/workspace-add-repo`, Architecture, code:typescript (export interface WorkspaceConfig {), code:block10, code:block11 (## Readonly Repos), code:typescript (// CURRENT: create worktree for every repo), code:typescript (// NEW: respect progressive mode) (+27 more)
 
 ### Community 217 - "Community 217"
 Cohesion: 0.06
-Nodes (34): `cli:interactive` and `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit, Gemini 3 Flash Preview Work Type Fit Analysis (+26 more)
+Nodes (35): Bug Tracking During Oversight, code:block1 (/pan-oversee PAN-129), code:bash (# Manually trigger review), code:bash (# Check specialist status), code:bash (# Wake it manually), code:bash (# Check if work agent received feedback), code:bash (# Check test status), code:bash (# Final status check) (+27 more)
 
 ### Community 218 - "Community 218"
 Cohesion: 0.06
-Nodes (34): `cli:interactive`, `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit (+26 more)
+Nodes (32): cb, completedState, dispatched, featureWorkspace, ghArgs, ghExecFileMock, { handler, dispose }, implSlot (+24 more)
 
 ### Community 219 - "Community 219"
-Cohesion: 0.06
-Nodes (34): Agent States, code:bash (# List recent boots — the previous boot (-1) is the crashed ), code:bash (# Check .pan/continue.json for each workspace), code:bash (# Current memory usage), code:markdown (## Crash Summary), code:typescript (pool: 'forks',), code:bash (# All OOM events from the crashed boot), code:bash (# Find the process table dump from the first OOM event) (+26 more)
+Cohesion: 0.09
+Nodes (31): activeViolations, checkAgentForViolations(), clearOldViolations(), clearOldViolationsEffect(), DEFAULT_FPP_CONFIG, FPPViolation, FPPViolationConfig, FPPViolationType (+23 more)
 
 ### Community 220 - "Community 220"
-Cohesion: 0.06
-Nodes (29): ClaudeMessageWithCwd, ClaudeUsage, ContentBlock, FILE_TOOLS, parseSessionJsonl(), SessionMetadata, corruptLines, file (+21 more)
+Cohesion: 0.07
+Nodes (24): SearchResult, RuntimeConversationsConfig, AgentIssueLookup, AgentIssueRecord, buildAgentIssueLookup(), buildEnrichSessionsJobPayload(), EnrichSessionsRpcInput, filterDomainEventForIssue() (+16 more)
 
 ### Community 221 - "Community 221"
 Cohesion: 0.07
-Nodes (28): getAvailableModelsRoute, getClaudeAuthRoute, getHarnessPolicyRoute, getMiniMaxDefaultsRoute, getOpenAIAuthRoute, getOpenRouterModelsRoute, getOptimalDefaultsRoute, getProviderEnvConflictsRoute (+20 more)
+Nodes (29): AgentDetailView(), AgentDetailViewProps, AgentHealthHistory, fetchHealthHistory(), fetchSpecialists(), formatDuration(), formatTokens(), HEALTH_STATE_EMOJI (+21 more)
 
 ### Community 222 - "Community 222"
-Cohesion: 0.06
-Nodes (33): 1. Upgrade CanonicalState to 9-State vBRIEF Lifecycle, 2. vBRIEF Lifecycle Folders, 3. `pan install` Bootstraps Deft, 4. Layered Rule Hierarchy for Agent Prompts, 5. Deterministic Gates in Cloister Pipeline, 6. Structured Planning Strategies, 7. Swarm Integration, 8. Issue Ingestion and Reconciliation (+25 more)
+Cohesion: 0.09
+Nodes (29): cleanFile(), configCommand(), execAsync, ExtendedProjectConfig, findFullProjectByTeam(), loadFullProjects(), seedCommand(), snapshotCommand() (+21 more)
 
 ### Community 223 - "Community 223"
 Cohesion: 0.06
-Nodes (31): `AgentStateService` — the single interface, Architectural principle, Backpressure, code:block1 (writers                          canonical state            ), code:typescript (// in AgentSnapshot Schema.Struct, add:), code:typescript (export const AgentActivityChanged = Schema.Struct({), code:typescript (export const AgentStateRestored = Schema.Struct({), code:typescript (// inside applyEvent switch, representative case:) (+23 more)
+Nodes (34): Authentication failure, Build and push, Building the pan-workspace Image, code:bash (curl -L https://fly.io/install.sh | sh), code:bash (pan workspace delete PAN-42), code:bash (# Tunnel remote port 4173 to local port 4173), code:bash (pan workspace sync-auth PAN-42), code:bash (# Via the dashboard UI (Costs tab)) (+26 more)
 
 ### Community 224 - "Community 224"
 Cohesion: 0.06
-Nodes (33): 10. Preserve power-user trust, 1. Replace the current page shell with a coherent settings shell, 2. Introduce reusable settings primitives, 3. Reorganize the settings information architecture, 4. Add explicit local settings navigation, 5. Redesign Providers into summary-first expandable management panels, 6. Redesign Model Routing around presets + overrides, not a wall of tiles, 7. Normalize Conversations, Terminal, Tracker Keys, Appearance, Maintenance, and Desktop sections into the shared system (+25 more)
+Nodes (34): 1. Filesystem: `.claude/agents/<name>.md`, 2. CLI JSON: `--agents '{"name":{...}}'`, 3. Hybrid: Filesystem base + CLI `--model` override, Agent Definition Format (Full Spec), Agent Teams: Out of Scope, Architecture: Three Injection Paths, `claude agents` Has No JSON Output, code:yaml (---) (+26 more)
 
 ### Community 225 - "Community 225"
 Cohesion: 0.06
-Nodes (32): 1. mem0 Overview, 2. Architecture, 3. Key Technical Details, 4. Managed Platform vs Open Source, 5. Performance Claims, 6. Panopticon Adoption Analysis, 7. References, AI Memory Layer Research: mem0 and Adoption Strategy for Panopticon (+24 more)
+Nodes (34): 1. Agent Triggers Inspection (Only When Flagged), 2. Inspect Specialist Runs, 3. Inspect Specialist Reports, 4. Checkpoint System, Agent Workflow Integration, Check 1: Spec Fidelity, Check 2: Constraint Compliance, Check 3: Compile + Smoke (+26 more)
 
 ### Community 226 - "Community 226"
 Cohesion: 0.06
-Nodes (33): 1. Public bootstrap/health/config endpoints, 2. Inspect the deployed frontend bundle, 3. SSH and inspect runtime directly, code:bash (pan remote setup), code:bash (fly auth whoami), code:bash (pan remote status), code:bash (fly proxy 4173:4173 -a <app>), code:bash (fly status -a <app>) (+25 more)
+Nodes (34): 1. Configuration Ownership, 2. Implementation Scope, 3. API Key Storage, 4. Complexity Routing, Acceptance Criteria Checklist, Agent Spawning Changes, Architecture, code:block1 (~/.panopticon/) (+26 more)
 
 ### Community 227 - "Community 227"
 Cohesion: 0.06
-Nodes (33): 1. Find the Agent Session, 2. Check Current Agent Status, 3. Send Your Message, 4. Verify Message Was Received, Change Priorities, code:bash (# ALWAYS use pan tell - it handles Enter correctly), code:bash (pan tell ISSUE-123 "Looks good! Please commit your changes a), code:bash (# List all sessions to find the correct name) (+25 more)
+Nodes (34): `cli:interactive` and `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit, Gemini 3 Flash Preview Work Type Fit Analysis (+26 more)
 
 ### Community 228 - "Community 228"
 Cohesion: 0.06
-Nodes (33): Backend Frameworks, code:yaml (projects:), code:bash (# Rebuild one workspace Docker stack from the configured com), code:bash (# Create workspace (uses configuration from projects.yaml)), code:yaml (services:), code:yaml (projects:), code:yaml (projects:), code:yaml (projects:) (+25 more)
+Nodes (34): `cli:interactive`, `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit (+26 more)
 
 ### Community 229 - "Community 229"
 Cohesion: 0.06
-Nodes (33): code:block1 (myproject/), code:block10 (your-project/), code:yaml (# ~/.panopticon/projects.yaml), code:yaml (# WRONG - causes Maven startup failure), code:yaml (projects:), code:yaml (projects:), code:yaml (services:), code:block4 (your-project/) (+25 more)
+Nodes (34): Agent States, code:bash (# List recent boots — the previous boot (-1) is the crashed ), code:bash (# Check .pan/continue.json for each workspace), code:bash (# Current memory usage), code:markdown (## Crash Summary), code:typescript (pool: 'forks',), code:bash (# All OOM events from the crashed boot), code:bash (# Find the process table dump from the first OOM event) (+26 more)
 
 ### Community 230 - "Community 230"
-Cohesion: 0.06
-Nodes (33): Agent Self-Requeue (Circuit Breaker), Automatic Handoffs, Cloister: AI Lifecycle Manager, code:block1 (┌───────────────────────────────────────────────────────────), code:json ({), code:javascript ({), code:json ({), code:bash (# Via dashboard - click "Start" in the Cloister status bar) (+25 more)
+Cohesion: 0.09
+Nodes (24): execAsync, rebaseFeatureBranch(), RebaseResult, ClaudeAuthStatus, getClaudeAuthStatusImpl, parseOAuthPayload(), readKeychainCredentials, CheckpointError (+16 more)
 
 ### Community 231 - "Community 231"
-Cohesion: 0.08
-Nodes (22): FetchFn, InternalState, LogFn, parsePositiveIntEnv(), readWatchdogConfig(), readWatchdogPersistentState(), SpawnRestart, SpawnRestartResult (+14 more)
+Cohesion: 0.06
+Nodes (33): 1. Upgrade CanonicalState to 9-State vBRIEF Lifecycle, 2. vBRIEF Lifecycle Folders, 3. `pan install` Bootstraps Deft, 4. Layered Rule Hierarchy for Agent Prompts, 5. Deterministic Gates in Cloister Pipeline, 6. Structured Planning Strategies, 7. Swarm Integration, 8. Issue Ingestion and Reconciliation (+25 more)
 
 ### Community 232 - "Community 232"
-Cohesion: 0.07
-Nodes (25): DeaconLogEntry, DeaconStatus(), DeaconStatusData, fetchDeaconLogs(), fetchDeaconStatus(), LOG_LEVEL_COLORS, LOG_LEVEL_LABELS, SpecialistHealthState (+17 more)
+Cohesion: 0.06
+Nodes (31): `AgentStateService` — the single interface, Architectural principle, Backpressure, code:block1 (writers                          canonical state            ), code:typescript (// in AgentSnapshot Schema.Struct, add:), code:typescript (export const AgentActivityChanged = Schema.Struct({), code:typescript (export const AgentStateRestored = Schema.Struct({), code:typescript (// inside applyEvent switch, representative case:) (+23 more)
 
 ### Community 233 - "Community 233"
-Cohesion: 0.09
-Nodes (15): getIssueDataService(), getIssueDataService(), getIssueDataService(), pruneClosedIssueReviewStatuses(), CACHE_DB_PATH, CacheEntry, CacheService, DEFAULT_TTLS (+7 more)
+Cohesion: 0.06
+Nodes (33): 10. Preserve power-user trust, 1. Replace the current page shell with a coherent settings shell, 2. Introduce reusable settings primitives, 3. Reorganize the settings information architecture, 4. Add explicit local settings navigation, 5. Redesign Providers into summary-first expandable management panels, 6. Redesign Model Routing around presets + overrides, not a wall of tiles, 7. Normalize Conversations, Terminal, Tracker Keys, Appearance, Maintenance, and Desktop sections into the shared system (+25 more)
 
 ### Community 234 - "Community 234"
-Cohesion: 0.11
-Nodes (28): drainPendingEvents(), envFor(), getDashboardUrl(), handlePanDone(), handleSessionStart(), handleToolExecutionEnd(), handleTurnEnd(), HookEnv (+20 more)
+Cohesion: 0.06
+Nodes (32): 1. mem0 Overview, 2. Architecture, 3. Key Technical Details, 4. Managed Platform vs Open Source, 5. Performance Claims, 6. Panopticon Adoption Analysis, 7. References, AI Memory Layer Research: mem0 and Adoption Strategy for Panopticon (+24 more)
 
 ### Community 235 - "Community 235"
 Cohesion: 0.06
-Nodes (32): 1. Installation Test, 2. DNS Setup Test, 3. Startup Test (pan up), 4. Port-based Fallback Test, 5. Traefik Routing Test, 6. Shutdown Test (pan down), 7. Minimal Mode Test, Automated Test Script (+24 more)
+Nodes (33): 1. Public bootstrap/health/config endpoints, 2. Inspect the deployed frontend bundle, 3. SSH and inspect runtime directly, code:bash (pan remote setup), code:bash (fly auth whoami), code:bash (pan remote status), code:bash (fly proxy 4173:4173 -a <app>), code:bash (fly status -a <app>) (+25 more)
 
 ### Community 236 - "Community 236"
 Cohesion: 0.06
-Nodes (32): 1.1 vBRIEF (Adopted), 1.2 Deft, 1.3 Superpowers, 1.4 Spec Kit (GitHub), 1.5 Taskmaster (eyaltoledano/claude-task-master), 1.6 OpenAI Agents SDK ("Agent OS" candidate), 1.7 Not Found / Need Clarification, 1. The Frameworks (+24 more)
+Nodes (33): 1. Find the Agent Session, 2. Check Current Agent Status, 3. Send Your Message, 4. Verify Message Was Received, Change Priorities, code:bash (# ALWAYS use pan tell - it handles Enter correctly), code:bash (pan tell ISSUE-123 "Looks good! Please commit your changes a), code:bash (# List all sessions to find the correct name) (+25 more)
 
 ### Community 237 - "Community 237"
 Cohesion: 0.06
-Nodes (31): 1. FizzyApiClient (`src/lib/tracker/fizzy-client.ts`), 2. FizzyCardMapping (SQLite), 3. FizzySyncService (`src/lib/fizzy/sync-service.ts`), 4. FizzyWebhookReceiver (`src/dashboard/server/routes/fizzy-webhooks.ts`), 5. FizzyColumnResolver (`src/lib/fizzy/column-resolver.ts`), Architecture, code:block1 (GitHub Issues (source of truth)), code:yaml (fizzy:) (+23 more)
+Nodes (33): Backend Frameworks, code:yaml (projects:), code:bash (# Rebuild one workspace Docker stack from the configured com), code:bash (# Create workspace (uses configuration from projects.yaml)), code:yaml (services:), code:yaml (projects:), code:yaml (projects:), code:yaml (projects:) (+25 more)
 
 ### Community 238 - "Community 238"
 Cohesion: 0.06
-Nodes (32): Automated Synthesis, Best Practices, Code Conflicts, code:bash (# Get convoy status and results), code:typescript (// Agent 1 added field:), code:bash (# Generate synthesis prompt), code:bash (# Convoy management), code:bash (# Check each workspace for changes) (+24 more)
+Nodes (33): code:block1 (myproject/), code:block10 (your-project/), code:yaml (# ~/.panopticon/projects.yaml), code:yaml (# WRONG - causes Maven startup failure), code:yaml (projects:), code:yaml (projects:), code:yaml (services:), code:block4 (your-project/) (+25 more)
 
 ### Community 239 - "Community 239"
 Cohesion: 0.06
-Nodes (32): code:bash (pan setup), code:yaml (# template.yaml), code:block11 (team-meta/), code:bash (# Setup Agent prompt includes:), code:block2 ($ pan setup), code:block3 (Step 2: Project Type Detection), code:block4 (Step 3: Template Selection), code:block5 (Step 4: Repository Configuration) (+24 more)
-
-### Community 240 - "Community 240"
-Cohesion: 0.06
-Nodes (32): Available TLDR Tools, Beads Tasks, code:block1 (1. Agent needs to understand auth.ts), code:bash (node -e "const fs=require('fs'); const p='.pan/spec.vbrief.j), code:bash (git fetch origin main && git rebase origin/main), code:bash (pan done {{ISSUE_ID}} -c "Work already complete from previou), code:json ({), code:bash (npm test                                         # Run tests) (+24 more)
+Nodes (33): Agent Self-Requeue (Circuit Breaker), Automatic Handoffs, Cloister: AI Lifecycle Manager, code:block1 (┌───────────────────────────────────────────────────────────), code:json ({), code:javascript ({), code:json ({), code:bash (# Via dashboard - click "Start" in the Cloister status bar) (+25 more)
 
 ### Community 241 - "Community 241"
-Cohesion: 0.11
-Nodes (4): createFlyApiClient(), effFromPromise(), execAsync, FlyProvider
+Cohesion: 0.08
+Nodes (25): approveReviewArtifactEffect(), ApproveReviewArtifactInput, buildRepositoryFlag(), commentOnArtifactEffect(), CommentOnArtifactInput, createReviewArtifactEffect(), CreateReviewArtifactInput, CreateReviewArtifactResult (+17 more)
 
 ### Community 242 - "Community 242"
-Cohesion: 0.14
-Nodes (26): ProcessSpawnError, TmuxError, CLAUDE_PROJECTS_DIR, SessionIndexEntry, agentDirFor(), agentsDir(), heartbeatsDir(), panopticonDir() (+18 more)
+Cohesion: 0.07
+Nodes (25): DeaconLogEntry, DeaconStatus(), DeaconStatusData, fetchDeaconLogs(), fetchDeaconStatus(), LOG_LEVEL_COLORS, LOG_LEVEL_LABELS, SpecialistHealthState (+17 more)
 
 ### Community 243 - "Community 243"
-Cohesion: 0.07
-Nodes (22): ChatMessage, MessagesTimeline, derivePlanningIssueId(), fetchOutput(), TerminalPanel(), TerminalPanelProps, SessionState, TerminalSessionWrapper() (+14 more)
+Cohesion: 0.11
+Nodes (28): drainPendingEvents(), envFor(), getDashboardUrl(), handlePanDone(), handleSessionStart(), handleToolExecutionEnd(), handleTurnEnd(), HookEnv (+20 more)
 
 ### Community 244 - "Community 244"
 Cohesion: 0.06
-Nodes (30): 1. JWT Expiry (Primary), 2. CLIProxy Log Tailing (Secondary), Automatic Retry, Bridging to CLIProxy, code:block1 (~/.panopticon/cliproxy/auth/codex-primary.json), code:bash (curl http://localhost:3000/api/settings/codex-auth), code:bash (pan config get issue-agent:implementation), code:block2 (~/.codex/) (+22 more)
+Nodes (32): 1. Installation Test, 2. DNS Setup Test, 3. Startup Test (pan up), 4. Port-based Fallback Test, 5. Traefik Routing Test, 6. Shutdown Test (pan down), 7. Minimal Mode Test, Automated Test Script (+24 more)
 
 ### Community 245 - "Community 245"
 Cohesion: 0.06
-Nodes (31): All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Critical Issue: Tool Behavior Bug (+23 more)
+Nodes (32): 1.1 vBRIEF (Adopted), 1.2 Deft, 1.3 Superpowers, 1.4 Spec Kit (GitHub), 1.5 Taskmaster (eyaltoledano/claude-task-master), 1.6 OpenAI Agents SDK ("Agent OS" candidate), 1.7 Not Found / Need Clarification, 1. The Frameworks (+24 more)
 
 ### Community 246 - "Community 246"
 Cohesion: 0.06
-Nodes (31): All subagents (except general-purpose), Claude Sonnet 4.6 Work Type Fit Analysis, `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent` (+23 more)
+Nodes (31): 1. FizzyApiClient (`src/lib/tracker/fizzy-client.ts`), 2. FizzyCardMapping (SQLite), 3. FizzySyncService (`src/lib/fizzy/sync-service.ts`), 4. FizzyWebhookReceiver (`src/dashboard/server/routes/fizzy-webhooks.ts`), 5. FizzyColumnResolver (`src/lib/fizzy/column-resolver.ts`), Architecture, code:block1 (GitHub Issues (source of truth)), code:yaml (fizzy:) (+23 more)
 
 ### Community 247 - "Community 247"
 Cohesion: 0.06
-Nodes (31): 1. Be Specific, 2. Explain Why, 3. Order Steps Logically, 4. Consider Edge Cases, 5. Be Realistic, code:typescript (// Find authentication code), code:typescript (AskUserQuestion({), code:markdown (# [ISSUE-ID]: [Issue Title]) (+23 more)
+Nodes (32): Automated Synthesis, Best Practices, Code Conflicts, code:bash (# Get convoy status and results), code:typescript (// Agent 1 added field:), code:bash (# Generate synthesis prompt), code:bash (# Convoy management), code:bash (# Check each workspace for changes) (+24 more)
 
 ### Community 248 - "Community 248"
 Cohesion: 0.06
-Nodes (31): Available Commands, Available Skills, Code Review, code:bash (# 1. Initialize Panopticon), code:bash (# 1. Optionally create a plan first), code:bash (# List all workspaces), Configuration, Configuration Files (+23 more)
+Nodes (32): code:bash (pan setup), code:yaml (# template.yaml), code:block11 (team-meta/), code:bash (# Setup Agent prompt includes:), code:block2 ($ pan setup), code:block3 (Step 2: Project Type Detection), code:block4 (Step 3: Template Selection), code:block5 (Step 4: Repository Configuration) (+24 more)
 
 ### Community 249 - "Community 249"
 Cohesion: 0.06
-Nodes (31): Best Practices, Built-in Convoy Templates, code-review Template, code:bash (# Run a parallel code review), code:block10 (1. Start command received), code:bash (# Watch convoy progress), code:bash (# Check individual agent status), code:block2 (pan convoy start code-review --files "src/**/*.ts") (+23 more)
+Nodes (32): Available TLDR Tools, Beads Tasks, code:block1 (1. Agent needs to understand auth.ts), code:bash (node -e "const fs=require('fs'); const p='.pan/spec.vbrief.j), code:bash (git fetch origin main && git rebase origin/main), code:bash (pan done {{ISSUE_ID}} -c "Work already complete from previou), code:json ({), code:bash (npm test                                         # Run tests) (+24 more)
 
 ### Community 250 - "Community 250"
 Cohesion: 0.09
-Nodes (29): ACCEPTANCE_CRITERIA_TEMPLATE, ALREADY_MIGRATED, AnalysisGraph, AnalysisOutput, assignWaves(), buildGraph(), buildPerFileItem(), buildSharedErrorsItem() (+21 more)
+Nodes (26): AlsoSyncTool, collectSkillDirs(), extractSkillName(), MultiToolSyncResult, readSkillContent(), stripFrontmatter(), syncSkillsToTools(), syncToAider() (+18 more)
 
 ### Community 251 - "Community 251"
-Cohesion: 0.08
-Nodes (26): applyBurnedTokenOverride(), CheckCodexAuthOptions, checkCodexAuthStatus(), CliproxyCodexCredentials, CodexAuthBurned, CodexAuthCheckError, CodexAuthExpired, CodexAuthMissing (+18 more)
+Cohesion: 0.12
+Nodes (31): getLocalFlywheelRunDir(), loadResumeSessionId(), saveResumeSessionId(), loadConfigAsyncNoMigrationEffect(), assertExistingPathInsideRoot(), createInitialFlywheelStatus(), dashboardSetting(), execAsync (+23 more)
 
 ### Community 252 - "Community 252"
-Cohesion: 0.09
-Nodes (26): buildFilterParams(), ConversationRpcFilter, ConversationsPage(), CostResponse, countCostFacets(), countFacetValues(), countTimeFacets(), DiscoveredSession (+18 more)
+Cohesion: 0.07
+Nodes (21): CLAUDE_PROJECTS_DIR, ClaudeMessage, getActiveSessionModel(), getRecentSessions(), getSessionFiles(), importSessionToCostLog(), normalizeModelName(), parseAllSessions() (+13 more)
 
 ### Community 253 - "Community 253"
-Cohesion: 0.09
-Nodes (25): captureTmuxOutput(), agentStatusCommand(), AgentStatusOptions, analyzeSession(), detectStatus(), extractCost(), extractModel(), MODEL_PATTERNS (+17 more)
+Cohesion: 0.08
+Nodes (20): ActivitySection, formatModel(), IsolationMode(), IsolationModeProps, TYPE_STYLES, ALLOWED_CSS_PROPERTIES, ALLOWED_SHIKI_ATTRS, ALLOWED_SHIKI_TAGS (+12 more)
 
 ### Community 254 - "Community 254"
-Cohesion: 0.12
-Nodes (21): cvCommand(), CVOptions, relativeTime(), showCommand(), ShowOptions, calls, logSpy, now (+13 more)
+Cohesion: 0.08
+Nodes (28): CategoryFilter, formatContextLength(), formatCost(), ModelCard(), OpenRouterModel, OpenRouterModelBrowser(), OpenRouterModelBrowserProps, fetchOpenRouterModels() (+20 more)
 
 ### Community 255 - "Community 255"
-Cohesion: 0.06
-Nodes (31): code:yaml (# Your original docker-compose.yml), code:bash (pan workspace create my-feature --template node-fullstack), code:block102 (~/.panopticon/templates/), code:toml ([template]), code:block109 (~/.panopticon/), code:yaml (# ~/.panopticon/traefik/dynamic/feature-min-648.yml), code:toml ([panopticon]), code:toml ([project]) (+23 more)
+Cohesion: 0.14
+Nodes (4): findProjectsByRallyProject(), IssueDataService, issuesChanged(), mapRallyStateToCanonical()
 
 ### Community 256 - "Community 256"
-Cohesion: 0.06
-Nodes (30): 1. Template File Resolution, 2. Config File Integration, 3. Docker Compose Integration, 4. Certificate Integration, code:bash (pan install), code:bash (node -e "import('./dist/chunk-*.js').then(m => console.log(m), code:bash (ls -la templates/traefik/), code:bash (ls -la ~/.panopticon/traefik/) (+22 more)
+Cohesion: 0.11
+Nodes (4): createFlyApiClient(), effFromPromise(), execAsync, FlyProvider
 
 ### Community 257 - "Community 257"
 Cohesion: 0.06
-Nodes (30): 1. Review Artifact Creation at `pan done`, 1. The work agent owns all code-changing git operations, 2. Merge-Set Data Model, 2. Review artifacts are created at work completion, 3. Merge agent is the coordinator for merge sets, 3. Work-Agent-Owned Rebase Flow, 4. Non-Mutating Post-Rebase Verification, 4. Verification runs twice (+22 more)
+Nodes (30): 1. JWT Expiry (Primary), 2. CLIProxy Log Tailing (Secondary), Automatic Retry, Bridging to CLIProxy, code:block1 (~/.panopticon/cliproxy/auth/codex-primary.json), code:bash (curl http://localhost:3000/api/settings/codex-auth), code:bash (pan config get issue-agent:implementation), code:block2 (~/.codex/) (+22 more)
 
 ### Community 258 - "Community 258"
 Cohesion: 0.06
-Nodes (30): 1. Extend XTerminal Component, 3. Smart Ctrl+C Logic, 4. Context Menu (Embedded in XTerminal), 5. Auto-Copy on Selection, 6. Configuration UI, Breakdown into Sub-Tasks, code:typescript (interface XTerminalProps {), code:typescript (// Pseudo-code) (+22 more)
+Nodes (31): All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Critical Issue: Tool Behavior Bug (+23 more)
 
 ### Community 259 - "Community 259"
 Cohesion: 0.06
-Nodes (30): All subagents, `cli:interactive` and `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit (+22 more)
+Nodes (31): All subagents (except general-purpose), Claude Sonnet 4.6 Work Type Fit Analysis, `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent` (+23 more)
 
 ### Community 260 - "Community 260"
 Cohesion: 0.06
-Nodes (30): Agent State Management, Architecture, code:block1 (┌───────────────────────────────────────────────────────────), code:bash (# Check what will be synced (including dev-skills)), code:block2 (~/.panopticon/), code:json ({), code:bash (pan remote init        # Initialize Fly.io provider), code:bash (pan work wipe MIN-123           # Basic cleanup) (+22 more)
+Nodes (31): 1. Be Specific, 2. Explain Why, 3. Order Steps Logically, 4. Consider Edge Cases, 5. Be Realistic, code:typescript (// Find authentication code), code:typescript (AskUserQuestion({), code:markdown (# [ISSUE-ID]: [Issue Title]) (+23 more)
 
 ### Community 261 - "Community 261"
 Cohesion: 0.06
-Nodes (30): 1. Planning Phase, 2. Implementation Phase, 3. Iteration, "API not enabled" errors, Available MCP Tools, Best Practices, Bidirectional Sync, Code Quality (+22 more)
+Nodes (31): Available Commands, Available Skills, Code Review, code:bash (# 1. Initialize Panopticon), code:bash (# 1. Optionally create a plan first), code:bash (# List all workspaces), Configuration, Configuration Files (+23 more)
 
 ### Community 262 - "Community 262"
 Cohesion: 0.06
-Nodes (30): Agent Commands, code:bash (# Spawn an agent for a Linear issue), code:bash (pan work request-review min-123 -m "Fixed: added tests and r), code:bash (# Clean up agents, state, Linear status), code:bash (# Recover a specific agent), code:bash (# Check status of all specialists), code:bash (# Initialize Fly.io provider), code:bash (pan work status) (+22 more)
+Nodes (31): Best Practices, Built-in Convoy Templates, code-review Template, code:bash (# Run a parallel code review), code:block10 (1. Start command received), code:bash (# Watch convoy progress), code:bash (# Check individual agent status), code:block2 (pan convoy start code-review --files "src/**/*.ts") (+23 more)
 
 ### Community 263 - "Community 263"
 Cohesion: 0.09
-Nodes (22): scanForConflictMarkers(), err, exec(), execFile(), execMock, kCustom, prompt, spawnRunMock (+14 more)
+Nodes (29): ACCEPTANCE_CRITERIA_TEMPLATE, ALREADY_MIGRATED, AnalysisGraph, AnalysisOutput, assignWaves(), buildGraph(), buildPerFileItem(), buildSharedErrorsItem() (+21 more)
 
 ### Community 264 - "Community 264"
-Cohesion: 0.1
-Nodes (22): buildMenuTemplate(), configureApplicationMenu(), fetchActiveWorkspaces(), rebuildMenu(), WorkspaceSummary, checkForUpdates(), currentStatus, downloadUpdate() (+14 more)
+Cohesion: 0.09
+Nodes (23): callServerApi(), buildMenuTemplate(), configureApplicationMenu(), fetchActiveWorkspaces(), rebuildMenu(), WorkspaceSummary, checkForUpdates(), currentStatus (+15 more)
 
 ### Community 265 - "Community 265"
 Cohesion: 0.1
-Nodes (18): cleanupOldEvents(), CLOISTER_DB_PATH, CloisterDatabaseError, deleteAgentHistory(), getAgentsWithHistory(), getAllHealthHistory(), getDatabaseStats(), getHealthDatabase() (+10 more)
+Nodes (27): buildReviewContext(), BuildReviewContextOpts, ChangedFile, execAsync, extractAcceptanceCriteria(), flattenAC(), getChangedFiles(), getCurrentBranch() (+19 more)
 
 ### Community 266 - "Community 266"
-Cohesion: 0.09
-Nodes (20): CapabilityStats, clearMetrics(), DailyStats, DEFAULT_METRICS, getAggregatedMetrics(), getAllRuntimeMetrics(), getIssueTasks(), getRecentTasks() (+12 more)
+Cohesion: 0.06
+Nodes (31): code:yaml (# Your original docker-compose.yml), code:bash (pan workspace create my-feature --template node-fullstack), code:block102 (~/.panopticon/templates/), code:toml ([template]), code:block109 (~/.panopticon/), code:yaml (# ~/.panopticon/traefik/dynamic/feature-min-648.yml), code:toml ([panopticon]), code:toml ([project]) (+23 more)
 
 ### Community 267 - "Community 267"
-Cohesion: 0.14
-Nodes (29): handleConversationImageUpload(), safeUploadExtension(), validateCwdContainment(), validateImageMagicBytes(), assertExistingPathInsideRoot(), assertWritePathInsideRoot(), isInsideRoot(), assertSafeName() (+21 more)
+Cohesion: 0.06
+Nodes (30): 1. Template File Resolution, 2. Config File Integration, 3. Docker Compose Integration, 4. Certificate Integration, code:bash (pan install), code:bash (node -e "import('./dist/chunk-*.js').then(m => console.log(m), code:bash (ls -la templates/traefik/), code:bash (ls -la ~/.panopticon/traefik/) (+22 more)
 
 ### Community 268 - "Community 268"
-Cohesion: 0.11
-Nodes (25): main(), print_usage(), build_compress_prompt(), build_fix_prompt(), call_claude(), compress_file(), Strip outer ```markdown ... ``` fence when it wraps the entire output., strip_llm_wrapper() (+17 more)
+Cohesion: 0.06
+Nodes (30): 1. Review Artifact Creation at `pan done`, 1. The work agent owns all code-changing git operations, 2. Merge-Set Data Model, 2. Review artifacts are created at work completion, 3. Merge agent is the coordinator for merge sets, 3. Work-Agent-Owned Rebase Flow, 4. Non-Mutating Post-Rebase Verification, 4. Verification runs twice (+22 more)
 
 ### Community 269 - "Community 269"
-Cohesion: 0.11
-Nodes (6): earliestOffset(), enqueueMemoryExtractionJob(), enqueueReconciledMemoryExtractionJobs(), MemoryExtractionWorkerPool, MemoryPipelineWorkerPool, normalizeQueueLimit()
+Cohesion: 0.06
+Nodes (30): 1. Extend XTerminal Component, 3. Smart Ctrl+C Logic, 4. Context Menu (Embedded in XTerminal), 5. Auto-Copy on Selection, 6. Configuration UI, Breakdown into Sub-Tasks, code:typescript (interface XTerminalProps {), code:typescript (// Pseudo-code) (+22 more)
 
 ### Community 270 - "Community 270"
-Cohesion: 0.1
-Nodes (24): AwaitingInputReason, compactPrompt(), detectAwaitingInputForAgent(), detectAwaitingInputFromPane(), findPermissionMenuEndIndex(), getPaneDetectionCacheKey(), isCurrentPromptIndex(), isRecentPromptIndex() (+16 more)
+Cohesion: 0.06
+Nodes (30): All subagents, `cli:interactive` and `cli:quick-command`, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit (+22 more)
 
 ### Community 271 - "Community 271"
-Cohesion: 0.12
-Nodes (17): contextCommand(), ContextOptions, appendSummary(), checkContextBudget(), ContextBudget, estimateTokens(), generateSummaryEntry(), getHistoryDir() (+9 more)
+Cohesion: 0.06
+Nodes (30): Agent State Management, Architecture, code:block1 (┌───────────────────────────────────────────────────────────), code:bash (# Check what will be synced (including dev-skills)), code:block2 (~/.panopticon/), code:json ({), code:bash (pan remote init        # Initialize Fly.io provider), code:bash (pan work wipe MIN-123           # Basic cleanup) (+22 more)
 
 ### Community 272 - "Community 272"
+Cohesion: 0.06
+Nodes (30): 1. Planning Phase, 2. Implementation Phase, 3. Iteration, "API not enabled" errors, Available MCP Tools, Best Practices, Bidirectional Sync, Code Quality (+22 more)
+
+### Community 273 - "Community 273"
+Cohesion: 0.06
+Nodes (30): Agent Commands, code:bash (# Spawn an agent for a Linear issue), code:bash (pan work request-review min-123 -m "Fixed: added tests and r), code:bash (# Clean up agents, state, Linear status), code:bash (# Recover a specific agent), code:bash (# Check status of all specialists), code:bash (# Initialize Fly.io provider), code:bash (pan work status) (+22 more)
+
+### Community 274 - "Community 274"
+Cohesion: 0.1
+Nodes (18): cleanupOldEvents(), CLOISTER_DB_PATH, CloisterDatabaseError, deleteAgentHistory(), getAgentsWithHistory(), getAllHealthHistory(), getDatabaseStats(), getHealthDatabase() (+10 more)
+
+### Community 275 - "Community 275"
 Cohesion: 0.13
 Nodes (26): buildDigestPrompt(), deleteContextDigest(), ensureContextDirectory(), execAsync(), generateContextDigest(), getContextDigestPath(), getContextDirectory(), getContextRunsCount() (+18 more)
 
-### Community 273 - "Community 273"
-Cohesion: 0.09
-Nodes (29): shouldSkipCheckpointReconciliation(), applyEvent(), bumpRuntimeSnapshotSequence(), DashboardLifecycleState, defaultRuntimeSnapshot(), getMaxMemoryObservationsPerIssue(), getMaxTurnDiffSummariesPerAgent(), isTerminalTurnDiffSummaryStatus() (+21 more)
+### Community 276 - "Community 276"
+Cohesion: 0.11
+Nodes (25): main(), print_usage(), build_compress_prompt(), build_fix_prompt(), call_claude(), compress_file(), Strip outer ```markdown ... ``` fence when it wraps the entire output., strip_llm_wrapper() (+17 more)
 
-### Community 274 - "Community 274"
+### Community 277 - "Community 277"
+Cohesion: 0.09
+Nodes (25): getTtsDaemonAuthHeaders(), buildDirectTtsSpeakPayload(), buildTtsSpeakPayload(), FetchLike, postSpeakPayload(), renderTemplate(), resolveAndSpeak(), ResolveAndSpeakDeps (+17 more)
+
+### Community 278 - "Community 278"
 Cohesion: 0.07
 Nodes (29): Agent Enrichment Service, API, Auto-Resume Gates, Bulk apply, code:yaml (cloister:), code:yaml (autoResume:), code:bash (tsx scripts/deacon-ignore-bulk.ts --prefix MIN --states "in ), Configuration (+21 more)
 
-### Community 275 - "Community 275"
+### Community 279 - "Community 279"
 Cohesion: 0.07
 Nodes (29): code:typescript (interface VBriefReference {), code:typescript (export interface VBriefInfo {), code:json ({), code:block4 (## vBRIEF Plan Format), code:markdown (| **vBRIEF Plan Format** | Machine-readable work plans using), code:typescript (// Scan for PRDs matching this issue), code:block7 (VBriefViewer), code:block8 (tests/vbrief/full-spec.test.ts) (+21 more)
 
-### Community 276 - "Community 276"
+### Community 280 - "Community 280"
 Cohesion: 0.07
 Nodes (29): 1. Be Realistic, 2. Verify with Code, 3. Consider Context, 4. Communicate Uncertainty, 5. Update Estimates, Best Practices, Bug Triage, code:bash (# Find related code) (+21 more)
 
-### Community 277 - "Community 277"
+### Community 281 - "Community 281"
 Cohesion: 0.07
 Nodes (29): Access Points, Alternative Backend Frameworks, API Communication, Backend CORS, Backend Development, code:block1 (project/), code:javascript (const cors = require('cors')), code:bash (docker compose exec backend npx prisma migrate dev) (+21 more)
 
-### Community 278 - "Community 278"
-Cohesion: 0.12
-Nodes (24): callServerApi(), createTerminalWindow(), createWindow(), dispatchMenuAction(), iconPath, IPC, isDevelopment, resolveResourcePath() (+16 more)
-
-### Community 279 - "Community 279"
+### Community 282 - "Community 282"
 Cohesion: 0.11
-Nodes (25): buildReviewContext(), BuildReviewContextOpts, ChangedFile, execAsync, extractAcceptanceCriteria(), flattenAC(), getChangedFiles(), getCurrentBranch() (+17 more)
+Nodes (4): getProjectDirs(), parseClaudeSession(), ClaudeCodeRuntime, ClaudeCodeRuntimeEffect
 
-### Community 280 - "Community 280"
+### Community 283 - "Community 283"
+Cohesion: 0.1
+Nodes (21): err, exec(), execFile(), execMock, kCustom, prompt, spawnRunMock, tmuxCapturePaneAsyncMock (+13 more)
+
+### Community 284 - "Community 284"
 Cohesion: 0.1
 Nodes (20): canonicalPrdSubdir(), findDraftPrd(), findPrdAnywhere(), findPrdAtStatus(), PrdFormat, PrdLocation, PrdStatus, STATUS_DIRS (+12 more)
 
-### Community 281 - "Community 281"
-Cohesion: 0.1
-Nodes (25): DiscoveredSession, findEnrichedSessionIdsMissingEmbedding(), getEmbedding(), buildEmbeddingText(), EmbedProgress, EmbedResult, EmbedSessionsOptions, selectSessionIdsForEmbedding() (+17 more)
-
-### Community 282 - "Community 282"
-Cohesion: 0.1
-Nodes (25): AnthropicContentBlock, AnthropicInputBlock, AnthropicMessage, AnthropicMessageResponse, AnthropicMessagesRequest, emptyBlock(), ensureOpenAICompatibleProxyRunning(), getOpenAICompatibleProxyBaseUrl() (+17 more)
-
-### Community 283 - "Community 283"
-Cohesion: 0.09
-Nodes (20): backfillDiscoveredSessionArrayIndexes(), initDiscoveredSessionsSchema(), initSchema(), initWorkspaceDiscoveredSessionsSchema(), base, cols, colsAfter, colsBefore (+12 more)
-
-### Community 284 - "Community 284"
-Cohesion: 0.07
-Nodes (28): API Endpoints, Architecture Overview, Backoff Strategy, CacheService (`src/dashboard/server/services/cache-service.ts`), code:block1 (Frontend (TanStack Query)), code:typescript (await issueDataService.invalidateTracker('github'); // or 'l), code:json ({), Dashboard API Caching & Real-Time Push Architecture (+20 more)
-
 ### Community 285 - "Community 285"
-Cohesion: 0.07
-Nodes (28): 1. Interactive CLI Wizard (`pan setup`), 2. Project Templates, 3. Setup Agent, Architecture, code:block1 ($ pan setup), code:typescript (interface SetupState {), code:typescript (async function detectRepos(projectPath: string): Promise<Det), code:block4 (templates/project-types/) (+20 more)
+Cohesion: 0.11
+Nodes (25): isNoResumeValueEnabled(), NO_RESUME_MODE_ACTIVE, TRUTHY_NO_RESUME_VALUES, formatGatingReason(), formatRestartAge(), formatRestartDuration(), formatTldrAge(), formatTldrRow() (+17 more)
 
 ### Community 286 - "Community 286"
-Cohesion: 0.07
-Nodes (28): 1. `ensureManagedTmuxConfig*` thrash on every tmux invocation, 2. 5000-line escape-coded snapshot on every attach, 3. `sendKeysAsync` per-line buffer + 50 ms sleep, Acceptance Criteria, Add, Code Changes Summary, code:typescript (// Lines 84-88 (sync) and 90-94 (async):), code:typescript (async function captureSnapshot(sessionName: string, cols: nu) (+20 more)
+Cohesion: 0.09
+Nodes (19): RoundMarker, ZoneCConversation(), ZoneCConversationProps, deriveRoundMarkers(), TimestampedItem, resolveWorkTypeKey(), useResolvedModels(), getViewKey() (+11 more)
 
 ### Community 287 - "Community 287"
 Cohesion: 0.07
-Nodes (28): 1. Keep or Remove Runtime Parameter?, 1. Remove Sync Targets and Runtime Adapters, 2. Config Migration Strategy, 2. Consolidate Cloister Runtime System, 3. Remove CLI Runtime Selection, 3. Symlink Cleanup Approach, 4. Cloister Runtime Consolidation, 4. Config Migration (+20 more)
+Nodes (28): API Endpoints, Architecture Overview, Backoff Strategy, CacheService (`src/dashboard/server/services/cache-service.ts`), code:block1 (Frontend (TanStack Query)), code:typescript (await issueDataService.invalidateTracker('github'); // or 'l), code:json ({), Dashboard API Caching & Real-Time Push Architecture (+20 more)
 
 ### Community 288 - "Community 288"
 Cohesion: 0.07
-Nodes (28): 1. Cleanup Strategy: **Delete Permanently**, 2. Age Threshold: **7 Days (Configurable)**, 3. Directory Types to Clean, 4. Cleanup Triggers: **Both Auto + Manual**, 5. Status Marking: **Add 'completed' Status**, 6. Cost Endpoint Migration: **Yes, Include It**, Acceptance Criteria, Blocker Status: RESOLVED ✓ (+20 more)
+Nodes (28): 1. Interactive CLI Wizard (`pan setup`), 2. Project Templates, 3. Setup Agent, Architecture, code:block1 ($ pan setup), code:typescript (interface SetupState {), code:typescript (async function detectRepos(projectPath: string): Promise<Det), code:block4 (templates/project-types/) (+20 more)
 
 ### Community 289 - "Community 289"
 Cohesion: 0.07
-Nodes (28): All subagents, inspect agent, merge agent, CLI modes, API Migration from Opus 4.6, Breaking Changes, Claude Opus 4.7 Work Type Fit Analysis, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer` (+20 more)
+Nodes (28): 1. `ensureManagedTmuxConfig*` thrash on every tmux invocation, 2. 5000-line escape-coded snapshot on every attach, 3. `sendKeysAsync` per-line buffer + 50 ms sleep, Acceptance Criteria, Add, Code Changes Summary, code:typescript (// Lines 84-88 (sync) and 90-94 (async):), code:typescript (async function captureSnapshot(sessionName: string, cols: nu) (+20 more)
 
 ### Community 290 - "Community 290"
 Cohesion: 0.07
-Nodes (28): All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, `convoy:performance-reviewer` and `convoy:correctness-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit, GLM-5.1 Work Type Fit Analysis (+20 more)
+Nodes (28): 1. Keep or Remove Runtime Parameter?, 1. Remove Sync Targets and Runtime Adapters, 2. Config Migration Strategy, 2. Consolidate Cloister Runtime System, 3. Remove CLI Runtime Selection, 3. Symlink Cleanup Approach, 4. Cloister Runtime Consolidation, 4. Config Migration (+20 more)
 
 ### Community 291 - "Community 291"
 Cohesion: 0.07
-Nodes (28): code:bash (# PAN-XXX -> /home/eltmon/projects/panopticon (GitHub)), code:block10 (Items:), code:block11 (Items:), code:json ({), code:json ({), code:bash (# Materialize beads and mark the workspace spec proposed), code:bash (# Load Stitch tools), code:bash (gh label create "planned" --color "0E8A16" 2>/dev/null || tr) (+20 more)
+Nodes (28): 1. Cleanup Strategy: **Delete Permanently**, 2. Age Threshold: **7 Days (Configurable)**, 3. Directory Types to Clean, 4. Cleanup Triggers: **Both Auto + Manual**, 5. Status Marking: **Add 'completed' Status**, 6. Cost Endpoint Migration: **Yes, Include It**, Acceptance Criteria, Blocker Status: RESOLVED ✓ (+20 more)
 
 ### Community 292 - "Community 292"
 Cohesion: 0.07
-Nodes (28): code:bash (# Check dashboard is running), code:bash (# Check for uncommitted changes), code:bash (# Create GitHub issue), code:bash (# Create test fixture), code:bash (# Trigger the approval - this kicks off review-agent), code:bash (# Watch review-agent (should complete review and hand off)), code:bash (# Check if branch was merged to main), code:bash (# Close the GitHub issue) (+20 more)
+Nodes (28): All subagents, inspect agent, merge agent, CLI modes, API Migration from Opus 4.6, Breaking Changes, Claude Opus 4.7 Work Type Fit Analysis, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer` (+20 more)
 
 ### Community 293 - "Community 293"
-Cohesion: 0.13
-Nodes (19): execFileAsync, gitFetch(), gitForcePush(), gitMerge(), gitPush(), gitRevParse(), MainDivergedError, appendGitOperation() (+11 more)
+Cohesion: 0.07
+Nodes (28): All subagents (`explore`, `plan`, `bash`, `general-purpose`), `cli:interactive` and `cli:quick-command`, `convoy:performance-reviewer` and `convoy:correctness-reviewer`, `convoy:requirements-reviewer`, `convoy:security-reviewer`, `convoy:synthesis-agent`, Excellent Fit, GLM-5.1 Work Type Fit Analysis (+20 more)
 
 ### Community 294 - "Community 294"
-Cohesion: 0.1
-Nodes (22): approveReviewArtifactEffect(), ApproveReviewArtifactInput, buildRepositoryFlag(), commentOnArtifactEffect(), CommentOnArtifactInput, createReviewArtifactEffect(), CreateReviewArtifactInput, CreateReviewArtifactResult (+14 more)
+Cohesion: 0.07
+Nodes (28): code:bash (# PAN-XXX -> /home/eltmon/projects/panopticon (GitHub)), code:block10 (Items:), code:block11 (Items:), code:json ({), code:json ({), code:bash (# Materialize beads and mark the workspace spec proposed), code:bash (# Load Stitch tools), code:bash (gh label create "planned" --color "0E8A16" 2>/dev/null || tr) (+20 more)
 
 ### Community 295 - "Community 295"
-Cohesion: 0.08
-Nodes (26): calculateCost(), CostEntry, DEFAULT_PRICING, getPricing(), logUsage(), ModelPricing, anthropicModels, cost (+18 more)
+Cohesion: 0.07
+Nodes (28): code:bash (# Check dashboard is running), code:bash (# Check for uncommitted changes), code:bash (# Create GitHub issue), code:bash (# Create test fixture), code:bash (# Trigger the approval - this kicks off review-agent), code:bash (# Watch review-agent (should complete review and hand off)), code:bash (# Check if branch was merged to main), code:bash (# Close the GitHub issue) (+20 more)
 
 ### Community 296 - "Community 296"
-Cohesion: 0.09
-Nodes (23): ComposerPlugin(), ComposerPromptEditor(), ComposerPromptEditorProps, EditorRefPluginProps, filterCommands(), getDraftKey(), InnerPluginProps, loadDraft() (+15 more)
+Cohesion: 0.11
+Nodes (24): AnthropicContentBlock, AnthropicInputBlock, AnthropicMessage, AnthropicMessageResponse, AnthropicMessagesRequest, emptyBlock(), ensureOpenAICompatibleProxyRunning(), getProxyPathname() (+16 more)
 
 ### Community 297 - "Community 297"
-Cohesion: 0.09
-Nodes (25): DEFAULT_FLYWHEEL_CONFIG, fetchFlywheelConversation(), fetchJson(), findFlywheelConversation(), FlywheelConversationPane(), FlywheelConversationPaneProps, FlywheelPaneViewMode, FlywheelRoleConfig (+17 more)
+Cohesion: 0.12
+Nodes (23): Role, buildChannelsArgs(), buildCommand(), buildNonConversationCommand(), buildPiCommand(), buildReviewSubRoleCommand(), generateLauncherWrapper(), LauncherConfig (+15 more)
 
 ### Community 298 - "Community 298"
 Cohesion: 0.08
-Nodes (18): PlanDialog(), PlanDialogProps, PlanningStatus, resolveSettingsModelRef(), SettingsResponse, StartPlanningResult, Step, fetchMock (+10 more)
+Nodes (26): calculateCost(), CostEntry, DEFAULT_PRICING, getPricing(), logUsage(), ModelPricing, anthropicModels, cost (+18 more)
 
 ### Community 299 - "Community 299"
-Cohesion: 0.07
-Nodes (27): 1.1 vBRIEF (Adopted), 1.2 Deft, 1.3 Superpowers, 1.4 Spec Kit (GitHub), 1.5 Not Found / Unavailable, 1. The Frameworks, 2.1 Ralph Wiggum Self-Assessment Loop, 2.2 Two-Stage Specialist Review Gate (+19 more)
+Cohesion: 0.18
+Nodes (22): AnyTrackerError, Comment, Issue, IssueFilters, IssueNotFoundError, IssueState, IssueTracker, IssueUpdate (+14 more)
 
 ### Community 300 - "Community 300"
-Cohesion: 0.07
-Nodes (28): Auto-Sync, `ccr` Utility Script, code:bash (# Direct execution (recommended)), code:bash (# Make executable (if needed)), code:block61 (~/.panopticon/skills/*     →  ~/.claude/skills/           # ), code:toml ([sync]), code:typescript (type SyncTargetState =), code:bash ($ pan sync) (+20 more)
+Cohesion: 0.13
+Nodes (19): execFileAsync, gitFetch(), gitForcePush(), gitMerge(), gitPush(), gitRevParse(), MainDivergedError, appendGitOperation() (+11 more)
 
 ### Community 301 - "Community 301"
-Cohesion: 0.07
-Nodes (27): 1. State of LLM Evals in 2026, 2.1 Compaction (`src/lib/conversations/smart-compaction.ts`), 2.2 Observability / Activity Feed (PAN-1052), 2.3 Other Panopticon surfaces (out of scope now, in scope soon), 2. What to evaluate in Panopticon, 3.1 Choice of base library: **`evalite` + `autoevals`** (both MIT, TS-native), in-tree under `evals/`., 3.2 Repo layout, 3.3 The `pan evals` CLI surface (+19 more)
+Cohesion: 0.09
+Nodes (23): ComposerPlugin(), ComposerPromptEditor(), ComposerPromptEditorProps, EditorRefPluginProps, filterCommands(), getDraftKey(), InnerPluginProps, loadDraft() (+15 more)
 
 ### Community 302 - "Community 302"
-Cohesion: 0.07
-Nodes (27): Async Gates for Workflow Coordination, Best Practices, Can't find gate ID, CI run ID detection fails, code:bash (bd config set types.custom '["gate"]'), code:bash (bd gate list | grep "spec-myfeature"), code:bash (# Check gate details), code:bash (# List all gates (including closed)) (+19 more)
+Cohesion: 0.08
+Nodes (18): PlanDialog(), PlanDialogProps, PlanningStatus, resolveSettingsModelRef(), SettingsResponse, StartPlanningResult, Step, fetchMock (+10 more)
 
 ### Community 303 - "Community 303"
 Cohesion: 0.07
-Nodes (27): code:block1 (User invokes /pan-code-review), code:typescript (// Read the synthesis report), code:bash (# Review all uncommitted changes (git diff)), code:bash (# Review specific files), code:bash (# Review all changes in current branch vs main), code:bash (# Focus on security only), code:typescript (// Default: review uncommitted changes), code:typescript (// Create reviews directory) (+19 more)
+Nodes (27): 1.1 vBRIEF (Adopted), 1.2 Deft, 1.3 Superpowers, 1.4 Spec Kit (GitHub), 1.5 Not Found / Unavailable, 1. The Frameworks, 2.1 Ralph Wiggum Self-Assessment Loop, 2.2 Two-Stage Specialist Review Gate (+19 more)
 
 ### Community 304 - "Community 304"
 Cohesion: 0.07
-Nodes (27): Case 1 — Expected Score: ~42 (Partial / Risky), Case 2 — Expected Score: ~35 (Not Ready), code:json ({), Deduction Examples, Deduction Examples, Deduction Examples, Deduction Examples, Deduction Examples (+19 more)
+Nodes (28): Auto-Sync, `ccr` Utility Script, code:bash (# Direct execution (recommended)), code:bash (# Make executable (if needed)), code:block61 (~/.panopticon/skills/*     →  ~/.claude/skills/           # ), code:toml ([sync]), code:typescript (type SyncTargetState =), code:bash ($ pan sync) (+20 more)
 
 ### Community 305 - "Community 305"
 Cohesion: 0.07
-Nodes (27): code:bash (pan project add <path> --name <name>), code:block10 (## New Project Setup Complete: <NAME>), code:yaml (<project-key>:), code:yaml (<project-key>:), code:bash (# Format: owner/repo:PREFIX (comma-separated)), code:bash (cd <project-path>), code:bash (mkdir -p <project-path>/workspaces), code:bash (grep -q '^workspaces/' <project-path>/.gitignore 2>/dev/null) (+19 more)
+Nodes (27): 1. State of LLM Evals in 2026, 2.1 Compaction (`src/lib/conversations/smart-compaction.ts`), 2.2 Observability / Activity Feed (PAN-1052), 2.3 Other Panopticon surfaces (out of scope now, in scope soon), 2. What to evaluate in Panopticon, 3.1 Choice of base library: **`evalite` + `autoevals`** (both MIT, TS-native), in-tree under `evals/`., 3.2 Repo layout, 3.3 The `pan evals` CLI surface (+19 more)
 
 ### Community 306 - "Community 306"
 Cohesion: 0.07
-Nodes (27): `.agent-template/`, code:block1 (team-meta/), code:bash (#!/bin/bash), code:yaml (groups:), code:block3 (Step 6: Meta Repo), code:bash (mkdir -p team-meta/{.agent-template/.claude,panopticon,docs/), code:bash (git clone git@github.com:yourorg/team-meta.git), code:bash (cd team-meta/docs/onboarding) (+19 more)
+Nodes (27): Async Gates for Workflow Coordination, Best Practices, Can't find gate ID, CI run ID detection fails, code:bash (bd config set types.custom '["gate"]'), code:bash (bd gate list | grep "spec-myfeature"), code:bash (# Check gate details), code:bash (# List all gates (including closed)) (+19 more)
 
 ### Community 307 - "Community 307"
 Cohesion: 0.07
-Nodes (27): 1. Test Coverage, 2. No Blocking Operations, 3. No Dead Code, 4. Error Handling, 5. Type Safety, 6. Temporal Dead Zone (TDZ), Acceptance Criteria (from vBRIEF plan) — MANDATORY GATE, APPROVED (rare — only for PERFECT code) (+19 more)
+Nodes (27): code:block1 (User invokes /pan-code-review), code:typescript (// Read the synthesis report), code:bash (# Review all uncommitted changes (git diff)), code:bash (# Review specific files), code:bash (# Review all changes in current branch vs main), code:bash (# Focus on security only), code:typescript (// Default: review uncommitted changes), code:typescript (// Create reviews directory) (+19 more)
 
 ### Community 308 - "Community 308"
-Cohesion: 0.11
-Nodes (16): cleanupPiTransientFiles(), execAsync, createPiFifo(), destroyPiFifo(), execAsync, PiFifoError, PiFifoPaths, PiNotReady (+8 more)
+Cohesion: 0.07
+Nodes (27): Case 1 — Expected Score: ~42 (Partial / Risky), Case 2 — Expected Score: ~35 (Not Ready), code:json ({), Deduction Examples, Deduction Examples, Deduction Examples, Deduction Examples, Deduction Examples (+19 more)
 
 ### Community 309 - "Community 309"
-Cohesion: 0.1
-Nodes (11): GitHubTracker, octokitToEffect(), parseIssueNumber(), error, mockComment, mockComments, mockIssue, mockIssues (+3 more)
+Cohesion: 0.07
+Nodes (27): code:bash (pan project add <path> --name <name>), code:block10 (## New Project Setup Complete: <NAME>), code:yaml (<project-key>:), code:yaml (<project-key>:), code:bash (# Format: owner/repo:PREFIX (comma-separated)), code:bash (cd <project-path>), code:bash (mkdir -p <project-path>/workspaces), code:bash (grep -q '^workspaces/' <project-path>/.gitignore 2>/dev/null) (+19 more)
 
 ### Community 310 - "Community 310"
-Cohesion: 0.13
-Nodes (20): CLAUDE_DIR, createClaudeAdapter(), createClaudeAdapterEffect(), createRuntimeRegistry(), getInstalledRuntimes(), getRuntimeAdapter(), getSupportedRuntimes(), isRuntimeInstalled() (+12 more)
+Cohesion: 0.07
+Nodes (27): `.agent-template/`, code:block1 (team-meta/), code:bash (#!/bin/bash), code:yaml (groups:), code:block3 (Step 6: Meta Repo), code:bash (mkdir -p team-meta/{.agent-template/.claude,panopticon,docs/), code:bash (git clone git@github.com:yourorg/team-meta.git), code:bash (cd team-meta/docs/onboarding) (+19 more)
 
 ### Community 311 - "Community 311"
 Cohesion: 0.07
-Nodes (21): createCall, createCalls, dbError, deleteCalls, doc, doctorCalls, existingBeads, expectedPrefix (+13 more)
+Nodes (27): 1. Test Coverage, 2. No Blocking Operations, 3. No Dead Code, 4. Error Handling, 5. Type Safety, 6. Temporal Dead Zone (TDZ), Acceptance Criteria (from vBRIEF plan) — MANDATORY GATE, APPROVED (rare — only for PERFECT code) (+19 more)
 
 ### Community 312 - "Community 312"
 Cohesion: 0.11
-Nodes (22): getTtsDaemonAuthHeaders(), buildDirectTtsSpeakPayload(), buildTtsSpeakPayload(), FetchLike, postSpeakPayload(), renderTemplate(), resolveAndSpeak(), ResolveAndSpeakDeps (+14 more)
+Nodes (21): buildACLookupByTitle(), buildActiveSliceContext(), buildWorkAgentPrompt(), extractStitchDesigns(), inferIssueIdFromWorkspace(), matchBeadToAC(), readBeadsTasks(), readFeatureContext() (+13 more)
 
 ### Community 313 - "Community 313"
-Cohesion: 0.07
-Nodes (26): A. Provider Billing & Observability → #730, Already Fixed / Shipped (14), B. Metrics Page v2 → #750, Biggest backlog themes, C. Documentation Overhaul → #634, Critical (5 issues) — 1.0 blockers or active pipeline corruption, D. Cost Display Polish → new umbrella or #77, Duplicates (10) (+18 more)
+Cohesion: 0.09
+Nodes (19): ActivityLevel, ActivitySource, emitActivityDetailed(), EmitActivityOptions, emitDashboardLifecycle(), EmitDetailedOptions, EmitTtsOptions, normalizeForSpeech() (+11 more)
 
 ### Community 314 - "Community 314"
-Cohesion: 0.07
-Nodes (26): 1. Check release readiness, 2. Create the release commit and tag, 3. Push intentionally, Branch and channel policy, Build or tests fail during preflight, Canary, Canary tags, code:bash (pan release check) (+18 more)
+Cohesion: 0.13
+Nodes (25): appendJsonl(), buildQueryExpansionCacheKey(), buildQueryExpansionPrompt(), CachedQueryExpansionResult, clearQueryExpansionCache(), expandMemoryQuery(), expansionCache, fallback() (+17 more)
 
 ### Community 315 - "Community 315"
 Cohesion: 0.07
-Nodes (26): Advanced: Work Type Table, Available Providers, Bulk Reset, Canonical Sources, Changing a Model Assignment, code:yaml (models:), code:yaml (openrouter:), Configuration File (+18 more)
+Nodes (26): A. Provider Billing & Observability → #730, Already Fixed / Shipped (14), B. Metrics Page v2 → #750, Biggest backlog themes, C. Documentation Overhaul → #634, Critical (5 issues) — 1.0 blockers or active pipeline corruption, D. Cost Display Polish → new umbrella or #77, Duplicates (10) (+18 more)
 
 ### Community 316 - "Community 316"
 Cohesion: 0.07
-Nodes (26): Anthropic-heavy reviews, cheaper helpers, Choosing What to Override, CLI Modes, code:yaml (models:), code:yaml (models:), code:yaml (models:), code:yaml (models:), code:yaml (models:) (+18 more)
+Nodes (26): 1. Check release readiness, 2. Create the release commit and tag, 3. Push intentionally, Branch and channel policy, Build or tests fail during preflight, Canary, Canary tags, code:bash (pan release check) (+18 more)
 
 ### Community 317 - "Community 317"
 Cohesion: 0.07
-Nodes (25): 1. The breaker logic and the reset logic do not match, 2. `manual_retry` does not fit the current history type, 3. The `markWorkspaceStuck()` sample call is type-wrong, 4. The new retry endpoint overlaps heavily with the existing unstick flow, 5. `checkStuckReviewing()` may become too aggressive if tmux output pauses, 6. The PRD should call out interaction with stale-session cleanup in `runParallelReview()`, 7. The frontend copy and state model are good, but the PRD under-specifies how `stuckReason` should drive copy, 8. Minor path/documentation mismatch (+17 more)
+Nodes (26): Advanced: Work Type Table, Available Providers, Bulk Reset, Canonical Sources, Changing a Model Assignment, code:yaml (models:), code:yaml (openrouter:), Configuration File (+18 more)
 
 ### Community 318 - "Community 318"
 Cohesion: 0.07
-Nodes (26): Acceptance Criteria, Architecture, Claude Code, CLI Surface, code:markdown (# Project Rules), code:block2 ([WARN] sync.devroot is deprecated. Run `pan context migrate`), code:block3 (pan context list                    # Show all three layers'), code:bash (claude --append-system-prompt-file "$WORKSPACE/.panopticon/c) (+18 more)
+Nodes (26): Anthropic-heavy reviews, cheaper helpers, Choosing What to Override, CLI Modes, code:yaml (models:), code:yaml (models:), code:yaml (models:), code:yaml (models:), code:yaml (models:) (+18 more)
 
 ### Community 319 - "Community 319"
 Cohesion: 0.07
-Nodes (26): A/B Infrastructure, code:markdown (## Simplicity First), code:markdown ({{#KARPATHY_GUIDELINES}}), code:markdown ({{#KARPATHY_GUIDELINES}}), code:markdown ({{#KARPATHY_GUIDELINES}}), code:yaml (# ~/.panopticon/config.yaml), Config Schema, Design (+18 more)
+Nodes (25): 1. The breaker logic and the reset logic do not match, 2. `manual_retry` does not fit the current history type, 3. The `markWorkspaceStuck()` sample call is type-wrong, 4. The new retry endpoint overlaps heavily with the existing unstick flow, 5. `checkStuckReviewing()` may become too aggressive if tmux output pauses, 6. The PRD should call out interaction with stale-session cleanup in `runParallelReview()`, 7. The frontend copy and state model are good, but the PRD under-specifies how `stuckReason` should drive copy, 8. Minor path/documentation mismatch (+17 more)
 
 ### Community 320 - "Community 320"
 Cohesion: 0.07
-Nodes (26): 1. Infrastructure Model: Self-Contained Machines, 2. Command Execution: Hybrid Approach, 3. Exe Provider: Delete and Reimplement, 4. Docker Image: Full Pipeline, 5. Workspace Flow: Full Parity (minus shared infra), 6. Cost Tracking: Existing JSONL System, 7. Agent Management: Fly Machine Exec API, Architecture (+18 more)
+Nodes (26): Acceptance Criteria, Architecture, Claude Code, CLI Surface, code:markdown (# Project Rules), code:block2 ([WARN] sync.devroot is deprecated. Run `pan context migrate`), code:block3 (pan context list                    # Show all three layers'), code:bash (claude --append-system-prompt-file "$WORKSPACE/.panopticon/c) (+18 more)
 
 ### Community 321 - "Community 321"
 Cohesion: 0.07
-Nodes (26): All implementation work types, All specialist agents (except review), All subagents, Claude Opus 4.6 Work Type Fit Analysis, CLI modes, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer` (+18 more)
+Nodes (26): A/B Infrastructure, code:markdown (## Simplicity First), code:markdown ({{#KARPATHY_GUIDELINES}}), code:markdown ({{#KARPATHY_GUIDELINES}}), code:markdown ({{#KARPATHY_GUIDELINES}}), code:yaml (# ~/.panopticon/config.yaml), Config Schema, Design (+18 more)
 
 ### Community 322 - "Community 322"
 Cohesion: 0.07
-Nodes (26): All convoy reviewers, All implementation work types, All specialist agents (except inspect), `cli:interactive`, `cli:quick-command`, Excellent Fit, Good Fit — Worth Benchmarking, GPT-5.4 Nano Work Type Fit Analysis (+18 more)
+Nodes (26): 1. Infrastructure Model: Self-Contained Machines, 2. Command Execution: Hybrid Approach, 3. Exe Provider: Delete and Reimplement, 4. Docker Image: Full Pipeline, 5. Workspace Flow: Full Parity (minus shared infra), 6. Cost Tracking: Existing JSONL System, 7. Agent Management: Fly Machine Exec API, Architecture (+18 more)
 
 ### Community 323 - "Community 323"
 Cohesion: 0.07
-Nodes (26): 1. Check Agent Status First, 2. Graceful Shutdown (Recommended), 3. Immediate Stop (If Needed), 4. Verify Stopped, 5. Clean Up (Optional), After Killing, code:bash (# Using pan CLI), code:bash (# List all matching sessions) (+18 more)
+Nodes (26): All implementation work types, All specialist agents (except review), All subagents, Claude Opus 4.6 Work Type Fit Analysis, CLI modes, `convoy:correctness-reviewer`, `convoy:performance-reviewer`, `convoy:requirements-reviewer` (+18 more)
 
 ### Community 324 - "Community 324"
 Cohesion: 0.07
-Nodes (26): code:bash (python3 scripts/conv-find.py <id>), code:text (Conversation #108), code:bash (python3 scripts/conv-find.py --jsonl 108), code:bash (python3 scripts/conv-find.py --summary 108), code:bash (python3 scripts/conv-find.py --json 108), code:bash (python3 scripts/conv-find.py --recent 20   # default 20), code:bash (python3 scripts/conv-find.py --search lexerra), code:python (import json, pathlib) (+18 more)
+Nodes (26): All convoy reviewers, All implementation work types, All specialist agents (except inspect), `cli:interactive`, `cli:quick-command`, Excellent Fit, Good Fit — Worth Benchmarking, GPT-5.4 Nano Work Type Fit Analysis (+18 more)
 
 ### Community 325 - "Community 325"
 Cohesion: 0.07
-Nodes (26): 1. Visual Theme & Atmosphere, 2. Color Palette & Roles, 3. Typography Rules, 4. Component Stylings, 5. Layout Principles, 6. Design System Notes for Stitch Generation, Accent & Interactive, Alignment & Visual Balance (+18 more)
+Nodes (26): 1. Check Agent Status First, 2. Graceful Shutdown (Recommended), 3. Immediate Stop (If Needed), 4. Verify Stopped, 5. Clean Up (Optional), After Killing, code:bash (# Using pan CLI), code:bash (# List all matching sessions) (+18 more)
 
 ### Community 326 - "Community 326"
 Cohesion: 0.07
-Nodes (26): Adding Repos Mid-Work, CLI Command, code:yaml (# ~/.panopticon/projects.yaml), code:yaml (# Old config — still works, all repos checked out), code:yaml (# team-meta/panopticon/repo-groups.yaml), code:bash (# Add specific repos), code:bash (# Add specific repos), code:block5 (/workspace-add-repo) (+18 more)
+Nodes (26): code:bash (python3 scripts/conv-find.py <id>), code:text (Conversation #108), code:bash (python3 scripts/conv-find.py --jsonl 108), code:bash (python3 scripts/conv-find.py --summary 108), code:bash (python3 scripts/conv-find.py --json 108), code:bash (python3 scripts/conv-find.py --recent 20   # default 20), code:bash (python3 scripts/conv-find.py --search lexerra), code:python (import json, pathlib) (+18 more)
 
 ### Community 327 - "Community 327"
 Cohesion: 0.07
-Nodes (26): Agent Self-Requeue (Circuit Breaker), code:block1 (Human clicks "Review"), code:bash (# All specialists with their current state), code:bash (# Via dashboard: click "Review" on an issue card), code:yaml (projects:), code:yaml (projects:), code:yaml (projects:), code:bash (# Via dashboard: click "Approve & Merge" on an issue card) (+18 more)
+Nodes (26): 1. Visual Theme & Atmosphere, 2. Color Palette & Roles, 3. Typography Rules, 4. Component Stylings, 5. Layout Principles, 6. Design System Notes for Stitch Generation, Accent & Interactive, Alignment & Visual Balance (+18 more)
 
 ### Community 328 - "Community 328"
-Cohesion: 0.08
-Nodes (23): CloisterEvent, setCloisterService(), capturedEvents, consoleSpy, customService, emergencyEvent, health, healths (+15 more)
+Cohesion: 0.07
+Nodes (26): Adding Repos Mid-Work, CLI Command, code:yaml (# ~/.panopticon/projects.yaml), code:yaml (# Old config — still works, all repos checked out), code:yaml (# team-meta/panopticon/repo-groups.yaml), code:bash (# Add specific repos), code:bash (# Add specific repos), code:block5 (/workspace-add-repo) (+18 more)
 
 ### Community 329 - "Community 329"
+Cohesion: 0.07
+Nodes (26): Agent Self-Requeue (Circuit Breaker), code:block1 (Human clicks "Review"), code:bash (# All specialists with their current state), code:bash (# Via dashboard: click "Review" on an issue card), code:yaml (projects:), code:yaml (projects:), code:yaml (projects:), code:bash (# Via dashboard: click "Approve & Merge" on an issue card) (+18 more)
+
+### Community 330 - "Community 330"
 Cohesion: 0.11
 Nodes (19): childEnv, expectedExits, killChildTree(), port, requiredFiles, restartQueue, shutdown(), startApp() (+11 more)
 
-### Community 330 - "Community 330"
-Cohesion: 0.12
-Nodes (21): markEnrichmentFailed(), buildConversationExcerpt(), buildL1Prompt(), buildL2Prompt(), buildL3Prompt(), callClaudeApi(), callClaudeApiWithConfig(), createConfiguredClaudeApi() (+13 more)
-
 ### Community 331 - "Community 331"
-Cohesion: 0.15
-Nodes (24): deletePRDDraft(), deletePRDDraftEffect(), getPRDDraftInfo(), getPRDDraftInfoEffect(), getPRDDraftPathEffect(), hasPRDDraftEffect(), listPRDDrafts(), listPRDDraftsEffect() (+16 more)
+Cohesion: 0.08
+Nodes (23): CloisterEvent, setCloisterService(), capturedEvents, consoleSpy, customService, emergencyEvent, health, healths (+15 more)
 
 ### Community 332 - "Community 332"
-Cohesion: 0.13
-Nodes (21): runCostSync(), buildSessionIndex(), decodeClaudeDirName(), extractCostEvents(), extractSessionId(), getAgentsDir(), getClaudeProjectsDir(), getSessionOffset() (+13 more)
-
-### Community 333 - "Community 333"
-Cohesion: 0.13
-Nodes (24): appendJsonl(), buildQueryExpansionCacheKey(), buildQueryExpansionPrompt(), CachedQueryExpansionResult, clearQueryExpansionCache(), expandMemoryQuery(), expansionCache, fallback() (+16 more)
-
-### Community 334 - "Community 334"
 Cohesion: 0.09
 Nodes (19): extractEmbedding(), ExtractEmbeddingInput, previewDesignVoice(), PreviewDesignVoiceInput, saveCloneVoice(), SaveCloneVoiceInput, saveDesignVoice(), SaveDesignVoiceInput (+11 more)
 
-### Community 335 - "Community 335"
-Cohesion: 0.13
-Nodes (21): extractTtsEmbedding(), speakTts(), startTtsDaemonFromDashboard(), StoredEvent, ActivityTtsPayload, drainQueue(), dropIndexForFullQueue(), enqueueActivityTts() (+13 more)
+### Community 333 - "Community 333"
+Cohesion: 0.1
+Nodes (23): CHANNEL_PERMISSION_LIMITS, normalizeChannelPermissionRequestFields(), NormalizedChannelPermissionRequestFields, normalizePermissionInputPreview(), PermissionPayloadValidationError, utf8ByteLength(), buildPermissionActivityDetails(), buildPermissionWaitingMessage() (+15 more)
 
-### Community 336 - "Community 336"
+### Community 334 - "Community 334"
 Cohesion: 0.08
 Nodes (22): body, bytes, claudeProjectDir, conv, created, deliverMock, encodedCwd, getTrustedOrigins() (+14 more)
 
-### Community 337 - "Community 337"
+### Community 335 - "Community 335"
 Cohesion: 0.08
 Nodes (25): BRANCH_NOT_FOUND, Check Merged, code:bash (# Standard naming convention), code:bash (# Get repo list from project config), code:bash (# Check local branches), code:bash (# Check for unmerged commits), code:bash (git -C "$PROJECT_PATH" fetch origin "$BRANCH" 2>/dev/null), code:bash (# Check if any commit in main references the issue ID) (+17 more)
 
-### Community 338 - "Community 338"
+### Community 336 - "Community 336"
 Cohesion: 0.08
 Nodes (25): 10. Footer, 1. Brand Stripe (4px), 2. Header Block (primary_color background), 3. Issue Info Row (Light Gray background, #F5F5F5), 4. Score Dashboard — 5 metric cards in a row/grid, 5. Overall Score Bar, 6. Top Blockers (Amber/warning callout box), 7. Dimension Details — One section per dimension (+17 more)
 
-### Community 339 - "Community 339"
-Cohesion: 0.12
-Nodes (16): ForgeType, buildMergeSetForIssue(), getRepoForge(), inferProjectForge(), normalizeForge(), resolveConfiguredRepos(), ResolvedProjectRepo, resolveProjectReposForIssue() (+8 more)
-
-### Community 340 - "Community 340"
+### Community 337 - "Community 337"
 Cohesion: 0.08
 Nodes (20): assistantIssues, assistantText, CLAUDE_PROJECTS, contextIssues, cost, db, DB_PATH, entries (+12 more)
 
-### Community 341 - "Community 341"
+### Community 338 - "Community 338"
 Cohesion: 0.12
 Nodes (15): completeSession(), DEFAULT_DATA, findSessionById(), getAllIssuesWithCosts(), getIssueCostSummary(), getIssueSessions(), IssueSessionMap, linkSessionToIssue() (+7 more)
 
-### Community 342 - "Community 342"
-Cohesion: 0.15
-Nodes (21): CostLimitsConfig, checkCostLimits(), checkDailyReset(), COST_DATA_FILE, CostAlert, CostAlertLevel, CostData, CostDataPersisted (+13 more)
-
-### Community 343 - "Community 343"
+### Community 339 - "Community 339"
 Cohesion: 0.12
 Nodes (10): defectQuery, hrQuery, mockCreate, mockQuery, mockUpdate, tracker, escapeQueryValue(), RallyTracker (+2 more)
 
+### Community 340 - "Community 340"
+Cohesion: 0.15
+Nodes (21): CostLimitsConfig, checkCostLimits(), checkDailyReset(), COST_DATA_FILE, CostAlert, CostAlertLevel, CostData, CostDataPersisted (+13 more)
+
+### Community 341 - "Community 341"
+Cohesion: 0.17
+Nodes (24): handleConversationImageUpload(), safeUploadExtension(), validateCwdContainment(), validateImageMagicBytes(), assertSafeName(), cleanupConversationAttachments(), cleanupUnreferencedConversationAttachments(), ensureConversationAttachmentDir() (+16 more)
+
+### Community 342 - "Community 342"
+Cohesion: 0.12
+Nodes (16): ForgeType, buildMergeSetForIssue(), getRepoForge(), inferProjectForge(), normalizeForge(), resolveConfiguredRepos(), ResolvedProjectRepo, resolveProjectReposForIssue() (+8 more)
+
+### Community 343 - "Community 343"
+Cohesion: 0.11
+Nodes (21): buildReviewFeedbackBody(), deliverReviewVerdictFeedback(), DeliverReviewVerdictFeedbackOptions, DeliverReviewVerdictFeedbackResult, execFileAsync, findLatestSynthesis(), parseGitHubPrUrl(), postPrComment() (+13 more)
+
 ### Community 344 - "Community 344"
-Cohesion: 0.08
-Nodes (18): generateRouterConfigFromWorkTypes(), Provider, ROUTER_CONFIG_DIR, ROUTER_CONFIG_FILE, RouterConfig, RouterRule, config, config1 (+10 more)
+Cohesion: 0.1
+Nodes (15): clearTtsVoices(), deleteTtsVoice(), fetchTtsVoices(), playTtsVoice(), requireTtsSpoken(), TtsVoiceListItem, playVoice(), requireTtsSpoken() (+7 more)
 
 ### Community 345 - "Community 345"
-Cohesion: 0.15
-Nodes (19): FsError, readWorkspaceContext(), writeWorkspaceContext(), ensureWorkspacePanDir(), getWorkspacePanPaths(), readWorkspaceContinue(), uniqueTmpPath(), workspacePanPaths() (+11 more)
+Cohesion: 0.13
+Nodes (8): CACHE_DB_PATH, CacheEntry, CacheService, DEFAULT_TTLS, L1Entry, openSqliteDb(), RateLimitInfo, _require
 
 ### Community 346 - "Community 346"
-Cohesion: 0.08
-Nodes (24): Agent Auto-Resume Gates, Beads Enforcement, Claude Code Channels (experimental), Commit and Push When Working on Main, CRITICAL: Deep-Wipe Destroys Everything — NEVER Run Without Explicit User Confirmation, CRITICAL: Deliver Complete Features — No Partial Implementations, CRITICAL: JSONL Session Files Are Sacred — NEVER Delete, CRITICAL: Never Do Agent Work — Fix the System (+16 more)
+Cohesion: 0.14
+Nodes (20): checkTtsHealth(), startTtsDaemonFromDashboard(), StoredEvent, ActivityTtsPayload, drainQueue(), dropIndexForFullQueue(), enqueueActivityTts(), eventPriority() (+12 more)
 
 ### Community 347 - "Community 347"
 Cohesion: 0.08
-Nodes (24): Architecture, Auto-Start, Auto-Updater Channels, Available Actions, Building the Desktop App, Cmd+K Command Palette, code:bash (chmod +x Panopticon-*.AppImage), code:bash (npx panopticon serve) (+16 more)
+Nodes (24): Agent Auto-Resume Gates, Beads Enforcement, Claude Code Channels (experimental), Commit and Push When Working on Main, CRITICAL: Deep-Wipe Destroys Everything — NEVER Run Without Explicit User Confirmation, CRITICAL: Deliver Complete Features — No Partial Implementations, CRITICAL: JSONL Session Files Are Sacred — NEVER Delete, CRITICAL: Never Do Agent Work — Fix the System (+16 more)
 
 ### Community 348 - "Community 348"
 Cohesion: 0.08
-Nodes (24): Backlog (hidden), Canonical States (Internal), Classification Labels (all trackers), Close-Out Ceremony, code:block1 (┌─────────────────────────────────────────┐), code:block2 (docs/prds/), code:block3 (backlog      -- Hidden from board, separate view), Columns (+16 more)
+Nodes (24): Architecture, Auto-Start, Auto-Updater Channels, Available Actions, Building the Desktop App, Cmd+K Command Palette, code:bash (chmod +x Panopticon-*.AppImage), code:bash (npx panopticon serve) (+16 more)
 
 ### Community 349 - "Community 349"
 Cohesion: 0.08
-Nodes (24): code:block1 (project-repo/), code:block2 (project-repo/), code:yaml (models:), code:yaml (# ~/.panopticon/config.yaml), code:yaml (# .pan.yaml (per-project, merges with global — never replace), code:block6 (project-repo/  (main branch)), code:block7 (project-repo/  (feature branch workspace)), code:block8 (.pan/events/) (+16 more)
+Nodes (24): Backlog (hidden), Canonical States (Internal), Classification Labels (all trackers), Close-Out Ceremony, code:block1 (┌─────────────────────────────────────────┐), code:block2 (docs/prds/), code:block3 (backlog      -- Hidden from board, separate view), Columns (+16 more)
 
 ### Community 350 - "Community 350"
 Cohesion: 0.08
-Nodes (24): Authentication & Network Exposure, Backpressure, Bash / curl, code:block1 (GET /events/stream), code:block2 (event: activity.entry), code:bash (curl -N -H "Accept: text/event-stream" \), code:python (import sseclient, requests, json), code:ts (import { EventSource } from 'eventsource';) (+16 more)
+Nodes (24): code:block1 (project-repo/), code:block2 (project-repo/), code:yaml (models:), code:yaml (# ~/.panopticon/config.yaml), code:yaml (# .pan.yaml (per-project, merges with global — never replace), code:block6 (project-repo/  (main branch)), code:block7 (project-repo/  (feature branch workspace)), code:block8 (.pan/events/) (+16 more)
 
 ### Community 351 - "Community 351"
 Cohesion: 0.08
-Nodes (25): Automatic Complexity Detection, Beads Integration, code:block10 (┌───────────────────────────────────────────────────────────), code:typescript (// Example: Task completion triggers handoff), code:yaml (# ~/.panopticon/cloister.yaml), code:typescript (interface HandoffContext {), code:block18 (┌───────────────────────────────────────────────────────────), code:typescript (interface HandoffEvent {) (+17 more)
+Nodes (24): Authentication & Network Exposure, Backpressure, Bash / curl, code:block1 (GET /events/stream), code:block2 (event: activity.entry), code:bash (curl -N -H "Accept: text/event-stream" \), code:python (import sseclient, requests, json), code:ts (import { EventSource } from 'eventsource';) (+16 more)
 
 ### Community 352 - "Community 352"
 Cohesion: 0.08
-Nodes (24): Adding New Assets, Build Commands, Build Commands, Build Pipeline, Build Tools, code:javascript (// Injected by tsdown shims), code:typescript (import { renderPrompt } from './prompts.js';), code:block3 (src/lib/cloister/prompts/*.md → dist/dashboard/prompts/) (+16 more)
+Nodes (25): Automatic Complexity Detection, Beads Integration, code:block10 (┌───────────────────────────────────────────────────────────), code:typescript (// Example: Task completion triggers handoff), code:yaml (# ~/.panopticon/cloister.yaml), code:typescript (interface HandoffContext {), code:block18 (┌───────────────────────────────────────────────────────────), code:typescript (interface HandoffEvent {) (+17 more)
 
 ### Community 353 - "Community 353"
 Cohesion: 0.08
-Nodes (23): Acceptance Criteria, Architecture, Budget Controls, Build Pipeline, CLI, code:bash (# scripts/build-docs-index.ts), code:block3 (pan docs query "<text>" [--top 5] [--kind docs|skill|rule|pr), code:markdown (## docs/HARNESSES.md → Installing Pi) (+15 more)
+Nodes (24): Adding New Assets, Build Commands, Build Commands, Build Pipeline, Build Tools, code:javascript (// Injected by tsdown shims), code:typescript (import { renderPrompt } from './prompts.js';), code:block3 (src/lib/cloister/prompts/*.md → dist/dashboard/prompts/) (+16 more)
 
 ### Community 354 - "Community 354"
 Cohesion: 0.08
-Nodes (24): Acceptance Criteria, Architecture, code:block1 (┌─────────────────────────────────────────────────────┐), code:typescript (// packages/contracts/src/editor.ts), code:typescript (// In WS_METHODS:), code:typescript ([WS_METHODS.shellOpenInEditor]: (input) => panOpen.openInEdi), code:block5 (┌─ Inspector: MIN-846 ─────────────────────────────────┐), Design Goals (+16 more)
+Nodes (23): Acceptance Criteria, Architecture, Budget Controls, Build Pipeline, CLI, code:bash (# scripts/build-docs-index.ts), code:block3 (pan docs query "<text>" [--top 5] [--kind docs|skill|rule|pr), code:markdown (## docs/HARNESSES.md → Installing Pi) (+15 more)
 
 ### Community 355 - "Community 355"
 Cohesion: 0.08
-Nodes (24): Architecture, code:block1 (MissionControl (index.tsx)), code:block2 (JSONL file (append-only)), code:block3 (@pierre/diffs, react-markdown, remark-gfm, lexical, @lexical), Data Flow, Decisions, Frontend Changes, Full Lexical Editor (+16 more)
+Nodes (24): Acceptance Criteria, Architecture, code:block1 (┌─────────────────────────────────────────────────────┐), code:typescript (// packages/contracts/src/editor.ts), code:typescript (// In WS_METHODS:), code:typescript ([WS_METHODS.shellOpenInEditor]: (input) => panOpen.openInEdi), code:block5 (┌─ Inspector: MIN-846 ─────────────────────────────────┐), Design Goals (+16 more)
 
 ### Community 356 - "Community 356"
 Cohesion: 0.08
-Nodes (24): code:yaml (projects:), code:bash (# Run all tests for a workspace), code:yaml (tests:), code:yaml (tests:), code:yaml (tests:), code:yaml (tests:), code:block7 (reports/), code:markdown (# Test Run Report - feature-min-123) (+16 more)
+Nodes (24): Architecture, code:block1 (MissionControl (index.tsx)), code:block2 (JSONL file (append-only)), code:block3 (@pierre/diffs, react-markdown, remark-gfm, lexical, @lexical), Data Flow, Decisions, Frontend Changes, Full Lexical Editor (+16 more)
 
 ### Community 357 - "Community 357"
 Cohesion: 0.08
-Nodes (24): Adding DNS Entries, Automatic (Recommended), Checking Status, code:bash (pan doctor --fix), code:powershell (powershell -ExecutionPolicy Bypass -File "$env:USERPROFILE\.), code:powershell (cd \\wsl$\Ubuntu-20.04\home\eltmon\projects\panopticon\infra), code:powershell (# Copy sync script), code:bash (echo "myapp.localhost" >> ~/.wsl2hosts) (+16 more)
+Nodes (24): code:yaml (projects:), code:bash (# Run all tests for a workspace), code:yaml (tests:), code:yaml (tests:), code:yaml (tests:), code:yaml (tests:), code:block7 (reports/), code:markdown (# Test Run Report - feature-min-123) (+16 more)
 
 ### Community 358 - "Community 358"
 Cohesion: 0.08
-Nodes (24): 1. Provider Configuration, 2. Cost Tracking, 3. Model Routing, 4. Dashboard Visibility, 5. CLI Visibility, API Contract, Chat Completions, code:block1 (POST /v1/chat/completions) (+16 more)
+Nodes (24): Adding DNS Entries, Automatic (Recommended), Checking Status, code:bash (pan doctor --fix), code:powershell (powershell -ExecutionPolicy Bypass -File "$env:USERPROFILE\.), code:powershell (cd \\wsl$\Ubuntu-20.04\home\eltmon\projects\panopticon\infra), code:powershell (# Copy sync script), code:bash (echo "myapp.localhost" >> ~/.wsl2hosts) (+16 more)
 
 ### Community 359 - "Community 359"
-Cohesion: 0.09
-Nodes (20): existingSkillDir, existsInTarget, mockClaudeSkills, mockPanopticonSkills, nonSkillDir, skillDir, skills, skillsToSync (+12 more)
+Cohesion: 0.08
+Nodes (24): 1. Provider Configuration, 2. Cost Tracking, 3. Model Routing, 4. Dashboard Visibility, 5. CLI Visibility, API Contract, Chat Completions, code:block1 (POST /v1/chat/completions) (+16 more)
 
 ### Community 360 - "Community 360"
 Cohesion: 0.13
-Nodes (18): buildAnthropicMessagesUrl(), cache, CacheEntry, cacheKey(), classifyError(), classifyFetchError(), doProbe(), formatProbeError() (+10 more)
+Nodes (17): createTerminalWindow(), createWindow(), dispatchMenuAction(), iconPath, IPC, isDevelopment, resolveResourcePath(), resolveServerStaticDir() (+9 more)
 
 ### Community 361 - "Community 361"
-Cohesion: 0.08
-Nodes (22): content, createTestDb(), db, event, goodLine, history, ids, latest (+14 more)
+Cohesion: 0.16
+Nodes (23): findAllWorkspacePaths(), findWorkspacePath(), buildPlaceholders(), clearLegacyPlanningDir(), clearProjectBeads(), clearShadowState(), deleteBranches(), deleteBranchesImpl() (+15 more)
 
 ### Community 362 - "Community 362"
-Cohesion: 0.14
-Nodes (20): setupCavemanCompressScripts(), addPanopticonHookIfMissing(), checkJqInstalled(), ClaudeSettings, HookConfig, installJq(), isHookConfigured(), McpServer (+12 more)
+Cohesion: 0.11
+Nodes (13): captureTldrMetrics(), daemonRegistry, getTldrMetrics(), listTldrDaemonServices(), LiveDaemonState, readLogLines(), readMetricsCheckpoint(), TldrDaemonStatus (+5 more)
 
 ### Community 363 - "Community 363"
-Cohesion: 0.08
-Nodes (23): Activity View, Adding Projects, Badge Bar, code:block1 (feature-pan-XXX/.planning/), Concept, Configuration, Conversation List, Conversations (+15 more)
+Cohesion: 0.12
+Nodes (20): DatabaseError, cleanupOldEntries(), dequeueMerge(), enqueueMerge(), getAllActiveQueues(), getCurrentMerge(), getQueueForProject(), markMergeProcessing() (+12 more)
 
 ### Community 364 - "Community 364"
-Cohesion: 0.08
-Nodes (23): Agent Guidance, Agent System, Architecture & Design, Build & Development, Configuration, Configuration & Models, Development, Documentation Maintenance (+15 more)
+Cohesion: 0.09
+Nodes (17): ALLOWED, AuthMode, AvailableModelsState, FALLBACK_GROUPS, getProviderForPickerModel(), Harness, HARNESS_OPTIONS, HarnessDecision (+9 more)
 
 ### Community 365 - "Community 365"
-Cohesion: 0.08
-Nodes (23): code:block1 (Session 1: AI queries users.created_at → Error (column is "c), code:block2 (myproject/), code:markdown (# In ~/.claude/CLAUDE.md (developer's personal config)), code:bash (pan start MIN-123 --shadow), code:yaml (# In <project>/.panopticon.yaml), code:yaml (# In ~/.panopticon/config.yaml), code:bash (SHADOW_MODE=true pan start MIN-123), code:yaml (# In .panopticon.yaml — only shadow Linear, not GitHub) (+15 more)
+Cohesion: 0.09
+Nodes (20): existingSkillDir, existsInTarget, mockClaudeSkills, mockPanopticonSkills, nonSkillDir, skillDir, skills, skillsToSync (+12 more)
 
 ### Community 366 - "Community 366"
 Cohesion: 0.08
-Nodes (23): Auth: Internal Token, CLI, code:bash (pan swarm <id>                       # Spawn dispatchable it), code:bash (pan swarm <id> --task next                        # List dis), code:ts (interface SwarmRuntime {), code:block4 (plan dispatch), `continue-state.ts` — async helpers, Continue vBRIEF (Runtime State) (+15 more)
+Nodes (23): Activity View, Adding Projects, Badge Bar, code:block1 (feature-pan-XXX/.planning/), Concept, Configuration, Conversation List, Conversations (+15 more)
 
 ### Community 367 - "Community 367"
 Cohesion: 0.08
-Nodes (23): Architecture, code:block1 (Main repo (host)), code:yaml (projects:), code:yaml (volumes:), code:yaml (# ✗ WRONG — causes two hard failures:), code:sh (bun install &&), code:json ("overrides": {), Container Image (+15 more)
+Nodes (23): Agent Guidance, Agent System, Architecture & Design, Build & Development, Configuration, Configuration & Models, Development, Documentation Maintenance (+15 more)
 
 ### Community 368 - "Community 368"
 Cohesion: 0.08
-Nodes (23): Architecture Decisions, Build Verification, code:bash (pan install), code:bash (pan up), code:bash (pan down), code:bash (pan install --minimal), Documentation, Files Created/Modified (+15 more)
+Nodes (23): code:block1 (Session 1: AI queries users.created_at → Error (column is "c), code:block2 (myproject/), code:markdown (# In ~/.claude/CLAUDE.md (developer's personal config)), code:bash (pan start MIN-123 --shadow), code:yaml (# In <project>/.panopticon.yaml), code:yaml (# In ~/.panopticon/config.yaml), code:bash (SHADOW_MODE=true pan start MIN-123), code:yaml (# In .panopticon.yaml — only shadow Linear, not GitHub) (+15 more)
 
 ### Community 369 - "Community 369"
 Cohesion: 0.08
-Nodes (22): Acceptance Criteria, Architecture, CLI Surface, code:markdown (# Working Inside Panopticon), code:bash (claude --append-system-prompt-file "$HOME/.panopticon/sessio), code:bash (# dist/hooks/briefing-refresh.sh), code:markdown (## Knowledge Registry), code:typescript (// src/lib/hooks/compliance-audit.ts) (+14 more)
+Nodes (23): Auth: Internal Token, CLI, code:bash (pan swarm <id>                       # Spawn dispatchable it), code:bash (pan swarm <id> --task next                        # List dis), code:ts (interface SwarmRuntime {), code:block4 (plan dispatch), `continue-state.ts` — async helpers, Continue vBRIEF (Runtime State) (+15 more)
 
 ### Community 370 - "Community 370"
 Cohesion: 0.08
-Nodes (23): Click Behavior Split on ProjectNode, code:block1 (selectedConversation → ConversationView), code:typescript (export type PipelineStage =), code:typescript (interface ProjectOverviewProps {), Command Deck — Project Overview Panel (PAN-1044), Component Design, Data Sources, Files (+15 more)
+Nodes (23): Architecture, code:block1 (Main repo (host)), code:yaml (projects:), code:yaml (volumes:), code:yaml (# ✗ WRONG — causes two hard failures:), code:sh (bun install &&), code:json ("overrides": {), Container Image (+15 more)
 
 ### Community 371 - "Community 371"
 Cohesion: 0.08
-Nodes (22): Acceptance Criteria, Architecture, CLI, CLI Examples, code:block1 (pan artifacts validate <file>              # validate, no pu), code:yaml (http:), code:bash (# Agent writes the file), Dashboard Integration (+14 more)
+Nodes (23): Architecture Decisions, Build Verification, code:bash (pan install), code:bash (pan up), code:bash (pan down), code:bash (pan install --minimal), Documentation, Files Created/Modified (+15 more)
 
 ### Community 372 - "Community 372"
 Cohesion: 0.08
-Nodes (23): Agent Slots, AgentSnapshot extensions, Architecture (3 sentences), CLI Command, Cloister as Monitor, code:block1 (Wave 1: [items with no unmet blocks dependencies]  → spawn N), code:block2 (PAN-970), code:bash (pan swarm <issueId>          # Analyze DAG, show wave plan, ) (+15 more)
+Nodes (22): Acceptance Criteria, Architecture, CLI Surface, code:markdown (# Working Inside Panopticon), code:bash (claude --append-system-prompt-file "$HOME/.panopticon/sessio), code:bash (# dist/hooks/briefing-refresh.sh), code:markdown (## Knowledge Registry), code:typescript (// src/lib/hooks/compliance-audit.ts) (+14 more)
 
 ### Community 373 - "Community 373"
 Cohesion: 0.08
-Nodes (23): Acceptance Criteria, code:block1 (click + → DraftConversationPanel mounts → user types first m), code:block2 (click + → POST /api/conversations { model, effort }), Compact-boundary offset, Design, Duplicate-id audit (#696), Goals, Implementation Notes (+15 more)
+Nodes (23): Click Behavior Split on ProjectNode, code:block1 (selectedConversation → ConversationView), code:typescript (export type PipelineStage =), code:typescript (interface ProjectOverviewProps {), Command Deck — Project Overview Panel (PAN-1044), Component Design, Data Sources, Files (+15 more)
 
 ### Community 374 - "Community 374"
 Cohesion: 0.08
-Nodes (23): A/B Testing, caveman-compress (manual only), caveman-review for Review Agent, code:json ({), code:yaml (# ~/.panopticon/config.yaml), code:block3 (## Panopticon Overrides (non-negotiable)), code:block4 (Format: L<line>: <problem>. <fix>.), Config Schema (+15 more)
+Nodes (22): Acceptance Criteria, Architecture, CLI, CLI Examples, code:block1 (pan artifacts validate <file>              # validate, no pu), code:yaml (http:), code:bash (# Agent writes the file), Dashboard Integration (+14 more)
 
 ### Community 375 - "Community 375"
 Cohesion: 0.08
-Nodes (23): Animations, Architecture, Charts (visx), code:block1 (GodViewPage (new tab component)), code:block2 (Server:), Data Flow, Decisions Made, Design System (God View scope) (+15 more)
+Nodes (23): Agent Slots, AgentSnapshot extensions, Architecture (3 sentences), CLI Command, Cloister as Monitor, code:block1 (Wave 1: [items with no unmet blocks dependencies]  → spawn N), code:block2 (PAN-970), code:bash (pan swarm <issueId>          # Analyze DAG, show wave plan, ) (+15 more)
 
 ### Community 376 - "Community 376"
 Cohesion: 0.08
-Nodes (23): 1a. Verification Gate Enhancement, 1b. Review Convoy Enhancement, Architecture, Attribution, code:typescript (async function checkForStubs(workspacePath: string): Promise), code:block2 (## Stub Detection), code:markdown (## Locked Decisions), code:block4 (## Decision Protocol) (+15 more)
+Nodes (23): Acceptance Criteria, code:block1 (click + → DraftConversationPanel mounts → user types first m), code:block2 (click + → POST /api/conversations { model, effort }), Compact-boundary offset, Design, Duplicate-id audit (#696), Goals, Implementation Notes (+15 more)
 
 ### Community 377 - "Community 377"
 Cohesion: 0.08
-Nodes (23): Architecture Decisions, D1: Extend existing command, not create new, D2: Transition to "In Progress", not Backlog, D3: Keep .planning-complete marker, D4: Reset specialist states to pending (preserve history), D5: Append-only STATE.md updates, D6: Core reopen logic in a shared function, D7: Remove issue from specialist queues on reopen (+15 more)
+Nodes (23): A/B Testing, caveman-compress (manual only), caveman-review for Review Agent, code:json ({), code:yaml (# ~/.panopticon/config.yaml), code:block3 (## Panopticon Overrides (non-negotiable)), code:block4 (Format: L<line>: <problem>. <fix>.), Config Schema (+15 more)
 
 ### Community 378 - "Community 378"
 Cohesion: 0.08
-Nodes (22): Architecture, code:block1 (main.ts: await startSharedIssueService()     ← BLOCKS until ), code:block2 (main.ts: startSharedIssueService()           ← NO await, fir), Current Flow (Slow), Decisions, Edge Cases, EventRouter Changes, Files Changed (Summary) (+14 more)
+Nodes (23): Animations, Architecture, Charts (visx), code:block1 (GodViewPage (new tab component)), code:block2 (Server:), Data Flow, Decisions Made, Design System (God View scope) (+15 more)
 
 ### Community 379 - "Community 379"
 Cohesion: 0.08
-Nodes (23): 1. God View: Token foundation only, 2. API rename: Full rename, 3. Chat components: Included in rebrand, 4. Sidebar: Custom component, Architecture Overview, Decisions Made, Design References, In Scope (+15 more)
+Nodes (23): 1a. Verification Gate Enhancement, 1b. Review Convoy Enhancement, Architecture, Attribution, code:typescript (async function checkForStubs(workspacePath: string): Promise), code:block2 (## Stub Detection), code:markdown (## Locked Decisions), code:block4 (## Decision Protocol) (+15 more)
 
 ### Community 380 - "Community 380"
 Cohesion: 0.08
-Nodes (23): By Gemini 3 Flash (for subagent:explore), By GPT-5.4 Nano (for subagent/CLI work), Claude Haiku 4.5 Work Type Fit Analysis, `cli:interactive`, `cli:quick-command`, Good Fit (Current Defaults), Integration Notes, Keep Haiku for: (+15 more)
+Nodes (23): Architecture Decisions, D1: Extend existing command, not create new, D2: Transition to "In Progress", not Backlog, D3: Keep .planning-complete marker, D4: Reset specialist states to pending (preserve history), D5: Append-only STATE.md updates, D6: Core reopen logic in a shared function, D7: Remove issue from specialist queues on reopen (+15 more)
 
 ### Community 381 - "Community 381"
 Cohesion: 0.08
-Nodes (23): Anti-Patterns, Chemistry Patterns, code:block1 (┌───────────────────────────────────────────────────────────), code:block2 (Will this work be referenced later?), code:bash (# Start grooming), code:bash (# Start review), code:bash (# Start spike (2 hour timebox)), code:bash (# Persistent mol (solid → liquid)) (+15 more)
+Nodes (22): Architecture, code:block1 (main.ts: await startSharedIssueService()     ← BLOCKS until ), code:block2 (main.ts: startSharedIssueService()           ← NO await, fir), Current Flow (Slow), Decisions, Edge Cases, EventRouter Changes, Files Changed (Summary) (+14 more)
 
 ### Community 382 - "Community 382"
 Cohesion: 0.08
-Nodes (23): code:block1 (~/.panopticon/skills/spec-readiness-{name}/), code:bash (mkdir -p ~/.panopticon/skills/spec-readiness-{name}), code:block11 (Created spec-readiness wrapper: spec-readiness-{name}), code:block12 (User: setup spec readiness), code:yaml (tracker:), code:yaml (tracker:), code:yaml (tracker:), code:yaml (tracker:) (+15 more)
+Nodes (23): 1. God View: Token foundation only, 2. API rename: Full rename, 3. Chat components: Included in rebrand, 4. Sidebar: Custom component, Architecture Overview, Decisions Made, Design References, In Scope (+15 more)
 
 ### Community 383 - "Community 383"
-Cohesion: 0.13
-Nodes (17): buildMergeAgentMemory(), checkAndRotateIfNeeded(), DEFAULT_MEMORY_TIERS, execAsync, MemoryTiers, MergeRecord, needsSessionRotation(), rotateSpecialistSession() (+9 more)
+Cohesion: 0.08
+Nodes (23): By Gemini 3 Flash (for subagent:explore), By GPT-5.4 Nano (for subagent/CLI work), Claude Haiku 4.5 Work Type Fit Analysis, `cli:interactive`, `cli:quick-command`, Good Fit (Current Defaults), Integration Notes, Keep Haiku for: (+15 more)
 
 ### Community 384 - "Community 384"
-Cohesion: 0.19
-Nodes (20): healthCommand(), HealthOptions, AgentHealth, formatHealthStatus(), getAgentHealth(), getAgentOutput(), getHealthFile(), handleStuckAgent() (+12 more)
+Cohesion: 0.08
+Nodes (23): Anti-Patterns, Chemistry Patterns, code:block1 (┌───────────────────────────────────────────────────────────), code:block2 (Will this work be referenced later?), code:bash (# Start grooming), code:bash (# Start review), code:bash (# Start spike (2 hour timebox)), code:bash (# Persistent mol (solid → liquid)) (+15 more)
 
 ### Community 385 - "Community 385"
-Cohesion: 0.11
-Nodes (5): parsePiSession(), PiRuntime, PiRuntimeEffect, safeReaddir(), walkJsonl()
+Cohesion: 0.08
+Nodes (23): code:block1 (~/.panopticon/skills/spec-readiness-{name}/), code:bash (mkdir -p ~/.panopticon/skills/spec-readiness-{name}), code:block11 (Created spec-readiness wrapper: spec-readiness-{name}), code:block12 (User: setup spec readiness), code:yaml (tracker:), code:yaml (tracker:), code:yaml (tracker:), code:yaml (tracker:) (+15 more)
 
 ### Community 386 - "Community 386"
-Cohesion: 0.13
-Nodes (9): DEFAULT_STORE, formatIssueRef(), LinkDirection, LinkManager, LinkStore, parseIssueRef(), pathExists(), newManager (+1 more)
-
-### Community 387 - "Community 387"
-Cohesion: 0.09
-Nodes (22): all, backing, cheap, enriched, expensive, fetched, inserted, malformed (+14 more)
-
-### Community 388 - "Community 388"
-Cohesion: 0.1
-Nodes (19): AvailableModel, AvailableModelsResponse, ClaudeAuthStatus, fetchAvailableModels(), fetchClaudeAuth(), fetchSettings(), PROVIDER_LABELS, providerForModel() (+11 more)
-
-### Community 389 - "Community 389"
-Cohesion: 0.12
-Nodes (17): BYTE_UNITS, cachedContainerLifecycleSnapshot, ContainerHistory, ContainerStats, DockerContainerLifecycle, DockerNetwork, DockerPsRaw, DockerStatsCollector (+9 more)
-
-### Community 390 - "Community 390"
 Cohesion: 0.16
 Nodes (21): ACTIVE_AGENT_STATUSES, CandidateGroup, collectActiveAgentIssueIds(), collectWorkspaceReapCandidatesFromInspect(), composeDown(), confirmApply(), DockerInspectContainer, execFileAsync (+13 more)
 
+### Community 387 - "Community 387"
+Cohesion: 0.13
+Nodes (17): handleAutoStartNag(), showFirstLaunchDialog(), deepClone(), DEFAULTS, DesktopSettings, getDesktopSettings(), loadDesktopSettings(), NotificationEventType (+9 more)
+
+### Community 388 - "Community 388"
+Cohesion: 0.12
+Nodes (6): clientMock, octokitMock, result, states, linearCall(), LinearTracker
+
+### Community 389 - "Community 389"
+Cohesion: 0.13
+Nodes (9): DEFAULT_STORE, formatIssueRef(), LinkDirection, LinkManager, LinkStore, parseIssueRef(), pathExists(), newManager (+1 more)
+
+### Community 390 - "Community 390"
+Cohesion: 0.12
+Nodes (17): BYTE_UNITS, cachedContainerLifecycleSnapshot, ContainerHistory, ContainerStats, DockerContainerLifecycle, DockerNetwork, DockerPsRaw, DockerStatsCollector (+9 more)
+
 ### Community 391 - "Community 391"
 Cohesion: 0.09
-Nodes (23): code:typescript (interface IssueTracker {), code:block78 (┌───────────────────────────────────────────────────────────), code:toml (# ~/.panopticon/projects.toml), code:block80 (┌──────────┐    ┌──────────┐    ┌──────────┐    ┌───────────), code:yaml (# ~/.panopticon/state-mappings.yaml), code:typescript (// ~/.panopticon/issue-states.json), code:typescript (interface StateManager {), code:block84 ($ pan project add ~/projects/myn --tracker linear --team MIN) (+15 more)
+Nodes (22): all, backing, cheap, enriched, expensive, fetched, inserted, malformed (+14 more)
 
 ### Community 392 - "Community 392"
-Cohesion: 0.09
-Nodes (23): code:block126 (┌─────────────────┐    ┌─────────────────┐    ┌─────────────), code:block127 (┌──────────────────────────────────────────────────────────┐), code:yaml (permissions:), code:json ({), code:bash (# 1. Login to npm (one-time)), code:bash (# Bump version (follows semver)), code:bash (# One-shot (no global install needed)), code:bash (# Tag beta releases) (+15 more)
+Cohesion: 0.1
+Nodes (19): AvailableModel, AvailableModelsResponse, ClaudeAuthStatus, fetchAvailableModels(), fetchClaudeAuth(), fetchSettings(), PROVIDER_LABELS, providerForModel() (+11 more)
 
 ### Community 393 - "Community 393"
 Cohesion: 0.09
-Nodes (23): 10. `onboard-codebase` - Understanding New Code, All Questions Resolved ✅, Appendix A: Key Concepts Reference, Appendix C: References, Appendix D: Open Questions, code:block141 (workspaces/feature-min-648/), code:bash (# 1. Mayor spawns convoy), code:block37 (+15 more)
+Nodes (23): code:typescript (interface IssueTracker {), code:block78 (┌───────────────────────────────────────────────────────────), code:toml (# ~/.panopticon/projects.toml), code:block80 (┌──────────┐    ┌──────────┐    ┌──────────┐    ┌───────────), code:yaml (# ~/.panopticon/state-mappings.yaml), code:typescript (// ~/.panopticon/issue-states.json), code:typescript (interface StateManager {), code:block84 ($ pan project add ~/projects/myn --tracker linear --team MIN) (+15 more)
 
 ### Community 394 - "Community 394"
 Cohesion: 0.09
-Nodes (22): A. Per-issue allow-list at plan time, Acceptance Criteria, Approach (Option 5 — combination), Architecture, Awaiting-input extension, Awaiting-input indicator (Section C), B. Outbound-write suppression during prompt display, C. Awaiting-input indicator + inspector deep link (+14 more)
+Nodes (23): code:block126 (┌─────────────────┐    ┌─────────────────┐    ┌─────────────), code:block127 (┌──────────────────────────────────────────────────────────┐), code:yaml (permissions:), code:json ({), code:bash (# 1. Login to npm (one-time)), code:bash (# Bump version (follows semver)), code:bash (# One-shot (no global install needed)), code:bash (# Tag beta releases) (+15 more)
 
 ### Community 395 - "Community 395"
 Cohesion: 0.09
-Nodes (22): 1. Root policy: what stays at root, 2. Root artifacts to relocate, 3. Destination policy, 4. Reference update pass, 5. Professionalism rule for future additions, Audits / investigations / findings, Constraints, Design (+14 more)
+Nodes (23): 10. `onboard-codebase` - Understanding New Code, All Questions Resolved ✅, Appendix A: Key Concepts Reference, Appendix C: References, Appendix D: Open Questions, code:block141 (workspaces/feature-min-648/), code:bash (# 1. Mayor spawns convoy), code:block37 (+15 more)
 
 ### Community 396 - "Community 396"
 Cohesion: 0.09
-Nodes (22): 1. Viewer in scope, 2. Model injection for plan.author, 3. vBRIEFInfo.author from package.json, 4. Artifact copy: skip if exists, 5. Testing approach, Architecture, Artifact auto-copy (issues.ts — complete-planning), Beads sync (beads.ts) (+14 more)
+Nodes (22): A. Per-issue allow-list at plan time, Acceptance Criteria, Approach (Option 5 — combination), Architecture, Awaiting-input extension, Awaiting-input indicator (Section C), B. Outbound-write suppression during prompt display, C. Awaiting-input indicator + inspector deep link (+14 more)
 
 ### Community 397 - "Community 397"
 Cohesion: 0.09
-Nodes (21): 1. KanbanBoard.tsx — `CycleFilter` type (line 678), 2. KanbanBoard.tsx — `groupByStatus()` (lines 191-193), 3. KanbanBoard.tsx — Filter bar UI (around line 1042), 4. KanbanBoard.tsx — Canceled list view, 5. issue-data-service.ts — `getIssues()` (around line 223), Acceptance Criteria, Architecture, code:typescript (// Before:) (+13 more)
+Nodes (22): 1. Root policy: what stays at root, 2. Root artifacts to relocate, 3. Destination policy, 4. Reference update pass, 5. Professionalism rule for future additions, Audits / investigations / findings, Constraints, Design (+14 more)
 
 ### Community 398 - "Community 398"
 Cohesion: 0.09
-Nodes (22): 1. Scope — all 5 phases in this issue, 2. Table model — new `discovered_sessions` table, separate from `conversations`, 3. Hash→path resolution — JSONL cwd primary, reverse-map fallback, 4. Adaptive parallelism — full probe as spec'd, 5. Embeddings — all three providers (OpenAI, Voyage, Ollama), 6. Enrichment execution — reuse `model-fallback.ts` routing, 7. Re-scanning — manual only in v1, 8. Blocking FS calls — must use async everywhere in server code (+14 more)
+Nodes (22): 1. Viewer in scope, 2. Model injection for plan.author, 3. vBRIEFInfo.author from package.json, 4. Artifact copy: skip if exists, 5. Testing approach, Architecture, Artifact auto-copy (issues.ts — complete-planning), Beads sync (beads.ts) (+14 more)
 
 ### Community 399 - "Community 399"
 Cohesion: 0.09
-Nodes (22): Acceptance criteria, Command Taxonomy Reorganization, Decision, Design principles, Implementation plan, Out of scope, Phase 1 — Scaffolding (non-breaking), Phase 2 — Collapse commands (+14 more)
+Nodes (21): 1. KanbanBoard.tsx — `CycleFilter` type (line 678), 2. KanbanBoard.tsx — `groupByStatus()` (lines 191-193), 3. KanbanBoard.tsx — Filter bar UI (around line 1042), 4. KanbanBoard.tsx — Canceled list view, 5. issue-data-service.ts — `getIssues()` (around line 223), Acceptance Criteria, Architecture, code:typescript (// Before:) (+13 more)
 
 ### Community 400 - "Community 400"
 Cohesion: 0.09
-Nodes (22): 1. Auth Configuration, 2. CCR Command, 3. claudish Installation, 4. Model Prefixes, 5. Dashboard Model Display, 6. OpenAI Model Registry, 7. Token Usage Tracking, Architecture (+14 more)
+Nodes (22): 1. Scope — all 5 phases in this issue, 2. Table model — new `discovered_sessions` table, separate from `conversations`, 3. Hash→path resolution — JSONL cwd primary, reverse-map fallback, 4. Adaptive parallelism — full probe as spec'd, 5. Embeddings — all three providers (OpenAI, Voyage, Ollama), 6. Enrichment execution — reuse `model-fallback.ts` routing, 7. Re-scanning — manual only in v1, 8. Blocking FS calls — must use async everywhere in server code (+14 more)
 
 ### Community 401 - "Community 401"
 Cohesion: 0.09
-Nodes (22): 10. Not yet decided, 1.1 PAN-722 (queue removal) left a per-project singleton, 1.2 Inverted model priority — Sonnet lurking under every config, 1.3 PAN-540 parallel review — invisible sibling tmux sessions, 1.4 Cross-cutting: duplicate-tab failure mode, 1. Problem inventory, 2. Root cause, 3. The DAG reframe (+14 more)
+Nodes (22): Acceptance criteria, Command Taxonomy Reorganization, Decision, Design principles, Implementation plan, Out of scope, Phase 1 — Scaffolding (non-breaking), Phase 2 — Collapse commands (+14 more)
 
 ### Community 402 - "Community 402"
 Cohesion: 0.09
-Nodes (22): ACCEPTANCE CRITERIA (WHAT SUCCESS LOOKS LIKE):, Ask the user before creating when:, code:markdown (bd update issue-9 --notes "IMPLEMENTATION GUIDE:), code:block2 (Two-phase Docs API approach:), code:block3 (- [ ] Markdown formatting renders in Doc (bold, italic, head), code:block4 (- [ ] Use two-phase batchUpdate approach), Contents, Create directly when: (+14 more)
+Nodes (22): 1. Auth Configuration, 2. CCR Command, 3. claudish Installation, 4. Model Prefixes, 5. Dashboard Model Display, 6. OpenAI Model Registry, 7. Token Usage Tracking, Architecture (+14 more)
 
 ### Community 403 - "Community 403"
 Cohesion: 0.09
-Nodes (22): 1. Confirm scope before destroying anything, 2. Kill work agents via the CLI (preferred), 3. Kill review coordinators and test specialists, 4. Verify only conversations and the server remain, 5. (Optional) Stop the dashboard, 6. Verify, code:bash (# List live tmux sessions, classified), code:bash (# Loop over agent sessions and kill each via pan) (+14 more)
+Nodes (22): 10. Not yet decided, 1.1 PAN-722 (queue removal) left a per-project singleton, 1.2 Inverted model priority — Sonnet lurking under every config, 1.3 PAN-540 parallel review — invisible sibling tmux sessions, 1.4 Cross-cutting: duplicate-tab failure mode, 1. Problem inventory, 2. Root cause, 3. The DAG reframe (+14 more)
 
 ### Community 404 - "Community 404"
 Cohesion: 0.09
-Nodes (22): Bead ID vs Issue ID, Beads Quick Reference for Panopticon Agents, code:bash (bd list --issue PAN-116), code:bash (# Option 1: Search in title (most common)), code:bash (# Find ALL beads for PAN-116 (including closed)), code:bash (# By status), code:bash (# Start work on a bead), code:bash (# ❌ WRONG) (+14 more)
+Nodes (22): ACCEPTANCE CRITERIA (WHAT SUCCESS LOOKS LIKE):, Ask the user before creating when:, code:markdown (bd update issue-9 --notes "IMPLEMENTATION GUIDE:), code:block2 (Two-phase Docs API approach:), code:block3 (- [ ] Markdown formatting renders in Doc (bold, italic, head), code:block4 (- [ ] Use two-phase batchUpdate approach), Contents, Create directly when: (+14 more)
 
 ### Community 405 - "Community 405"
 Cohesion: 0.09
-Nodes (23): 7. Components, Alerts, Badges, Buttons, Cards, code:block11 (Container:), code:block12 (Base:), code:block13 (Base:) (+15 more)
+Nodes (22): 1. Confirm scope before destroying anything, 2. Kill work agents via the CLI (preferred), 3. Kill review coordinators and test specialists, 4. Verify only conversations and the server remain, 5. (Optional) Stop the dashboard, 6. Verify, code:bash (# List live tmux sessions, classified), code:bash (# Loop over agent sessions and kill each via pan) (+14 more)
 
 ### Community 406 - "Community 406"
 Cohesion: 0.09
-Nodes (22): AI Self-Monitoring, Best Practices, Built-In Skills, Code Review Subagents, code:block1 (# In Claude Code, Cursor, Windsurf, etc:), code:bash (# Use the guided skill creator), code:markdown (# Skill Title), code:bash (# Sync all skills to AI tools (Claude Code, Cursor, etc.)) (+14 more)
+Nodes (22): Bead ID vs Issue ID, Beads Quick Reference for Panopticon Agents, code:bash (bd list --issue PAN-116), code:bash (# Option 1: Search in title (most common)), code:bash (# Find ALL beads for PAN-116 (including closed)), code:bash (# By status), code:bash (# Start work on a bead), code:bash (# ❌ WRONG) (+14 more)
 
 ### Community 407 - "Community 407"
 Cohesion: 0.09
-Nodes (22): Claude Code subagents (NOT Panopticon roles), code:block1 (pan plan finalize), code:json ({), code:json ({), continue.vbrief.json Format, CRITICAL: PLANNING ONLY - NO IMPLEMENTATION, Description, Difficulty Estimation (+14 more)
+Nodes (23): 7. Components, Alerts, Badges, Buttons, Cards, code:block11 (Container:), code:block12 (Base:), code:block13 (Base:) (+15 more)
 
 ### Community 408 - "Community 408"
 Cohesion: 0.09
-Nodes (22): Anthropic, Benchmark Leaderboards, code:json ({), Coding Benchmarks, Community Sources, Deliverables, Google, Important Notes (+14 more)
+Nodes (22): AI Self-Monitoring, Best Practices, Built-In Skills, Code Review Subagents, code:block1 (# In Claude Code, Cursor, Windsurf, etc:), code:bash (# Use the guided skill creator), code:markdown (# Skill Title), code:bash (# Sync all skills to AI tools (Claude Code, Cursor, etc.)) (+14 more)
 
 ### Community 409 - "Community 409"
 Cohesion: 0.09
-Nodes (21): consoleSpy, mirrorLog, mockCleanupLegacyRuntimeSymlinks, mockCreateBackup, mockEnsurePlaywrightIsolation, mockExecuteSync, mockGetDevrootPath, mockListProjects (+13 more)
+Nodes (22): Claude Code subagents (NOT Panopticon roles), code:block1 (pan plan finalize), code:json ({), code:json ({), continue.vbrief.json Format, CRITICAL: PLANNING ONLY - NO IMPLEMENTATION, Description, Difficulty Estimation (+14 more)
 
 ### Community 410 - "Community 410"
 Cohesion: 0.09
-Nodes (16): CLAUDE_PROJECTS, cost, db, DB_PATH, entry, insert, issueStats, lines (+8 more)
+Nodes (22): Anthropic, Benchmark Leaderboards, code:json ({), Coding Benchmarks, Community Sources, Deliverables, Google, Important Notes (+14 more)
 
 ### Community 411 - "Community 411"
-Cohesion: 0.14
-Nodes (16): handleAutoStartNag(), showFirstLaunchDialog(), deepClone(), DEFAULTS, DesktopSettings, getDesktopSettings(), loadDesktopSettings(), saveDesktopSettings() (+8 more)
-
-### Community 412 - "Community 412"
 Cohesion: 0.09
 Nodes (20): companionInTarget, contentAfterFirst, dstScript, gitCwd, gitManifestDir, manifest, manifestAfterFirst, result (+12 more)
 
+### Community 412 - "Community 412"
+Cohesion: 0.09
+Nodes (21): consoleSpy, mirrorLog, mockCleanupLegacyRuntimeSymlinks, mockCreateBackup, mockEnsurePlaywrightIsolation, mockExecuteSync, mockGetDevrootPath, mockListProjects (+13 more)
+
 ### Community 413 - "Community 413"
-Cohesion: 0.15
-Nodes (15): BUNDLED_AGENTS_DIR, BUNDLED_SKILLS_DIR, copyBundledAgents(), copyBundledSkills(), __dirname, __filename, initCommand(), PACKAGE_ROOT (+7 more)
+Cohesion: 0.09
+Nodes (16): CLAUDE_PROJECTS, cost, db, DB_PATH, entry, insert, issueStats, lines (+8 more)
 
 ### Community 414 - "Community 414"
-Cohesion: 0.13
-Nodes (17): workspaceRebuildCommand(), StepResult, tempDirs, workspace, ensureDevcontainer(), EnsureDevcontainerInput, EnsureDevcontainerResult, pathLeaf() (+9 more)
+Cohesion: 0.12
+Nodes (16): buildMergeAgentMemory(), checkAndRotateIfNeeded(), DEFAULT_MEMORY_TIERS, execAsync, MemoryTiers, MergeRecord, needsSessionRotation(), SessionRotationResult (+8 more)
 
 ### Community 415 - "Community 415"
-Cohesion: 0.14
-Nodes (19): applyClosedOutLabel(), applyLabelGitHub(), applyLabelLinear(), applyLabelViaTracker(), closeGitHubDirect(), closeGitHubPr(), closeIssue(), CloseIssueOptions (+11 more)
-
-### Community 416 - "Community 416"
-Cohesion: 0.18
-Nodes (21): approveCommand(), cancelCommand(), collectInFlightRows(), collectLifecycleRows(), completeCommand(), dedupeRows(), formatTransition(), getProjectPath() (+13 more)
-
-### Community 417 - "Community 417"
-Cohesion: 0.1
-Nodes (18): badPath, doc, draftPath, item, item2, makePlanDoc(), other, panDir (+10 more)
-
-### Community 418 - "Community 418"
 Cohesion: 0.09
 Nodes (21): TldrSessionMetrics, branch, branchMatch, buffer, cavemanVariant, cost, entry, input (+13 more)
 
+### Community 416 - "Community 416"
+Cohesion: 0.13
+Nodes (17): workspaceRebuildCommand(), StepResult, tempDirs, workspace, ensureDevcontainer(), EnsureDevcontainerInput, EnsureDevcontainerResult, pathLeaf() (+9 more)
+
+### Community 417 - "Community 417"
+Cohesion: 0.18
+Nodes (21): approveCommand(), cancelCommand(), collectInFlightRows(), collectLifecycleRows(), completeCommand(), dedupeRows(), formatTransition(), getProjectPath() (+13 more)
+
+### Community 418 - "Community 418"
+Cohesion: 0.09
+Nodes (18): agent2, baseAgent, bigOutput, events, existing, issues, next, planningAgent (+10 more)
+
 ### Community 419 - "Community 419"
-Cohesion: 0.14
-Nodes (16): InlineSparkline(), InlineSparklineProps, BranchNode(), BranchNodeProps, ContainerNode(), ContainerNodeProps, containerStatusColor(), containerStatusToDot() (+8 more)
+Cohesion: 0.09
+Nodes (18): fail, failLayer, githubLayer, layer, mockGitHubAddLabel, mockGitHubCloseIssue, mockGitHubEnsureLabel, mockGitHubRemoveLabel (+10 more)
 
 ### Community 420 - "Community 420"
 Cohesion: 0.17
@@ -2951,1519 +2942,1515 @@ Nodes (20): checkCommand(), execAsync, getMissingToolsForFeature(), INSTALLABLE_
 
 ### Community 421 - "Community 421"
 Cohesion: 0.09
-Nodes (18): fail, failLayer, githubLayer, layer, mockGitHubAddLabel, mockGitHubCloseIssue, mockGitHubEnsureLabel, mockGitHubRemoveLabel (+10 more)
+Nodes (19): assistantLine, content, existingFiles, firstLine, fixture, fixturePath, ids, lines (+11 more)
 
 ### Community 422 - "Community 422"
 Cohesion: 0.09
-Nodes (19): assistantLine, content, existingFiles, firstLine, fixture, fixturePath, ids, lines (+11 more)
+Nodes (21): 13 Dashboard Views, Agent Auto-Resume Controls, Architecture at a Glance, code:bash (npx @panctl/cli), code:block2 (Issue         PRD           Agent         Review        Test), Command Deck, Contributing, Documentation (+13 more)
 
 ### Community 423 - "Community 423"
 Cohesion: 0.09
-Nodes (18): agent2, baseAgent, bigOutput, events, existing, issues, next, planningAgent (+10 more)
+Nodes (21): 1. Batch Processing, 2. Cascade Approach, 3. Parallel Processing, Alternative Models, Claude Family (USD per million tokens), Cost Analysis, Detailed Recommendations, For Cost-Sensitive Deployments (+13 more)
 
 ### Community 424 - "Community 424"
 Cohesion: 0.09
-Nodes (21): 13 Dashboard Views, Agent Auto-Resume Controls, Architecture at a Glance, code:bash (npx @panctl/cli), code:block2 (Issue         PRD           Agent         Review        Test), Command Deck, Contributing, Documentation (+13 more)
+Nodes (21): 1. Supported harnesses, 2. Installing Pi, 3. Where you pick the harness, 4. ToS rules, 5. Troubleshooting, 6. Tradeoffs, Auth mode is exclusive, Claude Code (default) (+13 more)
 
 ### Community 425 - "Community 425"
 Cohesion: 0.09
-Nodes (21): 1. Batch Processing, 2. Cascade Approach, 3. Parallel Processing, Alternative Models, Claude Family (USD per million tokens), Cost Analysis, Detailed Recommendations, For Cost-Sensitive Deployments (+13 more)
+Nodes (20): Architecture, Backward Compatibility, code:typescript (/**), code:typescript (export interface ProjectConfig {), code:typescript (export function resolveTrackerType(issueId: string): Tracker), code:yaml (# Rally-tracked project with multiple artifact type prefixes), Configuration Example, Decision (+12 more)
 
 ### Community 426 - "Community 426"
 Cohesion: 0.09
-Nodes (21): 1. Supported harnesses, 2. Installing Pi, 3. Where you pick the harness, 4. ToS rules, 5. Troubleshooting, 6. Tradeoffs, Auth mode is exclusive, Claude Code (default) (+13 more)
+Nodes (21): 1. Event Bus & Real-Time Broadcast, 2. Webhook System, 3. Claude Session Introspection, 4. Alert Rules Engine, 5. Standup / Daily Reports, 6. Workflow Templates & Pipelines, 7. Quality Review Gate Improvements, 8. RBAC & Authentication (+13 more)
 
 ### Community 427 - "Community 427"
 Cohesion: 0.09
-Nodes (20): Architecture, Backward Compatibility, code:typescript (/**), code:typescript (export interface ProjectConfig {), code:typescript (export function resolveTrackerType(issueId: string): Tracker), code:yaml (# Rally-tracked project with multiple artifact type prefixes), Configuration Example, Decision (+12 more)
+Nodes (21): 1. Extract Project Identity (JSON), 2. Define the Atmosphere (Image/HTML), 3. Map the Color Palette (Tailwind Config/JSON), 4. Translate Geometry & Shape (CSS/Tailwind), 5. Describe Depth & Elevation, Analysis & Synthesis Instructions, Best Practices, code:markdown (# Design System: [Project Title]) (+13 more)
 
 ### Community 428 - "Community 428"
 Cohesion: 0.09
-Nodes (21): 1. Event Bus & Real-Time Broadcast, 2. Webhook System, 3. Claude Session Introspection, 4. Alert Rules Engine, 5. Standup / Daily Reports, 6. Workflow Templates & Pipelines, 7. Quality Review Gate Improvements, 8. RBAC & Authentication (+13 more)
+Nodes (21): Bead Description (What Was Asked), BLOCKED — Any check fails, Check 1: Spec Fidelity, Check 2: Constraint Compliance, code:bash (cd {{workspacePath}}), code:bash (# Check workspace CLAUDE.md), code:bash (# Example: check for prohibited imports), code:bash (pan tell {{issueId}} "INSPECTION PASSED for bead {{beadId}}.) (+13 more)
 
 ### Community 429 - "Community 429"
 Cohesion: 0.09
-Nodes (21): 1. Extract Project Identity (JSON), 2. Define the Atmosphere (Image/HTML), 3. Map the Color Palette (Tailwind Config/JSON), 4. Translate Geometry & Shape (CSS/Tailwind), 5. Describe Depth & Elevation, Analysis & Synthesis Instructions, Best Practices, code:markdown (# Design System: [Project Title]) (+13 more)
-
-### Community 430 - "Community 430"
-Cohesion: 0.09
-Nodes (21): Bead Description (What Was Asked), BLOCKED — Any check fails, Check 1: Spec Fidelity, Check 2: Constraint Compliance, code:bash (cd {{workspacePath}}), code:bash (# Check workspace CLAUDE.md), code:bash (# Example: check for prohibited imports), code:bash (pan tell {{issueId}} "INSPECTION PASSED for bead {{beadId}}.) (+13 more)
-
-### Community 431 - "Community 431"
-Cohesion: 0.09
 Nodes (21): code:bash (pan workspace create MIN-123), code:bash (pan workspace create MIN-123 --docker), code:javascript (// Disable Docker by default), code:bash (# From dashboard: click "Start Planning" (Docker enabled by ), code:bash (pan workspace list), code:bash (pan workspace destroy MIN-123), code:bash (export PANOPTICON_AUTO_REVERT_CHECKOUT=1  # Add to .bashrc/.), code:bash (./scripts/install-git-hooks.sh /path/to/your/project) (+13 more)
 
-### Community 432 - "Community 432"
-Cohesion: 0.17
-Nodes (17): buildChannelsArgs(), buildCommand(), buildNonConversationCommand(), buildPiCommand(), buildReviewSubRoleCommand(), generateLauncherWrapper(), LauncherConfig, LauncherHarness (+9 more)
+### Community 430 - "Community 430"
+Cohesion: 0.1
+Nodes (20): agents, count, deleted, end, events, futureEnd, futureStart, id (+12 more)
 
-### Community 433 - "Community 433"
+### Community 431 - "Community 431"
+Cohesion: 0.15
+Nodes (14): BUNDLED_AGENTS_DIR, BUNDLED_SKILLS_DIR, copyBundledAgents(), copyBundledSkills(), __dirname, __filename, initCommand(), PACKAGE_ROOT (+6 more)
+
+### Community 432 - "Community 432"
 Cohesion: 0.1
 Nodes (16): CLAUDE_PROJECTS, cost, db, DB_PATH, entry, insert, issueId, issueStats (+8 more)
 
-### Community 434 - "Community 434"
-Cohesion: 0.18
-Nodes (20): findAllWorkspacePaths(), findWorkspacePath(), buildPlaceholders(), clearLegacyPlanningDir(), clearProjectBeads(), clearShadowState(), deleteBranches(), isDockerContainerProcess() (+12 more)
-
-### Community 435 - "Community 435"
-Cohesion: 0.13
-Nodes (13): ZoneCConversation(), ZoneCConversationProps, resolveWorkTypeKey(), useResolvedModels(), getViewKey(), PanelView, readView(), SessionPanel() (+5 more)
-
-### Community 436 - "Community 436"
-Cohesion: 0.13
-Nodes (12): getShadowModeStatus(), getShadowModeSummary(), hasProjectShadowConfig(), isShadowModeEnabled(), resolveShadowMode(), ShadowModeError, ShadowModeOptions, ShadowModeResult (+4 more)
-
-### Community 437 - "Community 437"
-Cohesion: 0.13
-Nodes (19): parseLogMetadata(), execAsync, listLogsCommand(), logsCommand(), LogsOptions, tailLogCommand(), actual, allLogs (+11 more)
-
-### Community 438 - "Community 438"
+### Community 433 - "Community 433"
 Cohesion: 0.1
 Nodes (19): FlywheelAgent, FlywheelAgentStatus, FlywheelEffort, FlywheelHarness, FlywheelHeadline, FlywheelHttpUrl, FlywheelOrchestrator, FlywheelParkedItem (+11 more)
 
-### Community 439 - "Community 439"
-Cohesion: 0.1
-Nodes (21): 6. Agreed End-State, Agent Startup Context, code:yaml (devroot: ~/Projects        # where you launch Claude Code fr), code:bash (pan workspace update MIN-678    # explicit command, only whe), code:block16 (pan workspace create MIN-678), code:block17 (Agent starts on MIN-678 workspace), code:block18 (~/.panopticon/                          PANOPTICON'S PRIVATE), code:block19 (~/.claude/skills/my-override/               ← WINS (personal) (+13 more)
-
-### Community 440 - "Community 440"
+### Community 434 - "Community 434"
 Cohesion: 0.1
 Nodes (20): 10. B20 does not fully account for the current terminal surface area, 11. The resources event model is too narrow for the current resources UI, 12. The dependency DAG has one sequencing problem, 1. The current dashboard already has a real data layer; the problem is inconsistency, not total absence, 2. "Wrap existing libs in Effect" does not fix the blocking-call problem, 3. The storage plan should not introduce a third SQLite story without justification, 4. The toolchain/runtime section is not fully aligned with the repo as it exists today, 5. The dist/output migration has more blast radius than the PRD currently captures (+12 more)
 
-### Community 441 - "Community 441"
+### Community 435 - "Community 435"
 Cohesion: 0.1
 Nodes (20): Code Changes Required in Panopticon, code:block1 (┌─────────────────────────────────────────────────────────┐), code:yaml (myn:), Critical Constraint: exe.dev Single Port, Current State, Goals, Implementation Checklist, Manual Fixes Still Required Per-Project (+12 more)
 
-### Community 442 - "Community 442"
+### Community 436 - "Community 436"
 Cohesion: 0.1
 Nodes (20): Agent Navigation, Architecture, Backend (Server), code:block1 (docker stats (5s poll)), Container Detail View, Data Flow, Decisions, Files to Create/Modify (+12 more)
 
-### Community 443 - "Community 443"
+### Community 437 - "Community 437"
 Cohesion: 0.1
 Nodes (20): Architecture, btca CLI Skill, code:block1 (Browser (React + Vite)), code:json ({ "key": "mod+j", "command": "terminal.toggle" },), code:bash (btca ask -r codex -q "What is the return format for Codex Ap), Comparison to Panopticon, Feature Inventory, High priority (+12 more)
 
-### Community 444 - "Community 444"
+### Community 438 - "Community 438"
 Cohesion: 0.1
 Nodes (21): 10. Configuration, 1. High-Level Structure, 2. Entry Points, 3. Architecture Patterns, 4. Code Organization, 5. Feature Location, 6. Dependencies Analysis, 7. Data Models (+13 more)
 
-### Community 445 - "Community 445"
+### Community 439 - "Community 439"
 Cohesion: 0.1
 Nodes (20): Ad-Hoc Speak and CLI Smoke Test, Architecture, code:block1 (pan dashboard                  qwen-tts daemon            au), code:bash (pan install                # creates packages/qwen-tts-linux), code:yaml (endpoint: http://127.0.0.1:3000/events/stream), code:bash (# one-shot foreground run (smoke test)), code:bash (pan tts test), code:bash (./scripts/say.sh "Build is green, ready for review.") (+12 more)
 
-### Community 446 - "Community 446"
+### Community 440 - "Community 440"
 Cohesion: 0.1
 Nodes (20): code:block1 (skill-name/), code:yaml (---), code:bash (python scripts/init_skill.py <skill-name> --path <output-dir), code:bash (python scripts/package_skill.py <path/to/skill-folder> [outp), Concise is Key, Core Principles, Creation Process, Degrees of Freedom (+12 more)
 
-### Community 447 - "Community 447"
+### Community 441 - "Community 441"
 Cohesion: 0.1
 Nodes (20): Activity View, Adding Projects, Badge Bar, code:block1 (feature-pan-XXX/.planning/), Concept, Configuration, How It Works, Layout (+12 more)
 
-### Community 448 - "Community 448"
-Cohesion: 0.1
-Nodes (17): agentStateDir, closeIssueMock, commands, execMock, fixtureRoot, movePrdMock, planningStateDir, projectPath (+9 more)
-
-### Community 449 - "Community 449"
-Cohesion: 0.1
-Nodes (19): agentDir, body, commit, dir, files, launcher, LEGACY_FIELDS, legacyFields (+11 more)
-
-### Community 450 - "Community 450"
-Cohesion: 0.17
-Nodes (16): AgentContext, findSessionDirsByIssue(), getAgentsDir(), getClaudeProjectsDir(), getProjectPaths(), getProjectsYamlPath(), getSessionDir(), inferIssueId() (+8 more)
-
-### Community 451 - "Community 451"
+### Community 442 - "Community 442"
 Cohesion: 0.11
 Nodes (19): activeIssues, date1, date2, expectedOrder, filtered, filteredIds, filterRecentCompletedIssues(), getOneDayAgo() (+11 more)
 
-### Community 452 - "Community 452"
-Cohesion: 0.12
-Nodes (16): fetchFlywheelState(), FlywheelStatePane(), FlywheelStatePayload, formatLastModified(), fetchCurrentFlywheelStatus(), FlywheelLeftTab, FlywheelPage(), FlywheelPageProps (+8 more)
+### Community 443 - "Community 443"
+Cohesion: 0.1
+Nodes (19): agentDir, body, commit, dir, files, launcher, LEGACY_FIELDS, legacyFields (+11 more)
 
-### Community 453 - "Community 453"
-Cohesion: 0.12
-Nodes (17): CostThresholdDetails, embedSession(), EnrichRequest, enrichSession(), fetchSession(), formatDate(), fromRpcSession(), Props (+9 more)
-
-### Community 454 - "Community 454"
-Cohesion: 0.15
-Nodes (13): consumeDashboardBootstrapToken(), createPanRpcProtocolLayer(), dashboardMutationJsonHeaders(), dashboardSessionUrl(), DEFAULT_RETRY_DELAY, ensureDashboardSession(), makePanRpcClient, resetTransport() (+5 more)
-
-### Community 455 - "Community 455"
-Cohesion: 0.14
-Nodes (10): NormalizedTtsDaemonConfig, isTtsDaemonManuallyStopped(), parseTtsWatchdogIntEnv(), readTtsWatchdogConfig(), TtsWatchdog, TtsWatchdogConfig, TtsWatchdogStatus, log (+2 more)
-
-### Community 456 - "Community 456"
+### Community 444 - "Community 444"
 Cohesion: 0.13
-Nodes (9): ENV_KEYS, EnvSnapshot, ENV_FILE_PATH, loadPanopticonEnv(), parseEnvFile(), ServerConfig, ServerConfigError, ServerConfigLayer (+1 more)
+Nodes (8): wipeCommand(), WipeOptions, extractStandardNumber(), extractStandardPrefix(), normalizeIssueId(), ParsedIssueId, parseIssueId(), result
 
-### Community 457 - "Community 457"
-Cohesion: 0.15
-Nodes (16): CavemanVariant, determineCavemanVariant(), HookEntry, injectCavemanSettings(), injectMemoryHookSettings(), installTrustedMemoryHookScript(), memoryHookScript(), readWorkspaceSettings() (+8 more)
+### Community 445 - "Community 445"
+Cohesion: 0.14
+Nodes (16): assertIssueHasBeads(), assertIssueHasBeadsEffect(), BeadEntry, BeadsMissingError, execFileAsync, queryBeadById(), queryBeadsForIssue(), queryBeadsForIssueEffect() (+8 more)
 
-### Community 458 - "Community 458"
+### Community 446 - "Community 446"
 Cohesion: 0.1
 Nodes (20): 10 High-Value Skills, 1. `feature-work` - Standard Feature Development, 2. `bug-fix` - Bug Investigation and Fix, 3. `code-review` - Code Review Focus Areas, 4. `code-review-security` - Security-Focused Review, 5. `code-review-performance` - Performance-Focused Review, 6. `refactor` - Safe Refactoring, 7. `release` - Release Process (+12 more)
 
-### Community 459 - "Community 459"
+### Community 447 - "Community 447"
+Cohesion: 0.1
+Nodes (20): 6. Agreed End-State, Agent Startup Context, code:block10 (pan sync), code:block11 (pan sync), code:yaml (devroot: ~/Projects        # where you launch Claude Code fr), code:bash (pan workspace update MIN-678    # explicit command, only whe), code:block16 (pan workspace create MIN-678), code:block17 (Agent starts on MIN-678 workspace) (+12 more)
+
+### Community 448 - "Community 448"
 Cohesion: 0.1
 Nodes (19): Appendix: exe.dev CLI Reference, CLI Reference, code:bash (# Authentication), Documentation Updates, Future Enhancements, Goals, Modified Commands, New Commands (+11 more)
 
-### Community 460 - "Community 460"
+### Community 449 - "Community 449"
 Cohesion: 0.1
 Nodes (19): Canonical reviewer naming, code:block2 (┌───────────────────────────────────────────────────────────), code:typescript (// src/lib/cloister/specialists.ts), code:block3 (╔═══════════════════════════════════════════════════════════), code:typescript (// pseudocode for review-agent.ts after PAN-830), code:block31 (┌───────────────────────────────────────────────────────────), code:typescript (async function resolveJsonlPath(session: SessionDescriptor):), Goal (+11 more)
 
-### Community 461 - "Community 461"
+### Community 450 - "Community 450"
 Cohesion: 0.1
 Nodes (19): Architecture (3 sentences), code:block1 ([work items DAG] ──→ VERIFY ──→ REVIEW ──→ TEST ──→ MERGE ──), Data Sources, Depends On, Design, Escape State Overlays, Inline Diff Toggle, Motivation (+11 more)
 
-### Community 462 - "Community 462"
+### Community 451 - "Community 451"
 Cohesion: 0.1
 Nodes (19): 10. Cleanup, 1. `.panopticon/` → `.pan/` (project-level only), 2. `.panopticon.yaml` → `.pan.yaml`, 3. Archive structure: flat → per-issue subdirectory, 4. `findWorkspacePath` numeric suffix fix, 5. `.pan/skills/` as sync source, 6. Multi-tool sync (all 6 tools), 7. `.gitignore` injection (+11 more)
 
-### Community 463 - "Community 463"
+### Community 452 - "Community 452"
 Cohesion: 0.1
 Nodes (19): 9 items flagged for Epic D recovery review, Bug locations (as of HEAD), code:block1 (feature/pan-698@{2026-04-22 15:30:09}: reset: moving to e0ce), code:block2 (Epic D  →  Epic A  →  Epic B  →  Epic C), Context, Decisions (resolved 2026-04-23), Epic A — Labels as display, internal state as source of truth, Epic B — Work agent doesn't touch git (+11 more)
 
-### Community 464 - "Community 464"
+### Community 453 - "Community 453"
 Cohesion: 0.1
 Nodes (19): 10. Cleanup, 1. `.panopticon/` → `.pan/` (project-level only), 2. `.panopticon.yaml` → `.pan.yaml`, 3. Archive structure: flat → per-issue subdirectory, 4. `findWorkspacePath` numeric suffix fix, 5. `.pan/skills/` as sync source, 6. Multi-tool sync (all 6 tools), 7. `.gitignore` injection (+11 more)
 
-### Community 465 - "Community 465"
+### Community 454 - "Community 454"
 Cohesion: 0.1
 Nodes (19): API Endpoints, Auth Token Refresh, Check Recent Logs, CLIProxy — Check and Restart, code:bash (# Is it running?), code:bash (# Kill any existing instance), code:bash (# Last 30 lines of cliproxy log), code:yaml (host: "127.0.0.1") (+11 more)
 
-### Community 466 - "Community 466"
+### Community 455 - "Community 455"
 Cohesion: 0.1
 Nodes (17): code:bash (grep -E "FAIL|✗|Error|failed|BUILD FAILURE" /tmp/test-featur), code:bash (curl -s -X POST {{API_URL}}/api/review/{{ISSUE_ID}}/status \), code:bash (curl -s -X POST {{API_URL}}/api/review/{{ISSUE_ID}}/status \), code:bash (# Check if containers are running for this workspace), CRITICAL: Bash Timeout for Test Commands, CRITICAL: Context Management — Output Redirection, Memory Context, Never Close GitHub Issues (+9 more)
 
-### Community 467 - "Community 467"
+### Community 456 - "Community 456"
 Cohesion: 0.1
 Nodes (19): CLI Overview, code:bash (# Install Panopticon globally), code:bash (pan work issue MIN-123      # Spawn agent), code:bash (pan workspace create MIN-123         # Create workspace), code:bash (pan up    # Start dashboard at localhost:3011), code:bash (# General help), Command Structure, Common Options (+11 more)
 
-### Community 468 - "Community 468"
-Cohesion: 0.14
-Nodes (15): assertIssueHasBeads(), assertIssueHasBeadsEffect(), BeadEntry, BeadsMissingError, execFileAsync, queryBeadById(), queryBeadsForIssue(), queryBeadsForIssueEffect() (+7 more)
+### Community 457 - "Community 457"
+Cohesion: 0.16
+Nodes (16): mockCreateTracker, mockCreateTrackerFromConfig, mockFindProjectByPath, mockGetIssuePrefix, mockTracker, warnSpy, createTracker(), createTrackerFromConfig() (+8 more)
 
-### Community 469 - "Community 469"
+### Community 458 - "Community 458"
 Cohesion: 0.12
 Nodes (16): doCommit(), flushAutoCommits(), flushInner(), flushPromise(), FlushResult, GitResult, pending, QueuedCommit (+8 more)
 
-### Community 470 - "Community 470"
-Cohesion: 0.13
-Nodes (17): buildPermissionActivityDetails(), buildPermissionWaitingMessage(), normalizePermissionRequestBody(), parsePermissionResponseBehavior(), permissionResolutionVerb(), processPermissionResponse(), ProcessPermissionResponseDeps, ProcessPermissionResponseResult (+9 more)
-
-### Community 471 - "Community 471"
-Cohesion: 0.13
-Nodes (17): BunGlobal, ChannelPermissionRequest, ChannelPermissionRequestNotification, ChannelPushPayload, ChannelPushResult, constantTimeHeaderMatch(), forwardPermissionRequestToDashboard(), getDashboardBaseUrl() (+9 more)
-
-### Community 472 - "Community 472"
+### Community 459 - "Community 459"
 Cohesion: 0.15
 Nodes (13): addCandidateRoot(), collectCandidatePaths(), extractHashFromJsonlPath(), HashResolver, projectCandidateRoots(), ResolvedWorkspace, ReverseMapCache, a (+5 more)
 
-### Community 473 - "Community 473"
-Cohesion: 0.13
-Nodes (16): SessionUsage, emptyUsage(), isAssistantMessage(), isMessage(), KNOWN_TYPES, parsePiSessionContent(), ParseResult, PiEntry (+8 more)
+### Community 460 - "Community 460"
+Cohesion: 0.18
+Nodes (16): deliverQueuedFeedback(), enqueuePendingFeedbackDelivery(), FeedbackKind, isDeliveryStillRelevant(), markPendingFeedbackDelivered(), PENDING_FEEDBACK_FILE, PendingFeedbackDelivery, PendingFeedbackStore (+8 more)
 
-### Community 474 - "Community 474"
+### Community 461 - "Community 461"
 Cohesion: 0.11
 Nodes (14): CavemanExperimentRow, CostsPage(), CostsResponse, DailyTrend, ExperimentsResponse, fetchCosts(), fetchExperiments(), fetchIssueDetail() (+6 more)
 
-### Community 475 - "Community 475"
-Cohesion: 0.14
-Nodes (16): findVendoredDir(), getCavemanHooksDir(), getCavemanSkillsDir(), setupCavemanHooks(), compressSrc, destDir, dir, hookFiles (+8 more)
+### Community 462 - "Community 462"
+Cohesion: 0.12
+Nodes (16): bridgeCodexAuthToCliproxyEffect(), createSessionAsyncEffect(), cleanupExpiredReauthSessions(), codexAuthRouteLayer, consumeReauthTerminalToken(), getCodexAuthRoute, getExistingLiveReauthSession(), getLiveReauthSession() (+8 more)
 
-### Community 476 - "Community 476"
+### Community 463 - "Community 463"
+Cohesion: 0.13
+Nodes (17): AddOptions, BUNDLED_HOOKS_DIR, __dirname, __filename, installGitHooks(), ListOptions, projectAddCommand(), projectInitCommand() (+9 more)
+
+### Community 464 - "Community 464"
 Cohesion: 0.11
 Nodes (18): Agents, Beads, Cloister, Command Deck, Convoys, Core Concepts, Cost Tracking, Docker Integration (+10 more)
 
-### Community 477 - "Community 477"
+### Community 465 - "Community 465"
 Cohesion: 0.11
 Nodes (18): Architecture, Best Practices, CLI Commands, code:bash (# 1. Implement feature), code:bash (# List all specialists with status), code:toml ([specialists.review_agent]), code:typescript (type Priority = 'urgent' | 'high' | 'normal' | 'low';), Configuration (+10 more)
 
-### Community 478 - "Community 478"
+### Community 466 - "Community 466"
 Cohesion: 0.11
 Nodes (19): code:yaml (---), code:block20 (┌───────────────────────────────────────────────────────────), code:bash (# Skills tell the agent HOW to work), code:block22 (┌───────────────────────────────────────────────────────────), code:bash (# Update all agent workspaces with latest skills), code:bash (# Edit a skill in the canonical location), code:block25 (┌───────────────────────────────────────────────────────────), code:bash (# Parallel code review - spawn 4 agents with different focus) (+11 more)
 
-### Community 479 - "Community 479"
+### Community 467 - "Community 467"
 Cohesion: 0.11
 Nodes (18): Architecture, Backend Changes (`src/dashboard/server/index.ts`), code:block1 (socketIo.emit('planning:started', { issueId: issue.identifie), code:block2 (socketIo.emit('planning:failed', { issueId: issue.identifier), code:block3 (Background async task fails), Data Flow, Decision: Full Recovery Controls, Decision: Kanban Card Failure Indicator (+10 more)
 
-### Community 480 - "Community 480"
+### Community 468 - "Community 468"
 Cohesion: 0.11
 Nodes (18): Acceptance Criteria, Architecture, code:block1 (Cannot find module 'close-issue-BVnGI6Mw.js'), code:block2 (OLD SERVER PROCESS), Decision: Detached deploy script + pending lifecycle file, Difficulty, Edge Cases, Files to Modify (+10 more)
 
-### Community 481 - "Community 481"
+### Community 469 - "Community 469"
 Cohesion: 0.11
 Nodes (18): `cli:quick-command`, Flash-Lite's Niche in Panopticon, Gemini 3.1 Flash-Lite Preview Work Type Fit Analysis, Good Fit, Integration Notes, Key Benchmarks, Known Weaknesses, Model Profile (+10 more)
 
-### Community 482 - "Community 482"
+### Community 470 - "Community 470"
 Cohesion: 0.11
 Nodes (18): Abort, code:bash (pan flywheel start), code:bash (pan flywheel start), code:bash (pan flywheel status), code:bash (pan flywheel pause), code:bash (pan flywheel abort), code:bash (pan flywheel emit-status --file latest.json), code:bash (pan flywheel report) (+10 more)
 
-### Community 483 - "Community 483"
+### Community 471 - "Community 471"
 Cohesion: 0.11
 Nodes (18): Built-in Convoy Templates, code-review Template, code:bash (# Run a parallel code review), code:bash (# Show most recent convoy status), code:bash (# List all convoys), code:bash (pan convoy stop <convoy-id>), code:json ({), code:bash (pan convoy start lightweight-review --files "src/**/*.ts") (+10 more)
 
-### Community 484 - "Community 484"
-Cohesion: 0.2
-Nodes (12): BeadRecord, checkOpenBeads(), checkUncommittedChanges(), checkVBriefACStatus(), errorCode(), execAsync, execFileAsync, isMissingCommand() (+4 more)
-
-### Community 485 - "Community 485"
-Cohesion: 0.11
-Nodes (15): agentState, callOrder, checkFn, killed, mockGetAgentState, mockGetRuntimeForAgent, mockKillAgent, mockKillSession (+7 more)
-
-### Community 486 - "Community 486"
+### Community 472 - "Community 472"
 Cohesion: 0.11
 Nodes (16): capturedCmds, mockCreateReviewArtifactsForIssue, mockEnsureMergeSetForIssue, mockExecFileFn, mockExecFn, mockGetAgentState, mockGetDashboardApiUrl, mockGetReviewStatus (+8 more)
 
-### Community 487 - "Community 487"
+### Community 473 - "Community 473"
+Cohesion: 0.19
+Nodes (16): buildSessionIndex(), decodeClaudeDirName(), extractCostEvents(), extractSessionId(), getAgentsDir(), getClaudeProjectsDir(), getSessionOffset(), inferIssueFromPath() (+8 more)
+
+### Community 474 - "Community 474"
+Cohesion: 0.12
+Nodes (13): runCostSync(), CostEvent, parseWalFile(), SyncResult, syncWalFromAllProjects(), syncWalFromDir(), colNames, cols (+5 more)
+
+### Community 475 - "Community 475"
 Cohesion: 0.14
 Nodes (15): CloseOutContext, CloseOutError, CloseOutResult, CloseOutStep, execAsync, executeCloseOut(), findWorkspacePath(), isBranchMerged() (+7 more)
 
-### Community 488 - "Community 488"
-Cohesion: 0.2
-Nodes (17): ensureLogDir(), ensureLogDirAsync(), getHandoffStats(), getPendingVerificationHandoffs(), getPendingVerificationHandoffsEffect(), HANDOFF_LOG_FILE, HandoffEvent, logHandoffEvent() (+9 more)
-
-### Community 489 - "Community 489"
-Cohesion: 0.14
-Nodes (15): __dirname, __filename, isStringArray(), loadPromptFrontmatter(), ParsedPrompt, parsePrompt(), PromptError, PromptFrontmatter (+7 more)
-
-### Community 490 - "Community 490"
-Cohesion: 0.16
-Nodes (14): atomicWrite(), backupIfNeeded(), detectProviderEnvConflicts(), findNewestBackup(), injectPanopticonInfraDeny(), injectProviderEnvOverlay(), INVALID_LEGACY_PATTERNS, OverlayResult (+6 more)
-
-### Community 491 - "Community 491"
-Cohesion: 0.2
-Nodes (16): updateTtsConfig(), getDefaultTtsDaemonConfig(), getGlobalConfigPath(), mergeTtsConfig(), mergeTtsDaemonConfigs(), YamlConfig, cloneTtsConfig(), currentConfig (+8 more)
-
-### Community 492 - "Community 492"
+### Community 476 - "Community 476"
 Cohesion: 0.18
 Nodes (16): buildReport(), categorizeProcesses(), ClaudeProcess, detectRole(), formatGb(), formatMb(), getClaudeProcesses(), getHeavyProcesses() (+8 more)
 
-### Community 493 - "Community 493"
+### Community 477 - "Community 477"
+Cohesion: 0.16
+Nodes (13): EnrichedReviewStatus, enrichReviewStatus(), enrichReviewStatusFromSessions(), mostRecentByTimestamp(), parseReviewerTimestamp(), ReviewEnrichmentError, consolidateSpeakerCues(), decodeHtmlEntities() (+5 more)
+
+### Community 478 - "Community 478"
+Cohesion: 0.18
+Nodes (11): after, before, blockers, result, statuses, clearReviewStatus(), DEFAULT_STATUS_FILE, getReviewStatus() (+3 more)
+
+### Community 479 - "Community 479"
 Cohesion: 0.11
 Nodes (17): firstSelect, openaiKeyInput, openaiProvider, PANOPTICON_HOME, reviewAgentLabel, reviewAgentSelect, ROUTER_CONFIG, routerConfig (+9 more)
 
-### Community 494 - "Community 494"
+### Community 480 - "Community 480"
 Cohesion: 0.18
 Nodes (13): AutoPresoControls(), warmupIcon(), AutoPresoView(), Excalidraw, ExcalidrawApiLike, TranscriptPanel(), AutoPresoMessage, AutoPresoMode (+5 more)
 
-### Community 495 - "Community 495"
-Cohesion: 0.23
-Nodes (9): addVoice(), clearVoices(), deleteVoice(), findVoiceById(), findVoiceByName(), getTtsVoicesPath(), loadVoices(), saveVoices() (+1 more)
-
-### Community 496 - "Community 496"
+### Community 481 - "Community 481"
 Cohesion: 0.11
 Nodes (17): cb, cmdArgs, cmdStr, inline, issueCommentsJson, linearGetComments, linearGetIssueId, mockExec (+9 more)
 
-### Community 497 - "Community 497"
+### Community 482 - "Community 482"
+Cohesion: 0.14
+Nodes (9): NormalizedTtsDaemonConfig, parseTtsWatchdogIntEnv(), readTtsWatchdogConfig(), TtsWatchdog, TtsWatchdogConfig, TtsWatchdogStatus, log, mocks (+1 more)
+
+### Community 483 - "Community 483"
+Cohesion: 0.23
+Nodes (9): addVoice(), clearVoices(), deleteVoice(), findVoiceById(), findVoiceByName(), getTtsVoicesPath(), loadVoices(), saveVoices() (+1 more)
+
+### Community 484 - "Community 484"
+Cohesion: 0.19
+Nodes (12): startPostLaunchSidecars(), startSidecars(), getSupervisorPort(), getSupervisorUrl(), isProcessAlive(), isSupervisorRunning(), readSupervisorPid(), resolveSupervisorBundle() (+4 more)
+
+### Community 485 - "Community 485"
 Cohesion: 0.11
 Nodes (18): Approach 1: Passive Detection (MVP), Approach 2: Active Heartbeats (via Claude Code Hooks), Approach 3: Hybrid (Recommended), code:typescript (interface PassiveHeartbeat {), code:json ({), code:bash (#!/bin/bash), code:json ({), code:typescript (function getHeartbeat(agentId: string): Heartbeat {) (+10 more)
 
-### Community 498 - "Community 498"
+### Community 486 - "Community 486"
 Cohesion: 0.11
 Nodes (18): `<ActivitySparkline events={Event[]} windowMinutes={60} buckets={12} />`, Animation-timing reference, code:typescript (// Renders a 6×6 (small) or 8×8 (medium) circle with the rig), code:typescript (// Animates the number on change (vertical scroll fade, 250m), code:typescript (// Inline SVG, ~120×16px.), code:typescript (// 140-wide mini card with verdict, finding count, duration,), code:typescript (// Cross-fades the tool name on change (200ms each, with → b), code:typescript (// Wraps a lucide icon with the right ring color and avatar ) (+10 more)
 
-### Community 499 - "Community 499"
+### Community 487 - "Community 487"
 Cohesion: 0.11
 Nodes (17): Architecture Decisions, code:block1 (wire-converter ──blocks──> remove-bd-prompts), Decisions, Dependency Graph (text), Key Files to Modify, Out of Scope, PAN-388: vBRIEF Integration — Structured Plans, Programmatic Beads, DAG Visualization, Phase 2 (+9 more)
 
-### Community 500 - "Community 500"
+### Community 488 - "Community 488"
 Cohesion: 0.11
 Nodes (17): Access Points, Add Dependencies, Add Services, Change Java Version, code:bash (# Copy template to your project), code:bash (# Application), code:bash (# Connect to PostgreSQL), code:bash (docker compose restart app) (+9 more)
 
-### Community 501 - "Community 501"
+### Community 489 - "Community 489"
 Cohesion: 0.11
 Nodes (17): Access Points, Adding Dependencies, Alembic Migrations, code:bash (# Copy template to your project), code:bash (APP_PORT=8000), code:python (# database.py), code:bash (# Install alembic), code:bash (# Connect to PostgreSQL) (+9 more)
 
-### Community 502 - "Community 502"
+### Community 490 - "Community 490"
 Cohesion: 0.11
 Nodes (17): Adding Workspace Routes, code:block1 (~/.panopticon/traefik/), code:bash (mkcert "*.pan.localhost" "*.localhost" localhost 127.0.0.1 :), code:bash (cd ~/.panopticon/traefik), code:bash (cd ~/.panopticon/traefik), code:bash (docker logs -f panopticon-traefik), code:yaml (# dynamic/feature-pan-4.yml), Directory Structure (+9 more)
 
-### Community 503 - "Community 503"
+### Community 491 - "Community 491"
 Cohesion: 0.11
 Nodes (17): bd vs TodoWrite, Beads Skill for Claude Code, code:bash (# Global installation), code:block2 (beads/), code:bash (# Want: "Setup must complete before Implementation"), code:bash (bd update issue-123 --notes "COMPLETED: JWT auth with RS256), Contributing, File Structure (+9 more)
 
-### Community 504 - "Community 504"
+### Community 492 - "Community 492"
 Cohesion: 0.11
-Nodes (17): code:block1 (Session Start (when bd is available):), code:block13 (Side Quest Workflow:), code:block14 (Main task: Adding user profiles), code:block15 (Resume Workflow:), code:block25 (Hybrid Workflow:), code:block5 (Discovery Workflow:), code:block6 (Issue Lifecycle:), Contents (+9 more)
+Nodes (17): code:block1 (Session Start (when bd is available):), code:block15 (Resume Workflow:), code:block23 (Unblocking Workflow:), code:block24 (Situation: bd ready shows nothing), code:block25 (Hybrid Workflow:), code:block5 (Discovery Workflow:), code:block6 (Issue Lifecycle:), Contents (+9 more)
 
-### Community 505 - "Community 505"
+### Community 493 - "Community 493"
 Cohesion: 0.11
 Nodes (17): Benchmark: QuantumLlama Provider Integration, code:block1 (/benchmark <scenario description>), code:bash (cat /home/eltmon/Projects/panopticon-cli/benchmarks/template), code:bash (cd /home/eltmon/Projects/panopticon-cli && gh label create b), code:bash (cd /home/eltmon/Projects/panopticon-cli && gh issue create \), code:block5 (Created PAN-XXX: Benchmark: QuantumLlama — <scenario>), Execution Steps, Important Notes (+9 more)
 
-### Community 506 - "Community 506"
+### Community 494 - "Community 494"
 Cohesion: 0.11
 Nodes (17): API Documentation, Checklist Output, Code Generation, code:markdown (## Analysis Report), code:markdown (## Review Checklist), code:markdown (## Generated Code), code:markdown (## Changes Made), code:markdown (## Option Analysis) (+9 more)
 
-### Community 507 - "Community 507"
+### Community 495 - "Community 495"
 Cohesion: 0.11
 Nodes (17): code:bash (# Register a project), code:yaml (projects:), code:json ([), code:yaml (projects:), code:bash (#!/bin/bash), code:yaml (projects:), Configuration Fields, Custom Workspace Commands (Legacy) (+9 more)
 
-### Community 508 - "Community 508"
+### Community 496 - "Community 496"
 Cohesion: 0.11
 Nodes (17): 1. Review the shared context first, 2. Wait for convoy signals, 3. Read available reviewer reports, 4. Determine the cycle number and the diff scope to evaluate, 5. Synthesize the verdict, 6. Write the synthesis report, 7. Signal review status, Boundaries (+9 more)
 
-### Community 509 - "Community 509"
+### Community 497 - "Community 497"
 Cohesion: 0.12
 Nodes (15): activeAgent, address, agent, feature, frontendRoot, issue, newContext(), openRoute() (+7 more)
 
-### Community 510 - "Community 510"
-Cohesion: 0.12
-Nodes (15): CI_FAILED_STATUS, ciBlockedStatus, feedbackDir, mockGetAgentRuntimeState, mockLoadReviewStatuses, mockResolveProjectFromIssue, mockSendKeysAsync, mockSessionExists (+7 more)
-
-### Community 511 - "Community 511"
-Cohesion: 0.29
-Nodes (16): display_title(), extract_text_fragments(), extract_tool_names(), find_by_id(), format_cost(), get_db(), get_session_summary(), iter_session_messages() (+8 more)
-
-### Community 512 - "Community 512"
+### Community 498 - "Community 498"
 Cohesion: 0.19
-Nodes (11): startPostLaunchSidecars(), getSupervisorPort(), getSupervisorUrl(), isProcessAlive(), isSupervisorRunning(), readSupervisorPid(), resolveSupervisorBundle(), startSupervisorProcess() (+3 more)
+Nodes (10): backupCleanCommand(), backupListCommand(), restoreCommand(), BackupInfo, cleanOldBackups(), createBackup(), createBackupTimestamp(), listBackups() (+2 more)
 
-### Community 513 - "Community 513"
-Cohesion: 0.17
-Nodes (7): extractPrefix(), extractStandardNumber(), extractStandardPrefix(), normalizeIssueId(), ParsedIssueId, parseIssueId(), result
-
-### Community 514 - "Community 514"
+### Community 499 - "Community 499"
 Cohesion: 0.12
 Nodes (15): agentDir, agentResult, beadsDir, branchResult, clearResult, content, legacyDir, legacyResult (+7 more)
 
-### Community 515 - "Community 515"
-Cohesion: 0.14
-Nodes (10): TtsVoiceListItem, playVoice(), requireTtsSpoken(), TtsSystemVoicePicker(), TtsSystemVoicePickerProps, VoiceChoiceSectionProps, onSetStatusVoice, onSetSystemVoice (+2 more)
+### Community 500 - "Community 500"
+Cohesion: 0.12
+Nodes (15): CI_FAILED_STATUS, ciBlockedStatus, feedbackDir, mockGetAgentRuntimeState, mockLoadReviewStatuses, mockResolveProjectFromIssue, mockSendKeysAsync, mockSessionExists (+7 more)
 
-### Community 516 - "Community 516"
+### Community 501 - "Community 501"
+Cohesion: 0.29
+Nodes (16): display_title(), extract_text_fragments(), extract_tool_names(), find_by_id(), format_cost(), get_db(), get_session_summary(), iter_session_messages() (+8 more)
+
+### Community 502 - "Community 502"
+Cohesion: 0.21
+Nodes (15): getDefaultTtsDaemonConfig(), getGlobalConfigPath(), mergeTtsConfig(), mergeTtsDaemonConfigs(), YamlConfig, cloneTtsConfig(), currentConfig, findProjectRootAsync() (+7 more)
+
+### Community 503 - "Community 503"
+Cohesion: 0.15
+Nodes (12): GPT_5_5_API_KEY_BLOCK, HarnessPolicyDecision, PI_ANTHROPIC_SUBSCRIPTION_BLOCK, SUBSCRIPTION_ONLY_OPENAI_MODELS, AuthMode, RuntimeName, AUTH_MODES, cells (+4 more)
+
+### Community 504 - "Community 504"
+Cohesion: 0.12
+Nodes (16): Access, Agent Grid, code:block1 (┌────────────────────────────────────────────────────┐), code:css (--gv-bg: #0a0e1a          /* Dark navy background */), Components, Dependencies, Design System, Focus View (+8 more)
+
+### Community 505 - "Community 505"
 Cohesion: 0.12
 Nodes (17): Agent Sessions Not Appearing, code:bash (# Check if ports are in use), code:bash (# Regenerate certificates), code:bash (# Check tmux sessions), code:bash (# List worktrees), code:bash (# Install build tools (macOS)), code:bash (# Verify API key), code:bash (# Check Traefik status) (+9 more)
 
-### Community 517 - "Community 517"
+### Community 506 - "Community 506"
 Cohesion: 0.12
 Nodes (17): API Compatibility Levels, code:bash (# Option 1: Kimi coding endpoint), code:bash (# GLM/Z.AI endpoint (Anthropic-compatible)), code:bash (export ANTHROPIC_BASE_URL=https://open.bigmodel.cn/api/anthr), code:bash (# Kimi API configuration for Claude Code), code:bash (source ~/.bashrc  # or source ~/.zshrc), code:bash (claude /status), code:bash (# Install router) (+9 more)
 
-### Community 518 - "Community 518"
+### Community 507 - "Community 507"
 Cohesion: 0.12
 Nodes (16): code:block1 (work role completes beads and signals done), code:block2 (roles/), code:markdown (# Verdict: APPROVED | CHANGES_REQUESTED | FAILED), code:yaml (workhorses:), Cost attribution, Dashboard restart invariant, Instruction layout, Invariants (+8 more)
 
-### Community 519 - "Community 519"
+### Community 508 - "Community 508"
 Cohesion: 0.12
 Nodes (17): ActivitySource — After, ActivitySource — Before, AgentState interface — After, AgentState interface — Before (`src/lib/agents.ts:388-433`), code:yaml (# ~/.panopticon/config.yaml), code:typescript (export type ActivitySource = 'merge-agent' | 'cloister' | 'r), code:typescript (// In activity-logger.ts, the source is computed:), code:json ({) (+9 more)
 
-### Community 520 - "Community 520"
+### Community 509 - "Community 509"
 Cohesion: 0.12
 Nodes (16): Architecture, CLI Interface (full surface), code:block1 (┌──────────────────────────────────────────┐), code:bash (pan conversations embed                      # all enriched,), code:yaml (# config.yaml), code:bash (# Discovery), code:block20 (GET  /api/archived-conversations), Dependencies (+8 more)
 
-### Community 521 - "Community 521"
+### Community 510 - "Community 510"
 Cohesion: 0.12
 Nodes (17): code:block21 (- discovers all sessions in target dir), code:block22 (- detects SSD vs HDD via lsblk rotational flag), code:block23 (- structured filters compose with AND), code:block24 (- L1 selects cheapest available model), code:block25 (- correct dimensions stored per provider/model), code:block26 (- nav entry routes to /conversations), code:block27 (- all fields render), code:block28 (- scan → enrich → embed → search across all three tiers) (+9 more)
 
-### Community 522 - "Community 522"
+### Community 511 - "Community 511"
 Cohesion: 0.12
 Nodes (17): Action cluster, code:block10 ($0.04/min currently · projecting $1.20 for this session at t), code:block11 (+47 lines), code:block12 (○ idle for 4m 12s — needs nudge?    [Send Message] [Stop]), code:block6 (phase: review-response · tool: Grep), code:block7 (🧠 thinking · since 14:32:42 · last tool was Grep 8s ago), code:block8 (⏸ waiting · {reason} — {message}                    [Resolve), code:block9 (┌──────────────┐  ┌──────────────┐  ┌──────────────┐) (+9 more)
 
-### Community 523 - "Community 523"
+### Community 512 - "Community 512"
 Cohesion: 0.12
 Nodes (16): Additional Gaps, code:json ({), code:block2 (For each running work agent:), code:typescript ({), Files to Change, Non-Goals, PAN-309: Evidence-Based Completion Detection & Lifecycle Badges, Phase 1: Evidence-Based Completion Detection (stop-hook) (+8 more)
 
-### Community 524 - "Community 524"
+### Community 513 - "Community 513"
 Cohesion: 0.12
 Nodes (15): Approach: Pre-fetch in callers, pass to prompt builder, Architecture, code:block1 ([issueCommand() / server endpoint]), Data Flow, Data to include, Decisions, Error handling: Warn in prompt, Files to Modify (+7 more)
 
-### Community 525 - "Community 525"
+### Community 514 - "Community 514"
 Cohesion: 0.12
 Nodes (16): Constraints, Design, Draft-mode parity, Explicit reconciliation, Local outbox model, Must Have, Open Questions, Out of Scope (+8 more)
 
-### Community 526 - "Community 526"
+### Community 515 - "Community 515"
 Cohesion: 0.12
 Nodes (16): Architecture, Bootstrap, code:block1 (AgentEnrichmentService (3s poll)), Contracts Package (`packages/contracts/src/`), Data Flow, Decisions, Files to Modify, Frontend (verify only) (+8 more)
 
-### Community 527 - "Community 527"
+### Community 516 - "Community 516"
 Cohesion: 0.12
 Nodes (16): Access Points, code:bash (# Copy template to your project), code:bash (APP_PORT=5000), code:block3 (Server=sqlserver;Database=${DB_NAME};User Id=sa;Password=${D), code:json ({), code:bash (# Run migrations), code:bash (# Connect via sqlcmd), Connection String (+8 more)
 
-### Community 528 - "Community 528"
+### Community 517 - "Community 517"
 Cohesion: 0.12
 Nodes (16): Authentication Issues, code:bash (npx @_davideast/stitch-mcp init), code:json ({), code:bash (npx @_davideast/stitch-mcp doctor), code:bash (export STITCH_USE_SYSTEM_GCLOUD=1), Environment Detection, Manual Configuration, Prerequisites (+8 more)
 
-### Community 529 - "Community 529"
+### Community 518 - "Community 518"
 Cohesion: 0.12
 Nodes (16): 1. Generate the table, 2. Add an Awaiting Merge summary line, 3. (Optional) Defer to other status skills if user wants more detail, Cell semantics, code:block1 (ISSUE      TITLE                                            ), code:bash (python3 - <<'PY'), code:bash (curl -s http://localhost:3011/api/issues | python3 -c "), code:block4 (For deeper detail beyond the pipeline view:) (+8 more)
 
-### Community 530 - "Community 530"
+### Community 519 - "Community 519"
 Cohesion: 0.12
-Nodes (16): Cleanup After Shutdown, code:bash (# Method 1: Separate commands), code:bash (# Clean up log files), code:bash (# Monitor in one terminal), code:env (# Graceful shutdown timeout (seconds)), Configuration Options, Monitoring Shutdown, More Information (+8 more)
+Nodes (16): Basic Usage, code:bash (# Stop all Panopticon services), code:bash (# Method 1: Separate commands), code:bash (# Monitor in one terminal), code:env (# Graceful shutdown timeout (seconds)), Configuration Options, Monitoring Shutdown, More Information (+8 more)
 
-### Community 531 - "Community 531"
+### Community 520 - "Community 520"
 Cohesion: 0.12
 Nodes (16): 10. Scrollbars, 16. File Organization, 17. Quick Reference Card, 1. Design Philosophy, 5. Border Radius Scale, 6. Spacing & Sizing, 9. Fractal Noise Texture, code:css (--radius: 0.625rem;  /* 10px */) (+8 more)
 
-### Community 532 - "Community 532"
+### Community 521 - "Community 521"
 Cohesion: 0.12
 Nodes (16): code:bash (curl {{API_URL}}/api/health), code:bash (# Get test token (server-side, before opening browser)), code:javascript (// Launch browser), code:block4 (## UAT Results), Context, Critical Notes, Examples of BLOCKED vs PASS, Handling Playwright (Browser Automation) (+8 more)
 
-### Community 533 - "Community 533"
+### Community 522 - "Community 522"
 Cohesion: 0.12
 Nodes (16): Best Value by Tier, Budget Tasks, Changes from Baseline, Code Review & Security, Conclusion, Cost-Effectiveness Analysis, Debugging, Executive Summary (+8 more)
 
-### Community 534 - "Community 534"
+### Community 523 - "Community 523"
 Cohesion: 0.12
 Nodes (16): code:bash (# Full install (includes Traefik + mkcert for HTTPS)), code:bash (pan sync), code:bash (pan doctor), code:bash (# Start with default settings), code:bash (pan down), code:bash (pan restart), code:bash (pan health), Core Commands (+8 more)
 
-### Community 535 - "Community 535"
+### Community 524 - "Community 524"
 Cohesion: 0.15
 Nodes (6): MockRallyArtifact, RallyApiMock, compoundQueries, mock, sampleArtifacts, typeQueries
 
-### Community 536 - "Community 536"
-Cohesion: 0.13
-Nodes (13): getBridgeLogPath(), getPanopticonHome(), BRIDGE_ENTRY, entry, exitPromise, lines, logPath, params (+5 more)
-
-### Community 537 - "Community 537"
-Cohesion: 0.12
-Nodes (15): agentDir, cache1, cache2, events1, events2, eventsFile, sessionDir, stats (+7 more)
-
-### Community 538 - "Community 538"
-Cohesion: 0.14
-Nodes (14): fetchOpenRouterModels(), KeyStatus, OpenRouterModelsResponse, OpenRouterPage(), OpenRouterPageProps, saveApiKey(), saveFavorites(), SaveOpenRouterKeyResponse (+6 more)
-
-### Community 539 - "Community 539"
-Cohesion: 0.16
-Nodes (14): CategoryFilter, formatContextLength(), formatCost(), ModelCard(), OpenRouterModel, OpenRouterModelBrowser(), OpenRouterModelBrowserProps, { container } (+6 more)
-
-### Community 540 - "Community 540"
-Cohesion: 0.21
-Nodes (14): registerAdminCommands(), archiveCustomState(), CleanupOptions, cleanupStatesCommand(), LinearState, ListOptions, listStatesCommand(), listTeamStates() (+6 more)
-
-### Community 541 - "Community 541"
+### Community 525 - "Community 525"
 Cohesion: 0.19
 Nodes (12): getAllSpecialistStatus(), LegacySpecialistRuntimeStatus, displaySpecialist(), getRelativeTime(), getStatusColor(), getStatusIcon(), listCommand(), ListOptions (+4 more)
 
-### Community 542 - "Community 542"
+### Community 526 - "Community 526"
+Cohesion: 0.2
+Nodes (3): GitHubTracker, octokitToEffect(), parseIssueNumber()
+
+### Community 527 - "Community 527"
+Cohesion: 0.21
+Nodes (14): registerAdminCommands(), archiveCustomState(), CleanupOptions, cleanupStatesCommand(), LinearState, ListOptions, listStatesCommand(), listTeamStates() (+6 more)
+
+### Community 528 - "Community 528"
+Cohesion: 0.18
+Nodes (9): buildClaudeUserSettings(), ClaudeUserSettings, getClaudePermissionFlags(), readYoloEnv(), resolvePermissionMode(), YOLO_FALSE, YOLO_TRUE, ClaudePermissionMode (+1 more)
+
+### Community 529 - "Community 529"
 Cohesion: 0.12
 Nodes (16): Baseline-Aware Test Validation, code:block1 (┌───────────────────────────────────────────────────────────), code:bash (# In validate-merge.sh), code:typescript (// validation.ts — autoRevertMerge always uses ORIG_HEAD), code:typescript (const { stdout: statusOut } = await execAsync('git status --), code:typescript (if (stashCreated) {), code:block6 (┌──────────┐     ┌──────────┐     ┌──────────┐     ┌────────), code:typescript (POST /api/specialists/done) (+8 more)
 
-### Community 543 - "Community 543"
+### Community 530 - "Community 530"
 Cohesion: 0.12
 Nodes (15): code:block1 (tests/), code:typescript (// Mock execAsync for git command tests), code:typescript (// Preferred: testid), Conventions, Dashboard UI Testing, `data-testid` Convention, Mocking, Playwright MCP (+7 more)
 
-### Community 544 - "Community 544"
+### Community 531 - "Community 531"
 Cohesion: 0.12
 Nodes (15): API Integration, Component Structure, Core Layout, Design 1: Collapsed State, Design 2: Expanded State, Next Steps, Overrides (6 components), Overview (+7 more)
 
-### Community 545 - "Community 545"
+### Community 532 - "Community 532"
 Cohesion: 0.12
 Nodes (16): 10. Autonomous flywheel daemon, 11. Public flywheel dashboard page, 12. Updated `all-up` skill, 13. Updated `CLAUDE.md` (repo-level), 1. `retro-agent` — New agent type, 2. Retro storage, 3. Synthesis step — new Step 8 in `all-up` skill, 4. `docs/FLYWHEEL-REPORT.md` — user-facing living doc (+8 more)
 
-### Community 546 - "Community 546"
+### Community 533 - "Community 533"
 Cohesion: 0.12
 Nodes (15): Acceptance Criteria, Code to Preserve (Merge Queue), code:block1 (if (specialist busy) → submitToSpecialistQueue()), code:block2 (if (workspace already has running specialist) → no-op (dupli), Current Architecture, Goal, Key Files to Remove/Modify, New Dispatch Pattern (+7 more)
 
-### Community 547 - "Community 547"
+### Community 534 - "Community 534"
 Cohesion: 0.12
 Nodes (15): Approach, D1: Full scope — all 6 problem areas, D2: Typed error-to-HTTP mapping via `httpHandler` wrapper, D3: Convert ALL sync FS calls including `existsSync`, D4: Keep existing route composition pattern, Decisions, Out of Scope, PAN-470: Rewrite route handlers to idiomatic Effect (+7 more)
 
-### Community 548 - "Community 548"
+### Community 535 - "Community 535"
 Cohesion: 0.12
 Nodes (15): 1. Eliminating Waterfalls (CRITICAL), 2. Bundle Size Optimization (CRITICAL), 3. Server-Side Performance (HIGH), 4. Client-Side Data Fetching (MEDIUM-HIGH), 5. Re-render Optimization (MEDIUM), 6. Rendering Performance (MEDIUM), 7. JavaScript Performance (LOW-MEDIUM), 8. Advanced Patterns (LOW) (+7 more)
 
-### Community 549 - "Community 549"
+### Community 536 - "Community 536"
 Cohesion: 0.12
 Nodes (15): Auto-Fix Critical Issues, Check Specific Workspace, code:bash (python ~/.claude/skills/session-health/scripts/check_session), code:bash (python ~/.claude/skills/session-health/scripts/check_session), code:bash (# Replace with your actual project path), code:bash (tmux kill-session -t agent-proj-123), code:python (import os, glob), code:bash (pan start PROJ-123) (+7 more)
 
-### Community 550 - "Community 550"
+### Community 537 - "Community 537"
 Cohesion: 0.12
 Nodes (15): Beads Completion Check, BLOCKED - Open Beads Found, code:bash (# Check for open beads), code:block2 (BEADS CHECK: PASS), code:block3 (BEADS CHECK: BLOCKED), code:block4 (Task(subagent_type='beads-completion-check', prompt='Check i), code:json ({), Error Handling (+7 more)
 
-### Community 551 - "Community 551"
+### Community 538 - "Community 538"
 Cohesion: 0.12
 Nodes (15): Code Review Agent, code:markdown (---), code:markdown (---), code:markdown (---), code:markdown (---), code:markdown (---), code:markdown (---), code:markdown (---) (+7 more)
 
-### Community 552 - "Community 552"
+### Community 539 - "Community 539"
 Cohesion: 0.12
 Nodes (15): code:markdown (## Process), code:markdown (## Decision Tree), code:markdown (## Data Transformation), code:markdown (## Investigation Flow), code:markdown (## Setup Wizard), code:markdown (## Multi-Source Research), code:markdown (## Robust Execution), Conditional Branching (+7 more)
 
-### Community 553 - "Community 553"
+### Community 540 - "Community 540"
 Cohesion: 0.12
 Nodes (15): 1. Inspect commit context, 2. Choose the narrowest fitting scope, 3. Draft the commit message, 4. Commit safely, 5. If commitlint rejects the message, code:bash (git status --short --branch), code:text (feat(cli): add pan-commit skill), code:text (fix(dashboard): rehydrate snapshot after reconnect) (+7 more)
 
-### Community 554 - "Community 554"
+### Community 541 - "Community 541"
 Cohesion: 0.12
 Nodes (15): code:bash (cd {{projectPath}}), code:bash (git diff --check), code:bash (git commit --no-edit), code:block4 (MERGE_RESULT: SUCCESS), code:block5 (MERGE_RESULT: FAILURE), code:bash (git merge --abort), Conflict Files, Critical Rules (+7 more)
 
-### Community 555 - "Community 555"
-Cohesion: 0.17
-Nodes (12): emitDashboardLifecycle(), data, mockExistsSync, mockReadFile, mockUnlink, runner, LifecycleRunner, PENDING_FILE (+4 more)
+### Community 542 - "Community 542"
+Cohesion: 0.13
+Nodes (13): cleanupOldHealthEvents(), DatabaseError, deleteAgentHealthHistory(), getAgentsWithHistory(), getAllHealthHistory(), getHealthHistory(), getLatestHealthEvent(), getRecentHealthHistory() (+5 more)
 
-### Community 556 - "Community 556"
+### Community 543 - "Community 543"
 Cohesion: 0.13
 Nodes (14): backup, backup1, backup2, backupDir, backups, dir1, dir2, removed (+6 more)
 
-### Community 557 - "Community 557"
+### Community 544 - "Community 544"
 Cohesion: 0.17
-Nodes (12): AgentHealth, checkAllTriggers(), checkStuckEscalation(), checkTaskCompletion(), checkTestFailure(), detectTestFailure(), execAsync, taskCompletionCache (+4 more)
+Nodes (10): ApiKeyValidationResult, classifyModel(), detectThinkingSupport(), ModelCache, OpenRouterModel, OpenRouterService, OpenRouterServiceLive, OpenRouterServiceShape (+2 more)
 
-### Community 559 - "Community 559"
+### Community 545 - "Community 545"
+Cohesion: 0.17
+Nodes (13): SessionUsage, emptyUsage(), isAssistantMessage(), isMessage(), KNOWN_TYPES, parsePiSessionContent(), ParseResult, PiEntry (+5 more)
+
+### Community 546 - "Community 546"
+Cohesion: 0.22
+Nodes (11): showHelp(), startCommand(), statusCommand(), stopCommand(), tldrCommand(), TldrOptions, warmCommand(), getTldrDaemonService() (+3 more)
+
+### Community 547 - "Community 547"
+Cohesion: 0.16
+Nodes (10): criteria, doc, projectDoc, projectRoot, workspaceDoc, workspacePath, AutoSynthesizeIssueInput, AutoSynthesizeResult (+2 more)
+
+### Community 549 - "Community 549"
 Cohesion: 0.16
 Nodes (11): isStale(), PHASE_CONFIG, recentActionObservations(), issue, list, onOpenWorkspaceHome, status, summary (+3 more)
 
-### Community 560 - "Community 560"
+### Community 550 - "Community 550"
 Cohesion: 0.13
 Nodes (12): mockDeepWipe, mockExistsSync, mockGetAgentState, mockGetAgentStateAsync, mockMessageAgent, mockMkdir, mockSpawnAgent, mockSpawnPlanningSession (+4 more)
 
-### Community 561 - "Community 561"
-Cohesion: 0.13
-Nodes (13): after, backupPath, backups, calls, errSpy, exitSpy, original, out (+5 more)
-
-### Community 562 - "Community 562"
-Cohesion: 0.13
-Nodes (14): ExtractionProviderConfig, ExtractionProviderTarget, MemoryIdentity, MemoryObservation, MemoryStatus, MemoryStatusPhase, MemoryTokenUsage, PendingTurn (+6 more)
-
-### Community 563 - "Community 563"
+### Community 551 - "Community 551"
 Cohesion: 0.13
 Nodes (15): Agent Commands, code:bash (# Start dashboard (prefers Electron desktop app if installed), code:bash (# Create workspace for an issue), code:bash (# Check agent status), code:bash (# Start work agent for an issue), code:bash (# Add project), code:bash (# Sync skills to Claude Code), code:bash (# Verify that main is releasable) (+7 more)
 
-### Community 564 - "Community 564"
+### Community 552 - "Community 552"
 Cohesion: 0.13
 Nodes (15): code:block111 (┌───────────────────────────────────────────────────────────), code:bash (# Key configuration (written to /etc/dnsmasq.d/panopticon.co), code:bash (# 1. Install dnsmasq), code:powershell (# Reads ~/.wsl2hosts from WSL2), code:powershell (# Run sync every 5 minutes (or on-demand when workspaces cha), code:bash (# Creates a helper command that can be run with sudo without), code:bash (# 1. Create workspace directories, containers, etc.), Component 1: dnsmasq Wildcard DNS (WSL2 Side) (+7 more)
 
-### Community 565 - "Community 565"
+### Community 553 - "Community 553"
 Cohesion: 0.13
 Nodes (15): Artifact Lifecycle, code:block46 (docs/prds/), code:block47 (.planning/), code:block48 (.beads/), code:bash (# Before moving (on source machine)), code:bash (bd sync                              # Export beads DB → JSO), code:bash (git checkout feature/min-667), code:bash (pan workspace migrate MIN-667 --to remote) (+7 more)
 
-### Community 566 - "Community 566"
+### Community 554 - "Community 554"
 Cohesion: 0.13
 Nodes (15): code:yaml (models:), code:env (ANTHROPIC_API_KEY=sk-ant-api03-...), code:yaml (models:), code:env (ANTHROPIC_API_KEY=sk-ant-...), code:yaml (models:), code:env (ANTHROPIC_API_KEY=sk-ant-...), code:yaml (models:), code:yaml (models:) (+7 more)
 
-### Community 567 - "Community 567"
+### Community 555 - "Community 555"
 Cohesion: 0.13
 Nodes (15): Activity logger (`src/lib/activity-logger.ts`), API routes (`src/dashboard/server/routes/`), Backend Changes, Cloister service (`src/lib/cloister/service.ts`), code:typescript (type Workhorse = 'expensive' | 'mid' | 'cheap';), code:typescript (async function onIssueStateChange(issueId: string, newState:), code:yaml (workhorses:), Config schema (`~/.panopticon/config.yaml`) (+7 more)
 
-### Community 568 - "Community 568"
-Cohesion: 0.13
-Nodes (14): A.1 Add `isInfrastructureFailure` helper, A.2 Enhance `checkStuckReviewing` to detect dead parallel sessions, A.3 Add infrastructure-failure circuit breaker, A.4 Honor `stuck` flag in re-dispatch path, A.5 ~~Detect verification/review contradiction~~ — REMOVED, A.6 Partial results from incomplete parallel reviews, A. `src/lib/cloister/deacon.ts`, code:typescript (function isInfrastructureFailure(notes?: string): boolean {) (+6 more)
-
-### Community 569 - "Community 569"
+### Community 556 - "Community 556"
 Cohesion: 0.13
 Nodes (14): Acceptance Criteria, Bead 1: HarnessPicker Component, Bead 2: API harness params, Bead 3: PlanDialog picker, Bead 4: Start-agent picker, Bead 5: ConversationPanel picker, Bead 6: SettingsPage defaults, Design Goals (+6 more)
 
-### Community 570 - "Community 570"
+### Community 557 - "Community 557"
 Cohesion: 0.13
 Nodes (14): code:bash (# Migrate local → remote), Command Design, Current Architecture, Edge Cases, File: `src/cli/commands/workspace-migrate.ts`, Files to Create/Modify, Implementation, Local Workspaces (+6 more)
 
-### Community 571 - "Community 571"
+### Community 558 - "Community 558"
 Cohesion: 0.13
 Nodes (14): Decision, Difficulty Estimates, Implementation Complete, In Scope, Key Architectural Choices, Out of Scope, PAN-428: Dashboard Data Layer — Consolidate Polling, Push-First Architecture, Parallelization Strategy (+6 more)
 
-### Community 572 - "Community 572"
+### Community 559 - "Community 559"
 Cohesion: 0.13
 Nodes (14): Architecture Overview, Auto-Selection Logic, code:block1 (Command Deck (project selected)), Core Design: Conversation-First with Contextual Chrome, Data Flow, Decision Summary, Key Decisions Made, Key Patterns to Follow (+6 more)
 
-### Community 573 - "Community 573"
+### Community 560 - "Community 560"
 Cohesion: 0.13
 Nodes (14): Access Points, Adding Dependencies, App Router vs Pages Router, code:bash (# Copy template to your project), code:bash (APP_PORT=3000), code:javascript (/** @type {import('next').NextConfig} */), code:bash (# Install inside container), Development Workflow (+6 more)
 
-### Community 574 - "Community 574"
+### Community 561 - "Community 561"
 Cohesion: 0.13
 Nodes (14): Batch Operations, code:bash (# From a pipe), code:block2 (close <id> [reason...]), code:bash (# Close all open beads for PAN-116), code:bash (# Deprioritize multiple beads), Error Handling, Example: Bulk Close, Example: Bulk Update (+6 more)
 
-### Community 575 - "Community 575"
+### Community 562 - "Community 562"
 Cohesion: 0.13
 Nodes (15): Automatic Unblocking, blocks - Hard Blocker, code:block1 (db-schema-1: "Create users table"), code:block2 (migrate-1: "Backup production database"), code:block3 (setup-1: "Install JWT library"), code:bash (bd dep add prerequisite-issue blocked-issue), code:block5 (foundation-1: "Set up authentication system"), code:block6 (step-1 blocks step-2 blocks step-3 blocks step-4) (+7 more)
 
-### Community 576 - "Community 576"
+### Community 563 - "Community 563"
 Cohesion: 0.13
 Nodes (15): code:block22 (feature-10: "Add user profiles"), code:block23 (research-5: "Investigate caching options"), code:block24 (refactor-20: "Extract validation logic"), code:bash (bd dep add original-work-id discovered-issue-id --type disco), code:block26 (spike-1: "Investigate API redesign"), code:block27 (bug-1: "Login fails intermittently"), code:block28 (feature-main: "Add shopping cart"), code:block29 (feature-10: "Add user profiles") (+7 more)
 
-### Community 577 - "Community 577"
+### Community 564 - "Community 564"
 Cohesion: 0.13
 Nodes (15): Basic Filters, code:bash (# Labels (AND: must have ALL)), code:bash (# Title search (substring)), code:bash (# Date range filters (YYYY-MM-DD or RFC3339)), code:bash (# Empty/null checks), code:bash (# Priority ranges), code:bash (# Combine multiple filters), code:bash (# Filter by status, priority, type) (+7 more)
 
-### Community 578 - "Community 578"
+### Community 565 - "Community 565"
 Cohesion: 0.13
 Nodes (14): Architecture, code:bash (bd worktree create .worktrees/{name} --branch feature/{name}), code:block2 (main-repo/), code:bash (# Create worktree with beads support), code:bash (bd where              # Shows actual .beads location (follow), code:bash (bd init --branch beads-metadata    # Use separate branch for), Commands, Debugging (+6 more)
 
-### Community 579 - "Community 579"
+### Community 566 - "Community 566"
 Cohesion: 0.13
 Nodes (14): 1. Find the right document, 2. Decide the document type before editing, 3. Update the target document, 4. Update the index, 5. Verify the docs surface, Add or update documentation, Answer a docs question, Clean up confusing docs (+6 more)
 
-### Community 580 - "Community 580"
+### Community 567 - "Community 567"
 Cohesion: 0.14
 Nodes (11): cache, capped, cpuList, events, lines, memFree, memTotal, result (+3 more)
 
-### Community 581 - "Community 581"
-Cohesion: 0.25
-Nodes (12): buildStatus(), decodeBase64Url(), decodeJwtPayload(), getCodexAuthPath(), getJwtExpiry(), getOpenAIAuthStatus(), getOpenAIAuthStatusSync(), hasApiKey() (+4 more)
-
-### Community 582 - "Community 582"
-Cohesion: 0.19
-Nodes (9): calls, { mockExecAsync }, opts, compactBeads(), compactBeadsImpl(), CompactBeadsOptions, execAsync, { mockExecAsync } (+1 more)
-
-### Community 583 - "Community 583"
+### Community 568 - "Community 568"
 Cohesion: 0.18
 Nodes (9): RallyApiConfig, RallyCreateConfig, RallyCreateResult, RallyQueryConfig, RallyQueryResult, RallyRestApi, RallyUpdateConfig, RallyUpdateResult (+1 more)
 
-### Community 584 - "Community 584"
-Cohesion: 0.14
-Nodes (12): closedWorkspaceIcon, issueId, pan777Row, pan862Row, ProjectData, projectHeader, RESOURCE_DETAIL_IDENTIFIERS, RESOURCE_ISSUES (+4 more)
+### Community 569 - "Community 569"
+Cohesion: 0.19
+Nodes (9): calls, { mockExecAsync }, opts, compactBeads(), compactBeadsImpl(), CompactBeadsOptions, execAsync, { mockExecAsync } (+1 more)
 
-### Community 585 - "Community 585"
-Cohesion: 0.14
-Nodes (13): conversationButton, CONVERSATIONS_RESPONSE, conversationsTab, COSTS_RESPONSE, featureRow, ISSUES_RESPONSE, pipelineTab, projectHeader (+5 more)
-
-### Community 586 - "Community 586"
-Cohesion: 0.15
-Nodes (11): fetchProjectSpecialists(), fetchRunLogs(), formatDate(), ProjectSpecialist, ProjectSpecialistCard(), ProjectSpecialistCardProps, ProjectSpecialistMetadata, RunLogEntry (+3 more)
-
-### Community 588 - "Community 588"
-Cohesion: 0.14
-Nodes (11): mockDeepWipe, mockExistsSync, mockGetAgentState, mockGetAgentStateAsync, mockMessageAgent, mockMkdir, mockSpawnAgent, mockSpawnPlanningSession (+3 more)
-
-### Community 589 - "Community 589"
-Cohesion: 0.14
-Nodes (10): mockGetLinearApiKey, mockSdkCreateComment, mockSdkCreateIssueLabel, mockSdkIssue, mockSdkIssueLabels, mockSdkSearchIssues, mockSdkTeam, mockSdkUpdateIssue (+2 more)
-
-### Community 590 - "Community 590"
+### Community 570 - "Community 570"
 Cohesion: 0.25
 Nodes (4): execAsync, getPidFilePath(), readDaemonState(), TldrDaemonService
 
-### Community 591 - "Community 591"
+### Community 571 - "Community 571"
+Cohesion: 0.14
+Nodes (10): calls, claimRange, commitRange, emitObservationCreated, extract, maybeTriggerRollup, releaseRange, updateHealth (+2 more)
+
+### Community 572 - "Community 572"
+Cohesion: 0.14
+Nodes (12): closedWorkspaceIcon, issueId, pan777Row, pan862Row, ProjectData, projectHeader, RESOURCE_DETAIL_IDENTIFIERS, RESOURCE_ISSUES (+4 more)
+
+### Community 573 - "Community 573"
+Cohesion: 0.14
+Nodes (13): conversationButton, CONVERSATIONS_RESPONSE, conversationsTab, COSTS_RESPONSE, featureRow, ISSUES_RESPONSE, pipelineTab, projectHeader (+5 more)
+
+### Community 574 - "Community 574"
+Cohesion: 0.21
+Nodes (10): BranchNode(), BranchNodeProps, ContainerNodeProps, PrNode(), PrNodeProps, getStorageKey(), readExpanded(), ResourcesGroup() (+2 more)
+
+### Community 575 - "Community 575"
+Cohesion: 0.15
+Nodes (11): fetchProjectSpecialists(), fetchRunLogs(), formatDate(), ProjectSpecialist, ProjectSpecialistCard(), ProjectSpecialistCardProps, ProjectSpecialistMetadata, RunLogEntry (+3 more)
+
+### Community 577 - "Community 577"
+Cohesion: 0.14
+Nodes (11): mockDeepWipe, mockExistsSync, mockGetAgentState, mockGetAgentStateAsync, mockMessageAgent, mockMkdir, mockSpawnAgent, mockSpawnPlanningSession (+3 more)
+
+### Community 578 - "Community 578"
+Cohesion: 0.14
+Nodes (10): mockGetLinearApiKey, mockSdkCreateComment, mockSdkCreateIssueLabel, mockSdkIssue, mockSdkIssueLabels, mockSdkSearchIssues, mockSdkTeam, mockSdkUpdateIssue (+2 more)
+
+### Community 579 - "Community 579"
+Cohesion: 0.16
+Nodes (12): applyBurnedTokenOverride(), CheckCodexAuthOptions, checkCodexAuthStatus(), CliproxyCodexCredentials, CodexAuthBurned, CodexAuthCheckError, CodexAuthExpired, CodexAuthMissing (+4 more)
+
+### Community 580 - "Community 580"
+Cohesion: 0.25
+Nodes (12): buildStatus(), decodeBase64Url(), decodeJwtPayload(), getCodexAuthPath(), getJwtExpiry(), getOpenAIAuthStatus(), getOpenAIAuthStatusSync(), hasApiKey() (+4 more)
+
+### Community 581 - "Community 581"
 Cohesion: 0.14
 Nodes (13): code:bash (npx @panctl/cli), code:mermaid (flowchart LR), code:bash (npx @panctl/cli), Command Deck, Dashboard Views, How It Works, Key Features, Learn More (+5 more)
 
-### Community 592 - "Community 592"
+### Community 582 - "Community 582"
 Cohesion: 0.14
 Nodes (13): code:block1 (Claude Code fires hook), Global `~/.claude/settings.json`, Hook Execution Flow, Hook Scripts Inventory, Migration Pruning, Panopticon Hook System, Per-Agent Frontmatter (`agents/pan-*.md`), Pi Event Channel (PAN-1134) (+5 more)
 
-### Community 593 - "Community 593"
+### Community 583 - "Community 583"
 Cohesion: 0.14
 Nodes (13): 1. Browser / app shell, 2. Panopticon terminal wrapper (`XTerminal.tsx`), 3. xterm.js, 4. Remote PTY app (`tmux` + attached TUI), Debugging checklist, Managed tmux policy, Ownership rules, Right-click / context menu (+5 more)
 
-### Community 594 - "Community 594"
+### Community 584 - "Community 584"
 Cohesion: 0.14
 Nodes (13): code:bash (pan up), code:bash (pan dev), code:bash (npm run build), code:bash (pan reload), code:bash (pan status), code:bash (less ~/.panopticon/logs/supervisor.log), code:bash (less ~/.panopticon/logs/dashboard.log), Failure triage (+5 more)
 
-### Community 595 - "Community 595"
+### Community 585 - "Community 585"
 Cohesion: 0.14
 Nodes (14): Agent Attribution, Agent CVs (Work History), Beads Flow with Panopticon, Beyond Issue Tracking, code:block13 (┌───────────────────────────────────────────────────────────), code:bash (# Hook structure), code:json ({), code:bash (bd stats --actor=panopticon/agent-min-648) (+6 more)
 
-### Community 596 - "Community 596"
-Cohesion: 0.14
-Nodes (14): Available Hook Points, code:toml (# .panopticon/project.toml), code:toml ([hooks.pre_commit]), code:block122 (workspace_aware = false (default):), code:toml (# /home/eltmon/projects/myn/.panopticon/project.toml), code:toml ([hooks.post_agent_complete]), code:toml ([hooks.pre_commit]), Hook Configuration (+6 more)
-
-### Community 597 - "Community 597"
+### Community 586 - "Community 586"
 Cohesion: 0.14
 Nodes (14): Built-in Variables, CLAUDE.md Templating System, code:block104 (┌───────────────────────────────────────────────────────────), code:toml (# .panopticon/project.toml), code:markdown (<!-- ~/.panopticon/templates/claude-md/sections/workspace-in), code:markdown (<!-- .panopticon/claude-md/sections/principles.md -->), code:bash (pan workspace create min-648), Example: Panopticon-Provided Section (+6 more)
 
-### Community 598 - "Community 598"
+### Community 587 - "Community 587"
+Cohesion: 0.14
+Nodes (14): Available Hook Points, code:toml (# .panopticon/project.toml), code:toml ([hooks.pre_commit]), code:block122 (workspace_aware = false (default):), code:toml (# /home/eltmon/projects/myn/.panopticon/project.toml), code:toml ([hooks.post_agent_complete]), code:toml ([hooks.pre_commit]), Hook Configuration (+6 more)
+
+### Community 588 - "Community 588"
 Cohesion: 0.14
 Nodes (13): code:block1 (skills/pan-<verb>/SKILL.md            (canonical, committed)), Creating a new wrapper skill, For CLI-wrapper skills, For workflow / reference / topical skills, How skills are distributed, Linting, Panopticon Skills ↔ CLI Convention, Related (+5 more)
 
-### Community 599 - "Community 599"
+### Community 589 - "Community 589"
 Cohesion: 0.14
 Nodes (14): Claude Code Bypass Permissions (Automatic), code:block26 (https://github.com/owner/repo.git  → git@github.com:owner/re), code:bash (mkdir -p ~/.panopticon/ssh), code:bash (cat ~/.panopticon/ssh/exe-dev-key.pub | pbcopy  # Copy to cl), code:bash (# For GitHub:), code:bash (ssh exe.dev help), code:json ({), code:bash (ssh <vm-name>.exe.xyz 'echo "{\"bypassPermissionsModeAccepte) (+6 more)
 
-### Community 600 - "Community 600"
+### Community 590 - "Community 590"
 Cohesion: 0.14
 Nodes (14): 1.1 Add exe.dev Provider, 1.2 New Commands, 2.2 Modified docker-compose for Remote, 5.1 Workspace List View, 5.2 Agent Terminal View, code:yaml (# .devcontainer/docker-compose.remote.yml), code:block21 (┌───────────────────────────────────────────────────────────), code:typescript (// Server-side: bridge WebSocket to SSH) (+6 more)
 
-### Community 601 - "Community 601"
-Cohesion: 0.14
-Nodes (13): Agent Grid, code:block1 (┌────────────────────────────────────────────────────┐), code:css (--gv-bg: #0a0e1a          /* Dark navy background */), Components, Dependencies, Design System, Focus View, God View — Real-time Agent Activity Command Center (+5 more)
-
-### Community 602 - "Community 602"
+### Community 591 - "Community 591"
 Cohesion: 0.14
 Nodes (13): 12. Responsive Behavior, 14. File Structure, 15. Acceptance Criteria, 16. Risks & Mitigations, 17. Open Questions, 1. Problem Statement, 2. Design Philosophy, 6. Cloister Banner (+5 more)
 
-### Community 603 - "Community 603"
+### Community 592 - "Community 592"
 Cohesion: 0.14
-Nodes (13): Acceptance Criteria, code:ts (export class SignalingError      extends Data.TaggedError('S), Design Goals, Files Likely Touched, Goal, Host Role & Handoff, Implementation Phases (sequencing within PAN-658), New Error Types (+5 more)
+Nodes (13): Acceptance Criteria, Design Goals, Files Likely Touched, Goal, Host Role & Handoff, Implementation Phases (sequencing within PAN-658), Input Model, Open question — concurrent direct-submit ordering (+5 more)
 
-### Community 604 - "Community 604"
+### Community 593 - "Community 593"
 Cohesion: 0.14
 Nodes (14): A.1 Add `isInfrastructureFailure` helper, A.2 Enhance `checkStuckReviewing` to detect dead parallel sessions, A.3 Add infrastructure-failure circuit breaker, A.4 Honor `stuck` flag in re-dispatch path, A.5 Detect verification/review contradiction, A.6 Partial results from incomplete parallel reviews, A. `src/lib/cloister/deacon.ts`, code:typescript (function isInfrastructureFailure(notes?: string): boolean {) (+6 more)
 
-### Community 605 - "Community 605"
+### Community 594 - "Community 594"
 Cohesion: 0.14
 Nodes (13): Acceptance criteria, code:block1 (<Project: mind-your-now>), code:css (.resourcesGroup {), CSS additions, Goal, Non-goals, PAN-965: Command Deck — Hierarchical Resource Tree Under Issues, Problem (+5 more)
 
-### Community 606 - "Community 606"
+### Community 595 - "Community 595"
 Cohesion: 0.14
 Nodes (14): B0: Toolchain Setup, B18: Integration + Build, B19: Frontend Component Migration, B1: Contracts Package, B20: Terminal Streaming RPC (Dual-Runtime), B21: Cleanup + Verification, B2: Event Store, B3: ServerConfig Service (+6 more)
 
-### Community 607 - "Community 607"
+### Community 596 - "Community 596"
 Cohesion: 0.14
 Nodes (13): Acceptance Criteria, code:typescript (export async function buildAgentLaunchConfig(opts: {), code:block2 (POST /api/agents/:id/restart), code:typescript (export async function resumeAgent(agentId: string, message?:), Design, Files to Modify, Motivation, PAN-980: Agent Restart Refactor — Shared Launch Config, Model Override, Graceful Shutdown (+5 more)
 
-### Community 608 - "Community 608"
+### Community 597 - "Community 597"
 Cohesion: 0.14
 Nodes (13): Acceptance Criteria for the Epic, Architecture Overview, Children, code:block1 (┌───────────────────────────────────────────────────────────), Differentiation vs Prior Art, Files Likely Touched, Open Questions, PAN-1200 — Universal Context System (Epic) (+5 more)
 
-### Community 609 - "Community 609"
+### Community 598 - "Community 598"
 Cohesion: 0.14
 Nodes (13): 1. PAN-685 model-override frontend (`stash@{34}` + `d81260d0e`), 2. Material Symbols (`stash@{38}`), 3. PAN-TTS + model-routing README (`stash@{35}`), 4. Model-override work (`stash@{39}` + `df0982bcb`), 5. "Other changes to restore later" (`7b12b85990`), 6. Inspector panel (`stash@{18}`) — **NEEDS USER DECISION**, Flagged items — 9 total, 6 unique (3 duplicates), Follow-up tickets to file (if user agrees with recommendation) (+5 more)
 
-### Community 610 - "Community 610"
+### Community 599 - "Community 599"
 Cohesion: 0.14
 Nodes (13): Decisions, Files Modified, Implementation Plan, Out of Scope, PAN-290: Fix 9 Pre-existing Test Failures, Problem, Root Cause Analysis, Session-rotation (3 failures) (+5 more)
 
-### Community 611 - "Community 611"
+### Community 600 - "Community 600"
 Cohesion: 0.14
 Nodes (13): 1. Programmatic cleanup in `postMergeLifecycle()`, 2. Belt-and-suspenders: .gitignore, 3. Update planning code to use `git add -f`, 4. Ordering in postMergeLifecycle(), code:block1 (.planning/STATE.md), code:block2 (1. Move PRD (existing)), Decisions, Files to Modify (+5 more)
 
-### Community 612 - "Community 612"
+### Community 601 - "Community 601"
 Cohesion: 0.14
 Nodes (13): Approach, Architecture Notes, Endpoint location: conversations.ts, NOT agents.ts, Files Changed, Image storage: OS temp dir, Key Decisions, PAN-539: Image Paste Support in Activity View Conversation, Paste interception: wrapper div, not Lexical plugin (+5 more)
 
-### Community 613 - "Community 613"
+### Community 602 - "Community 602"
 Cohesion: 0.14
 Nodes (13): Do Not Route, Exception: One-Shot High-Stakes Analysis, GPT-5.4 Pro Work Type Fit Analysis, Integration Notes, Key Benchmarks, Known Weaknesses, Model Profile, Sources (+5 more)
 
-### Community 614 - "Community 614"
+### Community 603 - "Community 603"
 Cohesion: 0.14
 Nodes (13): Access Points, Adding Dependencies, code:bash (# Copy template to your project), code:bash (APP_PORT=5173), code:typescript (export default defineConfig({), code:bash (# Install inside container), Development Workflow, Environment Variables (+5 more)
 
-### Community 615 - "Community 615"
+### Community 604 - "Community 604"
 Cohesion: 0.14
 Nodes (13): After Reopening, code:bash (pan reopen PAN-123), code:bash (curl -X POST http://localhost:3011/api/issues/PAN-123/reopen), Do NOT Use `pan done` Until Re-Work Is Complete, How to Reopen, Preflight Guard, Reopen a Closed/Completed Issue for Re-Work, Via CLI (recommended for agents/supervisors) (+5 more)
 
-### Community 616 - "Community 616"
+### Community 605 - "Community 605"
 Cohesion: 0.14
 Nodes (14): code:block15 (oauth-epic: "Implement OAuth integration" (epic)), code:block16 (research-epic: "Investigate caching strategies" (epic)), code:bash (bd dep add child-task-id parent-epic-id --type parent-child), code:block18 (auth-epic (parent of all)), code:block19 (Epic with no ordering between children:), code:block20 (Epic with blocks dependencies between children:), code:block21 (major-epic), Combining with blocks (+6 more)
 
-### Community 617 - "Community 617"
+### Community 606 - "Community 606"
 Cohesion: 0.14
 Nodes (14): code:bash (# Check if pan command exists), code:bash (# Check for running services), code:bash (pan down), code:bash (pan up), code:block6 (✓ API server started on port 3002), code:bash (# Check all services are running), code:block8 (http://localhost:3001), code:bash (# View dashboard logs) (+6 more)
 
-### Community 618 - "Community 618"
+### Community 607 - "Community 607"
 Cohesion: 0.14
 Nodes (13): Basic Usage, code:bash (# Start all services), code:env (# Dashboard port (default: 3001)), code:bash (# Overall health check), Configuration Options, Health Checks, More Information, Next Steps (+5 more)
 
-### Community 619 - "Community 619"
+### Community 608 - "Community 608"
 Cohesion: 0.14
 Nodes (13): Auto-planning, Available commands, code:bash (pan plan <id> [--auto] [--model <model>] [--harness claude-c), code:bash (pan plan PAN-1071), code:bash (pan plan PAN-1071 --auto), code:bash (pan plan finalize), code:bash (pan plan done PAN-1071), Completing planning (`pan plan done`) (+5 more)
 
-### Community 620 - "Community 620"
+### Community 609 - "Community 609"
 Cohesion: 0.14
 Nodes (13): 1. Identify the Issue, 2. Gather Context, 3. Research (Interactive), 4. Write the Spec, 5. Confirm File Location, code:markdown (# {Issue ID}: {Title}), code:block2 (Spec written: docs/prds/active/{filename}-spec.md), Execution Steps (+5 more)
 
-### Community 621 - "Community 621"
+### Community 610 - "Community 610"
 Cohesion: 0.14
 Nodes (13): code:block1 (Session 1: AI queries users.created_at → Error (column is "c), code:block2 (myproject/), code:markdown (# In ~/.claude/CLAUDE.md (developer's personal config)), Configurable Per Team and Per Developer, For Executives, For Technical Leaders, How It Works, Legacy Codebase Support (+5 more)
 
-### Community 622 - "Community 622"
+### Community 611 - "Community 611"
 Cohesion: 0.14
 Nodes (14): 2. Typography, code:html (<!-- index.html -->), code:js (fontFamily: {), code:css (body {), Conversation Typography, CRITICAL: The Four Canonical Typography Rules (PAN-698), CSS Default, Deprecated Patterns (DO NOT USE) (+6 more)
 
-### Community 623 - "Community 623"
+### Community 612 - "Community 612"
 Cohesion: 0.14
 Nodes (13): CLI, code:bash (pan swarm <id>                       # Spawn dispatchable it), code:bash (pan swarm <id> --task next                              # Li), code:ts (interface SwarmRuntime {), HTTP Surface, Inspect and Mutate Items, Mental Model, Plan Authoring: `files_scope` and Synthesis (+5 more)
 
-### Community 624 - "Community 624"
+### Community 613 - "Community 613"
 Cohesion: 0.24
-Nodes (11): AgentRuntimeFetchError, emitActivity(), emitAgentEvent(), emitChannelReply(), emitMessageReceived(), emitModelSet(), emitResolution(), emitWaitingClear() (+3 more)
+Nodes (11): execAsync, formatDuration(), generateReport(), parseTestOutput(), runTests(), RunTestsOptions, runTestSuite(), sendNotification() (+3 more)
 
-### Community 625 - "Community 625"
-Cohesion: 0.15
-Nodes (12): agentDir, mockGetAgentRuntimeState, mockGetAgentState, mockGetTmuxSessionName, mockGetWorkspaceStackHealth, mockLoadReviewStatuses, mockRebuildWorkspaceStack, mockResolveProjectFromIssue (+4 more)
-
-### Community 626 - "Community 626"
+### Community 614 - "Community 614"
 Cohesion: 0.18
 Nodes (11): build, cliPromptsDir, copyCavemanAssets(), copyCloisterPrompts(), copyMatching(), dashboardDir, distDir, preservedDashboardDir (+3 more)
 
-### Community 627 - "Community 627"
-Cohesion: 0.28
-Nodes (11): cleanFile(), configCommand(), execAsync, ExtendedProjectConfig, findFullProjectByTeam(), loadFullProjects(), seedCommand(), snapshotCommand() (+3 more)
+### Community 615 - "Community 615"
+Cohesion: 0.24
+Nodes (11): AgentRuntimeFetchError, emitActivity(), emitAgentEvent(), emitChannelReply(), emitMessageReceived(), emitModelSet(), emitResolution(), emitWaitingClear() (+3 more)
 
-### Community 628 - "Community 628"
+### Community 616 - "Community 616"
 Cohesion: 0.15
-Nodes (10): cleanupMergedLabels(), calls, ctx, mockClientCreateIssueLabel, mockClientIssueLabels, mockClientIssues, { mockExecAsync, mockGetLinearApiKey }, mockIssueLabels (+2 more)
+Nodes (12): agentDir, mockGetAgentRuntimeState, mockGetAgentState, mockGetTmuxSessionName, mockGetWorkspaceStackHealth, mockLoadReviewStatuses, mockRebuildWorkspaceStack, mockResolveProjectFromIssue (+4 more)
 
-### Community 630 - "Community 630"
-Cohesion: 0.15
-Nodes (8): PendingCompletion, _pendingCompletions, ResumeCallback, SpecialistCancelledError, SpecialistCompletionError, SpecialistCompletionResult, SpecialistCompletionTimeoutError, SpecialistSupersededError
-
-### Community 631 - "Community 631"
+### Community 617 - "Community 617"
 Cohesion: 0.15
 Nodes (11): dir, event, eventsDir1, eventsDir2, line, lines, parsed, repo1 (+3 more)
 
-### Community 632 - "Community 632"
+### Community 618 - "Community 618"
+Cohesion: 0.15
+Nodes (10): constructorTracker, createdIssue, mockAssignee, mockClient, mockComment, mockIssue, mockLabels, mockState (+2 more)
+
+### Community 619 - "Community 619"
+Cohesion: 0.15
+Nodes (9): githubTracker, linearTracker, longBody, mockCreateTrackerFromConfig, mockExistsSync, mockLoadConfig, mockStatSync, STATE_MTIME (+1 more)
+
+### Community 620 - "Community 620"
+Cohesion: 0.15
+Nodes (10): cleanupMergedLabels(), calls, ctx, mockClientCreateIssueLabel, mockClientIssueLabels, mockClientIssues, { mockExecAsync, mockGetLinearApiKey }, mockIssueLabels (+2 more)
+
+### Community 621 - "Community 621"
+Cohesion: 0.15
+Nodes (8): PendingCompletion, _pendingCompletions, ResumeCallback, SpecialistCancelledError, SpecialistCompletionError, SpecialistCompletionResult, SpecialistCompletionTimeoutError, SpecialistSupersededError
+
+### Community 623 - "Community 623"
+Cohesion: 0.24
+Nodes (11): buildContinuation(), convertConversationTranscript(), ConvertOptions, ConvertResult, extractClaudeTranscript(), extractContentText(), extractPiTranscript(), renderTranscript() (+3 more)
+
+### Community 624 - "Community 624"
 Cohesion: 0.15
 Nodes (12): ACTIVITY_RESPONSE, AGENTS_RESPONSE, COSTS_RESPONSE, DISCUSSIONS_RESPONSE, ISSUES_RESPONSE, PLANNING_RESPONSE, PR_DIFF_RESPONSE, PR_RESPONSE (+4 more)
 
-### Community 633 - "Community 633"
+### Community 625 - "Community 625"
 Cohesion: 0.21
 Nodes (10): CapabilityStats, DailyStats, fetchRuntimeMetrics(), formatCost(), formatDuration(), formatPercent(), getSuccessColor(), MetricsResponse (+2 more)
 
-### Community 634 - "Community 634"
-Cohesion: 0.15
-Nodes (10): COST_RESPONSE, filterBtn, FilterOnChange, input, LIST_RESPONSE, rpcMocks, SEARCH_RESPONSE, SESSION_STUB (+2 more)
-
-### Community 635 - "Community 635"
+### Community 627 - "Community 627"
 Cohesion: 0.15
 Nodes (13): code:block53 (~/.panopticon/), code:block54 (~/projects/myn/.panopticon/), code:toml ([panopticon]), code:toml ([[projects]]), code:toml ([project]), code:toml (# panopticon/.panopticon/project.toml), Example: Open Source Project Config, Global Config (`~/.panopticon/config.toml`) (+5 more)
 
-### Community 636 - "Community 636"
+### Community 628 - "Community 628"
 Cohesion: 0.15
 Nodes (12): 1. Role file — `roles/*.md`, 2. Panopticon pipeline agent — `agents/pan-*-agent.md`, 3. Claude Code subagent — `.claude/agents/*.md`, Adding a new role or sub-role, code:block1 (Cloister decides to spawn (role, subRole?)), File shapes you will see, How a run actually gets the right instructions, Roles: Panopticon's Agent Definition Primitive (+4 more)
 
-### Community 637 - "Community 637"
+### Community 629 - "Community 629"
 Cohesion: 0.15
 Nodes (12): Agent Taxonomy, Architecture, CLI Commands, Cloister: Agent Watchdog Framework, code:block23 (┌───────────────────────────────────────────────────────────), code:bash (# Cloister control), Goals, Issue Agents (Ephemeral) (+4 more)
 
-### Community 638 - "Community 638"
+### Community 630 - "Community 630"
 Cohesion: 0.15
 Nodes (12): Dependencies, Design Principles, Implementation Notes, Key files, Non-goals, Phase 1: Interactive FeatureCard (Dashboard UI), Phase 2: Feature Planning Pipeline (Backend), Phase 3: Integration Testing (+4 more)
 
-### Community 639 - "Community 639"
+### Community 631 - "Community 631"
 Cohesion: 0.15
 Nodes (13): Actions vs Roles, code:block1 (User Action          Cloister spawns       Role (.md)       ), code:block2 (Run = (role, model, harness)), code:block3 (Tracker (GitHub Issue)          Cloister (Scheduler)        ), code:yaml (# ~/.panopticon/config.yaml — defaults), code:block5 (model), Convoy Reviewers, Eval Grid (+5 more)
 
-### Community 640 - "Community 640"
+### Community 632 - "Community 632"
 Cohesion: 0.15
 Nodes (12): code:typescript (export function isReviewPipelineStuck(status?: PipelineState), code:typescript (// PAN-794: Recovery state indicators), code:typescript (const recoveryBorderClass = isReviewRecoveryInProgress), code:typescript (className={`relative ... bg-gradient-to-br ${cardTone} ${rec), code:typescript (const phaseLabel =), E.1 Update `isReviewPipelineStuck` in `src/dashboard/frontend/src/lib/pipeline-state.ts`, E.2 Add recovery indicator helpers to `KanbanBoard.tsx`, E.3 Add recovery border and badges to the card (+4 more)
 
-### Community 641 - "Community 641"
+### Community 633 - "Community 633"
+Cohesion: 0.15
+Nodes (13): code:typescript (// POST /api/rally/validate - Test Rally connection and conf), code:typescript (describe('Rally Integration', () => {), code:markdown (### Rally Troubleshooting), code:block15, code:block16 (This will log the actual WSAPI queries being sent.), code:typescript (const mock = new RallyApiMock();), Task 1: Fix Query String Builder (CRITICAL), Task 2: Add Comprehensive Unit Tests (+5 more)
+
+### Community 634 - "Community 634"
 Cohesion: 0.15
 Nodes (12): Affected Components, Architecture, code:block1 (App.tsx), Decision, Difficulty: medium, Files to Create, Files to Modify, Key Decisions (+4 more)
 
-### Community 642 - "Community 642"
+### Community 635 - "Community 635"
 Cohesion: 0.15
 Nodes (12): Acceptance (feature-level), Approach, Decisions, Destination directories (none exist yet), Discovery Findings, Goal, PAN-697 Planning — Root Artifact Cleanup, Problem (+4 more)
 
-### Community 643 - "Community 643"
+### Community 636 - "Community 636"
 Cohesion: 0.15
 Nodes (12): Architecture, Difficulty Estimates, Discovery Summary, Files to Modify, Items NOT in scope for v1, Menu Integration, npx latest version, Package Distribution (+4 more)
 
-### Community 644 - "Community 644"
+### Community 637 - "Community 637"
 Cohesion: 0.15
 Nodes (12): Approach, Conversation list titles → DM Sans prose, Decomposition, Documentation, Out of scope, PAN-698: Dashboard Typography Cleanup — Planning State, Playwright isolation, Policy (final, to be encoded everywhere) (+4 more)
 
-### Community 645 - "Community 645"
+### Community 638 - "Community 638"
 Cohesion: 0.15
 Nodes (13): code:bash (# If project has override skill, this skill is permanently d), code:bash (grep -A 20 "## AI Suggestion Preferences" ~/.claude/CLAUDE.m), code:markdown (## AI Suggestion Preferences), code:javascript (// Pseudocode for decision), code:bash (mkdir -p .claude/skills/knowledge-capture), code:bash (# Ensure directory exists), Invocation Protocol, Step 0.5: Check User Preferences for Category Exclusions (+5 more)
 
-### Community 646 - "Community 646"
+### Community 639 - "Community 639"
 Cohesion: 0.15
 Nodes (13): code:bash (bd dep add issue-2 issue-1 --type blocks), code:bash (bd version), code:bash (# Via Homebrew (macOS/Linux)), code:bash (pkill -f "bd daemon"  # Kill old daemon), code:bash (bd create "Test A" -t task), code:bash (ps aux | grep "bd daemon"), code:bash (# Instead of: bd --no-daemon dep add ...), code:bash (cat .beads/issues.jsonl | jq '.dependencies') (+5 more)
 
-### Community 647 - "Community 647"
+### Community 640 - "Community 640"
 Cohesion: 0.15
 Nodes (12): `bd rules audit`, `bd rules compact`, Best Practices, code:bash (bd rules audit                    # Default scan), code:bash (bd rules compact --dry-run        # Preview merges without a), code:bash ($ bd rules audit), code:bash (# In pan sync workflow), Commands (+4 more)
 
-### Community 648 - "Community 648"
-Cohesion: 0.15
-Nodes (13): At Session End (Claude prompts user), At Session Start (Claude's responsibility), code:block16 (Session Start with in_progress issues:), code:block17 (Session End Handoff:), code:block18 (Good handoff note (current state):), code:block19 (Session End Checklist:), code:block20 (User Tips:), code:bash (bd update workspace-mcp-server-2 --notes "COMPLETED: Set up ) (+5 more)
-
-### Community 649 - "Community 649"
+### Community 641 - "Community 641"
 Cohesion: 0.15
 Nodes (13): code:block10 (Start: "What's the final deliverable?"), code:block11 (Ready Front 1:  gt-buffer (foundation)), code:bash (# Create epic (the goal)), code:block7 (Ready Front = Issues where all dependencies are closed), code:block8 (⚠️ COGNITIVE TRAP:), code:block9 (Epic Planning with Ready Fronts:), Epic Planning {#epic-planning}, Epic Planning Workflow (+5 more)
 
-### Community 650 - "Community 650"
+### Community 642 - "Community 642"
+Cohesion: 0.15
+Nodes (13): At Session End (Claude prompts user), At Session Start (Claude's responsibility), code:block16 (Session Start with in_progress issues:), code:block17 (Session End Handoff:), code:block18 (Good handoff note (current state):), code:block19 (Session End Checklist:), code:block20 (User Tips:), code:bash (bd update workspace-mcp-server-2 --notes "COMPLETED: Set up ) (+5 more)
+
+### Community 643 - "Community 643"
 Cohesion: 0.15
 Nodes (12): API Function, Categories, code:bash (pan tell ISSUE-123 "Your feedback message here"), code:block2 (Sending feedback to agent-pan-45:), code:block3 (Sending feedback to agent-pan-45:), Example: Merge Success, Example: Test Failure, Feedback Types (+4 more)
 
-### Community 651 - "Community 651"
+### Community 644 - "Community 644"
 Cohesion: 0.15
 Nodes (12): code:bash (#!/bin/bash), code:bash (# Check system health), Complete Quick Start Script, Feedback and Support, Overview, Panopticon Quick Start, Related Skills, Success Checklist (+4 more)
 
-### Community 652 - "Community 652"
-Cohesion: 0.15
-Nodes (13): "Certificate not trusted" warnings, code:bash (docker ps | grep traefik), code:bash (docker logs panopticon-traefik), code:bash (ls ~/.panopticon/traefik/certs/), code:bash (mkcert -install), code:bash (docker network inspect panopticon), code:bash (docker inspect <container> | grep -A 20 Labels), code:bash (# Find what's using the ports) (+5 more)
-
-### Community 653 - "Community 653"
+### Community 645 - "Community 645"
 Cohesion: 0.17
 Nodes (11): available, content, defaults, defaults1, defaults2, error, invalidSettings, loaded (+3 more)
 
-### Community 654 - "Community 654"
+### Community 646 - "Community 646"
+Cohesion: 0.29
+Nodes (8): cleanupAgentDirectories(), CleanupResult, findOrphanedAgentDirs(), getPlanningIssueId(), isLegacyConversationDirectory(), isValidAgentDirectoryName(), OrphanedAgentDir, names
+
+### Community 647 - "Community 647"
 Cohesion: 0.17
 Nodes (10): bin, binPath, content, desktopDir, devDeps, engines, files, p (+2 more)
 
-### Community 656 - "Community 656"
-Cohesion: 0.21
-Nodes (8): detectDriveType, DriveType, getSystemCapabilities(), measureDriveReadSpeed, probe(), probeImpl, resetSystemCapabilitiesCache(), SystemCapabilities
-
-### Community 657 - "Community 657"
-Cohesion: 0.17
-Nodes (10): mockClearConfigCache, mockLoadConfig, mockMergeConfigs, mockReadFile, mockResolveModelId, mockWriteFile, result, settings (+2 more)
-
-### Community 658 - "Community 658"
+### Community 649 - "Community 649"
 Cohesion: 0.17
 Nodes (10): allOps, divergedOp, execAsync, execFileMock, execMock, ops, opTypes, status (+2 more)
 
-### Community 660 - "Community 660"
-Cohesion: 0.17
-Nodes (11): agentIds, baseTimestamp, checkpoints, deleteLegacyCheckpointRefs, diffCheckpointFiles, encoder, getCheckpointTimestamp, listCheckpoints (+3 more)
+### Community 650 - "Community 650"
+Cohesion: 0.21
+Nodes (6): ENV_KEYS, EnvSnapshot, ServerConfig, ServerConfigError, ServerConfigLayer, ServerConfigShape
 
-### Community 661 - "Community 661"
+### Community 651 - "Community 651"
 Cohesion: 0.17
-Nodes (12): Before starting any work, Build before deploy, code:bash (# 1. Rebase onto latest main (always — even if STATE.md alre), code:bash (npm run build), code:bash (# WRONG — may stage .beads/, dist/, secrets), code:bash (bd ready -l pan-xxx          # Next unblocked bead for THIS ), code:bash (npm test                                         # Must pass), Completing work (+4 more)
+Nodes (9): execFileMock, mockCloseOut, mockEmitActivityEntry, mockLoadCloisterConfig, mockLoadReviewStatuses, mockResolveGitHubIssue, mockResolveProjectFromIssue, mockSetReviewStatus (+1 more)
 
-### Community 662 - "Community 662"
+### Community 652 - "Community 652"
+Cohesion: 0.17
+Nodes (11): clearReviewStatus(), cb, cmdArgs, key, mockExec, mockGetPullRequestState, mockIsGitHubAppConfigured, next (+3 more)
+
+### Community 654 - "Community 654"
 Cohesion: 0.17
 Nodes (12): Always pre-trust directories before spawning agents, Architecture Rules, code:typescript (// WRONG), code:bash (# CORRECT), code:typescript (// WRONG), code:typescript (let running = false;), code:typescript (import { preTrustDirectory } from '../workspace-manager.js';), Idempotency guards on background services (+4 more)
 
-### Community 663 - "Community 663"
+### Community 655 - "Community 655"
+Cohesion: 0.17
+Nodes (12): Before starting any work, Build before deploy, code:bash (# 1. Rebase onto latest main (always — even if STATE.md alre), code:bash (npm run build), code:bash (# WRONG — may stage .beads/, dist/, secrets), code:bash (bd ready -l pan-xxx          # Next unblocked bead for THIS ), code:bash (npm test                                         # Must pass), Completing work (+4 more)
+
+### Community 656 - "Community 656"
 Cohesion: 0.17
 Nodes (11): Agent Instructions, Beads Issue Tracker, code:bash (bd ready              # Find available work), code:bash (git pull --rebase), code:bash (bd ready              # Find available work), code:bash (git pull --rebase), Landing the Plane (Session Completion), Quick Reference (+3 more)
 
-### Community 664 - "Community 664"
+### Community 657 - "Community 657"
 Cohesion: 0.17
 Nodes (11): Architecture at a Glance, code:bash (npx @panctl/cli), code:bash (npm install -g @panctl/cli), code:bash (npm install -g @panctl/cli), Direct Desktop Downloads, Headless / CI, One Command, Power-User Path: Install Everything Up Front (+3 more)
 
-### Community 665 - "Community 665"
+### Community 658 - "Community 658"
 Cohesion: 0.17
 Nodes (11): code:typescript (interface ContextBudget {), Context Budget Manager, ⚠️ DECOUPLING FROM MYN (CRITICAL), DO NOT rely on MYN infrastructure:, If tests pass, commit, Migration checklist (from MYN):, Panopticon: Multi-Agent Orchestration for Claude Code, Panopticon MUST be self-contained: (+3 more)
 
-### Community 666 - "Community 666"
-Cohesion: 0.17
-Nodes (12): code:bash (# 1. Install Panopticon), code:bash (# Start the day), code:bash (# Create detailed plan before spawning agent), code:bash (# Update Panopticon itself), code:toml (# In projects.toml), code:bash (pan sync), Daily Development, Initial Setup (+4 more)
-
-### Community 667 - "Community 667"
+### Community 659 - "Community 659"
 Cohesion: 0.17
 Nodes (12): Agent Integration, Canonical PRD Sections, CLI Commands, code:block143 ({project}/), code:block144 (┌───────────────────────────────────────────────────────────), code:bash (# Initialize/regenerate canonical PRD), Feature PRDs Live in Workspaces, Naming Convention (+4 more)
 
-### Community 668 - "Community 668"
+### Community 660 - "Community 660"
+Cohesion: 0.17
+Nodes (12): code:bash (# 1. Install Panopticon), code:bash (# Start the day), code:bash (# Create detailed plan before spawning agent), code:bash (# Update Panopticon itself), code:toml (# In projects.toml), code:bash (pan sync), Daily Development, Initial Setup (+4 more)
+
+### Community 661 - "Community 661"
 Cohesion: 0.17
 Nodes (12): code:bash (pan workspace create MIN-667 --remote    # Create on exe.dev), code:toml (# ~/.panopticon/config.toml), code:block38 ($ pan workspace create MIN-667), code:block39 (┌───────────────────────────────────────────────────────────), code:block40 (┌─────────────────────┐), code:block41 (┌─────────────────────────────┐), code:block42 (┌────────────────────────────────────────────────────────┐), code:block43 (┌────────────────────────────────────────────────────────┐) (+4 more)
 
-### Community 669 - "Community 669"
+### Community 662 - "Community 662"
 Cohesion: 0.17
 Nodes (12): code:yaml (# Deprecated → Current), code:yaml (models:), code:yaml (models:), code:block24 (✓ Backed up config.yaml → config.yaml.bak), code:bash (cp ~/.panopticon/config.yaml.bak ~/.panopticon/config.yaml), Current Deprecations, Dashboard Behavior, Example Migration (+4 more)
 
-### Community 670 - "Community 670"
+### Community 663 - "Community 663"
 Cohesion: 0.17
 Nodes (11): code:yaml (models:), code:yaml (models:), code:env (ANTHROPIC_API_KEY=sk-ant-...), code:yaml (models:), Configuration Guide, Getting Help, Provider Configuration, Provider Management (+3 more)
 
-### Community 671 - "Community 671"
+### Community 664 - "Community 664"
 Cohesion: 0.17
 Nodes (11): C.1 Update `isReviewPipelineStuck` in `src/dashboard/frontend/src/lib/pipeline-state.ts`, C.2 Add recovery indicator helpers to `KanbanBoard.tsx`, C.4 Add recovery badge in the card header, C.5 Update `phaseLabel` to show recovery state, C.6 Style compliance, C. Frontend: Kanban Card Recovery Indicators, code:typescript (export function isReviewPipelineStuck(status?: PipelineState), code:typescript (export function isReviewPipelineStuck(status?: PipelineState) (+3 more)
 
-### Community 672 - "Community 672"
+### Community 665 - "Community 665"
 Cohesion: 0.17
 Nodes (11): code:typescript (// In src/dashboard/server/routes/resources.ts), code:typescript (HttpRouter.post('/api/resources/docker/container/:id/start',), code:typescript (// In src/dashboard/server/services/resource-discovery.ts (o), code:typescript (// New field on the response), Container name parsing utility (new), Extend `ResourceDetailIdentifiers` response, `GET /api/resources/docker/container/:id/logs`, New API endpoints (+3 more)
 
-### Community 673 - "Community 673"
+### Community 666 - "Community 666"
 Cohesion: 0.17
 Nodes (12): Branch node layout, code:block2 (├── MIN-846  [$12.40]  In Review  [📁 🔀 📻 📋 🐛 🔀 🐳]     ← reso), code:block3 (┌──────────────────────────────────────────────────────────┐), code:block4 (┌──────────────────────────────────────────────────────────┐), code:block5 (┌──────────────────────────────────────────────────────────┐), code:block6 (┌──────────────────────────────────────────────────────────┐), Container node context menu (right-click), Container node layout (single row) (+4 more)
 
-### Community 674 - "Community 674"
+### Community 667 - "Community 667"
 Cohesion: 0.17
 Nodes (12): 1. Status billboard, 2. Reviewer summary (when in review), 3. Test summary (when test has run), 4. PR summary (when PR exists), 5. Cost breakdown sparkline, 6. Recent activity feed (combined across all sessions), 7. Quick links, code:block17 (┌───────────────────────────────────────────────────────────) (+4 more)
 
-### Community 675 - "Community 675"
+### Community 668 - "Community 668"
 Cohesion: 0.17
 Nodes (11): Architecture Notes, code:typescript (const confirmed = await confirm({), code:typescript (catch (labelErr) {), Decisions, Implementation Plan, Out of Scope, PAN-445: Planning Abort button uses native JS confirm() instead of styled dialog, Problem (+3 more)
 
-### Community 676 - "Community 676"
+### Community 669 - "Community 669"
 Cohesion: 0.17
 Nodes (11): Architecture, Backend Changes, code:block1 (Backend /api/agents → includes planning-* agents with agentP), Data Flow, Decisions, Edge Cases, Files to Modify, Frontend Changes (+3 more)
 
-### Community 677 - "Community 677"
-Cohesion: 0.17
-Nodes (12): code:typescript (export function validateRallyConfig(config: RallyConfig): {), code:typescript (private async pollRally(): Promise<void> {), code:typescript (// POST /api/rally/validate - Test Rally connection and conf), code:typescript (describe('Rally Integration', () => {), code:typescript (const mock = new RallyApiMock();), Task 1: Fix Query String Builder (CRITICAL), Task 2: Add Comprehensive Unit Tests, Task 3: Create Mock Rally API Server (+4 more)
-
-### Community 678 - "Community 678"
+### Community 670 - "Community 670"
 Cohesion: 0.17
 Nodes (11): code:json ({ "HEAD": "abc1234", "branch": "feature/PAN-333" }), Decision: Implement the missing function, Difficulty: simple, Files to modify, Implementation approach, No changes needed, PAN-342: getWorkspaceCommitHashes is not a function, Problem (+3 more)
 
-### Community 679 - "Community 679"
+### Community 671 - "Community 671"
 Cohesion: 0.17
 Nodes (11): Affected Files, code:typescript (const inInput = ['INPUT', 'TEXTAREA'].includes(target.tagNam), code:typescript (const inInput = target.tagName === 'INPUT' || target.tagName), Complexity, Out of Scope, Part 1: Fix global search hotkey (App.tsx), Part 2: Add slash command menu (ComposerPromptEditor.tsx), Problem (+3 more)
 
-### Community 680 - "Community 680"
+### Community 672 - "Community 672"
 Cohesion: 0.17
 Nodes (11): 1. Eliminate Extended Token Layer, 2. Replace `text-white` with Semantic Foreground Tokens, 3. Rename Mission Control → Command Deck, 4. Delete Isolated Codex Theme, 5. Upgrade DialogProvider, 6. Align `index.css` with T3Code Formulas, Acceptance Criteria, Objective (+3 more)
 
-### Community 681 - "Community 681"
+### Community 673 - "Community 673"
 Cohesion: 0.17
 Nodes (11): Approach, Backend status: already done, Difficulty, Edit state, Empty/whitespace, Files touched, Out of scope, PAN-596: Allow editing a conversation title (+3 more)
 
-### Community 682 - "Community 682"
+### Community 674 - "Community 674"
 Cohesion: 0.17
 Nodes (11): Current architecture (observed), Decision summary, Difficulty, Files to change, Goal, Out of scope (explicit), PAN-509 — Inspector: Phase-Aware Terminal, Phase → session mapping (+3 more)
 
-### Community 683 - "Community 683"
+### Community 675 - "Community 675"
 Cohesion: 0.17
 Nodes (11): Approach, Decisions, Files to Modify, Layer 1: Frontend (toast + better messaging), Layer 2: Backend — complete-planning, Layer 3: Backend — POST /api/agents, Layer 4: beads.ts — robust initialization, Out of Scope (+3 more)
 
-### Community 684 - "Community 684"
+### Community 676 - "Community 676"
 Cohesion: 0.17
 Nodes (12): code:block10 (feature-1: "Add OAuth login"), code:block11 (perf-1: "Investigate Redis caching"), code:bash (bd dep add issue-1 issue-2 --type related), code:block13 (api-redesign related to:), code:block14 (security-audit related to:), code:block9 (refactor-1: "Extract validation logic"), Common Patterns, Creating related Dependencies (+4 more)
 
-### Community 685 - "Community 685"
-Cohesion: 0.17
-Nodes (12): Agent shows as crashed, code:bash (# Check tmux sessions directly), code:bash (# Check agent logs), code:bash (# Check Docker containers directly), code:bash (nvm install 18), code:bash (sudo systemctl start docker  # Linux), code:bash (pan up), code:bash (# Check API key in config) (+4 more)
-
-### Community 686 - "Community 686"
+### Community 677 - "Community 677"
 Cohesion: 0.17
 Nodes (11): Basic Usage, code:block1 (Invoke first: pipeline-status), code:bash (# Check all running agents (shorthand for work status)), Lead with the pipeline-status table, More Information, Next Steps, Overview, Panopticon Status Overview (+3 more)
 
-### Community 687 - "Community 687"
+### Community 678 - "Community 678"
+Cohesion: 0.17
+Nodes (12): Agent shows as crashed, code:bash (# Check tmux sessions directly), code:bash (# Check agent logs), code:bash (# Check Docker containers directly), code:bash (nvm install 18), code:bash (sudo systemctl start docker  # Linux), code:bash (pan up), code:bash (# Check API key in config) (+4 more)
+
+### Community 679 - "Community 679"
 Cohesion: 0.17
 Nodes (11): Canary, code:bash (pan release check), code:bash (pan release stable --version 0.7.1), code:bash (git push origin main), Core policy, Notes, Panopticon Release Workflow, Preferred operator flow (+3 more)
 
-### Community 688 - "Community 688"
+### Community 680 - "Community 680"
 Cohesion: 0.17
 Nodes (12): 3. Color System, Architecture, code:css (:root {), code:css (@variant dark {), code:block6 (NEVER: bg-gray-800, bg-gray-900, bg-gray-700), Color Restraint (Data-Dense Views), Column Semantic Colors (Kanban Pipeline), Dark Mode Tokens (+4 more)
 
-### Community 689 - "Community 689"
+### Community 681 - "Community 681"
 Cohesion: 0.17
 Nodes (11): Boundaries, code:bash (npm test), Completion, Deep depth: `inspect-deep`, Fast depth: `inspect`, Hardcoding it here would override the user's config and force everyone onto a, Jidoka Inspection Gates, No `model:` pin — Cloister resolves the model from config.yaml (roles.work.model). (+3 more)
 
-### Community 690 - "Community 690"
+### Community 682 - "Community 682"
 Cohesion: 0.17
 Nodes (11): Boundaries, code:bash (npm run typecheck), Hardcoding it here would override the user's config and force everyone onto a, Human-Merge Invariant, Inputs, No `model:` pin — Cloister resolves the model from config.yaml (roles.ship.model)., Panopticon Ship Role, Shipping Workflow (+3 more)
 
-### Community 691 - "Community 691"
+### Community 683 - "Community 683"
 Cohesion: 0.17
 Nodes (11): code:bash (curl -s -X POST {{API_URL}}/api/specialists/done \), code:bash (curl -s -X POST {{API_URL}}/api/specialists/done \), Hard Rules, Memory Context, Merge Task — {{ISSUE_ID}}, PHASE 1 — SYNC & BASELINE (before merge), PHASE 2 — MERGE, PHASE 3 — VERIFY (+3 more)
 
-### Community 692 - "Community 692"
+### Community 684 - "Community 684"
 Cohesion: 0.18
 Nodes (6): configFixture, __dirname, issueFixture, mockGitHubResponses, mockLinearResponses, skillFixture
 
-### Community 693 - "Community 693"
-Cohesion: 0.2
-Nodes (8): exec(), execMock, execResponses, kCustom, mockIsRunning, mockResolve, result, spawnRunMock
-
-### Community 694 - "Community 694"
+### Community 685 - "Community 685"
 Cohesion: 0.18
 Nodes (9): decode, events, identity, marker, next, observation, observationEvents, pendingTurn (+1 more)
 
-### Community 695 - "Community 695"
+### Community 686 - "Community 686"
+Cohesion: 0.2
+Nodes (8): exec(), execMock, execResponses, kCustom, mockIsRunning, mockResolve, result, spawnRunMock
+
+### Community 687 - "Community 687"
 Cohesion: 0.18
 Nodes (6): ACTIVE_STATUS_PATTERNS, agentDir, LAZY_PATTERNS, lazySamples, oldTime, stateFile
 
-### Community 696 - "Community 696"
+### Community 688 - "Community 688"
 Cohesion: 0.25
 Nodes (9): create_skill(), init_skill(), main(), Validate skill name follows conventions., Convert skill-name to Skill Name., Create a new skill directory structure., Initialize a new skill directory structure., to_title() (+1 more)
 
-### Community 697 - "Community 697"
+### Community 689 - "Community 689"
 Cohesion: 0.18
 Nodes (10): desktopDir, __dirname, pkg, pkgPath, publicDest, publicSrc, repoRoot, serverDest (+2 more)
 
-### Community 698 - "Community 698"
-Cohesion: 0.24
-Nodes (10): handlePermissionRequestNotification(), normalizePermissionRequest(), parsePermissionRequestNotification(), CHANNEL_PERMISSION_LIMITS, normalizeChannelPermissionRequestFields(), NormalizedChannelPermissionRequestFields, normalizePermissionInputPreview(), PermissionPayloadValidationError (+2 more)
+### Community 690 - "Community 690"
+Cohesion: 0.18
+Nodes (8): error, mockComment, mockComments, mockIssue, mockIssues, mockOctokit, stateTests, tracker
 
-### Community 699 - "Community 699"
+### Community 691 - "Community 691"
+Cohesion: 0.24
+Nodes (6): HookItem, computeQueuePositionFromStatus(), findPositionInQueue(), QueuePositionResult, items, result
+
+### Community 692 - "Community 692"
 Cohesion: 0.18
 Nodes (10): columns, db, divergedRows, id, indexes, indexNames, names, pushRows (+2 more)
 
-### Community 700 - "Community 700"
+### Community 693 - "Community 693"
 Cohesion: 0.22
 Nodes (7): BadgeBarProps, fetchPlanning(), PlanningData, MarkdownModal(), MarkdownModalProps, TranscriptUpload(), TranscriptUploadProps
 
-### Community 701 - "Community 701"
+### Community 694 - "Community 694"
+Cohesion: 0.22
+Nodes (9): EditorLaunch, execAsync, getFileManagerCommand(), isCommandAvailable(), launchDetached(), PanOpen, PanOpenLive, PanOpenShape (+1 more)
+
+### Community 695 - "Community 695"
 Cohesion: 0.18
 Nodes (7): mockAddComment, mockGetChildIssues, mockGetIssue, mockGetRallyConfig, mockTransitionIssue, program, RALLY_CONFIG
 
-### Community 702 - "Community 702"
+### Community 696 - "Community 696"
 Cohesion: 0.18
 Nodes (8): MOCK_PROJECT, mockCreateWorkspace, mockExistsSync, mockLoadProjectsConfig, mockRemoveWorkspace, mockResolveProjectFromIssue, mockStopWorkspaceDocker, program
 
-### Community 703 - "Community 703"
+### Community 697 - "Community 697"
 Cohesion: 0.18
 Nodes (8): MOCK_PROJECT, mockCreateWorkspace, mockExistsSync, mockLoadProjectsConfig, mockRemoveWorkspace, mockResolveProjectFromIssue, mockStopWorkspaceDocker, program
 
-### Community 704 - "Community 704"
+### Community 698 - "Community 698"
 Cohesion: 0.18
 Nodes (11): Acceptance Criteria Pipeline, Agent Environment Variables, Beads Prerequisite, code:block4 (1. Planning agent writes:), DAG-Aware Task Scheduling, Handling Pre-Existing PRDs, Lifecycle, Planning → Implementation Transition (+3 more)
 
-### Community 705 - "Community 705"
+### Community 699 - "Community 699"
 Cohesion: 0.18
 Nodes (11): 1. Tool Response Materialization, 2. Chat History as Queryable Files, 3. Skills as Discoverable Definitions, 4. MCP Tool Discovery, 5. Terminal Output Integration, code:block10 (~/.panopticon/mcp/), code:block11 (~/.panopticon/terminals/), code:typescript (// Before) (+3 more)
 
-### Community 706 - "Community 706"
-Cohesion: 0.18
-Nodes (11): Adopting GSD Patterns for Panopticon, code:markdown (# Workspace Context: MIN-648), code:markdown (# Agent State: MIN-648), code:markdown (# Work Summary: Research Phase), code:block43 (┌───────────────────────────────────────────────────────────), Context File Lifecycle, Part 5: Context Engineering from GSD-Plus, PROJECT.md → Workspace Context (+3 more)
-
-### Community 707 - "Community 707"
-Cohesion: 0.18
-Nodes (11): code:json ({), code:bash (# Cost for a specific issue), code:bash (bd show MIN-123), Cost Calculation, Data Sources, Implementation Notes, Part 15: Per-Feature Cost Tracking, Related Tools (+3 more)
-
-### Community 708 - "Community 708"
+### Community 700 - "Community 700"
 Cohesion: 0.18
 Nodes (11): code:typescript (interface Runtime {), code:toml (# ~/.panopticon/runtimes/claude.toml), code:toml (# ~/.panopticon/runtimes/codex.toml), code:bash (# Default: use project runtime), code:typescript (interface RuntimeMetrics {), Part 6: Multi-Runtime Architecture, Per-Agent Runtime Selection, Runtime Abstraction Layer (+3 more)
 
-### Community 709 - "Community 709"
+### Community 701 - "Community 701"
+Cohesion: 0.18
+Nodes (11): Adopting GSD Patterns for Panopticon, code:markdown (# Workspace Context: MIN-648), code:markdown (# Agent State: MIN-648), code:markdown (# Work Summary: Research Phase), code:block43 (┌───────────────────────────────────────────────────────────), Context File Lifecycle, Part 5: Context Engineering from GSD-Plus, PROJECT.md → Workspace Context (+3 more)
+
+### Community 702 - "Community 702"
+Cohesion: 0.18
+Nodes (11): code:json ({), code:bash (# Cost for a specific issue), code:bash (bd show MIN-123), Cost Calculation, Data Sources, Implementation Notes, Part 15: Per-Feature Cost Tracking, Related Tools (+3 more)
+
+### Community 703 - "Community 703"
 Cohesion: 0.18
 Nodes (10): Conversation Forks, Developer Notes, Fork Modes, Fork Options, Model Switching, Plain Fork, Summary Fork (Default), Thinking Block Behavior (+2 more)
 
-### Community 710 - "Community 710"
+### Community 704 - "Community 704"
 Cohesion: 0.18
 Nodes (11): 1. Claude Code's Native Hierarchy, Additional Loading Behavior, CLAUDE.md Precedence (team wins over personal), code:block1 (HIGHEST PRIORITY), code:block2 (HIGHEST PRIORITY), code:yaml (---), code:bash (export CLAUDE_CODE_DISABLE_AUTO_MEMORY=0  # Force ON), Rules vs. Skills vs. Agents (+3 more)
 
-### Community 711 - "Community 711"
+### Community 705 - "Community 705"
 Cohesion: 0.18
 Nodes (10): Autonomous planning auto-promote (commit 861cf8baa, 2026-05-20, RUN-1), Deacon orphan-detection races new agent spawn (observed RUN-1 tick 2), Flywheel State, GitHub App credential config fails ENOTDIR in worktrees (observed RUN-3), Open questions for the human, Orphan-test recovery loops on an unhealthy docker stack (commit ebb7f1387, 2026-05-20, RUN-3), Parked items, Recurring patterns to watch (+2 more)
 
-### Community 712 - "Community 712"
+### Community 706 - "Community 706"
 Cohesion: 0.18
 Nodes (10): Author allowlist (hard filter), End of run, Flywheel Brief, Human input invariant, Parked labels, Read first, Scope, Status vs State (+2 more)
 
-### Community 713 - "Community 713"
+### Community 707 - "Community 707"
 Cohesion: 0.18
 Nodes (10): Acceptance criteria, Architecture Overview, code:block1 (┌───────────────────────────────────────────────────────────), Decision, Implementation notes, Non-goals, Open questions, PAN-709: Self-Improving Flywheel — Retro Agent, Skill-Change Pipeline, and Autonomous Daemon (+2 more)
 
-### Community 714 - "Community 714"
+### Community 708 - "Community 708"
 Cohesion: 0.18
 Nodes (11): code:typescript (const isPlanningAgent = agent?.agentPhase === 'planning' || ), code:typescript (const isPlanningAgent = agent?.role === 'plan';), code:typescript (const label = specialist), code:typescript (const label = agent?.role), Dashboard Component Changes, Issue card phase label (`KanbanBoard.tsx`), PlanDialog (`PlanDialog.tsx:94-104`), Planning detection (`AgentOutputPanel.tsx:88`) (+3 more)
 
-### Community 715 - "Community 715"
+### Community 709 - "Community 709"
+Cohesion: 0.18
+Nodes (11): A.1 Add `isInfrastructureFailure` helper, A.2 Enhance `checkStuckReviewing` to detect dead parallel sessions, A.3 Add infrastructure-failure circuit breaker, A.4 Honor `stuck` flag in re-dispatch path, A.5 ~~Detect verification/review contradiction~~ — REMOVED, A. `src/lib/cloister/deacon.ts`, code:typescript (function isInfrastructureFailure(notes?: string): boolean {), code:typescript (// After building activeReviewIssues from specialist statuse) (+3 more)
+
+### Community 710 - "Community 710"
 Cohesion: 0.18
 Nodes (10): 1. `InlineSparkline.tsx`, 2. `ContainerNode.tsx`, 3. `ResourcesGroup.tsx`, 4. `FeatureItem.tsx` modifications, 5. Container stats polling in `CommandDeck/index.tsx`, code:typescript (interface InlineSparklineProps {), code:typescript (interface ContainerNodeProps {), code:typescript (interface ResourcesGroupProps {) (+2 more)
 
-### Community 716 - "Community 716"
+### Community 711 - "Community 711"
 Cohesion: 0.18
 Nodes (10): Acceptance Criteria, code:typescript (import { HttpRouter, HttpServer, HttpServerRequest, HttpServ), code:block8 (┌──────────────────┐), Decision, PAN-428: Full Effect.js Migration — Dashboard Server + Data Layer, Problem, Reference Implementation, Risk Assessment (Post-Investigation) (+2 more)
 
-### Community 717 - "Community 717"
+### Community 712 - "Community 712"
 Cohesion: 0.18
 Nodes (11): Activity sparkline (NEW, Zone A enrichment), code:block4 (⚠ Stuck — {reason}              [View details] [Mark unstuck), code:block5 (⚠ Salvageable user work in stash — recover before destructiv), Contextual actions row, Identity row (visual spec), Live cost ticker, Quality gates rollup (right side of stage row), Salvageable stash warning (+3 more)
 
-### Community 718 - "Community 718"
+### Community 713 - "Community 713"
 Cohesion: 0.18
 Nodes (11): P0 — Remove the worst offenders, P3 — Dashboard transcripts (stream from JSONL), P4 — WebSocket terminal (in-memory buffer), Per-Consumer Migration Plan, `src/dashboard/server/routes/agents.ts:526` — agent output endpoint, `src/dashboard/server/routes/mission-control.ts:161` — ActivityView agent transcript, `src/dashboard/server/routes/mission-control.ts:297` — specialist live output filter, `src/dashboard/server/routes/workspaces.ts:931` — model extraction (+3 more)
 
-### Community 719 - "Community 719"
+### Community 714 - "Community 714"
 Cohesion: 0.18
 Nodes (10): Approach, Constraints, Decisions, PAN-410: DAG Visualization — Match vBRIEF Studio Quality, Problem, Risks, Status: Planning Complete, Task 1: Node Enhancements (PlanDAG.tsx) (+2 more)
 
-### Community 720 - "Community 720"
+### Community 715 - "Community 715"
 Cohesion: 0.18
 Nodes (10): Approach, Decisions Made, Files Modified, Investigation: `scrollback: 0` History, Out of Scope, PAN-209: Mouse scroll in planning dialog scrolls chat input instead of agent output, Problem, Risk Assessment (+2 more)
 
-### Community 721 - "Community 721"
+### Community 716 - "Community 716"
 Cohesion: 0.18
 Nodes (10): code:block1 (specialists.review_agent = 'claude-opus-4-6'), Decisions, Failure Group 1: settings.test.ts (4 failures), Failure Group 2: tracker/factory.test.ts (2 failures), Files to Modify, PAN-136: Fix Pre-existing Test Failures, Problem, Root Cause Analysis (+2 more)
 
-### Community 722 - "Community 722"
+### Community 717 - "Community 717"
 Cohesion: 0.18
 Nodes (10): Architecture — new parallel-review runner, code:ts (async function runParallelReview(ctx: ReviewContext, agents:), Decisions, Out of scope, PAN-540: Remove convoy abstraction, inline parallel review into review-agent, Problem, Proposal, Quality gates (per bead, enforced by pipeline) (+2 more)
 
-### Community 723 - "Community 723"
+### Community 718 - "Community 718"
 Cohesion: 0.18
 Nodes (10): 1. `.claude/skills/test-specialist-workflow/SKILL.md` (4 refs), 2. `.claude/skills/update-panopticon-docs/resources/EXAMPLES.md` (1 ref), Approach, Audit findings, Current taxonomy (verified against `pan --help` on feature/pan-712), Decomposition, Out of scope, PAN-712: Fix stale pan work/cloister/specialists refs in .claude/skills/ (+2 more)
 
-### Community 724 - "Community 724"
+### Community 719 - "Community 719"
 Cohesion: 0.18
 Nodes (10): Architecture outline, Data flow (divergence case), Decisions, Modified files, New files, Out of scope, PAN-653 — Hotfix commits on main get silently lost, Problem (+2 more)
 
-### Community 725 - "Community 725"
+### Community 720 - "Community 720"
 Cohesion: 0.18
 Nodes (10): Architecture Decisions, Decision Summary, Feature Decisions, Framework: Electron, Out of Scope, PAN-442: Electron Desktop App for Panopticon Dashboard, Reference Architecture, Status: Planning Complete (+2 more)
 
-### Community 726 - "Community 726"
+### Community 721 - "Community 721"
 Cohesion: 0.18
 Nodes (9): Acceptance Criteria, Affected File, code:typescript (return yield* RallyClient.pipe(Effect.provide(RallyClientLiv), code:block2 (Error: Fiber.runLoop: Not a valid effect: { "_id": "Service"), Difficulty: Simple, Fix, Issue, Root Cause (+1 more)
 
-### Community 727 - "Community 727"
+### Community 722 - "Community 722"
 Cohesion: 0.18
 Nodes (11): A Mustache section renders when it shouldn't, A template renders the literal `{{VAR}}` instead of a value, code:block13 (Prompt "merge" (.../prompts/merge.md) requires variables tha), code:block14 (Prompt "review" (.../prompts/review.md) was passed unknown v), code:block15 (Prompt template "<name>" at .../<name>.md is missing YAML fr), code:block16 (Failed to load prompt template "work" from .../prompts/work.), "Failed to load prompt template", "missing YAML frontmatter" (+3 more)
 
-### Community 728 - "Community 728"
+### Community 723 - "Community 723"
 Cohesion: 0.18
 Nodes (10): ADR-0001: Use bd prime as CLI Reference Source of Truth, Consequences, Context, Date, Decision, Implementation, Negative, Positive (+2 more)
 
-### Community 729 - "Community 729"
+### Community 724 - "Community 724"
 Cohesion: 0.18
 Nodes (10): CLI Quick Reference, code:bash (bd mol distill bd-o5xe --as "Release Workflow"), code:bash (--var branch=feature-auth      # variable=value (recommended), Distilling Protos, Molecules and Wisps Reference, The Chemistry Metaphor, Troubleshooting, Use Protos/Mols When: (+2 more)
 
-### Community 730 - "Community 730"
+### Community 725 - "Community 725"
 Cohesion: 0.18
 Nodes (11): code:block31 (docs-1: "Update documentation"), code:block32 (epic-1: "OAuth integration"), code:block33 (Everything blocks everything else in strict sequential order), code:bash (bd dep add api-endpoint database-schema), code:bash (bd dep add database-schema api-endpoint), Common Mistakes, Mistake 1: Using blocks for Preferences, Mistake 2: Using discovered-from for Planning (+3 more)
 
-### Community 731 - "Community 731"
+### Community 726 - "Community 726"
 Cohesion: 0.18
 Nodes (10): code:block30 (Does Issue A prevent Issue B from starting?), code:block40 (Issue: feature-10), Contents, Decision Guide, Decision Tree, Dependency Types Guide, Overview, Quick Reference by Situation (+2 more)
 
-### Community 732 - "Community 732"
+### Community 727 - "Community 727"
 Cohesion: 0.18
 Nodes (11): Add Your First Project, code:bash (pan init), code:bash (# Edit ~/.panopticon.env and add:), code:bash (# Edit ~/.panopticon.env and add:), code:bash (# Edit ~/.panopticon.env and add:), code:bash (# Add the project you want to work on), code:bash (# Check system health), Configure Issue Tracker (+3 more)
 
-### Community 733 - "Community 733"
+### Community 728 - "Community 728"
 Cohesion: 0.18
 Nodes (10): code:bash (# CLI command), code:bash (# Sync PAN-123 workspace with latest main), Dashboard, Design Decisions, Examples, Outcomes, Related Commands, Sync with Main (+2 more)
 
-### Community 734 - "Community 734"
+### Community 729 - "Community 729"
 Cohesion: 0.18
 Nodes (11): code:bash (# Find what's using the port), code:bash (# Check if frontend built correctly), code:bash (# Check what's using port 80/443), code:bash (# Check browser console for errors), code:bash (# Run in foreground to see errors), Dashboard shows blank page, Port already in use, Services don't stay running (+3 more)
 
-### Community 735 - "Community 735"
+### Community 730 - "Community 730"
 Cohesion: 0.18
 Nodes (11): Buttons, Cards, code:tsx (// Blue gradient background), code:tsx (// Variants: default, destructive, success, error, warning, ), code:tsx (// Input), code:tsx (// Primary), code:tsx (// Main card (primary, higher elevation)), Component Patterns (+3 more)
 
-### Community 736 - "Community 736"
+### Community 731 - "Community 731"
 Cohesion: 0.18
 Nodes (11): Agent sessions remain after shutdown, Can't stop Traefik, code:bash (# Check for orphaned processes), code:bash (# Find what's using the port), code:bash (# Check Traefik status), code:bash (# List tmux sessions), code:bash (# Remove stale PID files), PID file exists but process doesn't (+3 more)
 
-### Community 737 - "Community 737"
+### Community 732 - "Community 732"
 Cohesion: 0.18
 Nodes (10): Code Review: Requirements Coverage, code:markdown (# Requirements Coverage Review - <timestamp>), Inputs from your spawn prompt, Method, Output format, Per-AC scope classification (REQUIRED), Scope, Severity and evidence (+2 more)
 
-### Community 738 - "Community 738"
+### Community 733 - "Community 733"
 Cohesion: 0.18
 Nodes (10): Claude Code Channels — Manual Smoke Test (PAN-985), code:block1 ([agent-pan-XXX] channels:eligible), code:block2 ({"ts":"2026-05-07T...","agentId":"agent-pan-XXX","contentLen), code:block3 ({"ts":"2026-...","agentId":"agent-pan-XXX","path":"channel",), code:block4 ({"ts":"2026-...","agentId":"agent-pan-XXX","path":"tmux","re), Expected log signatures, Failure modes & where to look, Prerequisites (+2 more)
 
-### Community 739 - "Community 739"
+### Community 734 - "Community 734"
 Cohesion: 0.29
 Nodes (9): AGENTS_DIR, AgentState, APPLY, dirExists(), execFileAsync, issueIsClosed(), loadState(), main() (+1 more)
 
-### Community 740 - "Community 740"
-Cohesion: 0.22
-Nodes (8): HealthCheck, systemHealthCommand(), mockExistsSync, mockFetch, mockGetDashboardApiUrl, mockIsCliproxyRunning, mockIsSmeeProcessRunning, output
+### Community 735 - "Community 735"
+Cohesion: 0.33
+Nodes (9): AgentStatus, buildContextMenu(), buildTooltip(), createTray(), createTrayIcon(), destroyTray(), HealthResponse, refreshTrayStatus() (+1 more)
 
-### Community 741 - "Community 741"
-Cohesion: 0.31
-Nodes (8): analyzeIssue(), sortByPriority(), issues, options, results, triageMultiple(), TriageOptions, TriageResult
-
-### Community 742 - "Community 742"
-Cohesion: 0.2
-Nodes (8): merge, mergeAgent, pollSpecialistApiStatus(), review, reviewAgent, SpecialistApiStatus, test, testAgent
-
-### Community 743 - "Community 743"
-Cohesion: 0.2
-Nodes (9): ArcProps, GroupProps, HTMLMotionProps, MotionComponent, PanopticonBridge, PanopticonBridgeDesktopSettings, Transition, Variants (+1 more)
-
-### Community 744 - "Community 744"
-Cohesion: 0.2
-Nodes (8): CONFIG, hadPackageDir, hadPython, hadVenvDir, killSpy, packageDir, python, scriptPath
-
-### Community 745 - "Community 745"
+### Community 736 - "Community 736"
 Cohesion: 0.44
 Nodes (9): compactCommand(), CompactOptions, detectPlatform(), doctorCommand(), execAsync, getOldClosedCount(), isBdAvailable(), statsCommand() (+1 more)
 
-### Community 746 - "Community 746"
+### Community 737 - "Community 737"
+Cohesion: 0.31
+Nodes (8): analyzeIssue(), sortByPriority(), issues, options, results, triageMultiple(), TriageOptions, TriageResult
+
+### Community 738 - "Community 738"
+Cohesion: 0.2
+Nodes (8): merge, mergeAgent, pollSpecialistApiStatus(), review, reviewAgent, SpecialistApiStatus, test, testAgent
+
+### Community 739 - "Community 739"
+Cohesion: 0.2
+Nodes (9): ArcProps, GroupProps, HTMLMotionProps, MotionComponent, PanopticonBridge, PanopticonBridgeDesktopSettings, Transition, Variants (+1 more)
+
+### Community 740 - "Community 740"
+Cohesion: 0.2
+Nodes (8): CONFIG, hadPackageDir, hadPython, hadVenvDir, killSpy, packageDir, python, scriptPath
+
+### Community 741 - "Community 741"
+Cohesion: 0.22
+Nodes (8): HealthCheck, systemHealthCommand(), mockExistsSync, mockFetch, mockGetDashboardApiUrl, mockIsCliproxyRunning, mockIsSmeeProcessRunning, output
+
+### Community 742 - "Community 742"
 Cohesion: 0.2
 Nodes (10): 1. TypeScript typecheck, 2. Lint, 3. Tests, 4. No ephemeral files staged, code:bash (npm run typecheck    # npx tsc --noEmit), code:bash (npm run lint), code:bash (npm test), code:typescript (// vitest.config.ts) (+2 more)
 
-### Community 747 - "Community 747"
+### Community 743 - "Community 743"
 Cohesion: 0.2
 Nodes (10): code:bash (npx @panctl/cli), code:bash (npm install -g @panctl/cli && pan install && pan up), code:bash (npm install -g @panctl/cli), code:bash (pan install), code:bash (pan sync), code:bash (cd /path/to/your-project), code:bash (pan up), Installation (+2 more)
 
-### Community 748 - "Community 748"
+### Community 744 - "Community 744"
 Cohesion: 0.2
 Nodes (9): Agent Types Index, code:ts (export type Role = 'plan' | 'work' | 'review' | 'test' | 'sh), Important distinction: roles vs helper subagents, Related docs, Runtime role inventory, Sub-roles, The big picture, Typical workflow (+1 more)
 
-### Community 749 - "Community 749"
+### Community 745 - "Community 745"
 Cohesion: 0.2
 Nodes (10): Caveats, code:json ({), code:yaml (claude:), code:bash (pan up                     # uses config (default: auto)), code:bash (pan --yolo=false up        # before subcommand), Permission Mode, Precedence, Prereq for `auto` mode (+2 more)
 
-### Community 750 - "Community 750"
+### Community 746 - "Community 746"
 Cohesion: 0.2
 Nodes (10): code:yaml (fpp_violation:), code:typescript (interface FPPViolation {), FPP (Fixed Point Principle) Violation Detection, Implementation Phases, Phase 1: Core Watchdog (MVP), Phase 2: Agent Management UI, Phase 3: Active Heartbeats & Hooks, Phase 4: Model Routing & Handoffs (+2 more)
 
-### Community 751 - "Community 751"
+### Community 747 - "Community 747"
 Cohesion: 0.2
 Nodes (10): Agent state — new `waiting-on-human` state, code:yaml (---), code:yaml (---), code:yaml (flywheel:), Dashboard schema — new kanban badge + Awaiting Merge sub-tab, Data model changes, `docs/FLYWHEEL-REPORT.md` (new), `docs/flywheel/retros/<issue-id>-<timestamp>.md` (new) (+2 more)
 
-### Community 752 - "Community 752"
+### Community 748 - "Community 748"
 Cohesion: 0.2
 Nodes (7): code:sql (CREATE VIEW archived_conversations_v AS), Data Model, Existing — `conversations` table, New — `discovered_sessions` table, New — FTS5 mirror, New — vector embeddings (optional), Unified view — `archived_conversations_v`
 
-### Community 753 - "Community 753"
+### Community 749 - "Community 749"
 Cohesion: 0.2
 Nodes (10): code:bash (pan conversations enrich), code:bash (pan conversations enrich --deep), code:bash (pan conversations enrich --with claude-opus-4-6 <session-id>), code:block15 (Session abc123 — 847 messages, ~125K tokens), L1 — Quick enrich (cheap, batch), L2 — Deep enrich (mid-tier model), L3 — Custom enrich (user-selected model), Re-enrichment rules (+2 more)
 
-### Community 754 - "Community 754"
+### Community 750 - "Community 750"
 Cohesion: 0.2
 Nodes (10): Architecture, Backend extraction, code:block1 (┌──────────────────────────┐         ┌──────────────────────), code:block2 (src/lib/setup/), code:typescript (// src/dashboard/frontend/src/stores/wizardStore.ts), Dashboard surfaces, High-level shape, Setup Agent as a first-class agent (+2 more)
 
-### Community 755 - "Community 755"
+### Community 751 - "Community 751"
 Cohesion: 0.2
 Nodes (9): Files to Create, Files to Modify, Goals, Non-goals, Open Questions, Problem, Project Setup Wizard — Dashboard UI, Risks (+1 more)
 
-### Community 756 - "Community 756"
+### Community 752 - "Community 752"
 Cohesion: 0.2
 Nodes (10): code:typescript (export interface ReviewStatusSnapshot {), code:typescript (describe('isInfrastructureFailure', () => {), D.1 Add new fields to `ReviewStatusSnapshot`, D. `packages/contracts/src/types.ts`, Detailed Changes, E.1 Unit test: `isInfrastructureFailure`, E.2 Unit test: circuit breaker in `checkOrphanedReviewStatuses`, E.3 Unit test: `checkStuckReviewing` with dead parallel sessions (+2 more)
 
-### Community 757 - "Community 757"
+### Community 753 - "Community 753"
 Cohesion: 0.2
 Nodes (9): 1. Do NOT rewrite `src/lib/*` modules, 2. Do NOT modify `server.ts` from route modules, 3. Preserve exact API contracts, 4. Socket.io → EventStore mapping, 5. Background processes become Effect fibers, 6. Effect service pattern for existing modules, code:typescript (// services/agent-manager.ts), code:typescript (// CORRECT — wrap existing async code in Effect) (+1 more)
 
-### Community 758 - "Community 758"
+### Community 754 - "Community 754"
 Cohesion: 0.2
 Nodes (9): Architecture, code:typescript ({), Data Flow, Decisions, Files to Modify, Key Implementation Details, PAN-426: Tasks Panel and DAG — AC Subtask Toggle, Scope (+1 more)
 
-### Community 759 - "Community 759"
+### Community 755 - "Community 755"
 Cohesion: 0.2
 Nodes (9): Approach, Architecture, code:block1 (DetailPanelLayout), Decision Record, Files Modified, Key Decisions, PAN-406: Workspace detail — replace polling logs with live interactive terminal, Problem (+1 more)
 
-### Community 760 - "Community 760"
+### Community 756 - "Community 756"
 Cohesion: 0.2
 Nodes (9): Architecture, Decisions, Edge Cases, Files to Modify, Flow After Fix, Out of Scope, PAN-208: Stale planning state causes premature 'Planning Complete' on restart, Problem (+1 more)
 
-### Community 761 - "Community 761"
+### Community 757 - "Community 757"
 Cohesion: 0.2
 Nodes (9): 1. Deep Link URL Format, 2. Deep Link Navigation Behavior, 3. Copy Button Feedback, Affected Files, Context, Decisions, Implementation Plan, Out of Scope (+1 more)
 
-### Community 762 - "Community 762"
+### Community 758 - "Community 758"
 Cohesion: 0.2
 Nodes (9): Context, Decision: Add unit tests for createBeadsFromVBrief, Difficulty, Files affected, PAN-507: beads db not initialized on fresh install, Status: Planning Complete, Test approach, What NOT to test (+1 more)
 
-### Community 763 - "Community 763"
+### Community 759 - "Community 759"
 Cohesion: 0.2
 Nodes (10): Boolean flags, code:mustache (Issue: {{ISSUE_ID}}), code:mustache ({{#USER_MESSAGE}}), code:mustache ({{^DO_PUSH}}), code:typescript (renderPrompt({), Inverted sections, Mustache syntax reference, No partials, no lambdas, no custom helpers (+2 more)
 
-### Community 764 - "Community 764"
+### Community 760 - "Community 760"
 Cohesion: 0.2
 Nodes (9): Codebase Explorer, Deliverables, Exploration Strategies, For Architecture Understanding, For New Codebases, For Specific Questions, Performance Tips, Remember (+1 more)
 
-### Community 765 - "Community 765"
+### Community 761 - "Community 761"
 Cohesion: 0.2
 Nodes (9): code:bash (tmux -L panopticon list-sessions), code:block2 ({{WORKSPACE_PATH}}), code:bash (# 1. Run tests), Completion Requirements (CRITICAL), CRITICAL: Workspace Isolation, Investigation First — NEVER Fix Inline, NEVER Defer Work (CRITICAL), tmux Socket — CRITICAL (+1 more)
 
-### Community 766 - "Community 766"
+### Community 762 - "Community 762"
 Cohesion: 0.2
 Nodes (9): AI Writing Patterns to Avoid, Bottom Line, Clear Writing, Composition Rules, Limited Context Strategy, Overview, Reference Files, Rules (+1 more)
 
-### Community 767 - "Community 767"
+### Community 763 - "Community 763"
 Cohesion: 0.2
 Nodes (10): code:bash (# In directory: /Users/name/Google Drive/...), code:bash (# Wrong location (cloud sync)), code:bash (mv ~/Google\ Drive/project ~/Repos/project), code:bash (bd init myproject), code:bash (bd import < issues-backup.jsonl), code:bash (# Don't initialize bd in cloud-synced directory), Database Errors on Cloud Storage, Resolution (+2 more)
 
-### Community 768 - "Community 768"
+### Community 764 - "Community 764"
 Cohesion: 0.2
 Nodes (10): code:bash (bd mol wisp mol-patrol                       # From proto), code:bash (bd mol wisp list                     # List all wisps), code:bash (bd mol squash wisp-abc123                              # Aut), code:bash (bd mol burn wisp-abc123                    # Delete wisp, no), code:bash (bd mol wisp gc                       # Clean up orphaned wis), Creating Wisps, Ending Wisps, Garbage Collection (+2 more)
 
-### Community 769 - "Community 769"
+### Community 765 - "Community 765"
 Cohesion: 0.2
 Nodes (9): 1. Verify Implementation, 2. Self-Review Your Changes, 3. Commit Your Work (BLOCKING - DO THIS FIRST), 4. Signal Completion, 5. Wait for User Response, code:bash (git diff origin/main...HEAD), code:bash (# Check for uncommitted changes), code:block3 (✅ WORK COMPLETE - Ready for Review) (+1 more)
 
-### Community 770 - "Community 770"
+### Community 766 - "Community 766"
 Cohesion: 0.2
 Nodes (10): Approve and Merge, Check Pending Work, code:bash (# Start dashboard and services), code:bash (# See completed work awaiting review), code:bash (# Approve work, merge MR, update tracker), Quick Start Workflow, Review in Dashboard, Step 1: Prerequisites Check (+2 more)
 
-### Community 771 - "Community 771"
+### Community 767 - "Community 767"
 Cohesion: 0.2
 Nodes (10): Agent Status, code:bash (pan status), code:block4 (Running Agents (3):), code:bash (pan workspace list), code:block6 (Workspaces (5):), code:bash (pan doctor), code:block8 (Panopticon System Health), System Health (+2 more)
 
-### Community 772 - "Community 772"
+### Community 768 - "Community 768"
 Cohesion: 0.2
 Nodes (10): code:bash (# Check Panopticon status), code:bash (# Check for agents), code:bash (pan down), code:block5 (✓ Stopping API server (PID 12345)), code:bash (# Check nothing is listening on ports), Step 1: Check What's Running, Step 2: Save Any Pending Work, Step 3: Stop Services (+2 more)
 
-### Community 773 - "Community 773"
+### Community 769 - "Community 769"
 Cohesion: 0.2
 Nodes (9): Code Review: Performance, code:markdown (# Performance Review - <timestamp>), Inputs from your spawn prompt, Method, Output format, Scope, Severity and evidence, TLDR: prefer code summaries over full reads (+1 more)
 
-### Community 774 - "Community 774"
+### Community 770 - "Community 770"
 Cohesion: 0.2
 Nodes (9): Code Review: Security, code:markdown (# Security Review - <timestamp>), Inputs from your spawn prompt, Method, Output format, Scope, Severity and evidence, TLDR: prefer code summaries over full reads (+1 more)
 
-### Community 775 - "Community 775"
+### Community 771 - "Community 771"
 Cohesion: 0.2
 Nodes (9): Code Review: Correctness, code:markdown (# Correctness Review - <timestamp>), Inputs from your spawn prompt, Method, Output format, Scope, Severity and evidence, TLDR: prefer code summaries over full reads (+1 more)
 
-### Community 776 - "Community 776"
+### Community 772 - "Community 772"
 Cohesion: 0.2
 Nodes (9): Boundaries, Browser UAT Contract, Hardcoding it here would override the user's config and force everyone onto a, Inputs, No `model:` pin — Cloister resolves the model from config.yaml (roles.test.model)., Panopticon Test Role, single model, defeating the per-role model configurability the dashboard exposes., TLDR: prefer code summaries over full reads (+1 more)
 
-### Community 777 - "Community 777"
+### Community 773 - "Community 773"
 Cohesion: 0.2
 Nodes (9): Boundaries, Hardcoding it here would override the user's config and force everyone onto a, No `model:` pin — Cloister resolves the model from config.yaml (roles.plan.model)., Outputs, Panopticon Planning Agent, Process, single model, defeating the per-role model configurability the dashboard exposes., State model (+1 more)
 
-### Community 778 - "Community 778"
-Cohesion: 0.22
-Nodes (8): cb, cmdArgs, { MainDivergedErrorClass }, mockExec, mockGitPush, mockMarkWorkspaceStuck, result, pushApproveMain()
-
-### Community 779 - "Community 779"
+### Community 774 - "Community 774"
 Cohesion: 0.22
 Nodes (7): activeBeadsIgnore, activePlanningBeadsIgnore, content, gitignorePath, lines, ROOT, tracked
 
-### Community 780 - "Community 780"
-Cohesion: 0.28
-Nodes (7): formatDuration(), fiveMinAgo, now, recent, threeDaysAgo, twoHoursAgo, timeAgo()
-
-### Community 781 - "Community 781"
+### Community 775 - "Community 775"
 Cohesion: 0.31
 Nodes (8): continuesDir, ensureContinuesDir(), legacyLifecycles, lifecycleDir, log(), migrateFile(), parseIssueId(), projectRoot
 
-### Community 782 - "Community 782"
+### Community 776 - "Community 776"
+Cohesion: 0.22
+Nodes (5): dispatchMenuAction(), consoleErrors, flywheelStatus, MockWebSocket, statusPane
+
+### Community 777 - "Community 777"
 Cohesion: 0.31
 Nodes (6): resolveServerEntry(), randomHex(), resolvePort(), spawnServer(), startServer(), stopServer()
 
-### Community 783 - "Community 783"
-Cohesion: 0.36
-Nodes (7): consolidateSpeakerCues(), decodeHtmlEntities(), formatTimestamp(), ParsedCue, parseTimestamp(), result, vttToMarkdown()
+### Community 778 - "Community 778"
+Cohesion: 0.28
+Nodes (7): formatDuration(), fiveMinAgo, now, recent, threeDaysAgo, twoHoursAgo, timeAgo()
 
-### Community 784 - "Community 784"
+### Community 779 - "Community 779"
+Cohesion: 0.22
+Nodes (5): execFileMock, postMergeLifecycleMock, readContinueStateAsyncMock, readdirSyncMock, resolveGitHubIssueMock
+
+### Community 780 - "Community 780"
 Cohesion: 0.28
 Nodes (7): detectTestCommand(), detectTestCommandEffect(), fileExists(), command, jestConfig, packageJson, testDir
 
-### Community 785 - "Community 785"
-Cohesion: 0.28
-Nodes (6): BYTE_UNITS, hist, parseBytes(), parseMemUsage(), parseNetIO(), result
-
-### Community 786 - "Community 786"
-Cohesion: 0.22
-Nodes (8): colNames, cols, columns, db, names, row, stuckCol, tables
-
-### Community 787 - "Community 787"
+### Community 781 - "Community 781"
 Cohesion: 0.22
 Nodes (6): chalk, exitSpy, logs, MockCostThresholdError, mockEnrichSessions, output
 
-### Community 788 - "Community 788"
-Cohesion: 0.22
-Nodes (7): colNames, cols, db, disabledRow, enabledRow, [row], rows
+### Community 782 - "Community 782"
+Cohesion: 0.28
+Nodes (6): BYTE_UNITS, hist, parseBytes(), parseMemUsage(), parseNetIO(), result
 
-### Community 789 - "Community 789"
+### Community 783 - "Community 783"
+Cohesion: 0.28
+Nodes (7): restoreTrackedBeadsExport(), runGit(), spawnerLayer, after, before, content, notGit
+
+### Community 784 - "Community 784"
+Cohesion: 0.22
+Nodes (8): cb, cmdArgs, { MainDivergedErrorClass }, mockExec, mockGitPush, mockMarkWorkspaceStuck, result, pushApproveMain()
+
+### Community 785 - "Community 785"
 Cohesion: 0.22
 Nodes (8): MOCK_HEALTH_RESPONSE, MOCK_PROJECT_SPECIALISTS_RESPONSE, MOCK_SPECIALISTS_RESPONSE, panBadge, perProjectHeader, sectionHeader, sessionCard, statusBar
 
-### Community 790 - "Community 790"
-Cohesion: 0.22
-Nodes (6): { getRuntimeForAgentMock, getAgentHealthMock }, issueId, MOCK_HEALTH, MOCK_RUNTIME, runtime, SHADOW_STATE_DIR
-
-### Community 791 - "Community 791"
+### Community 786 - "Community 786"
 Cohesion: 0.22
 Nodes (9): code:bash (# Activate Node 22 (always required)), code:bash (cp .env.example ~/.panopticon.env), code:bash (cd /path/to/panopticon-cli), code:bash (pan status          # Should show "Panopticon is running" or), Development Setup, Environment, Initialize beads (once per project), Prerequisites (+1 more)
 
-### Community 792 - "Community 792"
-Cohesion: 0.22
-Nodes (8): code:markdown (## Summary), code:block5 (panopticon-cli/), Contributing to Panopticon CLI, Filing Bugs, Issue Tracking, Key Invariants, Repository Layout, Table of Contents
-
-### Community 793 - "Community 793"
+### Community 787 - "Community 787"
 Cohesion: 0.22
 Nodes (9): After making changes, Building and Running, code:bash (npm run build           # Compiles TypeScript to dist/ via t), code:bash (npm run dev             # Dashboard with hot reload (Vite fr), code:bash (# ALWAYS use the explicit Node 22 path), code:bash (npm run build && npm link   # Rebuild + re-link `pan` global), Development mode, Full build (+1 more)
 
-### Community 794 - "Community 794"
+### Community 788 - "Community 788"
+Cohesion: 0.22
+Nodes (8): code:markdown (## Summary), code:block5 (panopticon-cli/), Contributing to Panopticon CLI, Filing Bugs, Issue Tracking, Key Invariants, Repository Layout, Table of Contents
+
+### Community 789 - "Community 789"
 Cohesion: 0.22
 Nodes (8): [0.7.0] — Command Taxonomy Reorganization, Breaking Changes, Changed, Changelog, Changes, Deprecations Removed, New Commands, Unreleased
 
-### Community 795 - "Community 795"
+### Community 790 - "Community 790"
 Cohesion: 0.22
 Nodes (9): 1. Reviewer canonical sessions (PAN-830) — persistent across rounds, 2. Other specialist dispatches (test-agent, merge-agent, etc.) — fresh per dispatch, code:block14 (specialist-<projectKey>-<issueId>-review-<role>), code:block15 (IMPORTANT: This is a NEW task dispatch. You may have context), code:bash (# Reset via CLI — clears session state and context digest), Context Digest (cross-dispatch memory), Event-driven status (PAN-915), Resetting a Specialist (+1 more)
 
-### Community 796 - "Community 796"
+### Community 791 - "Community 791"
 Cohesion: 0.22
 Nodes (8): Current State (2026), Decision Log, Guiding Principle, Panopticon Product Vision, Phase 1 — Shared Instance, Phase 2 — Multi-Tenant SaaS, Vision Roadmap, Why local-first?
 
-### Community 797 - "Community 797"
+### Community 792 - "Community 792"
 Cohesion: 0.22
 Nodes (9): code:bash (# Register a project), code:json ([), code:bash (LINEAR_API_KEY=lin_api_xxxxx), Configuration, Environment File, Issue Trackers, Map Linear Projects to Local Directories, Rally Features and Derived Status (+1 more)
 
-### Community 798 - "Community 798"
+### Community 793 - "Community 793"
 Cohesion: 0.22
 Nodes (9): code:block3 (┌───────────────────────────────────────────────────────────), code:block4 (┌───────────────────────────────────────────────────────────), code:block5 (~/.panopticon/), code:bash (# CLI equivalent of /work-issue MIN-648), Panopticon Ships Batteries-Included, The Mayor Architecture: Dual-Interface Design, The Mayor Concept (from Gastown), What `pan sync` Syncs (+1 more)
 
-### Community 799 - "Community 799"
+### Community 794 - "Community 794"
 Cohesion: 0.22
 Nodes (8): Automatic Recovery, code:block50 (┌───────────────────────────────────────────────────────────), code:typescript (interface AgentHealth {), code:typescript (async function handleStuckAgent(agentId: string) {), Health Check Flow, Panopticon Health Dashboard, Part 7: Stuck Detection and Health Monitoring, The Deacon Pattern
 
-### Community 800 - "Community 800"
+### Community 795 - "Community 795"
 Cohesion: 0.22
 Nodes (8): Brief authoring, code:text (${PANOPTICON_HOME:-~/.panopticon}/flywheel/runs/<RUN-ID>/), Flywheel, Lifecycle, Settings → Roles → Flywheel, Skill → CLI → API → UI map, Status contract, Status vs State
 
-### Community 801 - "Community 801"
+### Community 796 - "Community 796"
 Cohesion: 0.22
 Nodes (8): 10. Tracked Issues, 11. Implementation Scope, 4. Enterprise / Managed Policy, 5. Path Portability (Completed), 7. Rules: Planned Content, 9. Decisions Log, References, Skill Distribution Architecture: Analysis & Findings
 
-### Community 802 - "Community 802"
+### Community 797 - "Community 797"
 Cohesion: 0.22
 Nodes (9): 2.1 Workspace Creation Flow, code:bash (exe ssh min-667 "cd /workspace && docker compose up -d fe ap), code:bash (# exe.dev's HTTPS proxy handles this automatically), code:yaml (# ~/.panopticon/workspaces/min-667.yaml), code:bash (pan workspace create MIN-667 --remote), code:bash (exe vm create min-667), code:bash (exe ssh min-667 "git clone git@github.com:org/repo.git /work), code:bash (exe ssh min-667 "cat > /workspace/.env << 'EOF') (+1 more)
 
-### Community 803 - "Community 803"
+### Community 798 - "Community 798"
 Cohesion: 0.22
 Nodes (8): Acceptance Criteria, code:block24 (Foundation), Implementation — Single Branch, Hard Cut, Open Questions, PAN-1048: Unify Agent Type System — Role Primitive with Reactive Cloister, Problem, Related Issues, Vision
 
-### Community 804 - "Community 804"
+### Community 799 - "Community 799"
+Cohesion: 0.22
+Nodes (9): Problem 1: Dead/stuck parallel review sessions are invisible to deacon, Problem 2: No circuit breaker for infrastructure-failure cycling, Problem 3: Verification passed but review blocks the pipeline forever, Problem 4: Incomplete parallel reviews waste completed findings, Problem 5: `stuck` flag is never checked in re-dispatch path, Problem 6: No cycle boundary for the circuit breaker, Problem 7: No UI indication that recovery is happening, Problem 8: Multiple actors can manipulate the same review tmux sessions (+1 more)
+
+### Community 800 - "Community 800"
+Cohesion: 0.22
+Nodes (8): Acceptance Criteria, Backend: Deacon stuck detection, Background, Files Modified, Frontend: Recovery UI indicators, PRD: Stuck Parallel Review Detection, Recovery, and UI Indicators (PAN-794), Risks and Mitigations, Solution Overview
+
+### Community 801 - "Community 801"
+Cohesion: 0.22
+Nodes (9): code:typescript (describe('isInfrastructureFailure', () => {), F.1 Unit test: `isInfrastructureFailure`, F.2 Unit test: circuit breaker in `checkOrphanedReviewStatuses`, F.3 Unit test: `checkStuckReviewing` with dead parallel sessions, F.4 Unit test: `isProcessActive` etime parsing, F.5 Frontend test: recovery and infra-stuck badges, F.6 Unit test: breaker honors recovery window boundary, F.7 Unit test: unstick route resets recovery window (+1 more)
+
+### Community 802 - "Community 802"
 Cohesion: 0.22
 Nodes (9): C.1 Add migration in `schema.ts`, C.2 Update `upsertReviewStatus` in `review-status-db.ts`, C.3 Update `rowToReviewStatus` in `review-status-db.ts`, C. Database schema changes (`src/lib/database/schema.ts` + `src/lib/database/review-status-db.ts`), code:typescript (// v24 → v25: add review_retry_count and recovery_started_at), code:typescript (export const ReviewStatusSnapshot = Schema.Struct({), D.1 Add new fields to `ReviewStatusSnapshot`, D. `packages/contracts/src/types.ts` (+1 more)
+
+### Community 803 - "Community 803"
+Cohesion: 0.22
+Nodes (9): US-1 — First project (zero state), US-2 — Second project (existing user), US-3 — Watch the Setup Agent work, US-4 — Review generated docs, US-5 — Edit an existing project's config, US-6 — Re-run setup after adding repos, US-7 — Remove a project, US-8 — Dogfood through the dashboard (+1 more)
+
+### Community 804 - "Community 804"
+Cohesion: 0.22
+Nodes (9): code:block4 (┌───────────────────────────────────────────────────────────), code:block5 (┌──────────────────────────────────────────────────────────┐), First-run welcome, Project detail page (`/projects/:projectKey`), Project list page (`/projects`), Setup Agent in the agent list, Steps, UX Specification (+1 more)
 
 ### Community 805 - "Community 805"
 Cohesion: 0.22
@@ -4471,1505 +4458,1489 @@ Nodes (8): Acceptance Criteria, Backend: Deacon stuck detection, Background, Fil
 
 ### Community 806 - "Community 806"
 Cohesion: 0.22
-Nodes (9): code:typescript (describe('isInfrastructureFailure', () => {), F.1 Unit test: `isInfrastructureFailure`, F.2 Unit test: circuit breaker in `checkOrphanedReviewStatuses`, F.3 Unit test: `checkStuckReviewing` with dead parallel sessions, F.4 Unit test: `isProcessActive` etime parsing, F.5 Frontend test: recovery and infra-stuck badges, F.6 Unit test: breaker honors recovery window boundary, F.7 Unit test: unstick route resets recovery window (+1 more)
+Nodes (9): Agent Events, Cost / Bead Events, Domain Events Catalog, Issue Events, Pipeline Events, Planning Events, Resource Events, Specialist Events (+1 more)
 
 ### Community 807 - "Community 807"
 Cohesion: 0.22
-Nodes (9): Problem 1: Dead/stuck parallel review sessions are invisible to deacon, Problem 2: No circuit breaker for infrastructure-failure cycling, Problem 3: Verification passed but review blocks the pipeline forever, Problem 4: Incomplete parallel reviews waste completed findings, Problem 5: `stuck` flag is never checked in re-dispatch path, Problem 6: No cycle boundary for the circuit breaker, Problem 7: No UI indication that recovery is happening, Problem 8: Multiple actors can manipulate the same review tmux sessions (+1 more)
+Nodes (9): Build System: esbuild → tsdown + Vite, code:typescript (// Auto-detect runtime for HTTP server), code:typescript (// T3Code pattern: apps/server/src/terminal/Layers/BunPTY.ts), Effect Version: `4.0.0-beta.43` (pinned), Package Manager: npm → Bun, PTY: Dual-Runtime Terminal, Runtime: Dual-Mode (Bun + Node), SQLite: Dual-Runtime (+1 more)
 
 ### Community 808 - "Community 808"
 Cohesion: 0.22
-Nodes (9): code:block4 (┌───────────────────────────────────────────────────────────), code:block5 (┌──────────────────────────────────────────────────────────┐), First-run welcome, Project detail page (`/projects/:projectKey`), Project list page (`/projects`), Setup Agent in the agent list, Steps, UX Specification (+1 more)
+Nodes (9): Implementation plan, Phase 0 — Reading, Phase 1 — Reviewer canonical naming + resumption (server-side), Phase 2 — Three-zone Command Deck shell (frontend), Phase 3 — Liveness building blocks, Phase 4 — Issue-selected mode, Phase 5 — Action surface parity (additive only), Phase 6 — Tree node redesign + dividers (+1 more)
 
 ### Community 809 - "Community 809"
 Cohesion: 0.22
-Nodes (9): US-1 — First project (zero state), US-2 — Second project (existing user), US-3 — Watch the Setup Agent work, US-4 — Review generated docs, US-5 — Edit an existing project's config, US-6 — Re-run setup after adding repos, US-7 — Remove a project, US-8 — Dogfood through the dashboard (+1 more)
+Nodes (9): Acceptance criteria, Action parity, Density, Issue-selected mode, JSONL resolution, Liveness, Reviewer canonical naming + resumption, Three-zone Command Deck (+1 more)
 
 ### Community 810 - "Community 810"
 Cohesion: 0.22
-Nodes (8): Acceptance Criteria, Backend: Deacon stuck detection, Background, Files Modified, Frontend: Recovery UI indicators, PRD: Stuck Parallel Review Detection, Recovery, and UI Indicators (PAN-794), Risks and Mitigations, Solution Overview
+Nodes (8): Critical Discovery: PAN-759 Root Cause, Documents, Files to Modify, Guiding Principle, Open Questions / Research Needed, PAN-798: Eliminate All tmux capture-pane Usage, Problem Statement, Success Criteria
 
 ### Community 811 - "Community 811"
 Cohesion: 0.22
-Nodes (9): Build System: esbuild → tsdown + Vite, code:typescript (// Auto-detect runtime for HTTP server), code:typescript (// T3Code pattern: apps/server/src/terminal/Layers/BunPTY.ts), Effect Version: `4.0.0-beta.43` (pinned), Package Manager: npm → Bun, PTY: Dual-Runtime Terminal, Runtime: Dual-Mode (Bun + Node), SQLite: Dual-Runtime (+1 more)
+Nodes (8): Current Status, Decisions, PAN-408: Wire vBRIEF Acceptance Criteria into Specialist Pipeline, Part 1: Wire AC into Specialist Pipeline, Part 2: Documentation Alignment, Remaining Work, Specialist Feedback, What Was Done
 
 ### Community 812 - "Community 812"
 Cohesion: 0.22
-Nodes (9): Agent Events, Cost / Bead Events, Domain Events Catalog, Issue Events, Pipeline Events, Planning Events, Resource Events, Specialist Events (+1 more)
+Nodes (8): Not In Scope Here, PAN-632 Implementation Plan, Principles, Slice 1: Foundation, Slice 2: Review Artifact Creation, Slice 3: Readiness and Verification, Slice 4: Merge Orchestration, Slice 5: Recovery and Validation
 
 ### Community 813 - "Community 813"
 Cohesion: 0.22
-Nodes (9): Implementation plan, Phase 0 — Reading, Phase 1 — Reviewer canonical naming + resumption (server-side), Phase 2 — Three-zone Command Deck shell (frontend), Phase 3 — Liveness building blocks, Phase 4 — Issue-selected mode, Phase 5 — Action surface parity (additive only), Phase 6 — Tree node redesign + dividers (+1 more)
+Nodes (8): Acceptance summary, Approach (chosen), Changes, Files touched, Out of scope, PAN-699 — Conversation view renders tool calls out of terminal order, Problem, Testing
 
 ### Community 814 - "Community 814"
 Cohesion: 0.22
-Nodes (9): Acceptance criteria, Action parity, Density, Issue-selected mode, JSONL resolution, Liveness, Reviewer canonical naming + resumption, Three-zone Command Deck (+1 more)
+Nodes (8): Approach, code:block1 (vitest --run --no-file-parallelism && cd src/dashboard/front), code:block2 (vitest --run --no-file-parallelism), Convention, Decision, PAN-645: Tests: root Vitest config does not discover ActionsSection.test.tsx, Problem, Scope
 
 ### Community 815 - "Community 815"
 Cohesion: 0.22
-Nodes (8): Critical Discovery: PAN-759 Root Cause, Documents, Files to Modify, Guiding Principle, Open Questions / Research Needed, PAN-798: Eliminate All tmux capture-pane Usage, Problem Statement, Success Criteria
+Nodes (8): Acceptance Criteria, Approach, Difficulty, Goal, Out of Scope, PAN-655: PRD Pipeline Test Marker, Risks, Scope
 
 ### Community 816 - "Community 816"
 Cohesion: 0.22
-Nodes (8): Current Status, Decisions, PAN-408: Wire vBRIEF Acceptance Criteria into Specialist Pipeline, Part 1: Wire AC into Specialist Pipeline, Part 2: Documentation Alignment, Remaining Work, Specialist Feedback, What Was Done
+Nodes (8): Approach, Decision, Difficulty, Files Modified, PAN-494: pan start fails if workspace doesn't exist, Problem, Root Cause, Scope
 
 ### Community 817 - "Community 817"
 Cohesion: 0.22
-Nodes (8): Not In Scope Here, PAN-632 Implementation Plan, Principles, Slice 1: Foundation, Slice 2: Review Artifact Creation, Slice 3: Readiness and Verification, Slice 4: Merge Orchestration, Slice 5: Recovery and Validation
+Nodes (9): Cache invalidation, code:typescript (import { renderPrompt } from './prompts.js';), code:typescript (export function renderPrompt(options: RenderPromptOptions): ), code:block3 (Prompt "work" (.../prompts/work.md) requires variables that ), Error handling, Prompts directory resolution, Signature, The `renderPrompt` API (+1 more)
 
 ### Community 818 - "Community 818"
 Cohesion: 0.22
-Nodes (8): Acceptance summary, Approach (chosen), Changes, Files touched, Out of scope, PAN-699 — Conversation view renders tool calls out of terminal order, Problem, Testing
+Nodes (9): 1. Start Broad, Then Narrow, 2. Follow the Imports, 3. Read Tests to Understand Usage, 4. Look for README and Docs, 5. Use Multiple Techniques, Best Practices, code:typescript (Read file_path="src/index.ts"  // See what it imports), code:bash (Glob pattern="**/*.test.ts") (+1 more)
 
 ### Community 819 - "Community 819"
 Cohesion: 0.22
-Nodes (8): Approach, code:block1 (vitest --run --no-file-parallelism && cd src/dashboard/front), code:block2 (vitest --run --no-file-parallelism), Convention, Decision, PAN-645: Tests: root Vitest config does not discover ActionsSection.test.tsx, Problem, Scope
+Nodes (9): code:bash (Grep pattern="try.*catch|\.catch\(" output_mode="content" -A), code:bash (Grep pattern="process\.env\." output_mode="content" -A 0), code:bash (Grep pattern="@Entity|CREATE TABLE" output_mode="files_with_), code:bash (Glob pattern="**/*.test.ts"), Common Questions, "How are tests structured?", "How is error handling done?", "What database tables exist?" (+1 more)
 
 ### Community 820 - "Community 820"
 Cohesion: 0.22
-Nodes (8): Acceptance Criteria, Approach, Difficulty, Goal, Out of Scope, PAN-655: PRD Pipeline Test Marker, Risks, Scope
+Nodes (8): Blocking Issues, code:bash (bd list               # See all tasks), code:bash (bd dep tree <id>        # See what's blocking this issue), code:bash (# Close multiple beads atomically), code:bash (bd create --title "Implement feature X" --parent <parent-id>), code:bash (# Make issue-A blocked by issue-B (A cannot start until B is), Creating Sub-Tasks, Task Tracking (Beads)
 
 ### Community 821 - "Community 821"
 Cohesion: 0.22
-Nodes (8): Approach, Decision, Difficulty, Files Modified, PAN-494: pan start fails if workspace doesn't exist, Problem, Root Cause, Scope
+Nodes (8): Algorithm Complexity, Blocking Operations (CRITICAL for Node.js), code:typescript (// Replace execSync with async version), Concurrency, Database/API Patterns, Memory & Resources, Output Format, Performance Review
 
 ### Community 822 - "Community 822"
 Cohesion: 0.22
-Nodes (9): Cache invalidation, code:typescript (import { renderPrompt } from './prompts.js';), code:typescript (export function renderPrompt(options: RenderPromptOptions): ), code:block3 (Prompt "work" (.../prompts/work.md) requires variables that ), Error handling, Prompts directory resolution, Signature, The `renderPrompt` API (+1 more)
+Nodes (9): Agent Logs, Capture Full Session, code:bash (# Watch agent in real-time (Ctrl+b d to detach)), code:bash (# Capture entire scrollback buffer), code:bash (# Search for errors), code:bash (# Capture all agents), Live Output, Multiple Agents (+1 more)
 
 ### Community 823 - "Community 823"
 Cohesion: 0.22
-Nodes (9): code:bash (Grep pattern="try.*catch|\.catch\(" output_mode="content" -A), code:bash (Grep pattern="process\.env\." output_mode="content" -A 0), code:bash (Grep pattern="@Entity|CREATE TABLE" output_mode="files_with_), code:bash (Glob pattern="**/*.test.ts"), Common Questions, "How are tests structured?", "How is error handling done?", "What database tables exist?" (+1 more)
+Nodes (9): code:markdown (## Database Conventions), code:markdown (## Build Commands), code:markdown (## Architecture: CQRS Pattern), code:markdown (## Testing Philosophy), Example 1: Database Schema, Example 2: Build System, Example 3: Architecture Pattern, Example 4: Testing Approach (+1 more)
 
 ### Community 824 - "Community 824"
 Cohesion: 0.22
-Nodes (9): 1. Start Broad, Then Narrow, 2. Follow the Imports, 3. Read Tests to Understand Usage, 4. Look for README and Docs, 5. Use Multiple Techniques, Best Practices, code:typescript (Read file_path="src/index.ts"  // See what it imports), code:bash (Glob pattern="**/*.test.ts") (+1 more)
+Nodes (8): code:bash (rm -rf .claude/skills/knowledge-capture/), code:yaml (---), File Locations, For New/Legacy Codebases, Integration with Other Skills, Knowledge Capture, Override Skill Format, User Commands (Escalating Silence)
 
 ### Community 825 - "Community 825"
 Cohesion: 0.22
-Nodes (8): Blocking Issues, code:bash (bd list               # See all tasks), code:bash (bd dep tree <id>        # See what's blocking this issue), code:bash (# Close multiple beads atomically), code:bash (bd create --title "Implement feature X" --parent <parent-id>), code:bash (# Make issue-A blocked by issue-B (A cannot start until B is), Creating Sub-Tasks, Task Tracking (Beads)
+Nodes (8): code:bash (pan unarchive-conversation <query>), code:bash (pan unarchive-conversation "Models, Models, Models"), Notes, See Also, unarchive-conversation, Usage, What It Does, When to Use
 
 ### Community 826 - "Community 826"
 Cohesion: 0.22
-Nodes (8): Algorithm Complexity, Blocking Operations (CRITICAL for Node.js), code:typescript (// Replace execSync with async version), Concurrency, Database/API Patterns, Memory & Resources, Output Format, Performance Review
+Nodes (9): code:bash (# Don't use --no-daemon for CRUD operations), code:bash (bd --no-daemon update issue-1 --status in_progress), code:bash (bd --no-daemon update issue-1 --status in_progress), code:bash (bd --no-daemon update issue-1 --status in_progress), Resolution, Root Cause, Status Updates Not Visible, Symptom (+1 more)
 
 ### Community 827 - "Community 827"
 Cohesion: 0.22
-Nodes (9): Agent Logs, Capture Full Session, code:bash (# Watch agent in real-time (Ctrl+b d to detach)), code:bash (# Capture entire scrollback buffer), code:bash (# Search for errors), code:bash (# Capture all agents), Live Output, Multiple Agents (+1 more)
+Nodes (9): Basic Spawn (Creates Wisp by Default), code:bash (bd mol spawn mol-patrol                    # Creates wisp (e), code:bash (bd mol pour mol-feature                    # Shortcut for sp), code:bash (bd mol run mol-release --var version=2.0), code:bash (bd mol spawn mol-feature --attach mol-testing --var name=aut), code:bash (bd mol spawn mol-deploy --attach mol-rollback --attach-type ), Spawn with Attachments, Spawn with Immediate Execution (+1 more)
 
 ### Community 828 - "Community 828"
 Cohesion: 0.22
-Nodes (8): code:bash (rm -rf .claude/skills/knowledge-capture/), code:yaml (---), File Locations, For New/Legacy Codebases, Integration with Other Skills, Knowledge Capture, Override Skill Format, User Commands (Escalating Silence)
+Nodes (9): code:bash (# Create proto), code:bash (# Patrol proto exists), code:bash (bd mol spawn mol-deploy --attach mol-rollback --attach-type ), code:bash (# After completing a good workflow organically), Common Patterns, Pattern: Capture Tribal Knowledge, Pattern: Ephemeral Patrol Cycle, Pattern: Feature with Rollback (+1 more)
 
 ### Community 829 - "Community 829"
 Cohesion: 0.22
-Nodes (9): code:markdown (## Database Conventions), code:markdown (## Build Commands), code:markdown (## Architecture: CQRS Pattern), code:markdown (## Testing Philosophy), Example 1: Database Schema, Example 2: Build System, Example 3: Architecture Pattern, Example 4: Testing Approach (+1 more)
+Nodes (9): Advanced Patterns, code:block36 (setup), code:block37 (core-feature (ready immediately)), code:block38 (research-main), code:block39 (auth-epic), Pattern: Diamond Dependencies, Pattern: Discovery Cascade, Pattern: Epic with Phases (+1 more)
 
 ### Community 830 - "Community 830"
 Cohesion: 0.22
-Nodes (8): code:bash (pan unarchive-conversation <query>), code:bash (pan unarchive-conversation "Models, Models, Models"), Notes, See Also, unarchive-conversation, Usage, What It Does, When to Use
+Nodes (8): Agent Beads, Bead Types, CLI Reference, code:block1 (idle → spawning → running/working → done → idle), Monitoring Integration, Slot Architecture, State Machine, When to Use Agent Beads
 
 ### Community 831 - "Community 831"
 Cohesion: 0.22
-Nodes (9): code:bash (# Don't use --no-daemon for CRUD operations), code:bash (bd --no-daemon update issue-1 --status in_progress), code:bash (bd --no-daemon update issue-1 --status in_progress), code:bash (bd --no-daemon update issue-1 --status in_progress), Resolution, Root Cause, Status Updates Not Visible, Symptom (+1 more)
+Nodes (9): Close/Reopen Issues, code:bash (# Basic creation), code:bash (# Update one or more issues), code:bash (# Complete work (supports multiple IDs)), code:bash (# Show dependency tree), Create Issues, Issue Management, Update Issues (+1 more)
 
 ### Community 832 - "Community 832"
 Cohesion: 0.22
-Nodes (9): code:bash (# Create proto), code:bash (# Patrol proto exists), code:bash (bd mol spawn mol-deploy --attach mol-rollback --attach-type ), code:bash (# After completing a good workflow organically), Common Patterns, Pattern: Capture Tribal Knowledge, Pattern: Ephemeral Patrol Cycle, Pattern: Feature with Rollback (+1 more)
+Nodes (9): Advanced Operations, Cleanup, code:bash (# Clean up closed issues (bulk deletion)), code:bash (# Find and merge duplicate issues), code:bash (# Agent-driven compaction), code:bash (# Rename issue prefix (e.g., from 'knowledge-work-' to 'kw-'), Compaction (Memory Decay), Duplicate Detection & Merging (+1 more)
 
 ### Community 833 - "Community 833"
 Cohesion: 0.22
-Nodes (9): Basic Spawn (Creates Wisp by Default), code:bash (bd mol spawn mol-patrol                    # Creates wisp (e), code:bash (bd mol pour mol-feature                    # Shortcut for sp), code:bash (bd mol run mol-release --var version=2.0), code:bash (bd mol spawn mol-feature --attach mol-testing --var name=aut), code:bash (bd mol spawn mol-deploy --attach mol-rollback --attach-type ), Spawn with Attachments, Spawn with Immediate Execution (+1 more)
+Nodes (9): Batch Operations, Claim and Complete Work, code:bash (# 1. Find available work), code:bash (# While working on bd-100, discover a bug), code:bash (# Update multiple issues at once), code:bash (# Start of session), Common Patterns for AI Agents, Discover and Link Work (+1 more)
 
 ### Community 834 - "Community 834"
 Cohesion: 0.22
-Nodes (9): Advanced Patterns, code:block36 (setup), code:block37 (core-feature (ready immediately)), code:block38 (research-main), code:block39 (auth-epic), Pattern: Diamond Dependencies, Pattern: Discovery Cascade, Pattern: Epic with Phases (+1 more)
+Nodes (9): code:bash (# Explicitly enable sandbox mode), code:bash (# Skip staleness check (emergency escape hatch)), code:bash (# Force metadata update even when DB appears synced), code:bash (# JSON output for programmatic use), Force Import, Global Flags, Other Global Flags, Sandbox Mode (+1 more)
 
 ### Community 835 - "Community 835"
 Cohesion: 0.22
-Nodes (8): Agent Beads, Bead Types, CLI Reference, code:block1 (idle → spawning → running/working → done → idle), Monitoring Integration, Slot Architecture, State Machine, When to Use Agent Beads
+Nodes (9): code:bash (# Import issues from JSONL), code:bash (# Migrate databases after version upgrade), code:bash (# List all running daemons), code:bash (# Commit pending local Dolt changes), Daemon Management, Database Management, Import/Export, Migration (+1 more)
 
 ### Community 836 - "Community 836"
 Cohesion: 0.22
-Nodes (9): Advanced Operations, Cleanup, code:bash (# Clean up closed issues (bulk deletion)), code:bash (# Find and merge duplicate issues), code:bash (# Agent-driven compaction), code:bash (# Rename issue prefix (e.g., from 'knowledge-work-' to 'kw-'), Compaction (Memory Decay), Duplicate Detection & Merging (+1 more)
+Nodes (9): Checklist Templates, code:block30 (- [ ] Check for .beads/ directory), code:block31 (- [ ] Notice new work needed), code:block32 (- [ ] Implementation done), code:block33 (- [ ] Create epic for overall goal), Completing Work, Creating Issues During Work, Planning Complex Features (+1 more)
 
 ### Community 837 - "Community 837"
 Cohesion: 0.22
-Nodes (9): code:bash (# Explicitly enable sandbox mode), code:bash (# Skip staleness check (emergency escape hatch)), code:bash (# Force metadata update even when DB appears synced), code:bash (# JSON output for programmatic use), Force Import, Global Flags, Other Global Flags, Sandbox Mode (+1 more)
+Nodes (9): code:block26 (1. Create research issue with question to answer), code:block27 (1. Create bug issue), code:block28 (1. Create issues for each refactoring step), code:block29 (1. Create spike issue: "Investigate caching options"), Common Workflow Patterns, Pattern: Bug Investigation, Pattern: Refactoring with Dependencies, Pattern: Spike Investigation (+1 more)
 
 ### Community 838 - "Community 838"
 Cohesion: 0.22
-Nodes (9): code:bash (# Import issues from JSONL), code:bash (# Migrate databases after version upgrade), code:bash (# List all running daemons), code:bash (# Commit pending local Dolt changes), Daemon Management, Database Management, Import/Export, Migration (+1 more)
+Nodes (9): Agent session not starting, code:bash (# Start Docker daemon), code:bash (# Find what's using the port), code:bash (# Verify API key is set), code:bash (# Check tmux is installed), Common First-Time Issues, Docker not running, Issue tracker not configured (+1 more)
 
 ### Community 839 - "Community 839"
 Cohesion: 0.22
-Nodes (9): Close/Reopen Issues, code:bash (# Basic creation), code:bash (# Update one or more issues), code:bash (# Complete work (supports multiple IDs)), code:bash (# Show dependency tree), Create Issues, Issue Management, Update Issues (+1 more)
+Nodes (9): code:bash (# See issues from your tracker), code:bash (# Replace PAN-3 with your issue ID), code:bash (# Check agent status), code:bash (# Send message to agent), Create Workspace and Spawn Agent, Interact with Agent, List Available Issues, Monitor Agent Progress (+1 more)
 
 ### Community 840 - "Community 840"
 Cohesion: 0.22
-Nodes (9): Batch Operations, Claim and Complete Work, code:bash (# 1. Find available work), code:bash (# While working on bd-100, discover a bug), code:bash (# Update multiple issues at once), code:bash (# Start of session), Common Patterns for AI Agents, Discover and Link Work (+1 more)
+Nodes (8): code:bash (npx add-skill google-labs-code/stitch-skills --skill react:c), code:text (Convert my Landing Page screen in my Podcast Stitch Project ), code:text (skills/react-components/), Example Prompt, How it Works, Install, Skill Structure, Stitch to React Components Skill
 
 ### Community 841 - "Community 841"
 Cohesion: 0.22
-Nodes (9): code:block26 (1. Create research issue with question to answer), code:block27 (1. Create bug issue), code:block28 (1. Create issues for each refactoring step), code:block29 (1. Create spike issue: "Investigate caching options"), Common Workflow Patterns, Pattern: Bug Investigation, Pattern: Refactoring with Dependencies, Pattern: Spike Investigation (+1 more)
+Nodes (8): Close-Out Configuration, code:bash (pan close <issue-id>), code:bash (pan close <issue-id> --json), code:yaml (close_out:), pan close, See Also, What It Does, When to Use
 
 ### Community 842 - "Community 842"
 Cohesion: 0.22
-Nodes (9): Checklist Templates, code:block30 (- [ ] Check for .beads/ directory), code:block31 (- [ ] Notice new work needed), code:block32 (- [ ] Implementation done), code:block33 (- [ ] Create epic for overall goal), Completing Work, Creating Issues During Work, Planning Complex Features (+1 more)
+Nodes (9): Agent crashed, Agent is stuck, Agent Issues, Agent won't start, code:bash (# Check if session exists), code:bash (# List all), code:bash (# Check tmux is available), code:bash (# Check what it's doing) (+1 more)
 
 ### Community 843 - "Community 843"
 Cohesion: 0.22
-Nodes (9): Agent session not starting, code:bash (# Start Docker daemon), code:bash (# Find what's using the port), code:bash (# Verify API key is set), code:bash (# Check tmux is installed), Common First-Time Issues, Docker not running, Issue tracker not configured (+1 more)
+Nodes (9): code:bash (# Check config file exists), code:bash (# Test the key), code:bash (# Test the token), code:bash (# Fix permissions (should be readable only by owner)), Config file permissions, Configuration Issues, "GitHub token invalid", "Invalid Linear API key" (+1 more)
 
 ### Community 844 - "Community 844"
 Cohesion: 0.22
-Nodes (9): code:bash (# See issues from your tracker), code:bash (# Replace PAN-3 with your issue ID), code:bash (# Check agent status), code:bash (# Send message to agent), Create Workspace and Spawn Agent, Interact with Agent, List Available Issues, Monitor Agent Progress (+1 more)
+Nodes (9): code:bash (# Check port availability), code:bash (# Check API is running), code:bash (# Restart the API server), code:bash (# Check server logs), "CORS error" in browser, Dashboard Issues, Dashboard shows stale data, Dashboard won't start (+1 more)
 
 ### Community 845 - "Community 845"
 Cohesion: 0.22
-Nodes (8): code:bash (npx add-skill google-labs-code/stitch-skills --skill react:c), code:text (Convert my Landing Page screen in my Podcast Stitch Project ), code:text (skills/react-components/), Example Prompt, How it Works, Install, Skill Structure, Stitch to React Components Skill
+Nodes (8): code:bash (npx add-skill google-labs-code/stitch-skills --skill design-), code:text (Analyze my Furniture Collection project's Home screen and ge), code:text (design-md/), Example Prompt, How it Works, Install, Skill Structure, Stitch Design System Documentation Skill
 
 ### Community 846 - "Community 846"
 Cohesion: 0.22
-Nodes (8): Close-Out Configuration, code:bash (pan close <issue-id>), code:bash (pan close <issue-id> --json), code:yaml (close_out:), pan close, See Also, What It Does, When to Use
+Nodes (8): code:bash (cd /home/eltmon/projects/panopticon/src/dashboard/frontend &), code:bash (pkill -f "node.*dashboard" 2>/dev/null || true), code:bash (cd /home/eltmon/projects/panopticon/src/dashboard && npm run), code:bash (sleep 6), Notes, Pan Dashboard Restart, Steps, Triggers
 
 ### Community 847 - "Community 847"
 Cohesion: 0.22
-Nodes (9): Agent crashed, Agent is stuck, Agent Issues, Agent won't start, code:bash (# Check if session exists), code:bash (# List all), code:bash (# Check tmux is available), code:bash (# Check what it's doing) (+1 more)
+Nodes (9): code:bash (RALLY_API_KEY=_xxxxx), code:yaml (# ~/.panopticon/projects.yaml), code:yaml (issue_prefixes: [F, US, DE, TA, TC]), code:yaml (projects:), Configuration, Rally ID Formats, Rally Integration, Setup (+1 more)
 
 ### Community 848 - "Community 848"
 Cohesion: 0.22
-Nodes (9): code:bash (# Check config file exists), code:bash (# Test the key), code:bash (# Test the token), code:bash (# Fix permissions (should be readable only by owner)), Config file permissions, Configuration Issues, "GitHub token invalid", "Invalid Linear API key" (+1 more)
+Nodes (9): "Certificate not trusted" warnings, code:bash (mkcert -install), code:bash (docker network inspect panopticon), code:bash (docker inspect <container> | grep -A 20 Labels), code:bash (# Find what's using the ports), Port conflicts, Troubleshooting, Workspace containers not routable (+1 more)
 
 ### Community 849 - "Community 849"
-Cohesion: 0.22
-Nodes (9): code:bash (# Check port availability), code:bash (# Check API is running), code:bash (# Restart the API server), code:bash (# Check server logs), "CORS error" in browser, Dashboard Issues, Dashboard shows stale data, Dashboard won't start (+1 more)
-
-### Community 850 - "Community 850"
-Cohesion: 0.22
-Nodes (8): code:bash (npx add-skill google-labs-code/stitch-skills --skill design-), code:text (Analyze my Furniture Collection project's Home screen and ge), code:text (design-md/), Example Prompt, How it Works, Install, Skill Structure, Stitch Design System Documentation Skill
-
-### Community 851 - "Community 851"
-Cohesion: 0.22
-Nodes (8): code:bash (cd /home/eltmon/projects/panopticon/src/dashboard/frontend &), code:bash (pkill -f "node.*dashboard" 2>/dev/null || true), code:bash (cd /home/eltmon/projects/panopticon/src/dashboard && npm run), code:bash (sleep 6), Notes, Pan Dashboard Restart, Steps, Triggers
-
-### Community 852 - "Community 852"
-Cohesion: 0.22
-Nodes (9): code:bash (RALLY_API_KEY=_xxxxx), code:yaml (# ~/.panopticon/projects.yaml), code:yaml (issue_prefixes: [F, US, DE, TA, TC]), code:yaml (projects:), Configuration, Rally ID Formats, Rally Integration, Setup (+1 more)
-
-### Community 853 - "Community 853"
-Cohesion: 0.39
-Nodes (6): getAllActiveQueues(), MergeTriggerHandler, resumeQueuedMerges(), setMergeQueueTriggerHandler(), { getAllActiveQueuesMock }, triggerHandler
-
-### Community 854 - "Community 854"
-Cohesion: 0.32
-Nodes (7): BASE_TIME, loadAgents(), loadDeaconWithResumeMock(), saveStoppedAgent(), state, updated, workspaceFor()
-
-### Community 855 - "Community 855"
 Cohesion: 0.25
 Nodes (7): composeCall, globalSettings, hookPath, { mockExecAsync }, result, validHookPath, workspaceSettings
 
-### Community 856 - "Community 856"
+### Community 850 - "Community 850"
 Cohesion: 0.25
 Nodes (5): devroot, mockGetDevrootPath, result, skillsDir, userSkillDir
 
-### Community 857 - "Community 857"
+### Community 851 - "Community 851"
 Cohesion: 0.25
 Nodes (7): capturedArgs, capturedCmds, closedBeads, mockExecFileFn, mockExecFn, mockGetVBriefACStatus, mockSyncBeadStatusToVBrief
 
-### Community 858 - "Community 858"
+### Community 852 - "Community 852"
 Cohesion: 0.32
 Nodes (7): bin(), main(), repoRoot, run(), source, target, venvDir
 
-### Community 859 - "Community 859"
-Cohesion: 0.25
-Nodes (4): consoleErrors, flywheelStatus, MockWebSocket, statusPane
+### Community 853 - "Community 853"
+Cohesion: 0.32
+Nodes (7): BASE_TIME, loadAgents(), loadDeaconWithResumeMock(), saveStoppedAgent(), state, updated, workspaceFor()
 
-### Community 860 - "Community 860"
+### Community 854 - "Community 854"
 Cohesion: 0.25
-Nodes (7): RuntimeName, AUTH_MODES, cells, decision, HARNESSES, MODEL_BY_PROVIDER, PROVIDERS
+Nodes (6): closeResult, command, ctx, editCalls, labelResult, prResult
 
-### Community 861 - "Community 861"
+### Community 855 - "Community 855"
 Cohesion: 0.25
 Nodes (7): baseSettings, exp, method, section, sections, settingsBtn, toggle
 
-### Community 862 - "Community 862"
-Cohesion: 0.32
-Nodes (5): EDITOR_LABELS, PanOpenInPickerProps, PanRpcProtocolClient, getPreferredEditor(), setPreferredEditor()
-
-### Community 863 - "Community 863"
-Cohesion: 0.29
-Nodes (6): Props, ScanButton(), ScanProgress, ScanResult, lastResult, onScan
-
-### Community 864 - "Community 864"
+### Community 856 - "Community 856"
 Cohesion: 0.25
 Nodes (8): Activity Log, code:block17 (Agent runs `pan done` (Bash command)), Full Review Flow, Human Intervention, Key API Endpoints, Review Cycle Circuit Breaker, verificationStatus semantics, What Happens at the Limit
 
-### Community 865 - "Community 865"
+### Community 857 - "Community 857"
 Cohesion: 0.25
 Nodes (7): code:bash (pan workspace rebuild <issue-id>), Compose contract, Health surfaces, Recovery commands, Single-deacon invariant, Spawn gate and break-glass, Workspace Containers
 
-### Community 866 - "Community 866"
+### Community 858 - "Community 858"
 Cohesion: 0.25
 Nodes (7): code:block24 (Worker Agent completes work), Getting Help, Panopticon Usage Guide, Specialist Types, Specialist Workflow, Specialists, Table of Contents
 
-### Community 867 - "Community 867"
-Cohesion: 0.25
-Nodes (8): CLI Distribution Strategy, code:bash (# First time - zero install), code:bash (# pan init adds to ~/.bashrc or ~/.zshrc:), code:bash (npm install -g panopticon), code:bash (brew install panopticon      # macOS), Future: Homebrew/apt (v2), Primary: npx + Auto-Aliasing, Secondary: Global npm Install
-
-### Community 868 - "Community 868"
+### Community 859 - "Community 859"
 Cohesion: 0.25
 Nodes (8): Appendix B: Comparisons (FAQ), Can Panopticon and Gastown work together?, Can Panopticon and Vibe Kanban work together?, code:block140 (┌─────────────┐     ┌─────────────┐     ┌─────────────┐), How does Panopticon compare to Gastown?, How does Panopticon compare to Vibe Kanban?, Should I use Panopticon, Gastown, or Vibe Kanban?, Why build Panopticon when these tools exist?
 
-### Community 869 - "Community 869"
+### Community 860 - "Community 860"
+Cohesion: 0.25
+Nodes (8): CLI Distribution Strategy, code:bash (# First time - zero install), code:bash (# pan init adds to ~/.bashrc or ~/.zshrc:), code:bash (npm install -g panopticon), code:bash (brew install panopticon      # macOS), Future: Homebrew/apt (v2), Primary: npx + Auto-Aliasing, Secondary: Global npm Install
+
+### Community 861 - "Community 861"
 Cohesion: 0.25
 Nodes (8): 2. Panopticon's Current Distribution (Broken), code:block5 (TIER 1: REPO SOURCE), code:typescript (if (!existsSync(destPath)) {), Current Inventory, Problem 1: Stale Copies, Problem 2: Known Symlink Bug, Problem 3: Wrong Priority Level, The Three-Tier Flow
 
-### Community 870 - "Community 870"
+### Community 862 - "Community 862"
 Cohesion: 0.25
 Nodes (8): 3.1 Agent Spawning, 3.2 Agent Monitoring, 3.3 Agent Lifecycle Events, code:bash (pan agent start MIN-667 --remote), code:bash (# SSH to workspace VM and start agent in tmux), code:bash (# Get agent output), code:typescript (// Agent events forwarded to dashboard via SSH polling or We), Phase 3: Remote Agent Execution
 
-### Community 871 - "Community 871"
+### Community 863 - "Community 863"
 Cohesion: 0.25
 Nodes (8): Agent Detail View, Agents Page Layout, Cloister Control Bar, code:block35 (┌───────────────────────────────────────────────────────────), code:block36 (┌───────────────────────────────────────────────────────────), code:block37 (┌───────────────────────────────────────────────────────────), code:block38 (┌───────────────────────────────────────────────────────────), Dashboard UI
 
-### Community 872 - "Community 872"
+### Community 864 - "Community 864"
 Cohesion: 0.25
 Nodes (8): Risk 1: Retros produce too much noise (every issue triggers a "proposal"), Risk 2: Retro-agent cost escalates, Risk 3: The skill-change pipeline introduces new failure modes, Risk 4: Autonomous daemon runs during user's active work and causes unwanted side effects, Risk 5: Q&A detection false positives (agent gets marked `waiting-on-human` when it's actually stuck), Risk 6: Proposed skill changes by the retro-agent are low-quality or hallucinated, Risk 7: Existing skills break when we add the audience field, Risks and mitigations
 
-### Community 873 - "Community 873"
+### Community 865 - "Community 865"
 Cohesion: 0.25
 Nodes (8): 9.1 Header, 9.2 Tabs, 9.3 Terminal Tab, 9.4 Info Tab, 9.5 Actions Footer, 9. Agent Detail Panel (Slide-out), code:block8 (agent-pan-505                                [X]), code:block9 (+---------------+---------------+)
 
-### Community 874 - "Community 874"
-Cohesion: 0.25
-Nodes (8): code:block18 (┌───────────────────────────────────────────────────────────), Conversation viewer reuse (PAN-451 dependency), Dashboard: Archived Conversations Page, Page layout, Real-time updates, Route + navigation, Row badges (`source` field), Settings panel additions — "Conversations & Search"
-
-### Community 875 - "Community 875"
-Cohesion: 0.25
-Nodes (8): code:bash (pan conversations scan <dir> [<dir>...]   # Targeted directo), code:typescript (interface SystemCapabilities {), code:block8 (Scanning ~/.claude/projects/...), Discovery Subsystem, MUST NOT delete or modify JSONL files, Performance-adaptive parallelism (system scan), Scripted extraction (zero LLM), Three discovery modes
-
-### Community 876 - "Community 876"
+### Community 866 - "Community 866"
 Cohesion: 0.25
 Nodes (8): Acceptance Criteria, CLI parity, Discovery, Embeddings, Enrichment, Page, Search, Settings UI
 
-### Community 877 - "Community 877"
+### Community 867 - "Community 867"
+Cohesion: 0.25
+Nodes (8): code:block18 (┌───────────────────────────────────────────────────────────), Conversation viewer reuse (PAN-451 dependency), Dashboard: Archived Conversations Page, Page layout, Real-time updates, Route + navigation, Row badges (`source` field), Settings panel additions — "Conversations & Search"
+
+### Community 868 - "Community 868"
+Cohesion: 0.25
+Nodes (8): code:bash (pan conversations scan <dir> [<dir>...]   # Targeted directo), code:typescript (interface SystemCapabilities {), code:block8 (Scanning ~/.claude/projects/...), Discovery Subsystem, MUST NOT delete or modify JSONL files, Performance-adaptive parallelism (system scan), Scripted extraction (zero LLM), Three discovery modes
+
+### Community 869 - "Community 869"
 Cohesion: 0.25
 Nodes (8): B.1 Add new fields to `ReviewStatus` interface, B.2 Increment `reviewRetryCount` on each deacon re-dispatch, B.3 Reset recovery window on clean completion and on new commits, B. `src/lib/review-status.ts`, code:typescript (const { dispatchParallelReview } = await import('./review-ag), code:typescript (.then(result => {), code:typescript (setReviewStatus(issueId, {), code:typescript (export interface ReviewStatus {)
 
-### Community 878 - "Community 878"
+### Community 870 - "Community 870"
 Cohesion: 0.25
 Nodes (8): code:block4 (panopticon-cli/), code:block5 (panopticon-cli/), code:json ({), code:json ({), Current Layout, Monorepo Structure, Target Layout, Workspace Configuration
 
-### Community 879 - "Community 879"
+### Community 871 - "Community 871"
 Cohesion: 0.25
 Nodes (8): code:block16 (8 sessions · 1 alive · 7 ended · last activity 2m ago · idle), code:block21 (Select a session in the tree to send a message …), Composer behavior in issue-selected mode, Issue-selected mode, Selection rules, Why have this mode, Zone B in issue-selected mode, Zone C tab strip (NEW)
 
-### Community 880 - "Community 880"
+### Community 872 - "Community 872"
 Cohesion: 0.25
 Nodes (7): code:block1 ([IssueDataService] Rally poll error: Rally API query failed:), Dependencies, Follow-up Work, PAN-166: Rally WSAPI Query Parse Error Fix, Problem Statement, Risk Assessment, Success Criteria
 
-### Community 881 - "Community 881"
+### Community 873 - "Community 873"
 Cohesion: 0.25
 Nodes (7): Acceptance Criteria, Decision, Out of Scope, PAN-448: Start Agent confirmation timeout too short, Problem, Scope, Status: Planning Complete
 
-### Community 882 - "Community 882"
+### Community 874 - "Community 874"
 Cohesion: 0.25
 Nodes (8): Additional Windows 10 Workarounds, code:ini ([wsl2]), code:powershell (wsl --shutdown), code:bash (# Check resources), code:powershell (# 1. Update WSL to latest version), Recommended Configuration, Windows 10 Limitations, WSL2 Stability Issues (Windows Users)
 
-### Community 883 - "Community 883"
+### Community 875 - "Community 875"
 Cohesion: 0.25
 Nodes (8): Can't reach workspace URLs, code:bash (ls ~/.panopticon/traefik/certs/), code:bash (cd ~/.panopticon/traefik/certs), code:bash (mkcert -install), code:bash (docker ps | grep traefik), code:bash (ping feature-min-123.localhost), HTTPS not working, Network Issues
 
-### Community 884 - "Community 884"
+### Community 876 - "Community 876"
 Cohesion: 0.25
 Nodes (8): Bootstrap templates, Deleted (replaced by the loader), Legacy (ad-hoc) templates, Legacy templates, Planning agent templates, Specialist agent templates, Template catalogue, Work agent templates
 
-### Community 885 - "Community 885"
+### Community 877 - "Community 877"
 Cohesion: 0.25
 Nodes (8): Architecture Map, code:markdown (# Codebase Architecture), code:block12, code:markdown (# Feature: User Authentication), code:markdown (# Dependencies), Dependency Report, Feature Location Report, Output Formats
 
-### Community 886 - "Community 886"
+### Community 878 - "Community 878"
 Cohesion: 0.25
 Nodes (7): code:bash (# View agent output), Log Levels, Overview, Quick Commands, Related Skills, View Logs, When to Use
 
-### Community 887 - "Community 887"
+### Community 879 - "Community 879"
 Cohesion: 0.25
 Nodes (8): Available Categories, code:bash (# AI will add this section if it doesn't exist), code:bash (# Edit directly), code:bash (# Remove the AI Suggestion Preferences section), code:markdown (## AI Suggestion Preferences), Updating Preferences, User Preferences in ~/.claude/CLAUDE.md, Why Skip Categories?
 
-### Community 888 - "Community 888"
+### Community 880 - "Community 880"
 Cohesion: 0.25
 Nodes (7): code:bash (pan pause <issue-id>), code:bash (pan pause PAN-123), pan pause, See Also, Usage, What It Does, When to Use
 
-### Community 889 - "Community 889"
+### Community 881 - "Community 881"
 Cohesion: 0.25
 Nodes (8): Bond Types, Bonding Molecules, code:bash (# Found bug during wisp patrol? Persist it:), code:bash (bd mol bond mol-feature mol-deploy --as "Feature with Deploy), code:bash (bd mol bond A B                    # Sequential: B runs afte), Custom Compound Names, Operand Combinations, Phase Control in Bonds
 
-### Community 890 - "Community 890"
+### Community 882 - "Community 882"
 Cohesion: 0.25
 Nodes (7): code:bash (pan untroubled <issue-id>), code:bash (pan untroubled PAN-123), pan untroubled, See Also, Usage, What It Does, When to Use
 
-### Community 891 - "Community 891"
+### Community 883 - "Community 883"
 Cohesion: 0.25
 Nodes (7): 1. Audit Current State, 2. Update Strategy, 3. For Each Update, 4. Verify, code:bash (npm outdated          # See what's outdated), code:bash (npm install package@version), Dependency Update
 
-### Community 892 - "Community 892"
+### Community 884 - "Community 884"
 Cohesion: 0.25
 Nodes (7): code:bash (pan unpause <issue-id>), code:bash (pan unpause PAN-123), pan unpause, See Also, Usage, What It Does, When to Use
 
-### Community 893 - "Community 893"
+### Community 885 - "Community 885"
 Cohesion: 0.25
 Nodes (7): Add Repos to Workspace, After adding repos, code:bash (pan workspace add-repo <workspace-id> <repo-name> [repo-name), code:bash (# Add specific repos), How to decide which repos you need, Notes, Usage
 
-### Community 894 - "Community 894"
+### Community 886 - "Community 886"
 Cohesion: 0.25
 Nodes (7): code:bash (pan VERB <args>), code:block2 (pan VERB <id>           # Primary usage), pan VERB, See Also, Usage, What It Does, When to Use
 
-### Community 895 - "Community 895"
+### Community 887 - "Community 887"
 Cohesion: 0.25
 Nodes (7): code:bash (pan admin config <subcommand>), code:block2 (pan admin config shadow --status), pan admin config, See Also, Usage, What It Does, When to Use
 
-### Community 896 - "Community 896"
+### Community 888 - "Community 888"
 Cohesion: 0.25
 Nodes (7): code:bash (pan start <issue-id>), code:block2 (pan start PAN-123          # Spawn agent for issue PAN-123), pan start, See Also, Usage, What It Does, When to Use
 
-### Community 897 - "Community 897"
+### Community 889 - "Community 889"
 Cohesion: 0.25
 Nodes (7): code:bash (pan admin tracker <subcommand>), code:block2 (pan admin tracker linear-states    # List Linear workflow st), pan admin tracker, See Also, Usage, What It Does, When to Use
 
-### Community 898 - "Community 898"
+### Community 890 - "Community 890"
 Cohesion: 0.25
 Nodes (7): 1. Understand Requirements, 2. Design Approach, 3. Implement, 4. Test, 5. Self-Review, 6. Submit, Feature Work
 
-### Community 899 - "Community 899"
+### Community 891 - "Community 891"
 Cohesion: 0.25
 Nodes (7): code:block1 (pan review pending                                 # List co), Merging is NOT here, pan review, See also, Usage, What each subcommand does, When to use each
 
-### Community 900 - "Community 900"
+### Community 892 - "Community 892"
 Cohesion: 0.25
 Nodes (7): code:bash (pan show <issue-id>), code:block2 (pan show PAN-123           # Summary: shadow state + CV + he), pan show, See Also, Usage, What It Does, When to Use
 
-### Community 901 - "Community 901"
+### Community 893 - "Community 893"
 Cohesion: 0.25
 Nodes (7): Available MCP tools, Cost comparison, See also, The workflow, Troubleshooting, Use TLDR for code exploration, When TLDR is NOT a good fit
 
-### Community 902 - "Community 902"
+### Community 894 - "Community 894"
 Cohesion: 0.25
 Nodes (7): code:bash (pan admin tldr <subcommand>), code:block2 (pan admin tldr status              # Show TLDR daemon state), pan admin tldr, See Also, Usage, What It Does, When to Use
 
-### Community 903 - "Community 903"
+### Community 895 - "Community 895"
 Cohesion: 0.25
 Nodes (8): code:bash (# Authenticate with GitHub CLI (recommended)), code:block4 (PAN-45       # GitHub issue #45 on the panopticon-cli projec), code:yaml (projects:), code:bash (# Via CLI), Creating Issues, GitHub Issues, Issue Prefix, Setup
 
-### Community 904 - "Community 904"
+### Community 896 - "Community 896"
 Cohesion: 0.25
 Nodes (8): 4. Surfaces & Depth, code:block7 (Level 0 (Page):     bg-background     — the deepest surface), code:css (shadow-xs/5    — buttons, inputs (barely visible)), code:css (/* Light mode: top edge highlight */), Inner Shadows (Cards), Shadow Scale, Tonal Layering (not shadows), When to Use Shadows
 
-### Community 905 - "Community 905"
+### Community 897 - "Community 897"
 Cohesion: 0.25
 Nodes (7): End of run, Entrypoint, No `model:` pin — Cloister resolves it from config.yaml roles.flywheel., Panopticon Flywheel Role, Status vs State, Substrate bug policy, Tick loop
 
-### Community 906 - "Community 906"
+### Community 898 - "Community 898"
 Cohesion: 0.33
 Nodes (5): createTerminalWindow(), MockWindow, openTerminalWindow(), terminalWindows, win
 
-### Community 907 - "Community 907"
+### Community 899 - "Community 899"
 Cohesion: 0.33
 Nodes (5): execFileAsync, hooksLog, runHook(), runtimeRequests, SCRIPT_PATH
 
-### Community 908 - "Community 908"
+### Community 900 - "Community 900"
 Cohesion: 0.29
 Nodes (5): actual, CLI_PATH, __dirname, expected, FIXTURE_PATH
 
-### Community 909 - "Community 909"
+### Community 901 - "Community 901"
 Cohesion: 0.29
 Nodes (5): actual, __dirname, expected, FIXTURE_PATH, SKILLS_SOURCE_DIR
 
-### Community 910 - "Community 910"
+### Community 902 - "Community 902"
 Cohesion: 0.29
 Nodes (5): CLI_PATH, __dirname, { stdout }, { stdout, status }, { stdout, stderr }
 
-### Community 911 - "Community 911"
+### Community 903 - "Community 903"
 Cohesion: 0.29
 Nodes (5): next, restored, s, start, withAgent
 
-### Community 912 - "Community 912"
+### Community 904 - "Community 904"
+Cohesion: 0.29
+Nodes (5): firstRun, legacyNames, { mockClaudeSkills }, result, secondRun
+
+### Community 905 - "Community 905"
 Cohesion: 0.29
 Nodes (6): alicePos, bobPos, longBody, result, subDir, wsPath
 
-### Community 913 - "Community 913"
+### Community 906 - "Community 906"
 Cohesion: 0.29
 Nodes (4): BIN_DIR, __dirname, NATIVE_MODULES, PACKAGE_ROOT
 
-### Community 914 - "Community 914"
-Cohesion: 0.33
-Nodes (4): resolveServerStaticDir(), registerDesktopProtocol(), resolveStaticPath(), result
-
-### Community 915 - "Community 915"
+### Community 907 - "Community 907"
 Cohesion: 0.29
 Nodes (6): bridge, DesktopSettings, IPC, NotificationEventType, PanopticonBridge, Window
 
-### Community 916 - "Community 916"
-Cohesion: 0.43
-Nodes (6): checkNodeVersion(), checkServerBundle(), __dirname, launch(), packageDir, resolveElectron()
-
-### Community 917 - "Community 917"
+### Community 908 - "Community 908"
 Cohesion: 0.29
-Nodes (5): chalk, mockWatchDirs, p, scanSpy, sessions
+Nodes (6): agentState, mockGetAgentState, mockGetAgentStateAsync, mockGetReviewStatus, mockGetShadowState, mockResumeAgent
 
-### Community 918 - "Community 918"
-Cohesion: 0.29
-Nodes (3): mockFetch, mockGetGitHubConfig, program
+### Community 909 - "Community 909"
+Cohesion: 0.33
+Nodes (4): client, makeQueryClient(), messages, renderPanel()
 
-### Community 919 - "Community 919"
+### Community 910 - "Community 910"
+Cohesion: 0.33
+Nodes (5): DesktopSettings, DesktopSettingsSection(), isDesktopApp(), NOTIFICATION_LABELS, NotificationEventType
+
+### Community 911 - "Community 911"
 Cohesion: 0.38
 Nodes (5): decode, decodeCandidate(), ev, bodyToEvent(), decodeDomainEvent
 
-### Community 920 - "Community 920"
+### Community 912 - "Community 912"
+Cohesion: 0.29
+Nodes (3): mockFetch, mockGetGitHubConfig, program
+
+### Community 913 - "Community 913"
 Cohesion: 0.29
 Nodes (7): Auto-Behaviors, code:block7 (draft (in .pan/drafts/*.md) ──► proposed ──► approved ──► ac), Dashboard Viewer, Legacy paths, Status is a JSON field, not a directory, The four-artifact model (PAN-1124: single-spec-on-main), vBRIEF Plans & Lifecycle
 
-### Community 921 - "Community 921"
+### Community 914 - "Community 914"
 Cohesion: 0.29
 Nodes (7): Auto (non-interactive), Auto-Start (skip planning), code:bash (pan plan <id>), code:bash (pan plan <id> --auto), code:bash (pan start <id> --auto), Interactive (default), Planning Modes
 
-### Community 922 - "Community 922"
-Cohesion: 0.29
-Nodes (7): Branch and PR Workflow, Branch naming, code:block10 (feature/pan-<number>), code:bash (git checkout -b feature/pan-<number>), code:block12 (1. Create feature branch from latest main), PR checklist, The flow
-
-### Community 923 - "Community 923"
+### Community 915 - "Community 915"
 Cohesion: 0.29
 Nodes (7): code:block13 (<type>(<scope>): <short description> (PAN-<number>)), code:block14 (feat(cloister): add preTrustDirectory to initializeSpecialis), Commit Message Convention, Examples, Issue references, Scope (optional but encouraged), Types
 
-### Community 924 - "Community 924"
+### Community 916 - "Community 916"
 Cohesion: 0.29
-Nodes (7): Adding a New Template, Available Templates, code:yaml (---), Frontmatter Contract, Prompt Templates, Template Location, Template Syntax
+Nodes (7): Branch and PR Workflow, Branch naming, code:block10 (feature/pan-<number>), code:bash (git checkout -b feature/pan-<number>), code:block12 (1. Create feature branch from latest main), PR checklist, The flow
 
-### Community 925 - "Community 925"
-Cohesion: 0.29
-Nodes (7): code:bash (# Check if specialist is running), code:toml ([specialists.test_agent]), code:bash (cat ~/.panopticon/specialists/merge-agent/history.jsonl | ta), Merge agent conflict resolution failed, Review agent not dispatching, Test agent not detecting test runner, Troubleshooting
-
-### Community 926 - "Community 926"
-Cohesion: 0.29
-Nodes (7): Agent Workflow, Checkpoint System, CLI Reference, code:bash (# After closing a bead), code:bash (pan inspect <issueId> --bead <beadId>           # Fast inspe), Inspect Specialist (PAN-382), What Inspect Checks
-
-### Community 927 - "Community 927"
-Cohesion: 0.29
-Nodes (7): code:typescript (// Worker agent creates PR using gh CLI), code:bash (# Worker signals done — triggers verification gate → review-), Step 1: Complete Implementation, Step 2: Create Pull Request, Step 3: Signal Completion, Step 4: Specialist Pipeline Takes Over, Worker Agent Integration
-
-### Community 928 - "Community 928"
-Cohesion: 0.29
-Nodes (7): API, CLI, code:block21 (POST /api/issues/:issueId/sync-main), code:bash (pan sync-main PAN-143), Design Decisions, How It Works, Sync with Main (PAN-242)
-
-### Community 929 - "Community 929"
+### Community 917 - "Community 917"
 Cohesion: 0.29
 Nodes (7): code:typescript (interface MergeResult {), code:typescript (interface ReviewResult {), code:typescript (interface TestResult {), Merge Agent Results, Result Monitoring, Review Agent Results, Test Agent Results
 
-### Community 930 - "Community 930"
+### Community 918 - "Community 918"
 Cohesion: 0.29
-Nodes (7): code:markdown (---), code:bash (# Create skill directory), code:block27 (/my-skill), Creating Skills, Skill Structure, Skills, Using Skills
+Nodes (7): code:bash (# Check if specialist is running), code:toml ([specialists.test_agent]), code:bash (cat ~/.panopticon/specialists/merge-agent/history.jsonl | ta), Merge agent conflict resolution failed, Review agent not dispatching, Test agent not detecting test runner, Troubleshooting
 
-### Community 931 - "Community 931"
+### Community 919 - "Community 919"
 Cohesion: 0.29
-Nodes (7): Advanced Topics, code:bash (# Create remote workspace), code:yaml (# ~/.panopticon/work-types.yaml), code:json (// ~/.claude/hooks.json), Custom Work Types, Heartbeat Monitoring, Remote Workspaces
+Nodes (7): Adding a New Template, Available Templates, code:yaml (---), Frontmatter Contract, Prompt Templates, Template Location, Template Syntax
 
-### Community 932 - "Community 932"
+### Community 920 - "Community 920"
 Cohesion: 0.29
-Nodes (7): code:bash (# From Linear issue), code:block22 (~/.panopticon/workspaces/), code:block23 (https://feature-pan-123.localhost:3000     # Frontend), Creating Workspaces, Workspace Structure, Workspace URLs, Workspaces
+Nodes (7): API, CLI, code:block21 (POST /api/issues/:issueId/sync-main), code:bash (pan sync-main PAN-143), Design Decisions, How It Works, Sync with Main (PAN-242)
 
-### Community 933 - "Community 933"
+### Community 921 - "Community 921"
+Cohesion: 0.29
+Nodes (7): Agent Workflow, Checkpoint System, CLI Reference, code:bash (# After closing a bead), code:bash (pan inspect <issueId> --bead <beadId>           # Fast inspe), Inspect Specialist (PAN-382), What Inspect Checks
+
+### Community 922 - "Community 922"
+Cohesion: 0.29
+Nodes (7): code:typescript (// Worker agent creates PR using gh CLI), code:bash (# Worker signals done — triggers verification gate → review-), Step 1: Complete Implementation, Step 2: Create Pull Request, Step 3: Signal Completion, Step 4: Specialist Pipeline Takes Over, Worker Agent Integration
+
+### Community 923 - "Community 923"
 Cohesion: 0.29
 Nodes (7): code:bash (# ~/.panopticon.env), code:yaml (models:), code:bash (chmod 600 ~/.panopticon/config.yaml ~/.panopticon.env), Configuration via Dashboard, Multi-Model Support, Router Configuration, Supported Providers and Models
 
-### Community 934 - "Community 934"
+### Community 924 - "Community 924"
+Cohesion: 0.29
+Nodes (7): code:bash (# From Linear issue), code:block22 (~/.panopticon/workspaces/), code:block23 (https://feature-pan-123.localhost:3000     # Frontend), Creating Workspaces, Workspace Structure, Workspace URLs, Workspaces
+
+### Community 925 - "Community 925"
+Cohesion: 0.29
+Nodes (7): Advanced Topics, code:bash (# Create remote workspace), code:yaml (# ~/.panopticon/work-types.yaml), code:json (// ~/.claude/hooks.json), Custom Work Types, Heartbeat Monitoring, Remote Workspaces
+
+### Community 926 - "Community 926"
+Cohesion: 0.29
+Nodes (7): code:markdown (---), code:bash (# Create skill directory), code:block27 (/my-skill), Creating Skills, Skill Structure, Skills, Using Skills
+
+### Community 927 - "Community 927"
 Cohesion: 0.29
 Nodes (7): About the Name, Core Insight, Executive Summary, Industry Convergence, Key Insights, Opinionated Decisions, Skills over Molecules
 
-### Community 935 - "Community 935"
-Cohesion: 0.29
-Nodes (7): 6.1 Workspace Hibernation, 6.2 Workspace Cleanup, 6.3 Resource Monitoring, code:bash (pan workspace stop MIN-667), code:bash (pan workspace delete MIN-667), code:bash (pan remote resources), Phase 6: Lifecycle Management
-
-### Community 936 - "Community 936"
-Cohesion: 0.29
-Nodes (7): code:bash (# Expose port on VM), code:yaml (# pan-infra:/etc/traefik/docker-compose.yml), code:bash (# Tunnel remote services to local ports), Option A: exe.dev Native HTTPS Proxy, Option B: Traefik on Infra VM, Option C: Local SSH Tunnels (Fallback), Phase 4: URL Routing & Access
-
-### Community 937 - "Community 937"
+### Community 928 - "Community 928"
 Cohesion: 0.29
 Nodes (7): Architecture, code:block1 (┌───────────────────────────────────────────────────────────), code:block2 (Shared infra:     0.5 GB), High-Level Design, Memory Budget (16GB Plan), Per-Workspace VMs, Shared Infrastructure VM
 
-### Community 938 - "Community 938"
+### Community 929 - "Community 929"
+Cohesion: 0.29
+Nodes (7): code:bash (# Expose port on VM), code:yaml (# pan-infra:/etc/traefik/docker-compose.yml), code:bash (# Tunnel remote services to local ports), Option A: exe.dev Native HTTPS Proxy, Option B: Traefik on Infra VM, Option C: Local SSH Tunnels (Fallback), Phase 4: URL Routing & Access
+
+### Community 930 - "Community 930"
+Cohesion: 0.29
+Nodes (7): 6.1 Workspace Hibernation, 6.2 Workspace Cleanup, 6.3 Resource Monitoring, code:bash (pan workspace stop MIN-667), code:bash (pan workspace delete MIN-667), code:bash (pan remote resources), Phase 6: Lifecycle Management
+
+### Community 931 - "Community 931"
 Cohesion: 0.29
 Nodes (6): Agent Directory Structure, Cleanup, code:bash (# Preview orphaned directories), Legacy Directories, Standard Directory Contents, Valid Directory Naming Patterns
 
-### Community 939 - "Community 939"
+### Community 932 - "Community 932"
 Cohesion: 0.29
 Nodes (7): API Keys: `~/.panopticon.env`, code:yaml (models:), code:yaml (models:), code:env (# Anthropic (required)), Configuration Files, Global Configuration: `~/.panopticon/config.yaml`, Per-Project Configuration: `.panopticon.yaml`
 
-### Community 940 - "Community 940"
+### Community 933 - "Community 933"
 Cohesion: 0.29
 Nodes (7): Available Work Types, code:yaml (models:), code:yaml (models:), code:yaml (models:), code:yaml (models:), Override Examples, Per-Work-Type Overrides
 
-### Community 941 - "Community 941"
-Cohesion: 0.29
-Nodes (7): Balanced Preset (Recommended), Budget Preset, code:yaml (models:), code:yaml (models:), code:yaml (models:), Premium Preset, Presets
-
-### Community 942 - "Community 942"
-Cohesion: 0.29
-Nodes (7): Adding New Integrations, Cloudflare Tunnels, code:yaml (workspace:), code:yaml (workspace:), code:yaml (env_file:), External Service Integrations, Hume EVI (Voice AI)
-
-### Community 943 - "Community 943"
+### Community 934 - "Community 934"
 Cohesion: 0.29
 Nodes (7): code:toml (# Each entry controls one parallel reviewer.), code:yaml (models:), Configuration Schema, Default Reviewers, Fields, Parallel Review Agents, Per-Reviewer Model Overrides
 
-### Community 944 - "Community 944"
+### Community 935 - "Community 935"
+Cohesion: 0.29
+Nodes (7): Balanced Preset (Recommended), Budget Preset, code:yaml (models:), code:yaml (models:), code:yaml (models:), Premium Preset, Presets
+
+### Community 936 - "Community 936"
+Cohesion: 0.29
+Nodes (7): Adding New Integrations, Cloudflare Tunnels, code:yaml (workspace:), code:yaml (workspace:), code:yaml (env_file:), External Service Integrations, Hume EVI (Voice AI)
+
+### Community 937 - "Community 937"
 Cohesion: 0.29
 Nodes (7): Agent Management, API Endpoints, Cloister Control, code:typescript (// Get Cloister status), code:typescript (// List all agents (specialists + issue agents)), code:typescript (// Initialize a specialist agent), Specialist Management
 
-### Community 945 - "Community 945"
+### Community 938 - "Community 938"
 Cohesion: 0.29
 Nodes (5): code:block12 (┌─────────────┐     ┌─────────────┐     ┌─────────────┐), code:block14 (┌─────────────┐     ┌─────────────┐     ┌─────────────┐), Handoff Mechanics, Method 1: Kill & Spawn (Issue Agents), Method 2: Specialist Wake (--resume)
 
-### Community 946 - "Community 946"
+### Community 939 - "Community 939"
 Cohesion: 0.29
 Nodes (6): 1. Context Budget Manager (PRD Phase 12.8), 2. Runtime Metrics (PRD Phase 13.6), 3. Multi-Runtime Dashboard (PRD Phase 13), Critical Gaps (Missing Functionality), Panopticon Implementation Gaps, Summary
 
-### Community 947 - "Community 947"
+### Community 940 - "Community 940"
 Cohesion: 0.29
 Nodes (6): AgentList and GodView/AgentGrid deletion notes, Cleanup decision, Deletion gate, Inspector sub-file inventory, InspectorPanel feature inventory, InspectorPanel parity checklist
 
-### Community 948 - "Community 948"
+### Community 941 - "Community 941"
 Cohesion: 0.29
 Nodes (7): 1. Operator skills are already renamed, 2. Skill naming — operator vs. agent split, 3. `pan sync` — two changes, one codebase, 4. Dashboard API routes follow PAN-705 conventions, 5. Audience backfill and skill renaming, 6. Operator-skill description format for any new operator skills PAN-709 adds, Dependencies — aligned with PAN-705 (Command Taxonomy Reorg)
 
-### Community 949 - "Community 949"
+### Community 942 - "Community 942"
 Cohesion: 0.29
 Nodes (7): 3.1 Page Layout, 3.2 Detail Panel (Slide-out), 3.3 Component Tree, 3. Architecture Overview, code:block1 (+-----------------------------------------------------------), code:block2 (+-----------------------------------+ +---------------------), code:block3 (AgentsPage (new, replaces AgentList + GodView agent display))
 
-### Community 950 - "Community 950"
-Cohesion: 0.29
-Nodes (7): 4.1 Color Palette (Obsidian Dark), 4.2 Signal Colors, 4.3 Typography, 4.4 Spacing & Radius, 4.5 Shadows & Elevation, 4.6 Animations, 4. Visual Design System
-
-### Community 951 - "Community 951"
-Cohesion: 0.29
-Nodes (7): 5.1 Live Grid (Default), 5.2 Command Table, 5.3 Timeline, 5.4 Topology, 5. View Modes (Detailed), code:block4 (+----------------------------------+), code:block5 (●  2m ago)
-
-### Community 952 - "Community 952"
+### Community 943 - "Community 943"
 Cohesion: 0.29
 Nodes (7): 11.1 View Switching, 11.2 Agent Selection, 11.3 Filtering, 11.4 Filtering (Global), 11.5 Keyboard Shortcuts, 11.6 Empty States, 11. Interactions & Behaviors
 
-### Community 953 - "Community 953"
+### Community 944 - "Community 944"
+Cohesion: 0.29
+Nodes (7): 5.1 Live Grid (Default), 5.2 Command Table, 5.3 Timeline, 5.4 Topology, 5. View Modes (Detailed), code:block4 (+----------------------------------+), code:block5 (●  2m ago)
+
+### Community 945 - "Community 945"
+Cohesion: 0.29
+Nodes (7): 4.1 Color Palette (Obsidian Dark), 4.2 Signal Colors, 4.3 Typography, 4.4 Spacing & Radius, 4.5 Shadows & Elevation, 4.6 Animations, 4. Visual Design System
+
+### Community 946 - "Community 946"
 Cohesion: 0.29
 Nodes (7): After — Workhorse panel + 5 role cards, Before — 17 agent cards in 4 groups (`AgentCardsPanel.tsx:8-114`), code:block13 (Issue Agent (5 phases: Exploration, Implementation, Testing,), code:block14 (┌─ Workhorse Models ────────────────────────────────────────), code:typescript (const ROLES = [), Implementation, Settings UI Changes
 
-### Community 954 - "Community 954"
+### Community 947 - "Community 947"
 Cohesion: 0.29
 Nodes (7): code:bash (pan conversations search "redis cache invalidation"), code:bash (pan conversations search --semantic "debugging a race condit), code:bash (pan conversations search --workspace ~/Projects/myn), Search, Tier 1: Structured filters (instant, no LLM), Tier 2: Full-text search (FTS5, no LLM), Tier 3: Semantic search (optional, requires embeddings)
 
-### Community 955 - "Community 955"
+### Community 948 - "Community 948"
 Cohesion: 0.29
 Nodes (7): Implementation Plan, Phase 1 — Backend extraction, Phase 2 — Project list & detail pages (no wizard yet), Phase 3 — Wizard UI (without Setup Agent), Phase 4 — Setup Agent integration, Phase 5 — First-run welcome, Phase 6 — Polish
 
-### Community 956 - "Community 956"
+### Community 949 - "Community 949"
 Cohesion: 0.29
 Nodes (7): B.1 Add `reviewRetryCount` to `ReviewStatus` interface, B.2 Increment `reviewRetryCount` on each deacon re-dispatch, B.3 Reset `reviewRetryCount` on successful review completion, B. `src/lib/review-status.ts`, code:typescript (setReviewStatus(opts.issueId, {), code:typescript (export interface ReviewStatus {), code:typescript (setReviewStatus(issueId, {)
 
-### Community 957 - "Community 957"
+### Community 950 - "Community 950"
 Cohesion: 0.29
 Nodes (7): Problem 1: Dead/stuck parallel review sessions are invisible to deacon, Problem 2: No circuit breaker for infrastructure-failure cycling, Problem 3: Verification passed but review blocks the pipeline forever, Problem 4: Incomplete parallel reviews waste completed findings, Problem 5: `stuck` flag is never set, so re-dispatch never stops, Problem 6: No UI indication that recovery is happening, Problems Enumerated
 
-### Community 958 - "Community 958"
+### Community 951 - "Community 951"
 Cohesion: 0.29
 Nodes (7): code:block7 (DockerStatsCollector (5s poll)), code:block8 (DockerStatsCollector.getHistory(containerId) (60 samples)), code:block9 (resource-discovery.ts (30s cache)), Container history path (new, lazy), Container stats path (new), Data flow, Resource detail identifiers path (existing)
 
-### Community 959 - "Community 959"
+### Community 952 - "Community 952"
 Cohesion: 0.29
 Nodes (7): code:typescript ({), code:typescript ({), Commands (mutations), Key Type Definitions, RPC Methods, Streaming (server → client), Unary (request → response)
 
-### Community 960 - "Community 960"
-Cohesion: 0.29
-Nodes (7): code:typescript (interface RoundMarker {), code:block14 (── Round 1 · 14:02 → 14:06 · passed · 8 findings ─────), code:block15 (addressing: specialist-panopticon-540-review-correctness    ), Composer addressing, Session-tab strip (NEW), What changes, Zone C — Conversation + composer (agent-selected)
-
-### Community 961 - "Community 961"
+### Community 953 - "Community 953"
 Cohesion: 0.29
 Nodes (7): From `BadgeBar` modals, From `InspectorPanel` sections, From `IssueCard` (kanban card), From `StatusFlowControl`, From `WorkspacePane`, Parity smoke test, Reunified action layer (parity, additive)
 
-### Community 962 - "Community 962"
+### Community 954 - "Community 954"
+Cohesion: 0.29
+Nodes (7): code:typescript (interface RoundMarker {), code:block14 (── Round 1 · 14:02 → 14:06 · passed · 8 findings ─────), code:block15 (addressing: specialist-panopticon-540-review-correctness    ), Composer addressing, Session-tab strip (NEW), What changes, Zone C — Conversation + composer (agent-selected)
+
+### Community 955 - "Community 955"
 Cohesion: 0.29
 Nodes (7): P1 — Deacon health/stuck detection (structured state), `src/dashboard/lib/health-filtering.ts:13` — `checkAgentHealthAsync()`, `src/lib/cloister/deacon.ts:651` — `checkLazyAgent()`, `src/lib/cloister/deacon.ts:849` — `isAgentActiveInTmux()`, `src/lib/cloister/deacon.ts:935` — `parseThinkingDuration()`, `src/lib/cloister/deacon.ts:955` — `checkStuckWorkAgents()`, `src/lib/health.ts:91` — `getAgentOutput()`
 
-### Community 963 - "Community 963"
+### Community 956 - "Community 956"
 Cohesion: 0.29
 Nodes (7): P2 — Readiness and delivery (trust hooks, remove fallbacks), `src/dashboard/server/routes/conversations.ts:81` — `waitForClaudeReady()`, `src/lib/agents.ts:1041` — `startAgent` inline prompt-ready check, `src/lib/agents.ts:244` — `waitForReadySignal()`, `src/lib/cloister/specialists.ts:2484,2495` — specialist delivery confirmation, `src/lib/tmux.ts:527` — `waitForClaudePrompt()`, `src/lib/tmux.ts:559` — `confirmDelivery()`
 
-### Community 964 - "Community 964"
+### Community 957 - "Community 957"
 Cohesion: 0.29
 Nodes (6): Approach, Decision, Difficulty: trivial, PAN-415: Test: trace what calls complete-planning after agent finishes, Scope, Status: Planning Complete
 
-### Community 965 - "Community 965"
+### Community 958 - "Community 958"
 Cohesion: 0.29
 Nodes (7): 1. Core Fix (CRITICAL), 2. Comprehensive Testing, 3. Error Handling Improvements, 4. Configuration Validation, 5. Documentation, code:typescript (// Before:), Solution Design
 
-### Community 966 - "Community 966"
+### Community 959 - "Community 959"
 Cohesion: 0.29
 Nodes (6): Agent State: PAN-647, Blockers/Concerns, Current Position, Decisions Made During Planning, Notes, Planned Tasks
 
-### Community 967 - "Community 967"
+### Community 960 - "Community 960"
 Cohesion: 0.29
 Nodes (6): Agent State: MIN-794, Blockers/Concerns, Current Position, Decisions Made During Planning, Notes, Planned Tasks
 
-### Community 968 - "Community 968"
+### Community 961 - "Community 961"
 Cohesion: 0.29
 Nodes (6): Decision (per PRD), Out of scope (confirmed from PRD), PAN-705: Command Taxonomy Reorganization, Pipeline handoff notes for specialists, Problem, Scope anchors
 
-### Community 969 - "Community 969"
+### Community 962 - "Community 962"
 Cohesion: 0.29
 Nodes (7): Agent Issues, Agent keeps failing, Agent stuck / not responding, code:bash (# Check tmux session), code:bash (cat ~/.panopticon/agents/agent-min-123/state.json | jq .hand), code:bash (# Correct), Messages not reaching agent
 
-### Community 970 - "Community 970"
+### Community 963 - "Community 963"
 Cohesion: 0.29
 Nodes (7): code:bash (# Check container logs), code:bash (# Create the network), code:bash (# Use sudo to remove), Container won't start, Docker Issues, "No such network: panopticon", Permission denied on mounted volumes
 
-### Community 971 - "Community 971"
+### Community 964 - "Community 964"
 Cohesion: 0.29
 Nodes (7): Analyze Structure, code:bash (# By name), code:bash (# Function definitions), code:bash (# Directory tree (shallow)), Find Files, Quick Reference Commands, Search Code
 
-### Community 972 - "Community 972"
+### Community 965 - "Community 965"
 Cohesion: 0.29
 Nodes (7): code:bash (# Count errors per agent), code:bash (# If logs have timestamps, extract timeline), code:bash (# Count tool calls by type), Count Errors, Log Analysis, Timeline of Actions, Tool Usage Analysis
 
-### Community 973 - "Community 973"
+### Community 966 - "Community 966"
 Cohesion: 0.29
 Nodes (7): code:bash (# Check if session exists), code:bash (# Truncate log file), code:bash (# Add timestamps when capturing), Logs Too Large, Missing Timestamps, No Output from Agent, Troubleshooting
 
-### Community 974 - "Community 974"
+### Community 967 - "Community 967"
 Cohesion: 0.29
 Nodes (6): 1. Assess (First 5 minutes), 2. Mitigate (Stop the bleeding), 3. Investigate (Once stable), 4. Fix, 5. Postmortem, Incident Response
 
-### Community 975 - "Community 975"
-Cohesion: 0.29
-Nodes (7): code:bash (bd init myproject), code:bash (bd daemon --global=false &), code:bash (#!/bin/bash), JSONL File Not Created, Resolution, Root Cause, Symptom
-
-### Community 976 - "Community 976"
+### Community 968 - "Community 968"
 Cohesion: 0.29
 Nodes (7): code:bash (bd daemon), code:bash (# In your project directory), code:bash (# If you don't want daemon to pull from remote), Daemon Won't Start, Resolution, Root Cause, Symptom
 
-### Community 977 - "Community 977"
+### Community 969 - "Community 969"
+Cohesion: 0.29
+Nodes (7): code:bash (bd init myproject), code:bash (bd daemon --global=false &), code:bash (#!/bin/bash), JSONL File Not Created, Resolution, Root Cause, Symptom
+
+### Community 970 - "Community 970"
 Cohesion: 0.29
 Nodes (7): code:bash (# Project A ships a capability), code:bash (bd ship <capability>            # Ship capability (requires ), code:bash (bd dep add <issue> external:<project>:<capability>), Concept, Cross-Project Dependencies, Depending on External Capabilities, Shipping Capabilities
 
-### Community 978 - "Community 978"
+### Community 971 - "Community 971"
 Cohesion: 0.29
 Nodes (7): code:bash (# Manual creation), code:bash (bd formula list                 # List all formulas (protos)), code:bash (bd mol show mol-release         # Show template structure an), Creating a Proto, Listing Formulas, Proto Management, Viewing Proto Structure
 
-### Community 979 - "Community 979"
+### Community 972 - "Community 972"
 Cohesion: 0.29
 Nodes (6): CLI Command Reference, Dependency Types, Issue Types, Priorities, Quick Navigation, See Also
 
-### Community 980 - "Community 980"
+### Community 973 - "Community 973"
 Cohesion: 0.29
 Nodes (6): code:bash (pan wipe <issue-id>), pan wipe, See Also, Warning, What It Does, When to Use
 
-### Community 981 - "Community 981"
+### Community 974 - "Community 974"
 Cohesion: 0.29
 Nodes (7): Check Current Status, code:bash (pan doctor), code:bash (# Clone the repository), code:bash (# Use automated installer), Install Panopticon, Install Prerequisites, Step 2: Installation (5 minutes)
 
-### Community 982 - "Community 982"
+### Community 975 - "Community 975"
 Cohesion: 0.29
 Nodes (6): code:block1 (pan admin cloister status [--json]   # Show watchdog service), Confirm before emergency-stop, pan admin cloister, See also, Usage, When to use each subcommand
 
-### Community 983 - "Community 983"
-Cohesion: 0.29
-Nodes (7): Advanced Usage, code:bash (# Start with hot reload for development), code:bash (# Start only dashboard (no API)), code:bash (# Use environment variables), Custom Ports, Start in Development Mode, Start Specific Services
-
-### Community 984 - "Community 984"
+### Community 976 - "Community 976"
 Cohesion: 0.29
 Nodes (7): Auto-Start on Boot, code:ini ([Unit]), code:bash (sudo systemctl enable panopticon), code:xml (<?xml version="1.0" encoding="UTF-8"?>), code:bash (launchctl load ~/Library/LaunchAgents/com.panopticon.dashboa), Using launchd (macOS), Using systemd (Linux)
 
-### Community 985 - "Community 985"
+### Community 977 - "Community 977"
+Cohesion: 0.29
+Nodes (7): Advanced Usage, code:bash (# Start with hot reload for development), code:bash (# Start only dashboard (no API)), code:bash (# Use environment variables), Custom Ports, Start in Development Mode, Start Specific Services
+
+### Community 978 - "Community 978"
 Cohesion: 0.29
 Nodes (7): Check Resource Usage, Check Service Status, Check Specific Agent, code:bash (# Check if dashboard is running), code:bash (# Verbose status with CPU/memory), code:bash (# Show detailed status for one agent), Detailed Status Checks
 
-### Community 986 - "Community 986"
-Cohesion: 0.29
-Nodes (7): Border Radius, Border & Shadow, code:block5 (rounded-md   (6px)  Buttons, inputs, small cards), code:block6 (shadow-sm   Sidebar cards, secondary), code:tsx (bg-muted/40         // Very subtle containers), Opacity Modifiers, Shadows
-
-### Community 987 - "Community 987"
-Cohesion: 0.29
-Nodes (7): App Background, code:block2 (--background       Page background (white / slate-950)), Color System, MYN Task Type Colors (Methodology), Priority Colors, Semantic Colors, Shadcn/UI Semantic Tokens (CSS Variables)
-
-### Community 988 - "Community 988"
+### Community 979 - "Community 979"
 Cohesion: 0.29
 Nodes (6): code:block14 (src/), Design Principles, File Structure, Key Files, Mind Your Now Design System & Coding Standards, Tech Stack
 
-### Community 989 - "Community 989"
+### Community 980 - "Community 980"
+Cohesion: 0.29
+Nodes (7): App Background, code:block2 (--background       Page background (white / slate-950)), Color System, MYN Task Type Colors (Methodology), Priority Colors, Semantic Colors, Shadcn/UI Semantic Tokens (CSS Variables)
+
+### Community 981 - "Community 981"
+Cohesion: 0.29
+Nodes (7): Border Radius, Border & Shadow, code:block5 (rounded-md   (6px)  Buttons, inputs, small cards), code:block6 (shadow-sm   Sidebar cards, secondary), code:tsx (bg-muted/40         // Very subtle containers), Opacity Modifiers, Shadows
+
+### Community 982 - "Community 982"
 Cohesion: 0.29
 Nodes (6): Code Review, Correctness, Design, Output Format, Performance, Security
 
-### Community 990 - "Community 990"
+### Community 983 - "Community 983"
 Cohesion: 0.29
 Nodes (6): 1. Reproduce, 2. Investigate Root Cause, 3. Implement Fix, 4. Add Regression Test, 5. Verify, Bug Fix
 
-### Community 991 - "Community 991"
-Cohesion: 0.29
-Nodes (6): code:bash (# System info), Collecting Diagnostics, Issue Categories, Overview, Related Skills, Troubleshooting Guide
-
-### Community 992 - "Community 992"
-Cohesion: 0.29
-Nodes (7): "Cannot find module" errors, code:bash (# Check if installed), code:bash (# Reinstall dependencies), code:bash (# Check version), Installation Issues, Node.js version issues, "pan: command not found"
-
-### Community 993 - "Community 993"
+### Community 984 - "Community 984"
 Cohesion: 0.29
 Nodes (7): code:bash (# Check sync status), code:bash (# Check what's there), code:bash (# Check trigger patterns in SKILL.md), "Skill already exists", Skill Issues, Skill not triggering, Skills not showing up
 
-### Community 994 - "Community 994"
+### Community 985 - "Community 985"
 Cohesion: 0.29
 Nodes (7): Can't reach Linear API, code:bash (# Test connectivity), code:bash (# Check Traefik is running), code:bash (# Get WSL2 IP), Network Issues, Traefik not routing, WSL2 networking
 
-### Community 995 - "Community 995"
+### Community 986 - "Community 986"
+Cohesion: 0.29
+Nodes (7): "Cannot find module" errors, code:bash (# Check if installed), code:bash (# Reinstall dependencies), code:bash (# Check version), Installation Issues, Node.js version issues, "pan: command not found"
+
+### Community 987 - "Community 987"
+Cohesion: 0.29
+Nodes (6): code:bash (# System info), Collecting Diagnostics, Issue Categories, Overview, Related Skills, Troubleshooting Guide
+
+### Community 988 - "Community 988"
 Cohesion: 0.29
 Nodes (6): code:block1 (LIFECYCLE VERBS (top-level)), code:bash (pan <args>), Command Taxonomy (0.7.0), Dispatch, Panopticon CLI Umbrella Skill, Usage
 
-### Community 996 - "Community 996"
+### Community 989 - "Community 989"
 Cohesion: 0.29
 Nodes (6): 1. High-Level Structure, 2. Tech Stack, 3. Architecture Patterns, 4. Development Workflow, 5. Document Findings, Codebase Onboarding
 
-### Community 997 - "Community 997"
+### Community 990 - "Community 990"
 Cohesion: 0.29
 Nodes (7): Advanced Usage, code:bash (# Force kill all processes), code:bash (# Stop only dashboard (keep API running)), code:bash (# Stop dashboard and Traefik), Force Stop, Stop and Clean Up Workspaces, Stop Specific Services
 
-### Community 998 - "Community 998"
+### Community 991 - "Community 991"
 Cohesion: 0.29
 Nodes (6): code:bash (GITHUB_TOKEN=ghp_xxxxx     # For GitHub-tracked projects), Configuration, Issue Tracker Integration, Related Guides, Supported Trackers, Unified Dashboard
 
-### Community 999 - "Community 999"
-Cohesion: 0.29
-Nodes (6): code:bash (# Install mkcert), Docker & HTTPS Setup, Overview, Prerequisites, Quick Setup, Related Guides
-
-### Community 1000 - "Community 1000"
+### Community 992 - "Community 992"
 Cohesion: 0.29
 Nodes (7): code:yaml (# In projects.yaml), code:bash (# Add manually or let Panopticon manage it), code:yaml (dns:), DNS Configuration, Option 1: .localhost (Recommended), Option 2: /etc/hosts, Option 3: WSL2 Hosts Sync (Windows)
 
-### Community 1001 - "Community 1001"
+### Community 993 - "Community 993"
+Cohesion: 0.29
+Nodes (6): code:bash (# Install mkcert), Docker & HTTPS Setup, Overview, Prerequisites, Quick Setup, Related Guides
+
+### Community 994 - "Community 994"
 Cohesion: 0.29
 Nodes (7): 11. Theme Toggle, code:html (<script>), code:css (.no-transitions,), code:typescript (function toggleTheme() {), Flash Prevention, Implementation, Transition Suppression
 
-### Community 1002 - "Community 1002"
+### Community 995 - "Community 995"
 Cohesion: 0.29
 Nodes (6): code:bash (# Set up Kimi API), Files, Model Capability Research Framework, Overview, Research Workflow, Using Kimi 2.5 for Research
 
-### Community 1003 - "Community 1003"
+### Community 996 - "Community 996"
 Cohesion: 0.33
 Nodes (4): CLI_DIST, CONTRACTS_DIST, __dirname, ROOT
 
-### Community 1004 - "Community 1004"
+### Community 997 - "Community 997"
 Cohesion: 0.33
 Nodes (5): cache, cacheKey, config, configRepos, keys
 
-### Community 1005 - "Community 1005"
+### Community 998 - "Community 998"
 Cohesion: 0.33
 Nodes (5): beads, capturedArgs, err, mockExecFileFn, mockExecFn
 
-### Community 1006 - "Community 1006"
+### Community 999 - "Community 999"
 Cohesion: 0.33
 Nodes (4): desktopVersion, __dirname, repoRoot, rootVersion
 
-### Community 1007 - "Community 1007"
+### Community 1000 - "Community 1000"
 Cohesion: 0.47
 Nodes (5): create_agent(), get_agent_path(), main(), Get the appropriate agent directory based on scope., Create a new subagent file.
 
-### Community 1008 - "Community 1008"
+### Community 1001 - "Community 1001"
 Cohesion: 0.47
 Nodes (5): main(), package_skill(), Validate skill structure and contents., Package a skill folder into a .skill file., validate_skill()
 
-### Community 1009 - "Community 1009"
+### Community 1002 - "Community 1002"
 Cohesion: 0.47
 Nodes (3): emit(), load_model(), main()
 
-### Community 1010 - "Community 1010"
+### Community 1003 - "Community 1003"
 Cohesion: 0.33
 Nodes (3): body, content, { frontmatter, body }
 
-### Community 1011 - "Community 1011"
+### Community 1004 - "Community 1004"
+Cohesion: 0.33
+Nodes (5): after, body, result, { saveAgentRuntimeStateMock, getAgentRuntimeStateMock }, processResetReviewPipeline()
+
+### Community 1005 - "Community 1005"
 Cohesion: 0.33
 Nodes (5): mockConversation, mockMessages, raw, toggle, url
 
-### Community 1012 - "Community 1012"
+### Community 1006 - "Community 1006"
 Cohesion: 0.33
 Nodes (5): baseSettings, flywheelCard, method, settings, settingsBtn
 
-### Community 1014 - "Community 1014"
-Cohesion: 0.33
-Nodes (5): FacetPanel(), FacetValue, Filters, Props, SINCE_OPTIONS
-
-### Community 1015 - "Community 1015"
+### Community 1007 - "Community 1007"
 Cohesion: 0.4
 Nodes (3): LogViewerProps, SpecialistLogViewer(), SSEMessage
 
-### Community 1016 - "Community 1016"
+### Community 1009 - "Community 1009"
 Cohesion: 0.33
 Nodes (5): Audit Prompt: Distinct Data Captured from tmux Scrollback, Constraints, Instructions, Objective, Output Format
 
-### Community 1017 - "Community 1017"
+### Community 1010 - "Community 1010"
 Cohesion: 0.33
 Nodes (6): Auth Flow, code:bash (pan specialists done uat <issueId> --status passed   # Signa), Four Verification Phases, Pipeline Trigger, UAT Specialist (PAN-383), Why UAT Exists
 
-### Community 1018 - "Community 1018"
+### Community 1011 - "Community 1011"
 Cohesion: 0.33
 Nodes (6): Agent Behavior After Reopen, Preserving History, Preventing Stale Dispatch, Reopening Issues for Re-Work, What Reopen Resets, Why "In Progress" and Not Backlog
 
-### Community 1019 - "Community 1019"
+### Community 1012 - "Community 1012"
 Cohesion: 0.33
 Nodes (5): Central gate, CLI and dashboard break-glass, Non-agent tmux sessions, Spawn entrypoint audit, Spawn Gating
 
-### Community 1020 - "Community 1020"
+### Community 1013 - "Community 1013"
 Cohesion: 0.33
 Nodes (6): Browser-Only Mode, code:bash (npx panopticon serve), Desktop App, Installation, Key Features, `pan up` Electron Detection
 
-### Community 1021 - "Community 1021"
+### Community 1014 - "Community 1014"
 Cohesion: 0.33
 Nodes (6): code:block1 (┌───────────────────────────────────────────────────────────), code:block2 (┌───────────────────────────────────────────────────────────), Core Concept, Part 1: Architecture Vision, Success Metrics, Unified Architecture
 
-### Community 1022 - "Community 1022"
+### Community 1015 - "Community 1015"
 Cohesion: 0.33
 Nodes (6): 8. Complete Content Inventory, MYN Project Template Content, Panopticon Agents (8), Panopticon Dev-Skills (3), Panopticon Skills (64), Project-Scoped (Panopticon repo only)
 
-### Community 1023 - "Community 1023"
+### Community 1016 - "Community 1016"
 Cohesion: 0.33
 Nodes (6): 3. Real-World Conflict: Mind Your Now, code:block7 (pan workspace create MIN-678), code:yaml (agent:), MYN Project Configuration, Skill Audit (Feb 2026), The Override Problem
 
-### Community 1024 - "Community 1024"
+### Community 1017 - "Community 1017"
 Cohesion: 0.33
 Nodes (6): code:yaml (models:), code:block27 (Warning: Model gpt-5.2-codex requires openai API key - falli), Example Scenario, Fallback Behavior, Fallback Mappings, Fallback Strategy
 
-### Community 1025 - "Community 1025"
+### Community 1018 - "Community 1018"
 Cohesion: 0.33
 Nodes (6): Advanced Configuration, code:bash (# View effective configuration), code:bash (# Automatic migration (coming soon in PAN-118-6)), Debugging Model Resolution, Migration from settings.json, Validation
 
-### Community 1026 - "Community 1026"
-Cohesion: 0.33
-Nodes (6): 13. Implementation Plan, Phase 1: Foundation, Phase 2: Live Grid, Phase 3: Detail Panel, Phase 4: Additional Views, Phase 5: Polish
-
-### Community 1027 - "Community 1027"
+### Community 1019 - "Community 1019"
 Cohesion: 0.33
 Nodes (6): 10.1 Agent Object (Unified), 10.2 API Endpoints Needed, 10.3 Existing Endpoints to Reuse, 10.4 Real-time Updates, 10. Data Requirements, code:typescript (interface UnifiedAgent {)
 
-### Community 1028 - "Community 1028"
+### Community 1020 - "Community 1020"
 Cohesion: 0.33
-Nodes (6): Architecture, code:block1 (HOST machine                  panopticon-cli.com            ), Components, Reuse: the terminal-sharing primitive, Two-role decomposition of "host", Why the hub is the host's server, not the host's browser
+Nodes (6): 13. Implementation Plan, Phase 1: Foundation, Phase 2: Live Grid, Phase 3: Detail Panel, Phase 4: Additional Views, Phase 5: Polish
 
-### Community 1029 - "Community 1029"
+### Community 1021 - "Community 1021"
 Cohesion: 0.33
 Nodes (6): code:ts (interface Room {), HTTP API, Room state (in-memory), The Signaling Service, WebSocket API — `WS /signal`, What the signaling service can and cannot see
 
-### Community 1030 - "Community 1030"
+### Community 1022 - "Community 1022"
+Cohesion: 0.33
+Nodes (6): Architecture, code:block1 (HOST machine                  panopticon-cli.com            ), Components, Reuse: the terminal-sharing primitive, Two-role decomposition of "host", Why the hub is the host's server, not the host's browser
+
+### Community 1023 - "Community 1023"
 Cohesion: 0.33
 Nodes (6): code:typescript (// workspaces.ts processUnstickRequest — skip git check for ), code:typescript (setReviewStatusBase(issueId, {), G.1 Reuse existing unstick route — do NOT add a new endpoint, G.2 Session ownership, G.3 Liveness-check caveats, G. Recovery flow, session ownership, liveness caveats
 
-### Community 1031 - "Community 1031"
+### Community 1024 - "Community 1024"
 Cohesion: 0.33
 Nodes (6): Detailed flows, Flow A — First-run, Flow B — Adding a second project, Flow C — Editing branch config, Flow D — Re-detecting repos, Flow E — Killing a stuck Setup Agent
 
-### Community 1032 - "Community 1032"
+### Community 1025 - "Community 1025"
 Cohesion: 0.33
 Nodes (6): Agent Instructions, Bead Assignments, code:typescript (// src/dashboard/server/routes/{category}.ts), Pattern, Route Conversion Cheat Sheet, Route Migration Details (B6–B17)
 
-### Community 1033 - "Community 1033"
+### Community 1026 - "Community 1026"
 Cohesion: 0.33
 Nodes (6): 1. Reviewers fan out as fresh sessions on every round, 2. Conversation view never loads for agent sessions, 3. The Command Deck has no opinion on issue + agent + workflow as one surface, 4. The view doesn't feel alive, code:block1 (review                  ○ ended), Problem
 
-### Community 1034 - "Community 1034"
+### Community 1027 - "Community 1027"
 Cohesion: 0.33
 Nodes (6): P3 — Merge/test/review structured events, `src/lib/cloister/merge-agent.ts:1071` — test failure baseline, `src/lib/cloister/merge-agent.ts:1744` — `resolveConflictsWithAgent()` sync-main polling, `src/lib/cloister/merge-agent.ts:412` — `parseAgentOutput()`, `src/lib/cloister/merge-agent.ts:684` — `scanGitPatterns()`, `src/lib/cloister/review-agent.ts:139` — `parseAgentOutput()`
 
-### Community 1035 - "Community 1035"
+### Community 1028 - "Community 1028"
 Cohesion: 0.33
 Nodes (5): Context, Decision, Difficulty: trivial, PAN-448: Start Agent confirmation timeout too short, Scope
 
-### Community 1036 - "Community 1036"
+### Community 1029 - "Community 1029"
 Cohesion: 0.33
 Nodes (6): code:bash (# Option 1: Manual cleanup), Common Causes, Corrupted Workspaces, Prevention, Resolution, Symptoms
 
-### Community 1037 - "Community 1037"
+### Community 1030 - "Community 1030"
 Cohesion: 0.33
 Nodes (6): code:bash (# Restart the dashboard), code:bash (# Check Docker memory), Dashboard slow to load, High CPU usage, High memory usage, Performance Issues
 
-### Community 1038 - "Community 1038"
-Cohesion: 0.33
-Nodes (6): 1. Fail loud, fail early, 2. One template, one API, 3. Composition happens in TypeScript, 4. Variables are declared, not discovered, 5. Prompts are not docstrings, Core principles
-
-### Community 1039 - "Community 1039"
+### Community 1031 - "Community 1031"
 Cohesion: 0.33
 Nodes (5): code:block9 (<!-- panopticon:orchestration-context-start -->), Further reading, Orchestration markers, Prompt Templates, Why templates at all
 
-### Community 1040 - "Community 1040"
+### Community 1032 - "Community 1032"
+Cohesion: 0.33
+Nodes (6): 1. Fail loud, fail early, 2. One template, one API, 3. Composition happens in TypeScript, 4. Variables are declared, not discovered, 5. Prompts are not docstrings, Core principles
+
+### Community 1033 - "Community 1033"
 Cohesion: 0.33
 Nodes (5): Boundaries, Outputs, Panopticon Planning Agent, Process, State model
 
-### Community 1041 - "Community 1041"
+### Community 1034 - "Community 1034"
 Cohesion: 0.33
 Nodes (5): Boundaries, code:bash (npm test), Completion, Panopticon Work Agent, Per-Bead Workflow
 
-### Community 1042 - "Community 1042"
+### Community 1035 - "Community 1035"
 Cohesion: 0.33
 Nodes (5): Additional Context (Optional), code:markdown (## Agent: {ISSUE_ID} - {ISSUE_TITLE}), Required Information Table, When to Apply This Format, Workspace Status Display Format
 
-### Community 1043 - "Community 1043"
+### Community 1036 - "Community 1036"
 Cohesion: 0.33
 Nodes (5): code:bash (pan done <issue-id>), pan done, See Also, What It Does, When to Use
 
-### Community 1044 - "Community 1044"
-Cohesion: 0.33
-Nodes (5): Contents, Interface-Specific Troubleshooting, Quick Reference: Common Fixes, Related Documentation, Troubleshooting Guide
-
-### Community 1045 - "Community 1045"
+### Community 1037 - "Community 1037"
 Cohesion: 0.33
 Nodes (6): code:python (# Want: "task-2 depends on task-1" (task-1 blocks task-2)), code:python (# Correct: task-2 depends on task-1), code:bash (bd dep add task-2 task-1 --type blocks), code:bash (bd show task-2), Dependencies Created Backwards, MCP-Specific Issues
 
-### Community 1046 - "Community 1046"
+### Community 1038 - "Community 1038"
+Cohesion: 0.33
+Nodes (5): Contents, Interface-Specific Troubleshooting, Quick Reference: Common Fixes, Related Documentation, Troubleshooting Guide
+
+### Community 1039 - "Community 1039"
 Cohesion: 0.33
 Nodes (6): Claude Code Skill Issues, code:bash (# 1. Version), code:bash (ls -la ~/.claude/skills/bd-issue-tracking/), Debug Checklist, Getting Help, Report to beads GitHub
 
-### Community 1047 - "Community 1047"
+### Community 1040 - "Community 1040"
 Cohesion: 0.33
 Nodes (5): Limitations, Reference Databases / Glossaries (Alternative Use), Using bd for Static Reference Data, When to Use This Pattern, Work Tracking (Primary Use Case)
 
-### Community 1048 - "Community 1048"
+### Community 1041 - "Community 1041"
 Cohesion: 0.33
 Nodes (5): code:bash (pan resources), code:bash (pan resources --json), Interpreting results, JSON output, System Resource Inventory
 
-### Community 1049 - "Community 1049"
+### Community 1042 - "Community 1042"
 Cohesion: 0.33
 Nodes (5): code:bash (pan admin hooks install), pan admin hooks install, See Also, What It Does, When to Use
 
-### Community 1050 - "Community 1050"
+### Community 1043 - "Community 1043"
 Cohesion: 0.33
 Nodes (5): code:block1 (https://raw.githubusercontent.com/vercel-labs/web-interface-), Guidelines Source, How It Works, Usage, Web Interface Guidelines
 
-### Community 1051 - "Community 1051"
+### Community 1044 - "Community 1044"
 Cohesion: 0.33
 Nodes (5): Canonical paths, code:bash (# Build first if dashboard server or CLI code changed), Execution, Important Notes, Restart Panopticon
 
-### Community 1052 - "Community 1052"
+### Community 1045 - "Community 1045"
 Cohesion: 0.33
 Nodes (5): After Refactoring, Before Starting, During Refactoring, Refactoring, Refactoring Types
 
-### Community 1053 - "Community 1053"
-Cohesion: 0.33
-Nodes (6): code:bash (# One-liner to check everything), code:bash (# Watch agent status (updates every 2 seconds)), Continuous Monitoring, Dashboard Monitoring, Monitoring Workflows, Quick Health Check
-
-### Community 1054 - "Community 1054"
+### Community 1046 - "Community 1046"
 Cohesion: 0.33
 Nodes (6): Alert on Agent Crash, code:bash (#!/bin/bash), code:bash (chmod +x ~/scripts/pan-dashboard.sh), code:bash (#!/bin/bash), Custom Status Dashboard, Status Scripts
 
-### Community 1055 - "Community 1055"
+### Community 1047 - "Community 1047"
+Cohesion: 0.33
+Nodes (6): code:bash (# One-liner to check everything), code:bash (# Watch agent status (updates every 2 seconds)), Continuous Monitoring, Dashboard Monitoring, Monitoring Workflows, Quick Health Check
+
+### Community 1048 - "Community 1048"
 Cohesion: 0.33
 Nodes (5): Architectural rules, Execution steps, Retrieval and networking, Stitch to React Components, Troubleshooting
 
-### Community 1056 - "Community 1056"
+### Community 1049 - "Community 1049"
 Cohesion: 0.33
 Nodes (5): code:bash (pan reload), Command, Notes, Options, Pan Reload
 
-### Community 1057 - "Community 1057"
+### Community 1050 - "Community 1050"
 Cohesion: 0.33
 Nodes (5): code:bash (pan issues), pan issues, See Also, What It Does, When to Use
 
-### Community 1058 - "Community 1058"
+### Community 1051 - "Community 1051"
 Cohesion: 0.33
 Nodes (5): 1. Version Bump, 2. Final Verification, 3. Create Release, 4. Post-Release, Release Process
 
-### Community 1059 - "Community 1059"
+### Community 1052 - "Community 1052"
 Cohesion: 0.33
 Nodes (6): code:bash (# In ~/.panopticon.env), code:bash (DEBUG=rally pan up), code:bash (curl -X POST http://localhost:3011/api/rally/validate \), Finding Workspace and Project IDs, Rally Troubleshooting, WSAPI Query Parse Errors
 
-### Community 1060 - "Community 1060"
+### Community 1053 - "Community 1053"
 Cohesion: 0.33
 Nodes (6): code:bash (LINEAR_API_KEY=lin_api_xxxxx), code:yaml (projects:), Issue States, Linear Integration, Setup, Team Mapping
 
-### Community 1061 - "Community 1061"
+### Community 1054 - "Community 1054"
 Cohesion: 0.33
 Nodes (6): code:block2 (~/.panopticon/traefik/), code:yaml (api:), code:yaml (http:), Dynamic Configuration, Static Configuration, Traefik Configuration
 
-### Community 1062 - "Community 1062"
+### Community 1055 - "Community 1055"
 Cohesion: 0.33
 Nodes (6): 12. Animation & Motion, code:block29 (Duration: 200ms (default for all state transitions)), code:block30 (Hover highlight:   transition-colors duration-200), Patterns, Rules, Standard Timing
 
-### Community 1063 - "Community 1063"
-Cohesion: 0.33
-Nodes (6): 14. Accessibility, code:block33 (focus-visible:ring-[3px] focus-visible:ring-ring/24 focus-vi), Contrast Ratios, Focus Indicators, Keyboard Navigation, Touch Targets
-
-### Community 1064 - "Community 1064"
+### Community 1056 - "Community 1056"
 Cohesion: 0.33
 Nodes (6): 15. Page-Specific Notes, Agents, Board (Kanban), Command Deck (formerly Mission Control), God View, Settings
 
-### Community 1065 - "Community 1065"
+### Community 1057 - "Community 1057"
+Cohesion: 0.33
+Nodes (6): 14. Accessibility, code:block33 (focus-visible:ring-[3px] focus-visible:ring-ring/24 focus-vi), Contrast Ratios, Focus Indicators, Keyboard Navigation, Touch Targets
+
+### Community 1058 - "Community 1058"
 Cohesion: 0.33
 Nodes (5): Agent Resumed — {{ISSUE_ID}}, Last Known Status: {{STATE_STATUS}}, Operator Message, What To Do Now, Where You Left Off
 
-### Community 1066 - "Community 1066"
+### Community 1059 - "Community 1059"
 Cohesion: 0.33
 Nodes (5): Auto-Clarity, Boundaries, Intensity, Persistence, Rules
 
-### Community 1067 - "Community 1067"
+### Community 1060 - "Community 1060"
 Cohesion: 0.5
 Nodes (4): computeStaleResets(), hasSessionForSpecialist(), StatusSnapshot, updates
 
-### Community 1068 - "Community 1068"
+### Community 1061 - "Community 1061"
 Cohesion: 0.4
 Nodes (3): badge, { container }, DIFFICULTY_COLORS
 
-### Community 1069 - "Community 1069"
+### Community 1062 - "Community 1062"
 Cohesion: 0.4
 Nodes (4): consoleLogs, edges, mockGetStatus, output
 
-### Community 1070 - "Community 1070"
+### Community 1063 - "Community 1063"
 Cohesion: 0.4
 Nodes (4): hiddenDir, mockExecFn, subA, subB
 
-### Community 1071 - "Community 1071"
+### Community 1064 - "Community 1064"
 Cohesion: 0.4
 Nodes (3): content, LEGACY_TEMPLATE_FLAVORS, REVIEW_SUB_ROLES
 
-### Community 1072 - "Community 1072"
+### Community 1065 - "Community 1065"
 Cohesion: 0.4
 Nodes (4): REMOTE_PROVISIONERS, REPO_ROOT, src, stripped
 
-### Community 1073 - "Community 1073"
+### Community 1066 - "Community 1066"
 Cohesion: 0.4
 Nodes (3): entries, messages, workLog
 
-### Community 1076 - "Community 1076"
+### Community 1069 - "Community 1069"
+Cohesion: 0.4
+Nodes (3): fetchConversations(), GeneralConversation, GeneralSectionProps
+
+### Community 1070 - "Community 1070"
 Cohesion: 0.5
 Nodes (4): APP_DIR, generateJWT(), main(), WEBHOOK_EVENTS
 
-### Community 1077 - "Community 1077"
+### Community 1071 - "Community 1071"
 Cohesion: 0.4
 Nodes (4): mockCleanupUnreferencedConversationAttachments, mockListActiveConversations, mockListSessionNamesAsync, mockMarkConversationEnded
 
-### Community 1078 - "Community 1078"
+### Community 1072 - "Community 1072"
 Cohesion: 0.4
 Nodes (5): code:block26 (Issue Created), code:block27 (mergeStatus:  pending → merging → merged), How the Agent Pipeline Works, Review status state machine, Specialist initialization
 
-### Community 1079 - "Community 1079"
+### Community 1073 - "Community 1073"
 Cohesion: 0.4
 Nodes (5): Optional, Platform Support, Required, Requirements, Why CLI tools instead of API tokens?
 
-### Community 1080 - "Community 1080"
+### Community 1074 - "Community 1074"
 Cohesion: 0.4
 Nodes (5): code:block22 (Replace stale copies in ~/.panopticon/skills/ with fresh con), code:block23 (For each symlink in ~/.claude/skills/ pointing to ~/.panopti), code:block24 (Copy all skills, agents, rules from ~/.panopticon/ cache → <), code:block25 (Panopticon sync migration:), Migration Path
 
-### Community 1081 - "Community 1081"
-Cohesion: 0.4
-Nodes (5): code:bash (# Existing local workspace), code:bash (pan workspace migrate MIN-667 --to local), From Local to Remote, Migration Path, Rollback to Local
-
-### Community 1082 - "Community 1082"
+### Community 1075 - "Community 1075"
 Cohesion: 0.4
 Nodes (5): code:toml ([remote]), code:yaml (# Project-specific remote settings), Configuration, Project Config (`.panopticon/remote.yaml`), User Config (`~/.panopticon/config.toml`)
 
-### Community 1083 - "Community 1083"
+### Community 1076 - "Community 1076"
+Cohesion: 0.4
+Nodes (5): code:bash (# Existing local workspace), code:bash (pan workspace migrate MIN-667 --to local), From Local to Remote, Migration Path, Rollback to Local
+
+### Community 1077 - "Community 1077"
 Cohesion: 0.4
 Nodes (5): code:yaml (models:), code:yaml (models:), Example Resolution, Precedence Rules, Resolution Order
 
-### Community 1084 - "Community 1084"
+### Community 1078 - "Community 1078"
 Cohesion: 0.4
 Nodes (5): code:yaml (# ~/.panopticon/cloister.yaml), code:bash (# Override config file location), Configuration, Default Config File, Environment Variables
 
-### Community 1085 - "Community 1085"
+### Community 1079 - "Community 1079"
 Cohesion: 0.4
 Nodes (5): code:typescript (interface AgentRuntime {), code:yaml (# ~/.panopticon/cloister.yaml), Model Selection, Runtime Architecture, Runtime Interface
 
-### Community 1086 - "Community 1086"
+### Community 1080 - "Community 1080"
 Cohesion: 0.4
 Nodes (4): Claude Code Skills Inventory, Duplicate names, Maintenance, Skills
 
-### Community 1087 - "Community 1087"
+### Community 1081 - "Community 1081"
 Cohesion: 0.4
 Nodes (5): 8.1 Activity Feed, 8.2 Phase Distribution (Donut Chart), 8.3 System Health Gauges, 8. Right Panel (Persistent), code:block7 (2m    ●  agent-pan-505 started)
 
-### Community 1088 - "Community 1088"
+### Community 1082 - "Community 1082"
 Cohesion: 0.4
 Nodes (5): code:typescript (function readRole(state: any): Role {), Enum mapping table, Migration — Backward Compatibility, Old agent .md files, Reading old state.json files
 
-### Community 1089 - "Community 1089"
+### Community 1083 - "Community 1083"
 Cohesion: 0.4
 Nodes (5): Component, End-to-end (Playwright), Integration, Testing, Unit
 
-### Community 1090 - "Community 1090"
+### Community 1084 - "Community 1084"
 Cohesion: 0.4
 Nodes (5): Branch node (new), Container node (new), Data inventory, PR node (new), Resources group node (new)
 
-### Community 1091 - "Community 1091"
+### Community 1085 - "Community 1085"
 Cohesion: 0.4
 Nodes (5): Visual / data inventory by zone, Zone A — Issue header (always visible), Zone B — Agent context (selected session), Zone C — Conversation + composer (agent-selected), Zone C — Issue-selected mode (no agent selected)
 
-### Community 1092 - "Community 1092"
-Cohesion: 0.4
-Nodes (5): JSONL Session Files (use existing), `runtime.json` (extend existing schema), Specialist Event Files (new, lightweight), WebSocket Terminal (in-memory ring buffer), What Goes Where
-
-### Community 1093 - "Community 1093"
-Cohesion: 0.4
-Nodes (5): code:block1 (Agent → tmux pane → capture-pane → regex parsing → consumer), code:block2 (Agent → hooks → runtime.json ──┬──→ Dashboard (structured st), Data Flow: Today vs Target, Target (2 layers), Today (3 overlapping layers)
-
-### Community 1094 - "Community 1094"
-Cohesion: 0.4
-Nodes (5): Implementation Sequence (4 Phases), Phase 1: Fix hooks (BLOCKS EVERYTHING), Phase 2: Structured event files + JSONL readers (can start after Phase 1), Phase 3: Remove high-risk tmux patterns (can start after Phase 1), Phase 4: Migrate remaining consumers (can start after Phase 1)
-
-### Community 1095 - "Community 1095"
-Cohesion: 0.4
-Nodes (5): `AgentRuntimeState` (`src/lib/agents.ts:359`), code:typescript (export interface AgentRuntimeState {), code:typescript (// review-results.json), Interface Changes, Specialist Result Files (new)
-
-### Community 1096 - "Community 1096"
+### Community 1086 - "Community 1086"
 Cohesion: 0.4
 Nodes (5): Hook Extensions Required, Hook reliability (PAN-759), PostToolUse hook, SessionStart hook, Specialist hooks (new)
 
-### Community 1097 - "Community 1097"
+### Community 1087 - "Community 1087"
+Cohesion: 0.4
+Nodes (5): Implementation Sequence (4 Phases), Phase 1: Fix hooks (BLOCKS EVERYTHING), Phase 2: Structured event files + JSONL readers (can start after Phase 1), Phase 3: Remove high-risk tmux patterns (can start after Phase 1), Phase 4: Migrate remaining consumers (can start after Phase 1)
+
+### Community 1088 - "Community 1088"
+Cohesion: 0.4
+Nodes (5): `AgentRuntimeState` (`src/lib/agents.ts:359`), code:typescript (export interface AgentRuntimeState {), code:typescript (// review-results.json), Interface Changes, Specialist Result Files (new)
+
+### Community 1089 - "Community 1089"
+Cohesion: 0.4
+Nodes (5): code:block1 (Agent → tmux pane → capture-pane → regex parsing → consumer), code:block2 (Agent → hooks → runtime.json ──┬──→ Dashboard (structured st), Data Flow: Today vs Target, Target (2 layers), Today (3 overlapping layers)
+
+### Community 1090 - "Community 1090"
+Cohesion: 0.4
+Nodes (5): JSONL Session Files (use existing), `runtime.json` (extend existing schema), Specialist Event Files (new, lightweight), WebSocket Terminal (in-memory ring buffer), What Goes Where
+
+### Community 1091 - "Community 1091"
 Cohesion: 0.4
 Nodes (5): Core Changes, Documentation, Error Handling & Validation, Files Modified, Testing
 
-### Community 1098 - "Community 1098"
-Cohesion: 0.4
-Nodes (4): code:javascript (server: {), Related Guides, Slow Vite/React Frontend with Multiple Workspaces, Troubleshooting
-
-### Community 1099 - "Community 1099"
+### Community 1092 - "Community 1092"
 Cohesion: 0.4
 Nodes (5): Can't delete workspace, code:bash (# Check for existing workspace), code:bash (# Via Panopticon (handles Docker cleanup)), Workspace creation fails, Workspace Issues
 
-### Community 1100 - "Community 1100"
+### Community 1093 - "Community 1093"
+Cohesion: 0.4
+Nodes (4): code:javascript (server: {), Related Guides, Slow Vite/React Frontend with Multiple Workspaces, Troubleshooting
+
+### Community 1094 - "Community 1094"
 Cohesion: 0.4
 Nodes (5): Adding a new template, Authoring workflow, code:typescript (import { renderPrompt } from './prompts.js';), Editing an existing template, Migrating a legacy ad-hoc prompt
 
-### Community 1101 - "Community 1101"
-Cohesion: 0.4
-Nodes (5): code:mustache ({{#PENDING_FEEDBACK_BLOCK}}), code:typescript (const pendingFeedbackBlock = ctx.pendingFeedback.length > 0), Composition pattern, Example: `resume-work.md`, When to use in-template conditionals vs pre-built blocks
-
-### Community 1102 - "Community 1102"
+### Community 1095 - "Community 1095"
 Cohesion: 0.4
 Nodes (5): code:markdown (---), Fields, Frontmatter contract, `requires` vs `optional`, Unknown keys are an error
 
-### Community 1103 - "Community 1103"
+### Community 1096 - "Community 1096"
 Cohesion: 0.4
 Nodes (5): 1. Loader contract tests, 2. Live-template smoke tests, 3. Caller-side tests, Testing prompts, Writing a new smoke test
 
-### Community 1104 - "Community 1104"
+### Community 1097 - "Community 1097"
 Cohesion: 0.4
-Nodes (5): code:bash (# Command history (if configured)), code:bash (# Traefik logs), Docker Logs (if using), Panopticon Commands, System Logs
+Nodes (5): code:mustache ({{#PENDING_FEEDBACK_BLOCK}}), code:typescript (const pendingFeedbackBlock = ctx.pendingFeedback.length > 0), Composition pattern, Example: `resume-work.md`, When to use in-template conditionals vs pre-built blocks
 
-### Community 1105 - "Community 1105"
+### Community 1098 - "Community 1098"
 Cohesion: 0.4
 Nodes (5): Clean Old Logs, code:bash (# Create log archive for an issue), code:bash (# Remove logs older than 7 days), Log Retention, Save Important Logs
 
-### Community 1106 - "Community 1106"
+### Community 1099 - "Community 1099"
 Cohesion: 0.4
-Nodes (5): code:block15 (# Automatic logging), code:javascript (// Enable verbose logging), Configuring Log Output, Dashboard Logging, Enable tmux Logging
+Nodes (5): code:bash (# Command history (if configured)), code:bash (# Traefik logs), Docker Logs (if using), Panopticon Commands, System Logs
 
-### Community 1107 - "Community 1107"
+### Community 1100 - "Community 1100"
 Cohesion: 0.4
 Nodes (5): API Requests, code:bash (# If running in foreground, logs go to stdout), code:bash (# Filter API calls), Dashboard Logs, Server Logs
 
-### Community 1108 - "Community 1108"
+### Community 1101 - "Community 1101"
+Cohesion: 0.4
+Nodes (5): code:block15 (# Automatic logging), code:javascript (// Enable verbose logging), Configuring Log Output, Dashboard Logging, Enable tmux Logging
+
+### Community 1102 - "Community 1102"
 Cohesion: 0.4
 Nodes (5): code:bash (rm .panopticon/knowledge-capture.json), code:bash (rm -rf .claude/skills/project-knowledge/), code:bash (rm -rf .claude/skills/knowledge-capture/), code:bash (# Edit ~/.claude/CLAUDE.md and remove the "AI Suggestion Pre), Reset / Clean Slate
 
-### Community 1109 - "Community 1109"
+### Community 1103 - "Community 1103"
 Cohesion: 0.4
 Nodes (4): code:bash (pan memory search <query> [--project <id>] [--workspace <id>), Commands, Notes, Pan Memory
 
-### Community 1110 - "Community 1110"
+### Community 1104 - "Community 1104"
 Cohesion: 0.4
 Nodes (5): Breaking Changes, code:bash (bd version), code:bash (# Update Claude Code beads plugin), Minimum Version for Dependency Persistence, Version Requirements
 
-### Community 1111 - "Community 1111"
+### Community 1105 - "Community 1105"
 Cohesion: 0.4
 Nodes (5): code:bash (# Single issue), code:bash (bd ready), Human-Readable Output, JSON Output (Recommended for Agents), Output Formats
 
-### Community 1112 - "Community 1112"
+### Community 1106 - "Community 1106"
 Cohesion: 0.4
 Nodes (5): Basic Operations, Check Status, code:bash (# Check database path and daemon status), code:bash (# Find ready work (no blockers)), Find Work
 
-### Community 1113 - "Community 1113"
+### Community 1107 - "Community 1107"
 Cohesion: 0.4
 Nodes (5): code:bash (# Link discovered work (old way - two commands)), code:bash (# Label management (supports multiple IDs)), Dependencies, Dependencies & Labels, Labels
 
-### Community 1114 - "Community 1114"
+### Community 1108 - "Community 1108"
 Cohesion: 0.4
 Nodes (5): Background vs Foreground, Check Running Processes, code:bash (# Using pan), code:bash (# Foreground (default) - see logs in real time), Process Management
 
-### Community 1115 - "Community 1115"
-Cohesion: 0.4
-Nodes (5): Animation System, code:tsx (// Container: stagger children by 0.1s), Framer Motion (Auth/Splash), Tailwind Keyframes, Task Completion
-
-### Community 1116 - "Community 1116"
-Cohesion: 0.4
-Nodes (5): Brand Colors, Brand Identity, Brand Wordmark, code:tsx (<h1>), Logo
-
-### Community 1117 - "Community 1117"
-Cohesion: 0.4
-Nodes (5): code:block3 (text-foreground         Primary text), Font Stack, Text Colors, Type Scale, Typography
-
-### Community 1118 - "Community 1118"
+### Community 1109 - "Community 1109"
 Cohesion: 0.4
 Nodes (5): Breakpoints, code:tsx (// Page container), Common Patterns, Spacing & Layout, Spacing Scale
 
-### Community 1119 - "Community 1119"
+### Community 1110 - "Community 1110"
+Cohesion: 0.4
+Nodes (5): code:block3 (text-foreground         Primary text), Font Stack, Text Colors, Type Scale, Typography
+
+### Community 1111 - "Community 1111"
+Cohesion: 0.4
+Nodes (5): Animation System, code:tsx (// Container: stagger children by 0.1s), Framer Motion (Auth/Splash), Tailwind Keyframes, Task Completion
+
+### Community 1112 - "Community 1112"
+Cohesion: 0.4
+Nodes (5): Brand Colors, Brand Identity, Brand Wordmark, code:tsx (<h1>), Logo
+
+### Community 1113 - "Community 1113"
 Cohesion: 0.4
 Nodes (4): Architecture Quality Gate, Structural integrity, Styling and theming, Type safety and syntax
 
-### Community 1120 - "Community 1120"
+### Community 1114 - "Community 1114"
 Cohesion: 0.4
 Nodes (4): Additional Checks, Output Format, OWASP Top 10 Checklist, Security Review
 
-### Community 1121 - "Community 1121"
-Cohesion: 0.4
-Nodes (5): code:block10 (myproject!23  # GitLab issue/MR), code:bash (# Authenticate with GitLab CLI), GitLab Issues, Issue Prefix, Setup
-
-### Community 1122 - "Community 1122"
+### Community 1115 - "Community 1115"
 Cohesion: 0.4
 Nodes (5): code:yaml (projects:), code:markdown (<!-- In an agent's STATE.md -->), Mixed Tracker Pattern, Multi-Tracker Workflows, Syncing Between Trackers
 
-### Community 1123 - "Community 1123"
+### Community 1116 - "Community 1116"
+Cohesion: 0.4
+Nodes (5): code:block10 (myproject!23  # GitLab issue/MR), code:bash (# Authenticate with GitLab CLI), GitLab Issues, Issue Prefix, Setup
+
+### Community 1117 - "Community 1117"
 Cohesion: 0.4
 Nodes (5): code:yaml (projects:), Configuration Fields, Custom ID Patterns, Supported Formats, Unified Issue ID Parser
 
-### Community 1124 - "Community 1124"
-Cohesion: 0.4
-Nodes (5): code:bash (pan up), code:bash (# Start Traefik container), Manually, Starting Traefik, Via Dashboard
-
-### Community 1125 - "Community 1125"
-Cohesion: 0.4
-Nodes (5): code:yaml (# infra/.devcontainer-template/docker-compose.yml.template), code:bash (docker network create panopticon), Docker Compose Template, Network Setup, Workspace Container Setup
-
-### Community 1126 - "Community 1126"
+### Community 1118 - "Community 1118"
 Cohesion: 0.4
 Nodes (5): Certificate Generation, code:bash (# Generate certificates for localhost domains), code:bash (# Generate certificates for custom domain), For Custom Domains, Using mkcert
 
-### Community 1127 - "Community 1127"
+### Community 1119 - "Community 1119"
 Cohesion: 0.4
-Nodes (5): 8. Navigation (Sidebar), code:block22 (Sidebar), code:block23 (Expanded width:  256px  (16rem)), Specs, Structure
+Nodes (5): code:yaml (# infra/.devcontainer-template/docker-compose.yml.template), code:bash (docker network create panopticon), Docker Compose Template, Network Setup, Workspace Container Setup
 
-### Community 1128 - "Community 1128"
+### Community 1120 - "Community 1120"
+Cohesion: 0.4
+Nodes (5): code:bash (pan up), code:bash (# Start Traefik container), Manually, Starting Traefik, Via Dashboard
+
+### Community 1121 - "Community 1121"
 Cohesion: 0.4
 Nodes (5): 13. Icons, code:block31 (Default:  18px (w-[18px] h-[18px])), code:block32 (Command Deck:  Compass), Nav Icons, Sizing
 
-### Community 1129 - "Community 1129"
+### Community 1122 - "Community 1122"
+Cohesion: 0.4
+Nodes (5): 8. Navigation (Sidebar), code:block22 (Sidebar), code:block23 (Expanded width:  256px  (16rem)), Specs, Structure
+
+### Community 1123 - "Community 1123"
 Cohesion: 0.4
 Nodes (4): Acceptance Criteria, Scope, Summary, What NOT to do
 
-### Community 1130 - "Community 1130"
+### Community 1124 - "Community 1124"
 Cohesion: 0.4
 Nodes (4): Auto-Clarity, Boundaries, Examples, Rules
 
-### Community 1131 - "Community 1131"
+### Community 1125 - "Community 1125"
 Cohesion: 0.5
 Nodes (3): client, content, mockExeca
 
-### Community 1132 - "Community 1132"
+### Community 1126 - "Community 1126"
 Cohesion: 0.5
 Nodes (3): mockGetVBriefACStatus, mockSyncBeadStatusToVBrief, result
 
-### Community 1133 - "Community 1133"
+### Community 1127 - "Community 1127"
 Cohesion: 0.5
 Nodes (3): { mockMessageAgent, mockResolveProjectFromIssue, mockGetReviewStatus, mockWriteFeedbackFile }, reviewDir, workspace
 
-### Community 1134 - "Community 1134"
+### Community 1128 - "Community 1128"
 Cohesion: 0.5
 Nodes (3): config, env, mockExistsSync
 
-### Community 1135 - "Community 1135"
+### Community 1129 - "Community 1129"
 Cohesion: 0.5
 Nodes (3): src, stripped, topLevelAwaits
 
-### Community 1137 - "Community 1137"
-Cohesion: 0.67
-Nodes (4): appendBridgeLog(), handleUnixPost(), pushChannelNotification(), pushPermissionDecisionNotification()
-
-### Community 1140 - "Community 1140"
+### Community 1133 - "Community 1133"
 Cohesion: 0.5
 Nodes (3): mockSystemHealth, pill, requests
 
-### Community 1141 - "Community 1141"
+### Community 1134 - "Community 1134"
+Cohesion: 0.67
+Nodes (3): Issue, main(), parseArgs()
+
+### Community 1135 - "Community 1135"
 Cohesion: 0.67
 Nodes (3): fetchWithRetry(), isNetworkError(), RETRY_DELAYS
 
-### Community 1142 - "Community 1142"
+### Community 1136 - "Community 1136"
 Cohesion: 0.5
 Nodes (3): MOTION_CATALOG, MotionEntry, MotionEventType
 
-### Community 1143 - "Community 1143"
+### Community 1137 - "Community 1137"
 Cohesion: 0.5
 Nodes (3): mockExecAsync, mockSpawn, program
 
-### Community 1144 - "Community 1144"
+### Community 1138 - "Community 1138"
 Cohesion: 0.5
 Nodes (3): agentMocks, readlineMocks, written
 
-### Community 1145 - "Community 1145"
+### Community 1139 - "Community 1139"
 Cohesion: 0.5
 Nodes (4): Beads Issue Tracker, code:bash (bd ready              # Find available work), Quick Reference, Rules
 
-### Community 1146 - "Community 1146"
+### Community 1140 - "Community 1140"
 Cohesion: 0.5
 Nodes (4): Merge Agent Workflow, Review Agent Workflow, Specialist Agent Processing, Test Agent Workflow
 
-### Community 1147 - "Community 1147"
+### Community 1141 - "Community 1141"
+Cohesion: 0.5
+Nodes (4): code:block19 (~/.claude/skills/my-override/               ← WINS (personal), code:block20 (~/.claude/skills/my-override/               ← WINS (personal), code:block21 (workspace/.claude/skills/session-health/   ← MYN template ve), Precedence in Practice
+
+### Community 1142 - "Community 1142"
 Cohesion: 0.5
 Nodes (4): Comparison, Cost Analysis, exe.dev Pricing, Recommended Setup
 
-### Community 1148 - "Community 1148"
+### Community 1143 - "Community 1143"
 Cohesion: 0.5
 Nodes (4): CLI, Clients & Join Paths, Cold start, Dashboard
 
-### Community 1149 - "Community 1149"
-Cohesion: 0.5
-Nodes (3): Data Model, Host-side persistence, Signaling service
-
-### Community 1150 - "Community 1150"
+### Community 1144 - "Community 1144"
 Cohesion: 0.5
 Nodes (4): Conversation Sharing, Default surface & terminal toggle, Host side, Viewer side
 
-### Community 1151 - "Community 1151"
-Cohesion: 0.5
-Nodes (4): Access Control — Invite-Only, Controller actions, Defense in depth — the host gates content itself, The lobby
-
-### Community 1152 - "Community 1152"
+### Community 1145 - "Community 1145"
 Cohesion: 0.5
 Nodes (4): code:ts (interface SharedEnvelope {), Peer connections and data channels, Scoped, versioned wire format, Transport & Wire Format
 
-### Community 1153 - "Community 1153"
+### Community 1146 - "Community 1146"
+Cohesion: 0.5
+Nodes (4): Access Control — Invite-Only, Controller actions, Defense in depth — the host gates content itself, The lobby
+
+### Community 1147 - "Community 1147"
+Cohesion: 0.5
+Nodes (3): Data Model, Host-side persistence, Signaling service
+
+### Community 1148 - "Community 1148"
+Cohesion: 0.5
+Nodes (3): A.6 Partial results from incomplete parallel reviews, code:typescript (// ── Phase 3: Synthesis ───────────────────────────────────), code:typescript (const incompleteNote = incompleteReviewers.length > 0)
+
+### Community 1149 - "Community 1149"
 Cohesion: 0.5
 Nodes (4): C.3 Add pulsing border and recovery badge to the card, code:typescript (<div), code:typescript (const recoveryBorderClass = isRecoveryInProgress && !isPerma), code:typescript (className={`relative ... bg-gradient-to-br ${cardTone} ${rec)
 
-### Community 1154 - "Community 1154"
+### Community 1150 - "Community 1150"
 Cohesion: 0.5
 Nodes (4): Implementation phases, Phase 1: Core resource tree, Phase 2: Container actions, Phase 3: Data enrichment
 
-### Community 1155 - "Community 1155"
+### Community 1151 - "Community 1151"
 Cohesion: 0.5
 Nodes (4): Component architecture, Existing components reused, Modified components, New components
 
-### Community 1156 - "Community 1156"
-Cohesion: 0.5
-Nodes (4): code:typescript (// Before error throw:), code:typescript (// Add debug logging:), code:typescript (// Improve error logging:), Task 4: Improve Error Context & Logging
-
-### Community 1157 - "Community 1157"
-Cohesion: 0.5
-Nodes (4): Integration Tests, Manual Testing, Testing Strategy, Unit Tests
-
-### Community 1158 - "Community 1158"
-Cohesion: 0.5
-Nodes (4): Phase 1: Core Fix (Immediate), Phase 2: Validation & Testing (Same PR), Phase 3: Integration & Documentation (Follow-up), Rollout Plan
-
-### Community 1159 - "Community 1159"
+### Community 1152 - "Community 1152"
 Cohesion: 0.5
 Nodes (4): code:typescript (return conditions.length > 0 ? conditions.join(' AND ') : ''), code:block3 (((ScheduleState != "Completed") AND (ScheduleState != "Accep), code:block4 ((((ScheduleState != "Completed") AND (ScheduleState != "Acce), Root Cause Analysis
 
-### Community 1160 - "Community 1160"
+### Community 1153 - "Community 1153"
 Cohesion: 0.5
-Nodes (4): code:markdown (### Rally Troubleshooting), code:block15, code:block16 (This will log the actual WSAPI queries being sent.), Task 8: Update Documentation
+Nodes (4): Integration Tests, Manual Testing, Testing Strategy, Unit Tests
 
-### Community 1161 - "Community 1161"
+### Community 1154 - "Community 1154"
+Cohesion: 0.5
+Nodes (4): Phase 1: Core Fix (Immediate), Phase 2: Validation & Testing (Same PR), Phase 3: Integration & Documentation (Follow-up), Rollout Plan
+
+### Community 1155 - "Community 1155"
+Cohesion: 0.5
+Nodes (4): code:typescript (// Before error throw:), code:typescript (// Add debug logging:), code:typescript (// Improve error logging:), Task 4: Improve Error Context & Logging
+
+### Community 1156 - "Community 1156"
 Cohesion: 0.5
 Nodes (4): code:bash (# System info), Diagnostic Information, Getting Help, Resources
 
-### Community 1162 - "Community 1162"
+### Community 1157 - "Community 1157"
 Cohesion: 0.5
 Nodes (3): Boundaries, Panopticon Review Agent, Responsibilities
 
-### Community 1163 - "Community 1163"
+### Community 1158 - "Community 1158"
 Cohesion: 0.5
 Nodes (3): Boundaries, Panopticon Merge Agent, Responsibilities
 
-### Community 1164 - "Community 1164"
+### Community 1159 - "Community 1159"
 Cohesion: 0.5
 Nodes (3): Boundaries, Panopticon UAT Agent, Responsibilities
 
-### Community 1165 - "Community 1165"
+### Community 1160 - "Community 1160"
 Cohesion: 0.5
 Nodes (3): Boundaries, Panopticon Test Agent, Responsibilities
 
-### Community 1166 - "Community 1166"
+### Community 1161 - "Community 1161"
 Cohesion: 0.5
 Nodes (3): Boundaries, Panopticon Inspect Agent, Responsibilities
 
-### Community 1167 - "Community 1167"
+### Community 1162 - "Community 1162"
 Cohesion: 0.5
 Nodes (4): High-Confidence Triggers (Always Invoke), Low-Confidence Triggers (Check Config First), Medium-Confidence Triggers (Invoke After 2+ Occurrences), When to Trigger (Self-Assessment)
 
-### Community 1168 - "Community 1168"
+### Community 1163 - "Community 1163"
 Cohesion: 0.5
 Nodes (3): pan approve — REMOVED, What to do instead, Why
 
-### Community 1169 - "Community 1169"
+### Community 1164 - "Community 1164"
 Cohesion: 0.5
 Nodes (4): code:block2 (After Compaction:), code:block3 (bd update issue-42 --notes "COMPLETED: User authentication -), code:block4 (bd update issue-42 --notes "Working on auth feature. Made so), Compaction Survival {#compaction-survival}
 
-### Community 1170 - "Community 1170"
+### Community 1165 - "Community 1165"
 Cohesion: 0.5
 Nodes (4): Advanced Features, Learn More, Next Steps, Productivity Tips
 
-### Community 1171 - "Community 1171"
+### Community 1166 - "Community 1166"
 Cohesion: 0.5
 Nodes (4): Agent States, Service States, Status Interpretation, Workspace States
 
-### Community 1172 - "Community 1172"
+### Community 1167 - "Community 1167"
 Cohesion: 0.5
 Nodes (4): Critical Issues, Healthy System, Needs Attention, Performance Indicators
 
-### Community 1173 - "Community 1173"
+### Community 1168 - "Community 1168"
 Cohesion: 0.5
 Nodes (3): Metadata schema, Stitch API reference, Technical mapping rules
 
-### Community 1174 - "Community 1174"
+### Community 1169 - "Community 1169"
 Cohesion: 0.5
 Nodes (4): code:bash (pan down), Graceful Shutdown (default), Graceful vs Forceful Shutdown, Hung Shutdown
 
-### Community 1175 - "Community 1175"
+### Community 1170 - "Community 1170"
 Cohesion: 0.5
 Nodes (4): Auto-Shutdown, code:bash (# Stop on user logout), Manual Triggers, On System Shutdown (systemd)
 
-### Community 1176 - "Community 1176"
+### Community 1171 - "Community 1171"
 Cohesion: 0.5
 Nodes (4): Best Practices, Performance, Resource Management, Security
 
-### Community 1188 - "Community 1188"
+### Community 1172 - "Community 1172"
+Cohesion: 0.5
+Nodes (4): code:bash (docker ps | grep traefik), code:bash (docker logs panopticon-traefik), code:bash (ls ~/.panopticon/traefik/certs/), "Connection refused" on HTTPS
+
+### Community 1183 - "Community 1183"
 Cohesion: 0.67
 Nodes (3): Available MCP Tools, Recommended Workflow, TLDR: Token-Efficient Code Analysis
 
-### Community 1189 - "Community 1189"
+### Community 1184 - "Community 1184"
 Cohesion: 0.67
 Nodes (3): code:json ({), code:json ({), Manifest Tracking
 
-### Community 1190 - "Community 1190"
-Cohesion: 0.67
-Nodes (3): code:block10 (pan sync), code:block11 (pan sync), What `pan sync` Does: Today vs End-State
-
-### Community 1191 - "Community 1191"
-Cohesion: 0.67
-Nodes (3): Dependencies & Sequencing, New native dependency, PAN-1249 — `src/lib/` Effect migration (in flight on `feature/pan-1249`)
-
-### Community 1192 - "Community 1192"
+### Community 1185 - "Community 1185"
 Cohesion: 0.67
 Nodes (3): Host disconnect & reconnect, Link lifecycle, Link Lifecycle & Disconnect/Reconnect
 
-### Community 1196 - "Community 1196"
+### Community 1186 - "Community 1186"
+Cohesion: 0.67
+Nodes (3): Dependencies & Sequencing, New native dependency, PAN-1249 — `src/lib/` Effect migration (in flight on `feature/pan-1249`)
+
+### Community 1187 - "Community 1187"
+Cohesion: 0.67
+Nodes (3): code:typescript (export function validateRallyConfig(config: RallyConfig): {), code:typescript (private async pollRally(): Promise<void> {), Task 5: Add Configuration Validation
+
+### Community 1191 - "Community 1191"
 Cohesion: 0.67
 Nodes (3): code:bash (cat .panopticon/knowledge-capture.json 2>/dev/null || echo "), code:json ({), Step 1: Check Configuration
 
-### Community 1197 - "Community 1197"
+### Community 1192 - "Community 1192"
 Cohesion: 0.67
-Nodes (3): code:block23 (Unblocking Workflow:), code:block24 (Situation: bd ready shows nothing), Unblocking Work {#unblocking}
+Nodes (3): code:block13 (Side Quest Workflow:), code:block14 (Main task: Adding user profiles), Side Quest Handling {#side-quests}
 
 ## Knowledge Gaps
 - **13279 isolated node(s):** `__dirname`, `FIXTURES_DIR`, `TEMP_ROOT_DIR`, `__dirname`, `ROOT` (+13274 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **50 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **51 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `fetch` connect `Community 65` to `Community 1`, `Community 130`, `Community 3`, `Community 515`, `Community 5`, `Community 388`, `Community 4`, `Community 264`, `Community 10`, `Community 138`, `Community 13`, `Community 14`, `Community 15`, `Community 20`, `Community 278`, `Community 25`, `Community 282`, `Community 154`, `Community 28`, `Community 29`, `Community 538`, `Community 31`, `Community 32`, `Community 30`, `Community 34`, `Community 297`, `Community 47`, `Community 177`, `Community 50`, `Community 51`, `Community 1076`, `Community 435`, `Community 55`, `Community 56`, `Community 57`, `Community 186`, `Community 700`, `Community 192`, `Community 193`, `Community 67`, `Community 452`, `Community 70`, `Community 454`, `Community 200`, `Community 73`, `Community 330`, `Community 586`, `Community 75`, `Community 78`, `Community 334`, `Community 82`, `Community 84`, `Community 212`, `Community 471`, `Community 474`, `Community 92`, `Community 100`, `Community 740`, `Community 742`, `Community 360`, `Community 232`, `Community 234`, `Community 111`, `Community 243`, `Community 1141`, `Community 633`?**
-  _High betweenness centrality (0.057) - this node is a cross-community bridge._
-- **Why does `VBriefDocument` connect `Community 34` to `Community 416`, `Community 417`, `Community 35`, `Community 4`, `Community 39`, `Community 75`, `Community 12`, `Community 208`, `Community 19`, `Community 20`, `Community 311`, `Community 152`, `Community 26`?**
+- **Why does `fetch` connect `Community 43` to `Community 1`, `Community 3`, `Community 7`, `Community 264`, `Community 9`, `Community 392`, `Community 11`, `Community 12`, `Community 909`, `Community 13`, `Community 15`, `Community 144`, `Community 17`, `Community 16`, `Community 19`, `Community 21`, `Community 24`, `Community 153`, `Community 26`, `Community 285`, `Community 286`, `Community 160`, `Community 33`, `Community 167`, `Community 296`, `Community 42`, `Community 1069`, `Community 1070`, `Community 46`, `Community 49`, `Community 693`, `Community 53`, `Community 185`, `Community 58`, `Community 61`, `Community 62`, `Community 63`, `Community 575`, `Community 65`, `Community 66`, `Community 67`, `Community 68`, `Community 196`, `Community 64`, `Community 332`, `Community 205`, `Community 461`, `Community 79`, `Community 208`, `Community 344`, `Community 221`, `Community 93`, `Community 735`, `Community 738`, `Community 741`, `Community 103`, `Community 1134`, `Community 1135`, `Community 625`, `Community 242`, `Community 243`, `Community 123`, `Community 254`, `Community 255`?**
+  _High betweenness centrality (0.056) - this node is a cross-community bridge._
+- **Why does `VBriefDocument` connect `Community 21` to `Community 417`, `Community 547`, `Community 7`, `Community 27`, `Community 218`, `Community 10`, `Community 52`, `Community 25`, `Community 26`, `Community 91`, `Community 28`, `Community 158`, `Community 31`?**
   _High betweenness centrality (0.040) - this node is a cross-community bridge._
-- **Why does `FsError` connect `Community 345` to `Community 0`, `Community 1`, `Community 386`, `Community 5`, `Community 263`, `Community 8`, `Community 266`, `Community 12`, `Community 14`, `Community 271`, `Community 16`, `Community 15`, `Community 20`, `Community 279`, `Community 24`, `Community 27`, `Community 413`, `Community 158`, `Community 33`, `Community 38`, `Community 39`, `Community 169`, `Community 51`, `Community 310`, `Community 59`, `Community 63`, `Community 192`, `Community 450`, `Community 197`, `Community 581`, `Community 456`, `Community 72`, `Community 330`, `Community 331`, `Community 76`, `Community 205`, `Community 332`, `Community 457`, `Community 209`, `Community 82`, `Community 210`, `Community 211`, `Community 341`, `Community 342`, `Community 344`, `Community 473`, `Community 472`, `Community 475`, `Community 98`, `Community 488`, `Community 490`, `Community 495`, `Community 112`, `Community 113`, `Community 242`, `Community 115`, `Community 124`, `Community 254`?**
+- **Why does `FsError` connect `Community 175` to `Community 0`, `Community 128`, `Community 1`, `Community 389`, `Community 646`, `Community 6`, `Community 5`, `Community 265`, `Community 10`, `Community 17`, `Community 145`, `Community 153`, `Community 26`, `Community 283`, `Community 32`, `Community 545`, `Community 161`, `Community 547`, `Community 165`, `Community 37`, `Community 40`, `Community 46`, `Community 431`, `Community 183`, `Community 58`, `Community 64`, `Community 194`, `Community 580`, `Community 197`, `Community 72`, `Community 459`, `Community 76`, `Community 77`, `Community 78`, `Community 79`, `Community 207`, `Community 208`, `Community 338`, `Community 83`, `Community 340`, `Community 204`, `Community 214`, `Community 87`, `Community 473`, `Community 474`, `Community 219`, `Community 478`, `Community 97`, `Community 98`, `Community 483`, `Community 100`, `Community 101`, `Community 230`, `Community 250`, `Community 362`, `Community 124`, `Community 498`, `Community 122`, `Community 252`?**
   _High betweenness centrality (0.011) - this node is a cross-community bridge._
 - **Are the 198 inferred relationships involving `fetch` (e.g. with `main()` and `main()`) actually correct?**
   _`fetch` has 198 INFERRED edges - model-reasoned connections that need verification._

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1596,8 +1596,8 @@
     "hash": "1e078d841bf5e66fbdc975b9223323e8"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-10/src/lib/config-yaml.ts": {
-    "mtime": 1779437019.456017,
-    "hash": "2b28a1f688a2c73bf7509aab4167b798"
+    "mtime": 1779447023.1587977,
+    "hash": "5841c79989a053b11b2aa458d09aa4df"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-10/src/lib/format-duration.ts": {
     "mtime": 1779437019.4670174,
@@ -4700,8 +4700,8 @@
     "hash": "6161a9841fc244116bd9a569954d827a"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-10/src/dashboard/server/routes/codex-auth.ts": {
-    "mtime": 1779437019.4050152,
-    "hash": "8789e0c24b5796ceb5721858d4fc232e"
+    "mtime": 1779447087.2720222,
+    "hash": "8db131791e9a08a3177f90655a1525be"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-10/src/dashboard/server/routes/http-handler.ts": {
     "mtime": 1779437019.4070153,
@@ -4752,8 +4752,8 @@
     "hash": "477f979573b3d905253f978276c47bc1"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-10/src/dashboard/server/routes/cliproxy.ts": {
-    "mtime": 1779437019.404015,
-    "hash": "868ed27642371211ce7a3bd44e7fd946"
+    "mtime": 1779447063.0051804,
+    "hash": "c1e36e284b8874c3b3084188b6c1a1c0"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-10/src/dashboard/server/routes/prereqs.ts": {
     "mtime": 1779437019.4070153,
@@ -4772,8 +4772,8 @@
     "hash": "2dd6352843a64b5fb6e051c18f24879b"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-10/src/dashboard/server/routes/flywheel.ts": {
-    "mtime": 1779437019.4060152,
-    "hash": "4cc89963df31f429234fd00135b64823"
+    "mtime": 1779447094.6892796,
+    "hash": "3b0eedc4ceaf443b108772446a077b48"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-10/src/dashboard/server/routes/jsonl-resolver.ts": {
     "mtime": 1779437019.4070153,
@@ -4788,12 +4788,12 @@
     "hash": "0ffd82c6107592b862f4544ea269abca"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-10/src/dashboard/server/routes/specialists.ts": {
-    "mtime": 1779437019.4090154,
-    "hash": "e5004a528c8d23b7c454249ac4820c5e"
+    "mtime": 1779447138.3797946,
+    "hash": "bdc9a867e152e927f62bbde3252d6662"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-10/src/dashboard/server/routes/discovered-sessions.ts": {
-    "mtime": 1779437019.4060152,
-    "hash": "fdbd78df6e4de30e6a414789e83b507d"
+    "mtime": 1779447151.653255,
+    "hash": "24574e026e382ae9b7c92735827e9d84"
   },
   "/home/eltmon/Projects/panopticon-cli/workspaces/feature-pan-1312-slot-10/src/dashboard/server/routes/workspaces.ts": {
     "mtime": 1779437161.1141849,

--- a/src/dashboard/server/routes/cliproxy.ts
+++ b/src/dashboard/server/routes/cliproxy.ts
@@ -3,12 +3,12 @@ import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
 import { jsonResponse } from '../http-helpers.js';
 import { httpHandler } from './http-handler.js';
 import {
-  isCliproxyRunningAsync,
+  isCliproxyRunningEffect,
   isCliproxyInstalled,
-  installCliproxyAsync,
-  restartCliproxyAsync,
-  stopCliproxyAsync,
-  startCliproxyAsync,
+  installCliproxyEffect,
+  restartCliproxyEffect,
+  stopCliproxyEffect,
+  startCliproxyEffect,
   readPidFile,
 } from '../../../lib/cliproxy.js';
 
@@ -27,7 +27,7 @@ export function getCachedCliproxyStatus(): CliproxyStatus | null {
 }
 
 async function refreshStatus(): Promise<void> {
-  const running = await isCliproxyRunningAsync();
+  const running = await Effect.runPromise(isCliproxyRunningEffect());
   const pid = readPidFile();
   lastStatus = { running, pid, checkedAt: new Date().toISOString() };
 }
@@ -55,7 +55,7 @@ export function startCliproxyWatchdog(): void {
         }
         if (!isCliproxyInstalled()) lastInstallAttemptAt = now;
         console.log('[cliproxy-watchdog] CLIProxy is down, attempting auto-restart...');
-        await restartCliproxyAsync();
+        await Effect.runPromise(restartCliproxyEffect());
         await refreshStatus();
         if (lastStatus?.running) {
           console.log('[cliproxy-watchdog] CLIProxy auto-restarted successfully');
@@ -109,11 +109,11 @@ const postCliproxyRestartRoute = HttpRouter.add(
         // Force-reinstall: stop, redownload binary at the pinned version, restart.
         // Required when bumping CLIPROXY_RELEASE_VERSION — otherwise install* skips
         // because the old binary is still on disk.
-        yield* Effect.promise(() => stopCliproxyAsync());
-        yield* Effect.promise(() => installCliproxyAsync(true));
-        yield* Effect.promise(() => startCliproxyAsync());
+        yield* stopCliproxyEffect();
+        yield* installCliproxyEffect(true);
+        yield* startCliproxyEffect();
       } else {
-        yield* Effect.promise(() => restartCliproxyAsync());
+        yield* restartCliproxyEffect();
       }
 
       yield* Effect.promise(() => refreshStatus());

--- a/src/dashboard/server/routes/codex-auth.ts
+++ b/src/dashboard/server/routes/codex-auth.ts
@@ -7,8 +7,8 @@ import { join } from 'node:path';
 import { jsonResponse } from '../http-helpers.js';
 import { httpHandler } from './http-handler.js';
 import { checkCodexAuthStatus } from '../../../lib/codex-auth.js';
-import { bridgeCodexAuthToCliproxyAsync, getCliproxyAuthDir } from '../../../lib/cliproxy.js';
-import { createSessionAsync, sessionExistsAsync, listSessionNamesAsync } from '../../../lib/tmux.js';
+import { bridgeCodexAuthToCliproxyEffect, getCliproxyAuthDir } from '../../../lib/cliproxy.js';
+import { createSessionAsyncEffect, sessionExistsAsyncEffect, listSessionNamesAsyncEffect } from '../../../lib/tmux.js';
 import { getDashboardApiUrl } from '../../../lib/config.js';
 import { validateOrigin } from './origin-validation.js';
 
@@ -111,7 +111,7 @@ const getCodexAuthRoute = HttpRouter.add(
 
 async function getExistingLiveReauthSession(): Promise<{ sessionName: string; session: ReauthSession } | null> {
   cleanupExpiredReauthSessions();
-  const sessions = await listSessionNamesAsync();
+  const sessions = await Effect.runPromise(listSessionNamesAsyncEffect());
   for (const [sessionName, session] of reauthSessions.entries()) {
     if (sessions.includes(sessionName)) return { sessionName, session };
   }
@@ -142,11 +142,9 @@ const postCodexReauthRoute = HttpRouter.add(
       const headless = !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY;
       const command = headless ? 'codex login --device-auth' : 'codex login';
 
-      yield* Effect.promise(() =>
-        createSessionAsync(sessionName, homedir(), command, {
-          env: { PATH: process.env.PATH || '' },
-        }),
-      );
+      yield* createSessionAsyncEffect(sessionName, homedir(), command, {
+        env: { PATH: process.env.PATH || '' },
+      });
 
       return jsonResponse(
         { sessionName, statusToken, headless },
@@ -176,13 +174,13 @@ const postCodexReauthStatusRoute = HttpRouter.add(
         return jsonResponse({ completed: true, success: false, error: 'Re-auth session expired or invalid' });
       }
 
-      const exists = yield* Effect.promise(() => sessionExistsAsync(sessionName));
+      const exists = yield* sessionExistsAsyncEffect(sessionName);
       if (exists) {
         return jsonResponse({ completed: false });
       }
 
       const beforeCredential = yield* Effect.promise(() => readBridgedCodexCredential());
-      const bridged = yield* Effect.promise(() => bridgeCodexAuthToCliproxyAsync());
+      const bridged = yield* bridgeCodexAuthToCliproxyEffect();
       const afterCredential = yield* Effect.promise(() => readBridgedCodexCredential());
       const refreshedCredential = bridged && (
         (beforeCredential.accessToken !== null && afterCredential.accessToken !== beforeCredential.accessToken) ||

--- a/src/dashboard/server/routes/discovered-sessions.ts
+++ b/src/dashboard/server/routes/discovered-sessions.ts
@@ -34,7 +34,7 @@ import type { ConversationFilter, DiscoveredSession } from '../../../lib/databas
 import type { SearchResult } from '../../../lib/conversations/search.js';
 import { CostThresholdError } from '../../../lib/conversations/enrichment/index.js';
 import { parseRelativeTime } from '../../../lib/conversations/search.js';
-import { getConversationsConfigAsync, updateConversationsConfigAsync } from '../../../lib/config-yaml.js';
+import { getConversationsConfigAsyncEffect, updateConversationsConfigAsyncEffect } from '../../../lib/config-yaml.js';
 import { embed } from '../../../lib/conversations/embeddings/providers.js';
 import { validateOrigin } from './origin-validation.js';
 import { rejectUnauthorizedDashboardRequest } from './dashboard-auth.js';
@@ -321,7 +321,7 @@ const searchRoute = HttpRouter.add(
     const offset = Number.isFinite(rawOffset) && rawOffset >= 0 ? rawOffset : 0;
 
     const filter = parseSearchParams(params);
-    const config = yield* Effect.promise(() => getConversationsConfigAsync());
+    const config = yield* getConversationsConfigAsyncEffect();
     return yield* Effect.promise(async () => {
       try {
         const operation = semantic ? 'searchSessionsSemantic' : 'searchSessions';
@@ -426,7 +426,7 @@ const postEnrichByIdRoute = HttpRouter.add(
     const tier = rawTier as 1 | 2 | 3;
 
     try {
-      const config = yield* Effect.promise(() => getConversationsConfigAsync());
+      const config = yield* getConversationsConfigAsyncEffect();
       const eventStore = yield* EventStoreService;
       const result = yield* Effect.promise(() =>
         runDashboardDbJob<{ enriched: number; errors: number; estimatedCost: number; actualCost: number | null; durationMs: number }>('enrichSessions', {
@@ -501,7 +501,7 @@ const postScanRoute = HttpRouter.add(
 
     const maxParallel = body.maxParallel !== undefined ? Math.min(Math.max(1, body.maxParallel), 16) : undefined;
 
-    const config = yield* Effect.promise(() => getConversationsConfigAsync());
+    const config = yield* getConversationsConfigAsyncEffect();
     const watchDirs = config.watchDirs;
     const eventStore = yield* EventStoreService;
     let lastProgressEmit = 0;
@@ -584,7 +584,7 @@ const postEnrichRoute = HttpRouter.add(
       return jsonResponse({ error: 'Invalid tier: must be 1, 2, or 3' }, { status: 400 });
     }
     const tier = rawTier as 1 | 2 | 3;
-    const config = yield* Effect.promise(() => getConversationsConfigAsync());
+    const config = yield* getConversationsConfigAsyncEffect();
     const enrichMaxParallel = body.maxParallel !== undefined ? Math.min(Math.max(1, body.maxParallel), 16) : config.enrichment.maxParallel;
     const enrichSessionIds = body.sessionIds ? body.sessionIds.slice(0, 500) : undefined;
     const eventStore = yield* EventStoreService;
@@ -669,7 +669,7 @@ const postEmbedRoute = HttpRouter.add(
     if (body.provider !== undefined && !VALID_PROVIDERS.has(body.provider)) {
       return jsonResponse({ error: `Invalid provider: must be one of openai, voyage, ollama` }, { status: 400 });
     }
-    const config = yield* Effect.promise(() => getConversationsConfigAsync());
+    const config = yield* getConversationsConfigAsyncEffect();
     const embedMaxParallel = body.maxParallel !== undefined ? Math.min(Math.max(1, body.maxParallel), 16) : config.enrichment.maxParallel;
     const embedSessionIds = body.sessionIds ? body.sessionIds.slice(0, 500) : undefined;
     const eventStore = yield* EventStoreService;
@@ -708,7 +708,7 @@ const getConvConfigRoute = HttpRouter.add(
     const req = yield* HttpServerRequest.HttpServerRequest;
     const authError = rejectUnauthorizedDashboardRequest(req);
     if (authError) return authError;
-    const config = yield* Effect.promise(() => getConversationsConfigAsync());
+    const config = yield* getConversationsConfigAsyncEffect();
     return validatedJsonResponse(ConfigResponseSchema, {
       embeddings: config.embeddings,
       embeddingProvider: config.embeddingProvider,
@@ -733,12 +733,12 @@ const putConvConfigRoute = HttpRouter.add(
     if (!parsedBody.ok) return parsedBody.response;
     const body = parsedBody.body;
 
-    yield* Effect.promise(() => updateConversationsConfigAsync({
+    yield* updateConversationsConfigAsyncEffect({
       embeddings: body.embeddings,
       embedding_provider: body.embeddingProvider as 'openai' | 'voyage' | 'ollama' | undefined,
       embedding_model: body.embeddingModel,
       embedding_auto_on_deep: body.embeddingAutoOnDeep,
-    }));
+    });
 
     return validatedJsonResponse(OkResponseSchema, { ok: true });
   })),

--- a/src/dashboard/server/routes/flywheel.ts
+++ b/src/dashboard/server/routes/flywheel.ts
@@ -16,7 +16,7 @@ import {
   type FlywheelRunStateOptions,
 } from '../services/flywheel-run-state.js';
 import { hasDashboardInternalToken, rejectUnauthorizedDashboardRequest } from './dashboard-auth.js';
-import { sessionExistsAsync } from '../../../lib/tmux.js';
+import { sessionExistsAsyncEffect } from '../../../lib/tmux.js';
 import { runDashboardDbJob } from '../services/dashboard-db-task.js';
 import {
   abortFlywheelRunForDashboard,
@@ -173,7 +173,7 @@ export async function getFlywheelCurrentPayload() {
 export async function getFlywheelConversationPayload() {
   const conversation = await runDashboardDbJob<{ tmuxSession: string } | null>('getConversationByName', FLYWHEEL_CONVERSATION_NAME);
   if (!conversation) return null;
-  const sessionAlive = await sessionExistsAsync(conversation.tmuxSession);
+  const sessionAlive = await Effect.runPromise(sessionExistsAsyncEffect(conversation.tmuxSession));
   return { ...conversation, sessionAlive };
 }
 

--- a/src/dashboard/server/routes/specialists.ts
+++ b/src/dashboard/server/routes/specialists.ts
@@ -72,7 +72,7 @@ import { readWorkspacePlan } from '../../../lib/vbrief/io.js';
 import { getUnblockedItems } from '../../../lib/cloister/task-readiness.js';
 import { EventStoreService } from '../services/domain-services.js';
 import { extractPrefix } from '../../../lib/issue-id.js';
-import { createSessionAsync, killSessionAsync } from '../../../lib/tmux.js';
+import { killSessionAsyncEffect } from '../../../lib/tmux.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -195,8 +195,9 @@ const postSpecialistsResetAllRoute = HttpRouter.add(
 
       if (yield* Effect.promise(() => isRunning(name))) {
         const tmuxSession = getTmuxSessionName(name);
-        const killResult = yield* Effect.promise(() =>
-          killSessionAsync(tmuxSession).then(() => true).catch(() => false),
+        const killResult = yield* killSessionAsyncEffect(tmuxSession).pipe(
+          Effect.as(true),
+          Effect.catchAll(() => Effect.succeed(false)),
         );
         killed = killResult;
       }
@@ -359,7 +360,7 @@ const postSpecialistsDoneRoute = HttpRouter.add(
         // PAN-846: Kill the specialist tmux session so it doesn't leak RAM.
         // The session has completed its work; next dispatch spawns fresh.
         try {
-          await killSessionAsync(tmuxSession);
+          await Effect.runPromise(killSessionAsyncEffect(tmuxSession));
           console.log(`[specialists/done] Killed specialist session ${tmuxSession}`);
         } catch (err) {
           console.log(`[specialists/done] Session ${tmuxSession} already gone or failed to kill: ${err instanceof Error ? err.message : String(err)}`);
@@ -583,10 +584,10 @@ const postSpecialistsDoneRoute = HttpRouter.add(
         yield* Effect.promise(async () => {
           try {
             const workAgentId = `agent-${normalizedIssueId.toLowerCase()}`;
-            const { sessionExistsAsync } = await import('../../../lib/tmux.js');
-            const { messageAgent, spawnAgent, getAgentState } = await import('../../../lib/agents.js');
+            const { sessionExistsAsyncEffect } = await import('../../../lib/tmux.js');
+            const { messageAgent } = await import('../../../lib/agents.js');
 
-            if (await sessionExistsAsync(workAgentId)) {
+            if (await Effect.runPromise(sessionExistsAsyncEffect(workAgentId))) {
               // Agent is running — send rebase instructions directly
               const rebaseMsg = `MERGE CONFLICT: The merge-agent could not rebase your branch onto main due to conflicts. Please fix this now:\n\n1. git fetch origin main\n2. git rebase origin/main\n3. Resolve any conflicts (git add <file> && git rebase --continue)\n4. git push --force-with-lease\n5. Resubmit: curl -s -X POST http://localhost:3011/api/review/${normalizedIssueId}/request -H "Content-Type: application/json" -d "{}"\n\nConflict details: ${notes}`;
               await messageAgent(workAgentId, rebaseMsg);
@@ -987,7 +988,7 @@ const postProjectSpecialistKillRoute = HttpRouter.add(
     const tmuxSession = getRunMetadata(project, registryKey).tmuxSession
       ?? getTmuxSessionName(type, project, issueId);
 
-    yield* Effect.promise(() => killSessionAsync(tmuxSession).catch(() => {}));
+    yield* killSessionAsyncEffect(tmuxSession).pipe(Effect.catchAll(() => Effect.succeed(undefined)));
     // Leave Claude JSONL/session artifacts intact; only reset Panopticon runtime state.
     saveAgentRuntimeState(tmuxSession, {
       state: 'idle',

--- a/src/lib/config-yaml.ts
+++ b/src/lib/config-yaml.ts
@@ -621,6 +621,16 @@ export async function getConversationsConfigAsync(): Promise<RuntimeConversation
   });
 }
 
+export const getConversationsConfigAsyncEffect = (): Effect.Effect<RuntimeConversationsConfig, ConfigError> =>
+  Effect.tryPromise({
+    try: () => getConversationsConfigAsync(),
+    catch: (cause) =>
+      new ConfigError({
+        message: cause instanceof Error ? cause.message : String(cause),
+        cause,
+      }),
+  });
+
 export async function updateConversationsConfigAsync(updates: ConversationsConfig): Promise<void> {
   await loadConfigAsyncNoMigration();
   let existingContent = '{}\n';


### PR DESCRIPTION
## Summary
- Replace in-scope dashboard route imports of Promise-based `src/lib` `*Async` helpers with Effect siblings.
- Add the missing `getConversationsConfigAsyncEffect` wrapper used by discovered-sessions routes.
- Refresh graphify metadata after the route migration.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`
- [x] grep target route files for actual `*Async` symbols
- [x] `graphify update .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)