### PR TITLE
fix(cli): pan conv show resolves conversation first (PAN-2018)

### DIFF
--- a/.pan/records/pan-1888.json
+++ b/.pan/records/pan-1888.json
@@ -3,14 +3,15 @@
   "schemaVersion": 2,
   "feedback": [],
   "created": "2026-06-23T15:48:55.046Z",
-  "updated": "2026-06-23T15:56:57.643Z",
+  "updated": "2026-06-23T15:58:04.613Z",
   "pipeline": {
     "issueId": "PAN-1888",
-    "reviewStatus": "pending",
-    "testStatus": "pending",
+    "reviewStatus": "passed",
+    "testStatus": "passed",
     "mergeStatus": "merged",
     "readyForMerge": false,
-    "updatedAt": "2026-06-23T15:56:57.625Z"
+    "updatedAt": "2026-06-23T15:58:04.602Z",
+    "testNotes": "Skipped: issue is already merged"
   },
   "closeOut": {
     "usage": {
@@ -34,7 +35,7 @@
       },
       "costAtCloseOut": {
         "usd": 0,
-        "pricingAsOf": "2026-06-23T15:56:57.643Z"
+        "pricingAsOf": "2026-06-23T15:58:04.613Z"
       }
     },
     "merges": [],

--- a/.pan/records/pan-1932.json
+++ b/.pan/records/pan-1932.json
@@ -1,19 +1,41 @@
 {
   "issueId": "PAN-1932",
   "schemaVersion": 2,
+  "feedback": [],
   "created": "2026-06-23T15:48:42.575Z",
-  "updated": "2026-06-23T15:48:42.575Z",
+  "updated": "2026-06-23T15:58:20.128Z",
   "pipeline": {
     "issueId": "PAN-1932",
     "reviewStatus": "pending",
     "testStatus": "pending",
+    "mergeStatus": "merged",
     "readyForMerge": false,
-    "updatedAt": "2026-06-23T15:48:42.575Z"
+    "updatedAt": "2026-06-23T15:58:20.109Z"
   },
   "closeOut": {
     "usage": {
-      "byStage": {},
-      "totals": {}
+      "byStage": {
+        "memory-extraction": {
+          "cliproxy/gpt-5.4-mini": {
+            "input": 676,
+            "output": 201,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        }
+      },
+      "totals": {
+        "cliproxy/gpt-5.4-mini": {
+          "input": 676,
+          "output": 201,
+          "cacheRead": 0,
+          "cacheWrite": 0
+        }
+      },
+      "costAtCloseOut": {
+        "usd": 0,
+        "pricingAsOf": "2026-06-23T15:58:20.128Z"
+      }
     },
     "merges": [],
     "ranOn": "eltmon-z790"

--- a/.pan/records/pan-1932.json
+++ b/.pan/records/pan-1932.json
@@ -3,14 +3,15 @@
   "schemaVersion": 2,
   "feedback": [],
   "created": "2026-06-23T15:48:42.575Z",
-  "updated": "2026-06-23T15:58:20.128Z",
+  "updated": "2026-06-23T15:58:45.907Z",
   "pipeline": {
     "issueId": "PAN-1932",
-    "reviewStatus": "pending",
-    "testStatus": "pending",
+    "reviewStatus": "passed",
+    "testStatus": "passed",
     "mergeStatus": "merged",
     "readyForMerge": false,
-    "updatedAt": "2026-06-23T15:58:20.109Z"
+    "updatedAt": "2026-06-23T15:58:45.896Z",
+    "testNotes": "Skipped: issue is already merged"
   },
   "closeOut": {
     "usage": {
@@ -34,7 +35,7 @@
       },
       "costAtCloseOut": {
         "usd": 0,
-        "pricingAsOf": "2026-06-23T15:58:20.128Z"
+        "pricingAsOf": "2026-06-23T15:58:45.906Z"
       }
     },
     "merges": [],

--- a/src/cli/commands/conversations/__tests__/show.test.ts
+++ b/src/cli/commands/conversations/__tests__/show.test.ts
@@ -1,5 +1,9 @@
 /**
- * Regression tests for `pan conversations show` (PAN-457).
+ * Regression tests for `pan conversations show` (PAN-457, PAN-2018).
+ *
+ * PAN-2018: `<id>` resolves as a conversation first (matching `pan conv jsonl`
+ * and the dashboard `/conv/<id>` route), falling back to the discovered-session
+ * scan-order index only when no conversation matches.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -28,7 +32,7 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-async function seedSession() {
+async function seedSession(overrides: Record<string, unknown> = {}) {
   const { upsertDiscoveredSession } = await import('../../../../lib/overdeck/discovered-sessions.js');
   return upsertDiscoveredSession({
     jsonlPath: '/fake/show-test.jsonl',
@@ -50,6 +54,7 @@ async function seedSession() {
     fileSize: 2048,
     fileMtime: '2025-01-01T00:00:00Z',
     tags: ['feat'],
+    ...overrides,
   });
 }
 
@@ -65,7 +70,7 @@ describe('showAction', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  it('exits 1 for session not found', async () => {
+  it('exits 1 when neither conversation nor session matches the id', async () => {
     const { showAction } = await import('../show.js');
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => {
       throw new Error(`exit ${code}`);
@@ -76,20 +81,7 @@ describe('showAction', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  it('outputs JSON when --json flag set', async () => {
-    const session = await seedSession();
-    const { showAction } = await import('../show.js');
-    const logs: string[] = [];
-    vi.spyOn(console, 'log').mockImplementation((msg) => logs.push(String(msg)));
-
-    await showAction(String(session.id), { json: true });
-
-    const parsed = JSON.parse(logs.join(''));
-    expect(parsed.id).toBe(session.id);
-    expect(parsed.jsonlPath).toBe('/fake/show-test.jsonl');
-  });
-
-  it('outputs human-readable detail by default', async () => {
+  it('falls back to discovered-session index when no conversation matches', async () => {
     const session = await seedSession();
     const { showAction } = await import('../show.js');
     const logs: string[] = [];
@@ -98,7 +90,94 @@ describe('showAction', () => {
     await showAction(String(session.id), {});
 
     const output = logs.join('\n');
-    expect(output).toContain(String(session.id));
+    // Fallback namespace is a raw session, not a conversation.
+    expect(output).toContain(`Session #${session.id}`);
+    expect(output).not.toContain('Conversation #');
     expect(output).toContain('/fake/show-test.jsonl');
+  });
+
+  it('emits session-scoped JSON with source=session on fallback', async () => {
+    const session = await seedSession();
+    const { showAction } = await import('../show.js');
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((msg) => logs.push(String(msg)));
+
+    await showAction(String(session.id), { json: true });
+
+    const parsed = JSON.parse(logs.join(''));
+    expect(parsed.source).toBe('session');
+    expect(parsed.id).toBe(session.id);
+    // Session fields moved under `session` (no top-level jsonlPath anymore).
+    expect(parsed.session.jsonlPath).toBe('/fake/show-test.jsonl');
+    expect(parsed.session.messageCount).toBe(10);
+  });
+
+  // ── PAN-2018: conversation-first resolution ────────────────────────────────
+  it('resolves via conversation first and bridges to its discovered session', async () => {
+    const { createConversation } = await import('../../../../lib/overdeck/conversations.js');
+    const { resolveConversationTranscript } = await import(
+      '../../../../lib/conversations/transcript-path.js'
+    );
+
+    const cwd = '/home/user/Projects/myapp';
+    const claudeSessionId = '11111111-2222-3333-4444-555555555555';
+    const transcript = resolveConversationTranscript(cwd, claudeSessionId);
+    expect(transcript.path).toBeTruthy();
+
+    // Seed the discovered session at exactly the path the resolver derives.
+    await seedSession({ jsonlPath: transcript.path, messageCount: 42 });
+
+    const conv = createConversation({
+      name: '20260620-1699',
+      tmuxSession: 'conv-20260620-1699',
+      cwd,
+      claudeSessionId,
+      model: 'claude-opus-4-8',
+      title: 'Auto-memory: file-based persistence',
+      harness: 'claude-code',
+    });
+
+    const { showAction } = await import('../show.js');
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((msg) => logs.push(String(msg ?? '')));
+
+    await showAction(String(conv.id), {});
+
+    const output = logs.join('\n');
+    expect(output).toContain(`Conversation #${conv.id}`);
+    expect(output).toContain('Auto-memory: file-based persistence');
+    expect(output).toContain('claude-opus-4-8');
+    // Bridged session-derived data.
+    expect(output).toContain(transcript.path!);
+    expect(output).toContain('42'); // message count from the discovered session
+  });
+
+  it('shows conversation fields with no discovered session when transcript was never scanned', async () => {
+    const { createConversation } = await import('../../../../lib/overdeck/conversations.js');
+
+    const conv = createConversation({
+      name: '20260620-1700',
+      tmuxSession: 'conv-20260620-1700',
+      cwd: '/home/user/Projects/other',
+      claudeSessionId: '99999999-aaaa-bbbb-cccc-dddddddddddd',
+      model: 'glm-5.2',
+      title: 'A conversation with no scanned session',
+      harness: 'pi',
+    });
+
+    const { showAction } = await import('../show.js');
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((msg) => logs.push(String(msg ?? '')));
+
+    await showAction(String(conv.id), { json: true });
+
+    const parsed = JSON.parse(logs.join(''));
+    expect(parsed.source).toBe('conversation');
+    expect(parsed.id).toBe(conv.id);
+    expect(parsed.conversation.title).toBe('A conversation with no scanned session');
+    expect(parsed.conversation.model).toBe('glm-5.2');
+    expect(parsed.conversation.harness).toBe('pi');
+    // No bridged session row exists.
+    expect(parsed.session).toBeNull();
   });
 });

--- a/src/cli/commands/conversations/show.ts
+++ b/src/cli/commands/conversations/show.ts
@@ -1,79 +1,196 @@
 /**
- * pan conversations show <id> — show detailed session info (PAN-457)
+ * pan conversations show <id> — show detailed conversation / session info (PAN-457).
+ *
+ * Resolution order (PAN-2018): the numeric `<id>` is first treated as a
+ * **conversation** id (the same namespace `pan conv jsonl` and the dashboard
+ * `/conv/<id>` route use). If no conversation matches, it falls back to the
+ * `discovered_sessions` scan-order index — the original raw-session behavior —
+ * so nothing that previously resolved through that index is lost.
  */
 
 import chalk from 'chalk';
-import { getDiscoveredSessionById } from '../../../lib/overdeck/discovered-sessions.js';
 
-export async function showAction(id: string, opts: { json?: boolean }): Promise<void> {
-  const sessionId = parseInt(id, 10);
-  if (isNaN(sessionId)) {
-    console.error(chalk.red(`Invalid session ID: ${id}`));
+import { resolveConversationTranscript } from '../../../lib/conversations/transcript-path.js';
+import { getConversationById, type LegacyConversation } from '../../../lib/overdeck/conversations.js';
+import {
+  getDiscoveredSessionByJsonlPath,
+  getDiscoveredSessionById,
+  type DiscoveredSession,
+} from '../../../lib/overdeck/discovered-sessions.js';
+
+export interface ShowActionOptions {
+  json?: boolean;
+}
+
+interface Resolved {
+  /** Which namespace the id was resolved through. */
+  source: 'conversation' | 'session';
+  /** The numeric id used for display. */
+  displayId: number;
+  conversation: LegacyConversation | null;
+  session: DiscoveredSession | null;
+}
+
+function resolveShowTarget(id: number): Resolved | null {
+  // 1. Conversation first (canonical — matches `pan conv jsonl` + dashboard).
+  const conversation = getConversationById(id);
+  if (conversation) {
+    const transcript = resolveConversationTranscript(conversation.cwd, conversation.claudeSessionId);
+    // Look up by the resolved path even if the file has expired/been pruned —
+    // the discovered_sessions row may still hold the last-scan summary, tokens,
+    // models, etc., which is more useful than showing nothing.
+    const session = transcript.path
+      ? getDiscoveredSessionByJsonlPath(transcript.path)
+      : null;
+    return { source: 'conversation', displayId: id, conversation, session };
+  }
+
+  // 2. Fallback: raw discovered-session scan-order index (pre-PAN-2018 behavior).
+  const session = getDiscoveredSessionById(id);
+  if (session) {
+    return { source: 'session', displayId: session.id, conversation: null, session };
+  }
+
+  return null;
+}
+
+export async function showAction(id: string, opts: ShowActionOptions): Promise<void> {
+  const numericId = parseInt(id, 10);
+  if (isNaN(numericId)) {
+    console.error(chalk.red(`Invalid ID: ${id}`));
     process.exit(1);
   }
 
-  const session = getDiscoveredSessionById(sessionId);
-  if (!session) {
-    console.error(chalk.red(`Session ${sessionId} not found`));
+  const resolved = resolveShowTarget(numericId);
+  if (!resolved) {
+    console.error(
+      chalk.red(`No conversation or session found for ID ${numericId}.`),
+    );
+    console.error(
+      chalk.gray(`  Tried conversation #${numericId} and discovered-session #${numericId}.`),
+    );
     process.exit(1);
   }
 
   if (opts.json) {
-    console.log(JSON.stringify(session, null, 2));
+    printJson(resolved);
     return;
   }
 
-  const field = (label: string, value: unknown): void => {
-    const v = value == null ? chalk.dim('—') : String(value);
-    console.log(`  ${chalk.bold(label.padEnd(18))} ${v}`);
+  printHuman(resolved);
+}
+
+const field = (label: string, value: unknown): void => {
+  const v = value == null || value === '' ? chalk.dim('—') : String(value);
+  console.log(`  ${chalk.bold(label.padEnd(18))} ${v}`);
+};
+
+const yn = (v: boolean) => (v ? chalk.green('yes') : chalk.dim('no'));
+
+function printHuman(resolved: Resolved): void {
+  const { source, displayId, conversation, session } = resolved;
+
+  console.log();
+  const header = source === 'conversation' ? `Conversation #${displayId}` : `Session #${displayId}`;
+  console.log(chalk.bold(header));
+  console.log(chalk.dim('─'.repeat(60)));
+
+  if (conversation) {
+    field('Name', conversation.name);
+    field('Title', conversation.title);
+    field('Status', conversation.status);
+    field('Model', conversation.model);
+    field('Effort', conversation.effort);
+    field('Harness', conversation.harness);
+    field('CWD', conversation.cwd);
+    field('tmux', conversation.tmuxSession);
+    field('Issue', conversation.issueId);
+    field('Created', conversation.createdAt);
+    field('Ended', conversation.endedAt);
+    field('Claude session', conversation.claudeSessionId);
+    if (conversation.archivedAt) field('Archived', conversation.archivedAt);
+  }
+
+  if (session) {
+    // Session-derived data (parsed from the JSONL transcript).
+    if (conversation) console.log();
+    field('JSONL path', session.jsonlPath);
+    field('Workspace', session.workspacePath ?? '—');
+    field('Messages', session.messageCount);
+    field('First active', session.firstTs);
+    field('Last active', session.lastTs);
+    if (!conversation) {
+      // Avoid duplicating model info already shown from the conversation.
+      field('Primary model', session.primaryModel);
+    }
+    field('Models used', session.modelsUsed.join(', ') || '—');
+    field('Input tokens', session.tokenInput);
+    field('Output tokens', session.tokenOutput);
+    field('Est. cost', session.estimatedCost > 0 ? `$${session.estimatedCost.toFixed(6)}` : '—');
+    field('Tools used', session.toolsUsed.join(', ') || '—');
+    field('Overdeck', yn(session.overdeckManaged));
+    if (session.panIssueId) field('Issue ID', session.panIssueId);
+
+    console.log();
+    console.log(chalk.bold('Enrichment'));
+    console.log(chalk.dim('─'.repeat(60)));
+    field('Level', session.enrichmentLevel === 0 ? chalk.dim('none') : `L${session.enrichmentLevel}`);
+    field('Model', session.enrichmentModel ?? '—');
+    field('Failed', yn(session.enrichmentFailed));
+
+    if (session.summary) {
+      console.log();
+      console.log(chalk.bold('Summary'));
+      console.log(chalk.dim('─'.repeat(60)));
+      console.log(`  ${session.summary}`);
+    }
+
+    if (session.summaryDetailed) {
+      console.log();
+      console.log(chalk.bold('Detailed Summary'));
+      console.log(chalk.dim('─'.repeat(60)));
+      console.log(`  ${session.summaryDetailed}`);
+    }
+
+    if (session.tags.length > 0) {
+      console.log();
+      console.log(chalk.bold('Tags'));
+      console.log(chalk.dim('─'.repeat(60)));
+      console.log(`  ${session.tags.map((t) => chalk.cyan(t)).join('  ')}`);
+    }
+  } else if (conversation) {
+    // Conversation resolved but no scanned session row for its transcript yet.
+    console.log();
+    console.log(chalk.dim('No discovered-session data for this conversation\u2019s transcript yet.'));
+  }
+
+  console.log();
+}
+
+function printJson(resolved: Resolved): void {
+  const { source, displayId, conversation, session } = resolved;
+  // Always emit both keys (null when absent) for a stable JSON contract.
+  const payload: Record<string, unknown> = {
+    id: displayId,
+    source,
+    conversation: conversation
+      ? {
+          id: conversation.id,
+          name: conversation.name,
+          title: conversation.title,
+          status: conversation.status,
+          model: conversation.model,
+          effort: conversation.effort,
+          harness: conversation.harness,
+          cwd: conversation.cwd,
+          tmuxSession: conversation.tmuxSession,
+          issueId: conversation.issueId,
+          claudeSessionId: conversation.claudeSessionId,
+          createdAt: conversation.createdAt,
+          endedAt: conversation.endedAt,
+        }
+      : null,
+    session,
   };
-
-  const yn = (v: boolean) => (v ? chalk.green('yes') : chalk.dim('no'));
-
-  console.log();
-  console.log(chalk.bold(`Session #${session.id}`));
-  console.log(chalk.dim('─'.repeat(60)));
-  field('JSONL path', session.jsonlPath);
-  field('Workspace', session.workspacePath ?? '—');
-  field('Messages', session.messageCount);
-  field('First active', session.firstTs);
-  field('Last active', session.lastTs);
-  field('Primary model', session.primaryModel);
-  field('Models used', session.modelsUsed.join(', ') || '—');
-  field('Input tokens', session.tokenInput);
-  field('Output tokens', session.tokenOutput);
-  field('Est. cost', session.estimatedCost > 0 ? `$${session.estimatedCost.toFixed(6)}` : '—');
-  field('Tools used', session.toolsUsed.join(', ') || '—');
-  field('Overdeck', yn(session.overdeckManaged));
-  if (session.panIssueId) field('Issue ID', session.panIssueId);
-
-  console.log();
-  console.log(chalk.bold('Enrichment'));
-  console.log(chalk.dim('─'.repeat(60)));
-  field('Level', session.enrichmentLevel === 0 ? chalk.dim('none') : `L${session.enrichmentLevel}`);
-  field('Model', session.enrichmentModel ?? '—');
-  field('Failed', yn(session.enrichmentFailed));
-
-  if (session.summary) {
-    console.log();
-    console.log(chalk.bold('Summary'));
-    console.log(chalk.dim('─'.repeat(60)));
-    console.log(`  ${session.summary}`);
-  }
-
-  if (session.summaryDetailed) {
-    console.log();
-    console.log(chalk.bold('Detailed Summary'));
-    console.log(chalk.dim('─'.repeat(60)));
-    console.log(`  ${session.summaryDetailed}`);
-  }
-
-  if (session.tags.length > 0) {
-    console.log();
-    console.log(chalk.bold('Tags'));
-    console.log(chalk.dim('─'.repeat(60)));
-    console.log(`  ${session.tags.map((t) => chalk.cyan(t)).join('  ')}`);
-  }
-
-  console.log();
+  console.log(JSON.stringify(payload, null, 2));
 }


### PR DESCRIPTION
## Summary

Fixes #2018.

`pan conv show <id>` resolved against the `discovered_sessions` scan-order index, while `pan conv jsonl <id>` (and the dashboard `/conv/<id>` route) resolved against the conversations store — so the same `<id>` returned unrelated sessions. `show` never fell back to looking the id up as a conversation.

`show` now resolves via the canonical conversation door first (`getConversationById`, the same read door `jsonl` uses), bridges to the discovered session by transcript JSONL path for the parsed session data (messages/tokens/models/enrichment/summary/tags), and only falls back to the raw discovered-session index when no conversation matches. The output now carries a `source` field (`conversation` | `session`) so the namespace is explicit.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx vitest run src/cli/commands/conversations/` — **7 files, 46 tests pass** (added 3 new tests: conversation-first resolution + bridged session, conversation with no scanned session, and session-fallback namespace labeling; updated the `--json` assertion for the new shape)

## Files

- [`src/cli/commands/conversations/show.ts`](src/cli/commands/conversations/show.ts) — conversation-first resolution + unified render
- [`src/cli/commands/conversations/__tests__/show.test.ts`](src/cli/commands/conversations/__tests__/show.test.ts) — regression tests

## Notes

- `pan conv show --json` has no programmatic consumers (only CLI registration), so the JSON shape change (session fields moved under `session`, plus a `conversation` block and `source`) is safe. Both keys are always present (`null` when absent) for a stable contract.
- Related: #2019 (conv-lookup skill) enhances automatically once this lands — the skill reads `show --json`'s `conversation` block and populates metadata fields that currently show `N/A` via fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `pan conversations show` command now resolves conversations first before falling back to session lookup.
  * Output now includes source information indicating whether the result is from a conversation or session.

* **Bug Fixes**
  * Improved fallback behavior when neither conversation nor session matches the requested ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->