### PR TITLE
feat(dashboard): auto-detect post-/clear Claude Code JSONL orphans (PAN-1458)

### DIFF
--- a/src/dashboard/frontend/src/components/CommandDeck/ConversationList.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ConversationList.tsx
@@ -60,6 +60,8 @@ export interface Conversation {
   handoffTargetConvId?: number | null;
   /** Reason a requested handoff fork downgraded to summary mode. */
   forkFallbackReason?: string | null;
+  /** PAN-1458: if this conv was cleared via Claude Code's /clear, the sibling conv that continues it. */
+  clearedToConvId?: number | null;
 }
 
 // ─── Sort types ───────────────────────────────────────────────────────────────

--- a/src/dashboard/frontend/src/components/CommandDeck/styles/command-deck.module.css
+++ b/src/dashboard/frontend/src/components/CommandDeck/styles/command-deck.module.css
@@ -2689,6 +2689,34 @@
   cursor: not-allowed;
 }
 
+/* PAN-1458: "Conversation cleared — continued in conv/N" banner shown at the
+   bottom of a conversation panel when conversation.clearedToConvId is set. */
+.conversationClearedBanner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 16px;
+  width: 100%;
+  background: var(--muted);
+  color: var(--muted-foreground);
+  border: none;
+  border-top: 1px solid var(--border);
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+}
+
+.conversationClearedBanner:hover {
+  background: var(--accent);
+  color: var(--accent-foreground);
+}
+
+.conversationClearedBannerText strong {
+  color: var(--foreground);
+  font-weight: 600;
+}
+
 /* View toggle: [Conversation] [Terminal] */
 .viewToggle {
   display: flex;

--- a/src/dashboard/frontend/src/components/chat/ConversationPanel.tsx
+++ b/src/dashboard/frontend/src/components/chat/ConversationPanel.tsx
@@ -3,7 +3,7 @@ import { useDashboardStore } from '../../lib/store';
 import { useTheme } from '../../hooks/useTheme';
 import { useConversationUiState } from '../../hooks/useConversationUiState';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Circle, Copy, Check, Loader2, Pencil, Terminal, FileCode, Search, Globe, Wrench, Zap, GitBranchPlus, CheckCircle2, AlertCircle, Archive, Sparkles, Info, RefreshCw, FileText, ExternalLink } from 'lucide-react';
+import { Circle, Copy, Check, Loader2, Pencil, Terminal, FileCode, Search, Globe, Wrench, Zap, GitBranchPlus, CheckCircle2, AlertCircle, Archive, Sparkles, Info, RefreshCw, FileText, ExternalLink, RotateCcw, ArrowRight } from 'lucide-react';
 import { toast } from 'sonner';
 import { XTerminal } from '../XTerminal';
 import type { Conversation } from '../CommandDeck/ConversationList';
@@ -1083,7 +1083,25 @@ function ConversationView({ conversation, onResume, onArchive, resumePending, mo
           workingPhase={workingPhase}
         />
       )}
