### PR TITLE
fix(dashboard): persist pi-harness cost events into cost_events (PAN-1935)

### DIFF
--- a/docs/overdeck-remodel/END-STATE.md
+++ b/docs/overdeck-remodel/END-STATE.md
@@ -1,0 +1,295 @@
+# Overdeck — End-State Architecture (DRAFT)
+
+> **Status:** working draft. The architecture and the two fully-audited domains
+> (Issues, Agents) are firm. Sections marked ⏳ are being filled from in-flight
+> current-state audits; Effect code blocks are marked `‹fill from
+> ARCHITECTURE-CONVENTIONS.md›` until the Effect v4-beta idiom audit lands.
+> Companion docs: [`ARCHITECTURE-CONVENTIONS.md`](ARCHITECTURE-CONVENTIONS.md)
+> (the Effect house style) and [`investigations/`](investigations/) (the
+> evidence base).
+
+## 0. The thesis
+
+Every recurring state/pipeline bug roots to the same disease: **one fact, many
+writers, no owner, no integrity.** The remodel cures it structurally, not by
+discipline:
+
+- **One read door per domain** (a resolver `Service`) and **one write door per
+  domain** (a writer `Service`). Nothing else touches a store.
+- **The SQLite cache is the only surface running code uses, and it is
+  disposable** — rebuilt from the sources of truth. The new `overdeck.db` starts
+  **empty**; the old `panopticon.db` is kept untouched as a backup. That is why
+  this big-bang is *low-risk*, not dangerous.
+- **Effect everywhere, all the way down**: `@effect/schema` entities,
+  `@effect/sql` for the cache, `Service`/`Layer` for the two doors, `HttpApi`
+  controllers, typed errors. The two-door rule stops being a guideline you can
+  violate and becomes a **type** you cannot — a handler never receives the `Sql`
+  service in its requirements, only the domain resolver/writer.
+
+### Sources of truth (durable — survive a DB wipe, travel with the repo)
+
+| Source | Owns |
+|---|---|
+| **GitHub** | issue/PR open/closed/merged status, labels |
+| **git `.pan/records/<issue>.json`** | the durable per-issue record: plan, verdicts, decisions, hazards, ownership |
+| **JSONL transcripts** (`~/.claude/projects/.../*.jsonl`) | every conversation/agent message, token usage (→ cost), tool calls |
+| **tmux** (`-L panopticon`) | liveness — is a process actually running |
+
+Everything else in the DB is **cache** (rebuildable) or **dead** (deleted).
+
+### Running deletion scoreboard
+
+| Area | Before | After |
+|---|---|---|
+| Issue stage | 8 status axes, ~148 write sites | **1 stage**, one `advance()` |
+| Issue transitions | ~148 trigger sites | **~15 legal moves** |
+| Review/merge state | 49 fields (36 "kept") | **~5–8 durable verdict** fields on the issue; the rest → Orchestration runtime or deleted |
+| Agent state | 44-col table **+ `state.json` plane (48 files)** | **18 fields**, no `state.json` |
+| `ready_for_merge` + repair sweeps | a stored column + 2 boot-time repair sweeps | **derived**, sweeps deleted |
+| ⏳ Conversations/Transcripts | 2 overlapping entities | (audit pending) |
+| ⏳ Cost | 396k rows + scattered rollups | (audit pending) |
+| ⏳ Observability | 622k unbounded `events` | (audit pending) |
+| ⏳ Orchestration/Config | ~13 tables (many empty) | (audit pending) |
+
+---
+
+## 1. The two doors (the whole architecture in one picture)
+
+```
+   SOURCES OF TRUTH      GitHub · git .pan/records · JSONL · tmux
+          │  ▲
+   reconstruction        rebuild cache from sources   ·   writer mirrors durable state back to git
+          ▼  │
+   ┌──────────────────────────────────────────────┐
+   │   overdeck.db  (@effect/sql SqlClient)        │   ← a CACHE. starts empty. disposable.
+   └──────────────────────────────────────────────┘
+        ▲                              ▲
+   READ DOOR                      WRITE DOOR
+   <Domain>Resolver  Service      <Domain>Writer  Service     (one each, per domain)
+        ▲                              ▲
+   ┌────┴───────────┬──────────────────┴─────────┐
+  HttpApiGroup    RpcGroup (dashboard)         the CLI
+   per domain     subscribeDomainEvents
+        └──── every caller goes through a door; nothing touches Sql directly ────┘
+```
+
+- **Resolver (read door)** — one `Service` per domain. Requires `Sql` (+ source
+  clients like `GitHub`, `Records`). Returns decoded Schema entities. The *only*
+  reader of its domain's cache.
+- **Writer (write door)** — one `Service` per domain. The *only* mutator. It
+  validates the operation, writes the cache **and** mirrors durable state to the
+  git record in one boundary, then emits a domain event.
+- **Controllers** — one `HttpApiGroup` per domain; the dashboard's `RpcGroup`
+  for live reads. Both delegate to the same resolver/writer, so HTTP and RPC
+  cannot diverge.
+- **The guard** — because handlers only ever receive resolver/writer Tags in
+  their `R`, direct `Sql` access is a compile error. A CI check backs it up for
+  non-Effect code (CLI scripts, hooks).
+
+---
+
+## 2. Domain map
+
+Eight domains. Three boundary questions are being settled by the in-flight
+audits and are flagged ⏳ OPEN.
+
+| # | Domain | Read door | Write door | Source(s) of truth | Cache tables |
+|---|---|---|---|---|---|
+| 1 | **Issues** | `IssuesResolver` | `IssueWriter` (`advance`, `hold`) | GitHub + `.pan/records` | issue/verdict cache |
+| 2 | **Agents** | `AgentsResolver` | `AgentWriter` | tmux + `.pan/records` | agent cache |
+| 3 | **Conversations** | `ConversationsResolver` | `ConversationWriter` | `.pan/records` (metadata) + JSONL | conversation cache |
+| 4 | **Transcripts** ⏳ | `TranscriptsResolver` | (index writer) | JSONL | transcript index/FTS |
+| 5 | **Cost** | `CostResolver` | `CostWriter` (ingest) | JSONL usage (+ API billing?) | cost events |
+| 6 | **Projects/Config** | `ConfigResolver` | `ConfigWriter` | `projects.yaml` + config files | settings cache |
+| 7 | **Observability** ⏳ | `EventsResolver`? | event emitter | derived / ephemeral | events, health |
+| 8 | **Orchestration** ⏳ | `OrchestrationResolver` | control commands | DB flags + GitHub | merge-train, queue |
+
+**Open boundary questions (audits resolving):**
+- **(4) Transcript** — standalone domain with its own resolver, or an internal
+  index/service shared by Issues-Agents-Conversations? *Conversations+Transcripts
+  audit decides.*
+- **(7) Observability** — a real domain (queryable resolver) or pure infra (an
+  event bus + read-model, no domain surface)? Hinges on whether `events` is
+  event-sourced truth or disposable pub/sub. *Observability audit decides.*
+- **(8) Orchestration** — one domain or several (merge-train / deacon-control /
+  flywheel)? *Orchestration+Config audit decides.*
+
+Cross-cutting reminder, per the tenet: **"state" is not a domain.** Every entity
+*has* a status; there is no `/api/state` and no state resolver.
+
+---
+
+## 3. Domain: Issues  ✅ (fully audited)
+
+The keystone. Evidence: [`investigations/pipeline-transitions.md`](investigations/pipeline-transitions.md),
+[`investigations/review-state-audit.md`](investigations/review-state-audit.md).
+
+### 3.1 The central insight
+
+Today an issue's "stage" is **not stored** — it is a composite read across **8
+independent status axes**, each its own enum/store/writer, mutated from ~148
+sites. We replace all of it with **one `stage` field** advanced through **one
+write door** with a small, validated set of legal moves.
+
+### 3.2 Entity — `Issue`
+
+Durable (mirrored to `.pan/records/<issue>.json`) unless marked *cache*.
+
+| Field | Type | Source / cache | Notes |
+|---|---|---|---|
+| `id` | `IssueId` (branded) | GitHub | e.g. `PAN-1938` |
+| `stage` | `Stage` (literal union) | derived/record | the single composite stage (replaces 8 axes) |
+| `gates` | `{ review, test, verification?, inspect? }` → `GateOutcome` | record | the durable verdict per kept gate (see 3.4) |
+| `verdictCommit` | `Sha` | record | the commit a passing verdict applies to (collapses `reviewed_at_commit` + `last_verified_commit`) |
+| `blockers` | `Blocker[]` (typed) | record | merge-conflict etc.; replaces `blocker_reasons` JSON-sniffing |
+| `plan` | `PlanRef` → vBRIEF on main | git `.pan/specs` | the spec; status is the only mutable field |
+| `pr` | `{ url, number, headSha }` | GitHub | **issue/merge identity, not a "review" field**; `number` derives from `url` |
+| `sideStates` | set of `Hold` | cache | paused/troubled/stuck/blocked/cancelled/deacon-ignored — orthogonal toggles |
+
+Everything else from `review_status`/`issue_state`/`status_history` is either
+**Orchestration runtime** (review-run cache, retry counters) or **deleted**
+(`ready_for_merge` → derived; `merge_step` → derived; display-only timestamps;
+dead `inspect_bead_id`; phantom `reviewer_verdicts`/`lifetime_auto_requeue_count`).
+
+### 3.3 Write door — `IssueWriter`
+
+Two verbs cover everything (~148 sites collapse here):
+
+- **`advance(id, toStage, reason)`** — validates the move is one of the ~15
+  legal edges, writes the cache, mirrors `stage`/`gates`/`verdictCommit` to the
+  git record, emits `issue.advanced`. The *only* caller of the old
+  `transitionTo` / `setReviewStatus` / `updateSpecStatus` / GitHub-label ops.
+- **`hold(id, flag, on, reason?)`** — toggles an orthogonal side-state.
+
+**The ~15 legal moves** (from the transitions audit):
+spine (9): `todo→planning→planned→working→in_review→testing→verifying→merging→verifying_on_main→closed`;
+failure edges (3): `in_review→working`, `testing→working`, `merging→working`;
+out-of-band (3): `any→cancelled`, `closed→todo` (reopen), `any→todo` (wipe).
+
+This kills the drift class outright: there is exactly one function that writes a
+stage, and it writes every store in one boundary (no more GitHub-only path that
+forgets the event; no more three-ways-in-one-function `verifying_on_main`).
+
+### 3.4 Open product decision (sizes this domain)
+
+**Which gates does the new pipeline keep — review / test / verification /
+inspect / UAT?** Each kept gate is one `GateOutcome` in `gates` and justifies a
+slice of Orchestration's review-run runtime. The audit found `verification`
+overlaps `test`, `inspect`'s only durable field has a dead consumer, and `UAT`
+isn't even persisted today. Folding `verification`→`test` and dropping the
+separate `inspect` gate would leave **review + test (+ optional UAT)** — the
+smallest honest set. *Recommend deciding this with the operator before
+finalizing 3.2/3.3.*
+
+### 3.5 Controller — `IssuesApi` (`HttpApiGroup`)
+
+```ts
+‹fill from ARCHITECTURE-CONVENTIONS.md — HttpApiGroup "issues":
+   GET  /issues                      → list (filter)            → Issue[]
+   GET  /issues/:id                  → get                      → Issue | IssueNotFound
+   POST /issues/:id/advance          → advance(to, reason)      → Issue | IllegalTransition
+   POST /issues/:id/hold             → hold(flag, on, reason)   → Issue ›
+```
+
+---
+
+## 4. Domain: Agents  ✅ (fully audited)
+
+Evidence: [`investigations/agents-state-audit.md`](investigations/agents-state-audit.md).
+
+### 4.1 The central insight
+
+The 44-column `agents` table is a dumping ground. The real need is **18 fields**,
+and the entire **`state.json` plane (48 files) is deleted** — nothing lives only
+there. Three planes collapse to two: **DB cache + tmux liveness**, rebuilt from
+the git record.
+
+### 4.2 Entity — `Agent`
+
+| Group | Fields | Source / cache |
+|---|---|---|
+| **Identity / spawn-config (9)** | `id`, `issueId`, `role`, `workspace`, `harness`*, `model`*, `sessionId`, `hostOverride`, `deliveryMethod` | record-authoritative for `harness`/`model` (the PAN-1847/1927 trap — the row is a *mirror*); rest cache, rebuildable |
+| **Lifecycle gates (8)** | `startedAt`, `lastResumeAt`, `stoppedByUser`, `kickoffDelivered`, `paused`(+`reason`), `troubled`, `consecutiveFailures`, `firstFailureInRunAt`, `lastFailureNextRetryAt` | cache (no rebuild fallback — a wiped DB just hands agents a fresh retry budget, which is fine) |
+| **Liveness cache (2)** | `status` (reconciled from tmux each patrol), `updatedAt` | cache of the tmux oracle |
+
+**Leaves the domain:** `cost_so_far` → Cost; the review-run cluster
+(`review_run_id`, `review_synthesis_agent_id`, `review_output_path`,
+`review_deadline_at`, `review_monitor_signaled`, `review_retry_attempt`,
+`review_sub_role`) → Orchestration; `flywheel_run_id`/`role_run_head` →
+Orchestration *(boundary the agents-audit flips vs the review-audit; settle in
+the Orchestration section)*.
+
+**Deleted:** `phase`, `work_type` (dead legacy PAN-118 routing); `branch`
+(= `feature/<id>`, read live from git); `last_activity`, `stopped_at`
+(derivable); 3 transport booleans → folded into `deliveryMethod`.
+
+**Schema cleanup:** there are **two byte-identical `CREATE TABLE agents` blocks**
+(`schema.ts:433` and `:1543`) — collapse to one in the new schema.
+
+### 4.3 Doors
+
+- `AgentsResolver` — enumerate/get agents (from the cache, reconciled with tmux).
+- `AgentWriter` — `spawn` / `stop` / `pause` / `unpause` / `resume` / `markTroubled` / `clearTroubled`. Liveness columns rebuild from tmux; identity from the git record.
+
+### 4.4 Controller — `AgentsApi` (`HttpApiGroup`)
+
+```ts
+‹fill from ARCHITECTURE-CONVENTIONS.md›
+```
+
+---
+
+## 5. Domain: Conversations  ⏳ (audit in flight)
+
+Entity = a thin durable metadata record (name/title, archive, fork/handoff
+lineage, favorites, issue/cwd binding) + a **Transcript** (derived). The
+durable part is the only irreplaceable DB data (PAN-1937 export target). Open:
+does conversation metadata become a git `.pan/records`-style durable artifact
+(keeping the DB purely disposable), or stay the one DB-as-truth exception?
+*Conversations+Transcripts audit fills this.*
+
+## 6. Domain: Transcripts  ⏳ (audit in flight)
+
+The shared, JSONL-derived substrate under Conversations *and* Agents
+(`discovered_sessions` is already a universal transcript index). Open: standalone
+domain vs internal index/service. *Audit decides.*
+
+## 7. Domain: Cost  ⏳ (audit in flight)
+
+Likely pure cache rebuildable from JSONL usage; rollups become
+derived-on-read, not stored; must fix the pi/kimi capture gap (PAN-1935);
+consolidate ~5 read endpoints into one resolver. *Cost audit fills this.*
+
+## 8. Domain: Projects/Config  ⏳ (audit in flight)
+
+Source of truth is `projects.yaml` + config files; `app_settings` is a small
+cache. *Orchestration+Config audit fills this.*
+
+## 9. Domain: Observability  ⏳ (audit in flight)
+
+Hinges on whether `events` is event-sourced truth or disposable pub/sub. If
+pub/sub, this is infra (event bus + read-model), not a domain. *Observability
+audit decides.*
+
+## 10. Domain: Orchestration  ⏳ (audit in flight)
+
+The control plane: merge-train/queue, deacon, flywheel — plus the review-run
+runtime and per-issue policy flags (`deacon_ignored`, `auto_merge`) that the
+god-tables were squatting. Open: one domain or several; many candidate tables
+are empty (possibly dead features to delete). *Orchestration+Config audit fills
+this.*
+
+---
+
+## 11. Cross-cutting conventions (→ `ARCHITECTURE-CONVENTIONS.md`)
+
+- Entities are `@effect/schema`; IDs are branded; states are literal unions.
+- Every store access is a `Service` method returning an `Effect`; `Sql` is a
+  Tag only the resolver/writer Layers receive.
+- Domain failures are tagged errors in the `E` channel; controllers map them to
+  HTTP status.
+- Writes emit domain events on a `Stream`; the read-model is a `SubscriptionRef`
+  the dashboard subscribes to.
+- The writer mirrors durable fields to the git record in the same boundary as
+  the cache write — never a fire-and-forget mirror (the current silent-divergence
+  bug).

