### PR TITLE
feat(catalog): trim OpenAI catalog to Codex CLI list + flywheel addendum to model recs

### DIFF
--- a/docs/MODEL_RECOMMENDATIONS.md
+++ b/docs/MODEL_RECOMMENDATIONS.md
@@ -30,6 +30,8 @@ Mark the following as wrong or outdated:
 - **Speed rankings** (Gemini 2.0 Flash, GLM-4 Flash) — outdated. Use Gemini 3 Flash Preview, GLM-4.7 Flash, or MiniMax M2.7 Highspeed as the new fast-tier references; no current published latency benchmark covers the 2026 fleet uniformly, so we don't rank them numerically here.
 - **Monthly cost estimates** — kept as a rough order-of-magnitude only. Actual cost moved with new tokenizers, prompt caching defaults, and the broader provider mix.
 - **Sources list** — the 2025-era articles linked at the bottom are largely superseded; updated source URLs are inline per row in the per-model tables below.
+- **OpenAI catalog (2026-05-23 addendum, PAN-1122):** trimmed to match the Codex CLI published list. Kept: `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`. Dropped: `gpt-5.5-pro`, `gpt-5.4-pro`, `gpt-5.5-mini`, `gpt-5.5-nano`, `gpt-5.4-nano`, `o3`, `o4-mini`, `gpt-4o`, `gpt-4o-mini`. Saved configs referencing dropped IDs are migrated by `MODEL_DEPRECATIONS` in `src/lib/model-capabilities.ts` and warned at settings-load. `gpt-5.5-pro` is OUT of consideration for any role going forward.
+- **Sonnet 4.6 + Opus 4.7 capability notes already current.** No further Claude family changes in this revision.
 
 ## Performance benchmarks — what's verified
 
@@ -41,15 +43,18 @@ Confidence column: **H** = vendor page + ≥1 corroborating source. **M** = sing
 |---|---|---|---|
 | gpt-5.5 | 88.7% | H | openai.com/index/introducing-gpt-5-5, tokenmix |
 | claude-opus-4-7 | 87.6% | H | vellum.ai, anthropic news |
+| gpt-5.3-codex | 85.0% | M | marc0.dev/en/leaderboard (May 2026) |
 | gemini-3.1-pro-preview | 80.6% | H | smartchunks.com, vellum.ai |
 | kimi-k2.6 | 80.2% | H | benchlm.ai, automatio.ai |
+| gpt-5.2 | 80.0% (Thinking) | H | vellum.ai/blog/gpt-5-2-benchmarks, marc0.dev |
 | claude-sonnet-4-6 | 79.6% | H | digitalapplied.com, nxcode.io, rootly.com |
 | mimo-v2.5-pro | 78.9% | M | buildfastwithai |
 | gemini-3-flash-preview | 78% | H | blog.google flash announcement |
 | minimax-m2.7 | 78% | M | thomas-wiegold.com, wavespeed.ai |
 | claude-haiku-4-5 | 73.3% | H | llm-stats, medium leucopsis |
 | glm-4.7-flash | 59.2% | M | deepinfra |
-| gpt-5.5-pro | — | — | not separately published |
+| gpt-5.3-codex-spark | — | — | research preview; benchmark "coming soon" per benchlm.ai |
+| gpt-5.4 | — | — | not separately published |
 | gpt-5.4-mini | — | — | SWE-Bench Pro 54.4% reported, Verified not split out |
 | gemini-3.1-flash-lite-preview | — | — | not separately published |
 | glm-5.1 | — | — | SWE-Bench Pro 58.4% (SOTA), Verified not separately published |
@@ -59,9 +64,9 @@ Confidence column: **H** = vendor page + ≥1 corroborating source. **M** = sing
 
 | Model | Score | Confidence | Source |
 |---|---|---|---|
-| gpt-5.5-pro | 94.4% | M | almcorp.com (cited "5.4 Pro" / 5.5 Pro) |
 | gemini-3.1-pro-preview | 94.3% | H | DeepMind model card |
 | claude-opus-4-7 | 94.2% | H | vellum.ai, anthropic announcement |
+| gpt-5.2 | 92.4% (Thinking) | H | vellum.ai |
 | gemini-3-flash-preview | 90.4% | H | blog.google flash announcement |
 | kimi-k2.6 | 90.5% | H | benchlm.ai |
 | minimax-m2.7 | 87.4% | M | wavespeed.ai |
@@ -72,7 +77,10 @@ Confidence column: **H** = vendor page + ≥1 corroborating source. **M** = sing
 | mimo-v2.5-pro | 66.7% | M | buildfastwithai |
 | claude-haiku-4-5 | — | — | "middling" per vals.ai, no exact score |
 | gpt-5.5 | — | — | not separately published |
+| gpt-5.4 | — | — | not separately published |
 | gpt-5.4-mini | — | — | conflicting secondary numbers, none confirmed |
+| gpt-5.3-codex | — | — | pricepertoken lists "GPQA 91.5" but does not clarify Diamond subset |
+| gpt-5.3-codex-spark | — | — | no published score (research preview) |
 | minimax-m2.7-highspeed | — | — | no separate eval |
 
 ### MMLU-Pro
