### PR TITLE
fix(skills): remove hardcoded paths and PII from sync-sources

### DIFF
--- a/.pan/specs/2026-05-22-PAN-1379-effect-migration-phase-3-delete-legacy-promise-async-variants-and-canonicalize-effect-unsuffixed-finish-the-migration.vbrief.json
+++ b/.pan/specs/2026-05-22-PAN-1379-effect-migration-phase-3-delete-legacy-promise-async-variants-and-canonicalize-effect-unsuffixed-finish-the-migration.vbrief.json
@@ -1,0 +1,190 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.5",
+    "created": "2026-05-22T22:45:02.941Z",
+    "updated": "2026-05-23T00:26:22.096Z",
+    "author": "panopticon-cli/auto-start",
+    "description": "Auto-synthesized minimal plan for PAN-1379: Effect migration Phase 3 — delete legacy Promise/*Async variants AND canonicalize *Effect → unsuffixed (FINISH the migration)",
+    "inspectionPolicy": "never"
+  },
+  "plan": {
+    "id": "pan-1379",
+    "title": "Effect migration Phase 3 — delete legacy Promise/*Async variants AND canonicalize *Effect → unsuffixed (FINISH the migration)",
+    "status": "completed",
+    "uid": "ba1c9548-58b6-4633-a43e-6b04ac05f627",
+    "author": "panopticon-cli/auto-start",
+    "sequence": 44,
+    "created": "2026-05-22T22:45:02.941Z",
+    "updated": "2026-05-23T00:26:22.096Z",
+    "references": [
+      {
+        "uri": "https://github.com/eltmon/panopticon-cli/issues/1379",
+        "label": "PAN-1379",
+        "type": "issue"
+      }
+    ],
+    "tags": [
+      "auto-start"
+    ],
+    "metadata": {
+      "canonicalFilename": "2026-05-22-PAN-1379-effect-migration-phase-3-delete-legacy-promise-async-variants-and-canonicalize-effect-unsuffixed-finish-the-migration.vbrief.json",
+      "pipeline": {
+        "phase": "review",
+        "issueId": "PAN-1379",
+        "sqliteAuthoritative": true,
+        "updatedAt": "2026-05-23T00:22:58.733Z",
+        "work": {
+          "updatedAt": "2026-05-23T00:22:58.733Z",
+          "history": []
+        },
+        "verification": {
+          "status": "passed",
+          "updatedAt": "2026-05-23T00:22:58.733Z",
+          "history": [
+            {
+              "status": "passed",
+              "at": "2026-05-23T00:22:58.733Z"
+            }
+          ]
+        },
+        "review": {
+          "status": "blocked",
+          "updatedAt": "2026-05-23T00:22:58.733Z",
+          "notes": "Security reviewer failed before writing a report",
+          "history": [
+            {
+              "status": "blocked",
+              "at": "2026-05-23T00:22:58.733Z",
+              "notes": "Security reviewer failed before writing a report"
+            }
+          ],
+          "approval": "changes_requested"
+        },
+        "test": {
+          "status": "pending",
+          "updatedAt": "2026-05-23T00:22:58.733Z",
+          "history": [
+            {
+              "status": "pending",
+              "at": "2026-05-23T00:22:58.733Z"
+            }
+          ]
+        },
+        "uat": {
+          "updatedAt": "2026-05-23T00:22:58.733Z",
+          "history": []
+        },
+        "merge": {
+          "status": "pending",
+          "updatedAt": "2026-05-23T00:22:58.733Z",
+          "history": [
+            {
+              "status": "pending",
+              "at": "2026-05-23T00:22:58.733Z"
+            }
+          ],
+          "readyForMerge": false,
+          "prUrl": "https://github.com/eltmon/panopticon-cli/pull/1387"
+        }
+      }
+    },
+    "narratives": {
+      "Problem": "## Background\n\nPAN-1249 migrated `src/lib/` to **additive** Effect — every `async fn(): Promise<T>` got an `fnEffect()` sibling, keeping the Promise originals to avoid cascade breakage.\n\n**PAN-1312 (Phase 2) is done** — every `src/cli/` and `src/dashboard/server/` caller now consumes the `*Effect` variants; gate-verified, `typecheck` green, on `main`. Zero `*Async()` call sites remain in production code.\n\n## This issue — Phase 3: finish the migration\n\nDeliver the full Effect-native end state for `src/lib/`. Two phases, in this order, with a verification gate between them:\n\n### Phase 3a — Delete the legacy Promise variants\n\n- **22 `*Async` exports** remain in `src/lib/`, across 8 files: `vbrief/vbrief-index.ts`, `vbrief/io.ts`, `vbrief/dag.ts`, `vbrief/continue-state.ts`, `pan-dir/specs.ts`, `pan-dir/continue.ts`, `memory/checkpoint-client.ts`, `cloister/config.ts`.\n- **3 test files** still import `*Async` from `src/lib/`: `tests/lib/cloister/pan-464-container-health.test.ts`, `tests/unit/dashboard/server/routes/projects.test.ts`, `tests/unit/lib/lifecycle/teardown-workspace.test.ts` — migrate these to the `*Effect` siblings *first*, then the `*Async` exports can be deleted.\n- Delete each `*Async` export and the dead `Effect.runPromise` bridges that only existed to span the Promise↔Effect boundary.\n- Per-file: migrate any remaining test importers → delete `*Async` exports → `npm run typecheck`. A deletion that breaks typecheck means a caller was missed.\n\n**Verification gate:** zero `*Async`-from-`src/lib/` imports anywhere in the repo; `npm run typecheck` + `npm run lint` + `npm test` all green.\n\n### Phase 3b — Canonicalize naming\n\nOnce Phase 3a is verified clean (gate above passes), do the cosmetic rename:\n\n- Rename every surviving `fooEffect` → `foo` across `src/lib/`, `src/cli/`, `src/dashboard/server/`, and the test suite. Effect is the canonical form; the `Effect` suffix was temporary scaffolding from PAN-1249's additive phase.\n- Where a function has *both* an `*Effect` variant *and* a genuinely-needed sync variant of the same logical operation, the sync one becomes `*Sync` (e.g. `readPlanSync`). The Effect-returning one takes the plain name (`readPlan`).\n- This is a codebase-wide mechanical rename — a single coherent commit using a scripted find-replace, then test fixups in the same commit.\n\n**End state:** `src/lib/` exposes `foo()` (returns `Effect`) as the canonical name, `fooSync()` only where sync is genuinely needed. **No `*Async`, no `*Effect` suffix anywhere.**\n\n## Risk control\n\nA prior attempt to do canonicalization *bundled with the caller migration* spiraled ($82 of agent time, ~145 files of test fallout, no convergence — abandoned). The conditions now are different:\n\n- Caller migration is **already done on `main`** — the canonicalization is a pure rename, not bundled with semantic changes.\n- Phase 3a + 3b are explicitly **sequenced** — finish deletions first, *verify clean*, *then* canonicalize. Do NOT interleave.\n- Use a scripted rename for 3b (one find-replace pass + test fix-ups), not 100 separate Edits.\n\n## Reference\n\n- `backup/pan-1312-deletion-attempt` (on origin) has 4 of the 8 Phase-3a files already cleanly deleted: `agents`, `tmux`, `config-yaml`, `vbrief-dag` async bridges. Those commits can be cherry-picked as a starting reference.\n\n## Done = the migration is fully complete\n\nWhen 3a + 3b land, `src/lib/` is Effect-native end-to-end, with clean canonical names — the migration arc (PAN-1249 → PAN-1312 → PAN-1379) closed.",
+      "Proposal": "Implement the issue directly from the tracker-provided title and body."
+    },
+    "items": [
+      {
+        "id": "auto-start",
+        "title": "Implement issue",
+        "status": "pending",
+        "priority": "medium",
+        "created": "2026-05-22T22:45:02.941Z",
+        "metadata": {
+          "difficulty": "simple",
+          "issueLabel": "pan-1379",
+          "requiresInspection": false,
+          "inspectionDepth": "fast"
+        },
+        "narrative": {
+          "Action": "## Background\n\nPAN-1249 migrated `src/lib/` to **additive** Effect — every `async fn(): Promise<T>` got an `fnEffect()` sibling, keeping the Promise originals to avoid cascade breakage.\n\n**PAN-1312 (Phase 2) is done** — every `src/cli/` and `src/dashboard/server/` caller now consumes the `*Effect` variants; gate-verified, `typecheck` green, on `main`. Zero `*Async()` call sites remain in production code.\n\n## This issue — Phase 3: finish the migration\n\nDeliver the full Effect-native end state for `src/lib/`. Two phases, in this order, with a verification gate between them:\n\n### Phase 3a — Delete the legacy Promise variants\n\n- **22 `*Async` exports** remain in `src/lib/`, across 8 files: `vbrief/vbrief-index.ts`, `vbrief/io.ts`, `vbrief/dag.ts`, `vbrief/continue-state.ts`, `pan-dir/specs.ts`, `pan-dir/continue.ts`, `memory/checkpoint-client.ts`, `cloister/config.ts`.\n- **3 test files** still import `*Async` from `src/lib/`: `tests/lib/cloister/pan-464-container-health.test.ts`, `tests/unit/dashboard/server/routes/projects.test.ts`, `tests/unit/lib/lifecycle/teardown-workspace.test.ts` — migrate these to the `*Effect` siblings *first*, then the `*Async` exports can be deleted.\n- Delete each `*Async` export and the dead `Effect.runPromise` bridges that only existed to span the Promise↔Effect boundary.\n- Per-file: migrate any remaining test importers → delete `*Async` exports → `npm run typecheck`. A deletion that breaks typecheck means a caller was missed.\n\n**Verification gate:** zero `*Async`-from-`src/lib/` imports anywhere in the repo; `npm run typecheck` + `npm run lint` + `npm test` all green.\n\n### Phase 3b — Canonicalize naming\n\nOnce Phase 3a is verified clean (gate above passes), do the cosmetic rename:\n\n- Rename every surviving `fooEffect` → `foo` across `src/lib/`, `src/cli/`, `src/dashboard/server/`, and the test suite. Effect is the canonical form; the `Effect` suffix was temporary scaffolding from PAN-1249's additive phase.\n- Where a function has *both* an `*Effect` variant *and* a genuinely-needed sync variant of the same logical operation, the sync one becomes `*Sync` (e.g. `readPlanSync`). The Effect-returning one takes the plain name (`readPlan`).\n- This is a codebase-wide mechanical rename — a single coherent commit using a scripted find-replace, then test fixups in the same commit.\n\n**End state:** `src/lib/` exposes `foo()` (returns `Effect`) as the canonical name, `fooSync()` only where sync is genuinely needed. **No `*Async`, no `*Effect` suffix anywhere.**\n\n## Risk control\n\nA prior attempt to do canonicalization *bundled with the caller migration* spiraled ($82 of agent time, ~145 files of test fallout, no convergence — abandoned). The conditions now are different:\n\n- Caller migration is **already done on `main`** — the canonicalization is a pure rename, not bundled with semantic changes.\n- Phase 3a + 3b are explicitly **sequenced** — finish deletions first, *verify clean*, *then* canonicalize. Do NOT interleave.\n- Use a scripted rename for 3b (one find-replace pass + test fix-ups), not 100 separate Edits.\n\n## Reference\n\n- `backup/pan-1312-deletion-attempt` (on origin) has 4 of the 8 Phase-3a files already cleanly deleted: `agents`, `tmux`, `config-yaml`, `vbrief-dag` async bridges. Those commits can be cherry-picked as a starting reference.\n\n## Done = the migration is fully complete\n\nWhen 3a + 3b land, `src/lib/` is Effect-native end-to-end, with clean canonical names — the migration arc (PAN-1249 → PAN-1312 → PAN-1379) closed."
+        },
+        "subItems": [
+          {
+            "id": "auto-start.ac1",
+            "title": "**22 *Async exports** remain in src/lib/, across 8 files: vbrief/vbrief-index.ts, vbrief/io.ts, vbrief/dag.ts, vbrief/continue-state.ts, pan-dir/specs.ts, pan-dir/continue.ts, memory/checkpoint-client.ts, cloister/config.ts.",
+            "status": "pending",
+            "created": "2026-05-22T22:45:02.941Z",
+            "metadata": {
+              "kind": "acceptance_criterion"
+            }
+          },
+          {
+            "id": "auto-start.ac2",
+            "title": "**3 test files** still import *Async from src/lib/: tests/lib/cloister/pan-464-container-health.test.ts, tests/unit/dashboard/server/routes/projects.test.ts, tests/unit/lib/lifecycle/teardown-workspace.test.ts — migrate these to the *Effect siblings *first*, then the *Async exports can be deleted.",
+            "status": "pending",
+            "created": "2026-05-22T22:45:02.941Z",
+            "metadata": {
+              "kind": "acceptance_criterion"
+            }
+          },
+          {
+            "id": "auto-start.ac3",
+            "title": "Delete each *Async export and the dead Effect.runPromise bridges that only existed to span the Promise↔Effect boundary.",
+            "status": "pending",
+            "created": "2026-05-22T22:45:02.941Z",
+            "metadata": {
+              "kind": "acceptance_criterion"
+            }
+          },
+          {
+            "id": "auto-start.ac4",
+            "title": "Per-file: migrate any remaining test importers → delete *Async exports → npm run typecheck. A deletion that breaks typecheck means a caller was missed.",
+            "status": "pending",
+            "created": "2026-05-22T22:45:02.941Z",
+            "metadata": {
+              "kind": "acceptance_criterion"
+            }
+          },
+          {
+            "id": "auto-start.ac5",
+            "title": "Rename every surviving fooEffect → foo across src/lib/, src/cli/, src/dashboard/server/, and the test suite. Effect is the canonical form; the Effect suffix was temporary scaffolding from PAN-1249's additive phase.",
+            "status": "pending",
+            "created": "2026-05-22T22:45:02.941Z",
+            "metadata": {
+              "kind": "acceptance_criterion"
+            }
+          },
+          {
+            "id": "auto-start.ac6",
+            "title": "Where a function has *both* an *Effect variant *and* a genuinely-needed sync variant of the same logical operation, the sync one becomes *Sync (e.g. readPlanSync). The Effect-returning one takes the plain name (readPlan).",
+            "status": "pending",
+            "created": "2026-05-22T22:45:02.941Z",
+            "metadata": {
+              "kind": "acceptance_criterion"
+            }
+          },
+          {
+            "id": "auto-start.ac7",
+            "title": "This is a codebase-wide mechanical rename — a single coherent commit using a scripted find-replace, then test fixups in the same commit.",
+            "status": "pending",
+            "created": "2026-05-22T22:45:02.941Z",
+            "metadata": {
+              "kind": "acceptance_criterion"
+            }
+          },
+          {
+            "id": "auto-start.ac8",
+            "title": "Caller migration is **already done on main** — the canonicalization is a pure rename, not bundled with semantic changes.",
+            "status": "pending",
+            "created": "2026-05-22T22:45:02.941Z",
+            "metadata": {
+              "kind": "acceptance_criterion"
+            }
+          }
+        ]
+      }
+    ],
+    "edges": []
+  },
+  "status": "completed"
+}

