### PR TITLE
Add plural projects CLI alias

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1205,38 +1205,44 @@ program
   .option('--no-deacon', 'Skip Cloister/Deacon auto-start on restart (escape hatch when deacon\'s startup scan is starving the event loop)')
   .action(restartCommand);
 
+function registerProjectCommands(command: Command): void {
+  command
+    .command('add <path>')
+    .description('Register a project with Panopticon')
+    .option('--name <name>', 'Project name')
+    .option('--type <type>', 'Project type (standalone/monorepo)', 'standalone')
+    .option('--linear-team <team>', 'Linear team prefix (e.g., MIN, PAN)')
+    .option('--rally-project <oid>', 'Rally project OID (e.g., /project/822404704163)')
+    .action(projectAddCommand);
+
+  command
+    .command('list')
+    .description('List all registered projects')
+    .option('--json', 'Output as JSON')
+    .action(projectListCommand);
+
+  command
+    .command('show <key>')
+    .description('Show details for a specific project')
+    .action(projectShowCommand);
+
+  command
+    .command('remove <nameOrPath>')
+    .description('Remove a project from the registry')
+    .action(projectRemoveCommand);
+
+  command
+    .command('init')
+    .description('Initialize projects.yaml with example configuration')
+    .action(projectInitCommand);
+}
+
 // Project management commands
 const project = program.command('project').description('Project registry for multi-project workspace support');
+registerProjectCommands(project);
 
-project
-  .command('add <path>')
-  .description('Register a project with Panopticon')
-  .option('--name <name>', 'Project name')
-  .option('--type <type>', 'Project type (standalone/monorepo)', 'standalone')
-  .option('--linear-team <team>', 'Linear team prefix (e.g., MIN, PAN)')
-  .option('--rally-project <oid>', 'Rally project OID (e.g., /project/822404704163)')
-  .action(projectAddCommand);
-
-project
-  .command('list')
-  .description('List all registered projects')
-  .option('--json', 'Output as JSON')
-  .action(projectListCommand);
-
-project
-  .command('show <key>')
-  .description('Show details for a specific project')
-  .action(projectShowCommand);
-
-project
-  .command('remove <nameOrPath>')
-  .description('Remove a project from the registry')
-  .action(projectRemoveCommand);
-
-project
-  .command('init')
-  .description('Initialize projects.yaml with example configuration')
-  .action(projectInitCommand);
+const projects = program.command('projects').description('Project registry for multi-project workspace support');
+registerProjectCommands(projects);
 
 // Health command
 program