-      {isForking ? null : onResume ? (
+      {/* PAN-1458: when this conversation was cleared via Claude Code's /clear, show a
+          banner linking to the sibling that continues the work. The composer/resume bar
+          is suppressed because the conversation is permanently ended — interacting here
+          would either fail or branch off historical content. */}
+      {conversation.clearedToConvId ? (
+        <button
+          type="button"
+          className={styles.conversationClearedBanner}
+          onClick={() => { window.location.href = `/conv/${conversation.clearedToConvId}`; }}
+          title={`Open conv/${conversation.clearedToConvId}`}
+          aria-label={`Open conversation that continues after /clear (conv/${conversation.clearedToConvId})`}
+        >
+          <RotateCcw size={14} />
+          <span className={styles.conversationClearedBannerText}>
+            Conversation cleared — continued in <strong>conv/{conversation.clearedToConvId}</strong>
+          </span>
+          <ArrowRight size={14} />
+        </button>
+      ) : isForking ? null : onResume ? (
         <div className={styles.conversationResumeBar}>
           {modelPicker}
           <button

--- a/src/dashboard/frontend/src/components/chat/MessagesTimeline.tsx
+++ b/src/dashboard/frontend/src/components/chat/MessagesTimeline.tsx
@@ -540,7 +540,19 @@ function isReviewerContextMessage(text: string): boolean {
   return text.startsWith('# Review Context\n');
 }
 
+// PAN-1458: Detect a Claude Code slash-command user message (the literal token Claude
+// Code writes when the user types /clear, /compact, /resume, etc.). Returned object
+// carries the command name (e.g. '/clear') so the divider can label itself.
+function parseSlashCommandMessage(text: string): { command: string } | null {
+  const match = text.trimStart().match(/^<command-name>([^<]+)<\/command-name>/);
+  return match ? { command: match[1] } : null;
+}
+
 function UserMessageRow({ message, cwd, issueId }: { message: ChatMessage; cwd?: string; issueId?: string | null }) {
+  const slashCommand = parseSlashCommandMessage(message.text);
+  if (slashCommand) {
+    return <SlashCommandDivider command={slashCommand.command} createdAt={message.createdAt} />;
+  }
   if (isSummaryForkMessage(message.text)) {
     return <ContextMessageBlock message={message} cwd={cwd} issueId={issueId} />;
   }
@@ -963,6 +975,31 @@ function SessionPermissionsRow({ message }: { message: ChatMessage }) {
       <ShieldCheck size={11} className={styles.sessionPermissionsIcon} />
       <span className={styles.sessionPermissionsLabel}>Permissions:</span>
       <span className={styles.sessionPermissionsTools}>{message.text}</span>
+    </div>
+  );
+}
+
+// ─── Slash-command divider (PAN-1458) ────────────────────────────────────────
+
+/**
+ * Renders a Claude Code slash command (the kind Claude Code emits as a user
+ * message wrapped in `<command-name>X</command-name>`) as a horizontal divider
+ * instead of a regular message bubble. Most relevant for `/clear`, which
+ * signals the JSONL boundary — see PAN-1458 — but applies to any slash command
+ * Claude Code happens to record this way.
+ */
+function SlashCommandDivider({ command, createdAt }: { command: string; createdAt: string }) {
+  const isClear = command === '/clear';
+  const label = isClear ? 'Conversation cleared' : `Slash command: ${command}`;
+  return (
+    <div className={styles.compactBoundaryDivider}>
+      <div className={styles.compactBoundaryLine} />
+      <div className={styles.compactBoundaryLabel}>
+        <RotateCcw size={12} />
+        <span>{label}</span>
+        <span className={styles.compactBoundaryDetail}>{formatTimestamp(createdAt)}</span>
+      </div>
+      <div className={styles.compactBoundaryLine} />
     </div>
   );
 }

--- a/src/dashboard/server/services/__tests__/conversation-lifecycle.test.ts
+++ b/src/dashboard/server/services/__tests__/conversation-lifecycle.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, writeFileSync, mkdirSync, utimesSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { Effect } from 'effect';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -6,10 +9,18 @@ const mockListActiveConversations = vi.fn();
 const mockMarkConversationEnded = vi.fn();
 const mockCleanupUnreferencedConversationAttachments = vi.fn();
 const mockListSessionNames = vi.fn();
+const mockCreateConversation = vi.fn();
+const mockGetConversationByClaudeSessionId = vi.fn();
+const mockGetConversationByName = vi.fn();
+const mockSetClearedToConvId = vi.fn();
 
 vi.mock('../../../../lib/database/conversations-db.js', () => ({
   listActiveConversations: mockListActiveConversations,
   markConversationEnded: mockMarkConversationEnded,
+  createConversation: mockCreateConversation,
+  getConversationByClaudeSessionId: mockGetConversationByClaudeSessionId,
+  getConversationByName: mockGetConversationByName,
+  setClearedToConvId: mockSetClearedToConvId,
 }));
 
 vi.mock('../conversation-attachments.js', () => ({
@@ -121,5 +132,194 @@ describe('ConversationLifecycleService — pollConversations', () => {
 
     const { pollConversations } = await import('../conversation-lifecycle.js');
     await expect(pollConversations()).resolves.toBeUndefined();
+  });
+});
+
+describe('ConversationLifecycleService — detectOrphanedClaudeCodeSessions (PAN-1458)', () => {
+  // Each test uses a fresh tmp $HOME so the encoded ~/.claude/projects/<cwd> path is isolated.
+  let fakeHome: string;
+  let projectDir: string;
+  let cwd: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fakeHome = mkdtempSync(join(tmpdir(), 'pan-clear-orphan-'));
+    cwd = '/work/myproj';
+    // encodeClaudeProjectDir(/work/myproj) → -work-myproj (slashes/dots collapse to dashes)
+    projectDir = join(fakeHome, '.claude', 'projects', '-work-myproj');
+    mkdirSync(projectDir, { recursive: true });
+    vi.stubEnv('HOME', fakeHome);
+  });
+
+  function writeJsonl(filename: string, lines: object[], mtimeMs: number): string {
+    const filepath = join(projectDir, filename);
+    writeFileSync(filepath, lines.map((l) => JSON.stringify(l)).join('\n'), 'utf-8');
+    const mtimeSec = mtimeMs / 1000;
+    utimesSync(filepath, mtimeSec, mtimeSec);
+    return filepath;
+  }
+
+  it('adopts a post-/clear orphan and links the parent conversation', async () => {
+    const parentSessionId = 'aaaaaaaa-1111-1111-1111-aaaaaaaaaaaa';
+    const orphanSessionId = 'bbbbbbbb-2222-2222-2222-bbbbbbbbbbbb';
+
+    // Parent's JSONL — older mtime
+    writeJsonl(
+      `${parentSessionId}.jsonl`,
+      [
+        { type: 'user', message: { role: 'user', content: 'hello world' }, timestamp: '2026-05-24T19:30:00.000Z' },
+      ],
+      Date.parse('2026-05-24T19:48:00.000Z'),
+    );
+
+    // Orphan's JSONL — /clear sentinel on line 2, mtime AFTER parent
+    writeJsonl(
+      `${orphanSessionId}.jsonl`,
+      [
+        { type: 'file-history-snapshot', messageId: 'x', snapshot: {}, isSnapshotUpdate: false },
+        {
+          type: 'user',
+          message: { role: 'user', content: '<command-name>/clear</command-name>\n<command-message>clear</command-message>' },
+          timestamp: '2026-05-24T19:50:00.000Z',
+        },
+      ],
+      Date.parse('2026-05-24T19:50:30.000Z'),
+    );
+
+    const parent = {
+      id: 100,
+      name: 'parent-conv',
+      tmuxSession: 'conv-parent',
+      status: 'active',
+      cwd,
+      issueId: 'PAN-123',
+      claudeSessionId: parentSessionId,
+      title: 'Original work',
+      titleSource: 'ai',
+      titleSeed: null,
+      totalCost: 0,
+      archivedAt: null,
+      model: 'claude-opus-4-7',
+      effort: null,
+      forkStatus: null,
+      forkError: null,
+      harness: 'claude-code',
+      deliveryMethod: null,
+      spawnError: null,
+      handoffDocPath: null,
+      handoffTargetConvId: null,
+      forkFallbackReason: null,
+      clearedToConvId: null,
+      createdAt: '2026-05-24T19:00:00.000Z',
+      endedAt: null,
+      lastAttachedAt: '2026-05-24T19:48:00.000Z',
+    };
+
+    mockListActiveConversations.mockReturnValue([parent]);
+    mockListSessionNames.mockReturnValue(Effect.succeed(['conv-parent']));
+    mockGetConversationByClaudeSessionId.mockImplementation((id: string) =>
+      id === parentSessionId ? parent : null,
+    );
+    mockCreateConversation.mockReturnValue({ id: 200, name: 'parent-conv-post-clear-bbbbbbbb' });
+
+    const { pollConversations } = await import('../conversation-lifecycle.js');
+    await pollConversations();
+
+    expect(mockCreateConversation).toHaveBeenCalledTimes(1);
+    expect(mockCreateConversation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'parent-conv-post-clear-bbbbbbbb',
+        tmuxSession: 'conv-parent',
+        cwd,
+        issueId: 'PAN-123',
+        claudeSessionId: orphanSessionId,
+        title: '[post-/clear] Original work',
+        titleSource: 'auto',
+        titleSeed: '[post-/clear] Original work',
+        model: 'claude-opus-4-7',
+        harness: 'claude-code',
+      }),
+    );
+    expect(mockSetClearedToConvId).toHaveBeenCalledWith('parent-conv', 200);
+  });
+
+  it('skips JSONLs that are already linked to a conversation', async () => {
+    const known = 'cccccccc-3333-3333-3333-cccccccccccc';
+    writeJsonl(
+      `${known}.jsonl`,
+      [
+        {
+          type: 'user',
+          message: { role: 'user', content: '<command-name>/clear</command-name>' },
+          timestamp: '2026-05-24T19:50:00.000Z',
+        },
+      ],
+      Date.parse('2026-05-24T19:50:30.000Z'),
+    );
+
+    mockListActiveConversations.mockReturnValue([
+      { id: 1, name: 'p', tmuxSession: 'conv-p', status: 'active', cwd, claudeSessionId: 'parent-uuid', harness: 'claude-code', title: null },
+    ]);
+    mockListSessionNames.mockReturnValue(Effect.succeed(['conv-p']));
+    mockGetConversationByClaudeSessionId.mockReturnValue({ id: 999 }); // every session lookup says "known"
+
+    const { pollConversations } = await import('../conversation-lifecycle.js');
+    await pollConversations();
+
+    expect(mockCreateConversation).not.toHaveBeenCalled();
+    expect(mockSetClearedToConvId).not.toHaveBeenCalled();
+  });
+
+  it('skips orphans with no Panopticon parent in the same cwd', async () => {
+    const orphan = 'dddddddd-4444-4444-4444-dddddddddddd';
+    writeJsonl(
+      `${orphan}.jsonl`,
+      [
+        {
+          type: 'user',
+          message: { role: 'user', content: '<command-name>/clear</command-name>' },
+          timestamp: '2026-05-24T19:50:00.000Z',
+        },
+      ],
+      Date.parse('2026-05-24T19:50:30.000Z'),
+    );
+
+    // No active conversation has this cwd
+    mockListActiveConversations.mockReturnValue([]);
+    mockListSessionNames.mockReturnValue(Effect.succeed([]));
+    mockGetConversationByClaudeSessionId.mockReturnValue(null);
+
+    const { pollConversations } = await import('../conversation-lifecycle.js');
+    await pollConversations();
+
+    expect(mockCreateConversation).not.toHaveBeenCalled();
+  });
+
+  it('does not adopt JSONLs without the /clear sentinel', async () => {
+    const parent = 'eeeeeeee-5555-5555-5555-eeeeeeeeeeee';
+    const peer = 'ffffffff-6666-6666-6666-ffffffffffff';
+
+    writeJsonl(
+      `${parent}.jsonl`,
+      [{ type: 'user', message: { role: 'user', content: 'hi' }, timestamp: '2026-05-24T19:30:00.000Z' }],
+      Date.parse('2026-05-24T19:48:00.000Z'),
+    );
+    // Peer JSONL — no /clear sentinel (e.g., a standalone Claude Code session that started independently)
+    writeJsonl(
+      `${peer}.jsonl`,
+      [{ type: 'user', message: { role: 'user', content: 'hello from another session' }, timestamp: '2026-05-24T19:50:00.000Z' }],
+      Date.parse('2026-05-24T19:50:30.000Z'),
+    );
+
+    mockListActiveConversations.mockReturnValue([
+      { id: 1, name: 'p', tmuxSession: 'conv-p', status: 'active', cwd, claudeSessionId: parent, harness: 'claude-code', title: 'parent' },
+    ]);
+    mockListSessionNames.mockReturnValue(Effect.succeed(['conv-p']));
+    mockGetConversationByClaudeSessionId.mockImplementation((id: string) => (id === parent ? { id: 1 } : null));
+
+    const { pollConversations } = await import('../conversation-lifecycle.js');
+    await pollConversations();
+
+    expect(mockCreateConversation).not.toHaveBeenCalled();
   });
 });

--- a/src/dashboard/server/services/__tests__/conversation-lifecycle.test.ts
+++ b/src/dashboard/server/services/__tests__/conversation-lifecycle.test.ts
@@ -241,6 +241,7 @@ describe('ConversationLifecycleService — detectOrphanedClaudeCodeSessions (PAN
       }),
     );
     expect(mockSetClearedToConvId).toHaveBeenCalledWith('parent-conv', 200);