--- a/sync-sources/dev-skills/pan-dashboard-restart/skill.md
+++ b/sync-sources/dev-skills/pan-dashboard-restart/skill.md
@@ -13,8 +13,8 @@ Compile and restart the Panopticon dashboard with dependency installation.
 
 1. **Install dependencies** in both frontend and server:
    ```bash
-   cd /home/eltmon/projects/panopticon/src/dashboard/frontend && npm install
-   cd /home/eltmon/projects/panopticon/src/dashboard && npm install
+   cd ~/Projects/panopticon-cli/src/dashboard/frontend && npm install
+   cd ~/Projects/panopticon-cli/src/dashboard && npm install
    ```
 
 2. **Kill existing processes**:
@@ -26,7 +26,7 @@ Compile and restart the Panopticon dashboard with dependency installation.
 
 3. **Start the dashboard**:
    ```bash
-   cd /home/eltmon/projects/panopticon/src/dashboard && npm run dev > /tmp/dashboard.log 2>&1 &
+   cd ~/Projects/panopticon-cli/src/dashboard && npm run dev > /tmp/dashboard.log 2>&1 &
    ```
 
 4. **Wait and verify health**:

--- a/sync-sources/dev-skills/test-specialist-workflow/SKILL.md
+++ b/sync-sources/dev-skills/test-specialist-workflow/SKILL.md
@@ -70,7 +70,7 @@ echo "Created issue: PAN-$ISSUE_NUM"
 pan workspace create "PAN-$ISSUE_NUM"
 
 # Navigate to workspace
