### PR TITLE
fix(cli): pan dev surfaces dashboard auth token; drop redundant lower-left Deacon toggle (PAN-1607)

### DIFF
--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url';
 import { parse } from '@iarna/toml';
 import chalk from 'chalk';
 import { writeDevSupervisorMarker, clearDevSupervisorMarker } from '../../lib/dev-supervisor.js';
+import { getInternalTokenSync } from '../../lib/internal-token.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -461,13 +462,23 @@ export async function devCommand(options: { skipTraefik?: boolean; deacon?: bool
   await startSidecars();
 
   // ── URLs ───────────────────────────────────────────────────────────────────
+  // The dashboard mints its session from a one-time #panopticon_token=<internal
+  // token> in the URL hash (consumeDashboardBootstrapToken). Without it the
+  // browser can't authenticate and every gated API call 401s, so surface the
+  // Frontend URL WITH the token (PAN-1607).
+  const internalToken = getInternalTokenSync();
+  const authFragment = internalToken ? `#panopticon_token=${encodeURIComponent(internalToken)}` : '';
+  const frontendBase = config.traefikEnabled
+    ? `https://${config.traefikDomain}`
+    : `http://localhost:${config.dashboardPort}`;
+  const apiBase = config.traefikEnabled
+    ? `https://${config.traefikDomain}/api`
+    : `http://localhost:${config.dashboardApiPort}`;
   console.log('');
-  if (config.traefikEnabled) {
-    console.log(`  Frontend: ${chalk.cyan(`https://${config.traefikDomain}`)}`);
-    console.log(`  API:      ${chalk.cyan(`https://${config.traefikDomain}/api`)}`);
-  } else {
-    console.log(`  Frontend: ${chalk.cyan(`http://localhost:${config.dashboardPort}`)}`);
-    console.log(`  API:      ${chalk.cyan(`http://localhost:${config.dashboardApiPort}`)}`);
+  console.log(`  Frontend: ${chalk.cyan(`${frontendBase}${authFragment}`)}`);
+  console.log(`  API:      ${chalk.cyan(apiBase)}`);
+  if (authFragment) {
+    console.log(chalk.dim('  ↑ open the Frontend link — it carries a one-time auth token that signs the dashboard in.'));
   }
   console.log(chalk.dim('\nPress Ctrl+C to stop\n'));
 

--- a/src/dashboard/frontend/src/components/Sidebar.tsx
+++ b/src/dashboard/frontend/src/components/Sidebar.tsx
@@ -10,7 +10,6 @@ import type { LucideIcon } from 'lucide-react';
 import { fetchProjects, isUnscopedConversation, NO_PROJECT_KEY, NO_PROJECT_LABEL, type RegisteredProjectLite } from './CommandDeck/projectsData';
 import { fetchConversations } from './CommandDeck/ConversationList';
 import { FreshnessIndicator } from './FreshnessIndicator';
-import { DeaconPauseToggle } from './DeaconPauseToggle';
 import { useTheme } from '../hooks/useTheme';
 import { useDashboardStore, selectIssues, selectAgents } from '../lib/store';
 import { getPipelineIssuePhase } from '../lib/pipeline-state';
@@ -571,7 +570,7 @@ export function Sidebar({ activeTab, onTabChange, onSearchOpen, selectedProject 
                   </kbd>
                 </button>
                 <div className="ml-auto flex items-center gap-1">
-                  <DeaconPauseToggle />
+                  {/* Deacon Freeze/Resume moved to the top app bar (PAN-1607). */}
                   {isDev && (
                     <button
                       onClick={() => rebuildMutation.mutate()}
@@ -636,7 +635,6 @@ export function Sidebar({ activeTab, onTabChange, onSearchOpen, selectedProject 
                     : <Hammer className="w-3.5 h-3.5" />}
                 </button>
               )}
-              <DeaconPauseToggle compact />
               <button
                 onClick={toggleTheme}
                 className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"


### PR DESCRIPTION
Closes #1607. Fixes the dashboard 401 cascade + the stuck 'Loading embedding settings…'.

**Root cause:** the dashboard mints its session from a one-time `#panopticon_token=<internal-token>` URL hash. The bundled `pan up` launcher adds it; **`pan dev` printed bare URLs**, so its browser never authenticated → `/api/dashboard/session` 401 → no cookie → every gated call (incl. `/api/discovered-sessions/config` → embedding settings) 401s.

- `pan dev` now prints the Frontend URL **with** the token fragment + a note.
- Removed the redundant lower-left **Freeze/Resume Deacon** toggle (already in the top app bar).

typecheck (root+frontend), eslint, frontend build, Sidebar suite (11) green.