### PR TITLE
fix(dashboard): app-bar search min-w-0 so status pills stay on-screen (PAN-1603)

### DIFF
--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -1198,7 +1198,7 @@ export default function App() {
           <button
             type="button"
             onClick={() => setIsSearchOpen(true)}
-            className="mx-auto flex w-full max-w-md items-center gap-2 rounded-lg border border-border px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent"
+            className="mx-auto flex w-full min-w-0 max-w-md items-center gap-2 rounded-lg border border-border px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent"
             title="Search"
           >
             <Search className="h-4 w-4 shrink-0" aria-hidden="true" />


### PR DESCRIPTION
Closes #1603. One-class fix: the center search now has `min-w-0` so it shrinks instead of shoving the right-side status pills (incl. the Low-cost mode pill) off the right edge on narrow windows. Verified with Playwright at 1000px (pill was off-screen at x=1042 → now visible) and down to 760px. typecheck + vite build clean.