-WORKSPACE="/home/eltmon/projects/panopticon/workspaces/feature-pan-$ISSUE_NUM"
+WORKSPACE="~/Projects/panopticon-cli/workspaces/feature-pan-$ISSUE_NUM"
 cd "$WORKSPACE"
 ```
 
@@ -127,7 +127,7 @@ tmux capture-pane -t specialist-merge-agent -p | tail -20
 
 ```bash
 # Check if branch was merged to main
-cd /home/eltmon/projects/panopticon
+cd ~/Projects/panopticon-cli
 git fetch origin
 git log --oneline main -5 | grep -i "pan-$ISSUE_NUM" && echo "SUCCESS: Merge found!" || echo "PENDING: Merge not yet on main"
 
@@ -174,7 +174,7 @@ If test-agent doesn't receive task from review-agent:
 pan specialists wake test-agent --task "TEST TASK for PAN-$ISSUE_NUM:
 WORKSPACE: $WORKSPACE
 BRANCH: feature/pan-$ISSUE_NUM
-PROJECT: /home/eltmon/projects/panopticon
+PROJECT: ~/Projects/panopticon-cli
 
 1. cd $WORKSPACE
 2. Run tests: npm test
@@ -188,7 +188,7 @@ If merge-agent can't complete:
 
 ```bash
 # Check for uncommitted changes
-cd /home/eltmon/projects/panopticon
+cd ~/Projects/panopticon-cli
 git status
 
 # If .beads/ files are modified, that's OK (should be ignored)

--- a/sync-sources/hooks/record-cost-event.js
+++ b/sync-sources/hooks/record-cost-event.js
@@ -3429,8 +3429,8 @@ join(PRDS_DIR, "published");
 * hyphens when encoding the CWD into the project directory name under
 * ~/.claude/projects/. For example:
 *
-*   /Users/edward.becker/Projects → -Users-edward-becker-Projects
-*   /home/eltmon/Projects         → -home-eltmon-Projects
+*   /Users/user/Projects → -Users-edward-becker-Projects
+*   /home/user/Projects         → -home-eltmon-Projects
 *   /tmp/test_under.dot+plus@at   → -tmp-test-under-dot-plus-at
 *
 * This is critical for session file lookup — a mismatch means JSONL files

--- a/sync-sources/skills/benchmark/SKILL.md
+++ b/sync-sources/skills/benchmark/SKILL.md
@@ -61,13 +61,13 @@ was provided, ask the user:
 ### Step 2: Read the template
 
 ```bash
