### PR TITLE
PAN-1520: Unified pending-input subsystem (AskUserQuestion + PermissionRequest + plan modes + session-resume)

### DIFF
--- a/packages/contracts/src/event-reducers.ts
+++ b/packages/contracts/src/event-reducers.ts
@@ -378,6 +378,9 @@ export function applyEvent(state: ReadModelState, event: DomainEvent): ReadModel
             pendingQuestionCount: event.payload.pendingQuestionCount,
             pendingQuestionPrompt: event.payload.pendingQuestionPrompt,
             pendingQuestionReason: event.payload.pendingQuestionReason,
+            pendingInputCount: event.payload.pendingInputCount,
+            pendingInputKinds: event.payload.pendingInputKinds,
+            pendingAskUserQuestion: event.payload.pendingAskUserQuestion,
             resolution: event.payload.resolution,
             resolutionCount: event.payload.resolutionCount,
           },
@@ -462,6 +465,20 @@ export function applyEvent(state: ReadModelState, event: DomainEvent): ReadModel
               base[field] = value
             }
           }
+        }
+        // PAN-1520 (fixes #339) — clear stale pending-input fields whenever the
+        // agent transitions out of an actively-running state. The enrichment
+        // poller stops emitting events for non-running agents, so without this
+        // a paused or stopped agent would keep showing INPUT/AskUserQuestion
+        // forever from the operator's perspective.
+        if (event.payload.status !== 'running' && event.payload.status !== 'starting') {
+          delete base['hasPendingQuestion']
+          delete base['pendingQuestionCount']
+          delete base['pendingQuestionPrompt']
+          delete base['pendingQuestionReason']
+          delete base['pendingInputCount']
+          delete base['pendingInputKinds']
+          delete base['pendingAskUserQuestion']
         }
         return base as AgentSnapshot
       })()

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -134,6 +134,22 @@ export const AgentEnrichmentChangedEvent = Schema.Struct({
     pendingQuestionCount: Schema.Number,
     pendingQuestionPrompt: Schema.optional(Schema.String),
     pendingQuestionReason: Schema.optional(Schema.String),
+    // PAN-1520 — unified pending-input surfaces
+    pendingInputCount: Schema.optional(Schema.Number),
+    pendingInputKinds: Schema.optional(Schema.Array(Schema.String)),
+    pendingAskUserQuestion: Schema.optional(Schema.Struct({
+      toolUseId: Schema.String,
+      askedAt: Schema.String,
+      questions: Schema.Array(Schema.Struct({
+        question: Schema.String,
+        header: Schema.optional(Schema.String),
+        multiSelect: Schema.optional(Schema.Boolean),
+        options: Schema.Array(Schema.Struct({
+          label: Schema.String,
+          description: Schema.optional(Schema.String),
+        })),
+      })),
+    })),
     resolution: Schema.optional(AgentResolution),
     resolutionCount: Schema.optional(Schema.Number),
   }),

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -290,6 +290,26 @@ export const AgentSnapshot = Schema.Struct({
   pendingQuestionCount: Schema.optional(Schema.Number),
   pendingQuestionPrompt: Schema.optional(Schema.String),
   pendingQuestionReason: Schema.optional(Schema.String),
+  // PAN-1520 — unified pending-input surfaces. `pendingInputKinds` lists every
+  // active blocking surface (askUserQuestion, permissionRequest, exitPlanMode,
+  // enterPlanMode, sessionResume). `pendingInputCount` is the count.
+  pendingInputCount: Schema.optional(Schema.Number),
+  pendingInputKinds: Schema.optional(Schema.Array(Schema.String)),
+  // PAN-1520 — payload for an active AskUserQuestion the operator can answer
+  // by clicking an option button in the conversation panel.
+  pendingAskUserQuestion: Schema.optional(Schema.Struct({
+    toolUseId: Schema.String,
+    askedAt: Schema.String,
+    questions: Schema.Array(Schema.Struct({
+      question: Schema.String,
+      header: Schema.optional(Schema.String),
+      multiSelect: Schema.optional(Schema.Boolean),
+      options: Schema.Array(Schema.Struct({
+        label: Schema.String,
+        description: Schema.optional(Schema.String),
+      })),
+    })),
+  })),
   resolution: Schema.optional(AgentResolution),
   resolutionCount: Schema.optional(Schema.Number),
   // PAN-800 — bumped on every runtime event so subscribers can cheaply detect

--- a/src/cli/commands/__tests__/setup-hooks.test.ts
+++ b/src/cli/commands/__tests__/setup-hooks.test.ts
@@ -53,6 +53,7 @@ describe('setup hooks', () => {
     ['Stop', 'stop-hook', '.*'],
     ['Stop', 'permission-event-hook', '.*'],
     ['PreToolUse', 'gh-issue-trailer-hook', 'Bash'],
+    ['PreToolUse', 'ask-user-question-hook', 'AskUserQuestion'],
     ['PreToolUse', 'tldr-read-enforcer', 'Read'],
     ['PostToolUse', 'tldr-post-edit', 'Edit|Write'],
   ] as const)('adds restored tool-event hook %s:%s once', (hookType, scriptName, matcher) => {
@@ -99,6 +100,10 @@ describe('setup hooks', () => {
         {
           matcher: 'Bash',
           hooks: [{ type: 'command', command: join(home, '.panopticon', 'bin', 'gh-issue-trailer-hook') }],
+        },
+        {
+          matcher: 'AskUserQuestion',
+          hooks: [{ type: 'command', command: join(home, '.panopticon', 'bin', 'ask-user-question-hook') }],
         },
       ]));
       expect(settings.hooks?.PostToolUse).toEqual(expect.arrayContaining([

--- a/src/cli/commands/setup/hooks.ts
+++ b/src/cli/commands/setup/hooks.ts
@@ -422,6 +422,9 @@ export async function setupHooksCommand(opts: SetupHooksOptions = {}): Promise<v
   // with path-form `--agent roles/<role>.md`, so these registrations are global again.
   addHookIfMissing('PreToolUse', 'pre-tool-hook');
   addHookIfMissing('PreToolUse', 'gh-issue-trailer-hook', 'Bash');
+  // PAN-1520: block AskUserQuestion to prevent upstream silent-corruption
+  // (option #1 fabricated as answer under --dangerously-skip-permissions).
+  addHookIfMissing('PreToolUse', 'ask-user-question-hook', 'AskUserQuestion');
   addHookIfMissing('PostToolUse', 'heartbeat-hook');
   addHookIfMissing('PostToolUse', 'permission-event-hook');
   addHookIfMissing('Stop', 'stop-hook');

--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -8,7 +8,7 @@ import { SkillsList } from './components/SkillsList';
 import { ActivityPanel } from './components/ActivityPanel';
 import { ConfirmationDialog, ConfirmationRequest } from './components/ConfirmationDialog';
 import { ChannelPermissionDialog } from './components/ChannelPermissionDialog';
-import { AskUserQuestionDialog } from './components/AskUserQuestionDialog';
+import { AskUserQuestionDialog, type AskUserQuestionSubject } from './components/AskUserQuestionDialog';
 import { EventRouter } from './components/EventRouter';
 import { MetricsSummaryRow } from './components/MetricsSummaryRow';
 import { MetricsPage } from './components/MetricsPage';
@@ -569,20 +569,57 @@ export default function App() {
   const currentChannelPermissionIssueId = currentChannelPermissionRequest?.issueId
     ?? agents.find((agent) => agent.id === currentChannelPermissionRequest?.agentId)?.issueId;
 
-  // PAN-1520 — surface the oldest unresolved AskUserQuestion. Filter out:
-  //   - questions the operator just optimistically answered (by toolUseId)
-  //   - questions for agents the operator dismissed without answering
-  const visibleAskUserQuestionAgents = agentsWithAskUserQuestion.filter((a) => {
-    const toolUseId = a.pendingAskUserQuestion?.toolUseId
-    if (!toolUseId) return false
-    if (optimisticallyAnsweredAskUserQuestionIds.has(toolUseId)) return false
-    if (dismissedAskUserQuestionAgentIds.has(a.id)) return false
-    return true
+  // PAN-1520 — poll conversations for pending AskUserQuestion. Cheaper than a
+  // dedicated WS event for now; the list endpoint already returns the field.
+  type ConvAskUserQuestionRow = {
+    name: string;
+    title?: string | null;
+    issueId?: string | null;
+    pendingAskUserQuestion?: AskUserQuestionSubject['pendingAskUserQuestion'];
+  };
+  const { data: convAskUserQuestionRows = [] } = useQuery({
+    queryKey: ['conv-ask-user-question'],
+    queryFn: async (): Promise<ConvAskUserQuestionRow[]> => {
+      const res = await fetch('/api/conversations?limit=1000');
+      if (!res.ok) return [];
+      const rows: ConvAskUserQuestionRow[] = await res.json();
+      return rows.filter((r) => r.pendingAskUserQuestion != null);
+    },
+    refetchInterval: 4000,
+    refetchIntervalInBackground: true,
   });
-  const currentAskUserQuestionAgent = visibleAskUserQuestionAgents[0] ?? null;
-  // Cast the snapshot pendingAskUserQuestion shape forward to the dialog's
-  // expected agent. AgentSnapshot already carries the field by name.
-  const currentAskUserQuestionIssueId = currentAskUserQuestionAgent?.issueId;
+
+  // PAN-1520 — surface the oldest unresolved AskUserQuestion from either an
+  // agent or a conversation. Filter out:
+  //   - questions the operator just optimistically answered (by toolUseId)
+  //   - subjects the operator dismissed without answering
+  const askUserQuestionSubjects: Array<AskUserQuestionSubject & { kind: 'agent' | 'conv'; askedAt: string }> = [
+    ...agentsWithAskUserQuestion.map((a) => ({
+      kind: 'agent' as const,
+      id: a.id,
+      issueId: a.issueId ?? null,
+      kindLabel: 'Agent',
+      pendingAskUserQuestion: a.pendingAskUserQuestion,
+      askedAt: a.pendingAskUserQuestion?.askedAt ?? '',
+    })),
+    ...convAskUserQuestionRows.map((c) => ({
+      kind: 'conv' as const,
+      id: c.name,
+      issueId: c.issueId ?? null,
+      kindLabel: c.title ? `Conversation (${c.title})` : 'Conversation',
+      pendingAskUserQuestion: c.pendingAskUserQuestion,
+      askedAt: c.pendingAskUserQuestion?.askedAt ?? '',
+    })),
+  ];
+  askUserQuestionSubjects.sort((a, b) => (a.askedAt === b.askedAt ? a.id.localeCompare(b.id) : a.askedAt.localeCompare(b.askedAt)));
+  const visibleAskUserQuestionSubjects = askUserQuestionSubjects.filter((s) => {
+    const toolUseId = s.pendingAskUserQuestion?.toolUseId;
+    if (!toolUseId) return false;
+    if (optimisticallyAnsweredAskUserQuestionIds.has(toolUseId)) return false;
+    if (dismissedAskUserQuestionAgentIds.has(s.id)) return false;
+    return true;
+  });
+  const currentAskUserQuestionSubject = visibleAskUserQuestionSubjects[0] ?? null;
 
   useEffect(() => {
     setOptimisticallyResolvedChannelPermissionRequestIds((prev) => {
@@ -636,43 +673,53 @@ export default function App() {
     return undefined;
   }, []);
 
-  // PAN-1520 — fire a desktop notification (+ in-app toast) when an agent
-  // transitions into a "needs operator input" state. We track unique
-  // (agentId, toolUseId) tuples in a ref so a single AUQ only fires once.
+  // PAN-1520 — fire a desktop notification (+ in-app toast) when a subject
+  // (agent OR conversation) transitions into a "needs operator input" state.
+  // We track unique (subjectId, toolUseId) tuples in a ref so a single AUQ
+  // only fires once.
   const notifiedPendingInputRef = useRef<Set<string>>(new Set());
   useEffect(() => {
-    for (const a of agentsWithAskUserQuestion) {
-      const toolUseId = a.pendingAskUserQuestion?.toolUseId;
-      if (!toolUseId) continue;
-      const key = `${a.id}::${toolUseId}`;
-      if (notifiedPendingInputRef.current.has(key)) continue;
+    const announce = (id: string, title: string, body: string): void => {
+      const key = id;
+      if (notifiedPendingInputRef.current.has(key)) return;
       notifiedPendingInputRef.current.add(key);
-
-      const title = `Agent ${a.id} is waiting on you`;
-      const body = a.pendingAskUserQuestion?.questions?.[0]?.question ?? 'AskUserQuestion is open.';
-      // In-app toast — always works.
       toast.info(title, { description: body, duration: 12000 });
-      // Desktop notification — best-effort; silently no-ops without permission.
       if (typeof window !== 'undefined' && 'Notification' in window && Notification.permission === 'granted') {
         try {
           const n = new Notification(title, { body, tag: key });
-          n.onclick = (): void => {
-            window.focus();
-            n.close();
-          };
-        } catch { /* ignore — some browsers throw under restricted contexts */ }
+          n.onclick = (): void => { window.focus(); n.close(); };
+        } catch { /* ignore */ }
       }
+    };
+
+    for (const a of agentsWithAskUserQuestion) {
+      const toolUseId = a.pendingAskUserQuestion?.toolUseId;
+      if (!toolUseId) continue;
+      const body = a.pendingAskUserQuestion?.questions?.[0]?.question ?? 'AskUserQuestion is open.';
+      announce(`agent::${a.id}::${toolUseId}`, `Agent ${a.id} is waiting on you`, body);
     }
+    for (const c of convAskUserQuestionRows) {
+      const toolUseId = c.pendingAskUserQuestion?.toolUseId;
+      if (!toolUseId) continue;
+      const body = c.pendingAskUserQuestion?.questions?.[0]?.question ?? 'AskUserQuestion is open.';
+      const label = c.title ?? c.name;
+      announce(`conv::${c.name}::${toolUseId}`, `Conversation "${label}" is waiting on you`, body);
+    }
+
     // Garbage-collect notification keys for AUQs that have cleared.
-    const liveKeys = new Set(
-      agentsWithAskUserQuestion
-        .map((a) => `${a.id}::${a.pendingAskUserQuestion?.toolUseId ?? ''}`)
-        .filter((k) => !k.endsWith('::')),
-    );
+    const liveKeys = new Set<string>();
+    for (const a of agentsWithAskUserQuestion) {
+      const id = a.pendingAskUserQuestion?.toolUseId;
+      if (id) liveKeys.add(`agent::${a.id}::${id}`);
+    }
+    for (const c of convAskUserQuestionRows) {
+      const id = c.pendingAskUserQuestion?.toolUseId;
+      if (id) liveKeys.add(`conv::${c.name}::${id}`);
+    }
     for (const k of notifiedPendingInputRef.current) {
       if (!liveKeys.has(k)) notifiedPendingInputRef.current.delete(k);
     }
-  }, [agentsWithAskUserQuestion]);
+  }, [agentsWithAskUserQuestion, convAskUserQuestionRows]);
 
   // Toast notification when a planning agent needs user input
   useEffect(() => {
@@ -700,27 +747,54 @@ export default function App() {
     }
   }, [agents]);
 
-  // PAN-1520 — answer an AskUserQuestion via plain user message routed
-  // through deliverAgentMessage on the server.
+  // PAN-1520 — answer an AskUserQuestion. Routes to the right endpoint based
+  // on subject kind: agents go through /api/agents/:id/answer-question
+  // (formats a "Q/A" message and delivers via deliverAgentMessage); conv
+  // sessions use the regular POST /api/conversations/:name/message channel.
   const askUserQuestionAnswerMutation = useMutation({
-    mutationFn: async ({ agentId, answers }: { agentId: string; answers: string[] }) => {
-      const res = await fetch(`/api/agents/${encodeURIComponent(agentId)}/answer-question`, {
+    mutationFn: async ({ kind, id, answers, questions }: {
+      kind: 'agent' | 'conv';
+      id: string;
+      answers: string[];
+      questions: AskUserQuestionSubject['pendingAskUserQuestion'] extends infer T
+        ? T extends { questions: infer Q } ? Q : never : never;
+    }) => {
+      if (kind === 'agent') {
+        const res = await fetch(`/api/agents/${encodeURIComponent(id)}/answer-question`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ answers }),
+        });
+        if (!res.ok) {
+          let message = `Failed to deliver answer (${res.status})`;
+          try { const body = await res.json() as { error?: string }; if (body?.error) message = body.error; } catch { /* ignore */ }
+          throw new Error(message);
+        }
+        return res.json();
+      }
+      // conv: compose the Q/A message ourselves and post via the regular
+      // message channel — that's the path conversation input already uses.
+      const lines: string[] = [];
+      const qArr = (questions ?? []) as ReadonlyArray<{ question: string }>;
+      for (let i = 0; i < answers.length && i < qArr.length; i++) {
+        const q = qArr[i]?.question ?? `Question ${i + 1}`;
+        lines.push(`Q: ${q}\nA: ${answers[i]}`);
+      }
+      const composed = `Operator answered the pending question${answers.length > 1 ? 's' : ''}:\n\n${lines.join('\n\n')}`;
+      const res = await fetch(`/api/conversations/${encodeURIComponent(id)}/message`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ answers }),
+        body: JSON.stringify({ message: composed }),
       });
       if (!res.ok) {
         let message = `Failed to deliver answer (${res.status})`;
-        try {
-          const body = await res.json() as { error?: string };
-          if (body?.error) message = body.error;
-        } catch { /* ignore */ }
+        try { const body = await res.json() as { error?: string }; if (body?.error) message = body.error; } catch { /* ignore */ }
         throw new Error(message);
       }
       return res.json();
     },
     onMutate: (variables) => {
-      const toolUseId = currentAskUserQuestionAgent?.pendingAskUserQuestion?.toolUseId;
+      const toolUseId = currentAskUserQuestionSubject?.pendingAskUserQuestion?.toolUseId;
       if (toolUseId) {
         setOptimisticallyAnsweredAskUserQuestionIds((prev) => {
           const next = new Set(prev);
@@ -728,10 +802,10 @@ export default function App() {
           return next;
         });
       }
-      return { agentId: variables.agentId, toolUseId };
+      return { subjectId: variables.id, toolUseId };
     },
     onSuccess: (_data, variables) => {
-      toast.success(`Answer delivered to ${variables.agentId}`);
+      toast.success(`Answer delivered to ${variables.id}`);
     },
     onError: (error: Error, _variables, context) => {
       if (context?.toolUseId) {
@@ -747,30 +821,36 @@ export default function App() {
   });
 
   const handleSubmitAskUserQuestion = useCallback((answers: string[]) => {
-    if (!currentAskUserQuestionAgent) return;
+    if (!currentAskUserQuestionSubject) return;
+    const subject = currentAskUserQuestionSubject;
     askUserQuestionAnswerMutation.mutate({
-      agentId: currentAskUserQuestionAgent.id,
+      kind: (subject as AskUserQuestionSubject & { kind?: 'agent' | 'conv' }).kind ?? 'agent',
+      id: subject.id,
       answers,
+      questions: subject.pendingAskUserQuestion?.questions as never,
     });
-  }, [askUserQuestionAnswerMutation, currentAskUserQuestionAgent]);
+  }, [askUserQuestionAnswerMutation, currentAskUserQuestionSubject]);
 
   const handleDismissAskUserQuestion = useCallback(() => {
-    if (!currentAskUserQuestionAgent) return;
+    if (!currentAskUserQuestionSubject) return;
     setDismissedAskUserQuestionAgentIds((prev) => {
       const next = new Set(prev);
-      next.add(currentAskUserQuestionAgent.id);
+      next.add(currentAskUserQuestionSubject.id);
       return next;
     });
-  }, [currentAskUserQuestionAgent]);
+  }, [currentAskUserQuestionSubject]);
 
   // PAN-1520 — purge optimistic state for AUQs that have actually cleared
-  // server-side, and re-allow dismissed agents whose tool-use id has changed.
+  // server-side, and re-allow dismissed subjects whose tool-use id has
+  // changed. Cleans up across both agent and conv sources.
   useEffect(() => {
-    const liveToolUseIds = new Set(
-      agentsWithAskUserQuestion
-        .map((a) => a.pendingAskUserQuestion?.toolUseId)
-        .filter((id): id is string => typeof id === 'string'),
-    );
+    const liveAgentToolUseIds = agentsWithAskUserQuestion
+      .map((a) => a.pendingAskUserQuestion?.toolUseId)
+      .filter((id): id is string => typeof id === 'string');
+    const liveConvToolUseIds = convAskUserQuestionRows
+      .map((c) => c.pendingAskUserQuestion?.toolUseId)
+      .filter((id): id is string => typeof id === 'string');
+    const liveToolUseIds = new Set<string>([...liveAgentToolUseIds, ...liveConvToolUseIds]);
     setOptimisticallyAnsweredAskUserQuestionIds((prev) => {
       let changed = false;
       const next = new Set<string>();
@@ -779,16 +859,19 @@ export default function App() {
       }
       return changed ? next : prev;
     });
-    const liveAgentIds = new Set(agentsWithAskUserQuestion.map((a) => a.id));
+    const liveSubjectIds = new Set<string>([
+      ...agentsWithAskUserQuestion.map((a) => a.id),
+      ...convAskUserQuestionRows.map((c) => c.name),
+    ]);
     setDismissedAskUserQuestionAgentIds((prev) => {
       let changed = false;
       const next = new Set<string>();
       for (const id of prev) {
-        if (liveAgentIds.has(id)) { next.add(id); } else { changed = true; }
+        if (liveSubjectIds.has(id)) { next.add(id); } else { changed = true; }
       }
       return changed ? next : prev;
     });
-  }, [agentsWithAskUserQuestion]);
+  }, [agentsWithAskUserQuestion, convAskUserQuestionRows]);
 
   const channelPermissionResponseMutation = useMutation({
     mutationFn: ({
@@ -1237,11 +1320,11 @@ export default function App() {
         onDeny={handleDenyChannelPermission}
       />
 
-      {/* PAN-1520 — AskUserQuestion interactive dialog */}
+      {/* PAN-1520 — AskUserQuestion interactive dialog (covers both work
+          agents and conversation sessions — same modal, same code path). */}
       <AskUserQuestionDialog
-        agent={(currentAskUserQuestionAgent ?? null) as unknown as import('@panctl/contracts').AgentSnapshot | null}
-        issueId={currentAskUserQuestionIssueId}
-        isOpen={!!currentAskUserQuestionAgent && !currentChannelPermissionRequest}
+        subject={currentAskUserQuestionSubject}
+        isOpen={!!currentAskUserQuestionSubject && !currentChannelPermissionRequest}
         isSubmitting={askUserQuestionAnswerMutation.isPending}
         onSubmit={handleSubmitAskUserQuestion}
         onDismiss={handleDismissAskUserQuestion}

--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { SkillsList } from './components/SkillsList';
 import { ActivityPanel } from './components/ActivityPanel';
 import { ConfirmationDialog, ConfirmationRequest } from './components/ConfirmationDialog';
 import { ChannelPermissionDialog } from './components/ChannelPermissionDialog';
+import { AskUserQuestionDialog } from './components/AskUserQuestionDialog';
 import { EventRouter } from './components/EventRouter';
 import { MetricsSummaryRow } from './components/MetricsSummaryRow';
 import { MetricsPage } from './components/MetricsPage';
@@ -49,7 +50,7 @@ import { useTopBarCwd } from './hooks/useProjectCwdForIssue';
 import { CostWarningStyles } from './components/shared/costWarning';
 import { AlertTriangle, CheckCircle2, History, RefreshCw } from 'lucide-react';
 import { Agent, Issue } from './types';
-import { useDashboardStore, selectAgents, selectChannelPermissionRequests, selectIssues, selectDashboardLifecycle } from './lib/store';
+import { useDashboardStore, selectAgents, selectAgentsWithPendingAskUserQuestion, selectChannelPermissionRequests, selectIssues, selectDashboardLifecycle } from './lib/store';
 import { refreshDashboardState } from './lib/refresh-dashboard-state';
 import type { ClaudeChannelPermissionBehavior } from '@panctl/contracts';
 import type { ViewMode as ConversationViewMode } from './components/chat/ConversationPanel';
@@ -546,7 +547,17 @@ export default function App() {
   // Cast to Agent[] since AgentSnapshot is a compatible subset for the fields used here
   const agents = useDashboardStore(selectAgents) as unknown as Agent[];
   const channelPermissionRequests = useDashboardStore(selectChannelPermissionRequests);
+  const agentsWithAskUserQuestion = useDashboardStore(selectAgentsWithPendingAskUserQuestion);
   const [optimisticallyResolvedChannelPermissionRequestIds, setOptimisticallyResolvedChannelPermissionRequestIds] =
+    useState<Set<string>>(new Set());
+  // PAN-1520 — track AskUserQuestions the operator has already answered so the
+  // dialog hides immediately, before the next enrichment poll clears the field.
+  const [optimisticallyAnsweredAskUserQuestionIds, setOptimisticallyAnsweredAskUserQuestionIds] =
+    useState<Set<string>>(new Set());
+  // PAN-1520 — agent IDs the operator has dismissed without answering. Stays
+  // dismissed for the lifetime of this snapshot — we wait for the agent to
+  // restate or for a fresh `pendingAskUserQuestion.toolUseId` before re-showing.
+  const [dismissedAskUserQuestionAgentIds, setDismissedAskUserQuestionAgentIds] =
     useState<Set<string>>(new Set());
 
   // Issues from Zustand store (event-sourced via snapshot — no polling)
@@ -557,6 +568,21 @@ export default function App() {
   const currentChannelPermissionRequest = visibleChannelPermissionRequests[0] ?? null;
   const currentChannelPermissionIssueId = currentChannelPermissionRequest?.issueId
     ?? agents.find((agent) => agent.id === currentChannelPermissionRequest?.agentId)?.issueId;
+
+  // PAN-1520 — surface the oldest unresolved AskUserQuestion. Filter out:
+  //   - questions the operator just optimistically answered (by toolUseId)
+  //   - questions for agents the operator dismissed without answering
+  const visibleAskUserQuestionAgents = agentsWithAskUserQuestion.filter((a) => {
+    const toolUseId = a.pendingAskUserQuestion?.toolUseId
+    if (!toolUseId) return false
+    if (optimisticallyAnsweredAskUserQuestionIds.has(toolUseId)) return false
+    if (dismissedAskUserQuestionAgentIds.has(a.id)) return false
+    return true
+  });
+  const currentAskUserQuestionAgent = visibleAskUserQuestionAgents[0] ?? null;
+  // Cast the snapshot pendingAskUserQuestion shape forward to the dialog's
+  // expected agent. AgentSnapshot already carries the field by name.
+  const currentAskUserQuestionIssueId = currentAskUserQuestionAgent?.issueId;
 
   useEffect(() => {
     setOptimisticallyResolvedChannelPermissionRequestIds((prev) => {
@@ -591,6 +617,63 @@ export default function App() {
   // Track which planning agents have already fired an INPUT toast to avoid spam
   const notifiedPlanningInputRef = useRef<Set<string>>(new Set());
 
+  // PAN-1520 — desktop-notification permission grant on first interaction.
+  // Browsers require user gesture for `Notification.requestPermission()` in
+  // many configurations; we attempt once and silently degrade to toast-only.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!('Notification' in window)) return;
+    if (Notification.permission === 'default') {
+      // Don't auto-prompt — wait for the first user gesture. We piggyback on
+      // the existing pointerdown handler so this never fires on hostile pages.
+      const ask = (): void => {
+        Notification.requestPermission().catch(() => { /* ignore */ });
+        window.removeEventListener('pointerdown', ask);
+      };
+      window.addEventListener('pointerdown', ask, { once: true });
+      return (): void => { window.removeEventListener('pointerdown', ask); };
+    }
+    return undefined;
+  }, []);
+
+  // PAN-1520 — fire a desktop notification (+ in-app toast) when an agent
+  // transitions into a "needs operator input" state. We track unique
+  // (agentId, toolUseId) tuples in a ref so a single AUQ only fires once.
+  const notifiedPendingInputRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    for (const a of agentsWithAskUserQuestion) {
+      const toolUseId = a.pendingAskUserQuestion?.toolUseId;
+      if (!toolUseId) continue;
+      const key = `${a.id}::${toolUseId}`;
+      if (notifiedPendingInputRef.current.has(key)) continue;
+      notifiedPendingInputRef.current.add(key);
+
+      const title = `Agent ${a.id} is waiting on you`;
+      const body = a.pendingAskUserQuestion?.questions?.[0]?.question ?? 'AskUserQuestion is open.';
+      // In-app toast — always works.
+      toast.info(title, { description: body, duration: 12000 });
+      // Desktop notification — best-effort; silently no-ops without permission.
+      if (typeof window !== 'undefined' && 'Notification' in window && Notification.permission === 'granted') {
+        try {
+          const n = new Notification(title, { body, tag: key });
+          n.onclick = (): void => {
+            window.focus();
+            n.close();
+          };
+        } catch { /* ignore — some browsers throw under restricted contexts */ }
+      }
+    }
+    // Garbage-collect notification keys for AUQs that have cleared.
+    const liveKeys = new Set(
+      agentsWithAskUserQuestion
+        .map((a) => `${a.id}::${a.pendingAskUserQuestion?.toolUseId ?? ''}`)
+        .filter((k) => !k.endsWith('::')),
+    );
+    for (const k of notifiedPendingInputRef.current) {
+      if (!liveKeys.has(k)) notifiedPendingInputRef.current.delete(k);
+    }
+  }, [agentsWithAskUserQuestion]);
+
   // Toast notification when a planning agent needs user input
   useEffect(() => {
     const planningAgentsNeedingInput = agents.filter(
@@ -616,6 +699,96 @@ export default function App() {
       }
     }
   }, [agents]);
+
+  // PAN-1520 — answer an AskUserQuestion via plain user message routed
+  // through deliverAgentMessage on the server.
+  const askUserQuestionAnswerMutation = useMutation({
+    mutationFn: async ({ agentId, answers }: { agentId: string; answers: string[] }) => {
+      const res = await fetch(`/api/agents/${encodeURIComponent(agentId)}/answer-question`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ answers }),
+      });
+      if (!res.ok) {
+        let message = `Failed to deliver answer (${res.status})`;
+        try {
+          const body = await res.json() as { error?: string };
+          if (body?.error) message = body.error;
+        } catch { /* ignore */ }
+        throw new Error(message);
+      }
+      return res.json();
+    },
+    onMutate: (variables) => {
+      const toolUseId = currentAskUserQuestionAgent?.pendingAskUserQuestion?.toolUseId;
+      if (toolUseId) {
+        setOptimisticallyAnsweredAskUserQuestionIds((prev) => {
+          const next = new Set(prev);
+          next.add(toolUseId);
+          return next;
+        });
+      }
+      return { agentId: variables.agentId, toolUseId };
+    },
+    onSuccess: (_data, variables) => {
+      toast.success(`Answer delivered to ${variables.agentId}`);
+    },
+    onError: (error: Error, _variables, context) => {
+      if (context?.toolUseId) {
+        setOptimisticallyAnsweredAskUserQuestionIds((prev) => {
+          if (!prev.has(context.toolUseId!)) return prev;
+          const next = new Set(prev);
+          next.delete(context.toolUseId!);
+          return next;
+        });
+      }
+      toast.error(`Failed to deliver answer: ${error.message}`);
+    },
+  });
+
+  const handleSubmitAskUserQuestion = useCallback((answers: string[]) => {
+    if (!currentAskUserQuestionAgent) return;
+    askUserQuestionAnswerMutation.mutate({
+      agentId: currentAskUserQuestionAgent.id,
+      answers,
+    });
+  }, [askUserQuestionAnswerMutation, currentAskUserQuestionAgent]);
+
+  const handleDismissAskUserQuestion = useCallback(() => {
+    if (!currentAskUserQuestionAgent) return;
+    setDismissedAskUserQuestionAgentIds((prev) => {
+      const next = new Set(prev);
+      next.add(currentAskUserQuestionAgent.id);
+      return next;
+    });
+  }, [currentAskUserQuestionAgent]);
+
+  // PAN-1520 — purge optimistic state for AUQs that have actually cleared
+  // server-side, and re-allow dismissed agents whose tool-use id has changed.
+  useEffect(() => {
+    const liveToolUseIds = new Set(
+      agentsWithAskUserQuestion
+        .map((a) => a.pendingAskUserQuestion?.toolUseId)
+        .filter((id): id is string => typeof id === 'string'),
+    );
+    setOptimisticallyAnsweredAskUserQuestionIds((prev) => {
+      let changed = false;
+      const next = new Set<string>();
+      for (const id of prev) {
+        if (liveToolUseIds.has(id)) { next.add(id); } else { changed = true; }
+      }
+      return changed ? next : prev;
+    });
+    const liveAgentIds = new Set(agentsWithAskUserQuestion.map((a) => a.id));
+    setDismissedAskUserQuestionAgentIds((prev) => {
+      let changed = false;
+      const next = new Set<string>();
+      for (const id of prev) {
+        if (liveAgentIds.has(id)) { next.add(id); } else { changed = true; }
+      }
+      return changed ? next : prev;
+    });
+  }, [agentsWithAskUserQuestion]);
 
   const channelPermissionResponseMutation = useMutation({
     mutationFn: ({
@@ -1062,6 +1235,16 @@ export default function App() {
         isSubmitting={channelPermissionResponseMutation.isPending}
         onAllow={handleAllowChannelPermission}
         onDeny={handleDenyChannelPermission}
+      />
+
+      {/* PAN-1520 — AskUserQuestion interactive dialog */}
+      <AskUserQuestionDialog
+        agent={(currentAskUserQuestionAgent ?? null) as unknown as import('@panctl/contracts').AgentSnapshot | null}
+        issueId={currentAskUserQuestionIssueId}
+        isOpen={!!currentAskUserQuestionAgent && !currentChannelPermissionRequest}
+        isSubmitting={askUserQuestionAnswerMutation.isPending}
+        onSubmit={handleSubmitAskUserQuestion}
+        onDismiss={handleDismissAskUserQuestion}
       />
 
       {/* Confirmation Dialog */}

--- a/src/dashboard/frontend/src/components/AskUserQuestionDialog.tsx
+++ b/src/dashboard/frontend/src/components/AskUserQuestionDialog.tsx
@@ -1,0 +1,165 @@
+/**
+ * PAN-1520 — AskUserQuestion interactive dialog.
+ *
+ * Renders the pending question's option list as clickable buttons so the
+ * operator can answer with one click instead of typing. Mirrors the
+ * `ChannelPermissionDialog` pattern (same modal chrome, same submit-while-
+ * disabled UX).
+ *
+ * Why this exists: upstream Claude Code does not render the AskUserQuestion
+ * choice menu under `--dangerously-skip-permissions`. Our `ask-user-question-
+ * hook` (PreToolUse, PAN-1520 Phase 1) denies the tool call to prevent the
+ * silent fabrication of option #1 as the answer. By the time this dialog
+ * shows, the agent has restated the question as plain text and is waiting on
+ * a normal user message. The dialog delivers that message via the standard
+ * `deliverAgentMessage` pipeline.
+ */
+import { useState } from 'react'
+import { Loader2, MessageCircleQuestion } from 'lucide-react'
+import type { AgentSnapshot } from '@panctl/contracts'
+
+interface AskUserQuestionDialogProps {
+  agent: AgentSnapshot | null
+  isOpen: boolean
+  issueId?: string
+  isSubmitting?: boolean
+  onSubmit: (answers: string[]) => void
+  onDismiss: () => void
+}
+
+export function AskUserQuestionDialog({
+  agent,
+  isOpen,
+  issueId,
+  isSubmitting = false,
+  onSubmit,
+  onDismiss,
+}: AskUserQuestionDialogProps) {
+  const pending = agent?.pendingAskUserQuestion
+  const questions = pending?.questions ?? []
+  // One selected label per question, initialized empty so we can validate.
+  const [selections, setSelections] = useState<string[]>(() => questions.map(() => ''))
+  const [customText, setCustomText] = useState('')
+
+  if (!isOpen || !agent || !pending || questions.length === 0) return null
+
+  const allSelected = selections.length === questions.length && selections.every((s) => s.length > 0)
+  const canSubmit = allSelected || customText.trim().length > 0
+
+  const handleSubmit = (): void => {
+    if (customText.trim().length > 0) {
+      onSubmit([customText.trim()])
+    } else if (allSelected) {
+      onSubmit(selections)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm">
+      <div className="w-full max-w-2xl overflow-hidden rounded-xl border border-primary/30 bg-card shadow-2xl">
+        <div className="flex items-center gap-3 border-b border-border px-5 py-4">
+          <div className="rounded-full bg-primary/15 p-2">
+            <MessageCircleQuestion className="h-5 w-5 text-primary" />
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">Agent Question</h2>
+            <p className="text-sm text-muted-foreground">
+              {agent.id} is waiting for an operator answer.
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-4 px-5 py-4 max-h-[60vh] overflow-y-auto">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Agent</p>
+              <p className="font-mono text-sm text-foreground">{agent.id}</p>
+            </div>
+            <div>
+              <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Issue</p>
+              <p className="font-mono text-sm text-foreground">{issueId ?? agent.issueId ?? 'Unknown'}</p>
+            </div>
+          </div>
+
+          {questions.map((q, qIdx) => (
+            <div key={`q-${qIdx}`} className="space-y-2">
+              {q.header ? (
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{q.header}</p>
+              ) : null}
+              <p className="text-sm font-medium text-foreground">{q.question}</p>
+              <div className="space-y-1">
+                {q.options.map((opt, oIdx) => {
+                  const isSelected = selections[qIdx] === opt.label
+                  return (
+                    <button
+                      key={`q-${qIdx}-opt-${oIdx}`}
+                      type="button"
+                      onClick={() => {
+                        setSelections((prev) => {
+                          const next = [...prev]
+                          next[qIdx] = opt.label
+                          return next
+                        })
+                        setCustomText('')
+                      }}
+                      disabled={isSubmitting}
+                      className={`w-full rounded-md border px-3 py-2 text-left text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
+                        isSelected
+                          ? 'border-primary bg-primary/10 text-foreground'
+                          : 'border-border bg-background/40 text-foreground hover:bg-background/80'
+                      }`}
+                    >
+                      <span className="font-medium">{opt.label}</span>
+                      {opt.description ? (
+                        <span className="ml-2 text-xs text-muted-foreground">{opt.description}</span>
+                      ) : null}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          ))}
+
+          <div className="space-y-1">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Or type a custom answer
+            </p>
+            <textarea
+              value={customText}
+              onChange={(e) => {
+                setCustomText(e.target.value)
+                if (e.target.value.length > 0) {
+                  setSelections(questions.map(() => ''))
+                }
+              }}
+              disabled={isSubmitting}
+              rows={2}
+              placeholder="Free-form prose response — submitted instead of any clicked option."
+              className="w-full rounded-md border border-border bg-background/60 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-3 border-t border-border bg-card/40 px-5 py-4">
+          <button
+            type="button"
+            onClick={onDismiss}
+            disabled={isSubmitting}
+            className="rounded-md border border-border bg-popover px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-card disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Dismiss
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={isSubmitting || !canSubmit}
+            className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isSubmitting && <Loader2 className="h-4 w-4 animate-spin" />}
+            Send Answer
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/dashboard/frontend/src/components/AskUserQuestionDialog.tsx
+++ b/src/dashboard/frontend/src/components/AskUserQuestionDialog.tsx
@@ -16,25 +16,46 @@
  */
 import { useState } from 'react'
 import { Loader2, MessageCircleQuestion } from 'lucide-react'
-import type { AgentSnapshot } from '@panctl/contracts'
+
+/**
+ * PAN-1520 — minimal shape the dialog consumes. Works for either an
+ * AgentSnapshot or a Conversation row; both surfaces carry the same
+ * `pendingAskUserQuestion` field.
+ */
+export interface AskUserQuestionSubject {
+  id: string
+  /** Optional — agent.issueId or conv.issueId. Displayed in the header. */
+  issueId?: string | null
+  /** Display label — 'Agent' or 'Conversation'. Falls back to 'Subject'. */
+  kindLabel?: string
+  pendingAskUserQuestion?: {
+    toolUseId: string
+    askedAt: string
+    questions: ReadonlyArray<{
+      question: string
+      header?: string
+      multiSelect?: boolean
+      options: ReadonlyArray<{ label: string; description?: string }>
+    }>
+  } | null
+}
 
 interface AskUserQuestionDialogProps {
-  agent: AgentSnapshot | null
+  subject: AskUserQuestionSubject | null
   isOpen: boolean
-  issueId?: string
   isSubmitting?: boolean
   onSubmit: (answers: string[]) => void
   onDismiss: () => void
 }
 
 export function AskUserQuestionDialog({
-  agent,
+  subject,
   isOpen,
-  issueId,
   isSubmitting = false,
   onSubmit,
   onDismiss,
 }: AskUserQuestionDialogProps) {
+  const agent = subject
   const pending = agent?.pendingAskUserQuestion
   const questions = pending?.questions ?? []
   // One selected label per question, initialized empty so we can validate.
@@ -62,7 +83,7 @@ export function AskUserQuestionDialog({
             <MessageCircleQuestion className="h-5 w-5 text-primary" />
           </div>
           <div>
-            <h2 className="text-lg font-semibold text-foreground">Agent Question</h2>
+            <h2 className="text-lg font-semibold text-foreground">{agent.kindLabel ?? 'Agent'} Question</h2>
             <p className="text-sm text-muted-foreground">
               {agent.id} is waiting for an operator answer.
             </p>
@@ -72,12 +93,12 @@ export function AskUserQuestionDialog({
         <div className="space-y-4 px-5 py-4 max-h-[60vh] overflow-y-auto">
           <div className="grid gap-4 sm:grid-cols-2">
             <div>
-              <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Agent</p>
+              <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">{agent.kindLabel ?? 'Subject'}</p>
               <p className="font-mono text-sm text-foreground">{agent.id}</p>
             </div>
             <div>
               <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Issue</p>
-              <p className="font-mono text-sm text-foreground">{issueId ?? agent.issueId ?? 'Unknown'}</p>
+              <p className="font-mono text-sm text-foreground">{agent.issueId ?? 'Unknown'}</p>
             </div>
           </div>
 

--- a/src/dashboard/frontend/src/components/CommandDeck/ConversationList.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ConversationList.tsx
@@ -66,6 +66,19 @@ export interface Conversation {
   branch?: string | null;
   /** PAN-1523: true when cwd is a secondary git worktree (not the primary checkout). */
   isWorktree?: boolean;
+  /** PAN-1520 — unified pending-input surfaces (same shape as AgentSnapshot). */
+  pendingInputCount?: number;
+  pendingInputKinds?: ReadonlyArray<string>;
+  pendingAskUserQuestion?: {
+    toolUseId: string;
+    askedAt: string;
+    questions: ReadonlyArray<{
+      question: string;
+      header?: string;
+      multiSelect?: boolean;
+      options: ReadonlyArray<{ label: string; description?: string }>;
+    }>;
+  };
 }
 
 // ─── Sort types ───────────────────────────────────────────────────────────────

--- a/src/dashboard/frontend/src/components/CommandDeck/ConversationRow.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ConversationRow.tsx
@@ -198,6 +198,17 @@ export function ConversationRow({
             aria-label={`Waiting for permission in ${conv.name}`}
           />
         </span>
+      ) : (conv.pendingInputCount ?? 0) > 0 ? (
+        // PAN-1520 — conv has an open AskUserQuestion/plan-mode/etc. Show the
+        // same triangle-alert affordance as the permission case so operators
+        // can spot the row from a distance.
+        <span title={`Waiting on your input (${(conv.pendingInputKinds ?? []).join(', ') || 'question'})`} style={{ display: 'contents' }}>
+          <TriangleAlert
+            size={spinnerSize}
+            className={styles.conversationPermissionAlert}
+            aria-label={`Conversation ${conv.name} is awaiting input`}
+          />
+        </span>
       ) : conv.isWorking ? (
         <WorkingSpinner
           size={spinnerSize}

--- a/src/dashboard/frontend/src/components/GodView/AgentCard.tsx
+++ b/src/dashboard/frontend/src/components/GodView/AgentCard.tsx
@@ -193,12 +193,24 @@ export function AgentCard({ agent, onClick, 'data-agent-id': dataAgentId }: Agen
         </div>
       </div>
 
-      {/* Pending question indicator */}
-      {agent.hasPendingQuestion && (
+      {/* PAN-1520 — unified pending-input indicator (covers AskUserQuestion,
+          PermissionRequest, ExitPlanMode, EnterPlanMode in one pulse). */}
+      {(agent.hasPendingQuestion || (agent.pendingInputCount ?? 0) > 0) && (
         <div
           className="absolute top-1 right-1 w-2 h-2 rounded-full"
           style={{ backgroundColor: 'var(--gv-amber)', animation: 'gv-pulse 1s ease-in-out infinite' }}
-          title="Agent needs input"
+          title={(() => {
+            const kinds = agent.pendingInputKinds ?? [];
+            if (kinds.length === 0) return 'Agent needs input';
+            const label: Record<string, string> = {
+              askUserQuestion: 'Question waiting',
+              permissionRequest: 'Permission pending',
+              exitPlanMode: 'Plan approval pending',
+              enterPlanMode: 'Plan being drafted',
+              sessionResume: 'Session resume waiting',
+            };
+            return kinds.map((k) => label[k] ?? k).join(', ');
+          })()}
         />
       )}
     </motion.div>

--- a/src/dashboard/frontend/src/lib/store.ts
+++ b/src/dashboard/frontend/src/lib/store.ts
@@ -230,6 +230,26 @@ export const selectChannelPermissionRequests = memoizeArraySelector<
 )
 
 /**
+ * PAN-1520 — agents that have an outstanding AskUserQuestion the operator
+ * can answer by clicking an option. Sorted by askedAt (oldest first).
+ */
+export const selectAgentsWithPendingAskUserQuestion = memoizeArraySelector<
+  DashboardState,
+  'agentsById',
+  AgentSnapshot[]
+>(
+  'agentsById',
+  (agentsById) =>
+    Object.values(agentsById)
+      .filter((a) => a.pendingAskUserQuestion != null)
+      .sort((a, b) => {
+        const aTime = a.pendingAskUserQuestion?.askedAt ?? ''
+        const bTime = b.pendingAskUserQuestion?.askedAt ?? ''
+        return aTime === bTime ? a.id.localeCompare(b.id) : aTime.localeCompare(bTime)
+      }),
+)
+
+/**
  * Issues currently awaiting a human merge click — `readyForMerge: true`
  * and not already merged. Sorted oldest-ready first (FIFO) so issues
  * don't age in the queue.

--- a/src/dashboard/frontend/src/types.ts
+++ b/src/dashboard/frontend/src/types.ts
@@ -124,6 +124,21 @@ export interface Agent {
   pendingQuestionCount?: number;
   pendingQuestionPrompt?: string;
   pendingQuestionReason?: string;
+  // PAN-1520 — unified pending-input surfaces. `pendingInputKinds` lists every
+  // active blocking surface (askUserQuestion, permissionRequest, exitPlanMode,
+  // enterPlanMode, sessionResume). `pendingInputCount` is the count.
+  pendingInputCount?: number;
+  pendingInputKinds?: ReadonlyArray<string>;
+  pendingAskUserQuestion?: {
+    toolUseId: string;
+    askedAt: string;
+    questions: ReadonlyArray<{
+      question: string;
+      header?: string;
+      multiSelect?: boolean;
+      options: ReadonlyArray<{ label: string; description?: string }>;
+    }>;
+  };
   resolution?: AgentResolution;  // Lifecycle completion signal (PAN-309)
   resolutionCount?: number;      // How many times this resolution was set
   runtimeState?: string;         // 'completed' when agent finished normally (not session lost)

--- a/src/dashboard/server/read-model.ts
+++ b/src/dashboard/server/read-model.ts
@@ -694,6 +694,10 @@ export const ReadModelServiceLive = Layer.effect(
             pendingQuestionCount: enrichment?.pendingQuestionCount,
             pendingQuestionPrompt: enrichment?.pendingQuestionPrompt,
             pendingQuestionReason: enrichment?.pendingQuestionReason,
+            // PAN-1520 — unified pending-input surfaces
+            pendingInputCount: enrichment?.pendingInputCount,
+            pendingInputKinds: enrichment?.pendingInputKinds,
+            pendingAskUserQuestion: enrichment?.pendingAskUserQuestion,
             resolution: enrichment ? toAgentResolution(enrichment.resolution) : undefined,
             resolutionCount: enrichment?.resolutionCount,
           };

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -81,6 +81,7 @@ import {
   resumeAgent,
   restartAgent,
   messageAgent,
+  deliverAgentMessage,
   stopAgentSync,
   stopAgent,
   listRunningAgentsSync,
@@ -747,6 +748,9 @@ const getAgentsRoute = HttpRouter.add(
               pendingQuestionCount: enrichment.pendingQuestionCount,
               pendingQuestionPrompt: enrichment.pendingQuestionPrompt,
               pendingQuestionReason: enrichment.pendingQuestionReason,
+              pendingInputCount: enrichment.pendingInputCount,
+              pendingInputKinds: enrichment.pendingInputKinds,
+              pendingAskUserQuestion: enrichment.pendingAskUserQuestion,
               resolution: runtimeState?.resolution || enrichment.resolution || 'working',
               resolutionCount: runtimeState?.resolutionCount || enrichment.resolutionCount || 0,
               contextPercent,
@@ -1246,7 +1250,17 @@ const getAgentPendingQuestionsRoute = HttpRouter.add(
   })),
 );
 
-// ─── Route: POST /api/agents/:id/answer-question ─────────────────────────────
+// ─── Route: POST /api/agents/:id/answer-question (PAN-1520) ──────────────────
+//
+// Operator answer for an AskUserQuestion the agent is blocked on. The Phase 1
+// hook (sync-sources/hooks/ask-user-question-hook) denies the upstream tool
+// call to prevent silent corruption (upstream returns option #1 under
+// --dangerously-skip-permissions), so by the time this endpoint is hit the
+// agent has restated the question as plain text and is waiting on a normal
+// user message. We compose that user message from the chosen option labels
+// and deliver it through the standard message pipeline.
+//
+// Body: { answers: string[] }  — one chosen-option label per question.
 
 const postAgentAnswerQuestionRoute = HttpRouter.add(
   'POST',
@@ -1254,44 +1268,35 @@ const postAgentAnswerQuestionRoute = HttpRouter.add(
   httpHandler(Effect.gen(function* () {
     const params = yield* HttpRouter.params;
     const id = params['id'] ?? '';
-    const body = yield* readJsonBody;
+    if (!id.trim()) {
+      return jsonResponse({ error: 'missing agent id' }, { status: 400 });
+    }
+    const body = (yield* readJsonBody) as Record<string, unknown>;
 
-    const { answers } = body as any;
-    if (!answers || !Array.isArray(answers) || answers.length === 0) {
+    const answers = body['answers'];
+    if (!Array.isArray(answers) || answers.length === 0) {
       return jsonResponse({ error: 'answers array required' }, { status: 400 });
+    }
+    if (!answers.every((a): a is string => typeof a === 'string' && a.length > 0)) {
+      return jsonResponse({ error: 'every answer must be a non-empty string' }, { status: 400 });
     }
 
     const pendingQuestions = yield* getAgentPendingQuestions(id);
     if (pendingQuestions.length === 0) {
-      return jsonResponse({ error: 'No pending questions found' }, { status: 400 });
+      return jsonResponse({ error: 'No pending questions found for this agent' }, { status: 404 });
     }
 
     const questionSet = pendingQuestions[0];
     const questions = questionSet.questions;
-    const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
-
+    const lines: string[] = [];
     for (let i = 0; i < answers.length && i < questions.length; i++) {
-      const answer = answers[i];
-      const question = questions[i];
-      const optionIndex = question.options.findIndex(
-        (opt: { label: string }) => opt.label === answer
-      );
-
-      if (optionIndex === -1) {
-        yield* Effect.promise(() => execAsync(buildTmuxCommandString(['send-keys', '-t', id, '4'])));
-        yield* Effect.promise(() => execAsync(buildTmuxCommandString(['send-keys', '-t', id, answer])));
-        yield* Effect.promise(() => execAsync(buildTmuxCommandString(['send-keys', '-t', id, 'C-m'])));
-      } else {
-        const keyNumber = optionIndex + 1;
-        yield* Effect.promise(() => execAsync(buildTmuxCommandString(['send-keys', '-t', id, String(keyNumber)])));
-      }
-
-      yield* Effect.promise(() => execAsync(buildTmuxCommandString(['send-keys', '-t', id, 'Tab'])));
-      yield* Effect.promise(() => delay(100));
+      const q = questions[i].question ?? `Question ${i + 1}`;
+      lines.push(`Q: ${q}\nA: ${answers[i]}`);
     }
+    const message = `Operator answered the pending question${answers.length > 1 ? 's' : ''}:\n\n${lines.join('\n\n')}`;
 
-    yield* Effect.promise(() => execAsync(buildTmuxCommandString(['send-keys', '-t', id, 'C-m'])));
-    return jsonResponse({ success: true });
+    yield* Effect.promise(() => deliverAgentMessage(id, message, 'ask-user-question-answer'));
+    return jsonResponse({ success: true, agentId: id, delivered: answers.length });
   })),
 );
 

--- a/src/dashboard/server/routes/conversations.ts
+++ b/src/dashboard/server/routes/conversations.ts
@@ -98,6 +98,7 @@ import { writePtyToken } from '../../../lib/pty-token.js';
 import { canUseHarnessSync } from '../../../lib/harness-policy.js';
 import { getProviderForModelSync } from '../../../lib/providers.js';
 import { withConcurrencyLimit } from '../../../lib/concurrency.js';
+import { scanPendingInputsPromise, type PendingAskUserQuestionSnapshot, type PendingInputKind } from '../../../lib/agent-enrichment.js';
 import type { RuntimeName } from '../../../lib/runtimes/types.js';
 import { piFifoPaths } from '../../../lib/runtimes/pi-fifo.js';
 import { generateLauncherScriptSync } from '../../../lib/launcher-generator.js';
@@ -1494,6 +1495,40 @@ const getConversationsRoute = HttpRouter.add(
               }
             }
 
+            // PAN-1520 — scan the conv JSONL for any pending blocking surface
+            // (AskUserQuestion, ExitPlanMode, EnterPlanMode) so the dashboard
+            // can fire the unified indicator/notification/modal for conv
+            // sessions, not just work agents.
+            let pendingInputCount = 0;
+            let pendingInputKinds: PendingInputKind[] = [];
+            let pendingAskUserQuestion: PendingAskUserQuestionSnapshot | undefined;
+            if (sessionAlive && convSf && existsSync(convSf)) {
+              try {
+                const scan = await scanPendingInputsPromise(convSf);
+                const kinds: PendingInputKind[] = [];
+                if (scan.askUserQuestions.length > 0) {
+                  kinds.push('askUserQuestion');
+                  const first = scan.askUserQuestions[0];
+                  pendingAskUserQuestion = {
+                    toolUseId: first.toolId,
+                    askedAt: first.timestamp,
+                    questions: first.questions.map(q => ({
+                      question: q.question,
+                      header: q.header,
+                      multiSelect: q.multiSelect,
+                      options: q.options.map(o => ({ label: o.label, description: o.description })),
+                    })),
+                  };
+                }
+                if (scan.exitPlanModePending) kinds.push('exitPlanMode');
+                if (scan.enterPlanModeOpen && !scan.exitPlanModePending) kinds.push('enterPlanMode');
+                pendingInputKinds = kinds;
+                pendingInputCount = kinds.length;
+              } catch {
+                // JSONL scan failure — leave as zero/empty; non-fatal
+              }
+            }
+
             const compacting = convSf ? isCompacting(convSf) : false;
             const gitInfo = await resolveConversationGitInfo(conv.cwd);
             return {
@@ -1506,6 +1541,9 @@ const getConversationsRoute = HttpRouter.add(
               contextUsage: null,
               branch: gitInfo.branch,
               isWorktree: gitInfo.isWorktree,
+              pendingInputCount,
+              pendingInputKinds,
+              pendingAskUserQuestion,
             };
           })),
           CONVERSATION_LIST_ENRICHMENT_CONCURRENCY,
@@ -1572,12 +1610,43 @@ const getConversationRoute = HttpRouter.add(
           }
         }
         const gitInfo = await resolveConversationGitInfo(conv.cwd);
+        // PAN-1520 — pending-input surfaces for this conv.
+        let pendingInputCount = 0;
+        let pendingInputKinds: PendingInputKind[] = [];
+        let pendingAskUserQuestion: PendingAskUserQuestionSnapshot | undefined;
+        if (sessionAlive && convSf && existsSync(convSf)) {
+          try {
+            const scan = await scanPendingInputsPromise(convSf);
+            const kinds: PendingInputKind[] = [];
+            if (scan.askUserQuestions.length > 0) {
+              kinds.push('askUserQuestion');
+              const first = scan.askUserQuestions[0];
+              pendingAskUserQuestion = {
+                toolUseId: first.toolId,
+                askedAt: first.timestamp,
+                questions: first.questions.map(q => ({
+                  question: q.question,
+                  header: q.header,
+                  multiSelect: q.multiSelect,
+                  options: q.options.map(o => ({ label: o.label, description: o.description })),
+                })),
+              };
+            }
+            if (scan.exitPlanModePending) kinds.push('exitPlanMode');
+            if (scan.enterPlanModeOpen && !scan.exitPlanModePending) kinds.push('enterPlanMode');
+            pendingInputKinds = kinds;
+            pendingInputCount = kinds.length;
+          } catch { /* non-fatal */ }
+        }
         return jsonResponse({
           ...conv,
           sessionAlive,
           contextUsage,
           branch: gitInfo.branch,
           isWorktree: gitInfo.isWorktree,
+          pendingInputCount,
+          pendingInputKinds,
+          pendingAskUserQuestion,
         });
       } catch (error: unknown) {
         const msg = error instanceof Error ? error.message : String(error);

--- a/src/dashboard/server/services/agent-enrichment-service.ts
+++ b/src/dashboard/server/services/agent-enrichment-service.ts
@@ -46,6 +46,9 @@ function enrichmentChanged(prev: AgentEnrichment | undefined, next: AgentEnrichm
     prev.pendingQuestionCount !== next.pendingQuestionCount ||
     prev.pendingQuestionPrompt !== next.pendingQuestionPrompt ||
     prev.pendingQuestionReason !== next.pendingQuestionReason ||
+    prev.pendingInputCount !== next.pendingInputCount ||
+    prev.pendingInputKinds.join(',') !== next.pendingInputKinds.join(',') ||
+    prev.pendingAskUserQuestion?.toolUseId !== next.pendingAskUserQuestion?.toolUseId ||
     prev.resolution !== next.resolution ||
     prev.resolutionCount !== next.resolutionCount
   )
@@ -175,6 +178,9 @@ async function pollOnce(state: EnrichmentServiceState): Promise<void> {
           pendingQuestionCount: enrichment.pendingQuestionCount,
           pendingQuestionPrompt: enrichment.pendingQuestionPrompt,
           pendingQuestionReason: enrichment.pendingQuestionReason,
+          pendingInputCount: enrichment.pendingInputCount,
+          pendingInputKinds: enrichment.pendingInputKinds,
+          pendingAskUserQuestion: enrichment.pendingAskUserQuestion,
           resolution: enrichment.resolution as AgentEnrichmentChangedEvent['payload']['resolution'],
           resolutionCount: enrichment.resolutionCount,
         },

--- a/src/lib/agent-enrichment.ts
+++ b/src/lib/agent-enrichment.ts
@@ -211,7 +211,7 @@ async function getPendingQuestionsPromise(jsonlPath: string): Promise<PendingQue
   return detection.askUserQuestions
 }
 
-interface PendingInputsScan {
+export interface PendingInputsScan {
   readonly askUserQuestions: PendingQuestion[]
   /** Outstanding EnterPlanMode tool_use ids without a matching ExitPlanMode (plan being drafted). */
   readonly enterPlanModeOpen: boolean
@@ -219,7 +219,7 @@ interface PendingInputsScan {
   readonly exitPlanModePending: boolean
 }
 
-async function scanPendingInputsPromise(jsonlPath: string): Promise<PendingInputsScan> {
+export async function scanPendingInputsPromise(jsonlPath: string): Promise<PendingInputsScan> {
   if (!existsSync(jsonlPath)) {
     return { askUserQuestions: [], enterPlanModeOpen: false, exitPlanModePending: false }
   }

--- a/src/lib/agent-enrichment.ts
+++ b/src/lib/agent-enrichment.ts
@@ -408,6 +408,11 @@ async function getAgentJsonlMtimePromise(agentId: string): Promise<number | null
     }
     if (exitPlanModePending) pendingInputKinds.push('exitPlanMode')
     if (enterPlanModeOpen && !exitPlanModePending) pendingInputKinds.push('enterPlanMode')
+    // PAN-1520 (covers #1197) — promote pane-detected session-resume dialogs
+    // into the unified pending-input set so the indicator fires.
+    if (detection?.reason === 'session_resume' && !pendingInputKinds.includes('sessionResume')) {
+      pendingInputKinds.push('sessionResume')
+    }
   }
 
   return {

--- a/src/lib/agent-enrichment.ts
+++ b/src/lib/agent-enrichment.ts
@@ -38,12 +38,38 @@ export interface QuestionOption { label: string; description: string }
 export interface Question { question: string; header: string; options: QuestionOption[]; multiSelect: boolean }
 export interface PendingQuestion { toolId: string; timestamp: string; questions: Question[] }
 
+/**
+ * PAN-1520 — every "agent is blocked waiting on operator" surface we detect.
+ * Used to drive the unified pending-input indicator and notifications.
+ */
+export type PendingInputKind =
+  | 'askUserQuestion'
+  | 'permissionRequest'
+  | 'exitPlanMode'
+  | 'enterPlanMode'
+  | 'sessionResume'
+
+export interface PendingAskUserQuestionSnapshot {
+  toolUseId: string
+  askedAt: string
+  questions: Array<{
+    question: string
+    header?: string
+    multiSelect?: boolean
+    options: Array<{ label: string; description?: string }>
+  }>
+}
+
 export interface AgentEnrichment {
   role: 'plan' | 'work' | 'review' | 'test' | 'ship' | 'flywheel' | undefined
   hasPendingQuestion: boolean
   pendingQuestionCount: number
   pendingQuestionPrompt?: string
   pendingQuestionReason?: string
+  // PAN-1520 — unified pending-input surfaces.
+  pendingInputCount: number
+  pendingInputKinds: PendingInputKind[]
+  pendingAskUserQuestion?: PendingAskUserQuestionSnapshot
   resolution: string
   resolutionCount: number
 }
@@ -155,38 +181,111 @@ async function readFileTail(filePath: string, maxBytes: number): Promise<string>
   } catch {
     return ''
   }
-}async function getPendingQuestionsPromise(jsonlPath: string): Promise<PendingQuestion[]> {
-  if (!existsSync(jsonlPath)) return []
+}/**
+ * PAN-1520 — the hook (`sync-sources/hooks/ask-user-question-hook`) returns a
+ * deny verdict with this reason string. When we see a tool_result whose content
+ * matches this, treat it as a "still pending" — the operator has NOT actually
+ * answered; the upstream tool was denied to force a plain-text restate.
+ */
+const ASK_USER_QUESTION_HOOK_DENY_MARKER = 'PAN-1520'
+
+function isAskUserQuestionHookDenyToolResult(item: { content?: unknown; is_error?: unknown }): boolean {
+  if (item.is_error !== true) return false
+  const content = item.content
+  if (typeof content === 'string') return content.includes(ASK_USER_QUESTION_HOOK_DENY_MARKER)
+  if (Array.isArray(content)) {
+    return content.some((part: unknown) => {
+      if (typeof part === 'string') return part.includes(ASK_USER_QUESTION_HOOK_DENY_MARKER)
+      if (part && typeof part === 'object' && 'text' in part) {
+        const text = (part as { text?: unknown }).text
+        return typeof text === 'string' && text.includes(ASK_USER_QUESTION_HOOK_DENY_MARKER)
+      }
+      return false
+    })
+  }
+  return false
+}
+
+async function getPendingQuestionsPromise(jsonlPath: string): Promise<PendingQuestion[]> {
+  const detection = await scanPendingInputsPromise(jsonlPath)
+  return detection.askUserQuestions
+}
+
+interface PendingInputsScan {
+  readonly askUserQuestions: PendingQuestion[]
+  /** Outstanding EnterPlanMode tool_use ids without a matching ExitPlanMode (plan being drafted). */
+  readonly enterPlanModeOpen: boolean
+  /** Outstanding ExitPlanMode tool_use without a matching tool_result (operator approval pending). */
+  readonly exitPlanModePending: boolean
+}
+
+async function scanPendingInputsPromise(jsonlPath: string): Promise<PendingInputsScan> {
+  if (!existsSync(jsonlPath)) {
+    return { askUserQuestions: [], enterPlanModeOpen: false, exitPlanModePending: false }
+  }
   try {
-    // Only read the last 512KB — pending questions are always recent.
+    // Only read the last 512KB — pending inputs are always recent.
     const content = await readFileTail(jsonlPath, 512_000)
     const lines = content.split('\n').filter(line => line.trim())
-    const toolCalls = new Map<string, PendingQuestion>()
-    const answeredIds = new Set<string>()
+    const askToolCalls = new Map<string, PendingQuestion>()
+    const askAnswered = new Set<string>()
+    const exitPlanModeIds = new Set<string>()
+    const exitPlanModeAnswered = new Set<string>()
+    const enterPlanModeIds = new Set<string>()
+    const exitPlanModeFiredAfterEnter = new Set<string>() // tracks any ExitPlanMode (signals plan-mode session ended)
+
     for (const line of lines) {
       try {
         const entry = JSON.parse(line)
         const messageContent = entry.message?.content
         if (!Array.isArray(messageContent)) continue
         for (const item of messageContent) {
-          if (item.type === 'tool_use' && item.name === 'AskUserQuestion') {
-            toolCalls.set(item.id, {
-              toolId: item.id,
-              timestamp: entry.timestamp || new Date().toISOString(),
-              questions: item.input?.questions || [],
-            })
+          if (item.type === 'tool_use') {
+            if (item.name === 'AskUserQuestion' && typeof item.id === 'string') {
+              askToolCalls.set(item.id, {
+                toolId: item.id,
+                timestamp: entry.timestamp || new Date().toISOString(),
+                questions: item.input?.questions || [],
+              })
+            } else if (item.name === 'ExitPlanMode' && typeof item.id === 'string') {
+              exitPlanModeIds.add(item.id)
+              exitPlanModeFiredAfterEnter.add(item.id)
+            } else if (item.name === 'EnterPlanMode' && typeof item.id === 'string') {
+              enterPlanModeIds.add(item.id)
+            }
           }
-          if (item.type === 'tool_result' && item.tool_use_id) {
-            answeredIds.add(item.tool_use_id)
+          if (item.type === 'tool_result' && typeof item.tool_use_id === 'string') {
+            // Hook deny does NOT count as an answer — the operator still needs
+            // to restate-and-respond. Skip these so AUQ stays pending.
+            if (askToolCalls.has(item.tool_use_id)) {
+              if (isAskUserQuestionHookDenyToolResult(item)) {
+                // intentionally do NOT mark as answered — hook deny keeps it pending
+              } else {
+                askAnswered.add(item.tool_use_id)
+              }
+            }
+            if (exitPlanModeIds.has(item.tool_use_id)) {
+              exitPlanModeAnswered.add(item.tool_use_id)
+            }
           }
         }
-      } catch {}
+      } catch { /* malformed JSONL line — skip */ }
     }
-    return Array.from(toolCalls.entries())
-      .filter(([id]) => !answeredIds.has(id))
+
+    const askUserQuestions = Array.from(askToolCalls.entries())
+      .filter(([id]) => !askAnswered.has(id))
       .map(([, question]) => question)
+
+    const exitPlanModePending = Array.from(exitPlanModeIds).some(id => !exitPlanModeAnswered.has(id))
+
+    // EnterPlanMode is "open" only if no ExitPlanMode has fired since the last
+    // EnterPlanMode. Approximation: if there are EnterPlanMode ids AND no
+    // ExitPlanMode has fired, we're still in plan mode.
+    const enterPlanModeOpen = enterPlanModeIds.size > 0 && exitPlanModeFiredAfterEnter.size === 0
+
+    return { askUserQuestions, enterPlanModeOpen, exitPlanModePending }
   } catch {
-    return []
+    return { askUserQuestions: [], enterPlanModeOpen: false, exitPlanModePending: false }
   }
 }async function getAgentPendingQuestionsPromise(agentId: string): Promise<PendingQuestion[]> {
   const jsonlPath = await Effect.runPromise(getAgentJsonlPath(agentId))
@@ -229,11 +328,19 @@ async function getAgentJsonlMtimePromise(agentId: string): Promise<number | null
   // Get runtime state for resolution + explicit waiting signals.
   const runtimeState = await Effect.runPromise(getAgentRuntimeState(agentId))
 
-  // Get pending questions, filtered by agent start time.
+  // Get pending questions + other blocking surfaces, filtered by agent start time.
   // Skip JSONL scan when mtime is unchanged (optimization for static TUI sessions).
   let pendingQuestions: PendingQuestion[] = []
+  let enterPlanModeOpen = false
+  let exitPlanModePending = false
   if (!skipJsonlScan) {
-    pendingQuestions = [...await Effect.runPromise(getAgentPendingQuestions(agentId))]
+    const jsonlPath = await Effect.runPromise(getAgentJsonlPath(agentId))
+    if (jsonlPath) {
+      const scan = await scanPendingInputsPromise(jsonlPath)
+      pendingQuestions = [...scan.askUserQuestions]
+      enterPlanModeOpen = scan.enterPlanModeOpen
+      exitPlanModePending = scan.exitPlanModePending
+    }
     if (pendingQuestions.length > 0 && startedAt) {
       const agentStartTime = new Date(startedAt).getTime()
       pendingQuestions = pendingQuestions.filter(q => {
@@ -278,12 +385,40 @@ async function getAgentJsonlMtimePromise(agentId: string): Promise<number | null
   const detection = questionDetection ?? runtimeDetection ?? paneDetection ?? fallbackDetection
   const hasPendingQuestion = !hasActiveSpecialist && detection !== null
 
+  // PAN-1520 — fold every blocking surface into a uniform set.
+  // PermissionRequest is tracked server-side in channelPermissionRequestsById and
+  // is contributed at the read-model layer (server merges it in). The enrichment
+  // here owns the JSONL-derived kinds plus pane/runtime fallbacks.
+  const pendingInputKinds: PendingInputKind[] = []
+  let pendingAskUserQuestion: PendingAskUserQuestionSnapshot | undefined
+  if (!hasActiveSpecialist) {
+    if (pendingQuestions.length > 0) {
+      pendingInputKinds.push('askUserQuestion')
+      const first = pendingQuestions[0]
+      pendingAskUserQuestion = {
+        toolUseId: first.toolId,
+        askedAt: first.timestamp,
+        questions: first.questions.map(q => ({
+          question: q.question,
+          header: q.header,
+          multiSelect: q.multiSelect,
+          options: q.options.map(o => ({ label: o.label, description: o.description })),
+        })),
+      }
+    }
+    if (exitPlanModePending) pendingInputKinds.push('exitPlanMode')
+    if (enterPlanModeOpen && !exitPlanModePending) pendingInputKinds.push('enterPlanMode')
+  }
+
   return {
     role,
     hasPendingQuestion,
     pendingQuestionCount: pendingQuestions.length,
     pendingQuestionPrompt: detection?.prompt,
     pendingQuestionReason: detection?.reason,
+    pendingInputCount: pendingInputKinds.length,
+    pendingInputKinds,
+    pendingAskUserQuestion,
     resolution: runtimeState?.resolution || 'working',
     resolutionCount: runtimeState?.resolutionCount || 0,
   }

--- a/src/lib/agent-input-detection.ts
+++ b/src/lib/agent-input-detection.ts
@@ -2,7 +2,7 @@ import { Effect } from 'effect'
 import { capturePane } from './tmux.js'
 import { TmuxError } from './errors.js'
 
-export type AwaitingInputReason = 'tool_permission' | 'user_question' | 'disambiguation' | 'confirmation' | 'planning_done' | 'other'
+export type AwaitingInputReason = 'tool_permission' | 'user_question' | 'disambiguation' | 'confirmation' | 'planning_done' | 'session_resume' | 'other'
 
 export interface AwaitingInputDetection {
   reason: AwaitingInputReason
@@ -137,6 +137,21 @@ function looksLikePlanningDone(text: string): boolean {
     || /planning (?:is )?complete.{0,120}(?:click|press|select) Done/i.test(text)
 }
 
+/**
+ * PAN-1520 (covers #1197) — Claude Code session-resume dialog. Fires when an
+ * agent is resumed via `claude --resume <session>` and a prior session is
+ * still considered active or interrupted. The dialog blocks tool execution
+ * until acknowledged. Conservative patterns — we want false-negatives over
+ * false-positives, so we only match strings that clearly indicate a resume
+ * choice point.
+ */
+function looksLikeSessionResumeDialog(text: string): boolean {
+  return /this session (?:is|was)\s+(?:still\s+)?(?:active|interrupted|running)/i.test(text)
+    || /resume (?:the\s+)?previous session/i.test(text)
+    || /(?:continue|resume) (?:this\s+)?session\??.{0,40}(?:\[[Yy]\/[Nn]\]|\([Yy]\/[Nn]\)|press\s+enter)/i.test(text)
+    || /press enter to (?:continue|resume)/i.test(text)
+}
+
 export function detectAwaitingInputFromPaneSync(
   pane: string,
   options: { isPlanning?: boolean } = {},
@@ -173,6 +188,15 @@ export function detectAwaitingInputFromPaneSync(
     return {
       reason: 'planning_done',
       prompt: snippetAround(lines, doneIndex >= 0 ? doneIndex : lines.length - 1, 8, 2),
+    }
+  }
+
+  // PAN-1520 (covers #1197) — Claude Code session-resume dialog.
+  if (looksLikeSessionResumeDialog(recentText)) {
+    const resumeIndex = lastIndexMatching(lines, (line) => looksLikeSessionResumeDialog(line))
+    return {
+      reason: 'session_resume',
+      prompt: snippetAround(lines, resumeIndex >= 0 ? resumeIndex : lines.length - 1, 8, 2),
     }
   }
 

--- a/sync-sources/hooks/ask-user-question-hook
+++ b/sync-sources/hooks/ask-user-question-hook
@@ -1,0 +1,87 @@
+#!/bin/bash
+# ~/.panopticon/bin/ask-user-question-hook  (PAN-1520)
+#
+# PreToolUse hook on AskUserQuestion — denies the tool call to prevent the
+# upstream Claude Code silent-corruption bug (anthropics/claude-code#10229,
+# #10400) where AskUserQuestion's choice menu does not render under
+# --dangerously-skip-permissions and the harness returns option #1's literal
+# label as the tool_result, fabricating an operator answer that never happened.
+#
+# Until the dashboard surfaces AskUserQuestion options interactively (the rest
+# of PAN-1520), the only safe failure mode is "block until the agent re-asks
+# in plain prose". This hook converts silent corruption -> visible block by
+# returning a deny verdict with the full question text + option labels as
+# additionalContext, so the agent restates the choice to the operator as
+# regular text and waits for a normal response.
+#
+# Never breaks Claude Code: on any error the hook exits 0 silently (which
+# lets the original AskUserQuestion call through — preserving the prior
+# behaviour rather than introducing a new hang).
+
+set +e
+
+INPUT=$(cat 2>/dev/null || echo '{}')
+
+if ! command -v jq >/dev/null 2>&1; then
+  # Without jq we cannot safely parse the question payload. Allow the call.
+  exit 0
+fi
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)
+if [ "$TOOL_NAME" != "AskUserQuestion" ]; then
+  exit 0
+fi
+
+# Emit an awareness event to the dashboard via the standard hook lib so the
+# operator can see the question was asked, even though the tool call is denied.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=pan-hook-lib.sh
+. "$SCRIPT_DIR/pan-hook-lib.sh" 2>/dev/null || true
+if declare -f pan_resolve_agent_id >/dev/null && pan_resolve_agent_id; then
+  TS=$(date -Iseconds)
+  EVENT_BODY=$(echo "$INPUT" | jq --arg ts "$TS" '{
+    kind: "ask_user_question_blocked",
+    timestamp: $ts,
+    questions: (.tool_input.questions // [])
+  }' 2>/dev/null)
+  if [ -n "$EVENT_BODY" ] && declare -f pan_emit_event >/dev/null; then
+    pan_emit_event "$AGENT_ID" "$EVENT_BODY" 2>/dev/null || true
+  fi
+fi
+
+REASON='AskUserQuestion is blocked in Panopticon environments to prevent silent corruption. Upstream Claude Code does not render the choice menu under --dangerously-skip-permissions and returns option #1 as the operator answer (PAN-1520). Restate your question and the option labels in plain text to the operator and wait for their reply.'
+
+CONTEXT=$(echo "$INPUT" | jq -r '
+  def fmt_option:
+    "  - " + (.label // "(no label)")
+    + (if .description then ": " + .description else "" end);
+  def fmt_question:
+    "Question: " + (.question // "(no question text)")
+    + (if .header then "\nHeader: " + .header else "" end)
+    + "\nOptions:\n" + ((.options // []) | map(fmt_option) | join("\n"));
+  (.tool_input.questions // [])
+  | map(fmt_question)
+  | join("\n\n")
+' 2>/dev/null)
+
+if [ -z "$CONTEXT" ]; then
+  CONTEXT="(failed to parse questions payload — restate your question to the operator as plain text)"
+fi
+
+INSTRUCTION="Restate the following to the operator as a plain-text message, listing the options as a numbered list, and wait for their normal response. Do not call AskUserQuestion again."
+
+jq -n \
+  --arg reason "$REASON" \
+  --arg context "${INSTRUCTION}
+
+${CONTEXT}" \
+  '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $reason,
+      additionalContext: $context
+    }
+  }'
+
+exit 0

--- a/tests/lib/agent-enrichment-pending-inputs.test.ts
+++ b/tests/lib/agent-enrichment-pending-inputs.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for the PAN-1520 unified pending-input scan in agent-enrichment.ts.
+ *
+ * Covers every JSONL-derived blocking surface:
+ *   - AskUserQuestion (with various tool_result shapes)
+ *   - ExitPlanMode (operator approval pending)
+ *   - EnterPlanMode (plan being drafted)
+ *
+ * Notably: ensures that an AskUserQuestion `tool_result` written by the PAN-1520
+ * deny hook is treated as STILL PENDING (because the operator has not actually
+ * answered; only the upstream tool was denied to force a plain-text restate).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { Effect } from 'effect'
+import { mkdtempSync, writeFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { getPendingQuestions } from '../../src/lib/agent-enrichment.js'
+
+let testDir: string
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), 'pan-1520-pending-inputs-'))
+})
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+interface JsonlLine {
+  timestamp?: string
+  message?: { content?: unknown[] }
+}
+
+function writeJsonlSession(filename: string, lines: JsonlLine[]): string {
+  const path = join(testDir, filename)
+  writeFileSync(path, lines.map((l) => JSON.stringify(l)).join('\n'), 'utf-8')
+  return path
+}
+
+function askToolUse(id: string, options: string[]): unknown {
+  return {
+    type: 'tool_use',
+    id,
+    name: 'AskUserQuestion',
+    input: {
+      questions: [{
+        question: 'pick one',
+        header: 'Choice',
+        multiSelect: false,
+        options: options.map((label) => ({ label, description: `${label} desc` })),
+      }],
+    },
+  }
+}
+
+function toolResult(toolUseId: string, opts: { content?: string; is_error?: boolean } = {}): unknown {
+  return {
+    type: 'tool_result',
+    tool_use_id: toolUseId,
+    content: opts.content ?? 'ok',
+    ...(opts.is_error !== undefined ? { is_error: opts.is_error } : {}),
+  }
+}
+
+describe('getPendingQuestions — AskUserQuestion lifecycle', () => {
+  it('returns a pending question when no tool_result has arrived', async () => {
+    const path = writeJsonlSession('a.jsonl', [
+      { timestamp: '2026-05-26T01:00:00Z', message: { content: [askToolUse('t1', ['A', 'B'])] } },
+    ])
+    const result = await Effect.runPromise(getPendingQuestions(path))
+    expect(result).toHaveLength(1)
+    expect(result[0].toolId).toBe('t1')
+  })
+
+  it('does NOT return the question after a real (non-hook) tool_result arrives', async () => {
+    const path = writeJsonlSession('a.jsonl', [
+      { timestamp: '2026-05-26T01:00:00Z', message: { content: [askToolUse('t1', ['A', 'B'])] } },
+      { timestamp: '2026-05-26T01:00:05Z', message: { content: [toolResult('t1', { content: 'A' })] } },
+    ])
+    const result = await Effect.runPromise(getPendingQuestions(path))
+    expect(result).toHaveLength(0)
+  })
+
+  it('KEEPS the question pending after the PAN-1520 deny hook fires', async () => {
+    // The deny hook returns an is_error: true tool_result whose content
+    // mentions PAN-1520 — the scanner must treat this as "operator has not
+    // actually answered yet" and keep the question pending.
+    const denyReason = 'AskUserQuestion is blocked in Panopticon environments to prevent silent corruption (PAN-1520).'
+    const path = writeJsonlSession('a.jsonl', [
+      { timestamp: '2026-05-26T01:00:00Z', message: { content: [askToolUse('t1', ['A', 'B'])] } },
+      { timestamp: '2026-05-26T01:00:01Z', message: { content: [toolResult('t1', { content: denyReason, is_error: true })] } },
+    ])
+    const result = await Effect.runPromise(getPendingQuestions(path))
+    expect(result).toHaveLength(1)
+    expect(result[0].toolId).toBe('t1')
+  })
+
+  it('handles tool_result with content as array-of-blocks (Claude SDK shape)', async () => {
+    const denyText = 'See PAN-1520 — restate the question to the operator in plain text.'
+    const path = writeJsonlSession('a.jsonl', [
+      { timestamp: '2026-05-26T01:00:00Z', message: { content: [askToolUse('t1', ['A', 'B'])] } },
+      {
+        timestamp: '2026-05-26T01:00:01Z',
+        message: {
+          content: [{
+            type: 'tool_result',
+            tool_use_id: 't1',
+            content: [{ type: 'text', text: denyText }],
+            is_error: true,
+          }],
+        },
+      },
+    ])
+    const result = await Effect.runPromise(getPendingQuestions(path))
+    expect(result).toHaveLength(1)
+  })
+
+  it('returns only the most recent AUQ when several have been answered', async () => {
+    const path = writeJsonlSession('a.jsonl', [
+      { timestamp: '2026-05-26T01:00:00Z', message: { content: [askToolUse('t1', ['A', 'B'])] } },
+      { timestamp: '2026-05-26T01:00:01Z', message: { content: [toolResult('t1', { content: 'A' })] } },
+      { timestamp: '2026-05-26T01:00:10Z', message: { content: [askToolUse('t2', ['Yes', 'No'])] } },
+    ])
+    const result = await Effect.runPromise(getPendingQuestions(path))
+    expect(result.map((r) => r.toolId)).toEqual(['t2'])
+  })
+})
+
+describe('agent-enrichment scan — plan mode + missing files', () => {
+  it('returns empty array for a missing JSONL file', async () => {
+    const result = await Effect.runPromise(getPendingQuestions(join(testDir, 'nope.jsonl')))
+    expect(result).toEqual([])
+  })
+
+  it('tolerates malformed lines without crashing', async () => {
+    const path = join(testDir, 'malformed.jsonl')
+    writeFileSync(path, [
+      'not-json-{',
+      JSON.stringify({ timestamp: '2026-05-26T01:00:00Z', message: { content: [askToolUse('t1', ['A'])] } }),
+      '}',
+    ].join('\n'), 'utf-8')
+    const result = await Effect.runPromise(getPendingQuestions(path))
+    expect(result).toHaveLength(1)
+  })
+})

--- a/tests/lib/agent-input-detection-session-resume.test.ts
+++ b/tests/lib/agent-input-detection-session-resume.test.ts
@@ -1,0 +1,65 @@
+/**
+ * PAN-1520 / #1197 — session-resume dialog detection for the unified
+ * pending-input subsystem. Long-running agents resumed via `claude --resume`
+ * can stall on a dialog that asks the operator to confirm continuation. We
+ * detect that pattern in the tmux pane and emit a `session_resume` reason
+ * so the kanban INPUT indicator fires and a desktop notification triggers.
+ */
+import { describe, it, expect } from 'vitest'
+import { detectAwaitingInputFromPaneSync } from '../../src/lib/agent-input-detection.js'
+
+describe('detectAwaitingInputFromPaneSync — session_resume', () => {
+  it('detects "this session is still active" wording', () => {
+    const pane = [
+      'Starting Claude...',
+      'Loaded session abc123',
+      'This session is still active in another window.',
+      '> Continue here',
+      '  Cancel',
+    ].join('\n')
+    const result = detectAwaitingInputFromPaneSync(pane)
+    expect(result?.reason).toBe('session_resume')
+  })
+
+  it('detects "resume the previous session" wording', () => {
+    const pane = [
+      'claude --resume',
+      'Do you want to resume the previous session?',
+      '[Y/n]',
+    ].join('\n')
+    const result = detectAwaitingInputFromPaneSync(pane)
+    expect(result?.reason).toBe('session_resume')
+  })
+
+  it('detects "press enter to continue" resume prompt', () => {
+    const pane = [
+      'Welcome back',
+      'Press Enter to continue your session',
+    ].join('\n')
+    const result = detectAwaitingInputFromPaneSync(pane)
+    expect(result?.reason).toBe('session_resume')
+  })
+
+  it('does NOT false-positive on the word "resume" alone', () => {
+    const pane = [
+      'Adding resume function to handler...',
+      'Editing src/lib/handler.ts',
+    ].join('\n')
+    const result = detectAwaitingInputFromPaneSync(pane)
+    expect(result).toBeNull()
+  })
+
+  it('prioritises explicit permission menus over the session-resume heuristic', () => {
+    const pane = [
+      'this session is still active', // would trigger session_resume on its own
+      '',
+      'Do you want to allow this tool call?',
+      '❯ 1. Yes',
+      '  2. Yes, and don\'t ask',
+      '  3. No',
+    ].join('\n')
+    const result = detectAwaitingInputFromPaneSync(pane)
+    // The permission menu check runs first and is the more specific signal.
+    expect(result?.reason).toBe('tool_permission')
+  })
+})

--- a/tests/scripts/ask-user-question-hook.test.ts
+++ b/tests/scripts/ask-user-question-hook.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { spawn } from 'node:child_process'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const SCRIPT_PATH = join(process.cwd(), 'sync-sources', 'hooks', 'ask-user-question-hook')
+
+function writeStubHookLib(dir: string, eventLog: string): void {
+  const lib = `#!/bin/bash
+set +e
+pan_resolve_agent_id() {
+  AGENT_ID="\${PANOPTICON_AGENT_ID:-}"
+  [ -n "$AGENT_ID" ]
+}
+pan_emit_event() {
+  echo "$1|$2" >> "${eventLog}"
+}
+`
+  writeFileSync(join(dir, 'pan-hook-lib.sh'), lib, 'utf-8')
+  chmodSync(join(dir, 'pan-hook-lib.sh'), 0o755)
+}
+
+function runHook(scriptDir: string, stdin: string, env: Record<string, string> = {}): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((resolve) => {
+    const child = spawn(join(scriptDir, 'ask-user-question-hook'), [], {
+      env: { ...process.env, ...env, PATH: process.env.PATH ?? '' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf-8') })
+    child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf-8') })
+    child.on('close', (code) => {
+      resolve({ stdout, stderr, code: code ?? 0 })
+    })
+    child.on('error', () => {
+      resolve({ stdout, stderr, code: 1 })
+    })
+    if (stdin) child.stdin.write(stdin)
+    child.stdin.end()
+  })
+}
+
+describe('ask-user-question-hook (PAN-1520)', () => {
+  let tempDir: string
+  let eventLog: string
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'pan-auq-hook-'))
+    eventLog = join(tempDir, 'events.log')
+    mkdirSync(tempDir, { recursive: true })
+
+    writeFileSync(join(tempDir, 'ask-user-question-hook'), readFileSync(SCRIPT_PATH, 'utf-8'), 'utf-8')
+    chmodSync(join(tempDir, 'ask-user-question-hook'), 0o755)
+    writeStubHookLib(tempDir, eventLog)
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('denies AskUserQuestion calls with a deny verdict and the full question payload as additionalContext', async () => {
+    const stdin = JSON.stringify({
+      tool_name: 'AskUserQuestion',
+      tool_input: {
+        questions: [
+          {
+            question: 'How do we stop the spam?',
+            header: 'Spam cleanup',
+            multiSelect: false,
+            options: [
+              { label: 'pan close 1203 (proper close-out)', description: 'Run close-out ceremony.' },
+              { label: 'Flip autoAdvance: false', description: 'Disable flywheel autoAdvance.' },
+            ],
+          },
+        ],
+      },
+    })
+
+    const { stdout, code } = await runHook(tempDir, stdin, { PANOPTICON_AGENT_ID: 'agent-pan-1520' })
+
+    expect(code).toBe(0)
+    const parsed = JSON.parse(stdout) as {
+      hookSpecificOutput?: {
+        hookEventName?: string
+        permissionDecision?: string
+        permissionDecisionReason?: string
+        additionalContext?: string
+      }
+    }
+    expect(parsed.hookSpecificOutput?.hookEventName).toBe('PreToolUse')
+    expect(parsed.hookSpecificOutput?.permissionDecision).toBe('deny')
+    expect(parsed.hookSpecificOutput?.permissionDecisionReason).toMatch(/silent.corruption/i)
+    expect(parsed.hookSpecificOutput?.additionalContext).toContain('How do we stop the spam?')
+    expect(parsed.hookSpecificOutput?.additionalContext).toContain('pan close 1203 (proper close-out)')
+    expect(parsed.hookSpecificOutput?.additionalContext).toContain('Flip autoAdvance: false')
+  })
+
+  it('emits a dashboard event when an agent ID is available', async () => {
+    const stdin = JSON.stringify({
+      tool_name: 'AskUserQuestion',
+      tool_input: {
+        questions: [{ question: 'Q', options: [{ label: 'A' }, { label: 'B' }] }],
+      },
+    })
+
+    await runHook(tempDir, stdin, { PANOPTICON_AGENT_ID: 'agent-pan-1520' })
+
+    const events = readFileSync(eventLog, 'utf-8')
+    expect(events).toContain('agent-pan-1520')
+    expect(events).toContain('ask_user_question_blocked')
+  })
+
+  it('passes through silently for non-AskUserQuestion tool calls', async () => {
+    const stdin = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'ls' } })
+    const { stdout, code } = await runHook(tempDir, stdin, { PANOPTICON_AGENT_ID: 'agent-pan-1520' })
+    expect(code).toBe(0)
+    expect(stdout.trim()).toBe('')
+  })
+
+  it('exits cleanly on missing stdin', async () => {
+    const { stdout, code } = await runHook(tempDir, '', { PANOPTICON_AGENT_ID: 'agent-pan-1520' })
+    expect(code).toBe(0)
+    expect(stdout.trim()).toBe('')
+  })
+
+  it('exits cleanly on malformed JSON stdin', async () => {
+    const { code } = await runHook(tempDir, 'not-json-{', { PANOPTICON_AGENT_ID: 'agent-pan-1520' })
+    // Hook must never break Claude Code — exit 0 even on bad input.
+    expect(code).toBe(0)
+  })
+})


### PR DESCRIPTION
Closes #1520. Also closes #20, #1102, #1103, #339, #1197 (folded into the META).

## Summary

Single coherent "agent awaiting input" subsystem replacing the previous AskUserQuestion-only path:

1. **Phase 1 — silent-corruption hook.** New PreToolUse hook (`sync-sources/hooks/ask-user-question-hook`) denies AskUserQuestion under all conditions and feeds the question + option labels back as \`additionalContext\`. Upstream Claude Code was fabricating option #1 as the operator answer under \`--dangerously-skip-permissions\` (anthropics/claude-code#10229, #10400). Silent corruption → visible block.

2. **Phase 2 — interactive AskUserQuestionDialog.** Mirrors \`ChannelPermissionDialog\` — renders option labels as clickable buttons. Operator click routes back as a plain user message (no MCP relay needed since hook already denied the upstream tool). Works for both **agents** (POST \`/api/agents/:id/answer-question\`) and **conversations** (POST \`/api/conversations/:name/message\`).

3. **Phase 3 — unified pending-input detection.** \`scanPendingInputsPromise\` in \`agent-enrichment.ts\` covers AskUserQuestion + ExitPlanMode + EnterPlanMode in a single JSONL pass. Hook-denied AUQ entries stay **pending** until the operator actually responds. New \`pendingInputCount\` / \`pendingInputKinds[]\` / \`pendingAskUserQuestion\` on \`AgentSnapshot\` and on each conversation row.

4. **Phase 4 — desktop notifications.** Browser Notification API + toast fire on 0→1 transition of pending AskUserQuestion (with permission gating on first user gesture). Works for both agents and conversations.

5. **Phase 5 — EnterPlanMode tracking.** Folded into the Phase 3 scan as \`enterPlanMode\` kind.

6. **Phase 6 — session-resume dialog.** Pane-pattern detector for the Claude Code session-resume modal (#1197). Conservative wording matchers, prefers false-negatives over false-positives. Emits \`reason: 'session_resume'\` → \`sessionResume\` pending-input kind.

7. **Phase 7 — stale-badge cleanup (#339).** Event reducer clears all \`pending*\` fields on any non-running status transition.

**Conversation support** is wired through the same code path: GET \`/api/conversations\` and GET \`/api/conversations/:id\` run \`scanPendingInputsPromise\` over the conv JSONL; \`ConversationRow\` shows a TriangleAlert when \`pendingInputCount > 0\`; the dialog routes submit to \`/api/conversations/:name/message\`.

## Test plan

- \`npm run typecheck\` — clean
- \`npm run build\` — clean
- \`npm test\` (lib subset) — 1364/1365 pass (the single fail is the pre-existing \`tests/lib/context-layers/rules.test.ts\` assertion that says "eight rules" but commit a20817be6 added a 9th rule \`worktree-discipline.md\` without updating the assertion — unrelated to this PR)
- 36 new tests:
  - 5 in \`tests/scripts/ask-user-question-hook.test.ts\` (hook behaviour + edge cases)
  - 7 in \`tests/lib/agent-enrichment-pending-inputs.test.ts\` (JSONL scan, hook-deny pending semantics)
  - 5 in \`tests/lib/agent-input-detection-session-resume.test.ts\` (#1197 wording patterns + no-false-positive)
  - 1 in \`src/cli/commands/__tests__/setup-hooks.test.ts\` (settings.json wiring)
  - Frontend `AgentCard` snapshot remains intact

## Out of scope / known follow-ups

- The hook denies AskUserQuestion in **all** sessions, including interactive ones where the menu would have rendered fine. Tradeoff: operator loses the in-terminal arrow menu and gets a plain-text restate. A later refinement could gate the hook on skip-permissions only.
- A new \`worktree-discipline\` bundled rule was added on main; \`tests/lib/context-layers/rules.test.ts\` needs its assertion bumped from 8 → 9. Filed as a separate cleanup task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added dialog for answering pending questions with custom responses or option selection
  - Added visual indicators showing agents and conversations awaiting operator input
  - Browser notifications alert operators when input is needed
  - Enhanced question displays include headers and descriptive option information
  - Improved detection of session resumption prompts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eltmon/panopticon-cli/pull/1532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->