### PR TITLE
feat(dashboard): background-AI UX refinements (PAN-1601)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -59,7 +59,7 @@
     },
     "apps/desktop": {
       "name": "@panctl/desktop",
-      "version": "0.17.3",
+      "version": "0.18.0",
       "bin": {
         "panctl": "./bin/panctl.mjs",
       },
@@ -80,7 +80,7 @@
     },
     "packages/contracts": {
       "name": "@panctl/contracts",
-      "version": "0.17.3",
+      "version": "0.18.0",
       "dependencies": {
         "effect": "4.0.0-beta.73",
       },

--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -40,6 +40,7 @@ import { GodViewSkeleton } from './components/skeletons/GodViewSkeleton';
 import { StandaloneTerminal } from './components/StandaloneTerminal';
 import { DeaconPauseToggle } from './components/DeaconPauseToggle';
 import { NoResumeBanner } from './components/NoResumeBanner';
+import { LowCostModePill } from './components/LowCostModePill';
 import { StoppedAgentsBanner } from './components/StoppedAgentsBanner';
 import { OrphanTestAgentsSurface } from './components/OrphanTestAgentsSurface';
 import { CodexAuthBanner } from './components/CodexAuthBanner';
@@ -1214,6 +1215,7 @@ export default function App() {
               </span>
             )}
             <StoppedAgentsBanner variant="pill" />
+            <LowCostModePill onOpenSettings={() => setActiveTab('settings')} />
             <SystemHealthPill />
             {/* The Command Deck has the always-on Awareness rail, so the global
                 feed toggle only appears on other pages (PAN-1591). */}

--- a/src/dashboard/frontend/src/components/CloisterStatusBar.tsx
+++ b/src/dashboard/frontend/src/components/CloisterStatusBar.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Bell, BellOff, AlertTriangle, StopCircle, Settings, Zap, RefreshCw, Gauge } from 'lucide-react';
+import { Bell, BellOff, AlertTriangle, StopCircle, Settings, Zap, RefreshCw } from 'lucide-react';
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { useDashboardStore, selectAgents } from '../lib/store';
@@ -31,9 +31,6 @@ interface DashboardSettings {
     cheap_mode?: boolean;
   };
 }
