### PR TITLE
fix(dashboard): lock model switching to brand-new conversations only (PAN-1928)

### DIFF
--- a/docs/overdeck-remodel/investigations/pipeline-transitions.md
+++ b/docs/overdeck-remodel/investigations/pipeline-transitions.md
@@ -49,6 +49,27 @@ todo → planning → planned/proposed → working → in-review → testing
                            · deacon-ignored · cancelled
 ```
 
+### 1a-def. Spine stages — definition + entry/exit conditions
+
+The ten happy-path stages, each as the operator means them. "Entry/exit" name
+the *logical* condition; the physical writes that realize them are in §2.
+
+| Stage | One-line meaning | Entry condition | Exit condition |
+|---|---|---|---|
+| **todo** | Issue exists, no plan, no work | Issue opened / reset / wiped | Planning starts |
+| **planning** | Planning agent is producing a vBRIEF | `start-planning` spawns plan role (`IssueState=in_planning`) | Planning completes or aborts |
+| **planned/proposed** | Plan exists, awaiting start | `complete-planning` writes `plan.status=proposed` + beads | `pan start` (or auto-start) |
+| **working** | A work agent is implementing beads | `plan.status=running`, `IssueState=in_progress`, work agent running | Work agent signals done |
+| **in-review** | Code review role is judging the diff | `work.completed` event → review role dispatched (`reviewStatus=reviewing`) | Review verdict (approved / blocked) |
+| **testing** | Test role runs automated + UAT verification | `review.approved` event → test role (`testStatus=testing`) | Test verdict (passed / failed / skipped) |
+| **verifying/UAT** | Pre-merge verification gate / human UAT batch | `verificationStatus=running` or UAT assembled | Gate passes → ready-for-merge |
+| **merging** | Merge queue is landing the branch | `readyForMerge=true` + merge dispatched (`mergeStatus=queued/merging`) | Merge lands or fails |
+| **verifying-on-main** | Merged; awaiting post-merge verification | `postMergeLifecycle` sets `mergeStatus=merged`, `IssueState=verifying_on_main` | Close-out |
+| **closed** | Work complete, issue closed out | `pan close` / close-out: `plan.status=completed`, issue closed | (terminal; reopen re-enters at todo) |
+
+Side-states (paused/troubled/stuck/blocked/deacon-ignored/cancelled) are
+orthogonal toggles — see §1c.
+
 ### 1b. The axes that compose a stage
 
 | # | Axis (enum) | Values | Store | Writer of record | Source |
@@ -88,10 +109,12 @@ todo → planning → planned/proposed → working → in-review → testing
   cache*, not *logical stage transitions* — there is still **no single
   transition controller**. The closest thing, `transitionTo`, covers only
   axis 1/1b (tracker state) and never touches axes 2–7.
-- `status_history` (`schema.ts:272`, `type ∈ 'review'|'test'|'merge'`) logs
-  **only** review/test/merge sub-status. It does **not** capture `IssueState`
-  transitions, `plan.status`, agent lifecycle, or any side-flag. The audit
-  below is the **union** of all axes, not just `status_history` writers.
+- `status_history` (`schema.ts:272`) logs sub-status only. The schema comment
+  says `type ∈ 'review'|'test'|'merge'`, but the `StatusHistoryEntry` interface
+  (`review-status.ts:30`) is broader — `'review'|'test'|'merge'|'inspect'|'uat'`.
+  Either way it captures **none** of `IssueState` transitions, `plan.status`,
+  agent lifecycle, or side-flags. The audit below is the **union** of all axes,
+  not just `status_history` writers.
 - `docs/AGENT-STATE-PLANES.md` is accurate on *where* state lives (3 planes) but
   silent on *how many writers* mutate each plane. That count is the finding here.
 
@@ -155,10 +178,10 @@ and — critically — **emits reactive EV** (`review.approved` / `test.passed`,
 
 | From → To (sub-status) | Trigger (invoker) | Code location | Stores |
 |---|---|---|---|
-| review `pending→reviewing` | review-agent dispatch | `src/lib/cloister/review-agent.ts` (via setReviewStatus) | RS, REC, SH, EV |
+| review `pending→reviewing` | review-agent dispatch | `src/lib/cloister/review-agent.ts:417` | RS, REC, SH, EV |
 | review `reviewing→passed` | review verdict (approve) | `src/dashboard/server/routes/workspaces.ts:3494`; CLI `src/cli/commands/specialists/done.ts` | RS, REC, SH, **EV: review.approved** |
 | review `reviewing→failed/blocked` | review verdict (block) | `specialists.ts` done handler | RS, REC, SH |
-| test `pending→testing` | test dispatch | `src/lib/cloister/test-agent-queue.ts` | RS, REC, SH, EV |
+| test `pending→testing` | test dispatch | `src/lib/cloister/test-agent-queue.ts:90` | RS, REC, SH, EV |
 | test `testing→passed` | test verdict | `workspaces.ts:3939`; `specialists.ts:584`,`:981`; CLI `done.ts` | RS, REC, SH, **EV: test.passed** |
 | test `→skipped` | verification-gate skip | `src/lib/cloister/test-status-green-ci-reconciler.ts` | RS, REC |
 | merge `pending→queued/merging` | merge queue / approve | `workspaces.ts` merge route ~`:5676`; `done.ts:563` | RS, REC, SH |
@@ -223,7 +246,7 @@ Reactive event emission lives in `setReviewStatusSync`
 | From → To | Trigger | Code location | Stores |
 |---|---|---|---|
 | any → todo (deep-wipe) | `deep-wipe` route | `src/dashboard/server/routes/issues.ts:2345` | GH, RS(del), AG, SJ, SPEC(ws), branches |
-| any → todo (wipe CLI) | `pan wipe` | `src/cli/commands/` wipe | GH, RS, AG, SJ |
+| any → todo (wipe CLI) | `pan wipe` | `src/cli/commands/wipe.ts` | GH, RS, AG, SJ |
 | closed → reopened | `pan reopen` / route | `src/lib/reopen.ts`; `issues.ts` reopen | GH, RS, EV |
 | running → stopped (kill) | `pan kill` | `src/cli/commands/` kill | AG, SJ, EV (workspace preserved) |
 | → closed (close-out) | `pan close` / close-out route | `issues.ts:2556`; `src/lib/lifecycle/close-issue.ts` | GH, RS(clear), SPEC(completed), EV |
@@ -246,11 +269,15 @@ called from many places, the helper is one *function* but N *trigger sites*.
 | Side-flag (stuck/troubled/paused/ignored) writers | **~52** | `rg 'setStuck\|markTroubled\|paused: true\|deacon_ignored'` prod |
 | `plan.status` writers | **1 function** (`updateSpecStatus`), ~4 call sites | §2d |
 | Reactive event→role dispatch edges | **9** | §2e |
-| **Distinct trigger sites (union, approx.)** | **≈ 200+** | sum of the above, de-duped by file:line |
-| **Distinct logical (from→to) pairs** | **≈ 18** | §5 below |
+| **Distinct trigger sites (real dedup)** | **≈ 148** | combined grep of all transition verbs (`setReviewStatusSync`, `transitionTo`, `transitionIssueTo*`, label ops, `updateSpecStatus`, reactive emits, stuck/ignored writers), tests + defs excluded, piped to `awk -F: '{print $1":"$2}' \| sort -u` |
+| **Distinct (from→to) pairs** | **≈ 38** | unique from→to strings across all axes in §2 (sub-status granularity) |
+| **Minimal legal moves** | **≈ 15** | §5 — 9 spine + 6 failure/terminal edges |
 
-The gap between **~200 trigger sites** and **~18 logical moves** is the sprawl
-the remodel deletes.
+The descending tiers — **~148 trigger sites → ~38 distinct pairs → ~15 legal
+moves** — are the sprawl story. 148 places fire 38 logically-distinct moves that
+*should* be 15. The two collapses (148→38 by deduping redundant call sites,
+38→15 by unifying sub-status axes into stage advances) are what the remodel
+deletes.
 
 ---
 
@@ -295,9 +322,11 @@ the remodel deletes.
 
 ## 5. Collapsed logical moves — the minimal set (PART B §3)
 
-All ~200 trigger sites collapse to **~18 logical (from→to) moves**, which
-further collapse to **one linear advance chain + a handful of failure/terminal
-edges**:
+The ~148 trigger sites express **~38 distinct (from→to) pairs** (§3), which
+collapse to **~15 logical moves** — one linear advance chain + a handful of
+failure/terminal edges. The 38→15 collapse merges the per-axis sub-status pairs
+(review/test/merge/verify/inspect/uat each `pending→active→passed`) into the
+single stage advance they collectively signal:
 
 ### Forward advances (the spine)
 1. `todo → planning` (start planning)

--- a/docs/overdeck-remodel/investigations/pipeline-transitions.md
+++ b/docs/overdeck-remodel/investigations/pipeline-transitions.md
@@ -1,0 +1,334 @@
+# Pipeline Transitions — Full Audit
+
+> Evidence base for the Overdeck remodel
+> ([PAN-1938](https://github.com/eltmon/panopticon-cli/issues/1938)).
+> **Question:** What are the canonical pipeline stages, and every way an
+> issue/agent moves between them?
+> **Method:** `git grep` / `rg` over `src/`, production code only
+> (`__tests__/` and `*.test.ts` excluded). Line numbers checked at writing
+> time (2026-06-16, `main` @ `840117fadc`); where a number may drift the
+> anchor symbol is quoted so it can be re-grepped.
+
+---
+
+## Glossary
+
+- **Stage** — a human-meaningful pipeline position (e.g. "in review"). It is
+  **not a column.** There is no single `stage` field anywhere. A stage is a
+  *composite read* across ~8 independent enums + GitHub labels + side-flags
+  (see §1).
+- **Store** — a physical place a status value is persisted. Six exist:
+  GitHub labels/issue-state, SQLite `review_status`, SQLite `agents`, SQLite
+  `status_history` (append-only log), SQLite `events` (append-only log),
+  `.pan/<recordsPath>/<issue>.json` (git record), `~/.panopticon/agents/<id>/state.json`.
+- **Transition site** — a production code location that *writes* a stage-bearing
+  value into at least one store.
+- **Reactive dispatch** — the autonomous half: a write to one store emits an
+  `events`/pipeline-notifier event, which the Cloister deacon consumes and
+  reacts to (spawns a role, advances the issue). The trigger is the event, not
+  an HTTP route.
+- **Role** — `plan | work | review | test | ship | flywheel | strike`
+  (`packages/contracts/src/types.ts:21`). A role spawn *is* the physical
+  manifestation of a working stage.
+
+---
+
+## 1. Canonical stages — the multi-axis map (PART A)
+
+The "stage" the operator sees is computed from **eight independent status axes**,
+each with its own enum, its own store, and its own writer. There is no single
+column. This table IS the motivation for "one controller per domain."
+
+### 1a. Happy-path stage line (the documented intent)
+
+```
+todo → planning → planned/proposed → working → in-review → testing
+     → verifying/UAT → merging → verifying-on-main → closed
+                                                        │
+              side-states: paused · troubled · stuck · blocked
+                           · deacon-ignored · cancelled
+```
+
+### 1b. The axes that compose a stage
+
+| # | Axis (enum) | Values | Store | Writer of record | Source |
+|---|---|---|---|---|---|
+| 1 | **Tracker `IssueState`** | `open · in_progress · in_review · closed` | GitHub labels + issue open/closed | `IssueLifecycleService.transitionTo` | `src/lib/tracker/interface.ts:28`; lifecycle svc `src/dashboard/server/services/issue-lifecycle.ts:198` |
+| 1b | **Lifecycle `IssueState` (richer)** | `open · in_planning · in_progress · in_review · verifying_on_main · closed · canceled` | GitHub labels (`planned`, `in-progress`, `in-review`, `verifying-on-main`, `wontfix`) + `canonicalStatus` cache | `transitionTo` → `GITHUB_STATE_LABELS` | `src/dashboard/server/services/issue-lifecycle.ts:45`, label map `:154`, `canonicalStatus()` `:178` |
+| 2 | **`plan.status`** (vBRIEF spec) | `draft · proposed · approved · running · completed · cancelled` | `.pan/specs/*.vbrief.json` (git) | `updateSpecStatus` only (PAN-1124 single writer) | `src/lib/pan-dir/specs.ts:266`; finalize `src/cli/commands/plan-finalize.ts:377` |
+| 3 | **`review_status.review_status`** | `pending · reviewing · passed · failed · blocked` | SQLite `review_status` + mirrored to `.pan` record | `setReviewStatusSync` | `packages/contracts/src/types.ts:27`; writer `src/lib/review-status.ts:194` |
+| 4 | **`review_status.test_status`** | `pending · testing · passed · failed · skipped · dispatch_failed` | SQLite `review_status` (+ record) | `setReviewStatusSync` | `packages/contracts/src/types.ts:30` |
+| 5 | **`review_status.merge_status`** | `pending · queued · merging · verifying · merged · failed` | SQLite `review_status` (+ record) | `setReviewStatusSync` / merge-agent | `packages/contracts/src/types.ts:36` |
+| 6 | **`review_status.verification_status`** | `pending · running · passed · failed · skipped` | SQLite `review_status` | verification-runner | `packages/contracts/src/types.ts:39` |
+| 6b | **`review_status.uat_status`** | `pending · testing · passed · failed` | SQLite `review_status` | uat engine | `src/lib/review-status.ts:52` |
+| 6c | **`review_status.inspect_status`** | `pending · inspecting · passed · failed · error` | SQLite `review_status` | inspect-agent | `src/lib/review-status.ts:48` |
+| 7 | **Agent process `AgentStatus`** | `starting · running · stopped · error · unknown` | SQLite `agents` + `state.json` + `agent.*` events | `agents.ts` / runtime adapters | `packages/contracts/src/types.ts:18` |
+| 7b | **`AgentResolution`** (self-report) | `working · done · needs_input · stuck · completed · unclear · abandoned · api_error` | transcript/heartbeat → events | harness | `packages/contracts/src/types.ts:24` |
+| 8 | **Reactive `ReactiveIssueState`** | `todo · open · in_planning · in_progress · in_review · testing · shipping · closed · canceled` | derived (event payload), not stored | `issueStateChangeFromDomainEvent` | `src/lib/cloister/service.ts:137` |
+
+### 1c. Side-states (orthogonal flags, not on the main line)
+
+| Side-state | Store + field | Set by | Cleared by | Effect |
+|---|---|---|---|---|
+| **paused** | `state.json` / `agents` `paused` | `pan pause`, deacon advancing-reaper | `pan unpause`, `pan start --force` | Deacon auto-resume skips agent |
+| **troubled** | `state.json` / `agents` `troubled` + failure counters | deacon after repeated resume/crash; stuck-remediation | `pan untroubled` | Resume gate refuses; `handleAgentStoppedEvent` skips (`deacon.ts:6649`) |
+| **stuck** | `review_status.stuck` (+ `stuck_reason/at/details`) | approve-push divergence guard, conflict-gate | `/unstick` route | Deacon patrol skips the issue |
+| **deacon-ignored** | `review_status.deacon_ignored` | operator (`/deacon-ignore`) | operator | Patrol skips issue entirely |
+| **blocked** | `review_status.review_status='blocked'` + `blocker_reasons` | review verdict, webhook merge-blockers | re-review | Not merge-ready |
+| **cancelled** | `IssueState='canceled'` (`wontfix` label) + `plan.status='cancelled'` | `move-status`, issue-closed reaper | reopen | Terminal; reactive dispatch suppressed |
+| **ready-for-merge** | `review_status.ready_for_merge` | derived by `setReviewStatusSync` when review+test pass (`review-status.ts:283`) | reset/new commit | Gates merge queue |
+
+### 1d. Divergence from the documented model
+
+- `reference/state-model.mdx` claims phase is **derived** ("the DB is a cache;
+  phase is a function of GitHub + workspace") and that **all mutations go
+  through one write surface** (enforced by `scripts/lint-state-writes.sh`).
+  **Reality:** each axis above is written **imperatively and independently** by
+  its own helper. `lint-state-writes.sh` governs *which modules may touch the
+  cache*, not *logical stage transitions* — there is still **no single
+  transition controller**. The closest thing, `transitionTo`, covers only
+  axis 1/1b (tracker state) and never touches axes 2–7.
+- `status_history` (`schema.ts:272`, `type ∈ 'review'|'test'|'merge'`) logs
+  **only** review/test/merge sub-status. It does **not** capture `IssueState`
+  transitions, `plan.status`, agent lifecycle, or any side-flag. The audit
+  below is the **union** of all axes, not just `status_history` writers.
+- `docs/AGENT-STATE-PLANES.md` is accurate on *where* state lives (3 planes) but
+  silent on *how many writers* mutate each plane. That count is the finding here.
+
+---
+
+## 2. The transition table (PART B)
+
+Production transition sites, grouped by the axis they write. Each row:
+**from → to | trigger (invoker) | code location | stores written**.
+
+Stores legend: **GH** = GitHub labels/state · **RS** = SQLite `review_status` ·
+**REC** = `.pan` record · **SH** = `status_history` · **EV** = `events`/pipeline
+event · **AG** = SQLite `agents` · **SJ** = `state.json` · **SPEC** =
+`.pan/specs` vBRIEF.
+
+### 2a. The one near-controller — `IssueLifecycleService.transitionTo`
+
+Writes GH labels + `canonicalStatus` cache + emits `issue.transitioned`. Covers
+axis 1/1b only.
+
+| From → To | Trigger (invoker) | Code location | Stores |
+|---|---|---|---|
+| any → `in_planning` | `start-planning` route | `src/dashboard/server/routes/issues.ts:995` | GH, EV |
+| any → `open` (reset to todo) | `move-status` / abort / restart-from-plan | `issues.ts:1148`, `:1486` | GH, EV |
+| any → `targetState` (operator move) | `move-status` route | `issues.ts:1789` | GH, EV |
+| any → `in_progress` | generate-tasks / start fallback | `issues.ts:2124`, `:2216` | GH, EV |
+| any → `in_progress` | agent start / restart | `src/dashboard/server/routes/agents.ts:2971`, `:3187`, `:3538` | GH, EV |
+| any → `verifying_on_main` | `postMergeLifecycle` (server merge) | `src/lib/cloister/merge-agent.ts:629` | GH, EV |
+| service impl | (all of the above) | `issue-lifecycle.ts:198`–`247` | GH + `canonicalStatus` + EV |
+
+### 2b. Tracker transition — the *other* path (`transitionIssue` / helpers in `agents.ts`)
+
+A second, parallel route to the same axis-1 move, **bypassing** `transitionTo`.
+`transitionIssueState` (`src/lib/agents.ts:2801`) calls `tracker.transitionIssue`
+directly (GH labels via `github.ts:239`), with thin wrappers
+`transitionIssueToInProgress` (`agents.ts:2867`) and `transitionIssueToInReview`
+(`agents.ts:2875`).
+
+| From → To | Trigger (invoker) | Code location | Stores |
+|---|---|---|---|
+| → `in_progress` | work agent spawn | `src/lib/agents.ts:3661` | GH |
+| → `in_progress` | specialist done (re-enter work) | `src/dashboard/server/routes/specialists.ts:620` | GH |
+| → `in_review` | approve / re-review (3 sites) | `src/dashboard/server/routes/workspaces.ts:3739`, `:4027`, `:4192` | GH |
+| → `closed` | close-out workflow | `src/lib/lifecycle/close-issue.ts:105`, `:383` | GH |
+| → `verifying_on_main` (label) | merge-agent direct gh edit | `src/lib/cloister/merge-agent.ts:587`–`632` | GH |
+| review-fail → `in_progress` | `specialists/done` failure branch | `specialists.ts:623`, `:627` | GH |
+
+> **Same logical move, two code paths:** "→ in_review" is reachable via
+> `transitionTo` (axis 1b, emits events) AND via `transitionIssueToInReview`
+> (axis 1, GH only, no event). They write different stores. This is the
+> drift-risk pattern (see §4).
+
+### 2c. Review / test / merge sub-status — `setReviewStatusSync` (axis 3–6)
+
+`setReviewStatusSync` (`src/lib/review-status.ts:194`) is the single *function*
+but is called from **~70 production sites**. Every call writes **RS + REC**
+(mirror via `updateIssueRecordForIssue` `review-status.ts:345`), appends **SH**,
+and — critically — **emits reactive EV** (`review.approved` / `test.passed`,
+`review-status.ts:455`–`462`) when status flips to `passed`. So a status write
+*is* a transition trigger.
+
+| From → To (sub-status) | Trigger (invoker) | Code location | Stores |
+|---|---|---|---|
+| review `pending→reviewing` | review-agent dispatch | `src/lib/cloister/review-agent.ts` (via setReviewStatus) | RS, REC, SH, EV |
+| review `reviewing→passed` | review verdict (approve) | `src/dashboard/server/routes/workspaces.ts:3494`; CLI `src/cli/commands/specialists/done.ts` | RS, REC, SH, **EV: review.approved** |
+| review `reviewing→failed/blocked` | review verdict (block) | `specialists.ts` done handler | RS, REC, SH |
+| test `pending→testing` | test dispatch | `src/lib/cloister/test-agent-queue.ts` | RS, REC, SH, EV |
+| test `testing→passed` | test verdict | `workspaces.ts:3939`; `specialists.ts:584`,`:981`; CLI `done.ts` | RS, REC, SH, **EV: test.passed** |
+| test `→skipped` | verification-gate skip | `src/lib/cloister/test-status-green-ci-reconciler.ts` | RS, REC |
+| merge `pending→queued/merging` | merge queue / approve | `workspaces.ts` merge route ~`:5676`; `done.ts:563` | RS, REC, SH |
+| merge `merging→merged` | `postMergeLifecycle` | `src/lib/cloister/merge-agent.ts:357` | RS, REC |
+| merge `→failed` | merge failure | `merge-agent.ts:445` | RS, REC |
+| verification `pending→running→passed/failed` | verification-runner | `src/lib/cloister/verification-runner.ts:202` | RS |
+| inspect `→inspecting/passed/failed` | inspect-agent | `src/lib/cloister/inspect-agent.ts` | RS |
+| uat `→testing/passed/failed` | uat engine | `src/lib/cloister/uat-*.ts` | RS |
+| `readyForMerge` derived true | review+test both pass | `review-status.ts:283` (auto) | RS, REC |
+
+### 2d. `plan.status` (axis 2) — the cleanly-single-writer one
+
+| From → To | Trigger (invoker) | Code location | Stores |
+|---|---|---|---|
+| (new) → `draft` | `pan plan` PRD write | `src/lib/vbrief/builder.ts:41` | (file) |
+| `draft → proposed` | `complete-planning` / plan finalize | `src/cli/commands/plan-finalize.ts:377`; `src/lib/vbrief/auto-synthesize.ts:88`,`:133` | SPEC |
+| `proposed → approved/running` | `start-agent` | `updateSpecStatus` via `src/lib/vbrief/lifecycle-io.ts:246` | SPEC |
+| `running → completed` | close-out | `lifecycle-io.ts:338` | SPEC |
+| any → `cancelled` | issue closed | `updateSpecStatus` (`pan-dir/specs.ts:266`) | SPEC |
+
+> This axis is the model the remodel wants everywhere: **one writer**
+> (`updateSpecStatus`), file moves never happen, only the field changes.
+
+### 2e. Reactive dispatch — the autonomous half (axis 8 → role spawn)
+
+The Cloister deacon consumes events and dispatches roles. **No HTTP route is
+involved** — the trigger is an `events` row. This is where the pipeline
+*advances itself*.
+
+| Event (from) → role/state (to) | Mapper | Dispatcher | Code location |
+|---|---|---|---|
+| `work.completed` / `agent.completed`(role=work) → `in_review` | `issueStateChangeFromDomainEvent` | `onIssueStateChange` → review role | `src/lib/cloister/service.ts:399`–`411`, `:497` |
+| `review.approved` → `testing` | same | `onIssueStateChange` → test role | `service.ts:412`, `stateToRole` `:168`, `ROLE_RUN_STATES` `:153` |
+| `test.passed` → `shipping` | same | ship handoff (server merge) | `service.ts:414` |
+| `issue.transitioned`/`statusChanged` → role for state | same | `onIssueStateChangePromise` | `service.ts:278`–`381` |
+| `issue.statusChanged`(closed) → reap | — | `closed-issue-reaper` | `service.ts:484` |
+| `issue.statusChanged`(todo/planned) → reconcile proposed spec | — | `orphan-proposed-reconciler` | `service.ts:489` |
+| `agent.stopped` → resume/orphan handling | — | `handleAgentStoppedEvent` | `service.ts:422`, `deacon.ts:6649` |
+| `agent.heartbeat_dead` → orphan recovery | — | `handleAgentHeartbeatDeadEvent` | `service.ts:445` |
+| `review.coordinator.died` → re-dispatch review | — | `handleReviewCoordinatorDied` | `service.ts:457` |
+
+Reactive event emission lives in `setReviewStatusSync`
+(`review-status.ts:455`–`462`) and `notifyPipelineSync`
+(`src/lib/pipeline-notifier.ts:23`). So the *write* in §2c **is** the trigger here.
+
+### 2f. Deacon patrol & remediation — side-state writes (axis 7 + side-flags)
+
+| From → To | Trigger (invoker) | Code location | Stores |
+|---|---|---|---|
+| running → stopped (orphan) | `recoverOrphanedAgents` patrol | `src/lib/cloister/deacon.ts:5766`,`:5783` | AG, SJ, EV |
+| stopped → running (auto-resume) | `autoResumeStoppedWorkAgents` | `deacon.ts` (`autoResume*`) | AG, SJ, EV |
+| any → troubled | repeated resume/crash failures | `deacon.ts` failure markers `:5733`; stuck-remediation `:120` | SJ/AG |
+| idle → paused+troubled (flywheel) | stuck-remediation escalation | `src/lib/cloister/stuck-remediation.ts:186` | SJ |
+| advancing → paused (advancing reaper) | re-pause before kill | `deacon.ts:4853`–`4867` | SJ |
+| review-fail dead-end → circuit-break | auto-requeue ≥25 | `deacon.ts:3898`–`3900` | RS |
+| stuck set (main diverged) | approve-push divergence guard | `workspaces.ts` approve helper `:1334`–`1342` | RS |
+| stuck cleared | `/unstick` route | `workspaces.ts:4672`,`:4587`–`4645` | RS |
+| → verifying_on_main + pause agents | `postMergeLifecycle` | `merge-agent.ts:438` | GH, RS, SJ, EV |
+
+### 2g. Destructive / terminal resets
+
+| From → To | Trigger | Code location | Stores |
+|---|---|---|---|
+| any → todo (deep-wipe) | `deep-wipe` route | `src/dashboard/server/routes/issues.ts:2345` | GH, RS(del), AG, SJ, SPEC(ws), branches |
+| any → todo (wipe CLI) | `pan wipe` | `src/cli/commands/` wipe | GH, RS, AG, SJ |
+| closed → reopened | `pan reopen` / route | `src/lib/reopen.ts`; `issues.ts` reopen | GH, RS, EV |
+| running → stopped (kill) | `pan kill` | `src/cli/commands/` kill | AG, SJ, EV (workspace preserved) |
+| → closed (close-out) | `pan close` / close-out route | `issues.ts:2556`; `src/lib/lifecycle/close-issue.ts` | GH, RS(clear), SPEC(completed), EV |
+
+---
+
+## 3. Approximate counts (PART B rollup)
+
+Counts are of **production** sites (tests excluded). Where a single helper is
+called from many places, the helper is one *function* but N *trigger sites*.
+
+| Measure | Count | How counted |
+|---|---|---|
+| Axes that compose a "stage" | **8** (+3 sub-axes) | §1b |
+| Side-states | **7** | §1c |
+| `setReviewStatusSync` call sites (RS+REC+SH+EV per call) | **~70** | `rg setReviewStatusSync\(\|upsertReviewStatusSync\(` prod |
+| Direct GitHub label/state write sites | **~54** | `rg 'gh issue edit\|addLabel\|removeLabel\|transitionIssue\|closeIssue\|reopenIssue'` prod |
+| `transitionTo` call sites | **~12** | §2a |
+| `transitionIssueTo{InProgress,InReview}` call sites | **8** | §2b |
+| Side-flag (stuck/troubled/paused/ignored) writers | **~52** | `rg 'setStuck\|markTroubled\|paused: true\|deacon_ignored'` prod |
+| `plan.status` writers | **1 function** (`updateSpecStatus`), ~4 call sites | §2d |
+| Reactive event→role dispatch edges | **9** | §2e |
+| **Distinct trigger sites (union, approx.)** | **≈ 200+** | sum of the above, de-duped by file:line |
+| **Distinct logical (from→to) pairs** | **≈ 18** | §5 below |
+
+The gap between **~200 trigger sites** and **~18 logical moves** is the sprawl
+the remodel deletes.
+
+---
+
+## 4. Worst offenders (deletion targets)
+
+### 4a. Most-duplicated single move
+
+- **"→ in_review"** — fired from **at least 5 places** across **2 different
+  axes/code paths**:
+  - `transitionIssueToInReview` from `workspaces.ts:3739`, `:4027`, `:4192`
+  - `transitionTo(…, 'in_review')` reachable via the lifecycle service
+  - `setReviewStatusSync({reviewStatus:'reviewing'})` (axis 3)
+  Each writes a *different* subset of stores (GH-only vs GH+event vs RS+REC+EV).
+- **"→ in_progress"** — fired from **6+ places**: `agents.ts:2971`, `:3187`,
+  `:3538` (lifecycle), `agents.ts:3661` (spawn), `specialists.ts:620`
+  (re-enter), `issues.ts:2124`, `:2216` (generate-tasks/start).
+- **"→ verifying_on_main"** — written **3 ways in one function**: GH label via
+  raw `gh issue edit` (`merge-agent.ts:608`), `transitionTo` (`:629`), and
+  `review_status` mergeStatus (`:357`, `:445`).
+
+### 4b. One move writing many stores inconsistently (drift risk)
+
+- **`specialists/done` handler** (`specialists.ts:318`–`709`) — a single request
+  writes **RS + SH + EV + GH label + tmux kill + handoff log + `reviewedAtCommit`
+  snapshot**, with separate try/catch per store. Any one failing leaves the
+  others advanced → split-brain stage.
+- **`setReviewStatusSync`** (`review-status.ts:194`) — every call fans out to
+  **RS, REC (`:345`), SH, and conditionally EV (`:455`)**. The REC mirror is
+  fire-and-forget (`void updateIssueRecordForIssue` `:345`) — if it throws, the
+  DB and the git record diverge silently.
+- **"→ in_review" via two paths** (§4a) — `transitionIssueToInReview` writes
+  **GH only, no event**, while `transitionTo` writes **GH + cache + event**.
+  Issues advanced by the GH-only path never emit `issue.transitioned`, so the
+  reactive scheduler can miss the review dispatch. Classic drift.
+- **merge `verifying_on_main`** — GH label, `review_status.merge_status`, and the
+  `.pan` record `pipeline` block are each updated by different lines; a partial
+  failure (e.g. `transitionIssueToVerifyingOnMain` throws after mergeStatus set)
+  is explicitly handled at `merge-agent.ts:442`–`452` — evidence the drift is
+  real enough to need a recovery branch.
+
+---
+
+## 5. Collapsed logical moves — the minimal set (PART B §3)
+
+All ~200 trigger sites collapse to **~18 logical (from→to) moves**, which
+further collapse to **one linear advance chain + a handful of failure/terminal
+edges**:
+
+### Forward advances (the spine)
+1. `todo → planning` (start planning)
+2. `planning → planned` (planning complete; `plan.status=proposed`)
+3. `planned → working` (start work; `plan.status=running`, `IssueState=in_progress`)
+4. `working → in-review` (work complete)
+5. `in-review → testing` (review approved)
+6. `testing → verifying/UAT` (test passed) *(may be skipped per project)*
+7. `verifying/UAT → merging` (ready-for-merge, merge dispatched)
+8. `merging → verifying-on-main` (merge landed)
+9. `verifying-on-main → closed` (close-out)
+
+### Failure edges (back to an earlier stage)
+10. `in-review → working` (review blocked)
+11. `testing → working` (test failed)
+12. `merging → working` (merge conflict / push divergence → stuck)
+
+### Terminal / out-of-band
+13. `any → cancelled` (issue closed wontfix)
+14. `closed/cancelled → todo` (reopen)
+15. `any → todo` (deep-wipe / wipe — destructive reset)
+
+### Side-state toggles (orthogonal, not stage moves)
+16. `* ↔ paused` (operator / advancing reaper)
+17. `* ↔ troubled` (deacon crash gate)
+18. `* ↔ stuck` / `* ↔ deacon-ignored` (system / operator hold)
+
+**Proposed Overdeck controller.** One `advance(issueId, toStage, reason)` write
+surface that: validates the move against this 9-step spine + the 6 failure/
+terminal edges, writes **all** stores atomically in one transaction (RS + record
++ GH + event emission), and is the **only** caller of `transitionTo`,
+`setReviewStatusSync`, `updateSpecStatus`, and the GH label ops. Side-states
+become a separate small `hold(issueId, flag, on/off)` surface. Everything in §2
+that is not this controller gets deleted or rewritten to call it.

--- a/docs/overdeck-remodel/investigations/review-state-audit.md
+++ b/docs/overdeck-remodel/investigations/review-state-audit.md
@@ -1,0 +1,160 @@
+# Overdeck Remodel — Review / Verification / Merge / Inspect State Field Audit
+
+**Goal:** radical complexity reduction on a fresh empty DB. Keep only fields the
+pipeline genuinely NEEDS ("NEED, not nice-to-have"). For each field: where it is
+written, where it is read, whether a read actually BRANCHES on it, a verdict
+(`KEEP` / `DROP` / `MERGE-INTO` / `DERIVE`), and a class for each KEEP
+(DURABLE VERDICT vs EPHEMERAL REVIEW-RUN vs belongs-elsewhere).
+
+Method: every field traced through its camelCase accessor across `src/`
+(non-test), with the discriminator being **does any read drive control flow**
+(an `if`/`filter`/gate/comparison), not whether the field is "touched".
+
+## Glossary
+
+- **Branch-read** — a read site that feeds an `if`/`filter`/`switch`/comparison
+  that changes what the pipeline does. The opposite is a **display read** (value
+  is only serialized to the frontend / activity feed) or a **pass-through**
+  (copied into another record verbatim).
+- **DURABLE VERDICT** — the issue's review/test/merge/inspect *outcome*; belongs
+  in the per-issue permanent record (`.pan/<recordsPath>/<issue>.json`,
+  `pipeline` block) and must survive a DB wipe.
+- **EPHEMERAL REVIEW-RUN** — state of an in-flight review/test/merge run; pure
+  cache, dies with the run, rebuildable.
+- **Single write path** — almost every `review_status` column is written through
+  one function: `upsertReviewStatusSync` in
+  `src/lib/database/review-status-db.ts:30`, fed by `setReviewStatusSync`
+  (`src/lib/review-status.ts:194`) and read back through `rowToReviewStatus`
+  (`review-status-db.ts:443`). Targeted writers also exist:
+  `markWorkspaceStuck` (498), `setDeaconIgnored` (529), `setAutoMerge` (569),
+  `clearWorkspaceStuck` (591). "Written-at" below names the *semantic* writer,
+  not this plumbing.
+- **Durable mirror** — `src/lib/pan-dir/records.ts:80-111` (`projectPipeline`)
+  copies a subset of `ReviewStatus` into the permanent record. Whatever it
+  copies is the codebase's own DURABLE answer; whatever it drops is EPHEMERAL.
+
+---
+
+## Table 1 — `review_status`
+
+| Field | Written-at (semantic) | Branch-read-at | What it drives | Verdict | Class |
+| --- | --- | --- | --- | --- | --- |
+| `issue_id` | upsert (PK, upper-cased) | every read keys on it | Row identity | **KEEP** | DURABLE VERDICT |
+| `review_status` | review pipeline → setReviewStatus | `mergeGateEligibility` (review-status.ts:144); deacon gates; `fixStuckReadyForMerge` (515) | Core review outcome; gates merge eligibility | **KEEP** | DURABLE VERDICT |
+| `test_status` | test pipeline | `mergeGateEligibility` (145); `fixStuckReadyForMerge` (520); deacon test patrol (2497) | Core test outcome; gates merge | **KEEP** | DURABLE VERDICT |
+| `merge_status` | merge flow (workspaces.ts ~5016-5646), postMergeLifecycle | `mergeGateEligibility` (149 "already merged"); `clearStuckMergeStatuses` (483); `stuck-remediation.ts:35` | Merge outcome; `merged` is terminal | **KEEP** | DURABLE VERDICT |
+| `verification_status` | verification-runner.ts (234,365,408,453) | `verificationSatisfied` (123) → `mergeGateEligibility` (148) | Blocks merge only when `'failed'` | **KEEP** | DURABLE VERDICT |
+| `verification_cycle_count` | verification-runner.ts (233,364,407) | **verification-runner.ts:194** `currentCycles >= VERIFICATION_MAX_CYCLES` — circuit breaker | Stops infinite verification re-runs | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `verification_max_cycles` | verification-runner.ts — always set to the constant `VERIFICATION_MAX_CYCLES = 10` (29) | **none server-side** — only frontend display (ReviewPipelineSection.tsx:178, PlanDAG.tsx:361) | A stored copy of a compile-time constant | **DROP** (DERIVE from constant) | — |
+| `review_notes` | review pipeline | **deacon.ts:2058** `reviewNotes.includes('failing required checks')` — CI-failure branch | Substring-parsed to classify CI failure (fragile) | **KEEP** (1 verdict-explanation field) | DURABLE VERDICT |
+| `test_notes` | test pipeline; deacon strand marker (2487) | display only (activity feed, review-status.ts:401) | Human-readable test failure text | **DROP** (fold into one notes field) | — |
+| `merge_notes` | merge flow | **deacon.ts:3652/3735/3880** `mergeNotes.includes(...)` — CI / timeout / push-failure branches | Substring-parsed to classify merge failure | **KEEP** (verdict-explanation) | DURABLE VERDICT |
+| `updated_at` | every upsert | `idx_review_status_updated`; ORDER BY; staleness UI | Ordering / "last changed" | **KEEP** | DURABLE VERDICT |
+| `ready_for_merge` | workspaces.ts:3556 (`testStatus==='passed'`→true); ~30 merge-flow sites set false; deacon 3790/3952; recompute sweeps 497/532 | `WHERE ready_for_merge=1` (review-status-db.ts:233; resource-discovery; AwaitingMergePage) | "Awaiting merge" gate / list | **DERIVE** — `fixStuckReadyForMerge` (515) and `clearStuckMergeStatuses` (490) PROVE it is recomputable from `{review_status, test_status, verification_status, merge_status, uat_status}` (identical to `mergeGateEligibility`). The two repair sweeps exist *because* it drifts. Replace the column + `WHERE ready_for_merge=1` with the predicate. | — |
+| `auto_requeue_count` | deacon auto-requeue path | **deacon.ts:3899** `autoRequeueCount >= 25` — dead-end breaker | Caps auto-requeue attempts | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `merge_retry_count` | deacon merge-retry path | **deacon.ts:3906** `>= FAILED_MERGE_MAX_RETRIES` — merge breaker | Caps merge retries | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `pr_url` | done.ts / merge flow / webhook | `getMergeBlockerReconcileCandidates` (231); flywheel-merge-order; conflict reconcile; many display | Identifies the PR to operate on | **KEEP** | DURABLE VERDICT |
+| `pr_head_sha` | webhook-handlers.ts:390 | **webhook-handlers.ts:116** `headSha !== status.prHeadSha` — webhook identity validation | Rejects webhooks for a stale/foreign PR | **KEEP** | DURABLE VERDICT |
+| `pr_number` | webhook / done | **flywheel-merge-order.ts:156**; **orphan-proposed-reconciler.ts:50** `prNumber != null`; webhook-handlers.ts:101 | PR identity; orphan reconcile | **KEEP** (could MERGE-INTO derive from `pr_url`) | DURABLE VERDICT |
+| `stuck` | markWorkspaceStuck (498); deacon strand (2483) | **stuck-remediation.ts:35**; **deacon.ts:1006/1242** `if (stuck) skip patrol` | System failure marker; deacon skips stuck issues | **KEEP** | EPHEMERAL REVIEW-RUN (recoverable signal) |
+| `stuck_reason` | markWorkspaceStuck | **deacon.ts:1041** `stuckReason === 'context_overflow'`; **deacon.ts:2482** `!== 'test_signal_strand'`; agents.ts:4989 | Distinguishes stuck *kinds* for targeted remediation | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `stuck_at` | markWorkspaceStuck | display only | Timestamp of stuck event | **DROP** (DERIVE/fold) | — |
+| `stuck_details` | markWorkspaceStuck (JSON `{localSha,remoteSha}`) | display only (no parse for a branch found) | Diagnostic blob | **DROP** | — |
+| `reviewed_at_commit` | review-pass path | **deacon.ts:3052/3078** `currentHead === reviewedAtCommit` → skip/re-review on new push; review-status.ts:449 | Detects commits pushed after review passed | **KEEP** | DURABLE VERDICT |
+| `review_spawned_at` | review dispatch | **deacon.ts:2689/2691** `Date.parse(reviewSpawnedAt)` timeout | Review-dispatch timeout detection | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `conflict_resolution_dispatched_at` | conflict-gate dispatch | **conflict-gate.ts:262** `if (!conflictResolutionDispatchedAt) return false` — dedup | Prevents re-dispatching conflict resolver | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `test_retry_count` | deacon (2545/2551/2557) | **deacon.ts:2476** `retryCount >= 3` → surface stuck marker | Test re-dispatch breaker | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `review_retry_count` | deacon recovery path | **deacon.ts:2092** `>= REVIEW_INFRA_BREAKER_THRESHOLD` | Parallel-review re-dispatch breaker | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `recovery_started_at` | deacon (1941/2072) | **deacon.ts:1941/2072** history-cutoff for the breaker (`?? now`) | Scopes the breaker's failure window to current cycle | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `deacon_ignored` | setDeaconIgnored (529) | **stuck-remediation.ts:35**; **deacon.ts:1006/1242** `if (deaconIgnored) skip` | Human "pause this issue" toggle | **KEEP** | NEITHER — operator control flag, belongs with per-issue runtime control, not a review *verdict* |
+| `deacon_ignored_at` | setDeaconIgnored | display only | Timestamp | **DROP** | — |
+| `deacon_ignored_reason` | setDeaconIgnored | display only | Free-form reason | **DROP** | — |
+| `blocker_reasons` | webhook-handlers (242,252); mutateBlockers | **getMergeBlockerReconcileCandidates** (`LIKE '%merge_conflict%'`, 234); **conflict-gate.ts:160/168** `filter(isMergeBlocker)`; webhook | Drives merge-conflict reconcile + conflict gate | **KEEP** | DURABLE VERDICT |
+| `last_verified_commit` | verification gate pass | **deacon.ts:2710** `headSha !== lastVerifiedCommit` → re-verify; review-status.ts:448; deacon `isReviewSpawnStale` (2686) | Skips redundant test-agent when commit already verified | **KEEP** | DURABLE VERDICT |
+| `merge_step` | merge flow granular progress | **none server-side** — frontend display only (ProjectOverview.tsx:678, AwaitingMergePage.tsx:325) | Granular merge-progress label | **DROP** (DERIVE from `merge_status`) | — |
+| `inspect_status` | inspect-agent | **deacon.ts:738** `if (inspectStatus !== 'inspecting') continue` | Inspect outcome / patrol gate | **KEEP** | DURABLE VERDICT |
+| `inspect_notes` | inspect-agent | display only | Inspect failure text | **DROP** (fold into notes) | — |
+| `inspect_started_at` | inspect-agent | display only (no timeout branch found) | Timestamp | **DROP** | — |
+| `inspect_bead_id` | inspect-agent | **NONE — zero reads anywhere** | Dead | **DROP** (dead) | — |
+| `auto_merge` | setAutoMerge (569) | **auto-merge-eligibility.ts:111** `autoMerge === false` → hold for UAT | Per-issue merge-train routing | **KEEP** | NEITHER — routing policy, belongs with per-issue config not review verdict |
+| `uat_status` *(interface-only, no column)* | UAT flow | `fixStuckReadyForMerge` (526); `clearStuckMergeStatuses` (494) | UAT gate in readyForMerge recompute | **KEEP** | DURABLE VERDICT *(note: typed in ReviewStatus but NOT a `review_status` column — lives only in history/in-memory)* |
+
+### Phantom columns listed in the task that do NOT exist
+
+| Listed | Reality |
+| --- | --- |
+| `reviewer_verdicts` | **Not a `review_status` column.** No CREATE TABLE entry, no migration, not in `DbReviewStatusRow`, not in the `ReviewStatus` interface. Exists ONLY as `reviewerVerdicts?: unknown` on the durable `PanIssuePipelineRecord` (record.ts:83), passed through at records.ts:110 via a cast that reads a property the source type doesn't even declare — so it is **always `undefined`** in practice. Dead pass-through. **DROP.** |
+| `lifetime_auto_requeue_count` | **Does not exist anywhere in code.** Zero hits in `src/` or `tests/`. Only mention is in two docs: `docs/panopticon-db-erd.excalidraw` and `docs/STATE-STORAGE-AUDIT.md`. The ERD diagram and the task field-list are stale. **N/A — nothing to drop.** |
+
+---
+
+## Table 2 — `agents` table review-orchestration columns
+
+These are review-RUN state bleeding into the `agents` table. All are read by the
+deacon's review monitor *during* a live review run.
+
+| Field | Written-at | Branch-read-at | What it drives | Verdict | Class |
+| --- | --- | --- | --- | --- | --- |
+| `review_run_id` | review-agent.ts:275 | **deacon.ts:5983/5995/6041/6074** — locates `.pan/review/<runId>/` synthesis dir, dedup nudge key, staleness check (2764) | Which review run's reports to read/synthesize | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `review_synthesis_agent_id` | review-agent.ts:270/277; agents.ts:3455 | **deacon.ts:5999/6158** — who to signal/nudge/kill for synthesis | Identifies the synthesis agent to drive | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `review_output_path` | review-agent (per-sub-role) | **deacon.ts:5973/6176** — where the reviewer wrote its report | Path the monitor reads the verdict from | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `review_deadline_at` | review-agent.ts:278 (`now + REVIEWER_TIMEOUT_MS`) | **deacon.ts:6186** `Date.parse` past-deadline; 6248/6257 reason | Reviewer timeout / wedge detection | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `review_monitor_signaled` | deacon.ts:6276 | **deacon.ts:6159** `if (reviewMonitorSignaled) continue` — once-only dedup | Stops re-signaling a completed reviewer | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `review_retry_attempt` | deacon.ts:6013 | **deacon.ts:6237** `if (attempt < 1)` respawn idle reviewer once | Idle-reviewer single-retry gate | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `review_sub_role` | review-agent convoy spawn | **deacon.ts:5684/5983/6031/6158/6268** — sub-role routing for synthesis + signal text | Tags which convoy lane this agent is | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `inspect_sub_role` | inspect-agent.ts:253 | costs/reconciler.ts (cost attribution); spawn tag | Cost/session-type attribution only — no live decision branch found | **DROP** (DERIVE from agent-dir name regex, which reconciler already does at reconciler.ts:140) | — |
+| `flywheel_run_id` | agents.ts:3293 (spawn env) | **concurrency.ts:191** `filter(a => a.flywheelRunId)` — counts flywheel-spawned work for slot accounting | Concurrency slot accounting | **KEEP** | EPHEMERAL REVIEW-RUN (runtime, not a verdict) |
+| `role_run_head` | agents.ts:3547 | **service.ts:232** compares stamped HEAD vs current workspace HEAD (staleness) | Detects whether a role run is stale vs new commits | **KEEP** | NEITHER — work/role-run runtime state, not review-specific; belongs with agent runtime |
+
+---
+
+## Surprises
+
+1. **`ready_for_merge` is a derivable cache that the codebase already recomputes
+   — twice.** `fixStuckReadyForMerge` and `clearStuckMergeStatuses` both rebuild
+   it from `{review_status, test_status, verification_status, merge_status,
+   uat_status}` — exactly `mergeGateEligibility`'s inputs. The column drifts
+   often enough that two startup repair sweeps exist purely to fix it. Dropping
+   the column and replacing `WHERE ready_for_merge=1` with the predicate removes
+   the column, both repair sweeps, and ~40 `readyForMerge: false` write sites.
+
+2. **Two of the "columns" in the task list do not exist.** `reviewer_verdicts`
+   is a durable-record field (always `undefined` in practice — a dead cast),
+   not a `review_status` column. `lifetime_auto_requeue_count` exists **only in
+   the ERD diagram and a stale audit doc** — there is no such column or code.
+   The `docs/panopticon-db-erd.excalidraw` field list is out of date.
+
+3. **`inspect_bead_id` is written but never read** — zero consumers anywhere.
+   Pure dead weight.
+
+4. **`merge_step` and `verification_max_cycles` are server-write-only display
+   props.** `merge_step` is derivable from `merge_status`; `verification_max_cycles`
+   is a stored copy of the compile-time constant `VERIFICATION_MAX_CYCLES = 10`.
+   Neither drives any server branch.
+
+5. **The prose-notes columns are mostly display, but two are load-bearing via
+   fragile substring matching.** `review_notes.includes('failing required
+   checks')` and three `merge_notes.includes(...)` checks classify CI / timeout
+   / push failures. This is brittle (string-sniffing a free-text field for
+   control flow) and should ideally become a typed failure-reason enum rather
+   than a kept prose column. `test_notes`, `verification_notes`, `inspect_notes`
+   are display-only and can collapse into a single notes field.
+
+6. **Retry-count theater is minimal — most counters are real breakers.**
+   `verification_cycle_count` (≥10), `auto_requeue_count` (≥25),
+   `merge_retry_count` (≥max), `test_retry_count` (≥3), `review_retry_count`
+   (≥threshold), `review_retry_attempt` (<1) all gate a real abort. The only
+   counter-like field with no comparison is `verification_max_cycles` (a stored
+   constant). The counters are EPHEMERAL though — they belong to the recovery
+   cycle, not the durable verdict, and reset on `recovery_started_at`.
+
+7. **Timestamps split cleanly.** The ones a comparison parses
+   (`review_spawned_at`, `review_deadline_at`, `conflict_resolution_dispatched_at`,
+   `recovery_started_at`, `reviewed_at_commit`/`last_verified_commit` as SHAs)
+   are KEEP. The ones that are only displayed (`stuck_at`, `inspect_started_at`,
+   `deacon_ignored_at`) are DROP.
+
+8. **`deacon_ignored` and `auto_merge` are not review verdicts** — they are
+   operator/policy control flags that happen to live in `review_status`. In the
+   remodel they belong with per-issue runtime control / merge-train config, not
+   the durable review outcome.

--- a/docs/overdeck-remodel/investigations/review-state-audit.md
+++ b/docs/overdeck-remodel/investigations/review-state-audit.md
@@ -10,6 +10,13 @@ Method: every field traced through its camelCase accessor across `src/`
 (non-test), with the discriminator being **does any read drive control flow**
 (an `if`/`filter`/gate/comparison), not whether the field is "touched".
 
+**Headline counts:** 49 fields audited (39 `review_status` columns + 10 `agents`
+review-run columns). **36 KEEP, 12 DROP, 1 DERIVE.** Of the 36 KEEP: 13 DURABLE
+VERDICT, 19 EPHEMERAL REVIEW-RUN, 4 NEITHER (operator/runtime control). ~2,550
+read+write matches across 154 files touch the `review_status` set, plus ~158
+across 14 files for the agents-table set — that is the complexity surface the
+DROP/DERIVE collapse gets to shrink.
+
 ## Glossary
 
 - **Branch-read** — a read site that feeds an `if`/`filter`/`switch`/comparison
@@ -44,13 +51,14 @@ Method: every field traced through its camelCase accessor across `src/`
 | `test_status` | test pipeline | `mergeGateEligibility` (145); `fixStuckReadyForMerge` (520); deacon test patrol (2497) | Core test outcome; gates merge | **KEEP** | DURABLE VERDICT |
 | `merge_status` | merge flow (workspaces.ts ~5016-5646), postMergeLifecycle | `mergeGateEligibility` (149 "already merged"); `clearStuckMergeStatuses` (483); `stuck-remediation.ts:35` | Merge outcome; `merged` is terminal | **KEEP** | DURABLE VERDICT |
 | `verification_status` | verification-runner.ts (234,365,408,453) | `verificationSatisfied` (123) → `mergeGateEligibility` (148) | Blocks merge only when `'failed'` | **KEEP** | DURABLE VERDICT |
+| `verification_notes` | verification-runner.ts | display only (activity feed, review-status.ts:359 — no `.includes` branch) | Human-readable verification failure text | **DROP** (fold into notes) | — |
 | `verification_cycle_count` | verification-runner.ts (233,364,407) | **verification-runner.ts:194** `currentCycles >= VERIFICATION_MAX_CYCLES` — circuit breaker | Stops infinite verification re-runs | **KEEP** | EPHEMERAL REVIEW-RUN |
 | `verification_max_cycles` | verification-runner.ts — always set to the constant `VERIFICATION_MAX_CYCLES = 10` (29) | **none server-side** — only frontend display (ReviewPipelineSection.tsx:178, PlanDAG.tsx:361) | A stored copy of a compile-time constant | **DROP** (DERIVE from constant) | — |
-| `review_notes` | review pipeline | **deacon.ts:2058** `reviewNotes.includes('failing required checks')` — CI-failure branch | Substring-parsed to classify CI failure (fragile) | **KEEP** (1 verdict-explanation field) | DURABLE VERDICT |
+| `review_notes` | review pipeline | **deacon.ts:2058** `reviewNotes.includes('failing required checks')` — CI-failure branch | Substring-parsed to classify CI failure (fragile) | **KEEP-as-signal** — replace prose with a typed `failureReason` enum (ephemeral run state); keep at most one durable verdict-explanation field | EPHEMERAL REVIEW-RUN |
 | `test_notes` | test pipeline; deacon strand marker (2487) | display only (activity feed, review-status.ts:401) | Human-readable test failure text | **DROP** (fold into one notes field) | — |
-| `merge_notes` | merge flow | **deacon.ts:3652/3735/3880** `mergeNotes.includes(...)` — CI / timeout / push-failure branches | Substring-parsed to classify merge failure | **KEEP** (verdict-explanation) | DURABLE VERDICT |
+| `merge_notes` | merge flow | **deacon.ts:3652/3735/3880** `mergeNotes.includes(...)` — CI / timeout / push-failure branches | Substring-parsed to classify merge failure | **KEEP-as-signal** — replace prose with a typed `mergeFailureReason` enum (ephemeral run state) | EPHEMERAL REVIEW-RUN |
 | `updated_at` | every upsert | `idx_review_status_updated`; ORDER BY; staleness UI | Ordering / "last changed" | **KEEP** | DURABLE VERDICT |
-| `ready_for_merge` | workspaces.ts:3556 (`testStatus==='passed'`→true); ~30 merge-flow sites set false; deacon 3790/3952; recompute sweeps 497/532 | `WHERE ready_for_merge=1` (review-status-db.ts:233; resource-discovery; AwaitingMergePage) | "Awaiting merge" gate / list | **DERIVE** — `fixStuckReadyForMerge` (515) and `clearStuckMergeStatuses` (490) PROVE it is recomputable from `{review_status, test_status, verification_status, merge_status, uat_status}` (identical to `mergeGateEligibility`). The two repair sweeps exist *because* it drifts. Replace the column + `WHERE ready_for_merge=1` with the predicate. | — |
+| `ready_for_merge` | workspaces.ts:3556 (`testStatus==='passed'`→true); ~30 merge-flow sites set false; deacon 3790 & 3952; recompute sweeps 497/532 | `WHERE ready_for_merge=1` (review-status-db.ts:233; resource-discovery; AwaitingMergePage) | "Awaiting merge" gate / list | **DERIVE** — `fixStuckReadyForMerge` (515) and `clearStuckMergeStatuses` (490) PROVE it is recomputable from `{review_status, test_status, verification_status, merge_status}` (identical to `mergeGateEligibility`). **Verified the two deacon `readyForMerge: true` setters (3790, 3952): both are failed-merge *recovery* paths that set `mergeStatus: 'pending'` alongside — i.e. they eagerly re-stamp the SAME derived value (review passed + test passed + verif≠failed + merge pending) after clearing a merge failure. Neither sets it outside the predicate.** Replace the column + `WHERE ready_for_merge=1` with the predicate; both repair sweeps and ~40 `readyForMerge: false` write sites go away. | — |
 | `auto_requeue_count` | deacon auto-requeue path | **deacon.ts:3899** `autoRequeueCount >= 25` — dead-end breaker | Caps auto-requeue attempts | **KEEP** | EPHEMERAL REVIEW-RUN |
 | `merge_retry_count` | deacon merge-retry path | **deacon.ts:3906** `>= FAILED_MERGE_MAX_RETRIES` — merge breaker | Caps merge retries | **KEEP** | EPHEMERAL REVIEW-RUN |
 | `pr_url` | done.ts / merge flow / webhook | `getMergeBlockerReconcileCandidates` (231); flywheel-merge-order; conflict reconcile; many display | Identifies the PR to operate on | **KEEP** | DURABLE VERDICT |
@@ -75,9 +83,18 @@ Method: every field traced through its camelCase accessor across `src/`
 | `inspect_status` | inspect-agent | **deacon.ts:738** `if (inspectStatus !== 'inspecting') continue` | Inspect outcome / patrol gate | **KEEP** | DURABLE VERDICT |
 | `inspect_notes` | inspect-agent | display only | Inspect failure text | **DROP** (fold into notes) | — |
 | `inspect_started_at` | inspect-agent | display only (no timeout branch found) | Timestamp | **DROP** | — |
-| `inspect_bead_id` | inspect-agent | **NONE — zero reads anywhere** | Dead | **DROP** (dead) | — |
+| `inspect_bead_id` | inspect-agent | **written, never consumed for a decision** (zero branch-reads; no `bd close`/lookup use) | None | **DROP** | — |
 | `auto_merge` | setAutoMerge (569) | **auto-merge-eligibility.ts:111** `autoMerge === false` → hold for UAT | Per-issue merge-train routing | **KEEP** | NEITHER — routing policy, belongs with per-issue config not review verdict |
-| `uat_status` *(interface-only, no column)* | UAT flow | `fixStuckReadyForMerge` (526); `clearStuckMergeStatuses` (494) | UAT gate in readyForMerge recompute | **KEEP** | DURABLE VERDICT *(note: typed in ReviewStatus but NOT a `review_status` column — lives only in history/in-memory)* |
+
+> **`uat_status` is NOT a `review_status` column** (so it is excluded from the
+> 39-column count above). It is typed on the `ReviewStatus` interface and read
+> in the `readyForMerge` recompute (`fixStuckReadyForMerge` 526,
+> `clearStuckMergeStatuses` 494), but there is no `uat_status` column, no
+> upsert binding, and `rowToReviewStatus` never restores it — so after any DB
+> round-trip it is always `undefined`, which the gate treats as "pass". Net:
+> there is a UAT gate input that is **not actually persisted or enforced
+> through `readyForMerge`**. If UAT is a real gate it needs a real home; if it
+> isn't, the recompute branches referencing it are dead. Flagged, not counted.
 
 ### Phantom columns listed in the task that do NOT exist
 
@@ -103,8 +120,8 @@ deacon's review monitor *during* a live review run.
 | `review_retry_attempt` | deacon.ts:6013 | **deacon.ts:6237** `if (attempt < 1)` respawn idle reviewer once | Idle-reviewer single-retry gate | **KEEP** | EPHEMERAL REVIEW-RUN |
 | `review_sub_role` | review-agent convoy spawn | **deacon.ts:5684/5983/6031/6158/6268** — sub-role routing for synthesis + signal text | Tags which convoy lane this agent is | **KEEP** | EPHEMERAL REVIEW-RUN |
 | `inspect_sub_role` | inspect-agent.ts:253 | costs/reconciler.ts (cost attribution); spawn tag | Cost/session-type attribution only — no live decision branch found | **DROP** (DERIVE from agent-dir name regex, which reconciler already does at reconciler.ts:140) | — |
-| `flywheel_run_id` | agents.ts:3293 (spawn env) | **concurrency.ts:191** `filter(a => a.flywheelRunId)` — counts flywheel-spawned work for slot accounting | Concurrency slot accounting | **KEEP** | EPHEMERAL REVIEW-RUN (runtime, not a verdict) |
-| `role_run_head` | agents.ts:3547 | **service.ts:232** compares stamped HEAD vs current workspace HEAD (staleness) | Detects whether a role run is stale vs new commits | **KEEP** | NEITHER — work/role-run runtime state, not review-specific; belongs with agent runtime |
+| `flywheel_run_id` | agents.ts:3293 (spawn env) | **concurrency.ts:191** `filter(a => a.flywheelRunId)` — counts flywheel-spawned work for slot accounting | Concurrency slot accounting | **KEEP** | NEITHER — general agent-runtime field (concurrency), not review-run state; keep with agent runtime |
+| `role_run_head` | agents.ts:3547 | **service.ts:232** compares stamped HEAD vs current workspace HEAD (staleness) | Detects whether a role run is stale vs new commits | **KEEP** | NEITHER — general agent-runtime field (staleness), not review-specific; keep with agent runtime |
 
 ---
 
@@ -112,11 +129,23 @@ deacon's review monitor *during* a live review run.
 
 1. **`ready_for_merge` is a derivable cache that the codebase already recomputes
    — twice.** `fixStuckReadyForMerge` and `clearStuckMergeStatuses` both rebuild
-   it from `{review_status, test_status, verification_status, merge_status,
-   uat_status}` — exactly `mergeGateEligibility`'s inputs. The column drifts
-   often enough that two startup repair sweeps exist purely to fix it. Dropping
-   the column and replacing `WHERE ready_for_merge=1` with the predicate removes
-   the column, both repair sweeps, and ~40 `readyForMerge: false` write sites.
+   it from `{review_status, test_status, verification_status, merge_status}` —
+   exactly `mergeGateEligibility`'s inputs. All five `readyForMerge: true`
+   setters were checked: workspaces.ts:3556 (`test=passed`), the two sweeps, and
+   the two deacon recovery paths (3790, 3952) — every one is inside the predicate
+   (the deacon ones pair it with `mergeStatus: 'pending'`, re-stamping the same
+   derived value after a merge failure). Nothing writes `true` outside the
+   predicate, so DERIVE is safe. The column drifts often enough that two startup
+   repair sweeps exist purely to fix it. Dropping it and replacing
+   `WHERE ready_for_merge=1` with the predicate removes the column, both repair
+   sweeps, and ~40 `readyForMerge: false` write sites.
+
+   **Corollary UAT surprise:** the recompute predicate also references
+   `uat_status`, which is NOT a persisted column — `rowToReviewStatus` never
+   restores it, so post-round-trip it is always `undefined` (treated as "pass").
+   There is a UAT gate input that is not actually enforced through
+   `readyForMerge`. Either give UAT a real persisted home or delete the dead
+   recompute branches.
 
 2. **Two of the "columns" in the task list do not exist.** `reviewer_verdicts`
    is a durable-record field (always `undefined` in practice — a dead cast),

--- a/src/dashboard/server/routes/__tests__/agents-switch-model.test.ts
+++ b/src/dashboard/server/routes/__tests__/agents-switch-model.test.ts
@@ -1,0 +1,76 @@
+import { Effect } from 'effect';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+vi.mock('../../../../lib/agents.js', () => ({
+  getAgentState: vi.fn(),
+  getAgentDir: vi.fn((id: string) => join(process.env.PANOPTICON_HOME!, 'agents', id)),
+  stopAgent: vi.fn(),
+  saveAgentStateAndEmitEventProgram: vi.fn(),
+}));
+
+vi.mock('../../../../lib/tmux.js', () => ({
+  killSession: vi.fn(() => Effect.succeed(undefined)),
+}));
+
+vi.mock('../../../../lib/model-validation.js', () => ({
+  requireModelOverrideSync: vi.fn((model: string) => model),
+}));
+
+let testHome: string;
+let originalHome: string | undefined;
+
+function decodeJsonResponse(response: { status: number; body: unknown }) {
+  const payload = response.body as { body: Uint8Array } | null;
+  const text = payload?.body ? new TextDecoder().decode(payload.body) : '{}';
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+async function postSwitchModel(agentId: string, body: Record<string, unknown>) {
+  const { agentsRouteLayer } = await import('../agents.js');
+  const request = HttpServerRequest.fromWeb(new Request(`http://localhost/api/agents/${agentId}/switch-model`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Origin: 'http://localhost:3011' },
+    body: JSON.stringify(body),
+  }));
+
+  return Effect.runPromise(
+    Effect.scoped(
+      Effect.flatMap(HttpRouter.toHttpEffect(agentsRouteLayer), (app) =>
+        Effect.provideService(app, HttpServerRequest.HttpServerRequest, request)
+      ),
+    ),
+  );
+}
+
+describe('POST /api/agents/:id/switch-model', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    testHome = join(tmpdir(), `pan-agent-switch-model-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(testHome, { recursive: true });
+    originalHome = process.env.HOME;
+    process.env.HOME = testHome;
+    process.env.PANOPTICON_HOME = join(testHome, '.panopticon');
+    mkdirSync(process.env.PANOPTICON_HOME, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    delete process.env.PANOPTICON_HOME;
+    rmSync(testHome, { recursive: true, force: true });
+  });
+
+  it('rejects all agent model switches with a clear error', async () => {
+    const response = await postSwitchModel('agent-pan-1234', { model: 'claude-fable-5' });
+
+    expect(response.status).toBe(400);
+    const body = decodeJsonResponse(response);
+    expect(body.error).toMatch(/not allowed for agents/i);
+  });
+});

--- a/src/dashboard/server/routes/__tests__/conversations-switch-model.test.ts
+++ b/src/dashboard/server/routes/__tests__/conversations-switch-model.test.ts
@@ -1,7 +1,7 @@
 import { Effect } from 'effect';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
-import { chmodSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -147,296 +147,72 @@ describe('POST /api/conversations/:name/switch-model', () => {
     rmSync(testHome, { recursive: true, force: true });
   });
 
-  it('does not append a compact boundary for a 206k-token same-harness switch that fits the inferred target window', async () => {
+  it('allows switching the model of a brand-new conversation before the first message', async () => {
     const cwd = join(testHome, 'workspace');
     mkdirSync(cwd, { recursive: true });
 
-    const { createConversation } = await import('../../../../lib/database/conversations-db.js');
-    const { sessionFilePath } = await import('../../../../lib/paths.js');
-    const sessionId = '206k-session';
-    const sessionFile = sessionFilePath(cwd, sessionId);
-    mkdirSync(join(sessionFile, '..'), { recursive: true });
-    writeFileSync(sessionFile, [
-      JSON.stringify({
-        type: 'user',
-        message: { role: 'user', content: [{ type: 'text', text: 'Keep all of this context' }] },
-      }),
-      JSON.stringify({
-        type: 'assistant',
-        timestamp: '2026-06-10T00:00:00.000Z',
-        message: {
-          role: 'assistant',
-          model: 'claude-opus-4-8',
-          content: [{ type: 'text', text: 'Still in context' }],
-          usage: { input_tokens: 206_000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
-        },
-      }),
-    ].join('\n') + '\n');
-
+    const { createConversation, getConversationByName } = await import('../../../../lib/database/conversations-db.js');
     createConversation({
-      name: 'switch-regression',
-      tmuxSession: 'conv-switch-regression',
+      name: 'fresh-conversation',
+      tmuxSession: 'conv-fresh-conversation',
       cwd,
-      model: 'claude-opus-4-8',
+      model: 'claude-sonnet-4-6',
       harness: 'claude-code',
-      claudeSessionId: sessionId,
     });
 
-    const response = await postSwitchModel('switch-regression', { model: 'claude-fable-5' });
+    const response = await postSwitchModel('fresh-conversation', { model: 'claude-fable-5' });
 
     expect(response.status).toBe(200);
     expect(decodeJsonResponse(response)).toMatchObject({
       model: 'claude-fable-5',
       harness: 'claude-code',
-      sessionAlive: true,
     });
-    expect(deliverAgentMessageMock).toHaveBeenCalledWith(
-      'conv-switch-regression',
-      '/model claude-fable-5',
-      'conversation-switch-model',
-      'auto',
-    );
+    expect(getConversationByName('fresh-conversation')?.model).toBe('claude-fable-5');
     expect(killSessionMock).not.toHaveBeenCalled();
     expect(createSessionMock).not.toHaveBeenCalled();
-    expect(readFileSync(sessionFile, 'utf8')).not.toContain('"subtype":"compact_boundary"');
   });
 
-  it('falls back to respawn when Tier 1 delivery fails', async () => {
-    deliverAgentMessageMock.mockRejectedValueOnce(new Error('MessageDeliveryFailed: socket missing'));
-    const cwd = join(testHome, 'fallback-workspace');
+  it('rejects switching when the conversation already has a session', async () => {
+    const cwd = join(testHome, 'workspace');
     mkdirSync(cwd, { recursive: true });
 
     const { createConversation } = await import('../../../../lib/database/conversations-db.js');
-    const { sessionFilePath } = await import('../../../../lib/paths.js');
-    const sessionId = 'fallback-session';
-    const sessionFile = sessionFilePath(cwd, sessionId);
-    mkdirSync(join(sessionFile, '..'), { recursive: true });
-    writeFileSync(sessionFile, [
-      JSON.stringify({ type: 'user', message: { role: 'user', content: [{ type: 'text', text: 'Keep context' }] } }),
-      JSON.stringify({
-        type: 'assistant',
-        timestamp: '2026-06-10T00:00:00.000Z',
-        message: {
-          role: 'assistant',
-          model: 'claude-opus-4-8',
-          content: [{ type: 'text', text: 'Still in context' }],
-          usage: { input_tokens: 206_000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
-        },
-      }),
-    ].join('\n') + '\n');
-
     createConversation({
-      name: 'switch-fallback',
-      tmuxSession: 'conv-switch-fallback',
+      name: 'started-conversation',
+      tmuxSession: 'conv-started-conversation',
       cwd,
-      model: 'claude-opus-4-8',
+      model: 'claude-sonnet-4-6',
       harness: 'claude-code',
-      claudeSessionId: sessionId,
+      claudeSessionId: 'started-session',
     });
 
-    const response = await postSwitchModel('switch-fallback', { model: 'claude-fable-5' });
+    const response = await postSwitchModel('started-conversation', { model: 'claude-fable-5' });
 
-    expect(response.status).toBe(200);
-    expect(killSessionMock).toHaveBeenCalledWith('conv-switch-fallback');
-    expect(createSessionMock).toHaveBeenCalled();
-    expect(readFileSync(sessionFile, 'utf8')).not.toContain('"subtype":"compact_boundary"');
-  });
-
-  it('keeps default-model Anthropic switches in Tier 1 when provider exports only unset env', async () => {
-    getProviderExportsForModelMock.mockResolvedValue([
-      'unset ANTHROPIC_BASE_URL',
-      'unset ANTHROPIC_AUTH_TOKEN',
-      'unset OPENAI_API_KEY',
-    ].join('\n') + '\n');
-    const cwd = join(testHome, 'default-model-anthropic-workspace');
-    mkdirSync(cwd, { recursive: true });
-
-    const { createConversation } = await import('../../../../lib/database/conversations-db.js');
-    const { sessionFilePath } = await import('../../../../lib/paths.js');
-    const sessionId = 'default-model-anthropic-session';
-    const sessionFile = sessionFilePath(cwd, sessionId);
-    mkdirSync(join(sessionFile, '..'), { recursive: true });
-    writeFileSync(sessionFile, [
-      JSON.stringify({ type: 'user', message: { role: 'user', content: [{ type: 'text', text: 'Default Anthropic conversation' }] } }),
-      JSON.stringify({
-        type: 'assistant',
-        timestamp: '2026-06-10T00:00:00.000Z',
-        message: {
-          role: 'assistant',
-          content: [{ type: 'text', text: 'Still in context' }],
-          usage: { input_tokens: 206_000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
-        },
-      }),
-    ].join('\n') + '\n');
-
-    createConversation({
-      name: 'switch-default-anthropic',
-      tmuxSession: 'conv-switch-default-anthropic',
-      cwd,
-      model: null,
-      harness: 'claude-code',
-      claudeSessionId: sessionId,
-    });
-
-    const response = await postSwitchModel('switch-default-anthropic', { model: 'claude-fable-5' });
-
-    expect(response.status).toBe(200);
-    expect(deliverAgentMessageMock).toHaveBeenCalledWith(
-      'conv-switch-default-anthropic',
-      '/model claude-fable-5',
-      'conversation-switch-model',
-      'auto',
-    );
+    expect(response.status).toBe(400);
+    expect(decodeJsonResponse(response).error).toMatch(/locked/i);
     expect(killSessionMock).not.toHaveBeenCalled();
     expect(createSessionMock).not.toHaveBeenCalled();
-    expect(readFileSync(sessionFile, 'utf8')).not.toContain('"subtype":"compact_boundary"');
   });
 
-  it('respawns default-model conversations when switching to a routed provider target', async () => {
-    getProviderExportsForModelMock.mockImplementation(async (model: string) => (
-      model === 'gpt-5.5' ? 'export ANTHROPIC_BASE_URL=http://127.0.0.1:4545\nexport ANTHROPIC_AUTH_TOKEN=proxy-token' : ''
-    ));
-    const cwd = join(testHome, 'default-model-routed-workspace');
+  it('rejects switching when the conversation already has messages', async () => {
+    const cwd = join(testHome, 'workspace');
     mkdirSync(cwd, { recursive: true });
 
     const { createConversation } = await import('../../../../lib/database/conversations-db.js');
-    const { sessionFilePath } = await import('../../../../lib/paths.js');
-    const sessionId = 'default-model-routed-session';
-    const sessionFile = sessionFilePath(cwd, sessionId);
-    mkdirSync(join(sessionFile, '..'), { recursive: true });
-    writeFileSync(sessionFile, [
-      JSON.stringify({ type: 'user', message: { role: 'user', content: [{ type: 'text', text: 'Default model conversation' }] } }),
-      JSON.stringify({
-        type: 'assistant',
-        timestamp: '2026-06-10T00:00:00.000Z',
-        message: {
-          role: 'assistant',
-          content: [{ type: 'text', text: 'Small context' }],
-          usage: { input_tokens: 1_000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
-        },
-      }),
-    ].join('\n') + '\n');
-
     createConversation({
-      name: 'switch-default-routed',
-      tmuxSession: 'conv-switch-default-routed',
+      name: 'messaged-conversation',
+      tmuxSession: 'conv-messaged-conversation',
       cwd,
-      model: null,
+      model: 'claude-sonnet-4-6',
       harness: 'claude-code',
-      claudeSessionId: sessionId,
+      claudeSessionId: 'messaged-session',
     });
 
-    const response = await postSwitchModel('switch-default-routed', { model: 'gpt-5.5' });
+    const response = await postSwitchModel('messaged-conversation', { model: 'claude-fable-5' });
 
-    expect(response.status).toBe(200);
-    expect(deliverAgentMessageMock).not.toHaveBeenCalled();
-    expect(killSessionMock).toHaveBeenCalledWith('conv-switch-default-routed');
-    expect(createSessionMock).toHaveBeenCalled();
-    expect(readFileSync(sessionFile, 'utf8')).not.toContain('"subtype":"compact_boundary"');
-  });
-
-  it('does not treat an echoed /model command as Tier 1 statusline confirmation', async () => {
-    vi.useFakeTimers();
-    try {
-      capturePaneMock.mockImplementation(() => Effect.succeed([
-        '/model claude-fable-5',
-        'error: failed to switch to Claude Fable 5',
-        'Claude Opus 4.8 (claude-opus-4-8)',
-        'ctx 10% cost $0.0000',
-      ].join('\n')));
-      const cwd = join(testHome, 'echo-workspace');
-      mkdirSync(cwd, { recursive: true });
-
-      const { createConversation } = await import('../../../../lib/database/conversations-db.js');
-      const { sessionFilePath } = await import('../../../../lib/paths.js');
-      const sessionId = 'echo-session';
-      const sessionFile = sessionFilePath(cwd, sessionId);
-      mkdirSync(join(sessionFile, '..'), { recursive: true });
-      writeFileSync(sessionFile, [
-        JSON.stringify({ type: 'user', message: { role: 'user', content: [{ type: 'text', text: 'Keep context' }] } }),
-        JSON.stringify({
-          type: 'assistant',
-          timestamp: '2026-06-10T00:00:00.000Z',
-          message: {
-            role: 'assistant',
-            model: 'claude-opus-4-8',
-            content: [{ type: 'text', text: 'Still in context' }],
-            usage: { input_tokens: 206_000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
-          },
-        }),
-      ].join('\n') + '\n');
-
-      createConversation({
-        name: 'switch-echo',
-        tmuxSession: 'conv-switch-echo',
-        cwd,
-        model: 'claude-opus-4-8',
-        harness: 'claude-code',
-        claudeSessionId: sessionId,
-      });
-
-      const responsePromise = postSwitchModel('switch-echo', { model: 'claude-fable-5' });
-      await vi.waitFor(() => {
-        expect(capturePaneMock).toHaveBeenCalled();
-      });
-      await vi.advanceTimersByTimeAsync(5_500);
-      const response = await responsePromise;
-
-      expect(response.status).toBe(200);
-      expect(deliverAgentMessageMock).toHaveBeenCalledWith(
-        'conv-switch-echo',
-        '/model claude-fable-5',
-        'conversation-switch-model',
-        'auto',
-      );
-      expect(killSessionMock).toHaveBeenCalledWith('conv-switch-echo');
-      expect(createSessionMock).toHaveBeenCalled();
-      expect(readFileSync(sessionFile, 'utf8')).not.toContain('"subtype":"compact_boundary"');
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('appends a compact boundary when the same-harness switch exceeds the target window threshold', async () => {
-    const cwd = join(testHome, 'over-window-workspace');
-    mkdirSync(cwd, { recursive: true });
-
-    const { createConversation } = await import('../../../../lib/database/conversations-db.js');
-    const { sessionFilePath } = await import('../../../../lib/paths.js');
-    const sessionId = 'over-window-session';
-    const sessionFile = sessionFilePath(cwd, sessionId);
-    mkdirSync(join(sessionFile, '..'), { recursive: true });
-    writeFileSync(sessionFile, [
-      JSON.stringify({ type: 'user', message: { role: 'user', content: [{ type: 'text', text: 'Too much context' }] } }),
-      JSON.stringify({
-        type: 'assistant',
-        timestamp: '2026-06-10T00:00:00.000Z',
-        message: {
-          role: 'assistant',
-          model: 'claude-opus-4-8',
-          content: [{ type: 'text', text: 'Large context still in transcript' }],
-          usage: { input_tokens: 900_000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
-        },
-      }),
-    ].join('\n') + '\n');
-
-    createConversation({
-      name: 'switch-over-window',
-      tmuxSession: 'conv-switch-over-window',
-      cwd,
-      model: 'claude-opus-4-8',
-      harness: 'claude-code',
-      claudeSessionId: sessionId,
-    });
-
-    const response = await postSwitchModel('switch-over-window', { model: 'claude-fable-5' });
-    const finalContent = readFileSync(sessionFile, 'utf8');
-
-    expect(response.status).toBe(200);
-    expect(deliverAgentMessageMock).not.toHaveBeenCalled();
-    expect(killSessionMock).toHaveBeenCalledWith('conv-switch-over-window');
-    expect(createSessionMock).toHaveBeenCalled();
-    expect(finalContent).toContain('"subtype":"compact_boundary"');
-    expect(finalContent).toContain('"preTokens":900000');
+    expect(response.status).toBe(400);
+    expect(decodeJsonResponse(response).error).toMatch(/locked/i);
+    expect(killSessionMock).not.toHaveBeenCalled();
+    expect(createSessionMock).not.toHaveBeenCalled();
   });
 });

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -3777,78 +3777,12 @@ const postAgentSwitchModelRoute = HttpRouter.add(
   'POST',
   '/api/agents/:id/switch-model',
   httpHandler(Effect.gen(function* () {
-    const params = yield* HttpRouter.params;
-    const id = params['id'] ?? '';
-    const body = yield* readJsonBody;
-    const eventStore = yield* EventStoreService;
-
-    const { model: rawNewModel } = body as { model?: string; message?: string };
-    let newModel: string;
-    try {
-      newModel = requireModelOverrideSync(rawNewModel);
-    } catch (err) {
-      return jsonResponse({ error: err instanceof Error ? err.message : String(err) }, { status: 400 });
-    }
-
-    const agentState = yield* getAgentState(id);
-    if (!agentState) {
-      return jsonResponse({ error: `Agent ${id} not found` }, { status: 404 });
-    }
-
-    const previousModel = agentState.model ?? '';
-    const lifecycle = yield* getWorkAgentLifecycleState(id);
-
-    // Stop running agent if alive
-    if (lifecycle.hasLiveTmuxSession) {
-      yield* stopAgent(id);
-      // PAN-1908: write-through projection — agents-row upsert + lifecycle event
-      // append in one SQLite transaction. stopAgent already saved state, but
-      // repeating the upsert here makes the event append atomic.
-      const stateAfterStop = yield* getAgentState(id);
-      if (stateAfterStop) {
-        yield* saveAgentStateAndEmitEventProgram(stateAfterStop, {
-          type: 'agent.stopped',
-          timestamp: new Date().toISOString(),
-          payload: { agentId: id, issueId: stateAfterStop.issueId || agentState.issueId },
-        });
-      }
-    }
-
-    const agentDir = getAgentDir(id);
-
-    // Clear session tracking files
-    yield* Effect.promise(() => rm(join(agentDir, 'session.id'), { force: true }));
-    yield* Effect.promise(() => rm(join(agentDir, 'sessions.json'), { force: true }));
-
-    // Clear claudeSessionId from runtime.json (preserve other fields)
-    const runtimeFile = join(agentDir, 'runtime.json');
-    if (existsSync(runtimeFile)) {
-      try {
-        const runtimeContent = yield* Effect.promise(() => readFile(runtimeFile, 'utf-8'));
-        const runtime = JSON.parse(runtimeContent);
-        delete runtime.claudeSessionId;
-        yield* Effect.promise(() => writeFile(runtimeFile, JSON.stringify(runtime, null, 2)));
-      } catch { /* non-fatal */ }
-    }
-
-    // Kill zombie tmux session if exists
-    yield* killSession(id).pipe(Effect.catch(() => Effect.void));
-
-    // Update model in state.json
-    const stateFile = join(agentDir, 'state.json');
-    if (existsSync(stateFile)) {
-      try {
-        const stateContent = yield* Effect.promise(() => readFile(stateFile, 'utf-8'));
-        const state = JSON.parse(stateContent);
-        state.model = newModel;
-        yield* Effect.promise(() => writeFile(stateFile, JSON.stringify(state, null, 2)));
-      } catch { /* non-fatal */ }
-    }
-
-    yield* Effect.promise(() => appendAgentLifecycleLog(id, 'agent.model_switched', { previousModel, newModel }));
-    invalidateAgentsCache();
-
-    return jsonResponse({ success: true, agentId: id, previousModel, newModel });
+    // PAN-1928: pipeline agents must never switch model. Their model is fixed
+    // at spawn; switching tears down the live session and destroys context.
+    return jsonResponse(
+      { error: 'Model switching is not allowed for agents. Spawn a new agent to use a different model.' },
+      { status: 400 },
+    );
   })),
 );
 