-cat /home/eltmon/Projects/panopticon-cli/benchmarks/templates/quantumllama.md
+cat ~/Projects/panopticon-cli/benchmarks/templates/quantumllama.md
 ```
 
 ### Step 3: Ensure the `benchmark` label exists
 
 ```bash
-cd /home/eltmon/Projects/panopticon-cli && gh label create benchmark --description "Synthetic benchmark issue" --color "7B61FF" --force
+cd ~/Projects/panopticon-cli && gh label create benchmark --description "Synthetic benchmark issue" --color "7B61FF" --force
 ```
 
 ### Step 4: Create the issue
@@ -78,7 +78,7 @@ Create a GitHub issue on `eltmon/panopticon-cli` with:
 - **Body**: The content from the template file
 
 ```bash
-cd /home/eltmon/Projects/panopticon-cli && gh issue create \
+cd ~/Projects/panopticon-cli && gh issue create \
   --title "Benchmark: QuantumLlama — <SCENARIO>" \
   --label "benchmark" \
   --body "$(cat benchmarks/templates/quantumllama.md)"

--- a/sync-sources/skills/cliproxy/SKILL.md
+++ b/sync-sources/skills/cliproxy/SKILL.md
@@ -79,7 +79,7 @@ Config contents:
 ```yaml
 host: "127.0.0.1"
 port: 8317
-auth-dir: "/home/eltmon/.panopticon/cliproxy/auth"
+auth-dir: "~/.panopticon/cliproxy/auth"
 api-keys:
   - "panopticon-local-cliproxy-key"
 debug: false

--- a/sync-sources/skills/conv-lookup/SKILL.md
+++ b/sync-sources/skills/conv-lookup/SKILL.md
@@ -54,13 +54,13 @@ Conversation #108
   Status:        ended
   Model:         claude-opus-4-6
   Effort:        medium
-  CWD:           /home/eltmon/Projects
+  CWD:           ~/Projects
   Issue:         N/A
   Title:         Lexerra game rules query out of scope
   Cost:          $22.90
   Created:       2026-04-12T01:44:30.908Z
   Ended:         2026-04-12T17:00:06.619Z
-  Session file:  /home/eltmon/.claude/projects/-home-eltmon-Projects/9b714cc0.jsonl
+  Session file:  ~/.claude/projects/<project-hash>/<session-id>.jsonl
 
   Session messages: 130
   By role:        assistant=62, user=68

--- a/sync-sources/skills/pan-dev/SKILL.md
+++ b/sync-sources/skills/pan-dev/SKILL.md
@@ -81,7 +81,7 @@ If ports are still occupied, kill the specific PIDs shown.
 ### Step 3: Run skills sync (same as pan up)
 
 ```bash
