### PR TITLE
feat(dashboard): consolidate Cloister controls into top-bar System menu + relabel (PAN-1605)

### DIFF
--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -41,6 +41,7 @@ import { StandaloneTerminal } from './components/StandaloneTerminal';
 import { DeaconPauseToggle } from './components/DeaconPauseToggle';
 import { NoResumeBanner } from './components/NoResumeBanner';
 import { LowCostModePill } from './components/LowCostModePill';
+import { SystemMenu } from './components/SystemMenu';
 import { StoppedAgentsBanner } from './components/StoppedAgentsBanner';
 import { OrphanTestAgentsSurface } from './components/OrphanTestAgentsSurface';
 import { CodexAuthBanner } from './components/CodexAuthBanner';
@@ -1217,6 +1218,7 @@ export default function App() {
             <StoppedAgentsBanner variant="pill" />
             <LowCostModePill onOpenSettings={() => setActiveTab('settings')} />
             <SystemHealthPill />
+            <SystemMenu onOpenSettings={() => setActiveTab('settings')} />
             {/* The Command Deck has the always-on Awareness rail, so the global
                 feed toggle only appears on other pages (PAN-1591). */}
             {activeTab !== 'command-deck' && (

--- a/src/dashboard/frontend/src/components/CloisterStatusBar.tsx
+++ b/src/dashboard/frontend/src/components/CloisterStatusBar.tsx
@@ -313,8 +313,8 @@ export function CloisterStatusBar({ onOpenSettings }: { onOpenSettings?: () => v
           }`}
         >
           {isToggling
-            ? (status.running ? '...' : '...')
-            : (status.running ? 'Pause' : 'Start')}
+            ? '…'
+            : (status.running ? 'Stop Cloister' : 'Start Cloister')}
         </button>
 
         {/* Restart Sessions */}

--- a/src/dashboard/frontend/src/components/Sidebar.test.tsx
+++ b/src/dashboard/frontend/src/components/Sidebar.test.tsx
@@ -7,7 +7,6 @@ import { useDashboardStore } from '../lib/store';
 import type { Tab } from './Header';
 import type { Issue } from '../types';
 
-vi.mock('./CloisterStatusBar', () => ({ CloisterStatusBar: () => <div data-testid="cloister-status" /> }));
 vi.mock('./FreshnessIndicator', () => ({ FreshnessIndicator: () => <div data-testid="freshness-indicator" /> }));
 vi.mock('./DeaconPauseToggle', () => ({
   DeaconPauseToggle: () => <button type="button">Pause Deacon</button>,

--- a/src/dashboard/frontend/src/components/Sidebar.tsx
+++ b/src/dashboard/frontend/src/components/Sidebar.tsx
@@ -9,7 +9,6 @@ import {
 import type { LucideIcon } from 'lucide-react';
 import { fetchProjects, isUnscopedConversation, NO_PROJECT_KEY, NO_PROJECT_LABEL, type RegisteredProjectLite } from './CommandDeck/projectsData';
 import { fetchConversations } from './CommandDeck/ConversationList';
-import { CloisterStatusBar } from './CloisterStatusBar';
 import { FreshnessIndicator } from './FreshnessIndicator';
 import { DeaconPauseToggle } from './DeaconPauseToggle';
 import { useTheme } from '../hooks/useTheme';
@@ -554,7 +553,7 @@ export function Sidebar({ activeTab, onTabChange, onSearchOpen, selectedProject 
           {!collapsed && (
             <div className="px-3 py-2 space-y-1">
               <div className="flex items-center gap-2">
-                <CloisterStatusBar onOpenSettings={() => onTabChange('settings')} />
+                {/* Cloister system controls moved to the top app-bar SystemMenu (PAN-1605). */}
                 <div className="ml-auto">
                   <FreshnessIndicator />
                 </div>

--- a/src/dashboard/frontend/src/components/SystemMenu.test.tsx
+++ b/src/dashboard/frontend/src/components/SystemMenu.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SystemMenu } from './SystemMenu';
+
+// The menu just hosts CloisterStatusBar — mock it so we test the dropdown shell.
+vi.mock('./CloisterStatusBar', () => ({
+  CloisterStatusBar: () => <div data-testid="cloister-controls" />,
+}));
+
+describe('SystemMenu', () => {
+  it('is collapsed by default and opens on click', () => {
+    render(<SystemMenu />);
+    expect(screen.queryByTestId('cloister-controls')).toBeNull();
+    fireEvent.click(screen.getByLabelText('System controls'));
+    expect(screen.getByTestId('cloister-controls')).toBeInTheDocument();
+  });
+
+  it('closes on Escape', () => {
+    render(<SystemMenu />);
+    fireEvent.click(screen.getByLabelText('System controls'));
+    expect(screen.getByTestId('cloister-controls')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByTestId('cloister-controls')).toBeNull();
+  });
+
+  it('toggles closed on a second trigger click', () => {
+    render(<SystemMenu />);
+    const trigger = screen.getByLabelText('System controls');
+    fireEvent.click(trigger);
+    expect(screen.getByTestId('cloister-controls')).toBeInTheDocument();
+    fireEvent.click(trigger);
+    expect(screen.queryByTestId('cloister-controls')).toBeNull();
+  });
+});

--- a/src/dashboard/frontend/src/components/SystemMenu.tsx
+++ b/src/dashboard/frontend/src/components/SystemMenu.tsx
@@ -1,0 +1,55 @@
+import { useState, useRef, useEffect } from 'react';
+import { SlidersHorizontal } from 'lucide-react';
+import { CloisterStatusBar } from './CloisterStatusBar';
+
+/**
+ * SystemMenu (PAN-1605) — a compact app-bar dropdown that hosts the Cloister
+ * system controls (status, Start/Stop Cloister, Restart sessions, Emergency
+ * stop, Settings) that used to live in the lower-left sidebar status bar.
+ * Consolidates them into the top bar.
+ *
+ * It reuses the existing CloisterStatusBar verbatim (all its tested logic and
+ * its own portaled sub-popovers for restart/emergency-confirm). Because those
+ * sub-popovers portal to document.body — outside this dropdown — the dropdown
+ * closes only on Escape or a re-click of the trigger, NOT on outside-click, so
+ * interacting with a sub-popover never collapses the menu.
+ */
+export function SystemMenu({ onOpenSettings }: { onOpenSettings?: () => void }) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  return (
+    <div className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label="System controls"
+        aria-expanded={open}
+        title="System controls — Cloister, restart, emergency stop, settings"
+        onClick={() => setOpen((o) => !o)}
+        className={`rounded-md p-1.5 transition-colors focus:outline-none focus:ring-2 focus:ring-ring ${
+          open ? 'bg-accent text-foreground' : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+        }`}
+      >
+        <SlidersHorizontal className="h-4 w-4" aria-hidden="true" />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full z-50 mt-1 rounded-lg border border-border bg-popover p-2 shadow-lg"
+        >
+          <CloisterStatusBar onOpenSettings={onOpenSettings} />
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #1605.

- New app-bar **System** kebab (`SystemMenu`) hosts the Cloister controls (status, **Stop/Start Cloister**, Restart sessions, **Emergency stop**, settings) — reuses `CloisterStatusBar` verbatim so all tested logic + its restart/emergency popovers are intact. Closes on Escape / trigger-toggle (not outside-click) to avoid collapsing when a sub-popover is open.
- Removed `CloisterStatusBar` from the lower-left sidebar (and its dead test mock).
- Relabeled the toggle **'Pause' → 'Stop Cloister'** (it stops the whole Cloister service; distinct from the top's **Freeze Deacon**, which just freezes patrols).

Nothing lost — Emergency Stop / Restart / Start-Stop Cloister / Settings all moved up. eslint, frontend build, and SystemMenu/Sidebar/CloisterStatusBar suites (18) green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added system menu dropdown in the app bar for accessing system controls.

* **UI/UX**
  * Relocated Cloister monitoring controls from the sidebar to the new system menu in the app bar.
  * Updated Cloister control button labels to display "Start Cloister" or "Stop Cloister" based on current state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->