--- a/src/dashboard/server/routes/conversations.ts
+++ b/src/dashboard/server/routes/conversations.ts
@@ -2802,6 +2802,16 @@ const postConversationSwitchModelRoute = HttpRouter.add(
           return jsonResponse({ error: 'Conversation not found' }, { status: 404 });
         }
 
+        // PAN-1928: model switching is allowed only for brand-new conversations
+        // that have not yet started a session. Once a session exists, switching
+        // would tear down the live session and destroy accumulated context.
+        if (conv.claudeSessionId) {
+          return jsonResponse(
+            { error: 'Model is locked once a conversation has started. Start a new conversation to use a different model.' },
+            { status: 400 },
+          );
+        }
+
         const model = typeof body['model'] === 'string' && body['model'].trim()
           ? body['model'].trim()
           : (conv.model ?? undefined);


### PR DESCRIPTION
Closes [PAN-1928](https://github.com/eltmon/panopticon-cli/issues/1928)

- Reject all `POST /api/agents/:id/switch-model` requests: pipeline agents must never change model after spawn.
- Reject `POST /api/conversations/:name/switch-model` when the conversation has a `claudeSessionId` (i.e. has started). Allow it only for brand-new conversations before the first session/message.
- Add regression tests for both routes.

Quality gates pass (targeted tests + typecheck).