+    expect(mockMarkConversationEnded).toHaveBeenCalledWith('parent-conv');
   });
 
   it('skips JSONLs that are already linked to a conversation', async () => {

--- a/src/dashboard/server/services/conversation-lifecycle.ts
+++ b/src/dashboard/server/services/conversation-lifecycle.ts
@@ -15,15 +15,19 @@
  */
 
 import { readFile, readdir, stat } from 'fs/promises';
-import { existsSync } from 'fs';
+import { createReadStream, existsSync } from 'fs';
+import { createInterface } from 'readline';
 import { homedir } from 'os';
 import { join } from 'path';
 import { Effect } from 'effect';
 import {
   createConversation,
+  getConversationByClaudeSessionId,
   getConversationByName,
   listActiveConversations,
   markConversationEnded,
+  setClearedToConvId,
+  type Conversation,
 } from '../../../lib/database/conversations-db.js';
 import { listSessionNames } from '../../../lib/tmux.js';
 import { encodeClaudeProjectDir, sessionFilePath } from '../../../lib/paths.js';
@@ -90,6 +94,10 @@ export async function pollConversations(): Promise<void> {
     // missing them. Runs every poll so it converges over time even if any
     // single attempt fails partially.
     await backfillOrphanedSpecialistConversations(Array.from(aliveSessions));
+
+    // PAN-1458: detect Claude Code /clear orphans and link them to their parent.
+    // Reuses the conversations list already fetched above — do not re-query.
+    await detectOrphanedClaudeCodeSessions(conversations);
   } catch (err: unknown) {
     // Don't crash the server on poll errors
     console.error('[conversation-lifecycle] Poll error:', err);
@@ -146,6 +154,173 @@ async function backfillOrphanedSpecialistConversations(aliveSessions: string[]):
       console.warn(`[conversation-lifecycle] createConversation failed for ${sessionName}: ${(err as Error).message}`);
     }
   }
+}
+
+/**
+ * PAN-1458: Detect Claude Code `/clear` orphans and link them to their parent.
+ *
+ * When Claude Code receives `/clear`, the current JSONL stops being written and a
+ * new JSONL is created with a fresh session-id under the same project dir. The
+ * tmux session keeps running, so the parent `conversations` row is still active
+ * and pointing at the pre-clear `claude_session_id`. The new JSONL has no
+ * conversation row — it becomes an orphan that the dashboard cannot navigate to.
+ *
+ * Detection signal: any user-message in the first ~5 lines of a JSONL with
+ * `content: '<command-name>/clear</command-name>...'`. That's the literal token
+ * Claude Code writes when `/clear` kicks off a new session — unambiguous, no
+ * mtime guesswork.
+ *
+ * For each orphan found, attribute it to the parent conversation whose
+ * `claudeSessionId` JSONL has the most-recent mtime in the same `cwd` strictly
+ * before the orphan's first-message timestamp. If no Panopticon conversation
+ * owns that `cwd` (e.g., a standalone `claude` invocation outside Panopticon),
+ * skip — we only adopt orphans that descend from one of our conversations.
+ *
+ * Insert a sibling `conversations` row inheriting parent's `cwd`, `tmuxSession`,
+ * `issueId`, `model`, `harness`. Set an auto-derived title with
+ * `titleSource = 'auto'` so the existing AI title generator overwrites once the
+ * post-clear JSONL has enough content. Finally, write
+ * `parent.cleared_to_conv_id = sibling.id`.
+ */
+async function detectOrphanedClaudeCodeSessions(activeConvs: Conversation[]): Promise<void> {
+  // Group by cwd so we readdir each project dir at most once per tick.
+  // Pi conversations don't use ~/.claude/projects; harness === 'pi' is filtered out.
+  // Legacy rows with harness === null predate the harness column and were all claude-code.
+  const cwdGroups = new Map<string, Conversation[]>();
+  for (const conv of activeConvs) {
+    if (!conv.cwd) continue;
+    if (!conv.claudeSessionId) continue;
+    if (conv.harness === 'pi') continue;
+    const list = cwdGroups.get(conv.cwd) ?? [];
+    list.push(conv);
+    cwdGroups.set(conv.cwd, list);
+  }
+
+  for (const [cwd, convs] of cwdGroups) {
+    const projectDir = join(homedir(), '.claude', 'projects', encodeClaudeProjectDir(cwd));
+    let entries: string[];
+    try {
+      entries = await readdir(projectDir);
+    } catch (err: any) {
+      if (err?.code === 'ENOENT') continue;
+      console.warn(`[conversation-lifecycle] readdir(${projectDir}) failed: ${(err as Error).message}`);
+      continue;
+    }
+
+    for (const filename of entries) {
+      if (!filename.endsWith('.jsonl')) continue;
+      const sessionId = filename.slice(0, -'.jsonl'.length);
+
+      // Already linked to a conversation (either as a primary session or via a previous
+      // orphan-detect pass that adopted it).
+      if (getConversationByClaudeSessionId(sessionId)) continue;
+
+      const jsonlPath = join(projectDir, filename);
+      const firstClearTs = await readFirstClearTimestamp(jsonlPath);
+      if (firstClearTs === null) continue; // not a /clear orphan
+
+      // Parent attribution: among active convs in this cwd, pick the one whose
+      // own JSONL's mtime is the highest value strictly less than firstClearTs.
+      // Walks a chain naturally — if A→B→C all share this cwd, a new orphan D
+      // attaches to C (whichever has the freshest mtime under D's start).
+      let parent: Conversation | null = null;
+      let parentMtime = -Infinity;
+      for (const candidate of convs) {
+        if (!candidate.claudeSessionId) continue;
+        if (candidate.claudeSessionId === sessionId) continue;
+        const parentJsonl = join(projectDir, `${candidate.claudeSessionId}.jsonl`);
+        let mtimeMs: number;
+        try {
+          mtimeMs = (await stat(parentJsonl)).mtimeMs;
+        } catch {
+          continue; // parent's JSONL gone — can't use it as anchor
+        }
+        if (mtimeMs < firstClearTs && mtimeMs > parentMtime) {
+          parent = candidate;
+          parentMtime = mtimeMs;
+        }
+      }
+
+      if (!parent) {
+        // No Panopticon conversation owns the cwd-window before this orphan started.
+        // It's a standalone `claude` invocation — leave it alone.
+        continue;
+      }
+
+      const baseTitle = parent.title ?? 'Conversation';
+      const autoTitle = `[post-/clear] ${baseTitle}`;
+      let sibling: Conversation;
+      try {
+        sibling = createConversation({
+          name: `${parent.name}-post-clear-${sessionId.slice(0, 8)}`,
+          tmuxSession: parent.tmuxSession,
+          cwd: parent.cwd,
+          issueId: parent.issueId ?? undefined,
+          claudeSessionId: sessionId,
+          title: autoTitle,
+          titleSource: 'auto',
+          titleSeed: autoTitle,
+          model: parent.model ?? undefined,
+          effort: parent.effort ?? undefined,
+          harness: 'claude-code',
+        });
+      } catch (err) {
+        console.warn(`[conversation-lifecycle] Failed to create post-/clear sibling for ${sessionId}: ${(err as Error).message}`);
+        continue;
+      }
+
+      try {
+        setClearedToConvId(parent.name, sibling.id);
+      } catch (err) {
+        console.warn(`[conversation-lifecycle] Failed to link conv/${parent.id} → conv/${sibling.id}: ${(err as Error).message}`);
+      }
+
+      console.log(`[conversation-lifecycle] Adopted post-/clear orphan ${sessionId} → conv/${sibling.id} (parent: conv/${parent.id} "${parent.name}")`);
+    }
+  }
+}
+
+/**
+ * Read the first ~5 lines of a JSONL and return the timestamp (ms since epoch) of
+ * the first user-message whose content contains the literal `/clear` command
+ * sentinel that Claude Code writes when the user clears the session. Returns
+ * `null` if no such message is found in the early lines — i.e., this is not a
+ * post-`/clear` orphan.
+ *
+ * Uses a streaming line reader bounded at 5 lines so a multi-megabyte snapshot
+ * line at the head of the file doesn't load the whole transcript into memory.
+ */
+async function readFirstClearTimestamp(jsonlPath: string): Promise<number | null> {
+  const stream = createReadStream(jsonlPath, { encoding: 'utf-8' });
+  const rl = createInterface({ input: stream, crlfDelay: Infinity });
+  let lineCount = 0;
+  try {
+    for await (const line of rl) {
+      lineCount++;
+      if (lineCount > 5) break;
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let obj: any;
+      try {
+        obj = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      if (obj?.type !== 'user') continue;
+      const content = obj?.message?.content;
+      if (typeof content !== 'string') continue;
+      if (!content.includes('<command-name>/clear</command-name>')) continue;
+      const ts = obj?.timestamp;
+      if (typeof ts !== 'string') continue;
+      const ms = new Date(ts).getTime();
+      if (Number.isNaN(ms)) continue;
+      return ms;
+    }
+  } finally {
+    rl.close();
+    stream.destroy();
+  }
+  return null;
 }
 
 /**

--- a/src/dashboard/server/services/conversation-lifecycle.ts
+++ b/src/dashboard/server/services/conversation-lifecycle.ts
@@ -275,6 +275,16 @@ async function detectOrphanedClaudeCodeSessions(activeConvs: Conversation[]): Pr
         console.warn(`[conversation-lifecycle] Failed to link conv/${parent.id} → conv/${sibling.id}: ${(err as Error).message}`);
       }
 
+      // The /clear command IS the user closing this thread. Mark the parent ended
+      // so the chat panel stops waiting for an assistant response on a JSONL that
+      // will never receive one (the response went to the sibling's JSONL). The
+      // sibling stays 'active' and is the live thread going forward.
+      try {
+        markConversationEnded(parent.name);
+      } catch (err) {
+        console.warn(`[conversation-lifecycle] Failed to mark parent ${parent.name} ended: ${(err as Error).message}`);
+      }
+
       console.log(`[conversation-lifecycle] Adopted post-/clear orphan ${sessionId} → conv/${sibling.id} (parent: conv/${parent.id} "${parent.name}")`);
     }
   }

--- a/src/lib/database/conversations-db.ts
+++ b/src/lib/database/conversations-db.ts
@@ -60,6 +60,8 @@ export interface Conversation {
   handoffTargetConvId: number | null;
   /** Reason a requested fork mode fell back to summary fork. */
   forkFallbackReason: string | null;
+  /** If this conv was cleared via Claude Code's /clear, the sibling conv that continues it (PAN-1458). */
+  clearedToConvId: number | null;
 }
 
 export interface ArchivedConversationWithEnrichment {
@@ -123,6 +125,7 @@ function rowToConversation(row: Record<string, unknown>): Conversation {
     handoffDocPath: (row['handoff_doc_path'] as string | null) ?? null,
     handoffTargetConvId: (row['handoff_target_conv_id'] as number | null) ?? null,
     forkFallbackReason: (row['fork_fallback_reason'] as string | null) ?? null,
+    clearedToConvId: (row['cleared_to_conv_id'] as number | null) ?? null,
   };
 }
 