@@ -127,8 +135,11 @@ No vendor publishes effective-context retrieval scores for the 2026 fleet. Third
 | claude-sonnet-4-6 | $3.00 | $15.00 | 50% batch; 90% cache reads |
 | claude-haiku-4-5 | $1.00 | $5.00 | 50% batch; 90% cache reads |
 | gpt-5.5 | $5.00 | $30.00 | 50% batch/flex; cached input $0.50; Priority 2.5x; >272k input 2x in / 1.5x out |
-| gpt-5.5-pro | $30.00 | $180.00 | 50% batch/flex; Priority 2.5x; cached rate UNVERIFIED |
+| gpt-5.4 | UNVERIFIED | UNVERIFIED | Vendor pricing page didn't separate gpt-5.4 base from the family in retrievable excerpts |
 | gpt-5.4-mini | $0.75 | $4.50 | Cached input $0.075 (90% off); batch discount likely but not separately quoted |
+| gpt-5.3-codex | $1.75 | $14.00 | Cached input $0.175 (90% off); Priority 2.5x ($3.50/$28.00); batch UNVERIFIED |
+| gpt-5.3-codex-spark | n/a (API) | n/a (API) | ChatGPT-Pro-only research preview; routed via Codex CLI subscription auth through CLIProxy, not raw API. Headline rate card matches the family when reachable. |
+| gpt-5.2 | $1.75 | $14.00 | Cached input $0.175 (90% off); batch UNVERIFIED |
 | gemini-3.1-pro-preview | $2.00 (≤200k) / $4.00 (>200k) | $12.00 / $18.00 | 50% batch; context cache $0.20/1M ≤200k |
 | gemini-3-flash-preview | $0.50 | $3.00 | 50% batch; context caching available |
 | gemini-3.1-flash-lite-preview | $0.25 | $1.50 | 50% batch; context cache; flat across thinking levels |
@@ -147,8 +158,11 @@ No vendor publishes effective-context retrieval scores for the 2026 fleet. Third
 | claude-sonnet-4-6 | 1,000,000 (1M beta) | — |
 | claude-haiku-4-5 | 200,000 | — |
 | gpt-5.5 | 1,050,000 | 128,000 |
-| gpt-5.5-pro | 1,050,000 | 128,000 |
+| gpt-5.4 | 1,050,000 | 128,000 |
 | gpt-5.4-mini | 400,000 | 128,000 |
+| gpt-5.3-codex | 400,000 | UNVERIFIED |
+| gpt-5.3-codex-spark | 128,000 | UNVERIFIED |
+| gpt-5.2 | 400,000 | 128,000 |
 | gemini-3.1-pro-preview | 1,000,000 | — |
 | gemini-3-flash-preview | 1,000,000 | — |
 | gemini-3.1-flash-lite-preview | 1,048,576 | 64,000 |
@@ -172,8 +186,12 @@ No vendor publishes effective-context retrieval scores for the 2026 fleet. Third
 **claude-sonnet-4-6.** 79.6% SWE-Bench Verified single-run; near-Opus on practical enterprise tasks at 1/5 the cost. Default model for the implementation pipeline. The 1M ctx beta lets it carry the whole spec + relevant code without trimming.
 
 **Alternatives:**
+- `gpt-5.3-codex` ($1.75/$14.00, 400k ctx, 85.0% SWE-Bench Verified) — coding-optimized OpenAI flagship. Strong default when the operator wants ChatGPT subscription auth via Codex CLI / CLIProxy instead of an Anthropic key. Higher per-token output cost than Sonnet 4.6 but the cached-input rate ($0.175/1M, 90% off) makes long-running implementation loops competitive.
 - `minimax-m2.7` ($0.28/$1.20, 78% SWE-Bench Verified, 87.4% GPQA, auto-cache $0.06/1M) — cheapest verified high-quality coder. Best for high-volume work where cache reuse dominates cost. Tradeoff: smaller (205k) context; OpenAI-compatible JSON mode but no third-party reliability eval.
 - `kimi-k2.6` ($0.60/$2.50, 80.2% SWE-Bench Verified, 256k ctx) — strong middle ground. Open-weight with native INT4; agent-swarm primitive built in.
+
+#### `work.inspect` (high-volume code scanning, follow-up issue)
+**`gpt-5.3-codex-spark`** — ultra-fast (1000+ tok/sec) coding variant. ChatGPT-Pro-only research preview, no raw API; reachable through Codex CLI subscription auth via CLIProxy when a Pro account is configured. Right shape for short, code-touching scans that benefit from very low TTFT. The `work.inspect` sub-role itself is not yet implemented — see the follow-up issue for the work.* subtype taxonomy.
 
 ### `review.security`
 **claude-opus-4-7.** Don't compromise here. Mature tool-use schema, best published reliability profile, highest GPQA. Security bugs are 10-100x more expensive to fix later than the model spend on review.
@@ -194,15 +212,27 @@ No vendor publishes effective-context retrieval scores for the 2026 fleet. Third
 
 **Alternative:** `glm-4.7-flash` ($0.06/$0.40) — when you want to push the cost floor lower and the task is dominated by I/O (large `ls`/`grep`/`find` sweeps).
 