--- a/src/dashboard/server/routes/context.ts
+++ b/src/dashboard/server/routes/context.ts
@@ -1,0 +1,493 @@
+import { access, mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+
+import type { Harness } from '@panctl/contracts';
+import { Effect, Layer } from 'effect';
+import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
+
+import { renderForHarness, validateTemplate } from '../../../lib/context-layers/harness.js';
+import {
+  globalContextFile,
+  projectContextFile,
+  workspaceContextFile,
+  type ContextLayerKind,
+} from '../../../lib/context-layers/layers.js';
+import { listProjects, type ProjectConfig } from '../../../lib/projects.js';
+import { isDevMode, SYNC_SOURCES } from '../../../lib/paths.js';
+import { jsonResponse } from '../http-helpers.js';
+import { httpHandler } from './http-handler.js';
+
+type ContextLayerTarget =
+  | { kind: 'global' }
+  | { kind: 'project'; projectKey: string }
+  | { kind: 'workspace'; projectKey: string; workspacePath: string };
+
+type ContextProjectSummary = {
+  projectKey: string;
+  name: string;
+  path: string;
+  issuePrefix?: string;
+  tracker?: ProjectConfig['tracker'];
+  workspaceRoot?: string;
+};
+
+type ContextWorkspaceSummary = {
+  projectKey: string;
+  path: string;
+  name: string;
+  issueId?: string;
+  branch?: string;
+};
+
+type ContextEditableLayerRecord = {
+  kind: ContextLayerKind;
+  file: string;
+  exists: boolean;
+  content: string;
+  editable: boolean;
+  projectKey?: string;
+  workspacePath?: string;
+};
+
+type ContextLayerDraft = {
+  target: ContextLayerTarget;
+  content: string;
+};
+
+type ContextLayersResponse = {
+  operation: 'load';
+  projects: ContextProjectSummary[];
+  workspaces: ContextWorkspaceSummary[];
+  layers: ContextEditableLayerRecord[];
+};
+
+type ContextPreviewDiagnostic = {
+  level: 'info' | 'warning' | 'error';
+  message: string;
+  layer?: ContextLayerTarget;
+};
+
+type ContextPreviewResponse = {
+  operation: 'preview';
+  previews: Record<Harness | 'fullPrompt', string>;
+  diagnostics: ContextPreviewDiagnostic[];
+};
+
+type ContextLayerSaveResponse = {
+  operation: 'save';
+  layer: ContextEditableLayerRecord;
+  savedAt: string;
+};
+
+type ProjectEntry = { key: string; config: ProjectConfig };
+
+type ContextCatalog = {
+  projects: ProjectEntry[];
+  summaries: ContextProjectSummary[];
+  workspaces: ContextWorkspaceSummary[];
+};
+
+const PREVIEW_HARNESSES: readonly Harness[] = ['claude-code', 'pi'];
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+type RuleScope = 'universal' | 'dev';
+
+async function pathExists(path: string): Promise<boolean> {
+  return access(path).then(() => true, () => false);
+}
+
+async function readOptionalFile(path: string): Promise<{ exists: boolean; content: string }> {
+  try {
+    return { exists: true, content: await readFile(path, 'utf-8') };
+  } catch (error) {
+    if (isMissingFileError(error)) return { exists: false, content: '' };
+    throw error;
+  }
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
+}
+
+function assertPathInside(root: string, candidate: string): void {
+  const resolvedRoot = resolve(root);
+  const resolvedCandidate = resolve(candidate);
+  const rel = relative(resolvedRoot, resolvedCandidate);
+  if (rel === '' || (!rel.startsWith('..') && !isAbsolute(rel) && !rel.includes(`..${sep}`))) return;
+  throw new Error(`Path escapes allowed root: ${candidate}`);
+}
+
+function workspaceRootForProject(project: ProjectConfig): string {
+  const configured = project.workspace?.workspaces_dir ?? 'workspaces';
+  return isAbsolute(configured) ? resolve(configured) : resolve(project.path, configured);
+}
+
+function summarizeProject({ key, config }: ProjectEntry): ContextProjectSummary {
+  return {
+    projectKey: key,
+    name: config.name,
+    path: resolve(config.path),
+    issuePrefix: config.issue_prefix,
+    tracker: config.tracker,
+    workspaceRoot: workspaceRootForProject(config),
+  };
+}
+
+function workspaceIssueId(name: string): string | undefined {
+  const match = /^feature-([a-z]+)-(\d+)(?:-.+)?$/i.exec(name);
+  return match ? `${match[1]!.toUpperCase()}-${match[2]}` : undefined;
+}
+
+function workspaceBranch(name: string): string | undefined {
+  return name.startsWith('feature-') ? name : undefined;
+}
+
+async function discoverWorkspacesForProject(projectKey: string, config: ProjectConfig): Promise<ContextWorkspaceSummary[]> {
+  const root = workspaceRootForProject(config);
+  if (!(await pathExists(root))) return [];
+
+  const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const path = resolve(root, entry.name);
+      assertPathInside(root, path);
+      return {
+        projectKey,
+        path,
+        name: entry.name,
+        issueId: workspaceIssueId(entry.name),
+        branch: workspaceBranch(entry.name),
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function buildContextCatalog(projects: ProjectEntry[]): Promise<ContextCatalog> {
+  const summaries = projects.map(summarizeProject);
+  const workspaceGroups = await Promise.all(
+    projects.map((project) => discoverWorkspacesForProject(project.key, project.config)),
+  );
+  return {
+    projects,
+    summaries,
+    workspaces: workspaceGroups.flat(),
+  };
+}
+
+async function layerRecord(
+  kind: ContextLayerKind,
+  file: string,
+  extras: { projectKey?: string; workspacePath?: string } = {},
+): Promise<ContextEditableLayerRecord> {
+  const { exists, content } = await readOptionalFile(file);
+  return { kind, file, exists, content, editable: true, ...extras };
+}
+
+export async function buildContextLayersResponse(projects: ProjectEntry[]): Promise<ContextLayersResponse> {
+  const catalog = await buildContextCatalog(projects);
+  const layers: ContextEditableLayerRecord[] = [
+    await layerRecord('global', globalContextFile()),
+  ];
+
+  for (const project of catalog.projects) {
+    layers.push(await layerRecord('project', projectContextFile(project.config.path), { projectKey: project.key }));
+  }
+
+  for (const workspace of catalog.workspaces) {
+    layers.push(await layerRecord('workspace', workspaceContextFile(workspace.path), {
+      projectKey: workspace.projectKey,
+      workspacePath: workspace.path,
+    }));
+  }
+
+  return {
+    operation: 'load',
+    projects: catalog.summaries,
+    workspaces: catalog.workspaces,
+    layers,
+  };
+}
+
+function findProject(projects: ProjectEntry[], projectKey: string): ProjectEntry {
+  const project = projects.find((entry) => entry.key === projectKey);
+  if (!project) throw new Error(`Unknown project: ${projectKey}`);
+  return project;
+}
+
+async function resolveLayerFile(
+  target: ContextLayerTarget,
+  projects: ProjectEntry[],
+  catalog?: ContextCatalog,
+): Promise<{ file: string; kind: ContextLayerKind; projectKey?: string; workspacePath?: string }> {
+  if (target.kind === 'global') {
+    return { kind: 'global', file: globalContextFile() };
+  }
+
+  const project = findProject(projects, target.projectKey);
+  const projectRoot = resolve(project.config.path);
+
+  if (target.kind === 'project') {
+    const file = projectContextFile(projectRoot);
+    assertPathInside(projectRoot, file);
+    return { kind: 'project', file, projectKey: target.projectKey };
+  }
+
+  const resolvedWorkspacePath = resolve(target.workspacePath);
+  const contextCatalog = catalog ?? await buildContextCatalog(projects);
+  const allowedWorkspace = contextCatalog.workspaces.find(
+    (workspace) => workspace.projectKey === target.projectKey && resolve(workspace.path) === resolvedWorkspacePath,
+  );
+  if (!allowedWorkspace) throw new Error(`Unknown workspace for project ${target.projectKey}: ${target.workspacePath}`);
+
+  const file = workspaceContextFile(resolvedWorkspacePath);
+  assertPathInside(resolvedWorkspacePath, file);
+  return { kind: 'workspace', file, projectKey: target.projectKey, workspacePath: resolvedWorkspacePath };
+}
+
+function parseTarget(value: unknown): ContextLayerTarget {
+  if (!value || typeof value !== 'object') throw new Error('target must be an object');
+  const source = value as Record<string, unknown>;
+  if (source['kind'] === 'global') return { kind: 'global' };
+  if (source['kind'] === 'project' && typeof source['projectKey'] === 'string') {
+    return { kind: 'project', projectKey: source['projectKey'] };
+  }
+  if (
+    source['kind'] === 'workspace' &&
+    typeof source['projectKey'] === 'string' &&
+    typeof source['workspacePath'] === 'string'
+  ) {
+    return { kind: 'workspace', projectKey: source['projectKey'], workspacePath: source['workspacePath'] };
+  }
+  throw new Error('target must specify a valid global, project, or workspace layer');
+}
+
+function parseDrafts(value: unknown): ContextLayerDraft[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((draft) => {
+    if (!draft || typeof draft !== 'object') throw new Error('drafts must contain objects');
+    const source = draft as Record<string, unknown>;
+    if (typeof source['content'] !== 'string') throw new Error('draft content must be a string');
+    return { target: parseTarget(source['target']), content: source['content'] };
+  });
+}
+
+function parseJsonBody(text: string): Record<string, unknown> {
+  if (!text) return {};
+  const parsed = JSON.parse(text) as unknown;
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) throw new Error('JSON body must be an object');
+  return parsed as Record<string, unknown>;
+}
+
+function layerKey(target: ContextLayerTarget): string {
+  if (target.kind === 'global') return 'global';
+  if (target.kind === 'project') return `project:${target.projectKey}`;
+  return `workspace:${target.projectKey}:${resolve(target.workspacePath)}`;
+}
+
+async function resolveLayerContent(
+  target: ContextLayerTarget,
+  projects: ProjectEntry[],
+  catalog: ContextCatalog,
+  draftByKey: ReadonlyMap<string, string>,
+): Promise<{ target: ContextLayerTarget; file: string; content: string; exists: boolean }> {
+  const resolved = await resolveLayerFile(target, projects, catalog);
+  const normalizedTarget = resolved.kind === 'workspace'
+    ? { kind: 'workspace' as const, projectKey: resolved.projectKey!, workspacePath: resolved.workspacePath! }
+    : resolved.kind === 'project'
+      ? { kind: 'project' as const, projectKey: resolved.projectKey! }
+      : { kind: 'global' as const };
+  const draft = draftByKey.get(layerKey(normalizedTarget));
+  if (draft !== undefined) return { target: normalizedTarget, file: resolved.file, content: draft, exists: await pathExists(resolved.file) };
+  const { exists, content } = await readOptionalFile(resolved.file);
+  return { target: normalizedTarget, file: resolved.file, content, exists };
+}
+
+function parseRule(raw: string): { scope: RuleScope; body: string } {
+  const match = FRONTMATTER_RE.exec(raw);
+  if (!match) return { scope: 'universal', body: raw.trim() };
+  const scopeLine = match[1].split(/\r?\n/).find((line) => /^\s*scope\s*:/.test(line));
+  const scope = scopeLine?.split(':')[1]?.trim().replace(/["']/g, '');
+  return {
+    scope: scope === 'dev' ? 'dev' : 'universal',
+    body: raw.slice(match[0].length).trim(),
+  };
+}
+
+async function renderBundledRulesAsync(harness: Harness): Promise<string> {
+  const includeDev = isDevMode();
+  const entries = await readdir(SYNC_SOURCES.rules, { withFileTypes: true }).catch(() => []);
+  const sections = await Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map(async (entry) => {
+        const file = join(SYNC_SOURCES.rules, entry.name);
+        assertPathInside(SYNC_SOURCES.rules, file);
+        const rule = parseRule(await readFile(file, 'utf-8'));
+        if (!includeDev && rule.scope === 'dev') return '';
+        return renderForHarness(rule.body, harness).trim();
+      }),
+  );
+  const rendered = sections.filter((section) => section.length > 0);
+  return rendered.length > 0 ? `## Panopticon Engineering Rules\n\n${rendered.join('\n\n')}` : '';
+}
+
+function formatRenderedLayers(
+  harness: Harness,
+  layers: Array<{ title: string; content: string }>,
+  bundledRules: string,
+): string {
+  const renderedLayers = layers
+    .map((layer) => {
+      const rendered = renderForHarness(layer.content, harness).trim();
+      return rendered ? `## ${layer.title}\n\n${rendered}` : '';
+    })
+    .filter((section) => section.length > 0);
+
+  return [...renderedLayers, bundledRules].filter((section) => section.trim().length > 0).join('\n\n---\n\n');
+}
+
+function formatFullPrompt(previews: Record<Harness, string>): string {
+  return [
+    '# Full injected prompt preview',
+    '',
+    'Private harness base prompt: unavailable. Panopticon cannot inspect or reproduce the private base prompt owned by the harness provider.',
+    '',
+    '## Panopticon-controlled Claude Code bundle',
+    '',
+    previews['claude-code'] || '(no rendered context)',
+    '',
+    '## Panopticon-controlled Pi bundle',
+    '',
+    previews.pi || '(no rendered context)',
+    '',
+    '## Runtime-only sections',
+    '',
+    '- Memory retrieval: injected at agent spawn when enabled; unavailable in this layer editor preview.',
+    '- Issue briefing and vBRIEF excerpts: injected per agent run; unavailable until a specific issue/session is selected.',
+    '- Status and tool output: produced during the live session; not part of static context layers.',
+  ].join('\n');
+}
+
+export async function previewContextLayers(
+  projects: ProjectEntry[],
+  selectedLayer: ContextLayerTarget,
+  drafts: ContextLayerDraft[],
+): Promise<ContextPreviewResponse> {
+  const catalog = await buildContextCatalog(projects);
+  const draftByKey = new Map<string, string>();
+  for (const draft of drafts) {
+    const resolved = await resolveLayerFile(draft.target, projects, catalog);
+    const normalizedTarget = resolved.kind === 'workspace'
+      ? { kind: 'workspace' as const, projectKey: resolved.projectKey!, workspacePath: resolved.workspacePath! }
+      : draft.target;
+    draftByKey.set(layerKey(normalizedTarget), draft.content);
+  }
+
+  const resolvedSelected = await resolveLayerFile(selectedLayer, projects, catalog);
+  const selectedTarget = resolvedSelected.kind === 'workspace'
+    ? { kind: 'workspace' as const, projectKey: resolvedSelected.projectKey!, workspacePath: resolvedSelected.workspacePath! }
+    : selectedLayer;
+
+  const targets: Array<{ title: string; target: ContextLayerTarget }> = [{ title: 'Global context layer', target: { kind: 'global' } }];
+  if (selectedTarget.kind === 'project') {
+    targets.push({ title: `Project context layer (${selectedTarget.projectKey})`, target: selectedTarget });
+  } else if (selectedTarget.kind === 'workspace') {
+    targets.push({ title: `Project context layer (${selectedTarget.projectKey})`, target: { kind: 'project', projectKey: selectedTarget.projectKey } });
+    targets.push({ title: `Workspace context layer (${selectedTarget.workspacePath})`, target: selectedTarget });
+  }
+
+  const layerContents = await Promise.all(
+    targets.map(async ({ title, target }) => ({ title, ...(await resolveLayerContent(target, projects, catalog, draftByKey)) })),
+  );
+
+  const diagnostics: ContextPreviewDiagnostic[] = [];
+  for (const layer of layerContents) {
+    const validation = validateTemplate(layer.content);
+    diagnostics.push(...validation.issues.map((issue) => ({
+      level: issue.severity,
+      message: issue.message,
+      layer: layer.target,
+    })));
+  }
+
+  const previews = {} as Record<Harness, string>;
+  for (const harness of PREVIEW_HARNESSES) {
+    previews[harness] = formatRenderedLayers(
+      harness,
+      layerContents.map((layer) => ({ title: layer.title, content: layer.content })),
+      await renderBundledRulesAsync(harness),
+    );
+  }
+
+  return {
+    operation: 'preview',
+    previews: {
+      'claude-code': previews['claude-code'],
+      pi: previews.pi,
+      fullPrompt: formatFullPrompt(previews),
+    },
+    diagnostics,
+  };
+}
+
+export async function saveContextLayer(
+  projects: ProjectEntry[],
+  target: ContextLayerTarget,
+  content: string,
+): Promise<ContextLayerSaveResponse> {
+  const resolved = await resolveLayerFile(target, projects);
+  await mkdir(dirname(resolved.file), { recursive: true });
+  await writeFile(resolved.file, content, 'utf-8');
+  return {
+    operation: 'save',
+    layer: await layerRecord(resolved.kind, resolved.file, {
+      projectKey: resolved.projectKey,
+      workspacePath: resolved.workspacePath,
+    }),
+    savedAt: new Date().toISOString(),
+  };
+}
+
+const getContextLayersRoute = HttpRouter.add(
+  'GET',
+  '/api/context/layers',
+  httpHandler(Effect.gen(function* () {
+    const projects = yield* listProjects();
+    return jsonResponse(yield* Effect.promise(() => buildContextLayersResponse(projects)));
+  })),
+);
+
+const postContextPreviewRoute = HttpRouter.add(
+  'POST',
+  '/api/context/preview',
+  httpHandler(Effect.gen(function* () {
+    const projects = yield* listProjects();
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const body = parseJsonBody(yield* request.text);
+    const selectedLayer = parseTarget(body['selectedLayer']);
+    const drafts = parseDrafts(body['drafts']);
+    return jsonResponse(yield* Effect.promise(() => previewContextLayers(projects, selectedLayer, drafts)));
+  })),
+);
+
+const putContextLayerRoute = HttpRouter.add(
+  'PUT',
+  '/api/context/layers',
+  httpHandler(Effect.gen(function* () {
+    const projects = yield* listProjects();
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const body = parseJsonBody(yield* request.text);
+    const target = parseTarget(body['target']);
+    const content = body['content'];
+    if (typeof content !== 'string') throw new Error('content must be a string');
+    return jsonResponse(yield* Effect.promise(() => saveContextLayer(projects, target, content)));
+  })),
+);
+
+export const contextRouteLayer = Layer.mergeAll(
+  getContextLayersRoute,
+  postContextPreviewRoute,
+  putContextLayerRoute,
+);

--- a/src/dashboard/server/routes/context.ts
+++ b/src/dashboard/server/routes/context.ts
@@ -1,5 +1,7 @@
+import { execFile } from 'node:child_process';
 import { access, mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { promisify } from 'node:util';
 
 import type { Harness } from '@panctl/contracts';
 import { Effect, Layer } from 'effect';
@@ -79,6 +81,24 @@ type ContextLayerSaveResponse = {
   savedAt: string;
 };
 
+type ContextSyncCommandResult = {
+  stdout: string;
+  stderr: string;
+};
+
+type ContextSyncResponse = {
+  operation: 'sync';
+  ok: boolean;
+  status: 'synced' | 'failed';
+  stdout: string;
+  stderr: string;
+  error?: string;
+  exitCode?: number;
+  syncedAt: string;
+};
+
+export type ContextSyncRunner = () => Promise<ContextSyncCommandResult>;
+
 type ProjectEntry = { key: string; config: ProjectConfig };
 
 type ContextCatalog = {
@@ -89,6 +109,7 @@ type ContextCatalog = {
 
 const PREVIEW_HARNESSES: readonly Harness[] = ['claude-code', 'pi'];
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+const execFileAsync = promisify(execFile);
 
 type RuleScope = 'universal' | 'dev';
 
@@ -450,6 +471,53 @@ export async function saveContextLayer(
   };
 }
 
+async function runPanContextSync(): Promise<ContextSyncCommandResult> {
+  const { stdout, stderr } = await execFileAsync('pan', ['context', 'sync'], {
+    encoding: 'utf-8',
+  });
+  return { stdout, stderr };
+}
+
+function syncExitCode(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'number' ? code : undefined;
+}
+
+function syncOutput(error: unknown, key: 'stdout' | 'stderr'): string {
+  if (!error || typeof error !== 'object') return '';
+  const value = (error as Record<typeof key, unknown>)[key];
+  return typeof value === 'string' ? value : '';
+}
+
+export async function syncContextLayers(
+  runner: ContextSyncRunner = runPanContextSync,
+): Promise<ContextSyncResponse> {
+  const syncedAt = new Date().toISOString();
+  try {
+    const { stdout, stderr } = await runner();
+    return {
+      operation: 'sync',
+      ok: true,
+      status: 'synced',
+      stdout,
+      stderr,
+      syncedAt,
+    };
+  } catch (error) {
+    return {
+      operation: 'sync',
+      ok: false,
+      status: 'failed',
+      stdout: syncOutput(error, 'stdout'),
+      stderr: syncOutput(error, 'stderr'),
+      error: error instanceof Error ? error.message : 'pan context sync failed',
+      exitCode: syncExitCode(error),
+      syncedAt,
+    };
+  }
+}
+
 const getContextLayersRoute = HttpRouter.add(
   'GET',
   '/api/context/layers',
@@ -486,8 +554,18 @@ const putContextLayerRoute = HttpRouter.add(
   })),
 );
 
+const postContextSyncRoute = HttpRouter.add(
+  'POST',
+  '/api/context/sync',
+  httpHandler(Effect.gen(function* () {
+    const response = yield* Effect.promise(() => syncContextLayers());
+    return jsonResponse(response, { status: response.ok ? 200 : 500 });
+  })),
+);
+
 export const contextRouteLayer = Layer.mergeAll(
   getContextLayersRoute,
   postContextPreviewRoute,
   putContextLayerRoute,
+  postContextSyncRoute,
 );

--- a/src/dashboard/server/server.ts
+++ b/src/dashboard/server/server.ts
@@ -51,6 +51,7 @@ import { conversationsRouteLayer } from './routes/conversations.js';
 import { eventsRouteLayer } from './routes/events.js';
 import { showRouteLayer } from './routes/show.js';
 import { projectsRouteLayer } from './routes/projects.js';
+import { contextRouteLayer } from './routes/context.js';
 import { adminRouteLayer } from './routes/admin.js';
 import { prereqsRouteLayer } from './routes/prereqs.js';
 import { cliproxyRouteLayer } from './routes/cliproxy.js';
@@ -310,6 +311,7 @@ export const makeRoutesLayer = Layer.mergeAll(
   eventsRouteLayer,
   showRouteLayer,
   projectsRouteLayer,
+  contextRouteLayer,
   adminRouteLayer,
   prereqsRouteLayer,
   cliproxyRouteLayer,

--- a/tests/fixtures/pan-help.test.ts
+++ b/tests/fixtures/pan-help.test.ts
@@ -33,7 +33,11 @@ const FIXTURE_PATH = join(__dirname, 'pan-help.txt');
 const CLI_PATH = join(__dirname, '../../dist/cli/index.js');
 
 function captureHelp(): string {
-  return execSync(`node ${CLI_PATH} --help`, {
+  return captureCommandHelp('--help');
+}
+
+function captureCommandHelp(args: string): string {
+  return execSync(`node ${CLI_PATH} ${args}`, {
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'pipe'],
   });
@@ -51,5 +55,20 @@ describe('pan --help fixture', () => {
 
     const expected = readFileSync(FIXTURE_PATH, 'utf-8');
     expect(actual).toBe(expected);
+  });
+
+  it('exposes the plural projects command in root help', () => {
+    expect(captureHelp()).toContain('projects                        Project registry for multi-project workspace');
+  });
+
+  it('keeps singular and plural project add options in sync', () => {
+    const singular = captureCommandHelp('project add --help').replaceAll('pan project add', 'pan projects add');
+    const plural = captureCommandHelp('projects add --help');
+
+    expect(plural).toBe(singular);
+    expect(plural).toContain('--name <name>');
+    expect(plural).toContain('--type <type>');
+    expect(plural).toContain('--linear-team <team>');
+    expect(plural).toContain('--rally-project <oid>');
   });
 });

--- a/tests/fixtures/pan-help.txt
+++ b/tests/fixtures/pan-help.txt
@@ -97,6 +97,8 @@ Commands:
                                   TLDR running)
   project                         Project registry for multi-project workspace
                                   support
+  projects                        Project registry for multi-project workspace
+                                  support
   health                          Show runtime health of Panopticon services
   doctor [options]                Check system health and dependencies
   resources [options]             Show RAM usage by agents, conversations, and

--- a/tests/unit/dashboard/server/routes/context.test.ts
+++ b/tests/unit/dashboard/server/routes/context.test.ts
@@ -2,12 +2,13 @@ import { access, mkdtemp, mkdir, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   buildContextLayersResponse,
   previewContextLayers,
   saveContextLayer,
+  syncContextLayers,
 } from '../../../../../src/dashboard/server/routes/context.js';
 import type { ProjectConfig } from '../../../../../src/lib/projects.js';
 
@@ -95,9 +96,10 @@ describe('dashboard context routes helpers', () => {
     }));
   });
 
