### PR TITLE
docs(codebase-health): Epic A complete; Epic B wave-1 plan + PRDs

### DIFF
--- a/docs/CODEBASE-HEALTH-ROADMAP.md
+++ b/docs/CODEBASE-HEALTH-ROADMAP.md
@@ -42,17 +42,29 @@ What we measured, and which symptom it drives:
 
 Install mechanical ratchets so the debt can only shrink. Pure-gain, low blast radius, cheap-model-executable. **A must land before B** — extraction without a working type-checker just produces more runtime breakage.
 
-| # | Work | Executor | Branch | Status |
+| # | Work | Executor | PR | Status |
 |---|---|---|---|---|
-| **A1** | ESLint `no-explicit-any` ratchet (plugin + `.eslintrc.cjs` + generated baseline allowlist) | GPT-5.5 | `codebase-health/a1` | ☐ in progress |
-| **A2** | Adopt `ts-reset` (safe granular rules; fix surfaced typecheck errors) | GLM-5.2 | `codebase-health/a2` | ☐ queued |
-| **A3** | File-size ceiling guard (`scripts/lint-file-size.sh` + baseline) | Kimi-2.7 | `codebase-health/a3` | ☐ queued |
+| **A1** | ESLint `no-explicit-any` ratchet (plugin + `.eslintrc.cjs` + generated baseline allowlist) | GPT-5.5 | #2113 | ✅ merged 2026-06-28 |
+| **A2** | Adopt `ts-reset` (safe granular rules: `filter-boolean` + `array-includes`) | GLM-5.2 | #2114 | ✅ merged 2026-06-28 |
+| **A3** | File-size ceiling guard (`scripts/lint-file-size.sh` + 45-file baseline) | Kimi-2.7 | #2115 | ✅ merged 2026-06-28 |
 
-PRDs: [`docs/codebase-health/`](./codebase-health/).
+PRDs: [`docs/codebase-health/`](./codebase-health/). **Epic A complete** — combined `main` CI green.
 
 ### Epic B — Carve deep modules + unify the harness abstraction
 
-Decompose the god files into deep modules (narrow interface, hidden complexity) and replace the 396 harness branches with a single `Harness` interface (`spawn` / `deliver` / `resume` / `capabilities`) plus one implementation per harness. **Prereq: Epic A.**
+Decompose the god files into deep modules (narrow interface, hidden complexity) and replace the ~46 harness branch sites with a single `Harness` interface (extend the existing `src/lib/runtimes/AgentRuntimeSync`) plus one implementation per harness. **Prereq: Epic A (done).**
+
+**Sequencing decision:** B is far riskier than A — the highest-value seams (deacon auto-resume/merge, the harness migration, the `agents.ts` spawn path) touch the exact code behind our worst failure modes. So B proceeds in **waves, safest-first**: each wave extracts the *single lowest-risk seam* in a god file, behavior-preserving, compiler+test-verified, to prove the extraction pattern before the scary seams. Analysis maps for each file live in the agents' reports; the per-file full seam ladder is in each PRD's appendix.
+
+**Wave 1 (in flight) — the safest seam in each of the three god files, one per model, fully independent (different files, no `package.json` touches):**
+
+| # | Work | File → new module | Risk | Executor | Branch |
+|---|---|---|---|---|---|
+| **B1** | Extract inspect/timeout cluster | `deacon.ts` (7,180) → `deacon-inspect.ts` | LOW | GPT-5.5 | `codebase-health/b1` |
+| **B2** | Extract container/docker routes | `routes/workspaces.ts` (6,638) → `routes/workspaces/container-ops.ts` | LOW | GLM-5.2 | `codebase-health/b2` |
+| **B3** | Extract read-only agent queries | `agents.ts` (5,824) → `agents/queries.ts` | LOW | Kimi-2.7 | `codebase-health/b3` |
+
+PRDs: [`docs/codebase-health/`](./codebase-health/) (`B1-*`, `B2-*`, `B3-*`). Later waves tackle api-recovery/review/merge/auto-resume (deacon), workspace-data/review-pipeline/merge-ops (route), termination/delivery/state (agents), then the `Harness` interface migration.
 
 ### Epic C — Fitness functions (evals + a frozen kernel)
 
@@ -77,10 +89,13 @@ These changes modify the agents' **own substrate** — lint rules, the build, th
 
 ## Progress
 