@@ -142,7 +145,7 @@ export function listConversations(options?: { limit?: number; offset?: number })
               created_at, ended_at, last_attached_at, claude_session_id, title,
               title_source, title_seed, total_cost, archived_at, model, effort,
               fork_status, fork_error, harness, delivery_method, spawn_error,
-              handoff_doc_path, handoff_target_conv_id, fork_fallback_reason
+              handoff_doc_path, handoff_target_conv_id, fork_fallback_reason, cleared_to_conv_id
        FROM conversations
        WHERE archived_at IS NULL
          AND name NOT LIKE 'agent-%'
@@ -170,7 +173,7 @@ export function listActiveConversations(): Conversation[] {
               created_at, ended_at, last_attached_at, claude_session_id, title,
               title_source, title_seed, total_cost, archived_at, model, effort,
               fork_status, fork_error, harness, delivery_method, spawn_error,
-              handoff_doc_path, handoff_target_conv_id, fork_fallback_reason
+              handoff_doc_path, handoff_target_conv_id, fork_fallback_reason, cleared_to_conv_id
        FROM conversations
        WHERE archived_at IS NULL AND status = 'active'
        ORDER BY created_at DESC`,
@@ -187,7 +190,7 @@ export function getConversationByName(name: string): Conversation | null {
               created_at, ended_at, last_attached_at, claude_session_id, title,
               title_source, title_seed, total_cost, archived_at, model, effort,
               fork_status, fork_error, harness, delivery_method, spawn_error,
-              handoff_doc_path, handoff_target_conv_id, fork_fallback_reason
+              handoff_doc_path, handoff_target_conv_id, fork_fallback_reason, cleared_to_conv_id
        FROM conversations
        WHERE name = ?`,
     )