-### Orchestrator role (flywheel inventory, ranked suggestions)
+### Flywheel orchestrator (continuously inventory issues, diagnose pipeline state, emit ranked JSON suggestions)
 
-Top 3 ranked by `(quality × speed) / cost`, considering only models with verified pricing AND verified core benchmarks (SWE-Bench Verified, GPQA-Diamond):
+The Panopticon flywheel is high-frequency, stateless, schema-strict, and cost-sensitive. Per-poll work is: read N open issues, classify, rank, emit JSON. It is **not** a long-running agent workflow — each invocation is bounded.
 
-1. **gemini-3-flash-preview** — $0.50/$3.00, 1M ctx, SWE-Bench 78%, GPQA 90.4%. Best quality-per-dollar for a high-frequency loop. Native JSON schema mode. Lowest latency in the top tier.
+**Top 3** ranked by `(quality × speed) / cost`, restricted to models with verified pricing AND verified core benchmarks:
+
+1. **gemini-3-flash-preview** — $0.50/$3.00, 1M ctx, SWE-Bench 78%, GPQA 90.4%. Best quality-per-dollar for a high-frequency loop. Native JSON schema mode (`response_schema` with enums). Lowest latency in the top tier.
 2. **minimax-m2.7** — $0.28/$1.20, 205k ctx, SWE-Bench 78%, GPQA 87.4%. Cheapest verified high-quality option. Auto-cache at $0.06/1M makes the per-loop cost of re-feeding issue state nearly free. Tradeoff: non-US vendor with shallower docs; OpenAI-compatible JSON mode with UNVERIFIED strict-schema reliability.
-3. **claude-haiku-4-5** — $1.00/$5.00, 200k ctx, SWE-Bench 73.3%. More expensive than the other two, but with the most mature tool-use / structured-output stack and lowest tail-risk on schema adherence. Worth the premium when the orchestrator is the single point of decision for downstream agents.
+3. **claude-haiku-4-5** — $1.00/$5.00, 200k ctx, SWE-Bench 73.3%. More expensive than the other two, but with the most mature tool-use / structured-output stack and lowest tail-risk on schema adherence. Worth the premium when the flywheel is the single point of decision for downstream agents.
 
-**Excluded from the top 3:** `claude-opus-4-7` and `gpt-5.5-pro` are too expensive for continuous polling. `gemini-3.1-pro-preview` is strong but ~4x the cost of flash-preview with proportional quality gain only on hard tasks. `mimo-v2.5-pro` has the right price but GPQA 66.7% is well below the others. `kimi-k2.6` and `glm-5.1` are competitive but have UNVERIFIED structured-output reliability — risky for a role that emits JSON suggestions consumed by the dashboard.
+#### Why not `gpt-5.2` (the addendum specifically asked)
+
+**Verdict: overkill for the flywheel as currently scoped.** Reasoning:
+
+- **Cost:** $1.75 in / $14.00 out per 1M tokens — 5-50x the per-call cost of Flash/Haiku/MiniMax. Even with 90% cache-read discount on input, the output side dominates a polling workload that emits N ranked suggestions per call.
+- **Latency:** 0.70s median TTFT, 64 tok/sec — middling. Flash/Haiku-tier models routinely hit <300ms TTFT and 150+ tok/sec.
+- **Structured output:** standard OpenAI strict mode. No advantage over Anthropic / Google strict modes that Haiku and Flash already have.
+- **"Long-running agents" positioning:** real, but mis-targeted at this workload. OpenAI sells gpt-5.2 on multi-step tool-use chains and stateful "deep deliberation" — which a stateless polling loop emitting bounded JSON is not. The value prop doesn't apply.
+- **Where gpt-5.2 *would* be correct:** if the flywheel evolves into a stateful orchestrator that owns multi-step debugging sessions across many tool calls per invocation (e.g. autonomously triaging a failing PR end-to-end, calling git, ci, and test tools in sequence within a single agent loop), revisit gpt-5.2 then. Today it is the wrong instrument for the job.
+
+**Excluded from the top 3:** `claude-opus-4-7` is too expensive for continuous polling; `gpt-5.5-pro` is dropped from the catalog regardless; `gemini-3.1-pro-preview` is strong but ~4x the cost of flash-preview with proportional quality gain only on hard tasks; `mimo-v2.5-pro` has the right price but GPQA 66.7% is well below the others; `kimi-k2.6` and `glm-5.1` are competitive but have UNVERIFIED structured-output reliability — risky for a role that emits JSON consumed by the dashboard.
 
 ## Cost distribution (approximate)
 