--- a/docs/overdeck-remodel/README.md
+++ b/docs/overdeck-remodel/README.md
@@ -1,0 +1,33 @@
+# Overdeck Remodel — Investigations
+
+Evidence base for the Panopticon → **Overdeck** data-architecture remodel
+([PAN-1938](https://github.com/eltmon/panopticon-cli/issues/1938)). This directory
+collects the **detailed audits**; the high-level rollups feed the orchestrating
+design conversation.
+
+## What this remodel is
+
+Not a DB refactor — a **complexity amputation**. We rebuild on a fresh, empty
+`overdeck.db` (the old `panopticon.db` stays untouched as a backup, so this is a
+*low-risk* big-bang, not a dangerous migration). Because we start empty, we keep
+only what we genuinely **NEED**.
+
+## The three locked principles
+
+1. **Reduce complexity — delete a LOT of code.** Every field, table, endpoint,
+   and transition must justify itself by a concrete decision it drives. "Nice to
+   have" is a delete.
+2. **One controller per domain; all data access goes through it.** No code, agent,
+   CLI, hook, or route touches a store directly. Reads go through one resolver per
+   domain; writes through one write surface. ("State" is not a domain.)
+3. **A tiny set of legal moves.** An issue/agent can change pipeline stage in only
+   a few sanctioned ways, each behind the domain API — replacing the sprawl of
+   ad-hoc transition sites we have today.
+
+## Investigations
+
+| Doc | Question | Status |
+|---|---|---|
+| [`investigations/review-state-audit.md`](investigations/review-state-audit.md) | Of all the review/verification/merge state fields, which do we actually NEED? | in progress |
+| [`investigations/pipeline-transitions.md`](investigations/pipeline-transitions.md) | What are the canonical pipeline stages, and every way an agent moves between them? | done |
+| [`investigations/agents-state-audit.md`](investigations/agents-state-audit.md) | Of all the agent runtime fields (table + `state.json`), which do we actually NEED? Does `state.json` survive? | in progress |

--- a/docs/overdeck-remodel/investigations/pipeline-transitions.md
+++ b/docs/overdeck-remodel/investigations/pipeline-transitions.md
@@ -49,6 +49,27 @@ todo → planning → planned/proposed → working → in-review → testing
                            · deacon-ignored · cancelled
 ```
 
+### 1a-def. Spine stages — definition + entry/exit conditions
+
+The ten happy-path stages, each as the operator means them. "Entry/exit" name
+the *logical* condition; the physical writes that realize them are in §2.
+
+| Stage | One-line meaning | Entry condition | Exit condition |
+|---|---|---|---|
+| **todo** | Issue exists, no plan, no work | Issue opened / reset / wiped | Planning starts |
+| **planning** | Planning agent is producing a vBRIEF | `start-planning` spawns plan role (`IssueState=in_planning`) | Planning completes or aborts |
+| **planned/proposed** | Plan exists, awaiting start | `complete-planning` writes `plan.status=proposed` + beads | `pan start` (or auto-start) |
+| **working** | A work agent is implementing beads | `plan.status=running`, `IssueState=in_progress`, work agent running | Work agent signals done |
+| **in-review** | Code review role is judging the diff | `work.completed` event → review role dispatched (`reviewStatus=reviewing`) | Review verdict (approved / blocked) |
+| **testing** | Test role runs automated + UAT verification | `review.approved` event → test role (`testStatus=testing`) | Test verdict (passed / failed / skipped) |
+| **verifying/UAT** | Pre-merge verification gate / human UAT batch | `verificationStatus=running` or UAT assembled | Gate passes → ready-for-merge |
+| **merging** | Merge queue is landing the branch | `readyForMerge=true` + merge dispatched (`mergeStatus=queued/merging`) | Merge lands or fails |
+| **verifying-on-main** | Merged; awaiting post-merge verification | `postMergeLifecycle` sets `mergeStatus=merged`, `IssueState=verifying_on_main` | Close-out |
+| **closed** | Work complete, issue closed out | `pan close` / close-out: `plan.status=completed`, issue closed | (terminal; reopen re-enters at todo) |
+
+Side-states (paused/troubled/stuck/blocked/deacon-ignored/cancelled) are
+orthogonal toggles — see §1c.
+
 ### 1b. The axes that compose a stage
 
 | # | Axis (enum) | Values | Store | Writer of record | Source |
@@ -88,10 +109,12 @@ todo → planning → planned/proposed → working → in-review → testing
   cache*, not *logical stage transitions* — there is still **no single
   transition controller**. The closest thing, `transitionTo`, covers only
   axis 1/1b (tracker state) and never touches axes 2–7.
-- `status_history` (`schema.ts:272`, `type ∈ 'review'|'test'|'merge'`) logs
-  **only** review/test/merge sub-status. It does **not** capture `IssueState`
-  transitions, `plan.status`, agent lifecycle, or any side-flag. The audit
-  below is the **union** of all axes, not just `status_history` writers.
+- `status_history` (`schema.ts:272`) logs sub-status only. The schema comment
+  says `type ∈ 'review'|'test'|'merge'`, but the `StatusHistoryEntry` interface
+  (`review-status.ts:30`) is broader — `'review'|'test'|'merge'|'inspect'|'uat'`.
+  Either way it captures **none** of `IssueState` transitions, `plan.status`,
+  agent lifecycle, or side-flags. The audit below is the **union** of all axes,
+  not just `status_history` writers.
 - `docs/AGENT-STATE-PLANES.md` is accurate on *where* state lives (3 planes) but
   silent on *how many writers* mutate each plane. That count is the finding here.
 
@@ -155,10 +178,10 @@ and — critically — **emits reactive EV** (`review.approved` / `test.passed`,
 
 | From → To (sub-status) | Trigger (invoker) | Code location | Stores |
 |---|---|---|---|
-| review `pending→reviewing` | review-agent dispatch | `src/lib/cloister/review-agent.ts` (via setReviewStatus) | RS, REC, SH, EV |
+| review `pending→reviewing` | review-agent dispatch | `src/lib/cloister/review-agent.ts:417` | RS, REC, SH, EV |
 | review `reviewing→passed` | review verdict (approve) | `src/dashboard/server/routes/workspaces.ts:3494`; CLI `src/cli/commands/specialists/done.ts` | RS, REC, SH, **EV: review.approved** |
 | review `reviewing→failed/blocked` | review verdict (block) | `specialists.ts` done handler | RS, REC, SH |
-| test `pending→testing` | test dispatch | `src/lib/cloister/test-agent-queue.ts` | RS, REC, SH, EV |
+| test `pending→testing` | test dispatch | `src/lib/cloister/test-agent-queue.ts:90` | RS, REC, SH, EV |
 | test `testing→passed` | test verdict | `workspaces.ts:3939`; `specialists.ts:584`,`:981`; CLI `done.ts` | RS, REC, SH, **EV: test.passed** |
 | test `→skipped` | verification-gate skip | `src/lib/cloister/test-status-green-ci-reconciler.ts` | RS, REC |
 | merge `pending→queued/merging` | merge queue / approve | `workspaces.ts` merge route ~`:5676`; `done.ts:563` | RS, REC, SH |
@@ -223,7 +246,7 @@ Reactive event emission lives in `setReviewStatusSync`
 | From → To | Trigger | Code location | Stores |
 |---|---|---|---|
 | any → todo (deep-wipe) | `deep-wipe` route | `src/dashboard/server/routes/issues.ts:2345` | GH, RS(del), AG, SJ, SPEC(ws), branches |
-| any → todo (wipe CLI) | `pan wipe` | `src/cli/commands/` wipe | GH, RS, AG, SJ |
+| any → todo (wipe CLI) | `pan wipe` | `src/cli/commands/wipe.ts` | GH, RS, AG, SJ |
 | closed → reopened | `pan reopen` / route | `src/lib/reopen.ts`; `issues.ts` reopen | GH, RS, EV |
 | running → stopped (kill) | `pan kill` | `src/cli/commands/` kill | AG, SJ, EV (workspace preserved) |
 | → closed (close-out) | `pan close` / close-out route | `issues.ts:2556`; `src/lib/lifecycle/close-issue.ts` | GH, RS(clear), SPEC(completed), EV |
@@ -246,11 +269,15 @@ called from many places, the helper is one *function* but N *trigger sites*.
 | Side-flag (stuck/troubled/paused/ignored) writers | **~52** | `rg 'setStuck\|markTroubled\|paused: true\|deacon_ignored'` prod |
 | `plan.status` writers | **1 function** (`updateSpecStatus`), ~4 call sites | §2d |
 | Reactive event→role dispatch edges | **9** | §2e |
-| **Distinct trigger sites (union, approx.)** | **≈ 200+** | sum of the above, de-duped by file:line |
-| **Distinct logical (from→to) pairs** | **≈ 18** | §5 below |
+| **Distinct trigger sites (real dedup)** | **≈ 148** | combined grep of all transition verbs (`setReviewStatusSync`, `transitionTo`, `transitionIssueTo*`, label ops, `updateSpecStatus`, reactive emits, stuck/ignored writers), tests + defs excluded, piped to `awk -F: '{print $1":"$2}' \| sort -u` |
+| **Distinct (from→to) pairs** | **≈ 38** | unique from→to strings across all axes in §2 (sub-status granularity) |
+| **Minimal legal moves** | **≈ 15** | §5 — 9 spine + 6 failure/terminal edges |
 
-The gap between **~200 trigger sites** and **~18 logical moves** is the sprawl
-the remodel deletes.
+The descending tiers — **~148 trigger sites → ~38 distinct pairs → ~15 legal
+moves** — are the sprawl story. 148 places fire 38 logically-distinct moves that
+*should* be 15. The two collapses (148→38 by deduping redundant call sites,
+38→15 by unifying sub-status axes into stage advances) are what the remodel
+deletes.
 
 ---
 
@@ -295,9 +322,11 @@ the remodel deletes.
 
 ## 5. Collapsed logical moves — the minimal set (PART B §3)
 
-All ~200 trigger sites collapse to **~18 logical (from→to) moves**, which
-further collapse to **one linear advance chain + a handful of failure/terminal
-edges**:
+The ~148 trigger sites express **~38 distinct (from→to) pairs** (§3), which
+collapse to **~15 logical moves** — one linear advance chain + a handful of
+failure/terminal edges. The 38→15 collapse merges the per-axis sub-status pairs
+(review/test/merge/verify/inspect/uat each `pending→active→passed`) into the
+single stage advance they collectively signal:
 
 ### Forward advances (the spine)
 1. `todo → planning` (start planning)

--- a/docs/overdeck-remodel/investigations/pipeline-transitions.md
+++ b/docs/overdeck-remodel/investigations/pipeline-transitions.md
@@ -1,0 +1,334 @@
+# Pipeline Transitions — Full Audit
+
+> Evidence base for the Overdeck remodel
+> ([PAN-1938](https://github.com/eltmon/panopticon-cli/issues/1938)).
+> **Question:** What are the canonical pipeline stages, and every way an
+> issue/agent moves between them?
+> **Method:** `git grep` / `rg` over `src/`, production code only
+> (`__tests__/` and `*.test.ts` excluded). Line numbers checked at writing
+> time (2026-06-16, `main` @ `840117fadc`); where a number may drift the
+> anchor symbol is quoted so it can be re-grepped.
+
+---
+
+## Glossary
+
+- **Stage** — a human-meaningful pipeline position (e.g. "in review"). It is
+  **not a column.** There is no single `stage` field anywhere. A stage is a
+  *composite read* across ~8 independent enums + GitHub labels + side-flags
+  (see §1).
+- **Store** — a physical place a status value is persisted. Six exist:
+  GitHub labels/issue-state, SQLite `review_status`, SQLite `agents`, SQLite
+  `status_history` (append-only log), SQLite `events` (append-only log),
+  `.pan/<recordsPath>/<issue>.json` (git record), `~/.panopticon/agents/<id>/state.json`.
+- **Transition site** — a production code location that *writes* a stage-bearing
+  value into at least one store.
+- **Reactive dispatch** — the autonomous half: a write to one store emits an
+  `events`/pipeline-notifier event, which the Cloister deacon consumes and
+  reacts to (spawns a role, advances the issue). The trigger is the event, not
+  an HTTP route.
+- **Role** — `plan | work | review | test | ship | flywheel | strike`
+  (`packages/contracts/src/types.ts:21`). A role spawn *is* the physical
+  manifestation of a working stage.
+
+---
+
+## 1. Canonical stages — the multi-axis map (PART A)
+
+The "stage" the operator sees is computed from **eight independent status axes**,
+each with its own enum, its own store, and its own writer. There is no single
+column. This table IS the motivation for "one controller per domain."
+
+### 1a. Happy-path stage line (the documented intent)
+
+```
+todo → planning → planned/proposed → working → in-review → testing
+     → verifying/UAT → merging → verifying-on-main → closed
+                                                        │
+              side-states: paused · troubled · stuck · blocked
+                           · deacon-ignored · cancelled
+```
+
+### 1b. The axes that compose a stage
+
+| # | Axis (enum) | Values | Store | Writer of record | Source |
+|---|---|---|---|---|---|
+| 1 | **Tracker `IssueState`** | `open · in_progress · in_review · closed` | GitHub labels + issue open/closed | `IssueLifecycleService.transitionTo` | `src/lib/tracker/interface.ts:28`; lifecycle svc `src/dashboard/server/services/issue-lifecycle.ts:198` |
+| 1b | **Lifecycle `IssueState` (richer)** | `open · in_planning · in_progress · in_review · verifying_on_main · closed · canceled` | GitHub labels (`planned`, `in-progress`, `in-review`, `verifying-on-main`, `wontfix`) + `canonicalStatus` cache | `transitionTo` → `GITHUB_STATE_LABELS` | `src/dashboard/server/services/issue-lifecycle.ts:45`, label map `:154`, `canonicalStatus()` `:178` |
+| 2 | **`plan.status`** (vBRIEF spec) | `draft · proposed · approved · running · completed · cancelled` | `.pan/specs/*.vbrief.json` (git) | `updateSpecStatus` only (PAN-1124 single writer) | `src/lib/pan-dir/specs.ts:266`; finalize `src/cli/commands/plan-finalize.ts:377` |
+| 3 | **`review_status.review_status`** | `pending · reviewing · passed · failed · blocked` | SQLite `review_status` + mirrored to `.pan` record | `setReviewStatusSync` | `packages/contracts/src/types.ts:27`; writer `src/lib/review-status.ts:194` |
+| 4 | **`review_status.test_status`** | `pending · testing · passed · failed · skipped · dispatch_failed` | SQLite `review_status` (+ record) | `setReviewStatusSync` | `packages/contracts/src/types.ts:30` |
+| 5 | **`review_status.merge_status`** | `pending · queued · merging · verifying · merged · failed` | SQLite `review_status` (+ record) | `setReviewStatusSync` / merge-agent | `packages/contracts/src/types.ts:36` |
+| 6 | **`review_status.verification_status`** | `pending · running · passed · failed · skipped` | SQLite `review_status` | verification-runner | `packages/contracts/src/types.ts:39` |
+| 6b | **`review_status.uat_status`** | `pending · testing · passed · failed` | SQLite `review_status` | uat engine | `src/lib/review-status.ts:52` |
+| 6c | **`review_status.inspect_status`** | `pending · inspecting · passed · failed · error` | SQLite `review_status` | inspect-agent | `src/lib/review-status.ts:48` |
+| 7 | **Agent process `AgentStatus`** | `starting · running · stopped · error · unknown` | SQLite `agents` + `state.json` + `agent.*` events | `agents.ts` / runtime adapters | `packages/contracts/src/types.ts:18` |
+| 7b | **`AgentResolution`** (self-report) | `working · done · needs_input · stuck · completed · unclear · abandoned · api_error` | transcript/heartbeat → events | harness | `packages/contracts/src/types.ts:24` |
+| 8 | **Reactive `ReactiveIssueState`** | `todo · open · in_planning · in_progress · in_review · testing · shipping · closed · canceled` | derived (event payload), not stored | `issueStateChangeFromDomainEvent` | `src/lib/cloister/service.ts:137` |
+
+### 1c. Side-states (orthogonal flags, not on the main line)
+
+| Side-state | Store + field | Set by | Cleared by | Effect |
+|---|---|---|---|---|
+| **paused** | `state.json` / `agents` `paused` | `pan pause`, deacon advancing-reaper | `pan unpause`, `pan start --force` | Deacon auto-resume skips agent |
+| **troubled** | `state.json` / `agents` `troubled` + failure counters | deacon after repeated resume/crash; stuck-remediation | `pan untroubled` | Resume gate refuses; `handleAgentStoppedEvent` skips (`deacon.ts:6649`) |
+| **stuck** | `review_status.stuck` (+ `stuck_reason/at/details`) | approve-push divergence guard, conflict-gate | `/unstick` route | Deacon patrol skips the issue |
+| **deacon-ignored** | `review_status.deacon_ignored` | operator (`/deacon-ignore`) | operator | Patrol skips issue entirely |
+| **blocked** | `review_status.review_status='blocked'` + `blocker_reasons` | review verdict, webhook merge-blockers | re-review | Not merge-ready |
+| **cancelled** | `IssueState='canceled'` (`wontfix` label) + `plan.status='cancelled'` | `move-status`, issue-closed reaper | reopen | Terminal; reactive dispatch suppressed |
+| **ready-for-merge** | `review_status.ready_for_merge` | derived by `setReviewStatusSync` when review+test pass (`review-status.ts:283`) | reset/new commit | Gates merge queue |
+
+### 1d. Divergence from the documented model
+
+- `reference/state-model.mdx` claims phase is **derived** ("the DB is a cache;
+  phase is a function of GitHub + workspace") and that **all mutations go
+  through one write surface** (enforced by `scripts/lint-state-writes.sh`).
+  **Reality:** each axis above is written **imperatively and independently** by
+  its own helper. `lint-state-writes.sh` governs *which modules may touch the
+  cache*, not *logical stage transitions* — there is still **no single
+  transition controller**. The closest thing, `transitionTo`, covers only
+  axis 1/1b (tracker state) and never touches axes 2–7.
+- `status_history` (`schema.ts:272`, `type ∈ 'review'|'test'|'merge'`) logs
+  **only** review/test/merge sub-status. It does **not** capture `IssueState`
+  transitions, `plan.status`, agent lifecycle, or any side-flag. The audit
+  below is the **union** of all axes, not just `status_history` writers.
+- `docs/AGENT-STATE-PLANES.md` is accurate on *where* state lives (3 planes) but
+  silent on *how many writers* mutate each plane. That count is the finding here.
+
+---
+
+## 2. The transition table (PART B)
+
+Production transition sites, grouped by the axis they write. Each row:
+**from → to | trigger (invoker) | code location | stores written**.
+
+Stores legend: **GH** = GitHub labels/state · **RS** = SQLite `review_status` ·
+**REC** = `.pan` record · **SH** = `status_history` · **EV** = `events`/pipeline
+event · **AG** = SQLite `agents` · **SJ** = `state.json` · **SPEC** =
+`.pan/specs` vBRIEF.
+
+### 2a. The one near-controller — `IssueLifecycleService.transitionTo`
+
+Writes GH labels + `canonicalStatus` cache + emits `issue.transitioned`. Covers
+axis 1/1b only.
+
+| From → To | Trigger (invoker) | Code location | Stores |
+|---|---|---|---|
+| any → `in_planning` | `start-planning` route | `src/dashboard/server/routes/issues.ts:995` | GH, EV |
+| any → `open` (reset to todo) | `move-status` / abort / restart-from-plan | `issues.ts:1148`, `:1486` | GH, EV |
+| any → `targetState` (operator move) | `move-status` route | `issues.ts:1789` | GH, EV |
+| any → `in_progress` | generate-tasks / start fallback | `issues.ts:2124`, `:2216` | GH, EV |
+| any → `in_progress` | agent start / restart | `src/dashboard/server/routes/agents.ts:2971`, `:3187`, `:3538` | GH, EV |
+| any → `verifying_on_main` | `postMergeLifecycle` (server merge) | `src/lib/cloister/merge-agent.ts:629` | GH, EV |
+| service impl | (all of the above) | `issue-lifecycle.ts:198`–`247` | GH + `canonicalStatus` + EV |
+
+### 2b. Tracker transition — the *other* path (`transitionIssue` / helpers in `agents.ts`)
+
+A second, parallel route to the same axis-1 move, **bypassing** `transitionTo`.
+`transitionIssueState` (`src/lib/agents.ts:2801`) calls `tracker.transitionIssue`
+directly (GH labels via `github.ts:239`), with thin wrappers
+`transitionIssueToInProgress` (`agents.ts:2867`) and `transitionIssueToInReview`
+(`agents.ts:2875`).
+
+| From → To | Trigger (invoker) | Code location | Stores |
+|---|---|---|---|
+| → `in_progress` | work agent spawn | `src/lib/agents.ts:3661` | GH |
+| → `in_progress` | specialist done (re-enter work) | `src/dashboard/server/routes/specialists.ts:620` | GH |
+| → `in_review` | approve / re-review (3 sites) | `src/dashboard/server/routes/workspaces.ts:3739`, `:4027`, `:4192` | GH |
+| → `closed` | close-out workflow | `src/lib/lifecycle/close-issue.ts:105`, `:383` | GH |
+| → `verifying_on_main` (label) | merge-agent direct gh edit | `src/lib/cloister/merge-agent.ts:587`–`632` | GH |
+| review-fail → `in_progress` | `specialists/done` failure branch | `specialists.ts:623`, `:627` | GH |
+
+> **Same logical move, two code paths:** "→ in_review" is reachable via
+> `transitionTo` (axis 1b, emits events) AND via `transitionIssueToInReview`
+> (axis 1, GH only, no event). They write different stores. This is the
+> drift-risk pattern (see §4).
+
+### 2c. Review / test / merge sub-status — `setReviewStatusSync` (axis 3–6)
+
+`setReviewStatusSync` (`src/lib/review-status.ts:194`) is the single *function*
+but is called from **~70 production sites**. Every call writes **RS + REC**
+(mirror via `updateIssueRecordForIssue` `review-status.ts:345`), appends **SH**,
+and — critically — **emits reactive EV** (`review.approved` / `test.passed`,
+`review-status.ts:455`–`462`) when status flips to `passed`. So a status write
+*is* a transition trigger.
+
+| From → To (sub-status) | Trigger (invoker) | Code location | Stores |
+|---|---|---|---|
+| review `pending→reviewing` | review-agent dispatch | `src/lib/cloister/review-agent.ts` (via setReviewStatus) | RS, REC, SH, EV |
+| review `reviewing→passed` | review verdict (approve) | `src/dashboard/server/routes/workspaces.ts:3494`; CLI `src/cli/commands/specialists/done.ts` | RS, REC, SH, **EV: review.approved** |
+| review `reviewing→failed/blocked` | review verdict (block) | `specialists.ts` done handler | RS, REC, SH |
+| test `pending→testing` | test dispatch | `src/lib/cloister/test-agent-queue.ts` | RS, REC, SH, EV |
+| test `testing→passed` | test verdict | `workspaces.ts:3939`; `specialists.ts:584`,`:981`; CLI `done.ts` | RS, REC, SH, **EV: test.passed** |
+| test `→skipped` | verification-gate skip | `src/lib/cloister/test-status-green-ci-reconciler.ts` | RS, REC |
+| merge `pending→queued/merging` | merge queue / approve | `workspaces.ts` merge route ~`:5676`; `done.ts:563` | RS, REC, SH |
+| merge `merging→merged` | `postMergeLifecycle` | `src/lib/cloister/merge-agent.ts:357` | RS, REC |
+| merge `→failed` | merge failure | `merge-agent.ts:445` | RS, REC |
+| verification `pending→running→passed/failed` | verification-runner | `src/lib/cloister/verification-runner.ts:202` | RS |
+| inspect `→inspecting/passed/failed` | inspect-agent | `src/lib/cloister/inspect-agent.ts` | RS |
+| uat `→testing/passed/failed` | uat engine | `src/lib/cloister/uat-*.ts` | RS |
+| `readyForMerge` derived true | review+test both pass | `review-status.ts:283` (auto) | RS, REC |
+
+### 2d. `plan.status` (axis 2) — the cleanly-single-writer one
+
+| From → To | Trigger (invoker) | Code location | Stores |
+|---|---|---|---|
+| (new) → `draft` | `pan plan` PRD write | `src/lib/vbrief/builder.ts:41` | (file) |
+| `draft → proposed` | `complete-planning` / plan finalize | `src/cli/commands/plan-finalize.ts:377`; `src/lib/vbrief/auto-synthesize.ts:88`,`:133` | SPEC |
+| `proposed → approved/running` | `start-agent` | `updateSpecStatus` via `src/lib/vbrief/lifecycle-io.ts:246` | SPEC |
+| `running → completed` | close-out | `lifecycle-io.ts:338` | SPEC |
+| any → `cancelled` | issue closed | `updateSpecStatus` (`pan-dir/specs.ts:266`) | SPEC |
+
+> This axis is the model the remodel wants everywhere: **one writer**
+> (`updateSpecStatus`), file moves never happen, only the field changes.
+
+### 2e. Reactive dispatch — the autonomous half (axis 8 → role spawn)
+
+The Cloister deacon consumes events and dispatches roles. **No HTTP route is
+involved** — the trigger is an `events` row. This is where the pipeline
+*advances itself*.
+
+| Event (from) → role/state (to) | Mapper | Dispatcher | Code location |
+|---|---|---|---|
+| `work.completed` / `agent.completed`(role=work) → `in_review` | `issueStateChangeFromDomainEvent` | `onIssueStateChange` → review role | `src/lib/cloister/service.ts:399`–`411`, `:497` |
+| `review.approved` → `testing` | same | `onIssueStateChange` → test role | `service.ts:412`, `stateToRole` `:168`, `ROLE_RUN_STATES` `:153` |
+| `test.passed` → `shipping` | same | ship handoff (server merge) | `service.ts:414` |
+| `issue.transitioned`/`statusChanged` → role for state | same | `onIssueStateChangePromise` | `service.ts:278`–`381` |
+| `issue.statusChanged`(closed) → reap | — | `closed-issue-reaper` | `service.ts:484` |
+| `issue.statusChanged`(todo/planned) → reconcile proposed spec | — | `orphan-proposed-reconciler` | `service.ts:489` |
+| `agent.stopped` → resume/orphan handling | — | `handleAgentStoppedEvent` | `service.ts:422`, `deacon.ts:6649` |
+| `agent.heartbeat_dead` → orphan recovery | — | `handleAgentHeartbeatDeadEvent` | `service.ts:445` |
+| `review.coordinator.died` → re-dispatch review | — | `handleReviewCoordinatorDied` | `service.ts:457` |
+
+Reactive event emission lives in `setReviewStatusSync`
+(`review-status.ts:455`–`462`) and `notifyPipelineSync`
+(`src/lib/pipeline-notifier.ts:23`). So the *write* in §2c **is** the trigger here.
+
+### 2f. Deacon patrol & remediation — side-state writes (axis 7 + side-flags)
+
+| From → To | Trigger (invoker) | Code location | Stores |
+|---|---|---|---|
+| running → stopped (orphan) | `recoverOrphanedAgents` patrol | `src/lib/cloister/deacon.ts:5766`,`:5783` | AG, SJ, EV |
+| stopped → running (auto-resume) | `autoResumeStoppedWorkAgents` | `deacon.ts` (`autoResume*`) | AG, SJ, EV |
+| any → troubled | repeated resume/crash failures | `deacon.ts` failure markers `:5733`; stuck-remediation `:120` | SJ/AG |
+| idle → paused+troubled (flywheel) | stuck-remediation escalation | `src/lib/cloister/stuck-remediation.ts:186` | SJ |
+| advancing → paused (advancing reaper) | re-pause before kill | `deacon.ts:4853`–`4867` | SJ |
+| review-fail dead-end → circuit-break | auto-requeue ≥25 | `deacon.ts:3898`–`3900` | RS |
+| stuck set (main diverged) | approve-push divergence guard | `workspaces.ts` approve helper `:1334`–`1342` | RS |
+| stuck cleared | `/unstick` route | `workspaces.ts:4672`,`:4587`–`4645` | RS |
+| → verifying_on_main + pause agents | `postMergeLifecycle` | `merge-agent.ts:438` | GH, RS, SJ, EV |
+
+### 2g. Destructive / terminal resets
+
+| From → To | Trigger | Code location | Stores |
+|---|---|---|---|
+| any → todo (deep-wipe) | `deep-wipe` route | `src/dashboard/server/routes/issues.ts:2345` | GH, RS(del), AG, SJ, SPEC(ws), branches |
+| any → todo (wipe CLI) | `pan wipe` | `src/cli/commands/` wipe | GH, RS, AG, SJ |
+| closed → reopened | `pan reopen` / route | `src/lib/reopen.ts`; `issues.ts` reopen | GH, RS, EV |
+| running → stopped (kill) | `pan kill` | `src/cli/commands/` kill | AG, SJ, EV (workspace preserved) |
+| → closed (close-out) | `pan close` / close-out route | `issues.ts:2556`; `src/lib/lifecycle/close-issue.ts` | GH, RS(clear), SPEC(completed), EV |
+
+---
+
+## 3. Approximate counts (PART B rollup)
+
+Counts are of **production** sites (tests excluded). Where a single helper is
+called from many places, the helper is one *function* but N *trigger sites*.
+
+| Measure | Count | How counted |
+|---|---|---|
+| Axes that compose a "stage" | **8** (+3 sub-axes) | §1b |
+| Side-states | **7** | §1c |
+| `setReviewStatusSync` call sites (RS+REC+SH+EV per call) | **~70** | `rg setReviewStatusSync\(\|upsertReviewStatusSync\(` prod |
+| Direct GitHub label/state write sites | **~54** | `rg 'gh issue edit\|addLabel\|removeLabel\|transitionIssue\|closeIssue\|reopenIssue'` prod |
+| `transitionTo` call sites | **~12** | §2a |
+| `transitionIssueTo{InProgress,InReview}` call sites | **8** | §2b |
+| Side-flag (stuck/troubled/paused/ignored) writers | **~52** | `rg 'setStuck\|markTroubled\|paused: true\|deacon_ignored'` prod |
+| `plan.status` writers | **1 function** (`updateSpecStatus`), ~4 call sites | §2d |
+| Reactive event→role dispatch edges | **9** | §2e |
+| **Distinct trigger sites (union, approx.)** | **≈ 200+** | sum of the above, de-duped by file:line |
+| **Distinct logical (from→to) pairs** | **≈ 18** | §5 below |
+
+The gap between **~200 trigger sites** and **~18 logical moves** is the sprawl
+the remodel deletes.
+
+---
+
+## 4. Worst offenders (deletion targets)
+
+### 4a. Most-duplicated single move
+
+- **"→ in_review"** — fired from **at least 5 places** across **2 different
+  axes/code paths**:
+  - `transitionIssueToInReview` from `workspaces.ts:3739`, `:4027`, `:4192`
+  - `transitionTo(…, 'in_review')` reachable via the lifecycle service
+  - `setReviewStatusSync({reviewStatus:'reviewing'})` (axis 3)
+  Each writes a *different* subset of stores (GH-only vs GH+event vs RS+REC+EV).
+- **"→ in_progress"** — fired from **6+ places**: `agents.ts:2971`, `:3187`,
+  `:3538` (lifecycle), `agents.ts:3661` (spawn), `specialists.ts:620`
+  (re-enter), `issues.ts:2124`, `:2216` (generate-tasks/start).
+- **"→ verifying_on_main"** — written **3 ways in one function**: GH label via
+  raw `gh issue edit` (`merge-agent.ts:608`), `transitionTo` (`:629`), and
+  `review_status` mergeStatus (`:357`, `:445`).
+
+### 4b. One move writing many stores inconsistently (drift risk)
+
+- **`specialists/done` handler** (`specialists.ts:318`–`709`) — a single request
+  writes **RS + SH + EV + GH label + tmux kill + handoff log + `reviewedAtCommit`
+  snapshot**, with separate try/catch per store. Any one failing leaves the
+  others advanced → split-brain stage.
+- **`setReviewStatusSync`** (`review-status.ts:194`) — every call fans out to
+  **RS, REC (`:345`), SH, and conditionally EV (`:455`)**. The REC mirror is
+  fire-and-forget (`void updateIssueRecordForIssue` `:345`) — if it throws, the
+  DB and the git record diverge silently.
+- **"→ in_review" via two paths** (§4a) — `transitionIssueToInReview` writes
+  **GH only, no event**, while `transitionTo` writes **GH + cache + event**.
+  Issues advanced by the GH-only path never emit `issue.transitioned`, so the
+  reactive scheduler can miss the review dispatch. Classic drift.
+- **merge `verifying_on_main`** — GH label, `review_status.merge_status`, and the
+  `.pan` record `pipeline` block are each updated by different lines; a partial
+  failure (e.g. `transitionIssueToVerifyingOnMain` throws after mergeStatus set)
+  is explicitly handled at `merge-agent.ts:442`–`452` — evidence the drift is
+  real enough to need a recovery branch.
+
+---
+
+## 5. Collapsed logical moves — the minimal set (PART B §3)
+
+All ~200 trigger sites collapse to **~18 logical (from→to) moves**, which
+further collapse to **one linear advance chain + a handful of failure/terminal
+edges**:
+
+### Forward advances (the spine)
+1. `todo → planning` (start planning)
+2. `planning → planned` (planning complete; `plan.status=proposed`)
+3. `planned → working` (start work; `plan.status=running`, `IssueState=in_progress`)
+4. `working → in-review` (work complete)
+5. `in-review → testing` (review approved)
+6. `testing → verifying/UAT` (test passed) *(may be skipped per project)*
+7. `verifying/UAT → merging` (ready-for-merge, merge dispatched)
+8. `merging → verifying-on-main` (merge landed)
+9. `verifying-on-main → closed` (close-out)
+
+### Failure edges (back to an earlier stage)
+10. `in-review → working` (review blocked)
+11. `testing → working` (test failed)
+12. `merging → working` (merge conflict / push divergence → stuck)
+
+### Terminal / out-of-band
+13. `any → cancelled` (issue closed wontfix)
+14. `closed/cancelled → todo` (reopen)
+15. `any → todo` (deep-wipe / wipe — destructive reset)
+
+### Side-state toggles (orthogonal, not stage moves)
+16. `* ↔ paused` (operator / advancing reaper)
+17. `* ↔ troubled` (deacon crash gate)
+18. `* ↔ stuck` / `* ↔ deacon-ignored` (system / operator hold)
+
+**Proposed Overdeck controller.** One `advance(issueId, toStage, reason)` write
+surface that: validates the move against this 9-step spine + the 6 failure/
+terminal edges, writes **all** stores atomically in one transaction (RS + record
++ GH + event emission), and is the **only** caller of `transitionTo`,
+`setReviewStatusSync`, `updateSpecStatus`, and the GH label ops. Side-states
+become a separate small `hold(issueId, flag, on/off)` surface. Everything in §2
+that is not this controller gets deleted or rewritten to call it.

--- a/docs/overdeck-remodel/investigations/review-state-audit.md
+++ b/docs/overdeck-remodel/investigations/review-state-audit.md
@@ -1,0 +1,160 @@
+# Overdeck Remodel — Review / Verification / Merge / Inspect State Field Audit
+
+**Goal:** radical complexity reduction on a fresh empty DB. Keep only fields the
+pipeline genuinely NEEDS ("NEED, not nice-to-have"). For each field: where it is
+written, where it is read, whether a read actually BRANCHES on it, a verdict
+(`KEEP` / `DROP` / `MERGE-INTO` / `DERIVE`), and a class for each KEEP
+(DURABLE VERDICT vs EPHEMERAL REVIEW-RUN vs belongs-elsewhere).
+
+Method: every field traced through its camelCase accessor across `src/`
+(non-test), with the discriminator being **does any read drive control flow**
+(an `if`/`filter`/gate/comparison), not whether the field is "touched".
+
+## Glossary
+
+- **Branch-read** — a read site that feeds an `if`/`filter`/`switch`/comparison
+  that changes what the pipeline does. The opposite is a **display read** (value
+  is only serialized to the frontend / activity feed) or a **pass-through**
+  (copied into another record verbatim).
+- **DURABLE VERDICT** — the issue's review/test/merge/inspect *outcome*; belongs
+  in the per-issue permanent record (`.pan/<recordsPath>/<issue>.json`,
+  `pipeline` block) and must survive a DB wipe.
+- **EPHEMERAL REVIEW-RUN** — state of an in-flight review/test/merge run; pure
+  cache, dies with the run, rebuildable.
+- **Single write path** — almost every `review_status` column is written through
+  one function: `upsertReviewStatusSync` in
+  `src/lib/database/review-status-db.ts:30`, fed by `setReviewStatusSync`
+  (`src/lib/review-status.ts:194`) and read back through `rowToReviewStatus`
+  (`review-status-db.ts:443`). Targeted writers also exist:
+  `markWorkspaceStuck` (498), `setDeaconIgnored` (529), `setAutoMerge` (569),
+  `clearWorkspaceStuck` (591). "Written-at" below names the *semantic* writer,
+  not this plumbing.
+- **Durable mirror** — `src/lib/pan-dir/records.ts:80-111` (`projectPipeline`)
+  copies a subset of `ReviewStatus` into the permanent record. Whatever it
+  copies is the codebase's own DURABLE answer; whatever it drops is EPHEMERAL.
+
+---
+
+## Table 1 — `review_status`
+
+| Field | Written-at (semantic) | Branch-read-at | What it drives | Verdict | Class |
+| --- | --- | --- | --- | --- | --- |
+| `issue_id` | upsert (PK, upper-cased) | every read keys on it | Row identity | **KEEP** | DURABLE VERDICT |
+| `review_status` | review pipeline → setReviewStatus | `mergeGateEligibility` (review-status.ts:144); deacon gates; `fixStuckReadyForMerge` (515) | Core review outcome; gates merge eligibility | **KEEP** | DURABLE VERDICT |
+| `test_status` | test pipeline | `mergeGateEligibility` (145); `fixStuckReadyForMerge` (520); deacon test patrol (2497) | Core test outcome; gates merge | **KEEP** | DURABLE VERDICT |
+| `merge_status` | merge flow (workspaces.ts ~5016-5646), postMergeLifecycle | `mergeGateEligibility` (149 "already merged"); `clearStuckMergeStatuses` (483); `stuck-remediation.ts:35` | Merge outcome; `merged` is terminal | **KEEP** | DURABLE VERDICT |
+| `verification_status` | verification-runner.ts (234,365,408,453) | `verificationSatisfied` (123) → `mergeGateEligibility` (148) | Blocks merge only when `'failed'` | **KEEP** | DURABLE VERDICT |
+| `verification_cycle_count` | verification-runner.ts (233,364,407) | **verification-runner.ts:194** `currentCycles >= VERIFICATION_MAX_CYCLES` — circuit breaker | Stops infinite verification re-runs | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `verification_max_cycles` | verification-runner.ts — always set to the constant `VERIFICATION_MAX_CYCLES = 10` (29) | **none server-side** — only frontend display (ReviewPipelineSection.tsx:178, PlanDAG.tsx:361) | A stored copy of a compile-time constant | **DROP** (DERIVE from constant) | — |
+| `review_notes` | review pipeline | **deacon.ts:2058** `reviewNotes.includes('failing required checks')` — CI-failure branch | Substring-parsed to classify CI failure (fragile) | **KEEP** (1 verdict-explanation field) | DURABLE VERDICT |
+| `test_notes` | test pipeline; deacon strand marker (2487) | display only (activity feed, review-status.ts:401) | Human-readable test failure text | **DROP** (fold into one notes field) | — |
+| `merge_notes` | merge flow | **deacon.ts:3652/3735/3880** `mergeNotes.includes(...)` — CI / timeout / push-failure branches | Substring-parsed to classify merge failure | **KEEP** (verdict-explanation) | DURABLE VERDICT |
+| `updated_at` | every upsert | `idx_review_status_updated`; ORDER BY; staleness UI | Ordering / "last changed" | **KEEP** | DURABLE VERDICT |
+| `ready_for_merge` | workspaces.ts:3556 (`testStatus==='passed'`→true); ~30 merge-flow sites set false; deacon 3790/3952; recompute sweeps 497/532 | `WHERE ready_for_merge=1` (review-status-db.ts:233; resource-discovery; AwaitingMergePage) | "Awaiting merge" gate / list | **DERIVE** — `fixStuckReadyForMerge` (515) and `clearStuckMergeStatuses` (490) PROVE it is recomputable from `{review_status, test_status, verification_status, merge_status, uat_status}` (identical to `mergeGateEligibility`). The two repair sweeps exist *because* it drifts. Replace the column + `WHERE ready_for_merge=1` with the predicate. | — |
+| `auto_requeue_count` | deacon auto-requeue path | **deacon.ts:3899** `autoRequeueCount >= 25` — dead-end breaker | Caps auto-requeue attempts | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `merge_retry_count` | deacon merge-retry path | **deacon.ts:3906** `>= FAILED_MERGE_MAX_RETRIES` — merge breaker | Caps merge retries | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `pr_url` | done.ts / merge flow / webhook | `getMergeBlockerReconcileCandidates` (231); flywheel-merge-order; conflict reconcile; many display | Identifies the PR to operate on | **KEEP** | DURABLE VERDICT |
+| `pr_head_sha` | webhook-handlers.ts:390 | **webhook-handlers.ts:116** `headSha !== status.prHeadSha` — webhook identity validation | Rejects webhooks for a stale/foreign PR | **KEEP** | DURABLE VERDICT |
+| `pr_number` | webhook / done | **flywheel-merge-order.ts:156**; **orphan-proposed-reconciler.ts:50** `prNumber != null`; webhook-handlers.ts:101 | PR identity; orphan reconcile | **KEEP** (could MERGE-INTO derive from `pr_url`) | DURABLE VERDICT |
+| `stuck` | markWorkspaceStuck (498); deacon strand (2483) | **stuck-remediation.ts:35**; **deacon.ts:1006/1242** `if (stuck) skip patrol` | System failure marker; deacon skips stuck issues | **KEEP** | EPHEMERAL REVIEW-RUN (recoverable signal) |
+| `stuck_reason` | markWorkspaceStuck | **deacon.ts:1041** `stuckReason === 'context_overflow'`; **deacon.ts:2482** `!== 'test_signal_strand'`; agents.ts:4989 | Distinguishes stuck *kinds* for targeted remediation | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `stuck_at` | markWorkspaceStuck | display only | Timestamp of stuck event | **DROP** (DERIVE/fold) | — |
+| `stuck_details` | markWorkspaceStuck (JSON `{localSha,remoteSha}`) | display only (no parse for a branch found) | Diagnostic blob | **DROP** | — |
+| `reviewed_at_commit` | review-pass path | **deacon.ts:3052/3078** `currentHead === reviewedAtCommit` → skip/re-review on new push; review-status.ts:449 | Detects commits pushed after review passed | **KEEP** | DURABLE VERDICT |
+| `review_spawned_at` | review dispatch | **deacon.ts:2689/2691** `Date.parse(reviewSpawnedAt)` timeout | Review-dispatch timeout detection | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `conflict_resolution_dispatched_at` | conflict-gate dispatch | **conflict-gate.ts:262** `if (!conflictResolutionDispatchedAt) return false` — dedup | Prevents re-dispatching conflict resolver | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `test_retry_count` | deacon (2545/2551/2557) | **deacon.ts:2476** `retryCount >= 3` → surface stuck marker | Test re-dispatch breaker | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `review_retry_count` | deacon recovery path | **deacon.ts:2092** `>= REVIEW_INFRA_BREAKER_THRESHOLD` | Parallel-review re-dispatch breaker | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `recovery_started_at` | deacon (1941/2072) | **deacon.ts:1941/2072** history-cutoff for the breaker (`?? now`) | Scopes the breaker's failure window to current cycle | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `deacon_ignored` | setDeaconIgnored (529) | **stuck-remediation.ts:35**; **deacon.ts:1006/1242** `if (deaconIgnored) skip` | Human "pause this issue" toggle | **KEEP** | NEITHER — operator control flag, belongs with per-issue runtime control, not a review *verdict* |
+| `deacon_ignored_at` | setDeaconIgnored | display only | Timestamp | **DROP** | — |
+| `deacon_ignored_reason` | setDeaconIgnored | display only | Free-form reason | **DROP** | — |
+| `blocker_reasons` | webhook-handlers (242,252); mutateBlockers | **getMergeBlockerReconcileCandidates** (`LIKE '%merge_conflict%'`, 234); **conflict-gate.ts:160/168** `filter(isMergeBlocker)`; webhook | Drives merge-conflict reconcile + conflict gate | **KEEP** | DURABLE VERDICT |
+| `last_verified_commit` | verification gate pass | **deacon.ts:2710** `headSha !== lastVerifiedCommit` → re-verify; review-status.ts:448; deacon `isReviewSpawnStale` (2686) | Skips redundant test-agent when commit already verified | **KEEP** | DURABLE VERDICT |
+| `merge_step` | merge flow granular progress | **none server-side** — frontend display only (ProjectOverview.tsx:678, AwaitingMergePage.tsx:325) | Granular merge-progress label | **DROP** (DERIVE from `merge_status`) | — |
+| `inspect_status` | inspect-agent | **deacon.ts:738** `if (inspectStatus !== 'inspecting') continue` | Inspect outcome / patrol gate | **KEEP** | DURABLE VERDICT |
+| `inspect_notes` | inspect-agent | display only | Inspect failure text | **DROP** (fold into notes) | — |
+| `inspect_started_at` | inspect-agent | display only (no timeout branch found) | Timestamp | **DROP** | — |
+| `inspect_bead_id` | inspect-agent | **NONE — zero reads anywhere** | Dead | **DROP** (dead) | — |
+| `auto_merge` | setAutoMerge (569) | **auto-merge-eligibility.ts:111** `autoMerge === false` → hold for UAT | Per-issue merge-train routing | **KEEP** | NEITHER — routing policy, belongs with per-issue config not review verdict |
+| `uat_status` *(interface-only, no column)* | UAT flow | `fixStuckReadyForMerge` (526); `clearStuckMergeStatuses` (494) | UAT gate in readyForMerge recompute | **KEEP** | DURABLE VERDICT *(note: typed in ReviewStatus but NOT a `review_status` column — lives only in history/in-memory)* |
+
+### Phantom columns listed in the task that do NOT exist
+
+| Listed | Reality |
+| --- | --- |
+| `reviewer_verdicts` | **Not a `review_status` column.** No CREATE TABLE entry, no migration, not in `DbReviewStatusRow`, not in the `ReviewStatus` interface. Exists ONLY as `reviewerVerdicts?: unknown` on the durable `PanIssuePipelineRecord` (record.ts:83), passed through at records.ts:110 via a cast that reads a property the source type doesn't even declare — so it is **always `undefined`** in practice. Dead pass-through. **DROP.** |
+| `lifetime_auto_requeue_count` | **Does not exist anywhere in code.** Zero hits in `src/` or `tests/`. Only mention is in two docs: `docs/panopticon-db-erd.excalidraw` and `docs/STATE-STORAGE-AUDIT.md`. The ERD diagram and the task field-list are stale. **N/A — nothing to drop.** |
+
+---
+
+## Table 2 — `agents` table review-orchestration columns
+
+These are review-RUN state bleeding into the `agents` table. All are read by the
+deacon's review monitor *during* a live review run.
+
+| Field | Written-at | Branch-read-at | What it drives | Verdict | Class |
+| --- | --- | --- | --- | --- | --- |
+| `review_run_id` | review-agent.ts:275 | **deacon.ts:5983/5995/6041/6074** — locates `.pan/review/<runId>/` synthesis dir, dedup nudge key, staleness check (2764) | Which review run's reports to read/synthesize | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `review_synthesis_agent_id` | review-agent.ts:270/277; agents.ts:3455 | **deacon.ts:5999/6158** — who to signal/nudge/kill for synthesis | Identifies the synthesis agent to drive | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `review_output_path` | review-agent (per-sub-role) | **deacon.ts:5973/6176** — where the reviewer wrote its report | Path the monitor reads the verdict from | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `review_deadline_at` | review-agent.ts:278 (`now + REVIEWER_TIMEOUT_MS`) | **deacon.ts:6186** `Date.parse` past-deadline; 6248/6257 reason | Reviewer timeout / wedge detection | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `review_monitor_signaled` | deacon.ts:6276 | **deacon.ts:6159** `if (reviewMonitorSignaled) continue` — once-only dedup | Stops re-signaling a completed reviewer | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `review_retry_attempt` | deacon.ts:6013 | **deacon.ts:6237** `if (attempt < 1)` respawn idle reviewer once | Idle-reviewer single-retry gate | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `review_sub_role` | review-agent convoy spawn | **deacon.ts:5684/5983/6031/6158/6268** — sub-role routing for synthesis + signal text | Tags which convoy lane this agent is | **KEEP** | EPHEMERAL REVIEW-RUN |
+| `inspect_sub_role` | inspect-agent.ts:253 | costs/reconciler.ts (cost attribution); spawn tag | Cost/session-type attribution only — no live decision branch found | **DROP** (DERIVE from agent-dir name regex, which reconciler already does at reconciler.ts:140) | — |
+| `flywheel_run_id` | agents.ts:3293 (spawn env) | **concurrency.ts:191** `filter(a => a.flywheelRunId)` — counts flywheel-spawned work for slot accounting | Concurrency slot accounting | **KEEP** | EPHEMERAL REVIEW-RUN (runtime, not a verdict) |
+| `role_run_head` | agents.ts:3547 | **service.ts:232** compares stamped HEAD vs current workspace HEAD (staleness) | Detects whether a role run is stale vs new commits | **KEEP** | NEITHER — work/role-run runtime state, not review-specific; belongs with agent runtime |
+
+---
+
+## Surprises
+
+1. **`ready_for_merge` is a derivable cache that the codebase already recomputes
+   — twice.** `fixStuckReadyForMerge` and `clearStuckMergeStatuses` both rebuild
+   it from `{review_status, test_status, verification_status, merge_status,
+   uat_status}` — exactly `mergeGateEligibility`'s inputs. The column drifts
+   often enough that two startup repair sweeps exist purely to fix it. Dropping
+   the column and replacing `WHERE ready_for_merge=1` with the predicate removes
+   the column, both repair sweeps, and ~40 `readyForMerge: false` write sites.
+
+2. **Two of the "columns" in the task list do not exist.** `reviewer_verdicts`
+   is a durable-record field (always `undefined` in practice — a dead cast),
+   not a `review_status` column. `lifetime_auto_requeue_count` exists **only in
+   the ERD diagram and a stale audit doc** — there is no such column or code.
+   The `docs/panopticon-db-erd.excalidraw` field list is out of date.
+
+3. **`inspect_bead_id` is written but never read** — zero consumers anywhere.
+   Pure dead weight.
+
+4. **`merge_step` and `verification_max_cycles` are server-write-only display
+   props.** `merge_step` is derivable from `merge_status`; `verification_max_cycles`
+   is a stored copy of the compile-time constant `VERIFICATION_MAX_CYCLES = 10`.
+   Neither drives any server branch.
+
+5. **The prose-notes columns are mostly display, but two are load-bearing via
+   fragile substring matching.** `review_notes.includes('failing required
+   checks')` and three `merge_notes.includes(...)` checks classify CI / timeout
+   / push failures. This is brittle (string-sniffing a free-text field for
+   control flow) and should ideally become a typed failure-reason enum rather
+   than a kept prose column. `test_notes`, `verification_notes`, `inspect_notes`
+   are display-only and can collapse into a single notes field.
+
+6. **Retry-count theater is minimal — most counters are real breakers.**
+   `verification_cycle_count` (≥10), `auto_requeue_count` (≥25),
+   `merge_retry_count` (≥max), `test_retry_count` (≥3), `review_retry_count`
+   (≥threshold), `review_retry_attempt` (<1) all gate a real abort. The only
+   counter-like field with no comparison is `verification_max_cycles` (a stored
+   constant). The counters are EPHEMERAL though — they belong to the recovery
+   cycle, not the durable verdict, and reset on `recovery_started_at`.
+
+7. **Timestamps split cleanly.** The ones a comparison parses
+   (`review_spawned_at`, `review_deadline_at`, `conflict_resolution_dispatched_at`,
+   `recovery_started_at`, `reviewed_at_commit`/`last_verified_commit` as SHAs)
+   are KEEP. The ones that are only displayed (`stuck_at`, `inspect_started_at`,
+   `deacon_ignored_at`) are DROP.
+
+8. **`deacon_ignored` and `auto_merge` are not review verdicts** — they are
+   operator/policy control flags that happen to live in `review_status`. In the
+   remodel they belong with per-issue runtime control / merge-train config, not
+   the durable review outcome.

--- a/docs/overdeck-remodel/investigations/review-state-audit.md
+++ b/docs/overdeck-remodel/investigations/review-state-audit.md
@@ -10,6 +10,13 @@ Method: every field traced through its camelCase accessor across `src/`
 (non-test), with the discriminator being **does any read drive control flow**
 (an `if`/`filter`/gate/comparison), not whether the field is "touched".
 
+**Headline counts:** 49 fields audited (39 `review_status` columns + 10 `agents`
+review-run columns). **36 KEEP, 12 DROP, 1 DERIVE.** Of the 36 KEEP: 13 DURABLE
+VERDICT, 19 EPHEMERAL REVIEW-RUN, 4 NEITHER (operator/runtime control). ~2,550
+read+write matches across 154 files touch the `review_status` set, plus ~158
+across 14 files for the agents-table set — that is the complexity surface the
+DROP/DERIVE collapse gets to shrink.
+
 ## Glossary
 
 - **Branch-read** — a read site that feeds an `if`/`filter`/`switch`/comparison
@@ -44,13 +51,14 @@ Method: every field traced through its camelCase accessor across `src/`
 | `test_status` | test pipeline | `mergeGateEligibility` (145); `fixStuckReadyForMerge` (520); deacon test patrol (2497) | Core test outcome; gates merge | **KEEP** | DURABLE VERDICT |
 | `merge_status` | merge flow (workspaces.ts ~5016-5646), postMergeLifecycle | `mergeGateEligibility` (149 "already merged"); `clearStuckMergeStatuses` (483); `stuck-remediation.ts:35` | Merge outcome; `merged` is terminal | **KEEP** | DURABLE VERDICT |
 | `verification_status` | verification-runner.ts (234,365,408,453) | `verificationSatisfied` (123) → `mergeGateEligibility` (148) | Blocks merge only when `'failed'` | **KEEP** | DURABLE VERDICT |
+| `verification_notes` | verification-runner.ts | display only (activity feed, review-status.ts:359 — no `.includes` branch) | Human-readable verification failure text | **DROP** (fold into notes) | — |
 | `verification_cycle_count` | verification-runner.ts (233,364,407) | **verification-runner.ts:194** `currentCycles >= VERIFICATION_MAX_CYCLES` — circuit breaker | Stops infinite verification re-runs | **KEEP** | EPHEMERAL REVIEW-RUN |
 | `verification_max_cycles` | verification-runner.ts — always set to the constant `VERIFICATION_MAX_CYCLES = 10` (29) | **none server-side** — only frontend display (ReviewPipelineSection.tsx:178, PlanDAG.tsx:361) | A stored copy of a compile-time constant | **DROP** (DERIVE from constant) | — |
-| `review_notes` | review pipeline | **deacon.ts:2058** `reviewNotes.includes('failing required checks')` — CI-failure branch | Substring-parsed to classify CI failure (fragile) | **KEEP** (1 verdict-explanation field) | DURABLE VERDICT |
+| `review_notes` | review pipeline | **deacon.ts:2058** `reviewNotes.includes('failing required checks')` — CI-failure branch | Substring-parsed to classify CI failure (fragile) | **KEEP-as-signal** — replace prose with a typed `failureReason` enum (ephemeral run state); keep at most one durable verdict-explanation field | EPHEMERAL REVIEW-RUN |
 | `test_notes` | test pipeline; deacon strand marker (2487) | display only (activity feed, review-status.ts:401) | Human-readable test failure text | **DROP** (fold into one notes field) | — |
-| `merge_notes` | merge flow | **deacon.ts:3652/3735/3880** `mergeNotes.includes(...)` — CI / timeout / push-failure branches | Substring-parsed to classify merge failure | **KEEP** (verdict-explanation) | DURABLE VERDICT |
+| `merge_notes` | merge flow | **deacon.ts:3652/3735/3880** `mergeNotes.includes(...)` — CI / timeout / push-failure branches | Substring-parsed to classify merge failure | **KEEP-as-signal** — replace prose with a typed `mergeFailureReason` enum (ephemeral run state) | EPHEMERAL REVIEW-RUN |
 | `updated_at` | every upsert | `idx_review_status_updated`; ORDER BY; staleness UI | Ordering / "last changed" | **KEEP** | DURABLE VERDICT |
-| `ready_for_merge` | workspaces.ts:3556 (`testStatus==='passed'`→true); ~30 merge-flow sites set false; deacon 3790/3952; recompute sweeps 497/532 | `WHERE ready_for_merge=1` (review-status-db.ts:233; resource-discovery; AwaitingMergePage) | "Awaiting merge" gate / list | **DERIVE** — `fixStuckReadyForMerge` (515) and `clearStuckMergeStatuses` (490) PROVE it is recomputable from `{review_status, test_status, verification_status, merge_status, uat_status}` (identical to `mergeGateEligibility`). The two repair sweeps exist *because* it drifts. Replace the column + `WHERE ready_for_merge=1` with the predicate. | — |
+| `ready_for_merge` | workspaces.ts:3556 (`testStatus==='passed'`→true); ~30 merge-flow sites set false; deacon 3790 & 3952; recompute sweeps 497/532 | `WHERE ready_for_merge=1` (review-status-db.ts:233; resource-discovery; AwaitingMergePage) | "Awaiting merge" gate / list | **DERIVE** — `fixStuckReadyForMerge` (515) and `clearStuckMergeStatuses` (490) PROVE it is recomputable from `{review_status, test_status, verification_status, merge_status}` (identical to `mergeGateEligibility`). **Verified the two deacon `readyForMerge: true` setters (3790, 3952): both are failed-merge *recovery* paths that set `mergeStatus: 'pending'` alongside — i.e. they eagerly re-stamp the SAME derived value (review passed + test passed + verif≠failed + merge pending) after clearing a merge failure. Neither sets it outside the predicate.** Replace the column + `WHERE ready_for_merge=1` with the predicate; both repair sweeps and ~40 `readyForMerge: false` write sites go away. | — |
 | `auto_requeue_count` | deacon auto-requeue path | **deacon.ts:3899** `autoRequeueCount >= 25` — dead-end breaker | Caps auto-requeue attempts | **KEEP** | EPHEMERAL REVIEW-RUN |
 | `merge_retry_count` | deacon merge-retry path | **deacon.ts:3906** `>= FAILED_MERGE_MAX_RETRIES` — merge breaker | Caps merge retries | **KEEP** | EPHEMERAL REVIEW-RUN |
 | `pr_url` | done.ts / merge flow / webhook | `getMergeBlockerReconcileCandidates` (231); flywheel-merge-order; conflict reconcile; many display | Identifies the PR to operate on | **KEEP** | DURABLE VERDICT |
@@ -75,9 +83,18 @@ Method: every field traced through its camelCase accessor across `src/`
 | `inspect_status` | inspect-agent | **deacon.ts:738** `if (inspectStatus !== 'inspecting') continue` | Inspect outcome / patrol gate | **KEEP** | DURABLE VERDICT |
 | `inspect_notes` | inspect-agent | display only | Inspect failure text | **DROP** (fold into notes) | — |
 | `inspect_started_at` | inspect-agent | display only (no timeout branch found) | Timestamp | **DROP** | — |
-| `inspect_bead_id` | inspect-agent | **NONE — zero reads anywhere** | Dead | **DROP** (dead) | — |
+| `inspect_bead_id` | inspect-agent | **written, never consumed for a decision** (zero branch-reads; no `bd close`/lookup use) | None | **DROP** | — |
 | `auto_merge` | setAutoMerge (569) | **auto-merge-eligibility.ts:111** `autoMerge === false` → hold for UAT | Per-issue merge-train routing | **KEEP** | NEITHER — routing policy, belongs with per-issue config not review verdict |
-| `uat_status` *(interface-only, no column)* | UAT flow | `fixStuckReadyForMerge` (526); `clearStuckMergeStatuses` (494) | UAT gate in readyForMerge recompute | **KEEP** | DURABLE VERDICT *(note: typed in ReviewStatus but NOT a `review_status` column — lives only in history/in-memory)* |
+
+> **`uat_status` is NOT a `review_status` column** (so it is excluded from the
+> 39-column count above). It is typed on the `ReviewStatus` interface and read
+> in the `readyForMerge` recompute (`fixStuckReadyForMerge` 526,
+> `clearStuckMergeStatuses` 494), but there is no `uat_status` column, no
+> upsert binding, and `rowToReviewStatus` never restores it — so after any DB
+> round-trip it is always `undefined`, which the gate treats as "pass". Net:
+> there is a UAT gate input that is **not actually persisted or enforced
+> through `readyForMerge`**. If UAT is a real gate it needs a real home; if it
+> isn't, the recompute branches referencing it are dead. Flagged, not counted.
 
 ### Phantom columns listed in the task that do NOT exist
 
@@ -103,8 +120,8 @@ deacon's review monitor *during* a live review run.
 | `review_retry_attempt` | deacon.ts:6013 | **deacon.ts:6237** `if (attempt < 1)` respawn idle reviewer once | Idle-reviewer single-retry gate | **KEEP** | EPHEMERAL REVIEW-RUN |
 | `review_sub_role` | review-agent convoy spawn | **deacon.ts:5684/5983/6031/6158/6268** — sub-role routing for synthesis + signal text | Tags which convoy lane this agent is | **KEEP** | EPHEMERAL REVIEW-RUN |
 | `inspect_sub_role` | inspect-agent.ts:253 | costs/reconciler.ts (cost attribution); spawn tag | Cost/session-type attribution only — no live decision branch found | **DROP** (DERIVE from agent-dir name regex, which reconciler already does at reconciler.ts:140) | — |
-| `flywheel_run_id` | agents.ts:3293 (spawn env) | **concurrency.ts:191** `filter(a => a.flywheelRunId)` — counts flywheel-spawned work for slot accounting | Concurrency slot accounting | **KEEP** | EPHEMERAL REVIEW-RUN (runtime, not a verdict) |
-| `role_run_head` | agents.ts:3547 | **service.ts:232** compares stamped HEAD vs current workspace HEAD (staleness) | Detects whether a role run is stale vs new commits | **KEEP** | NEITHER — work/role-run runtime state, not review-specific; belongs with agent runtime |
+| `flywheel_run_id` | agents.ts:3293 (spawn env) | **concurrency.ts:191** `filter(a => a.flywheelRunId)` — counts flywheel-spawned work for slot accounting | Concurrency slot accounting | **KEEP** | NEITHER — general agent-runtime field (concurrency), not review-run state; keep with agent runtime |
+| `role_run_head` | agents.ts:3547 | **service.ts:232** compares stamped HEAD vs current workspace HEAD (staleness) | Detects whether a role run is stale vs new commits | **KEEP** | NEITHER — general agent-runtime field (staleness), not review-specific; keep with agent runtime |
 
 ---
 
@@ -112,11 +129,23 @@ deacon's review monitor *during* a live review run.
 
 1. **`ready_for_merge` is a derivable cache that the codebase already recomputes
    — twice.** `fixStuckReadyForMerge` and `clearStuckMergeStatuses` both rebuild
-   it from `{review_status, test_status, verification_status, merge_status,
-   uat_status}` — exactly `mergeGateEligibility`'s inputs. The column drifts
-   often enough that two startup repair sweeps exist purely to fix it. Dropping
-   the column and replacing `WHERE ready_for_merge=1` with the predicate removes
-   the column, both repair sweeps, and ~40 `readyForMerge: false` write sites.
+   it from `{review_status, test_status, verification_status, merge_status}` —
+   exactly `mergeGateEligibility`'s inputs. All five `readyForMerge: true`
+   setters were checked: workspaces.ts:3556 (`test=passed`), the two sweeps, and
+   the two deacon recovery paths (3790, 3952) — every one is inside the predicate
+   (the deacon ones pair it with `mergeStatus: 'pending'`, re-stamping the same
+   derived value after a merge failure). Nothing writes `true` outside the
+   predicate, so DERIVE is safe. The column drifts often enough that two startup
+   repair sweeps exist purely to fix it. Dropping it and replacing
+   `WHERE ready_for_merge=1` with the predicate removes the column, both repair
+   sweeps, and ~40 `readyForMerge: false` write sites.
+
+   **Corollary UAT surprise:** the recompute predicate also references
+   `uat_status`, which is NOT a persisted column — `rowToReviewStatus` never
+   restores it, so post-round-trip it is always `undefined` (treated as "pass").
+   There is a UAT gate input that is not actually enforced through
+   `readyForMerge`. Either give UAT a real persisted home or delete the dead
+   recompute branches.
 
 2. **Two of the "columns" in the task list do not exist.** `reviewer_verdicts`
    is a durable-record field (always `undefined` in practice — a dead cast),

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -966,6 +966,10 @@ export const CostEventRecordedEvent = Schema.Struct({
     cost: Schema.Number,
     inputTokens: Schema.Number,
     outputTokens: Schema.Number,
+    cacheReadTokens: Schema.optional(Schema.Number),
+    cacheWriteTokens: Schema.optional(Schema.Number),
+    model: Schema.optional(Schema.String),
+    sessionType: Schema.optional(Schema.String),
   }),
 })
 export type CostEventRecordedEvent = typeof CostEventRecordedEvent.Type

--- a/src/dashboard/server/services/__tests__/agent-event-utils.test.ts
+++ b/src/dashboard/server/services/__tests__/agent-event-utils.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { bodyToEvent, decodeDomainEvent } from '../agent-event-utils.js';
+
+describe('bodyToEvent', () => {
+  describe('kind=cost-event', () => {
+    it('maps a pi cost-event body to a cost.event_recorded domain event', () => {
+      const event = bodyToEvent('agent-pan-1935', {
+        kind: 'cost-event',
+        issueId: 'PAN-1935',
+        costUsd: 0.0042,
+        model: 'kimi-k2.7-code',
+        agentRole: 'work',
+        usage: {
+          inputTokens: 1000,
+          outputTokens: 250,
+          cacheReadTokens: 50,
+          cacheWriteTokens: 25,
+        },
+      }, '2026-06-16T12:00:00.000Z');
+
+      expect(event).toEqual({
+        type: 'cost.event_recorded',
+        timestamp: '2026-06-16T12:00:00.000Z',
+        payload: {
+          agentId: 'agent-pan-1935',
+          issueId: 'PAN-1935',
+          cost: 0.0042,
+          inputTokens: 1000,
+          outputTokens: 250,
+          cacheReadTokens: 50,
+          cacheWriteTokens: 25,
+          model: 'kimi-k2.7-code',
+          sessionType: 'work',
+        },
+      });
+    });
+
+    it('uses UNKNOWN-0 when issueId is missing and omits optional fields when absent', () => {
+      const event = bodyToEvent('agent-pan-1935', {
+        kind: 'cost-event',
+        costUsd: 0.001,
+      }, '2026-06-16T12:00:00.000Z');
+
+      expect(event).toEqual({
+        type: 'cost.event_recorded',
+        timestamp: '2026-06-16T12:00:00.000Z',
+        payload: {
+          agentId: 'agent-pan-1935',
+          issueId: 'UNKNOWN-0',
+          cost: 0.001,
+          inputTokens: 0,
+          outputTokens: 0,
+        },
+      });
+    });
+
+    it('falls back to cost when costUsd is not present', () => {
+      const event = bodyToEvent('agent-pan-1935', {
+        kind: 'cost-event',
+        cost: 0.0033,
+      }, '2026-06-16T12:00:00.000Z');
+
+      expect(event?.payload).toMatchObject({ cost: 0.0033 });
+    });
+
+    it('decodes against the DomainEvent schema', () => {
+      const event = bodyToEvent('agent-pan-1935', {
+        kind: 'cost-event',
+        issueId: 'PAN-1935',
+        costUsd: 0.0042,
+        model: 'kimi-k2.7-code',
+        agentRole: 'work',
+        usage: {
+          inputTokens: 1000,
+          outputTokens: 250,
+          cacheReadTokens: 50,
+          cacheWriteTokens: 25,
+        },
+      }, '2026-06-16T12:00:00.000Z');
+
+      const decoded = decodeDomainEvent({ ...event, sequence: 0 });
+      expect(decoded._tag).toBe('Success');
+    });
+  });
+});

--- a/src/dashboard/server/services/__tests__/cost-event-projection.test.ts
+++ b/src/dashboard/server/services/__tests__/cost-event-projection.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { persistCostEventFromDomainEvent } from '../cost-event-projection.js';
+
+let TEST_HOME: string;
+const originalHome = process.env.HOME;
+const originalPanopticonHome = process.env.PANOPTICON_HOME;
+
+async function resetDb() {
+  const { resetDatabase } = await import('../../../../lib/database/index.js');
+  resetDatabase();
+}
+
+beforeEach(() => {
+  TEST_HOME = join(tmpdir(), `pan-cost-projection-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(TEST_HOME, { recursive: true });
+  process.env.HOME = TEST_HOME;
+  process.env.PANOPTICON_HOME = TEST_HOME;
+});
+
+afterEach(async () => {
+  await resetDb();
+  process.env.HOME = originalHome;
+  process.env.PANOPTICON_HOME = originalPanopticonHome;
+  if (TEST_HOME && existsSync(TEST_HOME)) {
+    rmSync(TEST_HOME, { recursive: true, force: true });
+  }
+});
+
+async function seedAgent(agentId: string, issueId: string) {
+  const { getDatabase } = await import('../../../../lib/database/index.js');
+  const { upsertAgent } = await import('../../../../lib/database/agents-db.js');
+  const db = getDatabase();
+  db.prepare(`DELETE FROM agents WHERE id = ?`).run(agentId);
+  upsertAgent({
+    id: agentId,
+    issueId,
+    role: 'work',
+    status: 'running',
+    workspace: '/tmp/test-workspace',
+    harness: 'pi',
+    model: 'kimi-k2.7-code',
+    branch: 'feature/pan-1935',
+    sessionId: null,
+    startedAt: new Date().toISOString(),
+    lastActivity: null,
+    lastResumeAt: null,
+    stoppedAt: null,
+    stoppedByUser: null,
+    stoppedByPause: null,
+    kickoffDelivered: null,
+    hostOverride: null,
+    costSoFar: 0,
+    phase: null,
+    workType: null,
+    paused: null,
+    pausedReason: null,
+    pausedAt: null,
+    troubled: null,
+    troubledAt: null,
+    consecutiveFailures: null,
+    firstFailureInRunAt: null,
+    lastFailureAt: null,
+    lastFailureReason: null,
+    lastFailureNextRetryAt: null,
+    flywheelRunId: null,
+    roleRunHead: null,
+    reviewSubRole: null,
+    reviewRunId: null,
+    reviewSynthesisAgentId: null,
+    reviewOutputPath: null,
+    reviewDeadlineAt: null,
+    reviewMonitorSignaled: null,
+    reviewRetryAttempt: null,
+    inspectSubRole: null,
+    deliveryMethod: null,
+    supervisorEnabled: null,
+    channelsEnabled: null,
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+describe('persistCostEventFromDomainEvent', () => {
+  it('writes a pi/kimi cost event to the canonical cost log and SQLite', async () => {
+    await seedAgent('agent-pan-1935', 'PAN-1935');
+
+    persistCostEventFromDomainEvent({
+      type: 'cost.event_recorded',
+      timestamp: '2026-06-16T12:00:00.000Z',
+      payload: {
+        agentId: 'agent-pan-1935',
+        issueId: 'PAN-1935',
+        cost: 0.0042,
+        inputTokens: 1000,
+        outputTokens: 250,
+        cacheReadTokens: 50,
+        cacheWriteTokens: 25,
+        model: 'kimi-k2.7-code',
+        sessionType: 'work',
+      },
+    });
+
+    const eventsFile = join(TEST_HOME, '.panopticon', 'costs', 'events.jsonl');
+    expect(existsSync(eventsFile)).toBe(true);
+    const lines = readFileSync(eventsFile, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+    const written = JSON.parse(lines[0]!);
+    expect(written).toMatchObject({
+      type: 'cost',
+      agentId: 'agent-pan-1935',
+      issueId: 'PAN-1935',
+      cost: 0.0042,
+      input: 1000,
+      output: 250,
+      cacheRead: 50,
+      cacheWrite: 25,
+      provider: 'custom',
+      model: 'kimi-k2.7-code',
+      sessionType: 'work',
+    });
+
+    const { queryCostEvents } = await import('../../../../lib/database/cost-events-db.js');
+    const rows = queryCostEvents({ agentId: 'agent-pan-1935' });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      agentId: 'agent-pan-1935',
+      issueId: 'PAN-1935',
+      cost: 0.0042,
+      model: 'kimi-k2.7-code',
+      provider: 'custom',
+    });
+  });
+
+  it('increments agents.cost_so_far for the agent', async () => {
+    await seedAgent('agent-pan-1935', 'PAN-1935');
+
+    persistCostEventFromDomainEvent({
+      type: 'cost.event_recorded',
+      timestamp: '2026-06-16T12:00:00.000Z',
+      payload: {
+        agentId: 'agent-pan-1935',
+        issueId: 'PAN-1935',
+        cost: 0.005,
+        inputTokens: 100,
+        outputTokens: 50,
+        model: 'kimi-k2.7-code',
+        sessionType: 'work',
+      },
+    });
+
+    persistCostEventFromDomainEvent({
+      type: 'cost.event_recorded',
+      timestamp: '2026-06-16T12:00:01.000Z',
+      payload: {
+        agentId: 'agent-pan-1935',
+        issueId: 'PAN-1935',
+        cost: 0.007,
+        inputTokens: 200,
+        outputTokens: 75,
+        model: 'kimi-k2.7-code',
+        sessionType: 'work',
+      },
+    });
+
+    const { getAgent } = await import('../../../../lib/database/agents-db.js');
+    const agent = getAgent('agent-pan-1935');
+    expect(agent).not.toBeNull();
+    expect(agent!.costSoFar).toBeCloseTo(0.012, 6);
+  });
+
+  it('is a no-op for non-cost events', async () => {
+    await seedAgent('agent-pan-1935', 'PAN-1935');
+
+    persistCostEventFromDomainEvent({
+      type: 'agent.activity_changed',
+      timestamp: '2026-06-16T12:00:00.000Z',
+      payload: { agentId: 'agent-pan-1935', activity: 'idle' },
+    });
+
+    const eventsFile = join(TEST_HOME, '.panopticon', 'costs', 'events.jsonl');
+    expect(existsSync(eventsFile)).toBe(false);
+
+    const { getAgent } = await import('../../../../lib/database/agents-db.js');
+    const agent = getAgent('agent-pan-1935');
+    expect(agent!.costSoFar).toBe(0);
+  });
+});

--- a/src/dashboard/server/services/agent-event-utils.ts
+++ b/src/dashboard/server/services/agent-event-utils.ts
@@ -116,9 +116,17 @@ export const bodyToEvent = (
         payload: {
           agentId,
           issueId: typeof source['issueId'] === 'string' && source['issueId'] ? source['issueId'] : 'UNKNOWN-0',
-          cost: typeof source['costUsd'] === 'number' ? source['costUsd'] : 0,
+          cost: typeof source['costUsd'] === 'number'
+            ? source['costUsd']
+            : typeof source['cost'] === 'number'
+              ? source['cost']
+              : 0,
           inputTokens: typeof usage['inputTokens'] === 'number' ? usage['inputTokens'] : 0,
           outputTokens: typeof usage['outputTokens'] === 'number' ? usage['outputTokens'] : 0,
+          cacheReadTokens: typeof usage['cacheReadTokens'] === 'number' ? usage['cacheReadTokens'] : undefined,
+          cacheWriteTokens: typeof usage['cacheWriteTokens'] === 'number' ? usage['cacheWriteTokens'] : undefined,
+          model: typeof source['model'] === 'string' && source['model'] ? source['model'] : undefined,
+          sessionType: typeof source['agentRole'] === 'string' && source['agentRole'] ? source['agentRole'] : undefined,
         },
       };
     }

--- a/src/dashboard/server/services/cost-event-projection.ts
+++ b/src/dashboard/server/services/cost-event-projection.ts
@@ -1,0 +1,115 @@
+/**
+ * Cost-event projection — persist pi-harness (and other non-Claude) cost events
+ * into the canonical cost store.
+ *
+ * Claude-code agents write cost events directly via the PostToolUse hook
+ * (sync-sources/hooks/record-cost-event.js). Pi and other harnesses emit
+ * `cost-event` runtime events through the agent heartbeat endpoint; those are
+ * translated to `cost.event_recorded` domain events. This projection bridges
+ * those domain events into the same SQLite + JSONL cost store so dashboard
+ * rollups and runaway-spend detection work for every harness.
+ */
+
+import { appendCostEventSync, type CostEvent } from '../../../lib/costs/events.js';
+import { getDatabase } from '../../../lib/database/index.js';
+import type { SqliteDatabase } from '../../../lib/database/driver.js';
+
+export interface PersistableCostEvent {
+  type: string;
+  timestamp?: string;
+  payload?: unknown;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function usageNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function deriveProviderAndModel(model: string): { provider: string; model: string } {
+  const lower = model.toLowerCase();
+  if (lower.includes('claude')) {
+    return { provider: 'anthropic', model };
+  }
+  if (lower.includes('gpt')) {
+    return { provider: 'openai', model };
+  }
+  if (lower.includes('gemini')) {
+    return { provider: 'google', model };
+  }
+  if (lower.includes('kimi') || lower.startsWith('minimax')) {
+    return { provider: 'custom', model };
+  }
+  // Fall back to a sensible default rather than dropping the event.
+  return { provider: 'anthropic', model: 'claude-sonnet-4' };
+}
+
+function buildCostEvent(event: PersistableCostEvent): CostEvent | null {
+  if (event.type !== 'cost.event_recorded') return null;
+  const p = asRecord(event.payload);
+  const agentId = typeof p['agentId'] === 'string' && p['agentId'] ? p['agentId'] : null;
+  if (!agentId) return null;
+
+  const modelRaw = typeof p['model'] === 'string' && p['model'] ? p['model'] : 'pi';
+  const { provider, model } = deriveProviderAndModel(modelRaw);
+  const cost = usageNumber(p['cost']) ?? 0;
+  const input = usageNumber(p['inputTokens']) ?? 0;
+  const output = usageNumber(p['outputTokens']) ?? 0;
+  const cacheRead = usageNumber(p['cacheReadTokens']) ?? 0;
+  const cacheWrite = usageNumber(p['cacheWriteTokens']) ?? 0;
+
+  return {
+    ts: (typeof event.timestamp === 'string' && event.timestamp) ? event.timestamp : new Date().toISOString(),
+    type: 'cost',
+    agentId,
+    issueId: typeof p['issueId'] === 'string' && p['issueId'] ? p['issueId'] : 'UNKNOWN-0',
+    sessionType: typeof p['sessionType'] === 'string' && p['sessionType'] ? p['sessionType'] : 'implementation',
+    provider,
+    model,
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
+    cost,
+  };
+}
+
+function updateAgentCostSoFar(db: SqliteDatabase, agentId: string, cost: number): void {
+  if (cost === 0) return;
+  db.prepare(
+    `UPDATE agents
+     SET cost_so_far = COALESCE(cost_so_far, 0) + ?,
+         updated_at = ?
+     WHERE id = ?`,
+  ).run(cost, new Date().toISOString(), agentId);
+}
+
+/**
+ * Persist a `cost.event_recorded` domain event to the canonical cost store and
+ * update the agent's running cost total.
+ *
+ * Best-effort: failures are logged but not thrown, so a malformed cost event
+ * does not crash the dashboard event pipeline.
+ */
+export function persistCostEventFromDomainEvent(event: PersistableCostEvent): void {
+  const costEvent = buildCostEvent(event);
+  if (!costEvent) return;
+
+  try {
+    appendCostEventSync(costEvent);
+  } catch (err) {
+    console.error('[cost-event-projection] appendCostEventSync failed:', err);
+    return;
+  }
+
+  try {
+    const db = getDatabase();
+    updateAgentCostSoFar(db, costEvent.agentId, costEvent.cost);
+  } catch (err) {
+    console.error('[cost-event-projection] updateAgentCostSoFar failed:', err);
+  }
+}

--- a/src/dashboard/server/services/domain-services.ts
+++ b/src/dashboard/server/services/domain-services.ts
@@ -16,6 +16,7 @@ import { ReadModelService } from '../read-model.js';
 import { startSessionContextWriter } from './session-context-writer.js';
 import { emitActivityDetailedSync } from '../../../lib/activity-logger.js';
 import { captureCheckpoint, diffCheckpointFiles, listCheckpoints } from '../../../lib/checkpoint/checkpoint-manager.js';
+import { persistCostEventFromDomainEvent } from './cost-event-projection.js';
 import { randomUUID } from 'crypto';
 
 // ─── EventStoreService ────────────────────────────────────────────────────────
@@ -179,6 +180,16 @@ export const EventStoreServiceLive = Layer.effect(
       subscribe: (listener) => store.subscribe((event) => {
         if (shouldRefreshSessionContext(event.type)) listener();
       }),
+    });
+
+    // Persist cost events from non-Claude harnesses (pi/kimi, etc.) into the
+    // canonical cost store. Claude-code agents already write cost events via
+    // the PostToolUse hook; this projection catches the heartbeat-delivered
+    // `cost.event_recorded` events emitted by other harnesses (PAN-1935).
+    store.subscribe((event) => {
+      if (event.type === 'cost.event_recorded') {
+        persistCostEventFromDomainEvent(event);
+      }
     });
 
     // Auto-emit detailed activity entries for state-change domain events.

--- a/src/lib/cost.ts
+++ b/src/lib/cost.ts
@@ -119,6 +119,7 @@ export const DEFAULT_PRICING: ModelPricing[] = [
   { provider: 'google', model: 'gemini-3.1-flash-lite-preview', inputPer1k: 0.00025, outputPer1k: 0.0015, currency: 'USD' },
   // Moonshot AI (Kimi)
   { provider: 'custom', model: 'kimi-for-coding', inputPer1k: 0.0006, outputPer1k: 0.002, cacheReadPer1k: 0.00006, cacheWrite5mPer1k: 0.00075, currency: 'USD' },
+  { provider: 'custom', model: 'kimi-k2.7-code', inputPer1k: 0.0006, outputPer1k: 0.002, cacheReadPer1k: 0.00006, cacheWrite5mPer1k: 0.00075, currency: 'USD' },
   { provider: 'custom', model: 'kimi-k2.6', inputPer1k: 0.0006, outputPer1k: 0.002, cacheReadPer1k: 0.00006, cacheWrite5mPer1k: 0.00075, currency: 'USD' },
   { provider: 'custom', model: 'kimi-k2.5', inputPer1k: 0.0006, outputPer1k: 0.002, cacheReadPer1k: 0.00006, cacheWrite5mPer1k: 0.00075, currency: 'USD' },
   // MiniMax ($0.30/M input, $1.20/M output)


### PR DESCRIPTION
## Problem

Pi-harness work agents (e.g. `kimi-k2.7-code`) were recording **zero cost** in Panopticon. The pi-extension already emits `cost-event` runtime events via the agent heartbeat endpoint, but the dashboard only translated them into `cost.event_recorded` domain events — it never wrote them to the canonical `cost_events` store or updated `agents.cost_so_far`.

Claude-code agents avoid this gap by writing cost events directly through the `record-cost-event.js` PostToolUse hook. Pi agents have no such hook, so their spend was invisible.

## Changes

- **Contracts**: extend `CostEventRecordedEvent` payload with optional `cacheReadTokens`, `cacheWriteTokens`, `model`, and `sessionType`.
- **Heartbeat translation** (`agent-event-utils.ts`): preserve those fields from the pi `cost-event` body, including `agentRole` → `sessionType` and a `costUsd`/`cost` fallback.
- **Cost projection** (`cost-event-projection.ts`): new subscriber that writes `cost.event_recorded` domain events to the canonical JSONL + SQLite `cost_events` table and atomically increments `agents.cost_so_far`.
- **Dashboard wiring** (`domain-services.ts`): subscribe the projection to the event store.
- **Pricing**: add `kimi-k2.7-code` to the Moonshot/Kimi pricing table so future token-based cost calculations resolve correctly.
- **Tests**: cover body translation, schema decoding, SQLite persistence, JSONL logging, and `cost_so_far` accumulation.

## Acceptance

- [x] Pi/kimi work agents now produce non-zero `cost_events` rows.
- [x] `agents.cost_so_far` increments as cost events arrive.
- [x] Dashboard cost surfaces can aggregate pi/kimi spend.

Burn-rate pause/escalation is intentionally left as a follow-up; once cost is visible, that threshold logic can be wired against `agents.cost_so_far` / `cost_events` in a subsequent change.

Closes PAN-1935