-
-/** sessionStorage key the Settings page reads to scroll to a section on open. */
-export const SETTINGS_SECTION_INTENT_KEY = 'panopticon.settingsSection';
 
 interface TtsHealthStatus {
   ok: boolean;
@@ -140,16 +137,6 @@ export function CloisterStatusBar({ onOpenSettings }: { onOpenSettings?: () => v
     retry: false,
   });
   const ttsEnabled = settings?.tts?.enabled === true;
-  const lowCostMode = settings?.background_ai?.cheap_mode === true;
-
-  const openBackgroundAiSettings = useCallback(() => {
-    try {
-      sessionStorage.setItem(SETTINGS_SECTION_INTENT_KEY, 'background-ai');
-    } catch {
-      // sessionStorage unavailable (private mode) — fall through to plain open.
-    }
-    onOpenSettings?.();
-  }, [onOpenSettings]);
 
   const { data: ttsHealth, isError: ttsHealthFailed } = useQuery({
     queryKey: ['tts-health'],
@@ -232,7 +219,20 @@ export function CloisterStatusBar({ onOpenSettings }: { onOpenSettings?: () => v
   };
 
   if (!status) {
-    return null;
+    // Cloister status unavailable (e.g. the status fetch 401'd). Still render the
+    // settings gear so the user always has a way into Settings — previously the
+    // whole bar (gear included) vanished on any fetch failure (PAN-1600).
+    return (
+      <div className="flex items-center gap-1.5 shrink-0">
+        <button
+          onClick={onOpenSettings}
+          className="p-1 rounded text-xs bg-popover text-foreground hover:bg-card transition-colors"
+          title="Open Settings"
+        >
+          <Settings className="w-3.5 h-3.5" />
+        </button>
+      </div>
+    );
   }
 
   const hasWarnings = status.summary.warning > 0 || status.summary.stuck > 0;
@@ -285,19 +285,6 @@ export function CloisterStatusBar({ onOpenSettings }: { onOpenSettings?: () => v
         <span title={`${needsAttention} agent${needsAttention !== 1 ? 's' : ''} need attention`}>
           <AlertTriangle className="w-3.5 h-3.5 text-warning" />
         </span>
-      )}
-
-      {lowCostMode && (
-        <button
-          type="button"
-          data-testid="low-cost-mode-pill"
-          onClick={openBackgroundAiSettings}
-          className="flex items-center gap-1 rounded bg-popover px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground hover:bg-card hover:text-foreground transition-colors"
-          title="Background AI is off (low-cost mode). Click to configure which features run."
-        >
-          <Gauge className="h-3 w-3" />
-          Low-cost mode
-        </button>
       )}
 
       {ttsEnabled && (

--- a/src/dashboard/frontend/src/components/LowCostModePill.tsx
+++ b/src/dashboard/frontend/src/components/LowCostModePill.tsx
@@ -1,0 +1,53 @@
+import { useQuery } from '@tanstack/react-query';
+import { Gauge, AlertCircle } from 'lucide-react';
+import { requestSettingsSection } from '../lib/settingsSection';
+
+/**
+ * Low-cost mode pill (PAN-1600).
+ *
+ * Lives in the always-rendered app bar (not the cloister status bar, which
+ * hides itself when its status fetch fails) so the "background AI is off"
+ * notification is always visible while low-cost mode is on. Clicking it opens
+ * Settings and scrolls to the Background AI section.
+ *
+ * The exclamation is muted gray, not red: low-cost mode is a deliberately
+ * available choice, not an error — but background AI (especially durable
+ * memory) is valuable, so we gently flag that it's a less-than-ideal state.
+ */
+
+interface LowCostSettings {
+  background_ai?: { cheap_mode?: boolean };
+}
+
+async function fetchBackgroundAiCheapMode(): Promise<LowCostSettings> {
+  const res = await fetch('/api/settings');
+  if (!res.ok) throw new Error('settings fetch failed');
+  return res.json();
+}
+
+export function LowCostModePill({ onOpenSettings }: { onOpenSettings?: () => void }) {
+  const { data } = useQuery({
+    queryKey: ['settings'],
+    queryFn: fetchBackgroundAiCheapMode,
+    retry: false,
+  });
+
+  if (data?.background_ai?.cheap_mode !== true) return null;
+
+  return (
+    <button
+      type="button"
+      data-testid="low-cost-mode-pill"
+      onClick={() => {
+        requestSettingsSection('background-ai');
+        onOpenSettings?.();
+      }}
+      title="Background AI (titles, memory, enrichment, narration) is off to save cost. Memory in particular is one of Panopticon's most valuable features — click to choose what runs."
+      className="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/40 px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+    >
+      <Gauge className="h-3.5 w-3.5" aria-hidden="true" />
+      Low-cost mode
+      <AlertCircle className="h-3.5 w-3.5 text-muted-foreground/70" aria-hidden="true" />
+    </button>
+  );
+}

--- a/src/dashboard/frontend/src/components/Settings/SettingsPage.tsx
+++ b/src/dashboard/frontend/src/components/Settings/SettingsPage.tsx
@@ -33,6 +33,7 @@ import {
   Gauge,
 } from 'lucide-react';
 import { SettingsConfig, Provider, ModelId, type TtsConfig, type BackgroundAiConfig, type BackgroundAiFeature, BACKGROUND_AI_FEATURE_META } from './types';
+import { consumePendingSettingsSection, SETTINGS_SECTION_EVENT } from '../../lib/settingsSection';
 import { useUIPreferences } from '../../hooks/useUIPreferences';
 import { useDiffPreferences } from '../../hooks/useDiffPreferences';
 import { useCodexAuthStatus } from '../../hooks/useCodexAuthStatus';
@@ -512,26 +513,33 @@ export function SettingsPage() {
 
   const scrollToSection = useCallback((id: string) => {
     setActiveSection(id);
-    const el = document.getElementById(id);
-    if (el) {
-      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
+    // Retry until the target section is actually in the DOM — on a fresh
+    // navigation the section may not be mounted on the first frame, which made
+    // the deep-link miss intermittently (PAN-1600).
+    let tries = 0;
+    const tryScroll = () => {
+      const el = document.getElementById(id);
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        return;
+      }
+      if (tries++ < 40) setTimeout(tryScroll, 50);
+    };
+    tryScroll();
   }, []);
 
-  // Deep-link: when another surface (e.g. the low-cost-mode status pill) opens
-  // Settings with a section intent, scroll there once on mount (PAN-1589).
+  // Deep-link from other surfaces (e.g. the app-bar Low-cost mode pill). Handles
+  // both cases: navigated-then-mounted (consume the pending intent on mount) and
+  // already-open (react to the live event) — PAN-1600.
   useEffect(() => {
-    let intent: string | null = null;
-    try {
-      intent = sessionStorage.getItem('panopticon.settingsSection');
-      if (intent) sessionStorage.removeItem('panopticon.settingsSection');
-    } catch {
-      intent = null;
-    }
-    if (!intent) return;
-    // Defer to the next frame so the target section is mounted.
-    const t = setTimeout(() => scrollToSection(intent as string), 0);
-    return () => clearTimeout(t);
+    const pending = consumePendingSettingsSection();
+    if (pending) scrollToSection(pending);
+    const handler = (e: Event) => {
+      const id = (e as CustomEvent<string>).detail;
+      if (id) scrollToSection(id);
+    };
+    window.addEventListener(SETTINGS_SECTION_EVENT, handler);
+    return () => window.removeEventListener(SETTINGS_SECTION_EVENT, handler);
   }, [scrollToSection]);
 
   // ── Conversations & Search (embedding) config ──────────────────────────────
@@ -1070,28 +1078,28 @@ export function SettingsPage() {
   // Render the model control for one background feature. Heterogeneous: chat
   // features use the chat-model select; memory uses provider+model; embeddings
   // use a dedicated provider+embedding-model picker; TTS edits its own model.
-  const backgroundModelControl = (key: BackgroundAiFeature, disabled: boolean) => {
+  const backgroundModelControl = (key: BackgroundAiFeature) => {
     const setConv = (patch: NonNullable<SettingsConfig['conversations']>) =>
       applyBackgroundModelPatch({ ...formData!, conversations: { ...formData!.conversations, ...patch } });
     switch (key) {
       case 'conversationTitles':
       case 'titleRefinement':
         return (
-          <select disabled={disabled} value={formData?.conversations?.title_model || 'claude-haiku-4-5'}
+          <select value={formData?.conversations?.title_model || 'claude-haiku-4-5'}
             onChange={(e) => setConv({ title_model: e.target.value as ModelId })} className={`${bgSelectClass} max-w-[180px]`}>
             {chatModelOptionEls}
           </select>
         );
       case 'summaryFork':
         return (
-          <select disabled={disabled} value={formData?.conversations?.compaction_model || 'claude-haiku-4-5'}
+          <select value={formData?.conversations?.compaction_model || 'claude-haiku-4-5'}
             onChange={(e) => setConv({ compaction_model: e.target.value as ModelId })} className={`${bgSelectClass} max-w-[180px]`}>
             {chatModelOptionEls}
           </select>
         );
       case 'conversationEnrichment':
         return (
-          <select disabled={disabled} value={formData?.conversations?.enrichment?.quick_model || ''}
+          <select value={formData?.conversations?.enrichment?.quick_model || ''}
             onChange={(e) => setConv({ enrichment: { ...formData?.conversations?.enrichment, quick_model: e.target.value || null } })}
             className={`${bgSelectClass} max-w-[180px]`}>
             <option value="">Auto (tier default)</option>
@@ -1105,11 +1113,11 @@ export function SettingsPage() {
           applyBackgroundModelPatch({ ...formData!, memory: { ...formData!.memory, ...patch } });
         return (
           <div className="flex items-center gap-1">
-            <select disabled={disabled} value={provider} onChange={(e) => setMem({ provider: e.target.value as 'anthropic' | 'cliproxy' })} className={`${bgSelectClass} max-w-[110px]`}>
+            <select value={provider} onChange={(e) => setMem({ provider: e.target.value as 'anthropic' | 'cliproxy' })} className={`${bgSelectClass} max-w-[110px]`}>
               <option value="anthropic">Anthropic</option>
               <option value="cliproxy">cliproxy</option>
             </select>
-            <input disabled={disabled} type="text" value={formData?.memory?.model || ''}
+            <input type="text" value={formData?.memory?.model || ''}
               onChange={(e) => setMem({ model: e.target.value || undefined })}
               placeholder={provider === 'cliproxy' ? 'gpt-4.1-nano' : 'claude-haiku-4-5-20251001'}
               className="w-36 bg-background border border-border rounded-md px-2 py-1 text-[11px] font-mono text-foreground focus:ring-1 focus:ring-primary" />
@@ -1122,14 +1130,14 @@ export function SettingsPage() {
         const model = formData?.conversations?.embedding_model || models[0] || '';
         return (
           <div className="flex items-center gap-1">
-            <select disabled={disabled} value={provider}
+            <select value={provider}
               onChange={(e) => { const p = e.target.value as 'openai' | 'voyage' | 'ollama'; setConv({ embedding_provider: p, embedding_model: EMBEDDING_MODELS_BY_PROVIDER[p]?.[0] }); }}
               className={`${bgSelectClass} max-w-[100px]`}>
               <option value="openai">OpenAI</option>
               <option value="voyage">Voyage</option>
               <option value="ollama">Ollama</option>
             </select>
-            <select disabled={disabled} value={model} onChange={(e) => setConv({ embedding_model: e.target.value })} className={`${bgSelectClass} max-w-[170px]`}>
+            <select value={model} onChange={(e) => setConv({ embedding_model: e.target.value })} className={`${bgSelectClass} max-w-[170px]`}>
               {models.map((m) => <option key={m} value={m}>{m}</option>)}
             </select>
           </div>
@@ -1137,7 +1145,7 @@ export function SettingsPage() {
       }
       case 'ttsSummarizer':
         return (
-          <select disabled={disabled} value={formData?.tts_summarizer?.model || 'gpt-5.4-mini'}
+          <select value={formData?.tts_summarizer?.model || 'gpt-5.4-mini'}
             onChange={(e) => applyBackgroundModelPatch({ ...formData!, tts_summarizer: { ...formData!.tts_summarizer, model: e.target.value as ModelId } })}
             className={`${bgSelectClass} max-w-[180px]`}>
             {chatModelOptionEls}
@@ -2362,15 +2370,21 @@ export function SettingsPage() {
             return (
               <div
                 key={feature.key}
-                className={`flex items-center justify-between gap-4 px-4 py-3 rounded-lg transition-colors ${
-                  cheapMode ? 'opacity-50' : 'hover:bg-muted/30'
-                }`}
+                className="flex items-center justify-between gap-4 px-4 py-3 rounded-lg transition-colors hover:bg-muted/30"
               >
                 <div className="min-w-0">
-                  <span className="text-sm font-medium text-foreground">{feature.label}</span>
+                  <span className={`text-sm font-medium ${effectiveOn ? 'text-foreground' : 'text-muted-foreground'}`}>{feature.label}</span>
+                  {!effectiveOn && (
+                    <span
+                      className="ml-2 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+                      title="This feature is off, so it isn't running — but you can still change its model below; the new model takes effect when you enable it (or turn off low-cost mode)."
+                    >
+                      not active
+                    </span>
+                  )}
                   <p className="text-xs text-muted-foreground mt-0.5">{feature.description}</p>
                   <div className="mt-1.5 flex items-center gap-2">
-                    {backgroundModelControl(feature.key, cheapMode)}
+                    {backgroundModelControl(feature.key)}
                   </div>
                 </div>
                 <div className="flex items-center gap-3 shrink-0">
@@ -2402,8 +2416,11 @@ export function SettingsPage() {
           })}
         </div>
         <p className="text-[11px] text-muted-foreground mt-3 px-4">
-          24h figures are actual recorded spend per feature. Models shared between rows (e.g. titles
-          + refinement, memory extraction + query expansion) edit the same setting.
+          You can change any feature's model even while it's off (e.g. to pick a cheaper one) — the
+          choice is saved and takes effect when the feature runs, but a model shown under a
+          <span className="mx-1 rounded bg-muted px-1 py-0.5 font-medium">not active</span>
+          feature isn't being used yet. 24h figures are actual recorded spend. Models shared between
+          rows (titles + refinement, memory extraction + query expansion) edit the same setting.
         </p>
       </section>
 

--- a/src/dashboard/frontend/src/lib/settingsSection.ts
+++ b/src/dashboard/frontend/src/lib/settingsSection.ts
@@ -1,0 +1,33 @@
+/**
+ * Settings-section deep-linking (PAN-1600).
+ *
+ * Other surfaces (e.g. the app-bar Low-cost mode pill) ask the Settings page to
+ * scroll to a specific section. Two cases must both work:
+ *   1. Settings isn't mounted yet → the page reads the pending intent on mount.
+ *   2. Settings is already open → the page reacts to the live event.
+ * Using both a sessionStorage intent AND a window event covers both reliably.
+ */
+
+export const SETTINGS_SECTION_INTENT_KEY = 'panopticon.settingsSection';
+export const SETTINGS_SECTION_EVENT = 'panopticon:settings-section';
+
+/** Request that the Settings page scroll to `sectionId`, navigating if needed. */
+export function requestSettingsSection(sectionId: string): void {
+  try {
+    sessionStorage.setItem(SETTINGS_SECTION_INTENT_KEY, sectionId);
+  } catch {
+    // sessionStorage unavailable (private mode) — the live event still works.
+  }
+  window.dispatchEvent(new CustomEvent(SETTINGS_SECTION_EVENT, { detail: sectionId }));
+}
+
+/** Read and clear any pending section intent (called by Settings on mount). */
+export function consumePendingSettingsSection(): string | null {
+  try {
+    const id = sessionStorage.getItem(SETTINGS_SECTION_INTENT_KEY);
+    if (id) sessionStorage.removeItem(SETTINGS_SECTION_INTENT_KEY);
+    return id;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #1601. Follow-ups on PAN-1589.

1. **Low-cost pill → app bar** (new `LowCostModePill`), independent of `CloisterStatusBar` (which hides on a 401 status fetch). Always visible while low-cost mode is on.
2. **Gray, not red nudge** — muted exclamation: low-cost mode is a valid choice, but background AI (esp. durable memory) is valuable, so it's gently flagged.
3. **Settings gear resilience** — `CloisterStatusBar` no longer returns `null` on a failed status fetch; it renders a minimal bar keeping the settings gear reachable.
4. **Models editable while off** — per-feature model pickers are always enabled; pick a cheaper model without turning the feature on. Off features show a `not active` tag + a note that the model isn't used yet.
5. **Reliable deep-link** — shared `settingsSection` helper (sessionStorage intent + live event) + retry-until-mounted scroll, fixing the intermittent 'clicking the pill doesn't reach the section'.

Verified: typecheck (root+frontend), `eslint src/`, frontend build, Settings/CloisterStatusBar suites (86) green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added low-cost mode indicator to app bar that navigates to Background AI settings when clicked
  * Improved settings deep-linking with instant navigation to specific sections

* **Bug Fixes**
  * Settings gear icon now always visible, even when status data is unavailable

* **UI Improvements**
  * Background AI settings display clearer inactive state with explicit "not active" badges
  * Inactive features now render with muted styling for better visual hierarchy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->