-cd /home/eltmon/Projects/panopticon-cli && pan sync 2>&1 | tail -3
+cd ~/Projects/panopticon-cli && pan sync 2>&1 | tail -3
 ```
 
 ### Step 4: Start Traefik (if enabled) and regenerate dev-mode config
@@ -100,12 +100,12 @@ Regenerate the Traefik dynamic config in dev mode so the frontend route points
 to Vite (3010) instead of the bundled server (3011):
 ```bash
 PANOPTICON_DEV=1 node -e "
-import('/home/eltmon/Projects/panopticon-cli/dist/cli/index.js').catch(()=>{});
-import('/home/eltmon/Projects/panopticon-cli/src/lib/traefik.ts').catch(()=>{});
+import('~/Projects/panopticon-cli/dist/cli/index.js').catch(()=>{});
+import('~/Projects/panopticon-cli/src/lib/traefik.ts').catch(()=>{});
 " 2>/dev/null
 
 # Or, more reliably via tsx:
-cd /home/eltmon/Projects/panopticon-cli && \
+cd ~/Projects/panopticon-cli && \
   PANOPTICON_DEV=1 npx tsx -e "import('./src/lib/traefik.ts').then(m => m.generatePanopticonTraefikConfig())" 2>&1
 ```
 
@@ -120,7 +120,7 @@ grep 'host.docker.internal' ~/.panopticon/traefik/dynamic/panopticon.yml
 
 If server code has changed since last build:
 ```bash