@@ -203,7 +206,7 @@ export function getConversationById(id: number): Conversation | null {
               created_at, ended_at, last_attached_at, claude_session_id, title,
               title_source, title_seed, total_cost, archived_at, model, effort,
               fork_status, fork_error, harness, delivery_method, spawn_error,
-              handoff_doc_path, handoff_target_conv_id, fork_fallback_reason
+              handoff_doc_path, handoff_target_conv_id, fork_fallback_reason, cleared_to_conv_id
        FROM conversations
        WHERE id = ?`,
     )
@@ -219,7 +222,7 @@ export function getConversationByClaudeSessionId(claudeSessionId: string): Conve
               created_at, ended_at, last_attached_at, claude_session_id, title,
               title_source, title_seed, total_cost, archived_at, model, effort,
               fork_status, fork_error, harness, delivery_method, spawn_error,
-              handoff_doc_path, handoff_target_conv_id, fork_fallback_reason
+              handoff_doc_path, handoff_target_conv_id, fork_fallback_reason, cleared_to_conv_id
        FROM conversations
        WHERE claude_session_id = ?`,
     )
@@ -235,7 +238,7 @@ export function listArchivedConversations(): Conversation[] {
               created_at, ended_at, last_attached_at, claude_session_id, title,
               title_source, title_seed, total_cost, archived_at, model, effort,
               fork_status, fork_error, harness, delivery_method, spawn_error,
-              handoff_doc_path, handoff_target_conv_id, fork_fallback_reason
+              handoff_doc_path, handoff_target_conv_id, fork_fallback_reason, cleared_to_conv_id
        FROM conversations
        WHERE archived_at IS NOT NULL
        ORDER BY archived_at DESC, created_at DESC`,
@@ -474,7 +477,7 @@ export function createConversation(opts: {
               created_at, ended_at, last_attached_at, claude_session_id, title,
               title_source, title_seed, total_cost, archived_at, model, effort,
               fork_status, fork_error, harness, delivery_method, spawn_error,
-              handoff_doc_path, handoff_target_conv_id, fork_fallback_reason
+              handoff_doc_path, handoff_target_conv_id, fork_fallback_reason, cleared_to_conv_id
        FROM conversations WHERE id = ?`,
     )
     .get(result.lastInsertRowid) as Record<string, unknown>;
