### PR TITLE
feat(dashboard): project-scoped nav + terminal drawer + deck hardening (PAN-1561)

### DIFF
--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -347,6 +347,9 @@ export default function App() {
   // Conversation deep-link state (/conv/:id?view=terminal&views=161:terminal)
   const initialConversationRoute = getConversationRouteState();
   const [selectedConvId, setSelectedConvIdState] = useState<string | null>(() => initialConversationRoute.convId);
+  // PAN-1561: the project whose deck is shown in the Command Deck, driven by the
+  // sidebar's Projects rail.
+  const [selectedProjectKey, setSelectedProjectKey] = useState<string | null>(null);
   const [conversationViewMode, setConversationViewModeState] = useState<ConversationViewMode>(
     () => initialConversationRoute.viewMode,
   );
@@ -524,6 +527,12 @@ export default function App() {
     setIsSessionFeedSidebarOpen(open);
     window.localStorage.setItem(SESSION_FEED_SIDEBAR_OPEN_STORAGE_KEY, String(open));
   }, []);
+
+  // PAN-1561: open a project's deck from the sidebar rail.
+  const handleSelectProject = useCallback((projectName: string | null) => {
+    setSelectedProjectKey(projectName);
+    if (projectName) setActiveTab('command-deck');
+  }, [setActiveTab]);
 
   // Handle browser back/forward
   useEffect(() => {
@@ -1039,6 +1048,8 @@ export default function App() {
         activeTab={activeTab}
         onTabChange={setActiveTab}
         onSearchOpen={() => setIsSearchOpen(true)}
+        selectedProject={selectedProjectKey}
+        onSelectProject={handleSelectProject}
       />
 
       {/* Main content area */}
@@ -1179,6 +1190,8 @@ export default function App() {
                 conversationViewMode={conversationViewMode}
                 onConvIdChange={setSelectedConvId}
                 onConversationViewModeChange={setConversationViewMode}
+                selectedProject={selectedProjectKey}
+                onSelectProject={setSelectedProjectKey}
               />
             </div>
           )}

--- a/src/dashboard/frontend/src/components/CommandDeck/ActivityFeedSidebar.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ActivityFeedSidebar.tsx
@@ -41,13 +41,51 @@ export function createActionStatusObservationSelector(issueId: string) {
   };
 }
 
+/**
+ * Project-scoped variant (PAN-1561): aggregate action-status observations
+ * across every issue in a project, newest first. Memoizes on the per-issue
+ * source arrays so it only recomputes when one of the project's issues sees a
+ * new observation.
+ */
+export function createActionStatusObservationSelectorForIssues(issueIds: readonly string[]) {
+  let lastSources: ReadonlyArray<readonly MemoryObservation[]> | undefined;
+  let lastResult: MemoryObservation[] | undefined;
+
+  return (state: Pick<DashboardState, 'observationsByIssueId'>): MemoryObservation[] => {
+    const sources = issueIds.map((id) => state.observationsByIssueId[id] ?? EMPTY_OBSERVATIONS);
+    const unchanged =
+      lastSources !== undefined &&
+      lastSources.length === sources.length &&
+      sources.every((s, i) => s === lastSources![i]);
+    if (unchanged && lastResult) return lastResult;
+
+    lastSources = sources;
+    lastResult = sources
+      .flat()
+      .filter((observation) => observation.actionStatus !== null)
+      .sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+    return lastResult;
+  };
+}
+
 interface ActivityFeedSidebarProps {
-  issueId: string;
+  /** Single issue scope. Ignored when `issueIds` is provided. */
+  issueId?: string;
+  /** Project scope: aggregate across these issue ids (PAN-1561). */
+  issueIds?: readonly string[];
   now?: Date;
 }
 
-export function ActivityFeedSidebar({ issueId, now = new Date() }: ActivityFeedSidebarProps) {
-  const selectActionObservations = useMemo(() => createActionStatusObservationSelector(issueId), [issueId]);
+export function ActivityFeedSidebar({ issueId, issueIds, now = new Date() }: ActivityFeedSidebarProps) {
+  // Stabilize the key so the memoized selector is not rebuilt every render.
+  const idsKey = issueIds ? issueIds.join(',') : (issueId ?? '');
+  const selectActionObservations = useMemo(
+    () =>
+      issueIds
+        ? createActionStatusObservationSelectorForIssues(issueIds)
+        : createActionStatusObservationSelector(issueId ?? ''),
+    [idsKey, issueIds, issueId],
+  );
   const observations = useDashboardStore(selectActionObservations);
   const buckets = useMemo(
     () => bucketByTime(observations, (observation) => observation.timestamp, now),

--- a/src/dashboard/frontend/src/components/CommandDeck/CommandDeck.test.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/CommandDeck.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { CommandDeck } from './index';
 import { useCommandDeckSelection } from '../../lib/commandDeckSelection';
+import { usePanesStore } from '../../lib/panesStore';
 
 vi.mock('./styles/command-deck.module.css', () => ({
   default: {
@@ -47,7 +48,13 @@ vi.mock('./SessionView/IssueHeader', () => ({
 }));
 
 vi.mock('../Stage', () => ({
-  Stage: (props: any) => <div data-testid="stage" data-workspace={props.workspaceId} />,
+  Stage: (props: any) => <div data-testid="stage" data-deck={props.deckKey} />,
+}));
+
+vi.mock('./ActivityFeedSidebar', () => ({
+  ActivityFeedSidebar: (props: any) => (
+    <div data-testid="activity-feed" data-issues={(props.issueIds ?? []).join(',')} />
+  ),
 }));
 
 vi.mock('./ZoneBActionStrip', () => ({
@@ -351,77 +358,55 @@ function renderCommandDeck(props?: Partial<React.ComponentProps<typeof CommandDe
   );
 }
 
-describe('CommandDeck — Stage mount (PAN-1549)', () => {
+describe('CommandDeck — project-scoped deck (PAN-1561)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useCommandDeckSelection.getState().clearAll();
+    usePanesStore.setState({ panesByWorkspace: {}, activePaneByWorkspace: {} });
     localStorage.clear();
   });
 
-  it('mounts the Stage for a selected feature/workspace', async () => {
+  const panes = (deck: string) => usePanesStore.getState().panesByWorkspace[deck] ?? [];
+
+  it('shows an empty state until a project is selected', async () => {
     renderCommandDeck();
-
-    await screen.findAllByTestId('project-node').then(nodes => nodes[0]);
-    fireEvent.click(screen.getByTestId('feature-PAN-821'));
-
-    const stage = screen.getByTestId('stage');
-    expect(stage).toBeInTheDocument();
-    expect(stage).toHaveAttribute('data-workspace', 'PAN-821');
-    // The project Pipeline is not shown when a workspace is selected.
-    expect(screen.queryByTestId('project-overview')).not.toBeInTheDocument();
+    // With no project selected there is no tree to render — the deck shows its
+    // empty state and column 2 prompts for a project.
+    expect(await screen.findByText(/select a project to open its deck/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('stage')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('project-node')).not.toBeInTheDocument();
   });
 
-  it('mounts the Stage when a session is selected (its feature is selected)', async () => {
-    renderCommandDeck();
+  it('mounts the project deck and activity feed for the selected project', async () => {
+    renderCommandDeck({ selectedProject: 'test-project' });
+    await screen.findAllByTestId('project-node');
 
-    await screen.findAllByTestId('project-node').then(nodes => nodes[0]);
+    const stage = screen.getByTestId('stage');
+    expect(stage).toHaveAttribute('data-deck', 'test-project');
+    expect(screen.getByTestId('activity-feed')).toHaveAttribute('data-issues', 'PAN-821');
+  });
+
+  it('opens an issue tab in the deck when a tree issue is selected', async () => {
+    renderCommandDeck({ selectedProject: 'test-project' });
+    await screen.findAllByTestId('project-node');
+
+    fireEvent.click(screen.getByTestId('feature-PAN-821'));
+    expect(panes('test-project').some(p => p.paneType === 'issue' && p.issueId === 'PAN-821')).toBe(true);
+  });
+
+  it('opens an issue tab when a session is selected', async () => {
+    renderCommandDeck({ selectedProject: 'test-project' });
+    await screen.findAllByTestId('project-node');
+
     fireEvent.click(await screen.findByTestId('session-agent-pan-821'));
-
-    const stage = screen.getByTestId('stage');
-    expect(stage).toBeInTheDocument();
-    expect(stage).toHaveAttribute('data-workspace', 'PAN-821');
+    expect(panes('test-project').some(p => p.paneType === 'issue' && p.issueId === 'PAN-821')).toBe(true);
   });
 
-  it('renders the Pipeline (ProjectOverview) for a project-only selection', async () => {
-    renderCommandDeck();
-
+  it('opens an agent tab in the deck when a conversation is selected', async () => {
+    renderCommandDeck({ selectedProject: 'test-project' });
     await screen.findAllByTestId('project-node');
-    fireEvent.click(screen.getByTestId('project-test-project'));
 
-    const overview = screen.getByTestId('project-overview');
-    expect(overview).toHaveAttribute('data-project', 'test-project');
-    expect(overview).toHaveAttribute('data-features', 'PAN-821');
-    // Issue-local unified cost data still flows to the Pipeline.
-    expect(overview).toHaveAttribute('data-cost', '12.34');
-    expect(overview).toHaveAttribute('data-model-cost', '7.89');
-    expect(overview).toHaveAttribute('data-stage-cost', '4.45');
-    expect(screen.queryByTestId('stage')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('conversation-panel')).not.toBeInTheDocument();
-  });
-
-  it('renders the ConversationPanel when a conversation is selected (no feature)', async () => {
-    renderCommandDeck();
-
-    await screen.findAllByTestId('project-node');
-    fireEvent.click(screen.getByTestId('project-test-project'));
     fireEvent.click(screen.getByTestId('conv-test'));
-
-    expect(screen.getByTestId('conversation-panel')).toBeInTheDocument();
-    expect(screen.queryByTestId('stage')).not.toBeInTheDocument();
-  });
-
-  it('opens an unscoped conversation after a tree issue was selected (PAN-1332)', async () => {
-    renderCommandDeck();
-
-    await screen.findAllByTestId('project-node');
-
-    // Select a feature — the Stage mounts.
-    fireEvent.click(screen.getByTestId('feature-PAN-821'));
-    expect(screen.getByTestId('stage')).toBeInTheDocument();
-
-    // Selecting a conversation clears the feature and takes over the content area.
-    fireEvent.click(await screen.findByTestId('conv-unscoped'));
-    expect(screen.getByTestId('conversation-panel')).toBeInTheDocument();
-    expect(screen.queryByTestId('stage')).not.toBeInTheDocument();
+    expect(panes('test-project').some(p => p.paneType === 'agent' && p.conversationId === 'test-conv')).toBe(true);
   });
 });

--- a/src/dashboard/frontend/src/components/CommandDeck/CommandDeck.test.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/CommandDeck.test.tsx
@@ -51,8 +51,8 @@ vi.mock('../Stage', () => ({
   Stage: (props: any) => <div data-testid="stage" data-deck={props.deckKey} />,
 }));
 
-vi.mock('./ActivityFeedSidebar', () => ({
-  ActivityFeedSidebar: (props: any) => (
+vi.mock('../sessionFeed/SessionFeedSidebar', () => ({
+  SessionFeedSidebar: (props: any) => (
     <div data-testid="activity-feed" data-issues={(props.issueIds ?? []).join(',')} />
   ),
 }));

--- a/src/dashboard/frontend/src/components/CommandDeck/ConversationList.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ConversationList.tsx
@@ -170,11 +170,14 @@ interface ConversationListProps {
   selectedConversation: string | null;
   onSelectConversation: (name: string | null) => void;
   excludeIds?: Set<number>;
+  /** When provided, show only conversations whose id is in this set (PAN-1561
+   * project scope). Applied after `excludeIds`. */
+  includeIds?: Set<number>;
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-export function ConversationList({ selectedConversation, onSelectConversation, excludeIds }: ConversationListProps) {
+export function ConversationList({ selectedConversation, onSelectConversation, excludeIds, includeIds }: ConversationListProps) {
   const [sort, setSort] = useState<SortOption>(loadSort);
   const [tab, setTab] = useState<ListTab>(loadTab);
 
@@ -221,6 +224,10 @@ export function ConversationList({ selectedConversation, onSelectConversation, e
       filtered = filtered.filter((c) => !excludeIds.has(c.id));
     }
 
+    if (includeIds) {
+      filtered = filtered.filter((c) => includeIds.has(c.id));
+    }
+
     if (tab === 'favorites') {
       filtered = filtered.filter((c) => c.isFavorited);
     }
@@ -236,7 +243,7 @@ export function ConversationList({ selectedConversation, onSelectConversation, e
     );
 
     return [...active, ...inactive];
-  }, [conversations, sort, tab, excludeIds]);
+  }, [conversations, sort, tab, excludeIds, includeIds]);
 
   if (isLoading) {
     return (

--- a/src/dashboard/frontend/src/components/CommandDeck/index.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/index.tsx
@@ -8,9 +8,9 @@ import { type IssueCostBreakdown } from './ProjectOverview';
 import { Stage } from '../Stage';
 import { ProjectHome } from '../Stage/ProjectHome';
 import { IssueOverview } from '../Stage/IssueOverview';
-import { ActivityFeedSidebar } from './ActivityFeedSidebar';
+import { SessionFeedSidebar } from '../sessionFeed/SessionFeedSidebar';
 import { usePanesStore } from '../../lib/panesStore';
-import { fetchProjects } from './projectsData';
+import { fetchProjects, isUnscopedConversation, NO_PROJECT_KEY, NO_PROJECT_LABEL } from './projectsData';
 import { BeadsDialog } from '../BeadsDialog';
 import { PlanDialog } from '../PlanDialog';
 import { ConversationList, type Conversation } from './ConversationList';
@@ -354,7 +354,8 @@ export function CommandDeck({
     return () => clearInterval(interval);
   }, [projectsWithSessions]);
 
-  // Agents from dashboard store (for terminal panel in detail view)
+  // Agents from the dashboard store — used to scope issue tabs' Files/Commits
+  // panes to the issue's workspace agent (PAN-1561).
   const agents = useDashboardStore(selectAgents) as unknown as Agent[];
 
   // Map aggregated costs per issue for the project tree sidebar and project overview.
@@ -476,11 +477,9 @@ export function CommandDeck({
     if (conv) {
       setSelectedConversation(conv.name);
       setSelectedFeature(null);
-      const projectName = resolveConversationProjectName(conv);
-      if (projectName) {
-        onSelectProject?.(projectName);
-        openConversationTabIn(projectName, conv.name, conv.title ?? 'Agent');
-      }
+      const projectName = resolveConversationProjectName(conv) ?? NO_PROJECT_KEY;
+      onSelectProject?.(projectName);
+      openConversationTabIn(projectName, conv.name, conv.title ?? 'Agent');
       appliedConvId.current = convId;
     }
   }, [convId, conversations, resolveConversationProjectName, onSelectProject, openConversationTabIn]);
@@ -763,11 +762,10 @@ export function CommandDeck({
     if (name) {
       setSelectedFeature(null);
       const conv = conversations.find((c) => c.name === name);
-      const projectName = resolveConversationProjectName(conv) ?? selectedProject;
-      if (projectName) {
-        if (projectName !== selectedProject) onSelectProject?.(projectName);
-        openConversationTabIn(projectName, name, conv?.title ?? 'Agent');
-      }
+      // Unscoped conversations live in the No-project bucket.
+      const projectName = resolveConversationProjectName(conv) ?? NO_PROJECT_KEY;
+      if (projectName !== selectedProject) onSelectProject?.(projectName);
+      openConversationTabIn(projectName, name, conv?.title ?? 'Agent');
     }
   }, [selectSession, selectedFeature, conversations, resolveConversationProjectName, selectedProject, onSelectProject, openConversationTabIn]);
 
@@ -834,7 +832,8 @@ export function CommandDeck({
   );
 
   const handleNewConversation = useCallback(() => {
-    void createConversationForProject(selectedProject ?? undefined);
+    const projectKey = selectedProject && selectedProject !== NO_PROJECT_KEY ? selectedProject : undefined;
+    void createConversationForProject(projectKey);
   }, [createConversationForProject, selectedProject]);
 
   const handleNewProjectConversation = useCallback((projectKey: string) => {
@@ -847,7 +846,9 @@ export function CommandDeck({
   const createDeckConversation = useCallback(
     (agentId: string): Promise<string | undefined> => {
       const harness: Harness = agentId === 'codex' ? 'pi' : 'claude-code';
-      return createConversationForProject(selectedProject ?? undefined, harness);
+      // The No-project bucket creates unscoped conversations (no projectKey).
+      const projectKey = selectedProject && selectedProject !== NO_PROJECT_KEY ? selectedProject : undefined;
+      return createConversationForProject(projectKey, harness);
     },
     [createConversationForProject, selectedProject],
   );
@@ -947,11 +948,21 @@ export function CommandDeck({
   }, [projectsWithSessions, selectedProject]);
 
   // ── Project-scoped deck data (PAN-1561) ──────────────────────────────────────
-  // Conversations whose cwd is under the selected project, the id set that
-  // filters the column-2 list, and the project's issue ids for the activity feed.
+  // For a real project: its scoped conversations + issue ids. For the special
+  // "No project" bucket: conversations not under any registered project.
+  const isNoProject = selectedProject === NO_PROJECT_KEY;
+  const unscopedConversations = useMemo(
+    () => conversations.filter((c) => isUnscopedConversation(c, registeredProjects)),
+    [conversations, registeredProjects],
+  );
   const projectConvs = useMemo(
-    () => (selectedProject ? (projectConversations[selectedProject] ?? []) : []),
-    [selectedProject, projectConversations],
+    () =>
+      isNoProject
+        ? unscopedConversations
+        : selectedProject
+          ? (projectConversations[selectedProject] ?? [])
+          : [],
+    [isNoProject, unscopedConversations, selectedProject, projectConversations],
   );
   const projectConvIdSet = useMemo(() => new Set(projectConvs.map(c => c.id)), [projectConvs]);
   const projectIssueIds = useMemo(
@@ -971,7 +982,7 @@ export function CommandDeck({
         ?? agents.find(a => a.issueId?.toLowerCase() === key)?.id;
       return { title, createdAt, branch, agentId };
     },
-    [issueTitles, issues, agents, selectedProjectData],
+    [issueTitles, issues, selectedProjectData, agents],
   );
 
   return (
@@ -1145,9 +1156,13 @@ export function CommandDeck({
               key={selectedProject}
               deckKey={selectedProject}
               conversations={conversations}
+              onCreateConversation={createDeckConversation}
+              terminalCwd={
+                registeredProjects.find((rp) => (rp.name ?? rp.key) === selectedProject)?.path
+              }
               renderHome={(api) => (
                 <ProjectHome
-                  projectName={selectedProject}
+                  projectName={isNoProject ? NO_PROJECT_LABEL : selectedProject}
                   conversations={projectConvs}
                   onCreateConversation={createDeckConversation}
                   api={api}
@@ -1179,10 +1194,15 @@ export function CommandDeck({
           )}
         </div>
 
-        {/* Activity feed — project-scoped (PAN-1561, column 4) */}
+        {/* Project Activity — project-scoped session feed (PAN-1561, column 4).
+            The No-project bucket shows activity with no associated issue. */}
         {selectedProject && (
           <div className={styles.activityColumn}>
-            <ActivityFeedSidebar issueIds={projectIssueIds} />
+            {isNoProject ? (
+              <SessionFeedSidebar embedded heading="Activity" unscoped />
+            ) : (
+              <SessionFeedSidebar embedded heading="Project Activity" issueIds={projectIssueIds} />
+            )}
           </div>
         )}
       </div>

--- a/src/dashboard/frontend/src/components/CommandDeck/index.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/index.tsx
@@ -3,15 +3,20 @@ import { toast } from 'sonner';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Compass, Plus, ChevronDown, ChevronRight } from 'lucide-react';
 import { ProjectNode, ProjectFeature } from './ProjectTree/ProjectNode';
-import { sessionMatchesFilter, type TreeSessionFilter } from './ProjectTree/FeatureItem';
-import { ProjectOverview, type IssueCostBreakdown } from './ProjectOverview';
+import { type TreeSessionFilter } from './ProjectTree/FeatureItem';
+import { type IssueCostBreakdown } from './ProjectOverview';
 import { Stage } from '../Stage';
+import { ProjectHome } from '../Stage/ProjectHome';
+import { IssueOverview } from '../Stage/IssueOverview';
+import { ActivityFeedSidebar } from './ActivityFeedSidebar';
+import { usePanesStore } from '../../lib/panesStore';
+import { fetchProjects } from './projectsData';
 import { BeadsDialog } from '../BeadsDialog';
 import { PlanDialog } from '../PlanDialog';
 import { ConversationList, type Conversation } from './ConversationList';
 import { useConversationMutations } from './useConversationMutations';
 import { ForkModal } from './ForkModal';
-import { ConversationPanel, type ViewMode } from '../chat/ConversationPanel';
+import { type ViewMode } from '../chat/ConversationPanel';
 import { ModelPicker, loadStoredHarness, loadStoredModel, saveStoredHarness, saveStoredModel } from '../chat/ModelPicker';
 import type { Harness } from '../shared/ModelPicker';
 import type { Agent, Issue, StartAgentResponse } from '../../types';
@@ -29,62 +34,6 @@ async function fetchConversations(): Promise<Conversation[]> {
   const res = await fetch('/api/conversations');
   if (!res.ok) throw new Error('Failed to fetch conversations');
   return res.json();
-}
-
-interface ProjectData {
-  name: string;
-  path: string;
-  features: ProjectFeature[];
-}
-
-function groupProjects(issues: ProjectFeature[]): ProjectData[] {
-  const grouped = new Map<string, ProjectData>();
-
-  for (const issue of issues) {
-    const existing = grouped.get(issue.projectName);
-    if (existing) {
-      existing.features.push(issue);
-      continue;
-    }
-
-    grouped.set(issue.projectName, {
-      name: issue.projectName,
-      path: issue.projectName,
-      features: [issue],
-    });
-  }
-
-  return [...grouped.values()]
-    .map((project) => ({
-      ...project,
-      features: [...project.features].sort((a, b) => a.issueId.localeCompare(b.issueId)),
-    }))
-    .sort((a, b) => a.name.localeCompare(b.name));
-}
-
-async function fetchProjects(): Promise<ProjectData[]> {
-  const [issuesRes, registeredRes] = await Promise.all([
-    fetch('/api/issues/resource-allocated'),
-    fetch('/api/registered-projects'),
-  ]);
-  if (!issuesRes.ok) throw new Error('Failed to fetch resource-allocated issues');
-  if (!registeredRes.ok) throw new Error('Failed to fetch registered projects');
-
-  const issues = await issuesRes.json() as ProjectFeature[];
-  const registered = await registeredRes.json() as { key: string; name: string; path: string }[];
-
-  // Start with projects that have qualifying issues
-  const projectMap = new Map(groupProjects(issues).map(p => [p.name, p]));
-
-  // Add registered projects that have no qualifying issues (empty features list)
-  for (const proj of registered) {
-    const name = proj.name ?? proj.key;
-    if (!projectMap.has(name)) {
-      projectMap.set(name, { name, path: proj.path, features: [] });
-    }
-  }
-
-  return [...projectMap.values()].sort((a, b) => a.name.localeCompare(b.name));
 }
 
 interface IssueCostEntry {
@@ -189,6 +138,11 @@ interface CommandDeckProps {
   /** Called when the selected conversation changes so App can sync the URL */
   onConvIdChange?: (id: string | null) => void;
   onConversationViewModeChange?: (mode: ViewMode) => void;
+  /** PAN-1561: the project whose deck is shown, driven by the App sidebar. */
+  selectedProject?: string | null;
+  /** PAN-1561: switch the active project (e.g. when a conversation resolves to
+   * a different project than the one currently shown). */
+  onSelectProject?: (projectName: string | null) => void;
 }
 
 const CONVS_COLLAPSED_KEY = 'mc-convs-collapsed';
@@ -198,13 +152,12 @@ const SECTION_SPLIT_KEY = 'mc-section-split';
 export function CommandDeck({
   issues = [],
   convId,
-  conversationViewMode = 'conversation',
   onConvIdChange,
-  onConversationViewModeChange,
+  selectedProject = null,
+  onSelectProject,
 }: CommandDeckProps) {
   const [projectQueryEpoch, bumpProjectQueryEpoch] = useReducer((value: number) => value + 1, 0);
   const [selectedFeature, setSelectedFeature] = useState<string | null>(null);
-  const [selectedProject, setSelectedProject] = useState<string | null>(null);
   const [selectedConversation, setSelectedConversation] = useState<string | null>(null);
   const [showBeads, setShowBeads] = useState(false);
   const [planDialogIssue, setPlanDialogIssue] = useState<Issue | null>(null);
@@ -372,20 +325,6 @@ export function CommandDeck({
     });
   }, [projects, sessionTreeMap]);
 
-  // Split projects into active (has features) and inactive (empty features from registered projects with no issues)
-  const { activeProjects, inactiveProjects } = useMemo(() => {
-    const active: typeof projects = [];
-    const inactive: typeof projects = [];
-    for (const project of projectsWithSessions) {
-      if (project.features.length > 0) {
-        active.push(project);
-      } else {
-        inactive.push(project);
-      }
-    }
-    return { activeProjects: active, inactiveProjects: inactive };
-  }, [projectsWithSessions]);
-
   const [containerStats, setContainerStats] = useState<Record<string, ContainerStats>>({});
 
   // Poll container stats every 5s when issues have containers
@@ -419,7 +358,7 @@ export function CommandDeck({
   const agents = useDashboardStore(selectAgents) as unknown as Agent[];
 
   // Map aggregated costs per issue for the project tree sidebar and project overview.
-  const { issueCosts, issueCostDetails } = useMemo(() => {
+  const { issueCosts } = useMemo(() => {
     const costs: Record<string, number> = {};
     const detailsByIssue: Record<string, IssueCostBreakdown> = {};
 
@@ -456,7 +395,7 @@ export function CommandDeck({
   });
 
   // Partition conversations into project-scoped vs unscoped
-  const { projectConversations, excludeConvIds } = useMemo(() => {
+  const { projectConversations } = useMemo(() => {
     const map: Record<string, import('./ConversationList').Conversation[]> = {};
     const excludeSet = new Set<number>();
     if (!Array.isArray(registeredProjects) || registeredProjects.length === 0) return { projectConversations: map, excludeConvIds: excludeSet };
@@ -500,20 +439,51 @@ export function CommandDeck({
     [registeredProjects],
   );
 
-  // On mount or when convId changes (popstate), apply the deep-link
+  // ── Project-deck tab helpers (PAN-1561) ──────────────────────────────────────
+  // Open/focus tabs in a project's deck directly via the shared panesStore (the
+  // same store the Stage reads). `*In` variants take an explicit project key so
+  // the deep-link effect can target a project before selection state settles.
+  const openIssueTabIn = useCallback((projectKey: string, issueId: string, label: string) => {
+    const store = usePanesStore.getState();
+    store.ensureHome(projectKey);
+    const panes = store.panesByWorkspace[projectKey] ?? [];
+    const existing = panes.find((p) => p.paneType === 'issue' && p.issueId === issueId);
+    if (existing) store.setActivePane(projectKey, existing.paneId);
+    else store.addPane(projectKey, { paneType: 'issue', label, issueId });
+  }, []);
+
+  const openConversationTabIn = useCallback((projectKey: string, name: string, label: string) => {
+    const store = usePanesStore.getState();
+    store.ensureHome(projectKey);
+    const panes = store.panesByWorkspace[projectKey] ?? [];
+    const existing = panes.find((p) => p.paneType === 'agent' && p.conversationId === name);
+    if (existing) store.setActivePane(projectKey, existing.paneId);
+    else store.addPane(projectKey, { paneType: 'agent', label, conversationId: name });
+  }, []);
+
+  const openTerminalTabIn = useCallback((projectKey: string, sessionId: string) => {
+    const store = usePanesStore.getState();
+    store.ensureHome(projectKey);
+    store.addPane(projectKey, { paneType: 'terminal', label: 'Terminal', terminalId: sessionId });
+  }, []);
+
+  // On mount or when convId changes (popstate), apply the deep-link: switch to
+  // the conversation's project and open it as an agent tab in that deck.
   useEffect(() => {
     if (!convId || conversations.length === 0) return;
     if (convId === appliedConvId.current) return;
     const conv = conversations.find((c) => String(c.id) === convId || c.name === convId);
     if (conv) {
       setSelectedConversation(conv.name);
-      // A conversation selection owns the right pane — clear any feature so a
-      // stale resolvedProjectForFeature can't shadow it (see handleSelectConversation).
       setSelectedFeature(null);
-      setSelectedProject(resolveConversationProjectName(conv));
+      const projectName = resolveConversationProjectName(conv);
+      if (projectName) {
+        onSelectProject?.(projectName);
+        openConversationTabIn(projectName, conv.name, conv.title ?? 'Agent');
+      }
       appliedConvId.current = convId;
     }
-  }, [convId, conversations, resolveConversationProjectName]);
+  }, [convId, conversations, resolveConversationProjectName, onSelectProject, openConversationTabIn]);
 
   // Auto-select first conversation on initial load if no deep-link and no feature selected
   const hasAutoSelected = useRef(false);
@@ -542,13 +512,13 @@ export function CommandDeck({
     }
   }, [selectedConversation, conversations, onConvIdChange, convId]);
 
+  // PAN-1561: selecting an issue from the tree opens (or focuses) an issue tab
+  // in the current project's deck rather than replacing the whole content area.
   const handleSelectFeature = useCallback((issueId: string) => {
     setSelectedFeature(issueId);
-    setSelectedProject(null);
     setSelectedConversation(null);
+    if (selectedProject) openIssueTabIn(selectedProject, issueId, issueId);
 
-    // Auto-select the active work agent session so the user lands in
-    // conversation view instead of the overview with a disabled composer.
     const feature = projectsWithSessions
       .flatMap(p => p.features)
       .find(f => f.issueId === issueId);
@@ -556,14 +526,14 @@ export function CommandDeck({
       (s) => s.presence === 'active' && s.type === 'work',
     );
     selectSession(issueId, activeWorkSession?.sessionId ?? null);
-  }, [selectSession, projectsWithSessions]);
+  }, [selectSession, projectsWithSessions, selectedProject, openIssueTabIn]);
 
   const handleSelectSession = useCallback((issueId: string, sessionId: string) => {
     setSelectedFeature(issueId);
-    setSelectedProject(null);
     selectSession(issueId, sessionId);
     setSelectedConversation(null);
-  }, [selectSession]);
+    if (selectedProject) openIssueTabIn(selectedProject, issueId, issueId);
+  }, [selectSession, selectedProject, openIssueTabIn]);
 
   const handleStopSession = useCallback(async (sessionId: string) => {
     try {
@@ -590,19 +560,20 @@ export function CommandDeck({
   }, [queryClient]);
 
   const handleViewTerminal = useCallback((sessionId: string) => {
-    // Find which issue owns this session and select it
+    // Find which issue owns this session, highlight it, and open a terminal tab
+    // for the session in the project deck.
     for (const project of projectsWithSessions) {
       for (const feature of project.features) {
         if (feature.sessions?.some(s => s.sessionId === sessionId)) {
           setSelectedFeature(feature.issueId);
-          setSelectedProject(null);
           selectSession(feature.issueId, sessionId);
           setSelectedConversation(null);
+          if (selectedProject) openTerminalTabIn(selectedProject, sessionId);
           return;
         }
       }
     }
-  }, [projectsWithSessions, selectSession]);
+  }, [projectsWithSessions, selectSession, selectedProject, openTerminalTabIn]);
 
   const handlePauseSession = useCallback(async (sessionId: string) => {
     try {
@@ -760,41 +731,45 @@ export function CommandDeck({
   }, [issues]);
 
   const handleViewJsonl = useCallback((sessionId: string) => {
-    // Select the session so the conversation panel shows its JSONL transcript
+    // Highlight the owning issue and open its tab so its transcript is reachable.
     for (const project of projectsWithSessions) {
       for (const feature of project.features) {
         if (feature.sessions?.some(s => s.sessionId === sessionId)) {
           setSelectedFeature(feature.issueId);
-          setSelectedProject(null);
           selectSession(feature.issueId, sessionId);
           setSelectedConversation(null);
+          if (selectedProject) openIssueTabIn(selectedProject, feature.issueId, feature.issueId);
           return;
         }
       }
     }
-  }, [projectsWithSessions, selectSession]);
+  }, [projectsWithSessions, selectSession, selectedProject, openIssueTabIn]);
 
+  // The project header in column 2 is a single (selected) project; clicking it
+  // focuses the deck's HOME tab via the App sidebar's selection callback.
   const handleSelectProject = useCallback((projectName: string) => {
-    setSelectedProject(projectName);
+    onSelectProject?.(projectName);
     setSelectedFeature(null);
     setSelectedConversation(null);
-  }, []);
+  }, [onSelectProject]);
 
+  // PAN-1561: selecting a conversation opens it as an agent tab in its project's
+  // deck (switching project if it belongs to a different one than is shown).
   const handleSelectConversation = useCallback((name: string | null) => {
     setSelectedConversation(name);
     if (selectedFeature) {
       selectSession(selectedFeature, null);
     }
     if (name) {
-      // Selecting a conversation supersedes any feature/project selection, so
-      // the content area renders the conversation (not a feature's Stage).
-      // Anchoring selectedProject to the conversation's own project keeps the
-      // "Back to conversations" control working for project-scoped chats.
       setSelectedFeature(null);
       const conv = conversations.find((c) => c.name === name);
-      setSelectedProject(resolveConversationProjectName(conv));
+      const projectName = resolveConversationProjectName(conv) ?? selectedProject;
+      if (projectName) {
+        if (projectName !== selectedProject) onSelectProject?.(projectName);
+        openConversationTabIn(projectName, name, conv?.title ?? 'Agent');
+      }
     }
-  }, [selectSession, selectedFeature, conversations, resolveConversationProjectName]);
+  }, [selectSession, selectedFeature, conversations, resolveConversationProjectName, selectedProject, onSelectProject, openConversationTabIn]);
 
   const projectConvMutations = useConversationMutations(selectedConversation, handleSelectConversation);
 
@@ -816,44 +791,66 @@ export function CommandDeck({
     return () => window.removeEventListener('panopticon:open-fork-modal', handler);
   }, [projectConvMutations]);
 
-  const createConversationForProject = useCallback(async (projectKey?: string) => {
-    try {
-      const payload: Record<string, unknown> = { model: sidebarModel, harness: sidebarHarness };
-      if (projectKey) payload.projectKey = projectKey;
-      const res = await fetch('/api/conversations', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({ error: 'Request failed' }));
-        throw new Error((err as { error?: string }).error || 'Failed to create conversation');
+  // Create a conversation (optionally scoped to a project) and open it as an
+  // agent tab in the current project's deck. Returns the new conversation's
+  // name so the deck's launch components can focus the tab.
+  const createConversationForProject = useCallback(
+    async (projectKey?: string, harnessOverride?: Harness): Promise<string | undefined> => {
+      try {
+        const payload: Record<string, unknown> = {
+          model: sidebarModel,
+          harness: harnessOverride ?? sidebarHarness,
+        };
+        if (projectKey) payload.projectKey = projectKey;
+        const res = await fetch('/api/conversations', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({ error: 'Request failed' }));
+          throw new Error((err as { error?: string }).error || 'Failed to create conversation');
+        }
+        const conv = await res.json() as Conversation;
+        setSelectedConversation(conv.name);
+        if (convsCollapsed) setConvsCollapsed(false);
+        const deckKey = projectKey ?? selectedProject;
+        if (deckKey) openConversationTabIn(deckKey, conv.name, conv.title ?? 'Agent');
+        if (onConvIdChange) {
+          const newId = String(conv.id);
+          onConvIdChange(newId);
+          appliedConvId.current = newId;
+          prevSelectedRef.current = conv.name;
+        }
+        queryClient.invalidateQueries({ queryKey: ['conversations'] });
+        return conv.name;
+      } catch (err) {
+        console.error('[CommandDeck] Failed to create conversation:', err);
+        toast.error(err instanceof Error ? err.message : 'Failed to create conversation');
+        return undefined;
       }
-      const conv = await res.json() as Conversation;
-      setSelectedConversation(conv.name);
-      setSelectedProject(null);
-      setSelectedFeature(null);
-      if (convsCollapsed) setConvsCollapsed(false);
-      if (onConvIdChange) {
-        const newId = String(conv.id);
-        onConvIdChange(newId);
-        appliedConvId.current = newId;
-        prevSelectedRef.current = conv.name;
-      }
-      queryClient.invalidateQueries({ queryKey: ['conversations'] });
-    } catch (err) {
-      console.error('[CommandDeck] Failed to create conversation:', err);
-      toast.error(err instanceof Error ? err.message : 'Failed to create conversation');
-    }
-  }, [sidebarModel, sidebarHarness, queryClient, onConvIdChange, convsCollapsed]);
+    },
+    [sidebarModel, sidebarHarness, queryClient, onConvIdChange, convsCollapsed, selectedProject, openConversationTabIn],
+  );
 
   const handleNewConversation = useCallback(() => {
-    void createConversationForProject();
-  }, [createConversationForProject]);
+    void createConversationForProject(selectedProject ?? undefined);
+  }, [createConversationForProject, selectedProject]);
 
   const handleNewProjectConversation = useCallback((projectKey: string) => {
     void createConversationForProject(projectKey);
   }, [createConversationForProject]);
+
+  // Launch-component conversation creator (ProjectHome / IssueOverview): create
+  // a project conversation for the chosen agent and return its name so the deck
+  // can open/focus an agent tab on it.
+  const createDeckConversation = useCallback(
+    (agentId: string): Promise<string | undefined> => {
+      const harness: Harness = agentId === 'codex' ? 'pi' : 'claude-code';
+      return createConversationForProject(selectedProject ?? undefined, harness);
+    },
+    [createConversationForProject, selectedProject],
+  );
 
   // Section divider drag handlers
   const handleSectionDragStart = useCallback((e: React.MouseEvent) => {
@@ -949,80 +946,33 @@ export function CommandDeck({
     return projectsWithSessions.find(p => p.name === selectedProject) ?? null;
   }, [projectsWithSessions, selectedProject]);
 
-  const resolvedProjectForFeature = useMemo(() => {
-    if (!selectedFeature) return null;
-    for (const p of projectsWithSessions) {
-      if (p.features.some(f => f.issueId === selectedFeature)) return p;
-    }
-    return null;
-  }, [projectsWithSessions, selectedFeature]);
-
-  // PAN-1549: create a conversation for the active workspace using the chosen
-  // agent's harness and return its name so the Stage can open an agent pane
-  // focused on it. Unlike createConversationForProject, this does NOT clear
-  // selectedFeature — the user stays in the Stage rather than dropping into the
-  // global ConversationPanel.
-  const createWorkspaceConversation = useCallback(
-    async (agentId: string): Promise<string | undefined> => {
-      const harness = agentId === 'codex' ? 'pi' : 'claude-code';
-      const projectKey = resolvedProjectForFeature?.name;
-      try {
-        const payload: Record<string, unknown> = { model: sidebarModel, harness };
-        if (projectKey) payload.projectKey = projectKey;
-        const res = await fetch('/api/conversations', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload),
-        });
-        if (!res.ok) {
-          const err = await res.json().catch(() => ({ error: 'Request failed' }));
-          throw new Error((err as { error?: string }).error || 'Failed to create conversation');
-        }
-        const conv = (await res.json()) as Conversation;
-        queryClient.invalidateQueries({ queryKey: ['conversations'] });
-        return conv.name;
-      } catch (err) {
-        toast.error(err instanceof Error ? err.message : 'Failed to create conversation');
-        return undefined;
-      }
-    },
-    [resolvedProjectForFeature, sidebarModel, queryClient],
+  // ── Project-scoped deck data (PAN-1561) ──────────────────────────────────────
+  // Conversations whose cwd is under the selected project, the id set that
+  // filters the column-2 list, and the project's issue ids for the activity feed.
+  const projectConvs = useMemo(
+    () => (selectedProject ? (projectConversations[selectedProject] ?? []) : []),
+    [selectedProject, projectConversations],
+  );
+  const projectConvIdSet = useMemo(() => new Set(projectConvs.map(c => c.id)), [projectConvs]);
+  const projectIssueIds = useMemo(
+    () => (selectedProjectData?.features ?? []).map(f => f.issueId),
+    [selectedProjectData],
   );
 
-  const resolvedProjectForConversation = useMemo(() => {
-    if (!selectedConversation) return null;
-    const conv = conversations.find(c => c.name === selectedConversation);
-    const projectName = resolveConversationProjectName(conv);
-    if (!projectName) return null;
-    return projectsWithSessions.find(p => p.name === projectName) ?? null;
-  }, [conversations, selectedConversation, resolveConversationProjectName, projectsWithSessions]);
-
-  const rightPaneProject = selectedProjectData ?? resolvedProjectForFeature ?? resolvedProjectForConversation;
-
-  // The conversation backing a direct conversation selection. Selecting a
-  // conversation clears selectedFeature (see handleSelectConversation), so this
-  // covers both unscoped conversations and project-scoped ones chosen without a
-  // feature. PAN-1549: the Stage owns a feature's own conversations, so this
-  // branch only renders when no feature is selected.
-  const selectedConversationNode = useMemo(() => {
-    if (!selectedConversation) return null;
-    return conversations.find(c => c.name === selectedConversation) ?? null;
-  }, [selectedConversation, conversations]);
-
-  const selectedIssueTitle = selectedFeature
-    ? issueTitles[selectedFeature.toLowerCase()] || issueTitles[selectedFeature] || selectedFeature
-    : '';
-
-  const selectedIssue = selectedFeature
-    ? issues.find(i => i.identifier === selectedFeature)
-    : null;
-
-  const selectedAgent = useMemo(() => {
-    if (!selectedFeature) return undefined;
-    const key = selectedFeature.toLowerCase();
-    return agents.find(a => a.issueId?.toLowerCase() === key && a.id.startsWith('agent-'))
-      ?? agents.find(a => a.issueId?.toLowerCase() === key);
-  }, [agents, selectedFeature]);
+  // Resolve the per-issue data an issue tab's IssueOverview needs.
+  const resolveIssue = useCallback(
+    (issueId: string) => {
+      const key = issueId.toLowerCase();
+      const title = issueTitles[key] || issueTitles[issueId] || issueId;
+      const createdAt = issues.find(i => i.identifier === issueId)?.createdAt;
+      const branch = selectedProjectData?.features.find(f => f.issueId === issueId)?.branch;
+      const agentId =
+        agents.find(a => a.issueId?.toLowerCase() === key && a.id.startsWith('agent-'))?.id
+        ?? agents.find(a => a.issueId?.toLowerCase() === key)?.id;
+      return { title, createdAt, branch, agentId };
+    },
+    [issueTitles, issues, agents, selectedProjectData],
+  );
 
   return (
     <div className={styles.commandDeck}>
@@ -1067,15 +1017,19 @@ export function CommandDeck({
             <div className={styles.sectionHeader} onClick={toggleConvsCollapsed}>
               {convsCollapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
               <span className={styles.sectionTitle}>Conversations</span>
-              <span className={styles.segmentCount}>{conversations.length - excludeConvIds.size}</span>
+              <span className={styles.segmentCount}>{projectConvs.length}</span>
             </div>
             {!convsCollapsed && (
               <div className={styles.sectionBody}>
-                <ConversationList
-                  selectedConversation={selectedConversation}
-                  onSelectConversation={handleSelectConversation}
-                  excludeIds={excludeConvIds}
-                />
+                {selectedProject ? (
+                  <ConversationList
+                    selectedConversation={selectedConversation}
+                    onSelectConversation={handleSelectConversation}
+                    includeIds={projectConvIdSet}
+                  />
+                ) : (
+                  <div className={styles.emptyProject}>Select a project to see its conversations</div>
+                )}
               </div>
             )}
           </div>
@@ -1088,17 +1042,15 @@ export function CommandDeck({
             />
           )}
 
-          {/* ── Projects section ──────────────────────────────────── */}
+          {/* ── Issues section (selected project's tree, PAN-1561) ───── */}
           <div
             className={`${styles.sidebarSection} ${projectsCollapsed ? styles.sidebarSectionCollapsed : ''}`}
             style={!convsCollapsed && !projectsCollapsed ? { flex: `0 0 ${100 - sectionSplit}%` } : undefined}
           >
             <div className={styles.sectionHeader} onClick={toggleProjectsCollapsed}>
               {projectsCollapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
-              <span className={styles.sectionTitle}>Projects</span>
-              <span className={styles.segmentCount}>
-                {activeProjects.reduce((sum, p) => sum + p.features.length, 0)}
-              </span>
+              <span className={styles.sectionTitle}>Issues</span>
+              <span className={styles.segmentCount}>{selectedProjectData?.features.length ?? 0}</span>
             </div>
             {!projectsCollapsed && (
               <div className={styles.sectionBody}>
@@ -1113,97 +1065,47 @@ export function CommandDeck({
                     </button>
                   ))}
                 </div>
-                {isLoading && activeProjects.length === 0 && inactiveProjects.length === 0 ? (
+                {!selectedProject ? (
+                  <div className={styles.emptyProject}>Select a project to see its issues</div>
+                ) : isLoading && !selectedProjectData ? (
                   <div className={styles.skeletonList}>
                     <div className={styles.skeletonItem} style={{ width: '60%' }} />
                     <div className={styles.skeletonItem} style={{ width: '80%' }} />
                     <div className={styles.skeletonItem} style={{ width: '45%' }} />
-                    <div className={styles.skeletonItem} style={{ width: '70%' }} />
                   </div>
-                ) : activeProjects.length === 0 && inactiveProjects.length === 0 ? (
-                  <div className={styles.emptyProject}>No projects configured</div>
+                ) : selectedProjectData ? (
+                  <ProjectNode
+                    key={selectedProjectData.path}
+                    name={selectedProjectData.name}
+                    features={selectedProjectData.features}
+                    selectedFeature={selectedFeature}
+                    onSelectFeature={handleSelectFeature}
+                    onSelectProject={handleSelectProject}
+                    selectedProject={selectedProject}
+                    selectedSessionId={selectedSessionId}
+                    onSelectSession={handleSelectSession}
+                    issueTitles={issueTitles}
+                    issueCosts={issueCosts}
+                    filter={treeFilter}
+                    onStopSession={handleStopSession}
+                    onViewTerminal={handleViewTerminal}
+                    onPauseSession={handlePauseSession}
+                    onResumeSession={handleResumeSession}
+                    onRestartSession={handleRestartSession}
+                    onDeepWipe={handleDeepWipe}
+                    onOpenStateDir={handleOpenStateDir}
+                    onViewJsonl={handleViewJsonl}
+                    onCleanupOrphanedResources={handleCleanupOrphanedResources}
+                    onOpenPlanDialog={handleOpenPlanDialog}
+                    onNewConversation={handleNewProjectConversation}
+                    conversations={projectConvs}
+                    selectedConversation={selectedConversation}
+                    onSelectConversation={handleSelectConversation}
+                    conversationMutations={projectConvMutations}
+                    containerStats={containerStats}
+                  />
                 ) : (
-                  <>
-                    {activeProjects
-                      .filter((project) => {
-                        const hasConvs = (projectConversations[project.name]?.length ?? 0) > 0;
-                        if (treeFilter === 'all') return project.features.length > 0 || hasConvs;
-                        return project.features.some((feature) =>
-                          (feature.sessions ?? []).some((session) => sessionMatchesFilter(session, treeFilter)),
-                        ) || hasConvs;
-                      })
-                      .map(project => (
-                      <ProjectNode
-                        key={project.path}
-                        name={project.name}
-                        features={project.features}
-                        selectedFeature={selectedFeature}
-                        onSelectFeature={handleSelectFeature}
-                        onSelectProject={handleSelectProject}
-                        selectedProject={selectedProject}
-                        selectedSessionId={selectedSessionId}
-                        onSelectSession={handleSelectSession}
-                        issueTitles={issueTitles}
-                        issueCosts={issueCosts}
-                        filter={treeFilter}
-                        onStopSession={handleStopSession}
-                        onViewTerminal={handleViewTerminal}
-                        onPauseSession={handlePauseSession}
-                        onResumeSession={handleResumeSession}
-                        onRestartSession={handleRestartSession}
-                        onDeepWipe={handleDeepWipe}
-                        onOpenStateDir={handleOpenStateDir}
-                        onViewJsonl={handleViewJsonl}
-                        onCleanupOrphanedResources={handleCleanupOrphanedResources}
-                        onOpenPlanDialog={handleOpenPlanDialog}
-                        onNewConversation={handleNewProjectConversation}
-                        conversations={projectConversations[project.name] ?? []}
-                        selectedConversation={selectedConversation}
-                        onSelectConversation={handleSelectConversation}
-                        conversationMutations={projectConvMutations}
-                        containerStats={containerStats}
-                      />
-                    ))}
-                    {inactiveProjects.length > 0 && (
-                      <div className={styles.inactiveProjectsSection}>
-                        <div className={styles.inactiveProjectsSectionHeader}>
-                          Projects (Inactive)
-                        </div>
-                        {inactiveProjects.map(project => (
-                          <ProjectNode
-                            key={project.path}
-                            name={project.name}
-                            features={project.features}
-                            selectedFeature={selectedFeature}
-                            onSelectFeature={handleSelectFeature}
-                            onSelectProject={handleSelectProject}
-                            selectedProject={selectedProject}
-                            selectedSessionId={selectedSessionId}
-                            onSelectSession={handleSelectSession}
-                            issueTitles={issueTitles}
-                            issueCosts={issueCosts}
-                            filter={treeFilter}
-                            onStopSession={handleStopSession}
-                            onViewTerminal={handleViewTerminal}
-                            onPauseSession={handlePauseSession}
-                            onResumeSession={handleResumeSession}
-                            onRestartSession={handleRestartSession}
-                            onDeepWipe={handleDeepWipe}
-                            onOpenStateDir={handleOpenStateDir}
-                            onViewJsonl={handleViewJsonl}
-                            onCleanupOrphanedResources={handleCleanupOrphanedResources}
-                            onOpenPlanDialog={handleOpenPlanDialog}
-                            onNewConversation={handleNewProjectConversation}
-                            conversations={projectConversations[project.name] ?? []}
-                            selectedConversation={selectedConversation}
-                            onSelectConversation={handleSelectConversation}
-                            conversationMutations={projectConvMutations}
-                            containerStats={containerStats}
-                          />
-                        ))}
-                      </div>
-                    )}
-                  </>
+                  <div className={styles.emptyProject}>No issues for this project</div>
                 )}
               </div>
             )}
@@ -1236,52 +1138,53 @@ export function CommandDeck({
           onMouseDown={handleMouseDown}
         />
 
-        {/* Content Area */}
+        {/* Content Area — the project-scoped deck (PAN-1561) */}
         <div className={styles.content}>
-          {/* PAN-1549: Stage replaces the legacy ProjectRightPaneTabs shell.
-              A selected feature/workspace → the Stage (HOME pane + panes); a
-              selected conversation without a feature → the conversation; a
-              project-only selection → the Pipeline (ProjectOverview). */}
-          {selectedFeature ? (
+          {selectedProject ? (
             <Stage
-              workspaceId={selectedFeature}
-              issueTitle={selectedIssueTitle}
-              agentId={selectedAgent?.id}
-              issueCreatedAt={selectedIssue?.createdAt}
+              key={selectedProject}
+              deckKey={selectedProject}
               conversations={conversations}
-              onCreateConversation={createWorkspaceConversation}
-            />
-          ) : selectedConversationNode ? (
-            <div className="flex h-full min-h-0 flex-col">
-              <ConversationPanel
-                key={selectedConversationNode.name}
-                conversation={selectedConversationNode}
-                viewMode={conversationViewMode ?? 'conversation'}
-                onViewModeChange={onConversationViewModeChange}
-                agentId={selectedAgent?.id}
-                onArchived={() => {
-                  setSelectedConversation(null);
-                  queryClient.invalidateQueries({ queryKey: ['conversations'] });
-                }}
-              />
-            </div>
-          ) : rightPaneProject ? (
-            <ProjectOverview
-              projectName={rightPaneProject.name}
-              features={rightPaneProject.features}
-              issueCosts={issueCosts}
-              issueCostDetails={issueCostDetails}
-              onSelectFeature={(feature) => handleSelectFeature(feature.issueId)}
+              renderHome={(api) => (
+                <ProjectHome
+                  projectName={selectedProject}
+                  conversations={projectConvs}
+                  onCreateConversation={createDeckConversation}
+                  api={api}
+                />
+              )}
+              renderIssue={(issueId, api) => {
+                const info = resolveIssue(issueId);
+                return (
+                  <IssueOverview
+                    issueId={issueId}
+                    title={info.title}
+                    branch={info.branch}
+                    createdAt={info.createdAt}
+                    agentId={info.agentId}
+                    conversations={conversations}
+                    onCreateConversation={createDeckConversation}
+                    api={api}
+                  />
+                );
+              }}
             />
           ) : (
             <div className={styles.contentEmpty}>
               <div style={{ textAlign: 'center' }}>
                 <Compass size={48} style={{ marginBottom: '16px', opacity: 0.3 }} />
-                <p>Select a project to view activity</p>
+                <p>Select a project to open its deck</p>
               </div>
             </div>
           )}
         </div>
+
+        {/* Activity feed — project-scoped (PAN-1561, column 4) */}
+        {selectedProject && (
+          <div className={styles.activityColumn}>
+            <ActivityFeedSidebar issueIds={projectIssueIds} />
+          </div>
+        )}
       </div>
 
       {/* Beads Dialog */}

--- a/src/dashboard/frontend/src/components/CommandDeck/projectsData.ts
+++ b/src/dashboard/frontend/src/components/CommandDeck/projectsData.ts
@@ -1,0 +1,63 @@
+/**
+ * projectsData — shared project list fetch/shape for the project-scoped nav
+ * (PAN-1561). Both the App Sidebar (project rail) and the CommandDeck (project
+ * workspace) read this via the same react-query key `command-deck-projects`,
+ * so the network request is deduped and both surfaces agree on the list.
+ */
+import type { ProjectFeature } from './ProjectTree/ProjectNode';
+
+export interface ProjectData {
+  name: string;
+  path: string;
+  features: ProjectFeature[];
+}
+
+export function groupProjects(issues: ProjectFeature[]): ProjectData[] {
+  const grouped = new Map<string, ProjectData>();
+
+  for (const issue of issues) {
+    const existing = grouped.get(issue.projectName);
+    if (existing) {
+      existing.features.push(issue);
+      continue;
+    }
+
+    grouped.set(issue.projectName, {
+      name: issue.projectName,
+      path: issue.projectName,
+      features: [issue],
+    });
+  }
+
+  return [...grouped.values()]
+    .map((project) => ({
+      ...project,
+      features: [...project.features].sort((a, b) => a.issueId.localeCompare(b.issueId)),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function fetchProjects(): Promise<ProjectData[]> {
+  const [issuesRes, registeredRes] = await Promise.all([
+    fetch('/api/issues/resource-allocated'),
+    fetch('/api/registered-projects'),
+  ]);
+  if (!issuesRes.ok) throw new Error('Failed to fetch resource-allocated issues');
+  if (!registeredRes.ok) throw new Error('Failed to fetch registered projects');
+
+  const issues = await issuesRes.json() as ProjectFeature[];
+  const registered = await registeredRes.json() as { key: string; name: string; path: string }[];
+
+  // Start with projects that have qualifying issues
+  const projectMap = new Map(groupProjects(issues).map(p => [p.name, p]));
+
+  // Add registered projects that have no qualifying issues (empty features list)
+  for (const proj of registered) {
+    const name = proj.name ?? proj.key;
+    if (!projectMap.has(name)) {
+      projectMap.set(name, { name, path: proj.path, features: [] });
+    }
+  }
+
+  return [...projectMap.values()].sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/src/dashboard/frontend/src/components/CommandDeck/projectsData.ts
+++ b/src/dashboard/frontend/src/components/CommandDeck/projectsData.ts
@@ -6,6 +6,28 @@
  */
 import type { ProjectFeature } from './ProjectTree/ProjectNode';
 
+/** Sentinel deck key for the "No project" bucket — conversations/terminals not
+ * under any registered project (PAN-1561). */
+export const NO_PROJECT_KEY = '__no-project__';
+export const NO_PROJECT_LABEL = 'No project';
+
+export interface RegisteredProjectLite {
+  key: string;
+  name?: string;
+  path: string;
+}
+
+/** True when a conversation's cwd is not under any registered project (or has no
+ * cwd) — i.e. it belongs in the No-project bucket. */
+export function isUnscopedConversation(
+  conv: { cwd?: string | null },
+  registeredProjects: readonly RegisteredProjectLite[],
+): boolean {
+  const cwd = conv.cwd;
+  if (!cwd) return true;
+  return !registeredProjects.some((rp) => rp.path && (cwd === rp.path || cwd.startsWith(rp.path + '/')));
+}
+
 export interface ProjectData {
   name: string;
   path: string;

--- a/src/dashboard/frontend/src/components/CommandDeck/styles/command-deck.module.css
+++ b/src/dashboard/frontend/src/components/CommandDeck/styles/command-deck.module.css
@@ -1138,6 +1138,18 @@
   font-size: 14px;
 }
 
+/* Activity feed column (PAN-1561, column 4) */
+.activityColumn {
+  width: 300px;
+  min-width: 300px;
+  flex-shrink: 0;
+  border-left: 1px solid var(--border);
+  background: var(--card);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
 /* Feature Header */
 .featureHeader {
   display: flex;

--- a/src/dashboard/frontend/src/components/Sidebar.test.tsx
+++ b/src/dashboard/frontend/src/components/Sidebar.test.tsx
@@ -74,23 +74,18 @@ describe('Sidebar navigation', () => {
     }));
   });
 
-  it('orders Operations as Home, Command Deck, Board, Pipeline, Awaiting Merge, Agents, AutoPreso, Flywheel', () => {
+  it('shows Home and Flywheel as the primary rail, with other views under More (PAN-1561)', () => {
     const { container, onTabChange } = renderSidebar({ activeTab: 'command-deck' });
 
-    const operationLabels = Array.from(container.querySelectorAll('nav [data-testid^="sidebar-"]'))
-      .slice(0, 8)
-      .map((button) => button.textContent?.trim());
+    // Primary rail: the first two nav buttons are Home and Flywheel.
+    const navButtons = Array.from(container.querySelectorAll('nav button[data-testid^="sidebar-"]'));
+    const labels = navButtons.map((button) => button.textContent?.trim());
+    expect(labels[0]).toBe('Home');
+    expect(labels[1]).toBe('Flywheel');
 
-    expect(operationLabels).toEqual([
-      'Home',
-      'Command Deck',
-      'Board',
-      'Pipeline',
-      'Awaiting Merge',
-      'Agents',
-      'AutoPreso',
-      'Flywheel',
-    ]);
+    // Secondary views are relocated into the "More" section but still reachable.
+    expect(screen.getByTestId('sidebar-more')).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-command-deck')).toBeInTheDocument();
     expect(screen.getByTestId('sidebar-awaiting-merge')).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('sidebar-command-deck'));

--- a/src/dashboard/frontend/src/components/Sidebar.tsx
+++ b/src/dashboard/frontend/src/components/Sidebar.tsx
@@ -7,7 +7,8 @@ import {
   Hammer, Loader2, History, Mic, FileText, ChevronDown, ChevronRight, MoreHorizontal,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
-import { fetchProjects } from './CommandDeck/projectsData';
+import { fetchProjects, isUnscopedConversation, NO_PROJECT_KEY, NO_PROJECT_LABEL, type RegisteredProjectLite } from './CommandDeck/projectsData';
+import { fetchConversations } from './CommandDeck/ConversationList';
 import { CloisterStatusBar } from './CloisterStatusBar';
 import { FreshnessIndicator } from './FreshnessIndicator';
 import { DeaconPauseToggle } from './DeaconPauseToggle';
@@ -157,6 +158,29 @@ export function Sidebar({ activeTab, onTabChange, onSearchOpen, selectedProject 
     queryFn: fetchProjects,
     refetchInterval: 30000,
   });
+
+  // PAN-1561: the "No project" bucket appears once a conversation exists that
+  // isn't under any registered project. These queries share keys with the
+  // CommandDeck (react-query dedupes — no extra network).
+  const { data: sidebarConversations = [] } = useQuery({
+    queryKey: ['conversations'],
+    queryFn: fetchConversations,
+    refetchInterval: 10000,
+  });
+  const { data: registeredProjects = [] } = useQuery({
+    queryKey: ['registered-projects'],
+    queryFn: async (): Promise<RegisteredProjectLite[]> => {
+      const res = await fetch('/api/registered-projects');
+      if (!res.ok) return [];
+      const data = await res.json();
+      return Array.isArray(data) ? data : [];
+    },
+    staleTime: 60000,
+  });
+  const hasUnscopedConversations = useMemo(
+    () => sidebarConversations.some((c) => isUnscopedConversation(c, registeredProjects)),
+    [sidebarConversations, registeredProjects],
+  );
 
   const issues = useDashboardStore(selectIssues) as Issue[];
   const agents = useDashboardStore(selectAgents) as unknown as Agent[];
@@ -395,6 +419,24 @@ export function Sidebar({ activeTab, onTabChange, onSearchOpen, selectedProject 
                     </button>
                   );
                 })
+              )}
+              {/* No-project bucket — unscoped conversations/terminals (PAN-1561) */}
+              {hasUnscopedConversations && (
+                <button
+                  onClick={() => { onSelectProject?.(NO_PROJECT_KEY); setMobileOpen(false); }}
+                  title={NO_PROJECT_LABEL}
+                  data-testid="sidebar-project-no-project"
+                  className={`
+                    w-full flex items-center gap-3 px-3 py-1.5 transition-colors duration-150 text-sm font-medium border-l-2
+                    ${activeTab === 'command-deck' && selectedProject === NO_PROJECT_KEY
+                      ? 'bg-accent text-foreground border-primary'
+                      : 'text-muted-foreground hover:bg-accent hover:text-foreground border-transparent'
+                    }
+                  `}
+                >
+                  <span className="h-2 w-2 rounded-full shrink-0 bg-muted-foreground/30" aria-hidden="true" />
+                  <span className="truncate italic">{NO_PROJECT_LABEL}</span>
+                </button>
               )}
             </div>
           ) : (

--- a/src/dashboard/frontend/src/components/Sidebar.tsx
+++ b/src/dashboard/frontend/src/components/Sidebar.tsx
@@ -4,9 +4,10 @@ import {
   Eye, Home, LayoutGrid, Bot, Server,
   Terminal, BarChart3, DollarSign, HeartPulse, Cpu, Settings,
   Zap, Compass, GitBranch, GitMerge, ChevronsLeft, ChevronsRight, Sun, Moon, Menu,
-  Hammer, Loader2, History, Mic, FileText,
+  Hammer, Loader2, History, Mic, FileText, ChevronDown, ChevronRight, MoreHorizontal,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
+import { fetchProjects } from './CommandDeck/projectsData';
 import { CloisterStatusBar } from './CloisterStatusBar';
 import { FreshnessIndicator } from './FreshnessIndicator';
 import { DeaconPauseToggle } from './DeaconPauseToggle';
@@ -73,18 +74,24 @@ interface NavGroup {
   items: NavItem[];
 }
 
-const NAV_GROUPS: NavGroup[] = [
+// PAN-1561: the primary rail is Home · Flywheel · Projects. Everything else
+// moves into the collapsible "More" section (MORE_GROUPS) below the Projects
+// list — every route stays reachable, no feature is lost.
+const PRIMARY_ITEMS: NavItem[] = [
+  { id: 'home' as Tab, label: 'Home', icon: Home },
+  { id: 'flywheel' as Tab, label: 'Flywheel', icon: Loader2, badge: 'flywheel-live' },
+];
+
+const MORE_GROUPS: NavGroup[] = [
   {
     label: 'Operations',
     items: [
-      { id: 'home' as Tab, label: 'Home', icon: Home },
       { id: 'command-deck' as Tab, label: 'Command Deck', icon: Compass },
       { id: 'kanban' as Tab, label: 'Board', icon: LayoutGrid },
       { id: 'pipeline' as Tab, label: 'Pipeline', icon: GitBranch },
       { id: 'awaiting-merge' as Tab, label: 'Awaiting Merge', icon: GitMerge },
       { id: 'agents' as Tab, label: 'Agents', icon: Bot },
       { id: 'autopreso' as Tab, label: 'AutoPreso', icon: Mic },
-      { id: 'flywheel' as Tab, label: 'Flywheel', icon: Loader2, badge: 'flywheel-live' },
     ],
   },
   {
@@ -114,18 +121,42 @@ const NAV_GROUPS: NavGroup[] = [
   },
 ];
 
+const MORE_COLLAPSED_KEY = 'panopticon.ui.sidebarMoreCollapsed';
+
 interface SidebarProps {
   activeTab: Tab;
   onTabChange: (tab: Tab) => void;
   onSearchOpen: () => void;
+  /** PAN-1561: the project whose deck is open (rail highlight). */
+  selectedProject?: string | null;
+  /** PAN-1561: open a project's deck from the rail. */
+  onSelectProject?: (projectName: string) => void;
 }
 
-export function Sidebar({ activeTab, onTabChange, onSearchOpen }: SidebarProps) {
+export function Sidebar({ activeTab, onTabChange, onSearchOpen, selectedProject = null, onSelectProject }: SidebarProps) {
   const { theme, toggleTheme } = useTheme();
   const [collapsed, setCollapsed] = useState(() => {
     return localStorage.getItem(SIDEBAR_STORAGE_KEY) === 'true';
   });
+  const [moreCollapsed, setMoreCollapsed] = useState(() => {
+    return localStorage.getItem(MORE_COLLAPSED_KEY) === 'true';
+  });
+  const toggleMoreCollapsed = useCallback(() => {
+    setMoreCollapsed((prev) => {
+      const next = !prev;
+      try { localStorage.setItem(MORE_COLLAPSED_KEY, String(next)); } catch { /* ignore */ }
+      return next;
+    });
+  }, []);
   const [mobileOpen, setMobileOpen] = useState(false);
+
+  // PAN-1561: project rail — shares the `command-deck-projects` query with the
+  // CommandDeck so the list is deduped and consistent.
+  const { data: projects = [] } = useQuery({
+    queryKey: ['command-deck-projects'],
+    queryFn: fetchProjects,
+    refetchInterval: 30000,
+  });
 
   const issues = useDashboardStore(selectIssues) as Issue[];
   const agents = useDashboardStore(selectAgents) as unknown as Agent[];
@@ -223,6 +254,35 @@ export function Sidebar({ activeTab, onTabChange, onSearchOpen }: SidebarProps) 
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [toggleCollapsed]);
 
+  const renderNavItem = ({ id, label, icon: Icon, badge, title }: NavItem) => {
+    const isActive = activeTab === id;
+    const liveBadge = badge === 'flywheel-live' && hasActiveFlywheelRun;
+    return (
+      <button
+        key={id}
+        onClick={() => { onTabChange(id); setMobileOpen(false); }}
+        title={title ?? (collapsed ? label : undefined)}
+        data-testid={`sidebar-${id}`}
+        className={`
+          w-full flex items-center gap-3 transition-colors duration-150 text-sm font-medium
+          ${collapsed ? 'justify-center px-0 py-2.5' : 'px-3 py-1.5'}
+          ${isActive
+            ? 'bg-accent text-foreground border-l-2 border-primary'
+            : 'text-muted-foreground hover:bg-accent hover:text-foreground border-l-2 border-transparent'
+          }
+        `}
+      >
+        <Icon className="shrink-0 w-4 h-4" />
+        {!collapsed && <span className="truncate">{label}</span>}
+        {!collapsed && liveBadge && (
+          <span className="ml-auto rounded-full border border-success/30 bg-success/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-success">
+            live
+          </span>
+        )}
+      </button>
+    );
+  };
+
   return (
     <>
       {/* Mobile hamburger button — only visible on small screens */}
@@ -291,46 +351,86 @@ export function Sidebar({ activeTab, onTabChange, onSearchOpen }: SidebarProps) 
           )}
         </div>
 
-        {/* ─── Nav groups ─── */}
+        {/* ─── Nav: Home · Flywheel · Projects · More (PAN-1561) ─── */}
         <nav className="flex-1 overflow-y-auto overflow-x-hidden py-2 scrollbar-hide">
-          {NAV_GROUPS.map((group) => (
-            <div key={group.label} className={collapsed ? 'mb-2' : 'mb-1'}>
-              {!collapsed && (
-                <p className="px-3 text-[10px] font-medium uppercase tracking-widest text-muted-foreground mt-4 mb-1 first:mt-2">
-                  {group.label}
-                </p>
+          {/* Primary rail */}
+          <div className={collapsed ? 'mb-2' : 'mb-1'}>
+            {PRIMARY_ITEMS.map(renderNavItem)}
+          </div>
+
+          {/* ─── Projects ─── */}
+          {!collapsed ? (
+            <div className="mb-1" data-testid="sidebar-projects">
+              <p className="px-3 text-[10px] font-medium uppercase tracking-widest text-muted-foreground mt-4 mb-1">
+                Projects
+              </p>
+              {projects.length === 0 ? (
+                <p className="px-3 py-1.5 text-xs text-muted-foreground/70">No projects</p>
+              ) : (
+                projects.map((project) => {
+                  const isActive = activeTab === 'command-deck' && selectedProject === project.name;
+                  const hasActivity = project.features.length > 0;
+                  return (
+                    <button
+                      key={project.path}
+                      onClick={() => { onSelectProject?.(project.name); setMobileOpen(false); }}
+                      title={project.name}
+                      data-testid={`sidebar-project-${project.name}`}
+                      className={`
+                        w-full flex items-center gap-3 px-3 py-1.5 transition-colors duration-150 text-sm font-medium border-l-2
+                        ${isActive
+                          ? 'bg-accent text-foreground border-primary'
+                          : 'text-muted-foreground hover:bg-accent hover:text-foreground border-transparent'
+                        }
+                      `}
+                    >
+                      <span
+                        className={`h-2 w-2 rounded-full shrink-0 ${hasActivity ? 'bg-primary' : 'bg-muted-foreground/30'}`}
+                        aria-hidden="true"
+                      />
+                      <span className="truncate">{project.name}</span>
+                      {project.features.length > 0 && (
+                        <span className="ml-auto text-[11px] text-muted-foreground">{project.features.length}</span>
+                      )}
+                    </button>
+                  );
+                })
               )}
-              {collapsed && <div className="h-px mx-2 bg-border my-2" />}
-              {group.items.map(({ id, label, icon: Icon, badge, title }) => {
-                const isActive = activeTab === id;
-                const liveBadge = badge === 'flywheel-live' && hasActiveFlywheelRun;
-                return (
-                  <button
-                    key={id}
-                    onClick={() => { onTabChange(id); setMobileOpen(false); }}
-                    title={title ?? (collapsed ? label : undefined)}
-                    data-testid={`sidebar-${id}`}
-                    className={`
-                      w-full flex items-center gap-3 transition-colors duration-150 text-sm font-medium
-                      ${collapsed ? 'justify-center px-0 py-2.5' : 'px-3 py-1.5'}
-                      ${isActive
-                        ? 'bg-accent text-foreground border-l-2 border-primary'
-                        : 'text-muted-foreground hover:bg-accent hover:text-foreground border-l-2 border-transparent'
-                      }
-                    `}
-                  >
-                    <Icon className={`shrink-0 ${collapsed ? 'w-4 h-4' : 'w-4 h-4'}`} />
-                    {!collapsed && <span className="truncate">{label}</span>}
-                    {!collapsed && liveBadge && (
-                      <span className="ml-auto rounded-full border border-success/30 bg-success/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-success">
-                        live
-                      </span>
-                    )}
-                  </button>
-                );
-              })}
             </div>
-          ))}
+          ) : (
+            <div className="h-px mx-2 bg-border my-2" />
+          )}
+
+          {/* ─── More (collapsible) — every other view (PAN-1561) ─── */}
+          {!collapsed ? (
+            <div className="mb-1" data-testid="sidebar-more">
+              <button
+                type="button"
+                onClick={toggleMoreCollapsed}
+                aria-expanded={!moreCollapsed}
+                className="w-full flex items-center gap-1.5 px-3 text-[10px] font-medium uppercase tracking-widest text-muted-foreground mt-4 mb-1 hover:text-foreground transition-colors"
+              >
+                {moreCollapsed ? <ChevronRight className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+                <MoreHorizontal className="w-3 h-3" />
+                More
+              </button>
+              {!moreCollapsed && MORE_GROUPS.map((group) => (
+                <div key={group.label} className="mb-1">
+                  <p className="px-3 text-[10px] font-medium uppercase tracking-widest text-muted-foreground/70 mt-3 mb-1">
+                    {group.label}
+                  </p>
+                  {group.items.map(renderNavItem)}
+                </div>
+              ))}
+            </div>
+          ) : (
+            MORE_GROUPS.map((group) => (
+              <div key={group.label} className="mb-2">
+                <div className="h-px mx-2 bg-border my-2" />
+                {group.items.map(renderNavItem)}
+              </div>
+            ))
+          )}
 
           {/* ─── Pipeline filter groups ─── */}
           {!collapsed && activeTab === 'pipeline' && (

--- a/src/dashboard/frontend/src/components/Stage/HomePane/ActionDock.tsx
+++ b/src/dashboard/frontend/src/components/Stage/HomePane/ActionDock.tsx
@@ -6,52 +6,78 @@ import styles from '../stage.module.css'
 export interface ActionDockProps {
   /** Open (or focus) a pane of the given type. */
   onOpen: (paneType: PaneType) => void
+  /**
+   * Which actions to surface. Defaults to the full set. The project Home passes
+   * a project-appropriate subset (terminal + web), since Files/Commits/Plan/Docs
+   * are issue-scoped (PAN-1561).
+   */
+  actions?: PaneType[]
 }
+
+const DEFAULT_ACTIONS: PaneType[] = ['terminal', 'files', 'browser', 'commits', 'plan', 'docs']
 
 /**
  * ActionDock — the HomePane tool row (PAN-1549). Terminal, Files, Web, and
  * Commits buttons open their panes directly; a "+ Actions" overflow exposes
- * Plan and Docs. The Web button opens an (empty) browser pane.
+ * Plan and Docs. The Web button opens an (empty) browser pane. The `actions`
+ * prop limits which buttons appear so issue-scoped actions don't show on the
+ * project Home (PAN-1561).
  */
-export function ActionDock({ onOpen }: ActionDockProps) {
+export function ActionDock({ onOpen, actions = DEFAULT_ACTIONS }: ActionDockProps) {
   const [overflowOpen, setOverflowOpen] = useState(false)
+  const has = (a: PaneType) => actions.includes(a)
+  const hasOverflow = has('plan') || has('docs')
   return (
     <div className={`${styles.dock} ${styles.actionDock}`} role="group" aria-label="Actions">
-      <button type="button" className={`${styles.pill} ${styles.pillTool}`} onClick={() => onOpen('terminal')}>
-        <Terminal size={14} />
-        Terminal
-      </button>
-      <button type="button" className={`${styles.pill} ${styles.pillTool}`} onClick={() => onOpen('files')}>
-        <FileCode size={14} />
-        Files
-      </button>
-      <button type="button" className={`${styles.pill} ${styles.pillTool}`} onClick={() => onOpen('browser')}>
-        <Globe size={14} />
-        Web
-      </button>
-      <button type="button" className={`${styles.pill} ${styles.pillTool}`} onClick={() => onOpen('commits')}>
-        <GitCommit size={14} />
-        Commits
-      </button>
-      <button
-        type="button"
-        className={`${styles.pill} ${styles.pillGhost}`}
-        aria-expanded={overflowOpen}
-        onClick={() => setOverflowOpen((v) => !v)}
-      >
-        <Plus size={13} />
-        Actions
-      </button>
-      {overflowOpen && (
+      {has('terminal') && (
+        <button type="button" className={`${styles.pill} ${styles.pillTool}`} onClick={() => onOpen('terminal')}>
+          <Terminal size={14} />
+          Terminal
+        </button>
+      )}
+      {has('files') && (
+        <button type="button" className={`${styles.pill} ${styles.pillTool}`} onClick={() => onOpen('files')}>
+          <FileCode size={14} />
+          Files
+        </button>
+      )}
+      {has('browser') && (
+        <button type="button" className={`${styles.pill} ${styles.pillTool}`} onClick={() => onOpen('browser')}>
+          <Globe size={14} />
+          Web
+        </button>
+      )}
+      {has('commits') && (
+        <button type="button" className={`${styles.pill} ${styles.pillTool}`} onClick={() => onOpen('commits')}>
+          <GitCommit size={14} />
+          Commits
+        </button>
+      )}
+      {hasOverflow && (
+        <button
+          type="button"
+          className={`${styles.pill} ${styles.pillGhost}`}
+          aria-expanded={overflowOpen}
+          onClick={() => setOverflowOpen((v) => !v)}
+        >
+          <Plus size={13} />
+          Actions
+        </button>
+      )}
+      {hasOverflow && overflowOpen && (
         <div className={styles.actionOverflow} role="menu">
-          <button type="button" role="menuitem" className={styles.actionOverflowItem} onClick={() => onOpen('plan')}>
-            <ListTodo size={14} />
-            Plan
-          </button>
-          <button type="button" role="menuitem" className={styles.actionOverflowItem} onClick={() => onOpen('docs')}>
-            <FileText size={14} />
-            Docs
-          </button>
+          {has('plan') && (
+            <button type="button" role="menuitem" className={styles.actionOverflowItem} onClick={() => onOpen('plan')}>
+              <ListTodo size={14} />
+              Plan
+            </button>
+          )}
+          {has('docs') && (
+            <button type="button" role="menuitem" className={styles.actionOverflowItem} onClick={() => onOpen('docs')}>
+              <FileText size={14} />
+              Docs
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/src/dashboard/frontend/src/components/Stage/HomePane/AgentDock.tsx
+++ b/src/dashboard/frontend/src/components/Stage/HomePane/AgentDock.tsx
@@ -1,4 +1,5 @@
-import { Bot, Plus } from 'lucide-react'
+import { Plus } from 'lucide-react'
+import { AgentIcon } from './AgentIcon'
 import styles from '../stage.module.css'
 
 export interface AgentPill {
@@ -37,7 +38,7 @@ export function AgentDock({ agents = DEFAULT_AGENT_PILLS, onSelectAgent, onMore 
           className={styles.pill}
           onClick={() => onSelectAgent(a.id)}
         >
-          <Bot size={14} />
+          <AgentIcon id={a.id} label={a.label} size={14} />
           {a.label}
         </button>
       ))}

--- a/src/dashboard/frontend/src/components/Stage/HomePane/AgentIcon.tsx
+++ b/src/dashboard/frontend/src/components/Stage/HomePane/AgentIcon.tsx
@@ -1,0 +1,35 @@
+import { Bot } from 'lucide-react'
+import { ProviderIcon } from '../../chat/ProviderIcons'
+import styles from '../stage.module.css'
+
+export interface AgentIconProps {
+  /** Agent/harness id, e.g. 'claude-code', 'codex'. */
+  id: string
+  /** Display label, used only for the provider letter-badge fallback. */
+  label?: string
+  size?: number
+}
+
+/** Map a harness/agent id to a model-picker provider key. */
+function providerForAgent(id: string): string | null {
+  const key = id.toLowerCase()
+  if (key.includes('claude') || key.includes('anthropic')) return 'anthropic'
+  if (key.includes('codex') || key.includes('openai') || key.includes('gpt')) return 'openai'
+  return null
+}
+
+/**
+ * AgentIcon — brand mark for an agent pill (PAN-1561). Reuses the model/harness
+ * selector's `ProviderIcon`, so Claude Code / Codex render with the same
+ * full-color official logos (Anthropic, OpenAI) used everywhere else. Falls back
+ * to the generic lucide Bot glyph for agents without a provider mapping.
+ */
+export function AgentIcon({ id, label, size = 14 }: AgentIconProps) {
+  const provider = providerForAgent(id)
+  if (!provider) return <Bot size={size} />
+  return (
+    <span className={styles.agentLogo} style={{ width: size, height: size }}>
+      <ProviderIcon provider={provider} label={label ?? id} className={styles.agentLogoSvg} />
+    </span>
+  )
+}

--- a/src/dashboard/frontend/src/components/Stage/HomePane/Launcher.tsx
+++ b/src/dashboard/frontend/src/components/Stage/HomePane/Launcher.tsx
@@ -1,5 +1,6 @@
 import { useState, type ReactNode, type KeyboardEvent } from 'react'
-import { Bot, Terminal, Globe } from 'lucide-react'
+import { Terminal, Globe } from 'lucide-react'
+import { AgentIcon } from './AgentIcon'
 import { orderIntents } from './launcherOrdering'
 import styles from '../stage.module.css'
 
@@ -37,8 +38,9 @@ export function intentLabel(intent: LauncherIntent): string {
   }
 }
 
-function IntentIcon({ kind }: { kind: LauncherIntentKind }) {
-  const Icon = kind === 'terminal' ? Terminal : kind === 'web' ? Globe : Bot
+function IntentIcon({ kind, id, label }: { kind: LauncherIntentKind; id: string; label?: string }) {
+  if (kind === 'agent') return <AgentIcon id={id} label={label} size={14} />
+  const Icon = kind === 'terminal' ? Terminal : Globe
   return <Icon size={14} />
 }
 
@@ -145,7 +147,7 @@ export function Launcher({
               }}
             >
               <span className={styles.gicon}>
-                <IntentIcon kind={intent.kind} />
+                <IntentIcon kind={intent.kind} id={intent.id} label={intent.agentName} />
               </span>
               <span className={styles.ddLab}>
                 <b>{intentLabel(intent)}</b> {query}

--- a/src/dashboard/frontend/src/components/Stage/HomePane/WorkspaceHeader.tsx
+++ b/src/dashboard/frontend/src/components/Stage/HomePane/WorkspaceHeader.tsx
@@ -10,19 +10,36 @@ export interface WorkspaceHeaderProps {
   iconLabel?: string
   /** Renders the "↗ set parent" link when provided. */
   onSetParent?: () => void
+  /**
+   * 'issue' (default) → icon tile + name + feature branch (PAN-1549 style).
+   * 'project' (PAN-1561) → `# <project>` heading with no icon tile, branch is
+   * the project's working branch (e.g. `main`).
+   */
+  variant?: 'issue' | 'project'
 }
 
 /**
  * WorkspaceHeader — the HomePane header region (PAN-1549). Absorbs the Zone A
  * issue-header role: icon tile, name, branch line, and an optional set-parent
- * link. Pure presentation; data is supplied by the Stage mount point.
+ * link. PAN-1561 adds a project `variant` that renders `# <project>` + `main`
+ * for the project-scoped Home tab. Pure presentation; data is supplied by the
+ * Stage mount point.
  */
-export function WorkspaceHeader({ name, branch, iconLabel, onSetParent }: WorkspaceHeaderProps) {
+export function WorkspaceHeader({ name, branch, iconLabel, onSetParent, variant = 'issue' }: WorkspaceHeaderProps) {
+  const isProject = variant === 'project'
   return (
     <div className={styles.wsHead}>
       <div className={styles.wsTitle}>
-        {iconLabel && <span className={styles.wsIcon}>{iconLabel}</span>}
-        <h3 className={styles.wsName}>{name}</h3>
+        {isProject ? (
+          <h3 className={styles.wsName}>
+            <span className={styles.wsHash}>#</span> {name}
+          </h3>
+        ) : (
+          <>
+            {iconLabel && <span className={styles.wsIcon}>{iconLabel}</span>}
+            <h3 className={styles.wsName}>{name}</h3>
+          </>
+        )}
       </div>
       <div className={styles.wsBranch}>
         {branch && (

--- a/src/dashboard/frontend/src/components/Stage/IssueOverview.tsx
+++ b/src/dashboard/frontend/src/components/Stage/IssueOverview.tsx
@@ -1,0 +1,119 @@
+import { useMemo } from 'react'
+import type { Conversation } from '../CommandDeck/ConversationList'
+import { HomePane } from './HomePane'
+import { WorkspaceHeader } from './HomePane/WorkspaceHeader'
+import { StatChips } from './HomePane/StatChips'
+import { Launcher } from './HomePane/Launcher'
+import { AgentDock } from './HomePane/AgentDock'
+import { ActionDock } from './HomePane/ActionDock'
+import { Timeline } from './HomePane/Timeline'
+import { HomePaneSections } from './HomePane/HomePaneSections'
+import { dispatchLauncherIntent } from './HomePane/launcherActions'
+import { readLastUsedAgent, writeLastUsedAgent } from './HomePane/launcherOrdering'
+import type { TimelineConversation } from './HomePane/timeline-utils'
+import type { StageApi } from './types'
+
+export interface IssueOverviewProps {
+  issueId: string
+  /** Issue title for the header (falls back to the id). */
+  title: string
+  /** Feature branch; defaults to feature/<issueId>. */
+  branch?: string
+  /** Issue creation time for the age stat chip. */
+  createdAt?: number | string
+  /** The issue's agent id — used as the workspace terminal session. */
+  agentId?: string
+  /** All conversations; filtered to this issue. */
+  conversations?: Conversation[]
+  /** Create a conversation for this issue, returning the new conversation's
+   * name so the deck can open an agent tab on it. */
+  onCreateConversation?: (agentId: string) => Promise<string | undefined>
+  api: StageApi
+}
+
+/**
+ * IssueOverview — the body of an `issue` tab in a project-scoped deck
+ * (PAN-1561). This is the issue-scoped launch composition that used to be the
+ * Stage's HOME pane (PAN-1549): issue header (icon + name + feature/<id>),
+ * issue stats, launcher, agent/action docks, the issue's conversation timeline,
+ * and the collapsible detail sections. Reuses the launch components verbatim —
+ * only its scope (one issue) differs from ProjectHome.
+ */
+export function IssueOverview({
+  issueId,
+  title,
+  branch,
+  createdAt,
+  agentId,
+  conversations = [],
+  onCreateConversation,
+  api,
+}: IssueOverviewProps) {
+  const issueConversations = useMemo(
+    () =>
+      conversations.filter((c) => (c.issueId ?? '').toUpperCase() === issueId.toUpperCase()),
+    [conversations, issueId],
+  )
+  const timelineConversations: TimelineConversation[] = useMemo(
+    () =>
+      issueConversations.map((c) => ({
+        id: c.name,
+        agentLabel: c.title ?? c.model ?? 'Agent',
+        timestamp: c.lastAttachedAt ?? c.createdAt,
+        preview: c.title ?? undefined,
+      })),
+    [issueConversations],
+  )
+
+  const onAgentSelected = async (id: string) => {
+    writeLastUsedAgent(issueId, id)
+    const conversationName = await onCreateConversation?.(id)
+    if (conversationName) api.openOrFocusAgentPane(conversationName, 'Agent')
+  }
+  const openTerminal = () => api.openTypedPane('terminal', { terminalId: agentId ?? null })
+
+  return (
+    <HomePane
+      workspaceId={api.deckKey}
+      openPane={api.openPane}
+      header={
+        <>
+          <WorkspaceHeader
+            name={title}
+            branch={branch ?? `feature/${issueId.toLowerCase()}`}
+            iconLabel={title.charAt(0).toUpperCase()}
+          />
+          <StatChips createdAt={createdAt} conversationCount={issueConversations.length} />
+        </>
+      }
+      launcher={
+        <Launcher
+          lastUsedAgentId={readLastUsedAgent(issueId)}
+          onSelect={(intent, query) =>
+            dispatchLauncherIntent(intent, query, {
+              openAgent: (i) => onAgentSelected(i.id),
+              openTerminal,
+              openWeb: (_q, url) =>
+                api.openPane({ paneType: 'browser', label: 'Web', browserInitialUrl: url }),
+              onAgentRun: (id) => writeLastUsedAgent(issueId, id),
+            })
+          }
+        />
+      }
+      agentDock={<AgentDock onSelectAgent={onAgentSelected} />}
+      actionDock={
+        <ActionDock onOpen={(t) => (t === 'terminal' ? openTerminal() : api.openTypedPane(t))} />
+      }
+      timeline={
+        <Timeline
+          conversations={timelineConversations}
+          onOpen={(id) => {
+            const conv = issueConversations.find((c) => c.name === id)
+            api.openOrFocusAgentPane(id, conv?.title ?? 'Agent')
+          }}
+        />
+      }
+      detail={<HomePaneSections issueId={issueId} />}
+    />
+  )
+}

--- a/src/dashboard/frontend/src/components/Stage/IssueOverview.tsx
+++ b/src/dashboard/frontend/src/components/Stage/IssueOverview.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import type { PaneType } from '../../lib/panesStore'
 import type { Conversation } from '../CommandDeck/ConversationList'
 import { HomePane } from './HomePane'
 import { WorkspaceHeader } from './HomePane/WorkspaceHeader'
@@ -21,7 +22,7 @@ export interface IssueOverviewProps {
   branch?: string
   /** Issue creation time for the age stat chip. */
   createdAt?: number | string
-  /** The issue's agent id — used as the workspace terminal session. */
+  /** The issue's agent id — scopes Files/Commits panes to this issue's workspace. */
   agentId?: string
   /** All conversations; filtered to this issue. */
   conversations?: Conversation[]
@@ -70,7 +71,19 @@ export function IssueOverview({
     const conversationName = await onCreateConversation?.(id)
     if (conversationName) api.openOrFocusAgentPane(conversationName, 'Agent')
   }
-  const openTerminal = () => api.openTypedPane('terminal', { terminalId: agentId ?? null })
+  // PAN-1561: terminal actions open the drawer stacked below, not a tab.
+  const openTerminal = () => api.toggleTerminal()
+
+  // Issue-scoped action panes carry this issue's id (and agent for Files) so
+  // they query the right workspace, not the project deck key.
+  const ISSUE_PANE_LABELS: Partial<Record<PaneType, string>> = {
+    files: 'Files', commits: 'Commits', plan: 'Plan', docs: 'Docs',
+  }
+  const onAction = (t: PaneType) => {
+    if (t === 'terminal') return api.toggleTerminal()
+    if (t === 'browser') return api.openPane({ paneType: 'browser', label: 'Web' })
+    api.openPane({ paneType: t, label: ISSUE_PANE_LABELS[t] ?? 'Pane', issueId, agentId })
+  }
 
   return (
     <HomePane
@@ -101,9 +114,7 @@ export function IssueOverview({
         />
       }
       agentDock={<AgentDock onSelectAgent={onAgentSelected} />}
-      actionDock={
-        <ActionDock onOpen={(t) => (t === 'terminal' ? openTerminal() : api.openTypedPane(t))} />
-      }
+      actionDock={<ActionDock onOpen={onAction} />}
       timeline={
         <Timeline
           conversations={timelineConversations}

--- a/src/dashboard/frontend/src/components/Stage/PaneBar.tsx
+++ b/src/dashboard/frontend/src/components/Stage/PaneBar.tsx
@@ -1,10 +1,11 @@
 import { memo } from 'react'
-import { Home, Bot, Terminal, FileCode, GitCommit, ListTodo, FileText, Globe, Plus, X } from 'lucide-react'
+import { Home, CircleDot, Bot, Terminal, FileCode, GitCommit, ListTodo, FileText, Globe, Plus, X } from 'lucide-react'
 import type { PaneType, WorkspacePane, PaneId } from '../../lib/panesStore'
 import styles from './stage.module.css'
 
 const PANE_ICONS: Record<PaneType, typeof Home> = {
   home: Home,
+  issue: CircleDot,
   agent: Bot,
   terminal: Terminal,
   files: FileCode,

--- a/src/dashboard/frontend/src/components/Stage/PaneBar.tsx
+++ b/src/dashboard/frontend/src/components/Stage/PaneBar.tsx
@@ -1,7 +1,15 @@
-import { memo } from 'react'
-import { Home, CircleDot, Bot, Terminal, FileCode, GitCommit, ListTodo, FileText, Globe, Plus, X } from 'lucide-react'
+import { memo, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { Home, CircleDot, Bot, Terminal, FileCode, GitCommit, ListTodo, FileText, Globe, Plus, X, type LucideIcon } from 'lucide-react'
 import type { PaneType, WorkspacePane, PaneId } from '../../lib/panesStore'
 import styles from './stage.module.css'
+
+export interface NewPaneAction {
+  key: string
+  label: string
+  icon: LucideIcon
+  onSelect: () => void
+}
 
 const PANE_ICONS: Record<PaneType, typeof Home> = {
   home: Home,
@@ -20,7 +28,10 @@ export interface PaneBarProps {
   activePaneId: PaneId | null
   onSelect: (paneId: PaneId) => void
   onClose: (paneId: PaneId) => void
+  /** Fallback when no `newActions` menu is provided (e.g. ⌘T). */
   onAdd: () => void
+  /** When provided, the "+" opens a menu of these create actions (PAN-1561). */
+  newActions?: NewPaneAction[]
 }
 
 /**
@@ -29,7 +40,37 @@ export interface PaneBarProps {
  * ⌘N hint for the first nine panes, and exposes close (×, non-HOME only) and
  * add (+) affordances via callbacks.
  */
-export const PaneBar = memo(function PaneBar({ panes, activePaneId, onSelect, onClose, onAdd }: PaneBarProps) {
+export const PaneBar = memo(function PaneBar({ panes, activePaneId, onSelect, onClose, onAdd, newActions }: PaneBarProps) {
+  const [menuPos, setMenuPos] = useState<{ top: number; left: number } | null>(null)
+  const addBtnRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const menuOpen = menuPos !== null
+
+  const openMenu = () => {
+    const r = addBtnRef.current?.getBoundingClientRect()
+    if (r) setMenuPos({ top: r.bottom + 2, left: r.left })
+  }
+  // Close on outside click, scroll, or resize — the menu is portaled to <body>
+  // so it escapes the PaneBar's overflow clip; reposition isn't tracked, so we
+  // just dismiss on layout changes.
+  useEffect(() => {
+    if (!menuOpen) return
+    const onDoc = (e: MouseEvent) => {
+      const t = e.target as Node
+      if (addBtnRef.current?.contains(t) || menuRef.current?.contains(t)) return
+      setMenuPos(null)
+    }
+    const dismiss = () => setMenuPos(null)
+    document.addEventListener('mousedown', onDoc)
+    window.addEventListener('resize', dismiss)
+    window.addEventListener('scroll', dismiss, true)
+    return () => {
+      document.removeEventListener('mousedown', onDoc)
+      window.removeEventListener('resize', dismiss)
+      window.removeEventListener('scroll', dismiss, true)
+    }
+  }, [menuOpen])
+
   return (
     <div className={styles.panebar} role="tablist" aria-label="Workspace panes">
       {panes.map((pane, index) => {
@@ -74,9 +115,51 @@ export const PaneBar = memo(function PaneBar({ panes, activePaneId, onSelect, on
           </div>
         )
       })}
-      <button type="button" className={styles.add} aria-label="Open new pane" onClick={onAdd}>
-        <Plus size={18} />
-      </button>
+      {newActions && newActions.length > 0 ? (
+        <button
+          ref={addBtnRef}
+          type="button"
+          className={styles.add}
+          aria-label="Open new tab"
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+          onClick={() => (menuOpen ? setMenuPos(null) : openMenu())}
+        >
+          <Plus size={18} />
+        </button>
+      ) : (
+        <button type="button" className={styles.add} aria-label="Open new pane" onClick={onAdd}>
+          <Plus size={18} />
+        </button>
+      )}
+
+      {/* Portaled to <body> so the PaneBar's overflow-x clip can't hide it. */}
+      {menuOpen && menuPos && newActions &&
+        createPortal(
+          <div
+            ref={menuRef}
+            className={styles.addMenu}
+            role="menu"
+            style={{ position: 'fixed', top: menuPos.top, left: menuPos.left }}
+          >
+            {newActions.map((a) => {
+              const ActionIcon = a.icon
+              return (
+                <button
+                  key={a.key}
+                  type="button"
+                  role="menuitem"
+                  className={styles.addMenuItem}
+                  onClick={() => { setMenuPos(null); a.onSelect() }}
+                >
+                  <ActionIcon size={14} />
+                  {a.label}
+                </button>
+              )
+            })}
+          </div>,
+          document.body,
+        )}
     </div>
   )
 })

--- a/src/dashboard/frontend/src/components/Stage/ProjectHome.tsx
+++ b/src/dashboard/frontend/src/components/Stage/ProjectHome.tsx
@@ -1,0 +1,97 @@
+import { useMemo } from 'react'
+import type { Conversation } from '../CommandDeck/ConversationList'
+import { HomePane } from './HomePane'
+import { WorkspaceHeader } from './HomePane/WorkspaceHeader'
+import { StatChips } from './HomePane/StatChips'
+import { Launcher } from './HomePane/Launcher'
+import { AgentDock } from './HomePane/AgentDock'
+import { ActionDock } from './HomePane/ActionDock'
+import { Timeline } from './HomePane/Timeline'
+import { dispatchLauncherIntent } from './HomePane/launcherActions'
+import { readLastUsedAgent, writeLastUsedAgent } from './HomePane/launcherOrdering'
+import type { TimelineConversation } from './HomePane/timeline-utils'
+import type { StageApi } from './types'
+
+export interface ProjectHomeProps {
+  /** Project key/name shown as `# <projectName>`. */
+  projectName: string
+  /** Project working branch; defaults to `main`. */
+  branch?: string
+  /** Conversations already scoped to this project. */
+  conversations?: Conversation[]
+  /** Create a conversation for this project, returning the new conversation's
+   * name so the deck can open an agent tab on it. */
+  onCreateConversation?: (agentId: string) => Promise<string | undefined>
+  api: StageApi
+}
+
+/**
+ * ProjectHome — the permanent HOME tab of a project-scoped deck (PAN-1561).
+ * Reuses the PAN-1549 launch composition (Launcher, AgentDock, ActionDock,
+ * Timeline, StatChips) verbatim; only the header (`# <project>` + `main`, via
+ * WorkspaceHeader variant="project") and the data scope (the whole project, not
+ * one issue) differ. Project diff/age stats are not available, so StatChips
+ * degrades to neutral values and shows only the real conversation count.
+ */
+export function ProjectHome({
+  projectName,
+  branch = 'main',
+  conversations = [],
+  onCreateConversation,
+  api,
+}: ProjectHomeProps) {
+  const timelineConversations: TimelineConversation[] = useMemo(
+    () =>
+      conversations.map((c) => ({
+        id: c.name,
+        agentLabel: c.title ?? c.model ?? 'Agent',
+        timestamp: c.lastAttachedAt ?? c.createdAt,
+        preview: c.title ?? undefined,
+      })),
+    [conversations],
+  )
+
+  const onAgentSelected = async (id: string) => {
+    writeLastUsedAgent(api.deckKey, id)
+    const conversationName = await onCreateConversation?.(id)
+    if (conversationName) api.openOrFocusAgentPane(conversationName, 'Agent')
+  }
+
+  return (
+    <HomePane
+      workspaceId={api.deckKey}
+      openPane={api.openPane}
+      header={
+        <>
+          <WorkspaceHeader variant="project" name={projectName} branch={branch} />
+          <StatChips conversationCount={conversations.length} />
+        </>
+      }
+      launcher={
+        <Launcher
+          lastUsedAgentId={readLastUsedAgent(api.deckKey)}
+          onSelect={(intent, query) =>
+            dispatchLauncherIntent(intent, query, {
+              openAgent: (i) => onAgentSelected(i.id),
+              openTerminal: () => api.openTypedPane('terminal'),
+              openWeb: (_q, url) =>
+                api.openPane({ paneType: 'browser', label: 'Web', browserInitialUrl: url }),
+              onAgentRun: (id) => writeLastUsedAgent(api.deckKey, id),
+            })
+          }
+        />
+      }
+      agentDock={<AgentDock onSelectAgent={onAgentSelected} />}
+      actionDock={<ActionDock onOpen={(t) => api.openTypedPane(t)} />}
+      timeline={
+        <Timeline
+          conversations={timelineConversations}
+          onOpen={(id) => {
+            const conv = conversations.find((c) => c.name === id)
+            api.openOrFocusAgentPane(id, conv?.title ?? 'Agent')
+          }}
+        />
+      }
+    />
+  )
+}

--- a/src/dashboard/frontend/src/components/Stage/ProjectHome.tsx
+++ b/src/dashboard/frontend/src/components/Stage/ProjectHome.tsx
@@ -82,7 +82,18 @@ export function ProjectHome({
         />
       }
       agentDock={<AgentDock onSelectAgent={onAgentSelected} />}
-      actionDock={<ActionDock onOpen={(t) => api.openTypedPane(t)} />}
+      actionDock={
+        // Project scope: only project-appropriate actions. Files/Commits/Plan/
+        // Docs are issue-scoped and live on issue tabs (PAN-1561).
+        <ActionDock
+          actions={['terminal', 'browser']}
+          onOpen={(t) =>
+            t === 'terminal'
+              ? api.toggleTerminal()
+              : api.openPane({ paneType: 'browser', label: 'Web' })
+          }
+        />
+      }
       timeline={
         <Timeline
           conversations={timelineConversations}

--- a/src/dashboard/frontend/src/components/Stage/Stage.test.tsx
+++ b/src/dashboard/frontend/src/components/Stage/Stage.test.tsx
@@ -4,11 +4,18 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactElement } from 'react'
 import { Stage, type StageApi } from './index'
 import { usePanesStore } from '../../lib/panesStore'
+import { useTerminalStateStore } from '../terminal/terminalStateStore'
 
 // AgentPane pulls in ConversationPanel (heavy, needs many providers); stub it so
 // this test stays focused on the Stage's pane open/switch mechanics.
 vi.mock('./panes/AgentPane', () => ({
   AgentPane: () => <div data-testid="agent-pane" />,
+}))
+
+// TerminalDrawer mounts XTerminal + fetches /api/terminals; stub it so this test
+// stays focused on the Stage's pane/drawer toggle mechanics (PAN-1561).
+vi.mock('../terminal/TerminalDrawer', () => ({
+  TerminalDrawer: () => <div data-testid="terminal-drawer" />,
 }))
 
 const DECK = 'panopticon'
@@ -37,6 +44,7 @@ function renderStage(ui: ReactElement) {
 beforeEach(() => {
   localStorage.clear()
   usePanesStore.setState({ panesByWorkspace: {}, activePaneByWorkspace: {} })
+  useTerminalStateStore.setState({ terminalStateByThreadId: {} })
 })
 
 describe('Stage', () => {
@@ -66,27 +74,37 @@ describe('Stage', () => {
     expect(screen.getByTestId('issue-overview')).toHaveTextContent('PAN-42')
   })
 
-  it('switching the active pane swaps the rendered body', () => {
+  it('switching the active pane swaps the rendered body', async () => {
     const { container } = renderStage(<Stage deckKey={DECK} renderHome={renderHome} renderIssue={renderIssue} />)
 
-    // Open a second pane via the + button → terminal becomes active. The new
-    // terminal pane has no session, so TerminalPane shows its empty state.
-    fireEvent.click(screen.getByLabelText('Open new pane'))
-    expect(screen.getByText(/no terminal session/i)).toBeTruthy()
+    // Open an agent pane via the StageApi → it becomes the active tab.
+    fireEvent.click(screen.getByRole('button', { name: /open agent/ }))
+    await screen.findByTestId('agent-pane')
     expect(screen.getAllByRole('tab')).toHaveLength(2)
 
     // Switch back to HOME — the project home body renders again.
     const homeTab = screen.getAllByRole('tab')[0]
     fireEvent.click(homeTab)
     expect(homeTab).toHaveAttribute('aria-selected', 'true')
-    expect(screen.queryByText(/no terminal session/i)).toBeNull()
+    expect(screen.queryByTestId('agent-pane')).toBeNull()
     expect(container.querySelector('[data-section="header"]')).not.toBeNull()
   })
 
   it('opens (and focuses) an agent pane via the StageApi', async () => {
     renderStage(<Stage deckKey={DECK} renderHome={renderHome} renderIssue={renderIssue} />)
     fireEvent.click(screen.getByRole('button', { name: /open agent/ }))
-    await screen.findByRole('tab', { name: /Agent/ })
+    // The agent tab's label is derived from the live conversation (untitled →
+    // "Chat <id>"); assert the pane body + tab count rather than a static label.
+    await screen.findByTestId('agent-pane')
     expect(screen.getAllByRole('tab')).toHaveLength(2)
+  })
+
+  it('the + menu offers New terminal which opens the drawer (PAN-1561)', () => {
+    renderStage(<Stage deckKey={DECK} renderHome={renderHome} renderIssue={renderIssue} />)
+    expect(screen.queryByTestId('terminal-drawer')).toBeNull()
+    // "+" opens a menu of what to create, rather than guessing.
+    fireEvent.click(screen.getByLabelText('Open new tab'))
+    fireEvent.click(screen.getByRole('menuitem', { name: /New terminal/ }))
+    expect(screen.getByTestId('terminal-drawer')).toBeTruthy()
   })
 })

--- a/src/dashboard/frontend/src/components/Stage/Stage.test.tsx
+++ b/src/dashboard/frontend/src/components/Stage/Stage.test.tsx
@@ -2,16 +2,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactElement } from 'react'
-import { Stage } from './index'
+import { Stage, type StageApi } from './index'
 import { usePanesStore } from '../../lib/panesStore'
-import type { Conversation } from '../CommandDeck/ConversationList'
-
-// The re-homed tab bodies (OverviewTab etc.) require DialogProvider + live
-// data; HomePaneSections has its own test, so stub it here to keep this test
-// focused on the Stage's pane mechanics.
-vi.mock('./HomePane/HomePaneSections', () => ({
-  HomePaneSections: () => <div data-testid="home-sections" />,
-}))
 
 // AgentPane pulls in ConversationPanel (heavy, needs many providers); stub it so
 // this test stays focused on the Stage's pane open/switch mechanics.
@@ -19,10 +11,24 @@ vi.mock('./panes/AgentPane', () => ({
   AgentPane: () => <div data-testid="agent-pane" />,
 }))
 
-const WS = 'PAN-1549'
+const DECK = 'panopticon'
 
-// The composed HOME pane renders re-homed tab bodies (HomePaneSections) that
-// use react-query, so the Stage must render inside a QueryClientProvider.
+// PAN-1561: the Stage is project-scoped and composes HOME / issue tabs via
+// render props. These stubs keep the test focused on pane mechanics; a HOME
+// that can open an agent tab exercises the StageApi.
+function renderHome(api: StageApi) {
+  return (
+    <div data-section="header" data-testid="project-home">
+      <button type="button" onClick={() => api.openOrFocusAgentPane('conv-new', 'Agent')}>
+        open agent
+      </button>
+    </div>
+  )
+}
+function renderIssue(issueId: string) {
+  return <div data-testid="issue-overview">{issueId}</div>
+}
+
 function renderStage(ui: ReactElement) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>)
@@ -34,28 +40,34 @@ beforeEach(() => {
 })
 
 describe('Stage', () => {
-  it('auto-creates HOME and renders it active for a fresh workspace', () => {
-    renderStage(<Stage workspaceId={WS} />)
-    // HOME tab present and selected.
+  it('auto-creates HOME and renders it active for a fresh deck', () => {
+    renderStage(<Stage deckKey={DECK} renderHome={renderHome} renderIssue={renderIssue} />)
     const tabs = screen.getAllByRole('tab')
     expect(tabs).toHaveLength(1)
     expect(tabs[0]).toHaveTextContent('Home')
     expect(tabs[0]).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByTestId('project-home')).toBeTruthy()
   })
 
   it('renders a safe placeholder for an unknown pane type (defensive default)', () => {
-    usePanesStore.getState().ensureHome(WS)
-    // Inject a paneType outside the union (e.g. corrupt persisted state).
-    usePanesStore.getState().addPane(WS, { paneType: 'bogus' as never, label: 'Bogus' })
-    const { container } = renderStage(<Stage workspaceId={WS} />)
+    usePanesStore.getState().ensureHome(DECK)
+    usePanesStore.getState().addPane(DECK, { paneType: 'bogus' as never, label: 'Bogus' })
+    const { container } = renderStage(<Stage deckKey={DECK} renderHome={renderHome} renderIssue={renderIssue} />)
     const body = container.querySelector('[data-pane-type]')
     expect(body).not.toBeNull()
     expect(body).toHaveAttribute('data-pane-type', 'bogus')
     expect(screen.getByText(/not implemented yet/i)).toBeTruthy()
   })
 
+  it('renders an issue tab body via renderIssue', () => {
+    usePanesStore.getState().ensureHome(DECK)
+    usePanesStore.getState().addPane(DECK, { paneType: 'issue', label: 'PAN-42', issueId: 'PAN-42' })
+    renderStage(<Stage deckKey={DECK} renderHome={renderHome} renderIssue={renderIssue} />)
+    expect(screen.getByTestId('issue-overview')).toHaveTextContent('PAN-42')
+  })
+
   it('switching the active pane swaps the rendered body', () => {
-    const { container } = renderStage(<Stage workspaceId={WS} />)
+    const { container } = renderStage(<Stage deckKey={DECK} renderHome={renderHome} renderIssue={renderIssue} />)
 
     // Open a second pane via the + button → terminal becomes active. The new
     // terminal pane has no session, so TerminalPane shows its empty state.
@@ -63,7 +75,7 @@ describe('Stage', () => {
     expect(screen.getByText(/no terminal session/i)).toBeTruthy()
     expect(screen.getAllByRole('tab')).toHaveLength(2)
 
-    // Switch back to HOME — rendered body changes to the HomePane scaffold.
+    // Switch back to HOME — the project home body renders again.
     const homeTab = screen.getAllByRole('tab')[0]
     fireEvent.click(homeTab)
     expect(homeTab).toHaveAttribute('aria-selected', 'true')
@@ -71,20 +83,9 @@ describe('Stage', () => {
     expect(container.querySelector('[data-section="header"]')).not.toBeNull()
   })
 
-  it('opens an agent pane on the created conversation when an AgentDock pill is clicked', async () => {
-    const onCreateConversation = vi.fn(async () => 'conv-new')
-    renderStage(
-      <Stage
-        workspaceId={WS}
-        conversations={[{ name: 'conv-new', issueId: WS } as unknown as Conversation]}
-        onCreateConversation={onCreateConversation}
-      />,
-    )
-    fireEvent.click(screen.getByRole('button', { name: /Claude Code/ }))
-
-    // The conversation is created with the chosen agent id, then a Stage agent
-    // pane opens focused on it (a second tab appears).
-    expect(onCreateConversation).toHaveBeenCalledWith('claude-code')
+  it('opens (and focuses) an agent pane via the StageApi', async () => {
+    renderStage(<Stage deckKey={DECK} renderHome={renderHome} renderIssue={renderIssue} />)
+    fireEvent.click(screen.getByRole('button', { name: /open agent/ }))
     await screen.findByRole('tab', { name: /Agent/ })
     expect(screen.getAllByRole('tab')).toHaveLength(2)
   })

--- a/src/dashboard/frontend/src/components/Stage/index.tsx
+++ b/src/dashboard/frontend/src/components/Stage/index.tsx
@@ -8,8 +8,11 @@ import {
   type PaneSpec,
 } from '../../lib/panesStore'
 import type { Conversation } from '../CommandDeck/ConversationList'
-import { PaneBar } from './PaneBar'
+import { Bot, Terminal as TerminalIcon, Globe } from 'lucide-react'
+import { PaneBar, type NewPaneAction } from './PaneBar'
 import { useStageShortcuts } from './useStageShortcuts'
+import { TerminalDrawer } from '../terminal/TerminalDrawer'
+import { useTerminalStateStore, selectThreadTerminalState } from '../terminal/terminalStateStore'
 import { TerminalPane } from './panes/TerminalPane'
 import { CommitsPane } from './panes/CommitsPane'
 import { PlanPane } from './panes/PlanPane'
@@ -27,6 +30,11 @@ export interface StageProps {
   deckKey: string
   /** All conversations; used to resolve agent panes. */
   conversations?: Conversation[]
+  /** Working directory for new drawer terminals (the project path). */
+  terminalCwd?: string
+  /** Create a conversation for the deck's project (for the "+" New conversation
+   * action); returns the new conversation name. */
+  onCreateConversation?: (agentId: string) => Promise<string | undefined>
   /** Render the permanent HOME tab (project-scoped). */
   renderHome: (api: StageApi) => ReactNode
   /** Render an `issue` tab's body for the given issue id. */
@@ -88,17 +96,54 @@ function renderPane(pane: WorkspacePane, ctx: StageContext) {
  * are composed by the caller via `renderHome` / `renderIssue` (they need the
  * project's / issue's data); every other pane dispatches through `renderPane`.
  */
-export function Stage({ deckKey, conversations = [], renderHome, renderIssue }: StageProps) {
+export function Stage({ deckKey, conversations = [], terminalCwd, onCreateConversation, renderHome, renderIssue }: StageProps) {
   const ensureHome = usePanesStore((s) => s.ensureHome)
   const addPane = usePanesStore((s) => s.addPane)
   const closePane = usePanesStore((s) => s.closePane)
   const setActivePane = usePanesStore((s) => s.setActivePane)
   const panes = usePanesStore(selectPanesForWorkspace(deckKey))
   const activePaneId = usePanesStore(selectActivePaneId(deckKey))
+  const terminalOpen = useTerminalStateStore(
+    (s) => selectThreadTerminalState(s.terminalStateByThreadId, deckKey).terminalOpen,
+  )
+  const setTerminalOpen = useTerminalStateStore((s) => s.setTerminalOpen)
+  const toggleTerminal = useCallback(
+    () => setTerminalOpen(deckKey, !terminalOpen),
+    [setTerminalOpen, deckKey, terminalOpen],
+  )
 
   useEffect(() => {
     ensureHome(deckKey)
   }, [deckKey, ensureHome])
+
+  // PAN-1561: keep the deck tab bar clean. (a) terminals now live in the drawer,
+  // not as deck tabs — drop any `terminal` panes left from before the migration;
+  // (b) collapse duplicate agent panes that point at the same conversation
+  // (stale accumulation), keeping the first. Creation paths dedupe too, so this
+  // self-heals existing decks on load.
+  useEffect(() => {
+    const current = usePanesStore.getState().panesByWorkspace[deckKey] ?? []
+    const seenConversationIds = new Set<string>()
+    const ISSUE_SCOPED = new Set<PaneType>(['files', 'commits', 'plan', 'docs'])
+    for (const p of current) {
+      // Terminals are drawer-only now.
+      if (p.paneType === 'terminal') {
+        closePane(deckKey, p.paneId)
+        continue
+      }
+      // Issue-scoped panes created at project scope (no issueId) were broken —
+      // they queried the project key as an issue. Drop them.
+      if (ISSUE_SCOPED.has(p.paneType) && !p.issueId) {
+        closePane(deckKey, p.paneId)
+        continue
+      }
+      // Collapse duplicate agent panes pointing at the same conversation.
+      if (p.paneType === 'agent' && p.conversationId) {
+        if (seenConversationIds.has(p.conversationId)) closePane(deckKey, p.paneId)
+        else seenConversationIds.add(p.conversationId)
+      }
+    }
+  }, [deckKey, closePane])
 
   useStageShortcuts(deckKey)
 
@@ -137,8 +182,8 @@ export function Stage({ deckKey, conversations = [], renderHome, renderIssue }: 
   )
 
   const api: StageApi = useMemo(
-    () => ({ deckKey, openPane, openTypedPane, openIssue, openOrFocusAgentPane }),
-    [deckKey, openPane, openTypedPane, openIssue, openOrFocusAgentPane],
+    () => ({ deckKey, openPane, openTypedPane, openIssue, openOrFocusAgentPane, toggleTerminal }),
+    [deckKey, openPane, openTypedPane, openIssue, openOrFocusAgentPane, toggleTerminal],
   )
 
   const ctx: StageContext = useMemo(
@@ -162,18 +207,72 @@ export function Stage({ deckKey, conversations = [], renderHome, renderIssue }: 
     (paneId: string) => closePane(deckKey, paneId),
     [closePane, deckKey],
   )
-  const handleAddPane = useCallback(() => openTypedPane('terminal'), [openTypedPane])
+  // PAN-1561: the "+" opens a menu of what to create, so it's explicit rather
+  // than guessing. Fallback (⌘T / no menu) toggles the terminal drawer.
+  const handleAddPane = useCallback(() => toggleTerminal(), [toggleTerminal])
+  const newActions = useMemo<NewPaneAction[]>(() => {
+    const actions: NewPaneAction[] = []
+    if (onCreateConversation) {
+      actions.push({
+        key: 'conversation',
+        label: 'New conversation',
+        icon: Bot,
+        onSelect: () => {
+          void onCreateConversation('claude-code').then((name) => {
+            if (name) openOrFocusAgentPane(name, 'Agent')
+          })
+        },
+      })
+    }
+    actions.push({
+      key: 'terminal',
+      label: 'New terminal',
+      icon: TerminalIcon,
+      onSelect: () => setTerminalOpen(deckKey, true),
+    })
+    actions.push({
+      key: 'web',
+      label: 'Web',
+      icon: Globe,
+      onSelect: () => openPane({ paneType: 'browser', label: 'Web' }),
+    })
+    return actions
+  }, [onCreateConversation, openOrFocusAgentPane, setTerminalOpen, deckKey, openPane])
 
-  const activePane = panes.find((p) => p.paneId === activePaneId) ?? null
+  // Display panes: drop `terminal` panes (drawer-only now) and resolve agent
+  // tab labels from the live conversation title so tabs are distinguishable
+  // instead of a row of identical "New conversation"s.
+  const displayPanes = useMemo(
+    () =>
+      panes
+        .filter((p) => p.paneType !== 'terminal')
+        .map((p) => {
+          if (p.paneType !== 'agent') return p
+          const conv = conversations.find((c) => c.name === p.conversationId)
+          const title = conv?.title?.trim()
+          // The server seeds untitled chats with the literal title "New
+          // conversation"; treat that as untitled and disambiguate by a short
+          // id so a row of brand-new chats isn't a wall of identical tabs.
+          const isPlaceholder = !title || title.toLowerCase() === 'new conversation'
+          const label = isPlaceholder
+            ? `Chat ${(p.conversationId ?? '').split('-').pop() ?? ''}`.trim()
+            : title
+          return label === p.label ? p : { ...p, label }
+        }),
+    [panes, conversations],
+  )
+
+  const activePane = displayPanes.find((p) => p.paneId === activePaneId) ?? displayPanes[0] ?? null
 
   return (
     <div className={styles.stage}>
       <PaneBar
-        panes={panes}
-        activePaneId={activePaneId}
+        panes={displayPanes}
+        activePaneId={activePane?.paneId ?? activePaneId}
         onSelect={handleSelectPane}
         onClose={handleClosePane}
         onAdd={handleAddPane}
+        newActions={newActions}
       />
       <div className={styles.pane}>
         {activePane &&
@@ -183,6 +282,7 @@ export function Stage({ deckKey, conversations = [], renderHome, renderIssue }: 
               ? renderIssue(activePane.issueId ?? '', api)
               : renderPane(activePane, ctx))}
       </div>
+      {terminalOpen && <TerminalDrawer threadId={deckKey} cwd={terminalCwd} />}
     </div>
   )
 }

--- a/src/dashboard/frontend/src/components/Stage/index.tsx
+++ b/src/dashboard/frontend/src/components/Stage/index.tsx
@@ -1,27 +1,15 @@
-import { useEffect, useMemo, useCallback } from 'react'
+import { useEffect, useMemo, useCallback, type ReactNode } from 'react'
 import {
   usePanesStore,
   selectPanesForWorkspace,
   selectActivePaneId,
   type WorkspacePane,
-  type WorkspaceId,
   type PaneType,
   type PaneSpec,
 } from '../../lib/panesStore'
 import type { Conversation } from '../CommandDeck/ConversationList'
 import { PaneBar } from './PaneBar'
 import { useStageShortcuts } from './useStageShortcuts'
-import { HomePane } from './HomePane'
-import { WorkspaceHeader } from './HomePane/WorkspaceHeader'
-import { StatChips } from './HomePane/StatChips'
-import { Launcher } from './HomePane/Launcher'
-import { AgentDock } from './HomePane/AgentDock'
-import { ActionDock } from './HomePane/ActionDock'
-import { Timeline } from './HomePane/Timeline'
-import { HomePaneSections } from './HomePane/HomePaneSections'
-import { dispatchLauncherIntent } from './HomePane/launcherActions'
-import { readLastUsedAgent, writeLastUsedAgent } from './HomePane/launcherOrdering'
-import type { TimelineConversation } from './HomePane/timeline-utils'
 import { TerminalPane } from './panes/TerminalPane'
 import { CommitsPane } from './panes/CommitsPane'
 import { PlanPane } from './panes/PlanPane'
@@ -29,30 +17,25 @@ import { DocsPane } from './panes/DocsPane'
 import { AgentPane } from './panes/AgentPane'
 import { FilesPane } from './panes/FilesPane'
 import { BrowserPane } from './panes/BrowserPane'
-import type { StageContext, PaneWrapperProps } from './types'
+import type { StageContext, PaneWrapperProps, StageApi } from './types'
 import styles from './stage.module.css'
 
-export type { StageContext, PaneWrapperProps } from './types'
+export type { StageContext, PaneWrapperProps, StageApi } from './types'
 
 export interface StageProps {
-  workspaceId: WorkspaceId
-  /** Issue title for the workspace header (falls back to the id). */
-  issueTitle?: string
-  /** Feature branch; defaults to feature/<workspaceId>. */
-  branch?: string
-  /** Issue creation time for the age stat chip. */
-  issueCreatedAt?: number | string
-  /** The workspace's agent id — used as the workspace terminal session. */
-  agentId?: string
-  /** All conversations; the Stage filters to this workspace. */
+  /** Pane-store key for this deck (PAN-1561: the project key). */
+  deckKey: string
+  /** All conversations; used to resolve agent panes. */
   conversations?: Conversation[]
-  /** Create a conversation for this workspace via the existing flow, returning
-   * the new conversation's name (so the Stage can open an agent pane on it). */
-  onCreateConversation?: (agentId: string) => Promise<string | undefined>
+  /** Render the permanent HOME tab (project-scoped). */
+  renderHome: (api: StageApi) => ReactNode
+  /** Render an `issue` tab's body for the given issue id. */
+  renderIssue: (issueId: string, api: StageApi) => ReactNode
 }
 
 const PANE_LABELS: Record<PaneType, string> = {
   home: 'Home',
+  issue: 'Issue',
   agent: 'Agent',
   terminal: 'Terminal',
   files: 'Files',
@@ -74,8 +57,9 @@ function PanePlaceholder({ pane }: PaneWrapperProps) {
   )
 }
 
-/** Dispatch a non-home pane to its wrapper. The home pane is composed in the
- * Stage body (it needs workspace data), so it is handled before this. */
+/** Dispatch a non-home/non-issue pane to its wrapper. The home and issue panes
+ * are composed by the caller's render props (they need project/issue data), so
+ * they are handled before this. */
 function renderPane(pane: WorkspacePane, ctx: StageContext) {
   switch (pane.paneType) {
     case 'terminal':
@@ -98,165 +82,85 @@ function renderPane(pane: WorkspacePane, ctx: StageContext) {
 }
 
 /**
- * Stage — the Command Deck's main work area (PAN-1549). Renders the persistent
- * PaneBar plus the active pane. The permanent HOME pane is composed here from
- * the workspace's data (header/stats/launcher/docks/timeline/sections); all
- * other panes dispatch through renderPane. Pane state lives in `panesStore`.
+ * Stage — the project-scoped deck (PAN-1561, evolves PAN-1549). Renders the
+ * persistent PaneBar plus the active pane. Pane state lives in `panesStore`,
+ * keyed by `deckKey` (the project). The permanent HOME tab and any `issue` tab
+ * are composed by the caller via `renderHome` / `renderIssue` (they need the
+ * project's / issue's data); every other pane dispatches through `renderPane`.
  */
-export function Stage({
-  workspaceId,
-  issueTitle,
-  branch,
-  issueCreatedAt,
-  agentId,
-  conversations = [],
-  onCreateConversation,
-}: StageProps) {
+export function Stage({ deckKey, conversations = [], renderHome, renderIssue }: StageProps) {
   const ensureHome = usePanesStore((s) => s.ensureHome)
   const addPane = usePanesStore((s) => s.addPane)
   const closePane = usePanesStore((s) => s.closePane)
   const setActivePane = usePanesStore((s) => s.setActivePane)
-  const panes = usePanesStore(selectPanesForWorkspace(workspaceId))
-  const activePaneId = usePanesStore(selectActivePaneId(workspaceId))
+  const panes = usePanesStore(selectPanesForWorkspace(deckKey))
+  const activePaneId = usePanesStore(selectActivePaneId(deckKey))
 
   useEffect(() => {
-    ensureHome(workspaceId)
-  }, [workspaceId, ensureHome])
+    ensureHome(deckKey)
+  }, [deckKey, ensureHome])
 
-  useStageShortcuts(workspaceId)
+  useStageShortcuts(deckKey)
 
-  // Stable handlers (store actions are stable; live pane state is read via
-  // getState() where needed) so the memoized HOME subtree is not invalidated
-  // when the user merely switches tabs.
   const openPane = useCallback(
-    (spec: PaneSpec) => addPane(workspaceId, spec),
-    [addPane, workspaceId],
+    (spec: PaneSpec) => addPane(deckKey, spec),
+    [addPane, deckKey],
   )
   const openTypedPane = useCallback(
-    (paneType: PaneType) =>
-      addPane(workspaceId, {
+    (paneType: PaneType, opts?: { terminalId?: string | null }) =>
+      addPane(deckKey, {
         paneType,
         label: PANE_LABELS[paneType],
-        ...(paneType === 'terminal' ? { terminalId: agentId ?? null } : {}),
+        ...(paneType === 'terminal' ? { terminalId: opts?.terminalId ?? null } : {}),
       }),
-    [addPane, workspaceId, agentId],
+    [addPane, deckKey],
   )
   const openOrFocusAgentPane = useCallback(
     (conversationId: string, label: string) => {
-      const current = usePanesStore.getState().panesByWorkspace[workspaceId] ?? []
+      const current = usePanesStore.getState().panesByWorkspace[deckKey] ?? []
       const existing = current.find(
         (p) => p.paneType === 'agent' && p.conversationId === conversationId,
       )
-      if (existing) setActivePane(workspaceId, existing.paneId)
-      else addPane(workspaceId, { paneType: 'agent', label, conversationId })
+      if (existing) setActivePane(deckKey, existing.paneId)
+      else addPane(deckKey, { paneType: 'agent', label, conversationId })
     },
-    [workspaceId, setActivePane, addPane],
+    [deckKey, setActivePane, addPane],
   )
-  // Create a conversation for the chosen agent, then open a Stage agent pane
-  // focused on it (staying in the Stage).
-  const onAgentSelected = useCallback(
-    async (id: string) => {
-      writeLastUsedAgent(workspaceId, id)
-      const conversationName = await onCreateConversation?.(id)
-      if (conversationName) openOrFocusAgentPane(conversationName, 'Agent')
+  const openIssue = useCallback(
+    (issueId: string, label: string) => {
+      const current = usePanesStore.getState().panesByWorkspace[deckKey] ?? []
+      const existing = current.find((p) => p.paneType === 'issue' && p.issueId === issueId)
+      if (existing) setActivePane(deckKey, existing.paneId)
+      else addPane(deckKey, { paneType: 'issue', label, issueId })
     },
-    [workspaceId, onCreateConversation, openOrFocusAgentPane],
+    [deckKey, setActivePane, addPane],
   )
 
-  const wsConversations = useMemo(
-    () =>
-      conversations.filter((c) => (c.issueId ?? '').toUpperCase() === workspaceId.toUpperCase()),
-    [conversations, workspaceId],
-  )
-  const timelineConversations: TimelineConversation[] = useMemo(
-    () =>
-      wsConversations.map((c) => ({
-        id: c.name,
-        agentLabel: c.title ?? c.model ?? 'Agent',
-        timestamp: c.lastAttachedAt ?? c.createdAt,
-        preview: c.title ?? undefined,
-      })),
-    [wsConversations],
+  const api: StageApi = useMemo(
+    () => ({ deckKey, openPane, openTypedPane, openIssue, openOrFocusAgentPane }),
+    [deckKey, openPane, openTypedPane, openIssue, openOrFocusAgentPane],
   )
 
   const ctx: StageContext = useMemo(
     () => ({
-      workspaceId,
+      workspaceId: deckKey,
       openPane,
-      agentId,
       resolveAgentPane: (pane) => {
         if (!pane.conversationId) return undefined
         const conversation = conversations.find((c) => c.name === pane.conversationId)
         return conversation ? { conversation } : undefined
       },
     }),
-    [workspaceId, openPane, agentId, conversations],
-  )
-
-  const homePane = useMemo(
-    () => (
-      <HomePane
-        workspaceId={workspaceId}
-        openPane={openPane}
-        header={
-          <>
-            <WorkspaceHeader
-              name={issueTitle ?? workspaceId}
-              branch={branch ?? `feature/${workspaceId.toLowerCase()}`}
-              iconLabel={(issueTitle ?? workspaceId).charAt(0).toUpperCase()}
-            />
-            <StatChips createdAt={issueCreatedAt} conversationCount={wsConversations.length} />
-          </>
-        }
-        launcher={
-          <Launcher
-            lastUsedAgentId={readLastUsedAgent(workspaceId)}
-            onSelect={(intent, query) =>
-              dispatchLauncherIntent(intent, query, {
-                openAgent: (i) => onAgentSelected(i.id),
-                openTerminal: () => openTypedPane('terminal'),
-                openWeb: (_q, url) =>
-                  openPane({ paneType: 'browser', label: PANE_LABELS.browser, browserInitialUrl: url }),
-                onAgentRun: (id) => writeLastUsedAgent(workspaceId, id),
-              })
-            }
-          />
-        }
-        agentDock={<AgentDock onSelectAgent={onAgentSelected} />}
-        actionDock={<ActionDock onOpen={openTypedPane} />}
-        timeline={
-          <Timeline
-            conversations={timelineConversations}
-            onOpen={(id) => {
-              const conv = wsConversations.find((c) => c.name === id)
-              openOrFocusAgentPane(id, conv?.title ?? 'Agent')
-            }}
-          />
-        }
-        detail={<HomePaneSections issueId={workspaceId} />}
-      />
-    ),
-    [
-      workspaceId,
-      issueTitle,
-      branch,
-      issueCreatedAt,
-      openPane,
-      openTypedPane,
-      onAgentSelected,
-      openOrFocusAgentPane,
-      timelineConversations,
-      wsConversations,
-    ],
+    [deckKey, openPane, conversations],
   )
 
   const handleSelectPane = useCallback(
-    (paneId: string) => setActivePane(workspaceId, paneId),
-    [setActivePane, workspaceId],
+    (paneId: string) => setActivePane(deckKey, paneId),
+    [setActivePane, deckKey],
   )
   const handleClosePane = useCallback(
-    (paneId: string) => closePane(workspaceId, paneId),
-    [closePane, workspaceId],
+    (paneId: string) => closePane(deckKey, paneId),
+    [closePane, deckKey],
   )
   const handleAddPane = useCallback(() => openTypedPane('terminal'), [openTypedPane])
 
@@ -273,7 +177,11 @@ export function Stage({
       />
       <div className={styles.pane}>
         {activePane &&
-          (activePane.paneType === 'home' ? homePane : renderPane(activePane, ctx))}
+          (activePane.paneType === 'home'
+            ? renderHome(api)
+            : activePane.paneType === 'issue'
+              ? renderIssue(activePane.issueId ?? '', api)
+              : renderPane(activePane, ctx))}
       </div>
     </div>
   )

--- a/src/dashboard/frontend/src/components/Stage/panes/CommitsPane.tsx
+++ b/src/dashboard/frontend/src/components/Stage/panes/CommitsPane.tsx
@@ -5,6 +5,7 @@ import type { PaneWrapperProps } from '../types'
  * CommitsPane — paneType='commits' (PAN-1549). Renders the existing PrDiffTab
  * (git log + diff viewer) for the workspace issue. Reused as-is.
  */
-export function CommitsPane({ ctx }: PaneWrapperProps) {
-  return <PrDiffTab issueId={ctx.workspaceId} />
+export function CommitsPane({ pane, ctx }: PaneWrapperProps) {
+  // PAN-1561: the deck is project-scoped, so prefer the pane's own issue id.
+  return <PrDiffTab issueId={pane.issueId ?? ctx.workspaceId} />
 }

--- a/src/dashboard/frontend/src/components/Stage/panes/DocsPane.tsx
+++ b/src/dashboard/frontend/src/components/Stage/panes/DocsPane.tsx
@@ -22,7 +22,8 @@ const DOC_TABS: { key: DocKey; label: string; empty: string }[] = [
  * `docFilePath` selects the initial doc.
  */
 export function DocsPane({ pane, ctx }: PaneWrapperProps) {
-  const issueId = ctx.workspaceId
+  // PAN-1561: project-scoped deck — prefer the pane's own issue id.
+  const issueId = pane.issueId ?? ctx.workspaceId
   const summary = usePlanningSummaryQuery(issueId)
   const planning = usePlanningQuery(issueId)
   const hasInference = Boolean(summary.data?.hasInference)

--- a/src/dashboard/frontend/src/components/Stage/panes/FilesPane.tsx
+++ b/src/dashboard/frontend/src/components/Stage/panes/FilesPane.tsx
@@ -18,8 +18,9 @@ async function fetchChangedFiles(agentId: string): Promise<TurnDiffFileChange[]>
  * Clicking a file opens/focuses the Commits pane to view the diff. Real
  * filesystem browsing is a follow-up (#1550).
  */
-export function FilesPane({ ctx }: PaneWrapperProps) {
-  const agentId = ctx.agentId
+export function FilesPane({ pane, ctx }: PaneWrapperProps) {
+  // PAN-1561: project-scoped deck — the pane carries its issue's agent id.
+  const agentId = pane.agentId ?? ctx.agentId
   const setActivePane = usePanesStore((s) => s.setActivePane)
   const { data: files = [], isLoading, isError } = useQuery({
     queryKey: ['stage-files-vs-main', agentId],
@@ -44,9 +45,9 @@ export function FilesPane({ ctx }: PaneWrapperProps) {
   // than stacking a duplicate on every file click.
   const openCommits = () => {
     const current = usePanesStore.getState().panesByWorkspace[ctx.workspaceId] ?? []
-    const existing = current.find((p) => p.paneType === 'commits')
+    const existing = current.find((p) => p.paneType === 'commits' && p.issueId === pane.issueId)
     if (existing) setActivePane(ctx.workspaceId, existing.paneId)
-    else ctx.openPane({ paneType: 'commits', label: 'Commits' })
+    else ctx.openPane({ paneType: 'commits', label: 'Commits', issueId: pane.issueId, agentId })
   }
 
   return (

--- a/src/dashboard/frontend/src/components/Stage/panes/PlanPane.tsx
+++ b/src/dashboard/frontend/src/components/Stage/panes/PlanPane.tsx
@@ -11,7 +11,9 @@ type PlanView = 'plan' | 'beads'
  * existing VBriefTab (List/DAG/Raw) and BeadsTab for the workspace issue.
  * Both tab bodies are reused as-is.
  */
-export function PlanPane({ ctx }: PaneWrapperProps) {
+export function PlanPane({ pane, ctx }: PaneWrapperProps) {
+  // PAN-1561: project-scoped deck — prefer the pane's own issue id.
+  const issueId = pane.issueId ?? ctx.workspaceId
   const [view, setView] = useState<PlanView>('plan')
   return (
     <div className={styles.subPane}>
@@ -37,9 +39,9 @@ export function PlanPane({ ctx }: PaneWrapperProps) {
       </div>
       <div className={styles.subBody}>
         {view === 'plan' ? (
-          <VBriefTab issueId={ctx.workspaceId} />
+          <VBriefTab issueId={issueId} />
         ) : (
-          <BeadsTab issueId={ctx.workspaceId} />
+          <BeadsTab issueId={issueId} />
         )}
       </div>
     </div>

--- a/src/dashboard/frontend/src/components/Stage/stage.module.css
+++ b/src/dashboard/frontend/src/components/Stage/stage.module.css
@@ -57,6 +57,19 @@
   font-weight: 700;
 }
 
+/* Agent pill brand logo (PAN-1561) — sizes the shared ProviderIcon to the pill. */
+.agentLogo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.agentLogoSvg {
+  width: 100%;
+  height: 100%;
+}
+
 .wsBranch {
   color: var(--muted-foreground);
   font-size: 13px;
@@ -567,4 +580,38 @@
 .add:hover {
   color: var(--foreground);
   background: var(--secondary);
+}
+
+/* New-tab dropdown (PAN-1561) — portaled to <body> and positioned inline
+ * (position:fixed) so the PaneBar's overflow-x clip can't hide it. */
+.addMenu {
+  z-index: 1000;
+  min-width: 168px;
+  padding: 4px;
+  background: var(--popover, var(--card));
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.addMenuItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 10px;
+  font-size: 13px;
+  color: var(--foreground);
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.addMenuItem:hover {
+  background: var(--accent);
 }

--- a/src/dashboard/frontend/src/components/Stage/stage.module.css
+++ b/src/dashboard/frontend/src/components/Stage/stage.module.css
@@ -51,6 +51,12 @@
   letter-spacing: -0.01em;
 }
 
+/* Project-variant header: `#` accent before the project name (PAN-1561). */
+.wsHash {
+  color: var(--muted-foreground);
+  font-weight: 700;
+}
+
 .wsBranch {
   color: var(--muted-foreground);
   font-size: 13px;

--- a/src/dashboard/frontend/src/components/Stage/types.ts
+++ b/src/dashboard/frontend/src/components/Stage/types.ts
@@ -1,11 +1,30 @@
 import type { SessionNode as SessionNodeType } from '@panctl/contracts'
-import type { WorkspacePane, WorkspaceId, PaneSpec } from '../../lib/panesStore'
+import type { WorkspacePane, WorkspaceId, PaneSpec, PaneType } from '../../lib/panesStore'
 import type { Conversation } from '../CommandDeck/ConversationList'
 
 /** Backing data for an agent pane, resolved by the Stage mount point. */
 export interface AgentPaneData {
   conversation?: Conversation
   session?: SessionNodeType
+}
+
+/**
+ * StageApi — the pane-opening surface the Stage hands to its render props
+ * (ProjectHome and IssueOverview, PAN-1561). The Stage owns pane state keyed
+ * by the project deck; these helpers let the home/issue content open and focus
+ * tabs without reaching into the store directly.
+ */
+export interface StageApi {
+  /** The deck's pane-store key (the project key). */
+  deckKey: string
+  /** Open + activate an arbitrary pane. */
+  openPane: (spec: PaneSpec) => void
+  /** Open + activate a typed pane; `terminalId` scopes a terminal to an agent. */
+  openTypedPane: (paneType: PaneType, opts?: { terminalId?: string | null }) => void
+  /** Open (or focus, if already open) an issue tab in the project deck. */
+  openIssue: (issueId: string, label: string) => void
+  /** Open (or focus) an agent pane backed by a conversation. */
+  openOrFocusAgentPane: (conversationId: string, label: string) => void
 }
 
 /**

--- a/src/dashboard/frontend/src/components/Stage/types.ts
+++ b/src/dashboard/frontend/src/components/Stage/types.ts
@@ -25,6 +25,8 @@ export interface StageApi {
   openIssue: (issueId: string, label: string) => void
   /** Open (or focus) an agent pane backed by a conversation. */
   openOrFocusAgentPane: (conversationId: string, label: string) => void
+  /** Toggle the terminal drawer stacked below the deck (PAN-1561). */
+  toggleTerminal: () => void
 }
 
 /**

--- a/src/dashboard/frontend/src/components/Stage/useStageShortcuts.test.tsx
+++ b/src/dashboard/frontend/src/components/Stage/useStageShortcuts.test.tsx
@@ -6,6 +6,7 @@ import {
   selectPanesForWorkspace,
   selectActivePaneId,
 } from '../../lib/panesStore'
+import { useTerminalStateStore, selectThreadTerminalState } from '../terminal/terminalStateStore'
 
 const WS = 'PAN-1549'
 
@@ -27,6 +28,7 @@ function meta(key: string) {
 beforeEach(() => {
   localStorage.clear()
   usePanesStore.setState({ panesByWorkspace: {}, activePaneByWorkspace: {} })
+  useTerminalStateStore.setState({ terminalStateByThreadId: {} })
   usePanesStore.getState().ensureHome(WS)
 })
 afterEach(() => {
@@ -62,12 +64,17 @@ describe('useStageShortcuts', () => {
     expect(activeId()).toBe(homeId) // ⌘⇧2 must NOT focus pane 2
   })
 
-  it('⌘T adds a pane', () => {
+  it('⌘T toggles the terminal drawer (PAN-1561), not a deck tab', () => {
     render(<Host />)
+    const open = () => selectThreadTerminalState(useTerminalStateStore.getState().terminalStateByThreadId, WS).terminalOpen
+    expect(open()).toBe(false)
     expect(panes()).toHaveLength(1)
     meta('t')
-    expect(panes()).toHaveLength(2)
-    expect(panes()[1].paneType).toBe('terminal')
+    expect(open()).toBe(true)
+    // No new deck tab is created — terminals live in the drawer.
+    expect(panes()).toHaveLength(1)
+    meta('t')
+    expect(open()).toBe(false)
   })
 
   it('⌘W closes the active pane but never HOME', () => {

--- a/src/dashboard/frontend/src/components/Stage/useStageShortcuts.ts
+++ b/src/dashboard/frontend/src/components/Stage/useStageShortcuts.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { usePanesStore, type WorkspaceId } from '../../lib/panesStore'
+import { useTerminalStateStore, selectThreadTerminalState } from '../terminal/terminalStateStore'
 
 /** True when focus is in a text-entry context where the Launcher / fields own
  * the keyboard (so the Stage must not hijack ⌘-combos). */
@@ -43,8 +44,12 @@ export function useStageShortcuts(workspaceId: WorkspaceId): void {
 
       const key = e.key.toLowerCase()
       if (key === 't') {
+        // PAN-1561: ⌘T toggles the terminal drawer (terminals are drawer-only,
+        // not deck tabs).
         e.preventDefault()
-        store.addPane(workspaceId, { paneType: 'terminal', label: 'Terminal' })
+        const tStore = useTerminalStateStore.getState()
+        const open = selectThreadTerminalState(tStore.terminalStateByThreadId, workspaceId).terminalOpen
+        tStore.setTerminalOpen(workspaceId, !open)
         return
       }
       if (key === 'w') {

--- a/src/dashboard/frontend/src/components/XTerminal.tsx
+++ b/src/dashboard/frontend/src/components/XTerminal.tsx
@@ -1,7 +1,34 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
-import { Terminal } from '@xterm/xterm';
+import { Terminal, type ITheme } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import '@xterm/xterm/css/xterm.css';
+import { useTheme } from '../hooks/useTheme';
+
+// Terminal background, exported so embedders can match the surrounding chrome.
+export const XTERM_BG = { dark: '#1a1a2e', light: '#ffffff' } as const;
+
+// xterm palette that follows the app's light/dark theme (PAN-1561). The ANSI
+// colors are tuned per-mode for contrast against the background.
+function xtermTheme(isDark: boolean): ITheme {
+  if (isDark) {
+    return {
+      background: XTERM_BG.dark, foreground: '#eaeaea', cursor: '#eaeaea', cursorAccent: '#1a1a2e',
+      selectionBackground: '#3a3a5e',
+      black: '#1a1a2e', red: '#ff5555', green: '#50fa7b', yellow: '#f1fa8c', blue: '#6272a4',
+      magenta: '#ff79c6', cyan: '#8be9fd', white: '#f8f8f2',
+      brightBlack: '#6272a4', brightRed: '#ff6e6e', brightGreen: '#69ff94', brightYellow: '#ffffa5',
+      brightBlue: '#d6acff', brightMagenta: '#ff92df', brightCyan: '#a4ffff', brightWhite: '#ffffff',
+    };
+  }
+  return {
+    background: XTERM_BG.light, foreground: '#24292e', cursor: '#24292e', cursorAccent: '#ffffff',
+    selectionBackground: '#bcd3f5',
+    black: '#24292e', red: '#d73a49', green: '#22863a', yellow: '#b08800', blue: '#0366d6',
+    magenta: '#6f42c1', cyan: '#1b7c83', white: '#6a737d',
+    brightBlack: '#959da5', brightRed: '#cb2431', brightGreen: '#28a745', brightYellow: '#dbab09',
+    brightBlue: '#2188ff', brightMagenta: '#8a63d2', brightCyan: '#3192aa', brightWhite: '#24292e',
+  };
+}
 
 // Debounce utility to prevent resize spam
 function debounce<T extends (...args: unknown[]) => void>(fn: T, ms: number): (...args: Parameters<T>) => void {
@@ -36,6 +63,9 @@ interface XTerminalProps {
   token?: string;
   onDisconnect?: () => void;
   autoCopyOnSelect?: boolean;
+  /** When embedded in a host that owns its own chrome (e.g. the terminal
+   * drawer), hide the built-in settings gear to avoid duplicate controls. */
+  embedded?: boolean;
 }
 
 interface TerminalSnapshotMessage {
@@ -65,7 +95,10 @@ const AUTOCOPY_STORAGE_KEY = 'panopticon.terminal.autoCopyOnSelect';
 // Check if platform is Mac
 const isMac = navigator.platform.toLowerCase().includes('mac');
 
-export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: autoCopyProp }: XTerminalProps) {
+export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: autoCopyProp, embedded }: XTerminalProps) {
+  const isDark = useTheme((s) => s.resolvedTheme) !== 'light';
+  const isDarkRef = useRef(isDark);
+  isDarkRef.current = isDark;
   const terminalRef = useRef<HTMLDivElement>(null);
   const terminalInstance = useRef<Terminal | null>(null);
   const fitAddon = useRef<FitAddon | null>(null);
@@ -329,29 +362,7 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
         allowProposedApi: true,
         macOptionClickForcesSelection: true,
         rightClickSelectsWord: false,
-        theme: {
-          background: '#1a1a2e',
-          foreground: '#eaeaea',
-          cursor: '#eaeaea',
-          cursorAccent: '#1a1a2e',
-          selectionBackground: '#3a3a5e',
-          black: '#1a1a2e',
-          red: '#ff5555',
-          green: '#50fa7b',
-          yellow: '#f1fa8c',
-          blue: '#6272a4',
-          magenta: '#ff79c6',
-          cyan: '#8be9fd',
-          white: '#f8f8f2',
-          brightBlack: '#6272a4',
-          brightRed: '#ff6e6e',
-          brightGreen: '#69ff94',
-          brightYellow: '#ffffa5',
-          brightBlue: '#d6acff',
-          brightMagenta: '#ff92df',
-          brightCyan: '#a4ffff',
-          brightWhite: '#ffffff',
-        },
+        theme: xtermTheme(isDarkRef.current),
       });
 
       fit = new FitAddon();
@@ -665,13 +676,21 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
     };
   }, [sendResizeIfNeeded]);
 
+  // Recolor a live terminal when the app theme toggles (PAN-1561).
+  useEffect(() => {
+    if (terminalInstance.current) {
+      terminalInstance.current.options.theme = xtermTheme(isDark);
+    }
+  }, [isDark]);
+
   const handleClick = () => {
     terminalInstance.current?.focus();
   };
 
   return (
     <div className="relative w-full h-full">
-      {/* Settings button */}
+      {/* Settings button — hidden when embedded (the host owns the chrome). */}
+      {!embedded && (
       <div className="absolute top-2 right-2 z-10 flex gap-2">
         <button
           onClick={() => setShowSettings(!showSettings)}
@@ -684,9 +703,10 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
           </svg>
         </button>
       </div>
+      )}
 
       {/* Settings panel */}
-      {showSettings && (
+      {!embedded && showSettings && (
         <div className="absolute top-10 right-2 z-20 w-64 p-3 rounded-lg bg-card border border-border shadow-xl">
           <h3 className="text-sm font-semibold text-foreground mb-3">Terminal Settings</h3>
           <label className="flex items-center gap-2 cursor-pointer">
@@ -712,7 +732,7 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
         tabIndex={0}
         style={{
           padding: '8px',
-          backgroundColor: '#1a1a2e',
+          backgroundColor: isDark ? XTERM_BG.dark : XTERM_BG.light,
           overflow: 'hidden',
           outline: 'none',
         }}

--- a/src/dashboard/frontend/src/components/sessionFeed/SessionFeedSidebar.tsx
+++ b/src/dashboard/frontend/src/components/sessionFeed/SessionFeedSidebar.tsx
@@ -9,9 +9,17 @@ import { useMergedFeed } from './useMergedFeed';
 export const SESSION_FEED_TAB_STORAGE_KEY = 'panopticon.ui.sessionFeedSidebarTab';
 
 interface SessionFeedSidebarProps {
-  onClose: () => void;
+  onClose?: () => void;
   onSelect?: (entry: SessionFeedEntry) => void;
   now?: Date;
+  /** PAN-1561: project-scoped mode — filter the feed to these issue ids. */
+  issueIds?: readonly string[];
+  /** PAN-1561: No-project mode — show only activity with no associated issue. */
+  unscoped?: boolean;
+  /** Heading text (defaults to "Activity Feed"). */
+  heading?: string;
+  /** Embedded as a deck column — fills its container, no close button. */
+  embedded?: boolean;
 }
 
 const TABS: Array<{ id: SessionFeedTab; label: string }> = [
@@ -34,7 +42,7 @@ const EMPTY_STATES: Record<SessionFeedTab, string> = {
 
 let loggedGitNavigationNoop = false;
 
-export function SessionFeedSidebar({ onClose, onSelect = navigateToFeedEntry, now = new Date() }: SessionFeedSidebarProps) {
+export function SessionFeedSidebar({ onClose, onSelect = navigateToFeedEntry, now = new Date(), issueIds, unscoped, heading = 'Activity Feed', embedded = false }: SessionFeedSidebarProps) {
   const [activeTab, setActiveTab] = useState<SessionFeedTab>(readStoredTab);
 
   useEffect(() => {
@@ -43,20 +51,22 @@ export function SessionFeedSidebar({ onClose, onSelect = navigateToFeedEntry, no
   }, [activeTab]);
 
   return (
-    <aside className="flex h-full w-80 shrink-0 flex-col border-l border-border bg-background" aria-label="Session activity feed">
+    <aside className={`flex h-full min-h-0 flex-col bg-background ${embedded ? 'w-full' : 'w-80 shrink-0 border-l border-border'}`} aria-label="Session activity feed">
       <header className="flex items-center justify-between border-b border-border px-3 py-2">
         <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
           <History className="h-4 w-4" aria-hidden="true" />
-          Activity Feed
+          {heading}
         </div>
-        <button
-          type="button"
-          className="rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-          aria-label="Close activity feed"
-          onClick={onClose}
-        >
-          <X className="h-4 w-4" aria-hidden="true" />
-        </button>
+        {onClose && (
+          <button
+            type="button"
+            className="rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            aria-label="Close activity feed"
+            onClick={onClose}
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        )}
       </header>
 
       <div role="tablist" aria-label="Session feed tabs" className="grid grid-cols-3 gap-1 border-b border-border p-2">
@@ -80,7 +90,7 @@ export function SessionFeedSidebar({ onClose, onSelect = navigateToFeedEntry, no
         {isStubTab(activeTab) ? (
           <StubTabEmptyState tab={activeTab} />
         ) : (
-          <FeedTabContent tab={activeTab} onSelect={onSelect} now={now} />
+          <FeedTabContent tab={activeTab} onSelect={onSelect} now={now} issueIds={issueIds} unscoped={unscoped} />
         )}
       </div>
     </aside>
@@ -91,13 +101,29 @@ type WiredSessionFeedTab = Exclude<SessionFeedTab, 'files' | 'comments'>;
 
 type StubSessionFeedTab = Extract<SessionFeedTab, 'files' | 'comments'>;
 
-function FeedTabContent({ tab, onSelect, now }: { tab: WiredSessionFeedTab; onSelect: (entry: SessionFeedEntry) => void; now: Date }) {
+function FeedTabContent({ tab, onSelect, now, issueIds, unscoped }: { tab: WiredSessionFeedTab; onSelect: (entry: SessionFeedEntry) => void; now: Date; issueIds?: readonly string[]; unscoped?: boolean }) {
   const feed = useMergedFeed(tab);
-  const groups = useMemo(
-    () => groupByContiguousLabel(feed.entries, (entry) => formatBucketLabel(entry.timestamp, now)),
-    [feed.entries, now],
+  // PAN-1561 scoping: `unscoped` keeps only entries with no issue (the No-project
+  // bucket); otherwise `issueIds` keeps entries for those issues (case-insensitive).
+  const idSet = useMemo(
+    () => (issueIds ? new Set(issueIds.map((id) => id.toLowerCase())) : null),
+    [issueIds],
   );
-  const isEmpty = tab === 'all' ? feed.allEntries.length === 0 : feed.entries.length === 0;
+  const scope = useMemo(() => {
+    const keep = (e: SessionFeedEntry) =>
+      unscoped ? e.issueId == null : !idSet || (!!e.issueId && idSet.has(e.issueId.toLowerCase()));
+    return {
+      entries: unscoped || idSet ? feed.entries.filter(keep) : feed.entries,
+      allEntries: unscoped || idSet ? feed.allEntries.filter(keep) : feed.allEntries,
+    };
+  }, [feed.entries, feed.allEntries, idSet, unscoped]);
+  const scopedEntries = scope.entries;
+  const scopedAll = scope.allEntries;
+  const groups = useMemo(
+    () => groupByContiguousLabel(scopedEntries, (entry) => formatBucketLabel(entry.timestamp, now)),
+    [scopedEntries, now],
+  );
+  const isEmpty = tab === 'all' ? scopedAll.length === 0 : scopedEntries.length === 0;
 
   if (feed.error) return <p className="text-xs text-destructive">{feed.error.message}</p>;
   if (feed.isLoading) return <p className="text-xs text-muted-foreground">Loading activity…</p>;

--- a/src/dashboard/frontend/src/components/terminal/TerminalDrawer.tsx
+++ b/src/dashboard/frontend/src/components/terminal/TerminalDrawer.tsx
@@ -1,0 +1,387 @@
+import {
+  type PointerEvent as ReactPointerEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { toast } from 'sonner'
+import { Plus, SquareSplitHorizontal, TerminalSquare, Trash2, X as XIcon } from 'lucide-react'
+import { XTerminal } from '../XTerminal'
+import {
+  useTerminalStateStore,
+  selectThreadTerminalState,
+} from './terminalStateStore'
+import {
+  DEFAULT_THREAD_TERMINAL_ID,
+  MAX_TERMINALS_PER_GROUP,
+  type ThreadTerminalGroup,
+} from './types'
+
+/**
+ * TerminalDrawer — a resizable terminal drawer stacked below the deck content
+ * (PAN-1561). UI/state vendored from t3code's ThreadTerminalDrawer +
+ * terminalStateStore so upstream fixes merge cleanly; the one adapted seam is
+ * the viewport: each terminal is a Panopticon tmux session rendered by
+ * <XTerminal>, created/killed via /api/terminals. The RPC-backed viewport
+ * (t3code's TerminalViewport) lands later under PAN-1536.
+ */
+
+const MIN_DRAWER_HEIGHT = 180
+const MAX_DRAWER_HEIGHT_RATIO = 0.75
+
+function maxDrawerHeight(): number {
+  if (typeof window === 'undefined') return 280
+  return Math.max(MIN_DRAWER_HEIGHT, Math.floor(window.innerHeight * MAX_DRAWER_HEIGHT_RATIO))
+}
+
+function clampDrawerHeight(height: number): number {
+  return Math.min(Math.max(height, MIN_DRAWER_HEIGHT), maxDrawerHeight())
+}
+
+// ─── Backend seam: ad-hoc tmux sessions via /api/terminals (PAN-1545) ──────────
+async function createTerminalSession(cwd?: string): Promise<string | undefined> {
+  try {
+    const res = await fetch('/api/terminals', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(cwd ? { cwd } : {}),
+    })
+    if (!res.ok) return undefined
+    const data = (await res.json()) as { sessionName?: string }
+    return data.sessionName
+  } catch {
+    return undefined
+  }
+}
+
+function killTerminalSession(name: string): void {
+  // Fire-and-forget; the tmux session is the source of truth.
+  void fetch(`/api/terminals/${encodeURIComponent(name)}`, {
+    method: 'DELETE',
+    credentials: 'include',
+  }).catch(() => {})
+}
+
+/** Force xterm instances to refit after a layout change (height/split). */
+function pokeResize(): void {
+  if (typeof window !== 'undefined') window.dispatchEvent(new Event('resize'))
+}
+
+function TerminalActionButton({
+  className,
+  onClick,
+  label,
+  disabled,
+  children,
+}: {
+  className: string
+  onClick: () => void
+  label: string
+  disabled?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <button type="button" className={className} onClick={onClick} title={label} aria-label={label} disabled={disabled}>
+      {children}
+    </button>
+  )
+}
+
+export interface TerminalDrawerProps {
+  /** Scope key — the project deck. */
+  threadId: string
+  /** Working directory for new terminals (the project path). */
+  cwd?: string
+}
+
+export function TerminalDrawer({ threadId, cwd }: TerminalDrawerProps) {
+  const state = useTerminalStateStore((s) => selectThreadTerminalState(s.terminalStateByThreadId, threadId))
+  const setTerminalHeight = useTerminalStateStore((s) => s.setTerminalHeight)
+  const setActiveTerminal = useTerminalStateStore((s) => s.setActiveTerminal)
+  const newTerminal = useTerminalStateStore((s) => s.newTerminal)
+  const splitTerminal = useTerminalStateStore((s) => s.splitTerminal)
+  const closeTerminal = useTerminalStateStore((s) => s.closeTerminal)
+
+  const { terminalIds, activeTerminalId, terminalGroups, activeTerminalGroupId, terminalHeight } = state
+
+  // ── Derivations (mirrors t3code ThreadTerminalDrawer) ───────────────────────
+  const normalizedTerminalIds = useMemo(() => {
+    const cleaned = [...new Set(terminalIds.map((id) => id.trim()).filter((id) => id.length > 0))]
+    return cleaned.length > 0 ? cleaned : [DEFAULT_THREAD_TERMINAL_ID]
+  }, [terminalIds])
+
+  const resolvedActiveTerminalId = normalizedTerminalIds.includes(activeTerminalId)
+    ? activeTerminalId
+    : (normalizedTerminalIds[0] ?? DEFAULT_THREAD_TERMINAL_ID)
+
+  const resolvedTerminalGroups = useMemo<ThreadTerminalGroup[]>(() => {
+    const valid = new Set(normalizedTerminalIds)
+    const assigned = new Set<string>()
+    const used = new Set<string>()
+    const groups: ThreadTerminalGroup[] = []
+    const uniq = (gid: string): string => {
+      if (!used.has(gid)) { used.add(gid); return gid }
+      let s = 2
+      while (used.has(`${gid}-${s}`)) s += 1
+      const out = `${gid}-${s}`; used.add(out); return out
+    }
+    for (const g of terminalGroups) {
+      const ids = [...new Set(g.terminalIds.map((id) => id.trim()).filter((id) => id.length > 0))]
+        .filter((id) => valid.has(id) && !assigned.has(id))
+      if (ids.length === 0) continue
+      for (const id of ids) assigned.add(id)
+      const base = g.id.trim().length > 0 ? g.id.trim() : `group-${ids[0] ?? DEFAULT_THREAD_TERMINAL_ID}`
+      groups.push({ id: uniq(base), terminalIds: ids })
+    }
+    for (const id of normalizedTerminalIds) {
+      if (assigned.has(id)) continue
+      groups.push({ id: uniq(`group-${id}`), terminalIds: [id] })
+    }
+    return groups.length > 0 ? groups : [{ id: `group-${resolvedActiveTerminalId}`, terminalIds: [resolvedActiveTerminalId] }]
+  }, [normalizedTerminalIds, resolvedActiveTerminalId, terminalGroups])
+
+  const resolvedActiveGroupIndex = useMemo(() => {
+    const byId = resolvedTerminalGroups.findIndex((g) => g.id === activeTerminalGroupId)
+    if (byId >= 0) return byId
+    const byTerminal = resolvedTerminalGroups.findIndex((g) => g.terminalIds.includes(resolvedActiveTerminalId))
+    return byTerminal >= 0 ? byTerminal : 0
+  }, [activeTerminalGroupId, resolvedActiveTerminalId, resolvedTerminalGroups])
+
+  const visibleTerminalIds = resolvedTerminalGroups[resolvedActiveGroupIndex]?.terminalIds ?? [resolvedActiveTerminalId]
+  const hasTerminalSidebar = normalizedTerminalIds.length > 1
+  const isSplitView = visibleTerminalIds.length > 1
+  const showGroupHeaders =
+    resolvedTerminalGroups.length > 1 || resolvedTerminalGroups.some((g) => g.terminalIds.length > 1)
+  const hasReachedSplitLimit = visibleTerminalIds.length >= MAX_TERMINALS_PER_GROUP
+  const terminalLabelById = useMemo(
+    () => new Map(normalizedTerminalIds.map((id, i) => [id, `Terminal ${i + 1}`])),
+    [normalizedTerminalIds],
+  )
+
+  // ── Bootstrap: replace the placeholder "default" with a real tmux session ───
+  // Surfaces failures (e.g. an expired dashboard session → 401) with a Retry
+  // affordance instead of hanging forever on "Starting terminal…".
+  const bootstrappingRef = useRef(false)
+  const [bootstrapError, setBootstrapError] = useState(false)
+  const [retryNonce, setRetryNonce] = useState(0)
+  useEffect(() => {
+    const hasReal = normalizedTerminalIds.some((id) => id !== DEFAULT_THREAD_TERMINAL_ID)
+    if (hasReal || bootstrappingRef.current) return
+    bootstrappingRef.current = true
+    setBootstrapError(false)
+    void createTerminalSession(cwd)
+      .then((name) => {
+        if (name) {
+          newTerminal(threadId, name)
+          closeTerminal(threadId, DEFAULT_THREAD_TERMINAL_ID)
+        } else {
+          setBootstrapError(true)
+        }
+      })
+      .finally(() => { bootstrappingRef.current = false })
+  }, [normalizedTerminalIds, cwd, threadId, newTerminal, closeTerminal, retryNonce])
+
+  // ── Action handlers ─────────────────────────────────────────────────────────
+  const handleNew = useCallback(() => {
+    void createTerminalSession(cwd).then((name) => {
+      if (name) { newTerminal(threadId, name); pokeResize() }
+      else toast.error('Could not start terminal (dashboard session expired?)')
+    })
+  }, [cwd, threadId, newTerminal])
+
+  const handleSplit = useCallback(() => {
+    if (hasReachedSplitLimit) return
+    void createTerminalSession(cwd).then((name) => {
+      if (name) { splitTerminal(threadId, name); pokeResize() }
+      else toast.error('Could not start terminal (dashboard session expired?)')
+    })
+  }, [cwd, threadId, splitTerminal, hasReachedSplitLimit])
+
+  const handleClose = useCallback((terminalId: string) => {
+    closeTerminal(threadId, terminalId)
+    if (terminalId !== DEFAULT_THREAD_TERMINAL_ID) killTerminalSession(terminalId)
+    pokeResize()
+  }, [closeTerminal, threadId])
+
+  // ── Resize (drag the top handle) ────────────────────────────────────────────
+  const drawerHeight = clampDrawerHeight(terminalHeight)
+  const dragRef = useRef<{ pointerId: number; startY: number; startHeight: number } | null>(null)
+  const onResizeDown = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return
+    e.preventDefault()
+    e.currentTarget.setPointerCapture(e.pointerId)
+    dragRef.current = { pointerId: e.pointerId, startY: e.clientY, startHeight: clampDrawerHeight(terminalHeight) }
+  }, [terminalHeight])
+  const onResizeMove = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
+    const d = dragRef.current
+    if (!d || d.pointerId !== e.pointerId) return
+    e.preventDefault()
+    setTerminalHeight(threadId, clampDrawerHeight(d.startHeight + (d.startY - e.clientY)))
+  }, [setTerminalHeight, threadId])
+  const onResizeEnd = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
+    const d = dragRef.current
+    if (!d || d.pointerId !== e.pointerId) return
+    dragRef.current = null
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) e.currentTarget.releasePointerCapture(e.pointerId)
+    pokeResize()
+  }, [])
+
+  function renderViewport(terminalId: string) {
+    if (terminalId === DEFAULT_THREAD_TERMINAL_ID) {
+      if (bootstrapError) {
+        return (
+          <div className="flex h-full flex-col items-center justify-center gap-2 text-xs text-muted-foreground">
+            <span>Couldn't start a terminal.</span>
+            <button
+              type="button"
+              className="rounded border border-border px-2 py-1 text-foreground hover:bg-accent"
+              onClick={() => setRetryNonce((n) => n + 1)}
+            >
+              Retry
+            </button>
+          </div>
+        )
+      }
+      return <div className="flex h-full items-center justify-center text-xs text-muted-foreground">Starting terminal…</div>
+    }
+    return <XTerminal sessionName={terminalId} embedded onDisconnect={() => handleClose(terminalId)} />
+  }
+
+  return (
+    <aside
+      className="thread-terminal-drawer relative flex min-w-0 shrink-0 flex-col overflow-hidden border-t border-border/80 bg-background"
+      style={{ height: `${drawerHeight}px` }}
+      data-testid="terminal-drawer"
+    >
+      <div
+        className="absolute inset-x-0 top-0 z-20 h-1.5 cursor-row-resize"
+        onPointerDown={onResizeDown}
+        onPointerMove={onResizeMove}
+        onPointerUp={onResizeEnd}
+        onPointerCancel={onResizeEnd}
+      />
+
+      {!hasTerminalSidebar && (
+        <div className="pointer-events-none absolute right-2 top-2 z-20">
+          <div className="pointer-events-auto inline-flex items-center overflow-hidden rounded-md border border-border/80 bg-background/70">
+            <TerminalActionButton
+              className={`p-1 text-foreground/90 transition-colors ${hasReachedSplitLimit ? 'cursor-not-allowed opacity-45' : 'hover:bg-accent'}`}
+              onClick={handleSplit}
+              disabled={hasReachedSplitLimit}
+              label={hasReachedSplitLimit ? `Split Terminal (max ${MAX_TERMINALS_PER_GROUP} per group)` : 'Split Terminal'}
+            >
+              <SquareSplitHorizontal className="size-3.5" />
+            </TerminalActionButton>
+            <div className="h-4 w-px bg-border/80" />
+            <TerminalActionButton className="p-1 text-foreground/90 transition-colors hover:bg-accent" onClick={handleNew} label="New Terminal">
+              <Plus className="size-3.5" />
+            </TerminalActionButton>
+            <div className="h-4 w-px bg-border/80" />
+            <TerminalActionButton className="p-1 text-foreground/90 transition-colors hover:bg-accent" onClick={() => handleClose(resolvedActiveTerminalId)} label="Close Terminal">
+              <Trash2 className="size-3.5" />
+            </TerminalActionButton>
+          </div>
+        </div>
+      )}
+
+      <div className="min-h-0 w-full flex-1">
+        <div className={`flex h-full min-h-0 ${hasTerminalSidebar ? 'gap-1.5' : ''}`}>
+          <div className="min-w-0 flex-1">
+            {isSplitView ? (
+              <div
+                className="grid h-full w-full min-w-0 gap-0 overflow-hidden"
+                style={{ gridTemplateColumns: `repeat(${visibleTerminalIds.length}, minmax(0, 1fr))` }}
+              >
+                {visibleTerminalIds.map((terminalId) => (
+                  <div
+                    key={terminalId}
+                    className={`min-h-0 min-w-0 border-l first:border-l-0 ${terminalId === resolvedActiveTerminalId ? 'border-border' : 'border-border/70'}`}
+                    onMouseDown={() => { if (terminalId !== resolvedActiveTerminalId) setActiveTerminal(threadId, terminalId) }}
+                  >
+                    <div className="h-full p-1">{renderViewport(terminalId)}</div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="h-full p-1">{renderViewport(resolvedActiveTerminalId)}</div>
+            )}
+          </div>
+
+          {hasTerminalSidebar && (
+            <aside className="flex w-36 min-w-36 flex-col border border-border/70 bg-muted/10">
+              <div className="flex h-[22px] items-stretch justify-end border-b border-border/70">
+                <div className="inline-flex h-full items-stretch">
+                  <TerminalActionButton
+                    className={`inline-flex h-full items-center px-1 text-foreground/90 transition-colors ${hasReachedSplitLimit ? 'cursor-not-allowed opacity-45' : 'hover:bg-accent/70'}`}
+                    onClick={handleSplit}
+                    disabled={hasReachedSplitLimit}
+                    label={hasReachedSplitLimit ? `Split Terminal (max ${MAX_TERMINALS_PER_GROUP} per group)` : 'Split Terminal'}
+                  >
+                    <SquareSplitHorizontal className="size-3.5" />
+                  </TerminalActionButton>
+                  <TerminalActionButton className="inline-flex h-full items-center border-l border-border/70 px-1 text-foreground/90 transition-colors hover:bg-accent/70" onClick={handleNew} label="New Terminal">
+                    <Plus className="size-3.5" />
+                  </TerminalActionButton>
+                  <TerminalActionButton className="inline-flex h-full items-center border-l border-border/70 px-1 text-foreground/90 transition-colors hover:bg-accent/70" onClick={() => handleClose(resolvedActiveTerminalId)} label="Close Terminal">
+                    <Trash2 className="size-3.5" />
+                  </TerminalActionButton>
+                </div>
+              </div>
+
+              <div className="min-h-0 flex-1 overflow-y-auto px-1 py-1">
+                {resolvedTerminalGroups.map((group, groupIndex) => {
+                  const isGroupActive = group.terminalIds.includes(resolvedActiveTerminalId)
+                  const groupActiveTerminalId = isGroupActive ? resolvedActiveTerminalId : (group.terminalIds[0] ?? resolvedActiveTerminalId)
+                  return (
+                    <div key={group.id} className="pb-0.5">
+                      {showGroupHeaders && (
+                        <button
+                          type="button"
+                          className={`flex w-full items-center rounded px-1 py-0.5 text-[10px] uppercase tracking-[0.08em] ${isGroupActive ? 'bg-accent/70 text-foreground' : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'}`}
+                          onClick={() => setActiveTerminal(threadId, groupActiveTerminalId)}
+                        >
+                          {group.terminalIds.length > 1 ? `Split ${groupIndex + 1}` : `Terminal ${groupIndex + 1}`}
+                        </button>
+                      )}
+                      <div className={showGroupHeaders ? 'ml-1 border-l border-border/60 pl-1.5' : ''}>
+                        {group.terminalIds.map((terminalId) => {
+                          const isActive = terminalId === resolvedActiveTerminalId
+                          return (
+                            <div
+                              key={terminalId}
+                              className={`group flex items-center gap-1 rounded px-1 py-0.5 text-[11px] ${isActive ? 'bg-accent text-foreground' : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'}`}
+                            >
+                              {showGroupHeaders && <span className="text-[10px] text-muted-foreground/80">└</span>}
+                              <button type="button" className="flex min-w-0 flex-1 items-center gap-1 text-left" onClick={() => setActiveTerminal(threadId, terminalId)}>
+                                <TerminalSquare className="size-3 shrink-0" />
+                                <span className="truncate">{terminalLabelById.get(terminalId) ?? 'Terminal'}</span>
+                              </button>
+                              {normalizedTerminalIds.length > 1 && (
+                                <button
+                                  type="button"
+                                  className="inline-flex size-3.5 items-center justify-center rounded text-muted-foreground opacity-0 transition hover:bg-accent hover:text-foreground group-hover:opacity-100"
+                                  onClick={() => handleClose(terminalId)}
+                                  title={`Close ${terminalLabelById.get(terminalId) ?? 'terminal'}`}
+                                  aria-label={`Close ${terminalLabelById.get(terminalId) ?? 'terminal'}`}
+                                >
+                                  <XIcon className="size-2.5" />
+                                </button>
+                              )}
+                            </div>
+                          )
+                        })}
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            </aside>
+          )}
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/src/dashboard/frontend/src/components/terminal/terminalStateStore.ts
+++ b/src/dashboard/frontend/src/components/terminal/terminalStateStore.ts
@@ -1,0 +1,584 @@
+/**
+ * Single Zustand store for terminal UI state keyed by threadId.
+ *
+ * Terminal transition helpers are intentionally private to keep the public
+ * API constrained to store actions/selectors.
+ *
+ * VENDORED from t3code (apps/web/src/terminalStateStore.ts) for PAN-1561 — kept
+ * as verbatim as possible so upstream t3code fixes merge cleanly. The only
+ * deviations from upstream are the three seams marked `PAN-1561 SEAM` below:
+ *   1. `ThreadId` is sourced locally (plain string) rather than @t3tools/contracts.
+ *   2. storage uses window.localStorage with an in-memory fallback instead of
+ *      t3code's ./lib/storage resolveStorage helper.
+ *   3. the persisted-key namespace is `panopticon:` not `t3code:`.
+ */
+
+import { create } from "zustand";
+import { createJSONStorage, persist, type StateStorage } from "zustand/middleware";
+import {
+  DEFAULT_THREAD_TERMINAL_HEIGHT,
+  DEFAULT_THREAD_TERMINAL_ID,
+  MAX_TERMINALS_PER_GROUP,
+  type ThreadId,
+  type ThreadTerminalGroup,
+} from "./types";
+
+interface ThreadTerminalState {
+  terminalOpen: boolean;
+  terminalHeight: number;
+  terminalIds: string[];
+  runningTerminalIds: string[];
+  activeTerminalId: string;
+  terminalGroups: ThreadTerminalGroup[];
+  activeTerminalGroupId: string;
+}
+
+// PAN-1561 SEAM 3: namespace.
+const TERMINAL_STATE_STORAGE_KEY = "panopticon:terminal-state:v1";
+
+// PAN-1561 SEAM 2: localStorage with an in-memory fallback (replaces t3code's
+// resolveStorage(./lib/storage)).
+function createTerminalStateStorage(): StateStorage {
+  if (typeof window !== "undefined" && window.localStorage) return window.localStorage;
+  const mem = new Map<string, string>();
+  return {
+    getItem: (name) => mem.get(name) ?? null,
+    setItem: (name, value) => void mem.set(name, value),
+    removeItem: (name) => void mem.delete(name),
+  };
+}
+
+function normalizeTerminalIds(terminalIds: string[]): string[] {
+  const ids = [...new Set(terminalIds.map((id) => id.trim()).filter((id) => id.length > 0))];
+  return ids.length > 0 ? ids : [DEFAULT_THREAD_TERMINAL_ID];
+}
+
+function normalizeRunningTerminalIds(
+  runningTerminalIds: string[],
+  terminalIds: string[],
+): string[] {
+  if (runningTerminalIds.length === 0) return [];
+  const validTerminalIdSet = new Set(terminalIds);
+  return [...new Set(runningTerminalIds)]
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0 && validTerminalIdSet.has(id));
+}
+
+function fallbackGroupId(terminalId: string): string {
+  return `group-${terminalId}`;
+}
+
+function assignUniqueGroupId(baseId: string, usedGroupIds: Set<string>): string {
+  let candidate = baseId;
+  let index = 2;
+  while (usedGroupIds.has(candidate)) {
+    candidate = `${baseId}-${index}`;
+    index += 1;
+  }
+  usedGroupIds.add(candidate);
+  return candidate;
+}
+
+function findGroupIndexByTerminalId(
+  terminalGroups: ThreadTerminalGroup[],
+  terminalId: string,
+): number {
+  return terminalGroups.findIndex((group) => group.terminalIds.includes(terminalId));
+}
+
+function normalizeTerminalGroupIds(terminalIds: string[]): string[] {
+  return [...new Set(terminalIds.map((id) => id.trim()).filter((id) => id.length > 0))];
+}
+
+function normalizeTerminalGroups(
+  terminalGroups: ThreadTerminalGroup[],
+  terminalIds: string[],
+): ThreadTerminalGroup[] {
+  const validTerminalIdSet = new Set(terminalIds);
+  const assignedTerminalIds = new Set<string>();
+  const nextGroups: ThreadTerminalGroup[] = [];
+  const usedGroupIds = new Set<string>();
+
+  for (const group of terminalGroups) {
+    const groupTerminalIds = normalizeTerminalGroupIds(group.terminalIds).filter((terminalId) => {
+      if (!validTerminalIdSet.has(terminalId)) return false;
+      if (assignedTerminalIds.has(terminalId)) return false;
+      return true;
+    });
+    if (groupTerminalIds.length === 0) continue;
+    for (const terminalId of groupTerminalIds) {
+      assignedTerminalIds.add(terminalId);
+    }
+    const baseGroupId =
+      group.id.trim().length > 0
+        ? group.id.trim()
+        : fallbackGroupId(groupTerminalIds[0] ?? DEFAULT_THREAD_TERMINAL_ID);
+    nextGroups.push({
+      id: assignUniqueGroupId(baseGroupId, usedGroupIds),
+      terminalIds: groupTerminalIds,
+    });
+  }
+
+  for (const terminalId of terminalIds) {
+    if (assignedTerminalIds.has(terminalId)) continue;
+    nextGroups.push({
+      id: assignUniqueGroupId(fallbackGroupId(terminalId), usedGroupIds),
+      terminalIds: [terminalId],
+    });
+  }
+
+  if (nextGroups.length === 0) {
+    return [
+      {
+        id: fallbackGroupId(DEFAULT_THREAD_TERMINAL_ID),
+        terminalIds: [DEFAULT_THREAD_TERMINAL_ID],
+      },
+    ];
+  }
+
+  return nextGroups;
+}
+
+function arraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let index = 0; index < a.length; index += 1) {
+    if (a[index] !== b[index]) return false;
+  }
+  return true;
+}
+
+function terminalGroupsEqual(left: ThreadTerminalGroup[], right: ThreadTerminalGroup[]): boolean {
+  if (left.length !== right.length) return false;
+  for (let index = 0; index < left.length; index += 1) {
+    const leftGroup = left[index];
+    const rightGroup = right[index];
+    if (!leftGroup || !rightGroup) return false;
+    if (leftGroup.id !== rightGroup.id) return false;
+    if (!arraysEqual(leftGroup.terminalIds, rightGroup.terminalIds)) return false;
+  }
+  return true;
+}
+
+function threadTerminalStateEqual(left: ThreadTerminalState, right: ThreadTerminalState): boolean {
+  return (
+    left.terminalOpen === right.terminalOpen &&
+    left.terminalHeight === right.terminalHeight &&
+    left.activeTerminalId === right.activeTerminalId &&
+    left.activeTerminalGroupId === right.activeTerminalGroupId &&
+    arraysEqual(left.terminalIds, right.terminalIds) &&
+    arraysEqual(left.runningTerminalIds, right.runningTerminalIds) &&
+    terminalGroupsEqual(left.terminalGroups, right.terminalGroups)
+  );
+}
+
+const DEFAULT_THREAD_TERMINAL_STATE: ThreadTerminalState = Object.freeze({
+  terminalOpen: false,
+  terminalHeight: DEFAULT_THREAD_TERMINAL_HEIGHT,
+  terminalIds: [DEFAULT_THREAD_TERMINAL_ID],
+  runningTerminalIds: [],
+  activeTerminalId: DEFAULT_THREAD_TERMINAL_ID,
+  terminalGroups: [
+    {
+      id: fallbackGroupId(DEFAULT_THREAD_TERMINAL_ID),
+      terminalIds: [DEFAULT_THREAD_TERMINAL_ID],
+    },
+  ],
+  activeTerminalGroupId: fallbackGroupId(DEFAULT_THREAD_TERMINAL_ID),
+});
+
+function createDefaultThreadTerminalState(): ThreadTerminalState {
+  return {
+    ...DEFAULT_THREAD_TERMINAL_STATE,
+    terminalIds: [...DEFAULT_THREAD_TERMINAL_STATE.terminalIds],
+    runningTerminalIds: [...DEFAULT_THREAD_TERMINAL_STATE.runningTerminalIds],
+    terminalGroups: copyTerminalGroups(DEFAULT_THREAD_TERMINAL_STATE.terminalGroups),
+  };
+}
+
+function getDefaultThreadTerminalState(): ThreadTerminalState {
+  return DEFAULT_THREAD_TERMINAL_STATE;
+}
+
+function normalizeThreadTerminalState(state: ThreadTerminalState): ThreadTerminalState {
+  const terminalIds = normalizeTerminalIds(state.terminalIds);
+  const nextTerminalIds = terminalIds.length > 0 ? terminalIds : [DEFAULT_THREAD_TERMINAL_ID];
+  const runningTerminalIds = normalizeRunningTerminalIds(state.runningTerminalIds, nextTerminalIds);
+  const activeTerminalId = nextTerminalIds.includes(state.activeTerminalId)
+    ? state.activeTerminalId
+    : (nextTerminalIds[0] ?? DEFAULT_THREAD_TERMINAL_ID);
+  const terminalGroups = normalizeTerminalGroups(state.terminalGroups, nextTerminalIds);
+  const activeGroupIdFromState = terminalGroups.some(
+    (group) => group.id === state.activeTerminalGroupId,
+  )
+    ? state.activeTerminalGroupId
+    : null;
+  const activeGroupIdFromTerminal =
+    terminalGroups.find((group) => group.terminalIds.includes(activeTerminalId))?.id ?? null;
+
+  const normalized: ThreadTerminalState = {
+    terminalOpen: state.terminalOpen,
+    terminalHeight:
+      Number.isFinite(state.terminalHeight) && state.terminalHeight > 0
+        ? state.terminalHeight
+        : DEFAULT_THREAD_TERMINAL_HEIGHT,
+    terminalIds: nextTerminalIds,
+    runningTerminalIds,
+    activeTerminalId,
+    terminalGroups,
+    activeTerminalGroupId:
+      activeGroupIdFromState ??
+      activeGroupIdFromTerminal ??
+      terminalGroups[0]?.id ??
+      fallbackGroupId(DEFAULT_THREAD_TERMINAL_ID),
+  };
+  return threadTerminalStateEqual(state, normalized) ? state : normalized;
+}
+
+function isDefaultThreadTerminalState(state: ThreadTerminalState): boolean {
+  const normalized = normalizeThreadTerminalState(state);
+  return threadTerminalStateEqual(normalized, DEFAULT_THREAD_TERMINAL_STATE);
+}
+
+function isValidTerminalId(terminalId: string): boolean {
+  return terminalId.trim().length > 0;
+}
+
+function copyTerminalGroups(groups: ThreadTerminalGroup[]): ThreadTerminalGroup[] {
+  return groups.map((group) => ({
+    id: group.id,
+    terminalIds: [...group.terminalIds],
+  }));
+}
+
+function upsertTerminalIntoGroups(
+  state: ThreadTerminalState,
+  terminalId: string,
+  mode: "split" | "new",
+): ThreadTerminalState {
+  const normalized = normalizeThreadTerminalState(state);
+  if (!isValidTerminalId(terminalId)) {
+    return normalized;
+  }
+
+  const isNewTerminal = !normalized.terminalIds.includes(terminalId);
+  const terminalIds = isNewTerminal
+    ? [...normalized.terminalIds, terminalId]
+    : normalized.terminalIds;
+  const terminalGroups = copyTerminalGroups(normalized.terminalGroups);
+
+  const existingGroupIndex = findGroupIndexByTerminalId(terminalGroups, terminalId);
+  if (existingGroupIndex >= 0) {
+    terminalGroups[existingGroupIndex]!.terminalIds = terminalGroups[
+      existingGroupIndex
+    ]!.terminalIds.filter((id) => id !== terminalId);
+    if (terminalGroups[existingGroupIndex]!.terminalIds.length === 0) {
+      terminalGroups.splice(existingGroupIndex, 1);
+    }
+  }
+
+  if (mode === "new") {
+    const usedGroupIds = new Set(terminalGroups.map((group) => group.id));
+    const nextGroupId = assignUniqueGroupId(fallbackGroupId(terminalId), usedGroupIds);
+    terminalGroups.push({ id: nextGroupId, terminalIds: [terminalId] });
+    return normalizeThreadTerminalState({
+      ...normalized,
+      terminalOpen: true,
+      terminalIds,
+      activeTerminalId: terminalId,
+      terminalGroups,
+      activeTerminalGroupId: nextGroupId,
+    });
+  }
+
+  let activeGroupIndex = terminalGroups.findIndex(
+    (group) => group.id === normalized.activeTerminalGroupId,
+  );
+  if (activeGroupIndex < 0) {
+    activeGroupIndex = findGroupIndexByTerminalId(terminalGroups, normalized.activeTerminalId);
+  }
+  if (activeGroupIndex < 0) {
+    const usedGroupIds = new Set(terminalGroups.map((group) => group.id));
+    const nextGroupId = assignUniqueGroupId(
+      fallbackGroupId(normalized.activeTerminalId),
+      usedGroupIds,
+    );
+    terminalGroups.push({ id: nextGroupId, terminalIds: [normalized.activeTerminalId] });
+    activeGroupIndex = terminalGroups.length - 1;
+  }
+
+  const destinationGroup = terminalGroups[activeGroupIndex];
+  if (!destinationGroup) {
+    return normalized;
+  }
+
+  if (
+    isNewTerminal &&
+    !destinationGroup.terminalIds.includes(terminalId) &&
+    destinationGroup.terminalIds.length >= MAX_TERMINALS_PER_GROUP
+  ) {
+    return normalized;
+  }
+
+  if (!destinationGroup.terminalIds.includes(terminalId)) {
+    const anchorIndex = destinationGroup.terminalIds.indexOf(normalized.activeTerminalId);
+    if (anchorIndex >= 0) {
+      destinationGroup.terminalIds.splice(anchorIndex + 1, 0, terminalId);
+    } else {
+      destinationGroup.terminalIds.push(terminalId);
+    }
+  }
+
+  return normalizeThreadTerminalState({
+    ...normalized,
+    terminalOpen: true,
+    terminalIds,
+    activeTerminalId: terminalId,
+    terminalGroups,
+    activeTerminalGroupId: destinationGroup.id,
+  });
+}
+
+function setThreadTerminalOpen(state: ThreadTerminalState, open: boolean): ThreadTerminalState {
+  const normalized = normalizeThreadTerminalState(state);
+  if (normalized.terminalOpen === open) return normalized;
+  return { ...normalized, terminalOpen: open };
+}
+
+function setThreadTerminalHeight(state: ThreadTerminalState, height: number): ThreadTerminalState {
+  const normalized = normalizeThreadTerminalState(state);
+  if (!Number.isFinite(height) || height <= 0 || normalized.terminalHeight === height) {
+    return normalized;
+  }
+  return { ...normalized, terminalHeight: height };
+}
+
+function splitThreadTerminal(state: ThreadTerminalState, terminalId: string): ThreadTerminalState {
+  return upsertTerminalIntoGroups(state, terminalId, "split");
+}
+
+function newThreadTerminal(state: ThreadTerminalState, terminalId: string): ThreadTerminalState {
+  return upsertTerminalIntoGroups(state, terminalId, "new");
+}
+
+function setThreadActiveTerminal(
+  state: ThreadTerminalState,
+  terminalId: string,
+): ThreadTerminalState {
+  const normalized = normalizeThreadTerminalState(state);
+  if (!normalized.terminalIds.includes(terminalId)) {
+    return normalized;
+  }
+  const activeTerminalGroupId =
+    normalized.terminalGroups.find((group) => group.terminalIds.includes(terminalId))?.id ??
+    normalized.activeTerminalGroupId;
+  if (
+    normalized.activeTerminalId === terminalId &&
+    normalized.activeTerminalGroupId === activeTerminalGroupId
+  ) {
+    return normalized;
+  }
+  return {
+    ...normalized,
+    activeTerminalId: terminalId,
+    activeTerminalGroupId,
+  };
+}
+
+function closeThreadTerminal(state: ThreadTerminalState, terminalId: string): ThreadTerminalState {
+  const normalized = normalizeThreadTerminalState(state);
+  if (!normalized.terminalIds.includes(terminalId)) {
+    return normalized;
+  }
+
+  const remainingTerminalIds = normalized.terminalIds.filter((id) => id !== terminalId);
+  if (remainingTerminalIds.length === 0) {
+    return createDefaultThreadTerminalState();
+  }
+
+  const closedTerminalIndex = normalized.terminalIds.indexOf(terminalId);
+  const nextActiveTerminalId =
+    normalized.activeTerminalId === terminalId
+      ? (remainingTerminalIds[Math.min(closedTerminalIndex, remainingTerminalIds.length - 1)] ??
+        remainingTerminalIds[0] ??
+        DEFAULT_THREAD_TERMINAL_ID)
+      : normalized.activeTerminalId;
+
+  const terminalGroups = normalized.terminalGroups
+    .map((group) => ({
+      ...group,
+      terminalIds: group.terminalIds.filter((id) => id !== terminalId),
+    }))
+    .filter((group) => group.terminalIds.length > 0);
+
+  const nextActiveTerminalGroupId =
+    terminalGroups.find((group) => group.terminalIds.includes(nextActiveTerminalId))?.id ??
+    terminalGroups[0]?.id ??
+    fallbackGroupId(nextActiveTerminalId);
+
+  return normalizeThreadTerminalState({
+    terminalOpen: normalized.terminalOpen,
+    terminalHeight: normalized.terminalHeight,
+    terminalIds: remainingTerminalIds,
+    runningTerminalIds: normalized.runningTerminalIds.filter((id) => id !== terminalId),
+    activeTerminalId: nextActiveTerminalId,
+    terminalGroups,
+    activeTerminalGroupId: nextActiveTerminalGroupId,
+  });
+}
+
+function setThreadTerminalActivity(
+  state: ThreadTerminalState,
+  terminalId: string,
+  hasRunningSubprocess: boolean,
+): ThreadTerminalState {
+  const normalized = normalizeThreadTerminalState(state);
+  if (!normalized.terminalIds.includes(terminalId)) {
+    return normalized;
+  }
+  const alreadyRunning = normalized.runningTerminalIds.includes(terminalId);
+  if (hasRunningSubprocess === alreadyRunning) {
+    return normalized;
+  }
+  const runningTerminalIds = new Set(normalized.runningTerminalIds);
+  if (hasRunningSubprocess) {
+    runningTerminalIds.add(terminalId);
+  } else {
+    runningTerminalIds.delete(terminalId);
+  }
+  return { ...normalized, runningTerminalIds: [...runningTerminalIds] };
+}
+
+export function selectThreadTerminalState(
+  terminalStateByThreadId: Record<ThreadId, ThreadTerminalState>,
+  threadId: ThreadId,
+): ThreadTerminalState {
+  if (threadId.length === 0) {
+    return getDefaultThreadTerminalState();
+  }
+  return terminalStateByThreadId[threadId] ?? getDefaultThreadTerminalState();
+}
+
+function updateTerminalStateByThreadId(
+  terminalStateByThreadId: Record<ThreadId, ThreadTerminalState>,
+  threadId: ThreadId,
+  updater: (state: ThreadTerminalState) => ThreadTerminalState,
+): Record<ThreadId, ThreadTerminalState> {
+  if (threadId.length === 0) {
+    return terminalStateByThreadId;
+  }
+
+  const current = selectThreadTerminalState(terminalStateByThreadId, threadId);
+  const next = updater(current);
+  if (next === current) {
+    return terminalStateByThreadId;
+  }
+
+  if (isDefaultThreadTerminalState(next)) {
+    if (terminalStateByThreadId[threadId] === undefined) {
+      return terminalStateByThreadId;
+    }
+    const { [threadId]: _removed, ...rest } = terminalStateByThreadId;
+    return rest as Record<ThreadId, ThreadTerminalState>;
+  }
+
+  return {
+    ...terminalStateByThreadId,
+    [threadId]: next,
+  };
+}
+
+interface TerminalStateStoreState {
+  terminalStateByThreadId: Record<ThreadId, ThreadTerminalState>;
+  setTerminalOpen: (threadId: ThreadId, open: boolean) => void;
+  setTerminalHeight: (threadId: ThreadId, height: number) => void;
+  splitTerminal: (threadId: ThreadId, terminalId: string) => void;
+  newTerminal: (threadId: ThreadId, terminalId: string) => void;
+  setActiveTerminal: (threadId: ThreadId, terminalId: string) => void;
+  closeTerminal: (threadId: ThreadId, terminalId: string) => void;
+  setTerminalActivity: (
+    threadId: ThreadId,
+    terminalId: string,
+    hasRunningSubprocess: boolean,
+  ) => void;
+  clearTerminalState: (threadId: ThreadId) => void;
+  removeTerminalState: (threadId: ThreadId) => void;
+  removeOrphanedTerminalStates: (activeThreadIds: Set<ThreadId>) => void;
+}
+
+export type { ThreadTerminalState };
+
+export const useTerminalStateStore = create<TerminalStateStoreState>()(
+  persist(
+    (set) => {
+      const updateTerminal = (
+        threadId: ThreadId,
+        updater: (state: ThreadTerminalState) => ThreadTerminalState,
+      ) => {
+        set((state) => {
+          const nextTerminalStateByThreadId = updateTerminalStateByThreadId(
+            state.terminalStateByThreadId,
+            threadId,
+            updater,
+          );
+          if (nextTerminalStateByThreadId === state.terminalStateByThreadId) {
+            return state;
+          }
+          return {
+            terminalStateByThreadId: nextTerminalStateByThreadId,
+          };
+        });
+      };
+
+      return {
+        terminalStateByThreadId: {},
+        setTerminalOpen: (threadId, open) =>
+          updateTerminal(threadId, (state) => setThreadTerminalOpen(state, open)),
+        setTerminalHeight: (threadId, height) =>
+          updateTerminal(threadId, (state) => setThreadTerminalHeight(state, height)),
+        splitTerminal: (threadId, terminalId) =>
+          updateTerminal(threadId, (state) => splitThreadTerminal(state, terminalId)),
+        newTerminal: (threadId, terminalId) =>
+          updateTerminal(threadId, (state) => newThreadTerminal(state, terminalId)),
+        setActiveTerminal: (threadId, terminalId) =>
+          updateTerminal(threadId, (state) => setThreadActiveTerminal(state, terminalId)),
+        closeTerminal: (threadId, terminalId) =>
+          updateTerminal(threadId, (state) => closeThreadTerminal(state, terminalId)),
+        setTerminalActivity: (threadId, terminalId, hasRunningSubprocess) =>
+          updateTerminal(threadId, (state) =>
+            setThreadTerminalActivity(state, terminalId, hasRunningSubprocess),
+          ),
+        clearTerminalState: (threadId) =>
+          updateTerminal(threadId, () => createDefaultThreadTerminalState()),
+        removeTerminalState: (threadId) =>
+          set((state) => {
+            if (state.terminalStateByThreadId[threadId] === undefined) {
+              return state;
+            }
+            const next = { ...state.terminalStateByThreadId };
+            delete next[threadId];
+            return { terminalStateByThreadId: next };
+          }),
+        removeOrphanedTerminalStates: (activeThreadIds) =>
+          set((state) => {
+            const orphanedIds = Object.keys(state.terminalStateByThreadId).filter(
+              (id) => !activeThreadIds.has(id as ThreadId),
+            );
+            if (orphanedIds.length === 0) return state;
+            const next = { ...state.terminalStateByThreadId };
+            for (const id of orphanedIds) {
+              delete next[id as ThreadId];
+            }
+            return { terminalStateByThreadId: next };
+          }),
+      };
+    },
+    {
+      name: TERMINAL_STATE_STORAGE_KEY,
+      version: 1,
+      storage: createJSONStorage(createTerminalStateStorage),
+      partialize: (state) => ({
+        terminalStateByThreadId: state.terminalStateByThreadId,
+      }),
+    },
+  ),
+);

--- a/src/dashboard/frontend/src/components/terminal/types.ts
+++ b/src/dashboard/frontend/src/components/terminal/types.ts
@@ -1,0 +1,26 @@
+/**
+ * Terminal drawer types — vendored from t3code (apps/web/src/types.ts, terminal
+ * portion) for PAN-1561. Kept verbatim so upstream t3code fixes merge cleanly.
+ *
+ * Seam vs upstream: t3code brands `ThreadId` via @t3tools/contracts; here it is
+ * a plain string (a Panopticon project-deck / conversation key). See PAN-1536
+ * for the contract-consolidation follow-up.
+ */
+
+/** A terminal "scope" key (Panopticon: the project deck key). */
+export type ThreadId = string;
+
+/** Default terminal drawer height in pixels. */
+export const DEFAULT_THREAD_TERMINAL_HEIGHT = 280;
+
+/** Id of the implicit first terminal in a fresh scope. */
+export const DEFAULT_THREAD_TERMINAL_ID = "default";
+
+/** Max terminals allowed in a single split group. */
+export const MAX_TERMINALS_PER_GROUP = 4;
+
+/** A split group: an ordered set of terminals shown side-by-side. */
+export interface ThreadTerminalGroup {
+  id: string;
+  terminalIds: string[];
+}

--- a/src/dashboard/frontend/src/lib/panesStore.ts
+++ b/src/dashboard/frontend/src/lib/panesStore.ts
@@ -36,6 +36,8 @@ export interface WorkspacePane {
   isPermanent?: boolean
   // issue pane — an issue tab opened inside a project-scoped deck (PAN-1561)
   issueId?: string
+  // agent id backing an issue-scoped pane (e.g. FilesPane diff target, PAN-1561)
+  agentId?: string
   // agent pane
   conversationId?: string
   agentType?: string
@@ -261,6 +263,26 @@ export const usePanesStore = create<PanesStore>((set, get) => ({
 
   addPane: (workspaceId, spec) => {
     touchWorkspace(workspaceId)
+    // Opening a pane that already exists must focus it, never add a duplicate
+    // (PAN-1561). Agent panes key on the conversation; issue tabs on the issue;
+    // the issue-scoped singleton panes (files/commits/plan/docs) key on
+    // (type, issueId) so each issue gets at most one. Browser panes are exempt —
+    // multiple are legitimate (different URLs).
+    const SINGLETON_TYPES: PaneType[] = ['files', 'commits', 'plan', 'docs']
+    const existingPanes = get().panesByWorkspace[workspaceId] ?? []
+    const dup = existingPanes.find(
+      (p) =>
+        (spec.paneType === 'agent' && p.paneType === 'agent' && !!spec.conversationId && p.conversationId === spec.conversationId) ||
+        (spec.paneType === 'issue' && p.paneType === 'issue' && !!spec.issueId && p.issueId === spec.issueId) ||
+        (SINGLETON_TYPES.includes(spec.paneType) && p.paneType === spec.paneType && p.issueId === spec.issueId),
+    )
+    if (dup) {
+      set((s) => ({
+        activePaneByWorkspace: { ...s.activePaneByWorkspace, [workspaceId]: dup.paneId },
+      }))
+      schedulePersist(workspaceId, existingPanes, dup.paneId)
+      return dup.paneId
+    }
     const paneId = generatePaneId()
     const newPane: WorkspacePane = { ...spec, paneId, createdAt: Date.now() }
     set((s) => {

--- a/src/dashboard/frontend/src/lib/panesStore.ts
+++ b/src/dashboard/frontend/src/lib/panesStore.ts
@@ -18,6 +18,7 @@ export type PaneId = string
 
 export type PaneType =
   | 'home'
+  | 'issue'
   | 'agent'
   | 'terminal'
   | 'files'
@@ -33,6 +34,8 @@ export interface WorkspacePane {
   createdAt: number
   /** true for the HOME pane — it is synthesized and cannot be closed. */
   isPermanent?: boolean
+  // issue pane — an issue tab opened inside a project-scoped deck (PAN-1561)
+  issueId?: string
   // agent pane
   conversationId?: string
   agentType?: string

--- a/src/dashboard/frontend/vite.config.ts
+++ b/src/dashboard/frontend/vite.config.ts
@@ -4,6 +4,12 @@ import react from '@vitejs/plugin-react';
 // Detect if running in container/Traefik mode
 const isContainerMode = process.env.TRAEFIK_ENABLED === 'true' || process.env.CONTAINER_MODE === 'true';
 
+// Backend target. Defaults to the conventional port; override with
+// VITE_PROXY_TARGET to preview a workspace's own backend before merge
+// (e.g. VITE_PROXY_TARGET=http://localhost:3012).
+const apiTarget = process.env.VITE_PROXY_TARGET ?? (isContainerMode ? 'http://server:3011' : 'http://localhost:3011');
+const wsTarget = apiTarget.replace(/^http/, 'ws');
+
 export default defineConfig({
   plugins: [react()],
   server: {
@@ -16,11 +22,11 @@ export default defineConfig({
     } : undefined,
     proxy: {
       '/api': {
-        target: isContainerMode ? 'http://server:3011' : 'http://localhost:3011',
+        target: apiTarget,
         changeOrigin: true,
       },
       '/ws': {
-        target: isContainerMode ? 'ws://server:3011' : 'ws://localhost:3011',
+        target: wsTarget,
         ws: true,
       },
     },

--- a/src/dashboard/server/routes/terminals.ts
+++ b/src/dashboard/server/routes/terminals.ts
@@ -1,0 +1,99 @@
+/**
+ * Terminal routes (PAN-1545 / PAN-1561) — ad-hoc tmux sessions for the
+ * terminal drawer and the standalone terminal view.
+ *
+ *   POST   /api/terminals          — create a fresh tmux session, returns { sessionName, cwd }
+ *   DELETE /api/terminals/:name    — kill a session
+ *
+ * Each "terminal" in the T3-style drawer is one of these tmux sessions; the
+ * frontend then attaches via the existing raw `/ws/terminal?session=` socket
+ * (XTerminal). When PAN-1536 moves terminal streaming onto PanRpcGroup with
+ * t3code's `terminal.*` contracts, this create/kill pair is the seam that gets
+ * folded into that RPC surface.
+ */
+
+import { existsSync, statSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+
+import { Effect, Layer } from 'effect';
+import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
+
+import { jsonResponse } from '../http-helpers.js';
+import { httpHandler } from './http-handler.js';
+import { createSession, killSession } from '../../../lib/tmux.js';
+import { getDefaultCwd } from '../../../lib/default-cwd.js';
+import { validateOrigin } from './origin-validation.js';
+import { rejectUnauthorizedDashboardRequest } from './dashboard-auth.js';
+
+const readJsonBody = Effect.gen(function* () {
+  const request = yield* HttpServerRequest.HttpServerRequest;
+  const text = yield* request.text;
+  return text ? (JSON.parse(text) as Record<string, unknown>) : {};
+});
+
+/** Origin + dashboard-session guard, mirroring other mutating routes. */
+function rejectUnauthorized(request: HttpServerRequest.HttpServerRequest) {
+  const originCheck = validateOrigin(request);
+  if (!originCheck.ok) return jsonResponse({ error: originCheck.error }, { status: 403 });
+  return rejectUnauthorizedDashboardRequest(request);
+}
+
+/** Resolve a safe working directory: a caller cwd only if it's an existing dir,
+ * otherwise the dashboard default (~/Projects or $HOME). */
+function resolveCwd(raw: unknown): string {
+  if (typeof raw === 'string' && raw.startsWith('/')) {
+    try {
+      if (existsSync(raw) && statSync(raw).isDirectory()) return raw;
+    } catch {
+      /* fall through to default */
+    }
+  }
+  return getDefaultCwd();
+}
+
+function generateTerminalSessionName(): string {
+  return `term-${Date.now()}-${randomUUID().slice(0, 8)}`;
+}
+
+const postTerminalRoute = HttpRouter.add(
+  'POST',
+  '/api/terminals',
+  httpHandler(
+    Effect.gen(function* () {
+      const request = yield* HttpServerRequest.HttpServerRequest;
+      const authError = rejectUnauthorized(request);
+      if (authError) return authError;
+
+      const body = yield* readJsonBody;
+      const cwd = resolveCwd(body.cwd);
+      const sessionName = generateTerminalSessionName();
+
+      yield* createSession(sessionName, cwd, undefined, {
+        env: { PATH: process.env.PATH || '' },
+      });
+
+      return jsonResponse({ sessionName, cwd });
+    }),
+  ),
+);
+
+const deleteTerminalRoute = HttpRouter.add(
+  'DELETE',
+  '/api/terminals/:name',
+  httpHandler(
+    Effect.gen(function* () {
+      const request = yield* HttpServerRequest.HttpServerRequest;
+      const authError = rejectUnauthorized(request);
+      if (authError) return authError;
+
+      const params = yield* HttpRouter.params;
+      const name = params.name;
+      if (!name) return jsonResponse({ error: 'session name required' }, { status: 400 });
+
+      yield* killSession(name);
+      return jsonResponse({ ok: true });
+    }),
+  ),
+);
+
+export const terminalsRouteLayer = Layer.mergeAll(postTerminalRoute, deleteTerminalRoute);

--- a/src/dashboard/server/server.ts
+++ b/src/dashboard/server/server.ts
@@ -60,6 +60,7 @@ import { webhooksRouteLayer } from './routes/webhooks.js';
 import { hooksRouteLayer } from './routes/hooks.js';
 import { diffsRouteLayer } from './routes/diffs.js';
 import { codexAuthRouteLayer } from './routes/codex-auth.js';
+import { terminalsRouteLayer } from './routes/terminals.js';
 import { discoveredSessionsRouteLayer } from './routes/discovered-sessions.js';
 import { flywheelRouteLayer } from './routes/flywheel.js';
 import { artifactsRouteLayer } from './routes/artifacts.js';
@@ -321,6 +322,7 @@ export const makeRoutesLayer = Layer.mergeAll(
   hooksRouteLayer,
   diffsRouteLayer,
   codexAuthRouteLayer,
+  terminalsRouteLayer,
   discoveredSessionsRouteLayer,
   flywheelRouteLayer,
   artifactsRouteLayer,


### PR DESCRIPTION
Implements **PAN-1561** — project-scoped dashboard navigation — plus the follow-on UX work agreed during review.

## Highlights
- **Project-scoped deck nav**: sidebar = Home · Flywheel · Projects (others under *More*); selecting a project opens a deck of tabs scoped to it (project-scoped Home `# <project>`, conversations+issue-tree column, project activity).
- **T3-style terminal drawer**: resizable drawer stacked below the deck with split groups + right-rail list; store/types **vendored from t3code** for easy upstream merges. Backed by new `POST/DELETE /api/terminals` (delivers PAN-1545). RPC-backed viewport tracked by PAN-1536.
- **Agent logos**: real Anthropic/OpenAI marks via the shared `ProviderIcon`.
- **XTerminal**: follows light/dark theme; embedded gear hidden in the drawer.
- **Deck hardening**: idempotent `addPane` (no duplicate tabs), prune-on-load, issue-scoped Files/Commits/Plan/Docs panes, context-scoped action docks, live tab labels.
- **No-project bucket** for unscoped conversations/terminals; **Project Activity** column (project-scoped session feed; No-project shows unscoped activity).
- **`+`** opens a New conversation / New terminal / Web menu (portaled so it isn't clipped).

## Verification
typecheck · lint · frontend build · vitest all pass (suite updated for new APIs). The only failing test is a pre-existing, unrelated `IssueDrawer` snapshot. Extensive browser UAT across all navigation paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added project-scoped deck view with sidebar project selection and "No project" bucket
  * Introduced terminal drawer for managing multiple tmux sessions with create, split, and resize capabilities
  * Added issue overview pane with scoped conversations and file/commit/documentation views
  * Added project home view with dedicated conversation and agent management
  * Implemented action menu for quickly creating new conversations and terminals
  * Enhanced agent dock with branded provider icons for improved visual identification
  * Reorganized sidebar navigation with pinned "Home" and "Flywheel" items and collapsible "More" section

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eltmon/panopticon-cli/pull/1563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->