### PR TITLE
fix(dashboard): stop force-adding gitignored .pan state in complete-planning (PAN-1931)

### DIFF
--- a/src/dashboard/server/routes/__tests__/complete-planning.test.ts
+++ b/src/dashboard/server/routes/__tests__/complete-planning.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { execFile } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
+import { promisify } from 'node:util';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { completePlanningArtifacts, completePlanningAutoSpawn, completePlanningAutoSpawnAndKill, completePlanningFilesToStage } from '../issues.js';
+import { commitWorkspacePlanningArtifacts, completePlanningArtifacts, completePlanningAutoSpawn, completePlanningAutoSpawnAndKill, completePlanningFilesToStage } from '../issues.js';
 import { PlanQualityLintError } from '../../../../lib/vbrief/quality-lint.js';
 import type { VBriefDocument } from '../../../../lib/vbrief/types.js';
 
@@ -343,5 +345,49 @@ describe('completePlanningArtifacts', () => {
       workAgentSession: 'agent-pan-1151',
     });
     expect(events).toEqual([]);
+  });
+});
+
+describe('commitWorkspacePlanningArtifacts', () => {
+  const execFileAsync = promisify(execFile);
+  const issueId = 'PAN-1931';
+  let gitRoot: string | null = null;
+
+  afterEach(() => {
+    if (gitRoot) {
+      rmSync(gitRoot, { recursive: true, force: true });
+      gitRoot = null;
+    }
+  });
+
+  it('stages tracked .pan artifacts and skips gitignored ephemeral files', async () => {
+    gitRoot = mkdtempSync(join(tmpdir(), 'complete-planning-git-'));
+
+    await execFileAsync('git', ['init'], { cwd: gitRoot });
+    await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: gitRoot });
+    await execFileAsync('git', ['config', 'user.name', 'Test'], { cwd: gitRoot });
+
+    writeFileSync(join(gitRoot, '.gitignore'), [
+      '.pan/continue.json',
+      '.pan/spec.vbrief.json',
+    ].join('\n'));
+
+    const trackedSpecPath = join(gitRoot, '.pan', 'specs', `${issueId}.vbrief.json`);
+    mkdirSync(join(gitRoot, '.pan', 'specs'), { recursive: true });
+    writeFileSync(trackedSpecPath, JSON.stringify({ plan: { id: issueId } }));
+    writeFileSync(join(gitRoot, '.pan', 'continue.json'), JSON.stringify({ issueId }));
+    writeFileSync(join(gitRoot, '.pan', 'spec.vbrief.json'), JSON.stringify({ issueId }));
+
+    await execFileAsync('git', ['add', '.gitignore'], { cwd: gitRoot });
+    await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: gitRoot });
+
+    await commitWorkspacePlanningArtifacts(gitRoot, issueId);
+
+    const { stdout: tree } = await execFileAsync('git', ['show', '--pretty=format:', '--name-only', 'HEAD'], { cwd: gitRoot });
+    const committedFiles = tree.split('\n').filter(Boolean);
+
+    expect(committedFiles).toContain('.pan/specs/PAN-1931.vbrief.json');
+    expect(committedFiles).not.toContain('.pan/continue.json');
+    expect(committedFiles).not.toContain('.pan/spec.vbrief.json');
   });
 });

--- a/src/dashboard/server/routes/issues.ts
+++ b/src/dashboard/server/routes/issues.ts
@@ -235,6 +235,26 @@ export function completePlanningFilesToStage(projectPath: string, proposedFilena
   return filesToStage;
 }
 
+export async function commitWorkspacePlanningArtifacts(gitRoot: string, issueId: string): Promise<void> {
+  const isGitRepo = existsSync(join(gitRoot, '.git'));
+  if (!isGitRepo) {
+    await execFileAsync('git', ['init'], { cwd: gitRoot, encoding: 'utf-8' });
+  }
+
+  if (existsSync(join(gitRoot, '.pan'))) {
+    await execFileAsync('git', ['add', '.pan/'], { cwd: gitRoot, encoding: 'utf-8' });
+  }
+  if (existsSync(join(gitRoot, '.beads'))) {
+    await execFileAsync('git', ['add', '.beads/'], { cwd: gitRoot, encoding: 'utf-8' });
+  }
+
+  try {
+    await execFileAsync('git', ['diff', '--cached', '--quiet'], { cwd: gitRoot, encoding: 'utf-8' });
+  } catch {
+    await execFileAsync('git', ['commit', '-m', `chore(plan): complete planning for ${issueId}`, '--no-verify'], { cwd: gitRoot, encoding: 'utf-8' });
+  }
+}
+
 function getInternalDashboardOrigin(): string {
   const port = Number.parseInt(process.env['API_PORT'] ?? process.env['PORT'] ?? '3011', 10);
   return process.env['PANOPTICON_INTERNAL_DASHBOARD_URL'] ?? `http://127.0.0.1:${port}`;
@@ -1417,23 +1437,7 @@ const postIssueCompletePlanningRoute = HttpRouter.add(
         }
       }
 
-      const isGitRepo = existsSync(join(gitRoot, '.git'));
-      if (!isGitRepo) {
-        await execFileAsync('git', ['init'], { cwd: gitRoot, encoding: 'utf-8' });
-      }
-
-      if (existsSync(join(gitRoot, '.pan'))) {
-        await execFileAsync('git', ['add', '-f', '.pan/'], { cwd: gitRoot, encoding: 'utf-8' });
-      }
-      if (existsSync(join(gitRoot, '.beads'))) {
-        await execFileAsync('git', ['add', '.beads/'], { cwd: gitRoot, encoding: 'utf-8' });
-      }
-
-      try {
-        await execFileAsync('git', ['diff', '--cached', '--quiet'], { cwd: gitRoot, encoding: 'utf-8' });
-      } catch {
-        await execFileAsync('git', ['commit', '-m', `chore(plan): complete planning for ${id}`, '--no-verify'], { cwd: gitRoot, encoding: 'utf-8' });
-      }
+      await commitWorkspacePlanningArtifacts(gitRoot, id);
 
       try {
         const { stdout: remotes } = await execFileAsync('git', ['remote'], { cwd: gitRoot, encoding: 'utf-8' });


### PR DESCRIPTION
Closes [PAN-1931](https://github.com/eltmon/panopticon-cli/issues/1931)

The `complete-planning` route used `git add -f .pan/`, which bypassed `.gitignore` and committed ephemeral workspace files such as `.pan/continue.json` and `.pan/spec.vbrief.json`. This regressed PAN-1215 and violated PAN-1819.

Changes:
- Replace the inline force-add/commit block with a new exported helper `commitWorkspacePlanningArtifacts` that stages `.pan/` and `.beads/` without `-f`.
- Add a regression test verifying that gitignored files are skipped while tracked `.pan/specs/` files are committed.

All quality gates pass (typecheck + targeted tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for planning artifact commit operations, ensuring proper handling of git repositories and correct management of tracked specification files versus ephemeral artifacts

* **Refactor**
  * Improved code organization by extracting planning artifact commit logic into a dedicated reusable helper function for better maintainability and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->