@@ -644,6 +647,19 @@ export function recordConversationHandoff(sourceName: string, targetName: string
   ).run(target.id, sourceName);
 
   return getConversationByName(targetName) ?? target;
+}
+
+/**
+ * Link a parent conversation to its post-/clear sibling (PAN-1458). Called by the
+ * conversation-lifecycle orphan detector when it discovers a new JSONL whose first
+ * user-message is `<command-name>/clear</command-name>` and attributes it to this
+ * parent. The dashboard surfaces the link as a "continued in conv/N" footer.
+ */
+export function setClearedToConvId(name: string, convId: number): void {
+  const db = getDatabase();
+  db.prepare(
+    `UPDATE conversations SET cleared_to_conv_id = ? WHERE name = ?`,
+  ).run(convId, name);
 }
 
 export function updateSpawnError(name: string, error: string | null): void {

--- a/src/lib/database/schema.ts
+++ b/src/lib/database/schema.ts
@@ -19,7 +19,7 @@ import { existsSync } from 'fs';
 import { encodeClaudeProjectDir } from '../paths.js';
 
 // Schema version — increment when making breaking schema changes
-export const SCHEMA_VERSION = 42;
+export const SCHEMA_VERSION = 43;
 
 function parseArrayColumn(value: string | null): string[] {
   if (!value) return [];
@@ -399,7 +399,8 @@ export function initSchema(db: Database.Database): void {
       spawn_error      TEXT,                               -- error message when background spawn failed (quota, auth, etc.)
       handoff_doc_path TEXT,                               -- target conversation's agent-authored handoff document path
       handoff_target_conv_id INTEGER,                      -- source conversation's handoff target conversation id
-      fork_fallback_reason TEXT                            -- reason a requested fork mode fell back to summary fork
+      fork_fallback_reason TEXT,                           -- reason a requested fork mode fell back to summary fork
+      cleared_to_conv_id INTEGER                           -- PAN-1458: if this conv was cleared via /clear, the sibling conv that continues it
     );
 
     CREATE INDEX IF NOT EXISTS idx_conversations_status
@@ -1202,6 +1203,18 @@ export function runMigrations(db: Database.Database): void {
     try { db.exec(`ALTER TABLE conversations ADD COLUMN handoff_doc_path TEXT`); } catch { /* already exists */ }
     try { db.exec(`ALTER TABLE conversations ADD COLUMN handoff_target_conv_id INTEGER`); } catch { /* already exists */ }
     try { db.exec(`ALTER TABLE conversations ADD COLUMN fork_fallback_reason TEXT`); } catch { /* already exists */ }
+  }
+
+  // v42 → v43: track post-/clear sibling relationship for Claude Code conversations (PAN-1458).
+  // When Claude Code receives /clear, a new JSONL is created with a fresh session-id. The
+  // background orphan detector in conversation-lifecycle.ts creates a sibling conversation row
+  // for the new JSONL and links the parent via this column. UI can then surface the boundary.
+  if (currentVersion < 43) {
+    try { db.exec(`ALTER TABLE conversations ADD COLUMN cleared_to_conv_id INTEGER`); } catch { /* already exists */ }
+    try {
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_conversations_cleared_to
+                 ON conversations(cleared_to_conv_id) WHERE cleared_to_conv_id IS NOT NULL`);
+    } catch { /* already exists */ }
   }
 
   // After all migrations, set the version


### PR DESCRIPTION
Closes #1458

## Summary

- Detects post-\`/clear\` Claude Code JSONL orphans inside the existing 10s \`pollConversations()\` cycle and creates linked sibling \`conversations\` rows so the post-clear session shows up in the dashboard.
- Schema: \`SCHEMA_VERSION\` 42 → 43, adds nullable \`cleared_to_conv_id\` to \`conversations\` + sparse index on non-null values.
- Auto-derives a \`[post-/clear] <parent title>\` placeholder with \`title_source = 'auto'\` so the existing AI title generator overwrites once the new JSONL has enough content.

## Detection logic

For each active claude-code conversation grouped by \`cwd\`:

1. \`readdir(~/.claude/projects/<encoded-cwd>/)\` once per cwd.
2. For each JSONL whose \`session_id\` isn't already a known \`claude_session_id\`: stream the first 5 lines via \`readline\` and check for \`<command-name>/clear</command-name>\` in a user-message.
3. If found, attribute to the active conv in the same cwd whose \`claudeSessionId\` JSONL has the highest mtime strictly before the orphan's first-message timestamp. Chains correctly across multiple \`/clear\`s (A→B→C → new orphan attaches to C).
4. \`createConversation\` for the sibling inheriting \`tmuxSession\`, \`cwd\`, \`issueId\`, \`model\`, \`harness\`. \`setClearedToConvId(parent.name, sibling.id)\`.
5. If no Panopticon parent owns this cwd, skip (don't adopt standalone \`claude\` invocations).

## Test plan

- [x] \`npm run typecheck\` clean.
- [x] \`npm run build\` clean (warnings pre-existing).
- [x] \`npx eslint src/\` clean.
- [x] \`conversation-lifecycle.test.ts\` — 10/10 pass (6 pre-existing + 4 new):
  - happy path: adopts orphan, calls \`createConversation\` with inherited fields, calls \`setClearedToConvId\`.
  - already-linked: skips if \`getConversationByClaudeSessionId\` returns truthy.
  - no parent: skips when no active conv shares the cwd.
  - no sentinel: skips JSONLs without \`<command-name>/clear</command-name>\` in the first 5 lines.
- [x] Broader test sweep: 302/302 across 27 conversation-related test files.

## Manual verification (post-merge)

After \`pan restart\` applies the migration:
- Existing data: conv/2209 (pre-clear) and conv/2210 (manually-created post-clear sibling I inserted earlier this session) remain as-is. The detector finds 337484c1's JSONL already linked to conv/2210 and skips.
- A fresh \`/clear\` in any Panopticon-spawned Claude Code conversation should trigger a sibling row within 10s, with \`parent.cleared_to_conv_id\` pointing at the new row.

## Follow-up scope (NOT in this PR)

- Renderer: style \`<command-name>X</command-name>\` user-messages as dividers in the conv transcript (benefits \`/clear\`, \`/compact\`, \`/resume\`).
- Footer banner: in pre-clear conv view, surface "→ Session cleared, continued in conv/N" when \`cleared_to_conv_id\` is set.
- Optional one-time backfill: link existing pre-clear/post-clear pairs that predate this PR (e.g., conv/2209 ↔ conv/2210).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved conversation management: Dashboard now automatically detects orphaned Claude Code sessions and links them to parent conversations, providing clearer tracking of conversation continuity and relationships across your projects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eltmon/panopticon-cli/pull/1460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->