### PR TITLE
fix(dashboard): Settings page crash — React #310 from misplaced useMemo (PAN-1598)

### DIFF
--- a/src/dashboard/frontend/src/components/Settings/SettingsPage.tsx
+++ b/src/dashboard/frontend/src/components/Settings/SettingsPage.tsx
@@ -765,6 +765,21 @@ export function SettingsPage() {
     if (ttsSaveDebounceRef.current) clearTimeout(ttsSaveDebounceRef.current);
   }, []);
 
+  // Shared chat-model <option> list (same catalog as the Conversations selects).
+  // MUST be declared before the early returns below — it's a hook (PAN-1597 fix:
+  // a misplaced useMemo here caused React error #310 / hooks-order violation that
+  // crashed the entire Settings page).
+  const chatModelOptionEls = useMemo(() => [
+    ...Object.entries(MODELS_BY_PROVIDER).flatMap(([, providerDef]) =>
+      providerDef.models.map((model) => (
+        <option key={model.id} value={model.id}>{providerDef.name} — {model.name}</option>
+      )),
+    ),
+    ...openRouterFavoriteModels.map((model) => (
+      <option key={model.id} value={model.id}>OpenRouter — {model.name}</option>
+    )),
+  ], [openRouterFavoriteModels]);
+
   if (isLoading || voiceSettingsLoading) {
     return (
       <div className="flex items-center justify-center h-64">
@@ -1049,18 +1064,6 @@ export function SettingsPage() {
     setFormData(next);
     saveMutation.mutate({ settings: next, voiceSettings: voiceFormData });
   };
-
-  // Shared chat-model <option> list (same catalog as the Conversations selects).
-  const chatModelOptionEls = useMemo(() => [
-    ...Object.entries(MODELS_BY_PROVIDER).flatMap(([, providerDef]) =>
-      providerDef.models.map((model) => (
-        <option key={model.id} value={model.id}>{providerDef.name} — {model.name}</option>
-      )),
-    ),
-    ...openRouterFavoriteModels.map((model) => (
-      <option key={model.id} value={model.id}>OpenRouter — {model.name}</option>
-    )),
-  ], [openRouterFavoriteModels]);
 
   const bgSelectClass = 'bg-background border border-border rounded-md px-2 py-1 text-[11px] text-foreground focus:ring-1 focus:ring-primary';
 


### PR DESCRIPTION
Closes #1598. Hotfix for a regression introduced by PAN-1589 (#1590).

The Settings page crashed with **React error #310** ("rendered more hooks than during the previous render"): the `chatModelOptionEls = useMemo(...)` added for the Background AI per-feature model pickers was placed **after** `SettingsPage`'s early returns, so the hook count changed between the loading render and the loaded render.

**Fix:** moved the `useMemo` above the early returns, with the other top-level hooks. One-file change.

Verified: frontend typecheck (0 errors) + `vite build` clean.