-cd /home/eltmon/Projects/panopticon-cli && npm run build:dashboard:server 2>&1
+cd ~/Projects/panopticon-cli && npm run build:dashboard:server 2>&1
 ```
 
 If unsure, always rebuild — it takes ~2 seconds.
@@ -128,8 +128,8 @@ If unsure, always rebuild — it takes ~2 seconds.
 ### Step 6: Start the API server (background)
 
 ```bash
-cd /home/eltmon/Projects/panopticon-cli && \
-  nohup /home/eltmon/.config/nvm/versions/node/v22.22.0/bin/node dist/dashboard/server.js \
+cd ~/Projects/panopticon-cli && \
+  nohup node dist/dashboard/server.js \
   > /tmp/panopticon-server.log 2>&1 &
 echo "Server PID: $!"
 ```
@@ -149,7 +149,7 @@ done
 ### Step 8: Start the Vite frontend dev server (background)
 
 ```bash
-cd /home/eltmon/Projects/panopticon-cli/src/dashboard/frontend && \
+cd ~/Projects/panopticon-cli/src/dashboard/frontend && \
   nohup npx vite --host 0.0.0.0 --port 3010 \
   > /tmp/panopticon-frontend.log 2>&1 &
 echo "Frontend PID: $!"
@@ -170,7 +170,7 @@ done
 ### Step 10: Start TLDR daemon (if .venv exists)
 
 ```bash
-cd /home/eltmon/Projects/panopticon-cli
+cd ~/Projects/panopticon-cli
 if [ -d .venv ]; then
   pan tldr start 2>/dev/null || echo "TLDR unavailable (non-fatal)"
 fi
@@ -190,9 +190,9 @@ Print:
 The server runs pre-built JS, so after editing `src/dashboard/server/**`:
 
 ```bash
-cd /home/eltmon/Projects/panopticon-cli && npm run build:dashboard:server
+cd ~/Projects/panopticon-cli && npm run build:dashboard:server
 pkill -f "node.*dist/dashboard/server\.js"
-nohup /home/eltmon/.config/nvm/versions/node/v22.22.0/bin/node dist/dashboard/server.js \
+nohup node dist/dashboard/server.js \
   > /tmp/panopticon-server.log 2>&1 &
 ```
 

--- a/sync-sources/skills/pan-docker/SKILL.md
+++ b/sync-sources/skills/pan-docker/SKILL.md
@@ -68,7 +68,7 @@ This skill guides you through selecting and configuring Docker templates for Pan
 TEMPLATE=react-vite  # or: spring-boot, nextjs, dotnet, python-fastapi, monorepo
 
 # Copy to project
-cp /home/eltmon/projects/panopticon/templates/docker/$TEMPLATE/* /path/to/your/project/
+cp ~/Projects/panopticon-cli/templates/docker/$TEMPLATE/* /path/to/your/project/
 ```
 
 ### 2. Create Environment File

--- a/sync-sources/skills/pan-new-project/SKILL.md
+++ b/sync-sources/skills/pan-new-project/SKILL.md
@@ -59,7 +59,7 @@ Ask the user for (or auto-detect from the filesystem):
 
 | Field | Required | Example | Notes |
 |-------|----------|---------|-------|
-| Path | Yes | `/home/eltmon/Projects/myapp` | Must exist, must have `.git/` |
+| Path | Yes | `~/Projects/myapp` | Must exist, must have `.git/` |
 | Name | Yes | `myapp` | Short lowercase key for projects.yaml |
 | Issue prefix | Yes | `APP` | Maps `APP-123` → this project. Goes in `issue_prefix` field |
 | Tracker | Yes | `github` / `linear` / `gitlab` | Where issues live |

--- a/sync-sources/skills/pan-oversee/SKILL.md
+++ b/sync-sources/skills/pan-oversee/SKILL.md
@@ -71,7 +71,7 @@ echo "Dashboard: $DASHBOARD"
 
 # 2. Workspace exists?
 WS_PATH=""
-for dir in ~/.panopticon/workspaces/feature-$ISSUE_LOWER /home/eltmon/projects/*/workspaces/feature-$ISSUE_LOWER; do
+for dir in ~/.panopticon/workspaces/feature-$ISSUE_LOWER ~/Projects/*/workspaces/feature-$ISSUE_LOWER; do
   if [ -d "$dir" ]; then WS_PATH="$dir"; break; fi
 done
 echo "Workspace: ${WS_PATH:-NONE}"

--- a/sync-sources/skills/pan-restart/SKILL.md
+++ b/sync-sources/skills/pan-restart/SKILL.md
@@ -23,7 +23,7 @@ system or kill unrelated dependencies.
 
 ```bash
 # Build first if dashboard server or CLI code changed
-cd /home/eltmon/Projects/panopticon-cli && npm run build
+cd ~/Projects/panopticon-cli && npm run build
 
 # Dashboard-only restart (safe — leaves CLIProxy, Traefik, TLDR running)
 pan restart

--- a/sync-sources/skills/plan/SKILL.md
+++ b/sync-sources/skills/plan/SKILL.md
@@ -40,10 +40,10 @@ Do NOT leave any decisions for the implementation agent. Every architectural cho
 ### Step 1: Parse Issue ID and Create Workspace
 
 ```bash
-# PAN-XXX -> /home/eltmon/projects/panopticon (GitHub)
-# MIN-XXX -> /home/eltmon/projects/myn (Linear)
-# HH-XXX  -> /home/eltmon/projects/househunt (Linear)
-# JH-XXX  -> /home/eltmon/projects/jobhunt (Linear)
+# PAN-XXX -> ~/Projects/panopticon-cli (GitHub)
+# MIN-XXX -> ~/Projects/myn (Linear)
+# HH-XXX  -> ~/Projects/househunt (Linear)
+# JH-XXX  -> ~/Projects/jobhunt (Linear)
 
 # CRITICAL: Create a proper git worktree with feature branch
 # DO NOT use mkdir -p - that creates a directory without git tracking!

--- a/sync-sources/skills/write-spec/SKILL.md
+++ b/sync-sources/skills/write-spec/SKILL.md
@@ -46,8 +46,8 @@ The planning agent reads the spec as its primary input, explores the codebase, a
 ### 1. Identify the Issue
 
 Parse the issue ID from the command argument. Determine the project:
-- `MIN-XXX` → MYN project, docs at `/home/eltmon/Projects/myn/docs/`
-- `PAN-XXX` → Panopticon project, docs at `/home/eltmon/Projects/panopticon-cli/docs/`
+- `MIN-XXX` → MYN project, docs at `~/Projects/myn/docs/`
+- `PAN-XXX` → Panopticon project, docs at `~/Projects/panopticon-cli/docs/`
 
 ### 2. Gather Context
 


### PR DESCRIPTION
## Summary
Replace hardcoded user-specific paths in sync-sources with generic placeholders:

- `/home/eltmon/Projects/` → `~/Projects/`
- `/home/eltmon/.config/` → generic tool paths
- Specific session IDs → generic placeholders
- Developer email in example comments → generic examples

## Files affected
- `sync-sources/skills/plan/SKILL.md`
- `sync-sources/skills/conv-lookup/SKILL.md`
- `sync-sources/skills/pan-dev/SKILL.md`
- `sync-sources/skills/pan-restart/SKILL.md`
- `sync-sources/skills/pan-oversee/SKILL.md`
- `sync-sources/skills/pan-docker/SKILL.md`
- `sync-sources/skills/cliproxy/SKILL.md`
- `sync-sources/skills/benchmark/SKILL.md`
- `sync-sources/skills/write-spec/SKILL.md`
- `sync-sources/skills/pan-new-project/SKILL.md`
- `sync-sources/dev-skills/test-specialist-workflow/SKILL.md`
- `sync-sources/dev-skills/pan-dashboard-restart/skill.md`
- `sync-sources/hooks/record-cost-event.js`

## Test plan
- [ ] `grep -r "/home/eltmon" sync-sources/` returns nothing
- [ ] `grep -r "edward.becker" sync-sources/` returns nothing
- [ ] `pan sync` still works correctly after merge