--- a/src/dashboard/frontend/src/components/Settings/modelCatalog.ts
+++ b/src/dashboard/frontend/src/components/Settings/modelCatalog.ts
@@ -39,19 +39,18 @@ export const MODELS_BY_PROVIDER: Record<string, ProviderDef> = {
   },
   openai: {
     name: 'OpenAI',
+    // Trimmed 2026-05-23 to match OpenAI's Codex CLI published list.
+    // Dropped: gpt-5.5-pro, gpt-5.4-pro, gpt-5.5-mini, gpt-5.5-nano,
+    // gpt-5.4-nano, o3, o4-mini, gpt-4o, gpt-4o-mini.
+    // Saved configs referencing dropped IDs are migrated by MODEL_DEPRECATIONS
+    // in src/lib/model-capabilities.ts and warned-on by settings-api.ts.
     models: [
-      { id: 'gpt-5.5-pro' as ModelId, name: 'GPT-5.5 Pro', icon: Gem, tier: 'premium', costPer1MTokens: 119, capabilities: ['reasoning', 'code', 'vision', 'agentic', 'large-context'], description: 'Most advanced GPT-5.5 model. EXTREMELY expensive — only for hardest problems.' },
-      { id: 'gpt-5.5' as ModelId, name: 'GPT-5.5', icon: Gem, tier: 'premium', costPer1MTokens: 10.5, capabilities: ['reasoning', 'code', 'vision', 'agentic', 'large-context'], description: 'Latest OpenAI flagship. Enhanced reasoning and coding.' },
-      { id: 'gpt-5.5-mini' as ModelId, name: 'GPT-5.5 Mini', icon: FlaskConical, tier: 'fast', costPer1MTokens: 1.25, capabilities: ['fast', 'cost-efficient', 'code'], description: 'Fast GPT-5.5 variant.' },
-      { id: 'gpt-5.5-nano' as ModelId, name: 'GPT-5.5 Nano', icon: Zap, tier: 'fast', costPer1MTokens: 0.875, capabilities: ['fast', 'cost-efficient'], description: 'Most efficient GPT-5.5 variant.' },
-      { id: 'gpt-5.4-pro' as ModelId, name: 'GPT-5.4 Pro', icon: Gem, tier: 'premium', costPer1MTokens: 105, capabilities: ['reasoning', 'code', 'vision', 'agentic', 'large-context'], description: 'Most advanced GPT-5.4 model. Pro subscribers only.' },
-      { id: 'gpt-5.4' as ModelId, name: 'GPT-5.4', icon: Sparkles, tier: 'balanced', costPer1MTokens: 8.75, capabilities: ['reasoning', 'code', 'vision', 'agentic', 'large-context'], description: 'OpenAI flagship. 1.05M context, strong coding.' },
-      { id: 'gpt-5.4-mini' as ModelId, name: 'GPT-5.4 Mini', icon: FlaskConical, tier: 'fast', costPer1MTokens: 1, capabilities: ['fast', 'cost-efficient', 'code'], description: 'Fast and efficient. 400K context.' },
-      { id: 'gpt-5.4-nano' as ModelId, name: 'GPT-5.4 Nano', icon: Zap, tier: 'fast', costPer1MTokens: 0.7, capabilities: ['fast', 'cost-efficient'], description: 'Fastest GPT-5.4 model. API-only.' },
-      { id: 'o3' as ModelId, name: 'O3', icon: Gem, tier: 'premium', costPer1MTokens: 5, capabilities: ['reasoning', 'code', 'agentic'], description: 'Deep reasoning. Best for debugging and complex analysis.' },
-      { id: 'o4-mini' as ModelId, name: 'O4 Mini', icon: Sparkles, tier: 'balanced', costPer1MTokens: 2.75, capabilities: ['reasoning', 'code', 'fast'], description: 'Compact reasoning model. Fast, cost-efficient.' },
-      { id: 'gpt-4o' as ModelId, name: 'GPT-4o', icon: FlaskConical, tier: 'balanced', costPer1MTokens: 7.5, capabilities: ['reasoning', 'code', 'vision'], description: 'Versatile multimodal model' },
-      { id: 'gpt-4o-mini' as ModelId, name: 'GPT-4o Mini', icon: Zap, tier: 'fast', costPer1MTokens: 0.6, capabilities: ['fast', 'cost-efficient'], description: 'Budget option for simple tasks' },
+      { id: 'gpt-5.5' as ModelId, name: 'GPT-5.5', icon: Gem, tier: 'premium', costPer1MTokens: 17.5, capabilities: ['reasoning', 'code', 'vision', 'agentic', 'large-context'], description: 'OpenAI flagship (April 2026). 1.05M context, $5 in / $30 out per 1M.' },
+      { id: 'gpt-5.4' as ModelId, name: 'GPT-5.4', icon: Sparkles, tier: 'balanced', costPer1MTokens: 8.75, capabilities: ['reasoning', 'code', 'vision', 'agentic', 'large-context'], description: 'Balanced GPT-5.4. 1.05M context, strong coding.' },
+      { id: 'gpt-5.4-mini' as ModelId, name: 'GPT-5.4 Mini', icon: FlaskConical, tier: 'fast', costPer1MTokens: 2.625, capabilities: ['fast', 'cost-efficient', 'code'], description: 'Fast and efficient. 400K context. $0.75 in / $4.50 out.' },
+      { id: 'gpt-5.3-codex' as ModelId, name: 'GPT-5.3 Codex', icon: Gem, tier: 'premium', costPer1MTokens: 7.875, capabilities: ['reasoning', 'code', 'agentic', 'large-context'], description: 'Coding-optimized (Feb 2026). 400K context, 85% SWE-Bench Verified. $1.75 in / $14 out.' },
+      { id: 'gpt-5.3-codex-spark' as ModelId, name: 'GPT-5.3 Codex Spark', icon: Zap, tier: 'fast', costPer1MTokens: 7.875, capabilities: ['fast', 'code', 'cost-efficient'], description: 'Ultra-fast coder (1000+ tok/s). ChatGPT-Pro-only research preview; routes via Codex CLI subscription auth — not generally available via raw API.' },
+      { id: 'gpt-5.2' as ModelId, name: 'GPT-5.2', icon: Sparkles, tier: 'balanced', costPer1MTokens: 7.875, capabilities: ['reasoning', 'code', 'agentic'], description: 'Long-running agents (Dec 2025). 80% SWE-Bench, 92.4% GPQA-Diamond. Reserve for deep deliberation, not high-frequency polling.' },
     ],
   },
   google: {

--- a/src/dashboard/frontend/tests/multi-model-settings.spec.ts
+++ b/src/dashboard/frontend/tests/multi-model-settings.spec.ts
@@ -101,7 +101,7 @@ test.describe('Multi-Model Settings', () => {
     await page.waitForTimeout(1000); // Wait for models to refresh
     console.log('  ✓ API key saved, OpenAI models now available');
 
-    // 5. Configure review agent to use gpt-4o
+    // 5. Configure review agent to use gpt-5.4
     console.log('\n[5/6] Configuring review agent model...');
 
     // Find the review agent dropdown (should be in Specialist Models section)
@@ -118,8 +118,8 @@ test.describe('Multi-Model Settings', () => {
     const currentValue = await reviewAgentSelect.inputValue();
     console.log(`  Current review agent model: ${currentValue}`);
 
-    // Select gpt-4o (if not already selected, choose something different)
-    const targetModel = currentValue === 'gpt-4o' ? 'claude-sonnet-4-5' : 'gpt-4o';
+    // Select gpt-5.4 (if not already selected, choose something different)
+    const targetModel = currentValue === 'gpt-5.4' ? 'claude-sonnet-4-6' : 'gpt-5.4';
     await reviewAgentSelect.selectOption(targetModel);
 
     console.log(`  ✓ Model changed to: ${targetModel}`);

--- a/src/lib/model-capabilities.ts
+++ b/src/lib/model-capabilities.ts
@@ -34,14 +34,20 @@ import type { SubscriptionPlan } from './subscription-types.js';
 export const MODEL_DEPRECATIONS: Record<string, ModelId> = {
   'claude-opus-4-5': 'claude-opus-4-7',
   'claude-sonnet-4-5': 'claude-sonnet-4-6',
-  // OpenAI retired/superseded models
-  'gpt-5.2-codex': 'gpt-5.3-codex', // superseded by gpt-5.3-codex (April 2026)
-  'gpt-5.5-mini': 'gpt-5.4-mini',   // hallucinated tier — never shipped
-  'gpt-5.5-nano': 'gpt-5.4-mini',   // hallucinated tier — never shipped
-  'gpt-5.4-nano': 'gpt-5.4-mini',   // hallucinated tier — never shipped
-  'o3-deep-research': 'o3',
-  // NOTE: gpt-5.4 family is Panopticon's abstraction over real OpenAI models.
-  // Do NOT treat gpt-4o/gpt-4o-mini as deprecated — they are the actual API names.
+  // OpenAI retired/superseded models — addendum 2026-05-23 trim to the
+  // Codex CLI catalog (gpt-5.5, 5.4, 5.4-mini, 5.3-codex, 5.3-codex-spark,
+  // 5.2). Pro tiers and the o-series reasoning models are out.
+  'gpt-5.2-codex': 'gpt-5.3-codex',     // superseded by gpt-5.3-codex (April 2026)
+  'gpt-5.5-mini': 'gpt-5.4-mini',       // hallucinated tier — never shipped
+  'gpt-5.5-nano': 'gpt-5.4-mini',       // hallucinated tier — never shipped
+  'gpt-5.4-nano': 'gpt-5.4-mini',       // hallucinated tier — never shipped
+  'gpt-5.5-pro': 'gpt-5.5',             // dropped 2026-05-23 — flagship absorbs Pro role
+  'gpt-5.4-pro': 'gpt-5.4',             // dropped 2026-05-23 — drop the -pro tier
+  'o3': 'gpt-5.4',                      // dropped 2026-05-23 — reasoning -> balanced flagship
+  'o3-deep-research': 'gpt-5.4',        // dropped 2026-05-23 — was already aliased to o3
+  'o4-mini': 'gpt-5.4-mini',            // dropped 2026-05-23 — compact reasoning -> mini
+  'gpt-4o': 'gpt-5.4',                  // dropped 2026-05-23 — legacy flagship -> current balanced
+  'gpt-4o-mini': 'gpt-5.4-mini',        // dropped 2026-05-23 — legacy economy -> mini
   // Google deprecated models
   'gemini-3-pro-preview': 'gemini-3.1-pro-preview',
   'gemini-3-flash': 'gemini-3-flash-preview',
@@ -438,7 +444,34 @@ export const MODEL_CAPABILITIES: Record<CapabilityModelId, ModelCapability> = {
       speed: 70,
       'context-length': 85,
     },
-    notes: 'Previous-generation general-purpose model (Oct 2025). Superseded by GPT-5.4.',
+    notes: 'Previous-generation general-purpose model (Oct 2025). Positioned by OpenAI for long-running agent workloads — strong candidate for orchestrator/flywheel roles.',
+  },
+
+  'gpt-5.3-codex-spark': {
+    model: 'gpt-5.3-codex-spark',
+    provider: 'openai',
+    displayName: 'GPT-5.3 Codex Spark',
+    // Headline rate card matches the Codex family ($1.75 in / $14 out) when
+    // the model is reachable, but Spark is a ChatGPT-Pro-only research
+    // preview as of 2026-05-23 — no raw API access. Panopticon routes via
+    // Codex CLI subscription auth through CLIProxy, so it is reachable
+    // when the operator has a Pro account.
+    costPer1MTokens: 7.875,
+    contextWindow: 128000, // 128K per OpenAI excerpt + multiple secondary sources
+    skills: {
+      'code-generation': 92,
+      'code-review': 86,
+      debugging: 84,
+      planning: 78,
+      documentation: 82,
+      testing: 88,
+      security: 76,
+      performance: 82,
+      synthesis: 84,
+      speed: 98, // "1000+ tok/sec" per OpenAI launch material
+      'context-length': 72, // 128K — smaller than the Codex base 400K
+    },
+    notes: 'Ultra-fast coding research preview (Feb 2026). Text-only, 128K context, ChatGPT-Pro-only. Candidate for work.inspect / high-volume code scans when a Pro account is available.',
   },
 
   // Retired OpenAI model IDs — kept for backward compat

--- a/src/lib/model-fallback.ts
+++ b/src/lib/model-fallback.ts
@@ -27,18 +27,20 @@ const MODEL_PROVIDERS: Record<ModelId, ModelProvider> = {
   'claude-sonnet-4-5': 'anthropic',
   'claude-haiku-4-5': 'anthropic',
 
-  // OpenAI models (current — per developers.openai.com/codex/models)
+  // OpenAI models (supported per Codex CLI catalog, 2026-05-23)
   'gpt-5.5': 'openai',
-  'gpt-5.5-pro': 'openai',
   'gpt-5.4': 'openai',
   'gpt-5.4-mini': 'openai',
-  'gpt-5.4-pro': 'openai',
   'gpt-5.3-codex': 'openai',
+  'gpt-5.3-codex-spark': 'openai',
   'gpt-5.2': 'openai',
+
+  // OpenAI retired (kept for backward compat with saved configs; migrated
+  // out via MODEL_DEPRECATIONS in src/lib/model-capabilities.ts)
+  'gpt-5.5-pro': 'openai',
+  'gpt-5.4-pro': 'openai',
   'o3': 'openai',
   'o4-mini': 'openai',
-
-  // OpenAI legacy (for backward compat with existing configs/tests)
   'o3-deep-research': 'openai',
   'gpt-4o': 'openai',
   'gpt-4o-mini': 'openai',
@@ -101,6 +103,7 @@ const FALLBACK_MAP: Record<string, AnthropicModel> = {
   'gpt-5.4-mini': 'claude-haiku-4-5', // Mid-tier → Haiku
   'gpt-5.4-pro': 'claude-sonnet-4-6', // Top-tier model → Sonnet
   'gpt-5.3-codex': 'claude-sonnet-4-6', // Coding flagship → Sonnet
+  'gpt-5.3-codex-spark': 'claude-haiku-4-5', // Ultra-fast coder → Haiku
   'gpt-5.2': 'claude-sonnet-4-6', // Previous-gen flagship → Sonnet
   'o3': 'claude-sonnet-4-6', // Reasoning model → Sonnet
   'o4-mini': 'claude-sonnet-4-6', // Compact reasoning model → Sonnet
@@ -162,16 +165,19 @@ const DEFAULT_FALLBACK: AnthropicModel = 'claude-sonnet-4-6';
  * Used for within-provider tier-aware fallback.
  */
 const MODEL_TIER_RANK: Record<string, number> = {
-  // OpenAI tiers
-  'gpt-5.5-pro': 3,
+  // OpenAI tiers — addendum 2026-05-23 catalog (Codex CLI)
   'gpt-5.5': 2,
-  'gpt-5.4-pro': 3,
   'gpt-5.4': 2,
   'gpt-5.3-codex': 2,
+  'gpt-5.3-codex-spark': 1,
   'gpt-5.2': 2,
+  'gpt-5.4-mini': 0,
+  // Retired — kept for backward compat with saved configs until users
+  // re-save (deprecation migrations in MODEL_DEPRECATIONS will rewrite them)
+  'gpt-5.5-pro': 3,
+  'gpt-5.4-pro': 3,
   'o3': 2,
   'o4-mini': 1,
-  'gpt-5.4-mini': 0,
 };
 
 /**

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -81,8 +81,8 @@ export const PROVIDERS: Record<ProviderName, ProviderConfig> = {
     name: 'openai',
     displayName: 'OpenAI',
     compatibility: 'direct',
-    models: ['gpt-5.5', 'gpt-5.5-pro', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-pro', 'gpt-5.3-codex', 'gpt-5.2', 'o3', 'o4-mini'],
-    tierModels: { opus: 'gpt-5.5-pro', sonnet: 'gpt-5.4', haiku: 'gpt-5.4-mini' },
+    models: ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.3-codex', 'gpt-5.3-codex-spark', 'gpt-5.2'],
+    tierModels: { opus: 'gpt-5.5', sonnet: 'gpt-5.4', haiku: 'gpt-5.4-mini' },
     tested: true,
     description: 'Route through the local CLIProxyAPI Anthropic-compatible sidecar using Codex/ChatGPT subscription auth.',
   },
@@ -195,8 +195,9 @@ export function getProviderForModelSync(modelId: ModelId | string): ProviderConf
     return PROVIDERS.anthropic;
   }
 
-  // Check OpenAI models
-  if (['gpt-5.5', 'gpt-5.5-pro', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-pro', 'gpt-5.3-codex', 'gpt-5.2', 'o3', 'o4-mini', 'o3-deep-research', 'gpt-4o', 'gpt-4o-mini'].includes(modelId)) {
+  // Check OpenAI models — supported set + retired IDs (still routed so the
+  // deprecation-migration path can fire warnings before remap).
+  if (['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.3-codex', 'gpt-5.3-codex-spark', 'gpt-5.2', 'gpt-5.5-pro', 'gpt-5.4-pro', 'o3', 'o4-mini', 'o3-deep-research', 'gpt-4o', 'gpt-4o-mini'].includes(modelId)) {
     return PROVIDERS.openai;
   }
 

--- a/src/lib/router-config.ts
+++ b/src/lib/router-config.ts
@@ -67,7 +67,7 @@ export function generateRouterConfig(settings: SettingsConfig): RouterConfig {
       apiKey: settings.api_keys.openai.startsWith('$')
         ? settings.api_keys.openai
         : settings.api_keys.openai,
-      models: ['gpt-5.5', 'gpt-5.5-pro', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-pro', 'gpt-5.3-codex', 'gpt-5.2', 'o3', 'o4-mini'],
+      models: ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.3-codex', 'gpt-5.3-codex-spark', 'gpt-5.2'],
     });
   }
 
@@ -134,7 +134,7 @@ export function generateRouterConfigFromWorkTypes(): RouterConfig {
       name: 'openai',
       baseURL: 'https://api.openai.com/v1',
       apiKey: apiKeys.openai.startsWith('$') ? apiKeys.openai : apiKeys.openai,
-      models: ['gpt-5.5', 'gpt-5.5-pro', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-pro', 'gpt-5.3-codex', 'gpt-5.2', 'o3', 'o4-mini'],
+      models: ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.3-codex', 'gpt-5.3-codex-spark', 'gpt-5.2'],
     });
   }
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -5,7 +5,24 @@ import { FsError } from './errors.js';
 
 // Model identifiers
 export type AnthropicModel = 'claude-opus-4-7' | 'claude-opus-4-6' | 'claude-sonnet-4-6' | 'claude-sonnet-4-5' | 'claude-haiku-4-5';
-export type OpenAIModel = 'gpt-5.5' | 'gpt-5.5-pro' | 'gpt-5.4' | 'gpt-5.4-mini' | 'gpt-5.4-pro' | 'gpt-5.3-codex' | 'gpt-5.2' | 'o3' | 'o4-mini' | 'o3-deep-research' | 'gpt-4o' | 'gpt-4o-mini';
+export type OpenAIModel =
+  // Supported (Codex CLI catalog, 2026-05-23)
+  | 'gpt-5.5'
+  | 'gpt-5.4'
+  | 'gpt-5.4-mini'
+  | 'gpt-5.3-codex'
+  | 'gpt-5.3-codex-spark'
+  | 'gpt-5.2'
+  // Retired — kept in the type for backward-compat with saved configs and
+  // for the deprecation migration in src/lib/model-capabilities.ts. New
+  // configs and UI dropdowns must not surface these.
+  | 'gpt-5.5-pro'
+  | 'gpt-5.4-pro'
+  | 'o3'
+  | 'o4-mini'
+  | 'o3-deep-research'
+  | 'gpt-4o'
+  | 'gpt-4o-mini';
 export type GoogleModel = 'gemini-3.1-pro-preview' | 'gemini-3.1-flash-lite-preview' | 'gemini-3-pro-preview' | 'gemini-3-flash-preview' | 'gemini-2.5-pro' | 'gemini-2.5-flash';
 export type KimiModel = 'kimi-k2.6' | 'kimi-k2.5' | 'K2.6-code-preview' | 'kimi-k2';
 export type MiniMaxModel = 'minimax-m2.7' | 'minimax-m2.7-highspeed';
@@ -226,7 +243,7 @@ export function getAvailableModelsSync(settings: SettingsConfig): {
   ];
 
   const openaiModels: OpenAIModel[] = settings.api_keys.openai
-    ? ['gpt-5.5', 'gpt-5.5-pro', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-pro', 'gpt-5.3-codex', 'gpt-5.2', 'o3', 'o4-mini']
+    ? ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.3-codex', 'gpt-5.3-codex-spark', 'gpt-5.2']
     : [];
 
   const googleModels: GoogleModel[] = settings.api_keys.google


### PR DESCRIPTION
## Summary

Implements the OpenAI catalog trim (PAN-1122 revised) and folds the flywheel-specific evaluation requested in the addendum into the model recommendations doc. The original doc refresh shipped in #1420 (already merged); this PR layers the catalog change + flywheel section on top.

## Catalog trim (PAN-1122)

OpenAI dropdown now matches the Codex CLI published list:

**Kept (6):** \`gpt-5.5\`, \`gpt-5.4\`, \`gpt-5.4-mini\`, \`gpt-5.3-codex\`, \`gpt-5.3-codex-spark\`, \`gpt-5.2\`

**Dropped (9):** \`gpt-5.5-pro\`, \`gpt-5.4-pro\`, \`gpt-5.5-mini\`, \`gpt-5.5-nano\`, \`gpt-5.4-nano\`, \`o3\`, \`o4-mini\`, \`gpt-4o\`, \`gpt-4o-mini\`

**Migration:** Every dropped ID has a deprecation entry in \`MODEL_DEPRECATIONS\` (\`src/lib/model-capabilities.ts\`). Saved configs referencing dropped IDs are auto-remapped and warned at settings-load via \`settings-api.ts\` (\`detectDeprecatedModels\` flow that already exists). \`OpenAIModel\` type retains the dropped IDs for backward-compat parsing of pre-migration configs; \`getAvailableModelsSync\` exposes only the 6.

**\`gpt-5.3-codex-spark\` caveat:** ChatGPT-Pro-only research preview as of 2026-05-23 — no raw API access. Panopticon reaches it via Codex CLI subscription auth through CLIProxy, which is the existing OpenAI provider routing. Flagged in the catalog description and capability profile.

## docs/MODEL_RECOMMENDATIONS.md additions

- Benchmark, cost, and context tables now include rows for \`gpt-5.3-codex\` (85.0% SWE-Bench Verified, \$1.75/\$14, 400k ctx), \`gpt-5.2\` (80.0%, 92.4% GPQA, \$1.75/\$14, 400k ctx), and \`gpt-5.3-codex-spark\` (most fields UNVERIFIED — research preview, no published scores yet).
- \`gpt-5.5-pro\` row removed everywhere.
- New **"Flywheel orchestrator"** section evaluates \`gpt-5.2\` specifically (per addendum request). **Verdict: overkill for the current flywheel as scoped** — stateless polling loop emitting JSON does not benefit from gpt-5.2's "long-running agent" positioning, and at \$14/1M output it is 5-50x more expensive than the top-3 (\`gemini-3-flash-preview\`, \`minimax-m2.7\`, \`claude-haiku-4-5\`). The section also flags when gpt-5.2 *would* be the right pick: if the flywheel evolves into a stateful multi-step orchestrator.
- Stale-from-prior-version callout gets an entry for the catalog trim.

## Follow-up issue (NOT in this PR)

The addendum also specified two larger changes deliberately kept out of this PR: **modelPool dispatch** (round-robin / weighted-random / rate-limit-aware) and **\`work.*\` subtype taxonomy** (\`work.documentation\`, \`work.algorithm\`, \`work.frontend\`, etc., with explicit and heuristic detection rules). Those need their own planning cycle. Spec filed as **#1424** — DO NOT implement until that issue is planned.

## Files changed

- \`src/dashboard/frontend/src/components/Settings/modelCatalog.ts\` — openai section trimmed to 6, new descriptions with verified pricing
- \`src/lib/providers.ts\` — \`PROVIDERS.openai.models\` trimmed; \`tierModels\` opus flipped to \`gpt-5.5\`; retired IDs still routable for migration
- \`src/lib/router-config.ts\` — both router emit paths trimmed
- \`src/lib/settings.ts\` — \`OpenAIModel\` type comment-grouped (supported vs retired); \`getAvailableModelsSync\` exposes only the 6
- \`src/lib/model-capabilities.ts\` — \`MODEL_DEPRECATIONS\` gains migration entries for every dropped ID; new \`gpt-5.3-codex-spark\` capability profile
- \`src/lib/model-fallback.ts\` — \`MODEL_PROVIDERS\`/\`FALLBACK_MAP\`/\`MODEL_TIER_RANK\` updated for \`gpt-5.3-codex-spark\`
- \`src/dashboard/frontend/tests/multi-model-settings.spec.ts\` — e2e test no longer selects dropped \`gpt-4o\`; switched to \`gpt-5.4\`
- \`docs/MODEL_RECOMMENDATIONS.md\` — additions described above

## Test plan

- [x] \`npx tsc --noEmit\` passes at root and frontend (no type errors from catalog changes)
- [x] \`vitest run\` passes for affected unit tests (settings-api, config-yaml-async, config-yaml-roles, cost-calculation): 63 tests pass
- [ ] Manually verify the OpenAI dropdown in the dashboard Settings page shows exactly the 6 supported models
- [ ] Manually load a saved config with \`gpt-4o\` as a role model and confirm the deprecation warning fires + migration rewrites to \`gpt-5.4\`
- [ ] Visual confirmation that \`gpt-5.3-codex-spark\` works through Codex CLI subscription auth (requires ChatGPT Pro account; if no Pro, the model will 404 — expected)

## Related

- Closes #1122
- Follow-up: #1424 (modelPool + work.* subtypes)
- Builds on already-merged #1420

🤖 Generated with [Claude Code](https://claude.com/claude-code)