-- [ ] **A1** — `no-explicit-any` ratchet — GPT-5.5 — `codebase-health/a1`
-- [ ] **A2** — `ts-reset` — GLM-5.2 — `codebase-health/a2`
-- [ ] **A3** — file-size guard — Kimi-2.7 — `codebase-health/a3`
-- [ ] **B** — deep-module extraction + harness seam (PRDs TBD after A lands)
+- [x] **A1** — `no-explicit-any` ratchet — GPT-5.5 — merged #2113
+- [x] **A2** — `ts-reset` — GLM-5.2 — merged #2114
+- [x] **A3** — file-size guard — Kimi-2.7 — merged #2115
+- [ ] **B1** — extract `deacon-inspect.ts` — GPT-5.5 — `codebase-health/b1`
+- [ ] **B2** — extract `container-ops.ts` — GLM-5.2 — `codebase-health/b2`
+- [ ] **B3** — extract `agents/queries.ts` — Kimi-2.7 — `codebase-health/b3`
+- [ ] **B (later waves)** — api-recovery/review/merge/auto-resume · workspace-data/review-pipeline/merge-ops · termination/delivery/state · `Harness` interface
 - [ ] **C** — evals + frozen kernel (PRDs TBD)
 - [ ] **D** — process gates (PRDs TBD)
 