-  it('renders preview drafts per harness without writing files', async () => {
+  it('renders preview drafts per harness without writing files or syncing', async () => {
     const projects = await fixtureProject();
     const globalFile = join(tempRoot, 'home', 'context', 'global.md');
+    const syncRunner = vi.fn();
     const content = [
       'Shared guidance.',
       '{{#harness:claude}}',
@@ -120,6 +122,53 @@ describe('dashboard context routes helpers', () => {
     expect(response.previews.pi).toContain('Pi guidance.');
     expect(response.previews.pi).not.toContain('Claude guidance.');
     expect(response.previews.fullPrompt).toContain('Private harness base prompt: unavailable');
+    expect(syncRunner).not.toHaveBeenCalled();
     await expect(exists(globalFile)).resolves.toBe(false);
+  });
+
+  it('saves layer content without syncing', async () => {
+    const projects = await fixtureProject();
+    const syncRunner = vi.fn();
+
+    await saveContextLayer(projects, { kind: 'global' }, 'saved');
+
+    expect(syncRunner).not.toHaveBeenCalled();
+  });
+
+  it('runs context sync only through the explicit sync helper', async () => {
+    const runner = vi.fn().mockResolvedValue({ stdout: 'synced\n', stderr: '' });
+
+    const response = await syncContextLayers(runner);
+
+    expect(runner).toHaveBeenCalledOnce();
+    expect(response).toMatchObject({
+      operation: 'sync',
+      ok: true,
+      status: 'synced',
+      stdout: 'synced\n',
+      stderr: '',
+    });
+  });
+
+  it('returns structured context sync failures', async () => {
+    const error = Object.assign(new Error('sync failed'), {
+      code: 42,
+      stdout: 'partial output',
+      stderr: 'bad config',
+    });
+    const runner = vi.fn().mockRejectedValue(error);
+
+    const response = await syncContextLayers(runner);
+
+    expect(runner).toHaveBeenCalledOnce();
+    expect(response).toMatchObject({
+      operation: 'sync',
+      ok: false,
+      status: 'failed',
+      stdout: 'partial output',
+      stderr: 'bad config',
+      error: 'sync failed',
+      exitCode: 42,
+    });
   });
 });

--- a/tests/unit/dashboard/server/routes/context.test.ts
+++ b/tests/unit/dashboard/server/routes/context.test.ts
@@ -1,0 +1,125 @@
+import { access, mkdtemp, mkdir, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  buildContextLayersResponse,
+  previewContextLayers,
+  saveContextLayer,
+} from '../../../../../src/dashboard/server/routes/context.js';
+import type { ProjectConfig } from '../../../../../src/lib/projects.js';
+
+async function exists(path: string): Promise<boolean> {
+  return access(path).then(() => true, () => false);
+}
+
+describe('dashboard context routes helpers', () => {
+  let tempRoot: string;
+  let oldPanopticonHome: string | undefined;
+
+  beforeEach(async () => {
+    oldPanopticonHome = process.env.PANOPTICON_HOME;
+    tempRoot = await mkdtemp(join(tmpdir(), 'pan-context-route-'));
+    process.env.PANOPTICON_HOME = join(tempRoot, 'home');
+  });
+
+  afterEach(async () => {
+    if (oldPanopticonHome === undefined) {
+      delete process.env.PANOPTICON_HOME;
+    } else {
+      process.env.PANOPTICON_HOME = oldPanopticonHome;
+    }
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  async function fixtureProject(): Promise<Array<{ key: string; config: ProjectConfig }>> {
+    const projectPath = join(tempRoot, 'project');
+    const workspacePath = join(projectPath, 'workspaces', 'feature-pan-1201');
+    await mkdir(workspacePath, { recursive: true });
+    return [{
+      key: 'pan',
+      config: {
+        name: 'Panopticon',
+        path: projectPath,
+        issue_prefix: 'PAN',
+        workspace: { workspaces_dir: 'workspaces' },
+      },
+    }];
+  }
+
+  it('saves only allowlisted global, project, and workspace layer files', async () => {
+    const projects = await fixtureProject();
+    const projectPath = projects[0]!.config.path;
+    const workspacePath = join(projectPath, 'workspaces', 'feature-pan-1201');
+
+    await saveContextLayer(projects, { kind: 'global' }, 'global layer');
+    await saveContextLayer(projects, { kind: 'project', projectKey: 'pan' }, 'project layer');
+    await saveContextLayer(projects, {
+      kind: 'workspace',
+      projectKey: 'pan',
+      workspacePath,
+    }, 'workspace layer');
+
+    await expect(readFile(join(tempRoot, 'home', 'context', 'global.md'), 'utf-8')).resolves.toBe('global layer');
+    await expect(readFile(join(projectPath, '.pan', 'context', 'project.md'), 'utf-8')).resolves.toBe('project layer');
+    await expect(readFile(join(workspacePath, '.pan', 'context', 'workspace.md'), 'utf-8')).resolves.toBe('workspace layer');
+
+    const outsideWorkspace = join(tempRoot, 'outside-workspace');
+    await mkdir(outsideWorkspace, { recursive: true });
+    await expect(saveContextLayer(projects, {
+      kind: 'workspace',
+      projectKey: 'pan',
+      workspacePath: outsideWorkspace,
+    }, 'escape')).rejects.toThrow('Unknown workspace');
+    await expect(exists(join(outsideWorkspace, '.pan', 'context', 'workspace.md'))).resolves.toBe(false);
+  });
+
+  it('loads registered projects, workspace candidates, and layer contents', async () => {
+    const projects = await fixtureProject();
+    const projectPath = projects[0]!.config.path;
+    await saveContextLayer(projects, { kind: 'project', projectKey: 'pan' }, 'project content');
+
+    const response = await buildContextLayersResponse(projects);
+
+    expect(response.operation).toBe('load');
+    expect(response.projects).toMatchObject([{ projectKey: 'pan', name: 'Panopticon', issuePrefix: 'PAN' }]);
+    expect(response.workspaces).toMatchObject([{ projectKey: 'pan', name: 'feature-pan-1201', issueId: 'PAN-1201' }]);
+    expect(response.layers).toContainEqual(expect.objectContaining({
+      kind: 'project',
+      projectKey: 'pan',
+      file: join(projectPath, '.pan', 'context', 'project.md'),
+      exists: true,
+      content: 'project content',
+    }));
+  });
+
+  it('renders preview drafts per harness without writing files', async () => {
+    const projects = await fixtureProject();
+    const globalFile = join(tempRoot, 'home', 'context', 'global.md');
+    const content = [
+      'Shared guidance.',
+      '{{#harness:claude}}',
+      'Claude guidance.',
+      '{{/harness:claude}}',
+      '{{#harness:pi}}',
+      'Pi guidance.',
+      '{{/harness:pi}}',
+    ].join('\n');
+
+    const response = await previewContextLayers(projects, { kind: 'global' }, [{
+      target: { kind: 'global' },
+      content,
+    }]);
+
+    expect(response.previews['claude-code']).toContain('Shared guidance.');
+    expect(response.previews['claude-code']).toContain('Claude guidance.');
+    expect(response.previews['claude-code']).not.toContain('Pi guidance.');
+    expect(response.previews.pi).toContain('Shared guidance.');
+    expect(response.previews.pi).toContain('Pi guidance.');
+    expect(response.previews.pi).not.toContain('Claude guidance.');
+    expect(response.previews.fullPrompt).toContain('Private harness base prompt: unavailable');
+    await expect(exists(globalFile)).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `pan projects` as a plural command group for project registry commands.
- Register singular and plural project commands through one helper so add/list/show/remove/init stay aligned.
- Update help fixture coverage and assert `pan projects add --help` matches the singular add command options.

## Test plan
- [x] `npx vitest run tests/fixtures/pan-help.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)