--- a/docs/codebase-health/B1-deacon-inspect-extract.md
+++ b/docs/codebase-health/B1-deacon-inspect-extract.md
@@ -1,0 +1,60 @@
+# B1 — Extract the inspect/timeout cluster out of `deacon.ts`
+
+**Epic:** B (Carve deep modules) — see [`docs/CODEBASE-HEALTH-ROADMAP.md`](../CODEBASE-HEALTH-ROADMAP.md)
+**Branch:** `codebase-health/b1` (stacked on `codebase-health/b-kickoff` → main) · **Executor:** GPT-5.5 (handoff), supervised by conversation #182
+**Mode:** orchestrated handoff — **do NOT run `pan done`, do NOT open a PR, do NOT touch the pipeline.** Commit on this branch; the orchestrator reviews and merges.
+
+---
+
+## Glossary
+- **God file** — `src/lib/cloister/deacon.ts` is ~7,180 lines (the orchestrator core). This is the first, deliberately *small* and *low-risk* extraction to prove the pattern before the scary seams (merge, auto-resume).
+- **Behavior-preserving extraction** — move code verbatim into a new module and re-wire imports so runtime behavior is byte-identical. No logic changes.
+- **Re-export** — `export { x } from './new-module.js'` in `deacon.ts` so any external importer of `deacon.ts` keeps working unchanged.
+- **The patrol** — `runPatrol()` in `deacon.ts` calls each check function once per cycle.
+
+## Problem
+`deacon.ts` is the single largest, highest-cognitive-load file in the repo and the home of most recurring failure modes. We are decomposing it into deep modules. B1 extracts the **smallest self-contained cluster** — inspection/bead-timeout management — to validate the extraction pattern with near-zero risk.
+
+## Scope — the cluster to extract
+The inspect/timeout functions (locate by name with `grep -n`; the approximate region is ~lines 759–849, but **use the names, not the line numbers**, which drift):
+- `checkInspectAgentTimeouts` (the exported check called from `runPatrol`)
+- `inspectSessionName` (private helper)
+- `formatInspectElapsed` (private helper)
+- the `INSPECT_TIMEOUT_MS` constant
+- any other symbol used **only** by the above (verify with `grep` that nothing else in `deacon.ts` references it before moving)
+
+## Requirements
+**FR-1** — A new module `src/lib/cloister/deacon-inspect.ts` contains the inspect/timeout cluster verbatim.
+**FR-2** — `deacon.ts` imports `checkInspectAgentTimeouts` from `./deacon-inspect.js` and calls it in `runPatrol` exactly as before (same call site, same arguments, same ordering).
+**FR-3** — If any file **outside** `deacon.ts` imports a moved symbol, `deacon.ts` re-exports it (`export { … } from './deacon-inspect.js'`) so no external import path changes. (Check with `grep -rn "checkInspectAgentTimeouts\|INSPECT_TIMEOUT_MS" src/` before and after.)
+**FR-4** — Runtime behavior is unchanged: `npm run typecheck`, `npm run lint`, and `npm run build` all pass, and no test that passed on `main` now fails.
+
+**NFR-1** — Behavior-preserving only. No logic edits, no renames, no "improvements" (Karpathy rule #3). The moved code is identical except for added imports it now needs at the top of the new file.
+**NFR-2** — No new explicit `any` (the A1 ratchet is live on this branch; `npm run lint` enforces it).
+**NFR-3** — No circular import: `deacon-inspect.ts` should import only from leaf modules it actually uses (e.g. `agents.js`, `tmux.js`, `effect`). It must **not** import from `deacon.ts`. If the cluster genuinely needs a symbol that lives in `deacon.ts`, pass it as a function argument instead — or, if that's not clean, **stop and report to the orchestrator** rather than creating a `deacon.ts ↔ deacon-inspect.ts` cycle.
+
+## Steps
+1. `grep -n 'checkInspectAgentTimeouts\|inspectSessionName\|formatInspectElapsed\|INSPECT_TIMEOUT_MS' src/lib/cloister/deacon.ts` to get exact ranges and confirm the cluster boundary.
+2. `grep -rn 'checkInspectAgentTimeouts\|INSPECT_TIMEOUT_MS' src/` to find external importers (determines what to re-export per FR-3).
+3. Create `src/lib/cloister/deacon-inspect.ts`; move the functions + constant verbatim; add the imports they need at the top.
+4. In `deacon.ts`: delete the moved code, add `import { checkInspectAgentTimeouts } from './deacon-inspect.js';` (plus any others `runPatrol` calls), and the re-export line if FR-3 applies.
+5. Verify (FR-4): `npm run typecheck && npm run lint && npm run build`, then run the deacon-related tests (`grep -rl deacon tests/ | head` to find them) — they must pass.
+
+## Acceptance criteria
+- **AC-1 (FR-1/2):** `deacon-inspect.ts` exists with the cluster; `runPatrol` calls `checkInspectAgentTimeouts` via the import.
+- **AC-2 (FR-3):** `grep -rn 'checkInspectAgentTimeouts' src/` shows external callers still resolve (via re-export or direct import).
+- **AC-3 (FR-4/NFR-3):** `npm run typecheck`, `npm run lint`, `npm run build` all exit 0; deacon tests green.
+- **AC-4 (NFR-1):** `git diff` shows the moved lines are identical (a pure move + import wiring), no logic change.
+
+## Intersecting repo rules (restated)
+- **No bandaids / surgical changes:** pure move; every changed line traces to the extraction.
+- **A1 `no-explicit-any` ratchet is live** — don't add `any`.
+- **No `execSync` in server-reachable code** — the moved code already complies; don't introduce it.
+- **Async tmux only** (`sendKeysAsync`, never `sendKeys`) — preserve whatever the code already uses.
+- **Worktree discipline:** verify `git branch --show-current` = `codebase-health/b1` before editing; never `git checkout <branch>`; never `git stash`.
+- **Commit per step**, conventional commits, never `--no-verify`. Suggested: `refactor(cloister): extract inspect-timeout cluster to deacon-inspect.ts`.
+- **Do NOT run `pan done` / open a PR.** Report blockers (especially any circular-import surprise) to the orchestrator.
+
+## Out of scope
+- Any other deacon cluster (api-recovery, review, merge, auto-resume — later waves).
+- Any behavior/logic change. This is a move only.

--- a/docs/codebase-health/B2-container-ops-extract.md
+++ b/docs/codebase-health/B2-container-ops-extract.md
@@ -1,0 +1,60 @@
+# B2 — Extract container/docker routes out of `routes/workspaces.ts`
+
+**Epic:** B (Carve deep modules) — see [`docs/CODEBASE-HEALTH-ROADMAP.md`](../CODEBASE-HEALTH-ROADMAP.md)
+**Branch:** `codebase-health/b2` (stacked on `codebase-health/b-kickoff` → main) · **Executor:** GLM-5.2 (handoff), supervised by conversation #182
+**Mode:** orchestrated handoff — **do NOT run `pan done`, do NOT open a PR, do NOT touch the pipeline.** Commit on this branch; the orchestrator reviews and merges.
+
+---
+
+## Glossary
+- **God file** — `src/dashboard/server/routes/workspaces.ts` is ~6,638 lines, a dashboard HTTP route module built on **Effect.js** (routes composed via `Layer`).
+- **Route module + Layer composition** — each `routes/*.ts` exports route handlers that are merged into a layer; `workspaces.ts` composes them. **You must match the existing idiom** — read a sibling module in `src/dashboard/server/routes/` and how `workspaces.ts` currently registers its routes, and mirror it exactly.
+- **probe cache** — `probeCache` Map + `setCachedProbe`/`getCachedProbe`/`pruneProbeCache`, used only by the container routes. Local state; moves with them.
+- **Behavior-preserving extraction** — move handlers + their private helpers into a new module, register them identically, so every route responds exactly as before.
+
+## Problem
+`workspaces.ts` is the second-largest file in the repo. B2 extracts the **container/docker cluster** — the lowest-risk, most self-contained seam (no coupling to the merge queue, review status, or EventStore) — to start decomposing it.
+
+## Scope — the cluster to extract
+Locate by route path / function name (`grep -n`); approximate regions noted but **use names, not line numbers**:
+- Routes: `POST /api/workspaces/:issueId/containerize`, `POST /api/workspaces/:issueId/containers/:containerName/:action`, `POST /api/workspaces/:issueId/memory-summary`, `POST /api/workspaces/:issueId/refresh-db`.
+- Helpers used **only** by those routes: `getContainerStatusAsync`, `probeContainerPortAsync`, `extractContainerServiceHealth`, `repairFlywayIfNeeded`, `setCachedProbe`, `getCachedProbe`, `pruneProbeCache`, and the `probeCache` Map.
+- Verify with `grep` that each helper is used **only** by the four routes before moving it. Anything also used elsewhere stays in `workspaces.ts` and is imported.
+
+Target module: `src/dashboard/server/routes/workspaces/container-ops.ts` (create the `workspaces/` subdirectory).
+
+## Requirements
+**FR-1** — The four container routes + their exclusive helpers + `probeCache` live in `routes/workspaces/container-ops.ts`.
+**FR-2** — The routes are registered identically: `container-ops.ts` exports a layer (matching the existing pattern) and `workspaces.ts` composes it into its route layer. Every route keeps its exact method + path.
+**FR-3** — Shared singletons stay put and are imported, never duplicated: `pendingOperations`, `activityLog`, `getProjectPath`, `getWorkspaceInfoForIssue`, `_serverManagedMerges`, etc. remain owned by their current module; `container-ops.ts` imports what it needs.
+**FR-4** — Behavior unchanged: `npm run typecheck`, `npm run lint`, `npm run build` pass; no test green on `main` now fails.
+
+**NFR-1** — Behavior-preserving only — no logic edits, no renames (Karpathy #3).
+**NFR-2** — No new explicit `any` (A1 ratchet live; `npm run lint` enforces).
+**NFR-3** — No new circular import. If composition forces `container-ops.ts` to import from `workspaces.ts` AND vice-versa in a way that breaks `npm run build`, prefer moving the genuinely-shared helper to a small shared module — but if that balloons scope, **stop and report to the orchestrator**.
+**NFR-4** — No `execSync` anywhere reachable from the server (existing rule). Preserve the async patterns already in the moved code.
+
+## Steps
+1. Read 1–2 sibling modules in `src/dashboard/server/routes/` and the route-composition section of `workspaces.ts` to learn the exact Layer idiom.
+2. `grep -n` the four route registrations + each helper; `grep -rn` each helper across `src/` to confirm it's container-only (else leave + import).
+3. Create `routes/workspaces/container-ops.ts`; move routes + exclusive helpers + `probeCache`; add imports for shared symbols (from `../workspaces.js` or their true source).
+4. Export the container-ops layer; in `workspaces.ts`, remove the moved code and merge the imported layer into the composed route layer.
+5. Verify (FR-4): `npm run typecheck && npm run lint && npm run build`. Then confirm the routes still exist (search the composed layer) and run workspace/route tests (`grep -rl workspaces tests/`); all green.
+
+## Acceptance criteria
+- **AC-1 (FR-1/2):** `container-ops.ts` holds the four routes + helpers; `workspaces.ts` composes its layer; all four paths still registered.
+- **AC-2 (FR-3):** no shared singleton is duplicated (`grep` shows `probeCache` only in container-ops; `_serverManagedMerges`/`pendingOperations` still single-owned).
+- **AC-3 (FR-4/NFR-3):** `npm run typecheck`, `npm run lint`, `npm run build` exit 0; route tests green.
+- **AC-4 (NFR-1):** diff is a pure move + wiring; no logic change.
+
+## Intersecting repo rules (restated)
+- **Dashboard server is Node-22 / no `execSync`** — don't introduce blocking calls; keep async.
+- **A1 `no-explicit-any` ratchet is live** — no new `any` (Effect boundaries: prefer precise types; if truly unavoidable a file would need to enter the allowlist — instead, **report to the orchestrator**, don't add `any`).
+- **Surgical, behavior-preserving** — move only.
+- **Worktree discipline:** verify `git branch --show-current` = `codebase-health/b2`; never `git checkout <branch>`; never `git stash`.
+- **Commit per step**, conventional commits, never `--no-verify`. Suggested: `refactor(dashboard): extract container-ops routes from workspaces.ts`.
+- **Do NOT run `pan done` / open a PR.** Report blockers to the orchestrator.
+
+## Out of scope
+- Other workspaces.ts clusters (review-pipeline, merge-ops, workspace-data, stash/clean — later waves).
+- Any behavior/logic change.

--- a/docs/codebase-health/B3-agents-queries-extract.md
+++ b/docs/codebase-health/B3-agents-queries-extract.md
@@ -1,0 +1,66 @@
+# B3 — Extract read-only agent queries out of `agents.ts`
+
+**Epic:** B (Carve deep modules) — see [`docs/CODEBASE-HEALTH-ROADMAP.md`](../CODEBASE-HEALTH-ROADMAP.md)
+**Branch:** `codebase-health/b3` (stacked on `codebase-health/b-kickoff` → main) · **Executor:** Kimi-k2.7-code (handoff), supervised by conversation #182
+**Mode:** orchestrated handoff — **do NOT run `pan done`, do NOT open a PR, do NOT touch the pipeline.** Commit on this branch; the orchestrator reviews and merges.
+
+---
+
+## Glossary
+- **God file** — `src/lib/agents.ts` is ~5,824 lines, the core agent lifecycle/state library, imported by ~155 files (almost all via `from '.../agents.js'`).
+- **Read-only queries** — functions that *enumerate / inspect* agents without writing any state. The safest possible thing to extract: no writers move, so the state-write lint guard is untouched.
+- **state-write guard** — `scripts/lint-state-writes.sh` (run by `npm run lint`) whitelists `writeAgentStateJsonSync` **in `src/lib/agents.ts`** as the only approved agent-state writer. B3 must **not** move that function (or any writer). Read-only queries don't touch it, so the guard stays green.
+- **Re-export** — `export { x } from './agents/queries.js'` in `agents.ts`, so the ~155 importers that do `import { listRunningAgents } from '.../agents.js'` keep working with zero changes.
+
+## Problem
+`agents.ts` is the third-largest file and the most widely-imported. B3 extracts the **read-only query cluster** — the cleanest, lowest-risk seam (no state writes, no spawn logic) — to begin decomposing it without touching the lint-guarded writers or the spawn path.
+
+## Scope — the cluster to extract
+Locate by name (`grep -n`); approximate region ~lines 4200–4415, but **use names, not line numbers**:
+- `listRunningAgentsSync`
+- `listAgentStates`
+- `listRunningAgents`
+- `warnOnBareNumericIssueIds`
+- `dropLegacyAgentStatesMissingRoleAsync`
+- any private helper used **only** by the above (verify with `grep`).
+
+Do **NOT** move: `writeAgentStateJsonSync`, `saveAgentStateSync`, `saveAgentState`, `getAgentStateSync`, or anything that writes state. `getAgentStateSync` is a *reader* but is imported by the queries and by ~33 other call sites — **leave it in `agents.ts`** and import it into `queries.ts`.
+
+Target module: `src/lib/agents/queries.ts` (create the `agents/` subdirectory).
+
+## Requirements
+**FR-1** — The read-only query functions live in `src/lib/agents/queries.ts`.
+**FR-2** — `queries.ts` imports what it needs from `agents.ts` (e.g. `getAgentStateSync`) and from leaf modules (`tmux.js` `sessionExists`/`sessionExistsSync`, overdeck rollback-state readers).
+**FR-3** — `agents.ts` re-exports every moved function (`export { listRunningAgents, listRunningAgentsSync, listAgentStates, warnOnBareNumericIssueIds, dropLegacyAgentStatesMissingRoleAsync } from './agents/queries.js'`) so all ~155 existing importers keep resolving unchanged.
+**FR-4** — The state-write guard stays green: `npm run lint` (which runs `scripts/lint-state-writes.sh`) passes. No writer moved.
+**FR-5** — Behavior unchanged: `npm run typecheck`, `npm run lint`, `npm run build` pass; no test green on `main` now fails.
+
+**NFR-1** — Behavior-preserving only — pure move + re-export, no logic edits, no renames (Karpathy #3).
+**NFR-2** — No new explicit `any` (A1 ratchet live).
+**NFR-3** — Circular import: `agents.ts` re-exports from `queries.ts`, and `queries.ts` imports `getAgentStateSync` from `agents.ts` — this is a cycle. The repo bundles with tsdown (which resolves cycles) and already contains cycles, and vitest tolerates them, so it should be fine. **Verify `npm run build` succeeds** (this is the real cycle check). If the build throws an actual ESM-cycle error at runtime, **stop and report to the orchestrator** — do not paper over it.
+
+## Steps
+1. `grep -n` the five functions in `agents.ts`; `grep -rn` each across `src/` to confirm read-only and find importers (all should resolve via the `agents.ts` re-export after the move).
+2. Create `src/lib/agents/queries.ts`; move the functions + their exclusive private helpers; add imports (`getAgentStateSync` from `../agents.js`, tmux readers, etc.).
+3. In `agents.ts`: delete the moved code; add the re-export line (FR-3).
+4. Verify (FR-4/FR-5): `npm run typecheck && npm run lint && npm run build`, then run agent-related tests (`grep -rl "agents" tests/unit | head`) — all green. Explicitly confirm `lint:state-writes` passed (it's part of `npm run lint`).
+
+## Acceptance criteria
+- **AC-1 (FR-1/3):** `agents/queries.ts` holds the queries; `agents.ts` re-exports them; `grep -rn 'listRunningAgents' src/` shows callers still resolve.
+- **AC-2 (FR-4):** `npm run lint` exits 0 — including the `state-write lint passed (single write surface intact)` line. No state writer was moved.
+- **AC-3 (FR-5/NFR-3):** `npm run typecheck`, `npm run build` exit 0; agent tests green.
+- **AC-4 (NFR-1):** diff is a pure move + re-export; no logic change.
+
+## Intersecting repo rules (restated)
+- **state-write guard:** never move `writeAgentStateJsonSync` or any writer out of `agents.ts` — it would turn `lint:state-writes` red. B3 moves readers only.
+- **A1 `no-explicit-any` ratchet is live** — no new `any`.
+- **No `execSync`** in server-reachable code — preserve async patterns.
+- **Surgical, behavior-preserving** — move + re-export only.
+- **Worktree discipline:** verify `git branch --show-current` = `codebase-health/b3`; never `git checkout <branch>`; never `git stash`.
+- **Commit per step**, conventional commits, never `--no-verify`. Suggested: `refactor(agents): extract read-only queries to agents/queries.ts`.
+- **Do NOT run `pan done` / open a PR.** Report blockers (especially a real build-breaking cycle) to the orchestrator.
+
+## Out of scope
+- Moving any state writer or the spawn path (later waves / never for the guard'd writer without coordination).
+- Other agents.ts clusters (termination, delivery, runtime-state, recovery — later waves).
+- Any behavior/logic change.


### PR DESCRIPTION
Marks Epic A (A1–A3, merged via #2113/#2114/#2115) complete in the roadmap, and adds the Epic B wave-1 PRDs: the **single lowest-risk extraction seam in each of the three god files**, fully independent, behavior-preserving.

- **B1** `deacon.ts` → `deacon-inspect.ts` (inspect/timeout cluster) — GPT-5.5
- **B2** `routes/workspaces.ts` → `routes/workspaces/container-ops.ts` (container/docker routes) — GLM-5.2
- **B3** `agents.ts` → `agents/queries.ts` (read-only queries) — Kimi-k2.7-code

Docs-only PR (planning). Implementation lands on the per-seam branches, orchestrator-reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the codebase health roadmap with completed Epic A items and a more detailed, wave-based plan for Epic B.
  * Added planning docs for three upcoming extraction tasks, each outlining the target areas, safety constraints, and acceptance criteria.
  * Clarified execution order, branch progress, and verification steps to help track the next implementation phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->