### PR TITLE
docs(codebase-health): Epic E (de-leak core) + B wave-1 complete

### DIFF
--- a/docs/CODEBASE-HEALTH-ROADMAP.md
+++ b/docs/CODEBASE-HEALTH-ROADMAP.md
@@ -56,7 +56,7 @@ Decompose the god files into deep modules (narrow interface, hidden complexity) 
 
 **Sequencing decision:** B is far riskier than A — the highest-value seams (deacon auto-resume/merge, the harness migration, the `agents.ts` spawn path) touch the exact code behind our worst failure modes. So B proceeds in **waves, safest-first**: each wave extracts the *single lowest-risk seam* in a god file, behavior-preserving, compiler+test-verified, to prove the extraction pattern before the scary seams. Analysis maps for each file live in the agents' reports; the per-file full seam ladder is in each PRD's appendix.
 
-**Wave 1 (in flight) — the safest seam in each of the three god files, one per model, fully independent (different files, no `package.json` touches):**
+**Wave 1 — ✅ COMPLETE (merged 2026-06-28) — the safest seam in each of the three god files, one per model, fully independent (different files, no `package.json` touches):**
 
 | # | Work | File → new module | Risk | Executor | Branch |
 |---|---|---|---|---|---|
@@ -64,7 +64,7 @@ Decompose the god files into deep modules (narrow interface, hidden complexity) 
 | **B2** | Extract container/docker routes | `routes/workspaces.ts` (6,638) → `routes/workspaces/container-ops.ts` | LOW | GLM-5.2 | `codebase-health/b2` |
 | **B3** | Extract read-only agent queries | `agents.ts` (5,824) → `agents/queries.ts` | LOW | Kimi-2.7 | `codebase-health/b3` |
 
-PRDs: [`docs/codebase-health/`](./codebase-health/) (`B1-*`, `B2-*`, `B3-*`). Later waves tackle api-recovery/review/merge/auto-resume (deacon), workspace-data/review-pipeline/merge-ops (route), termination/delivery/state (agents), then the `Harness` interface migration.
+Merged: B1 #2117, B2 #2119, B3 #2118 — combined `main` CI green. PRDs: [`docs/codebase-health/`](./codebase-health/) (`B1-*`, `B2-*`, `B3-*`). Later waves tackle api-recovery/review/merge/auto-resume (deacon), workspace-data/review-pipeline/merge-ops (route), termination/delivery/state (agents), then the `Harness` interface migration.
 
 ### Epic C — Fitness functions (evals + a frozen kernel)
 
@@ -73,6 +73,10 @@ Adopt [`evalite`](https://github.com/mattpocock/evalite) for agent-behavior regr
 ### Epic D — Process
 
 One large migration at a time (finished before the next); a `/grilling` design-review gate before any feature that would widen a god file or add a harness branch; a "no new `any` / no god-file growth" checklist in the PR template.
+
+### Epic E — De-leak core (project-specifics out of Overdeck core)
+
+Core (`pan` CLI + dashboard server) must serve **any** project, but MYN-specific Postgres/Flyway database logic — including a hardcoded `myn` database name — is baked into core files. Same disease as the god files (wrong-layer logic), different flavor (domain leakage). **Tier 1:** de-hardcode `myn` → drive the DB name from project config (add a `name` field; replace ~6 hardcoded literals in `cli/commands/db.ts` and `routes/workspaces.ts`). **Tier 2 (direction TBD):** move the Flyway/Postgres machinery out of core — either invoke a project-declared command, or extract a plugin/extension. Full audit + plan: [`docs/codebase-health/E-de-leak-core.md`](./codebase-health/E-de-leak-core.md).
 
 ---
 
@@ -92,12 +96,13 @@ These changes modify the agents' **own substrate** — lint rules, the build, th
 - [x] **A1** — `no-explicit-any` ratchet — GPT-5.5 — merged #2113
 - [x] **A2** — `ts-reset` — GLM-5.2 — merged #2114
 - [x] **A3** — file-size guard — Kimi-2.7 — merged #2115
-- [ ] **B1** — extract `deacon-inspect.ts` — GPT-5.5 — `codebase-health/b1`
-- [ ] **B2** — extract `container-ops.ts` — GLM-5.2 — `codebase-health/b2`
-- [ ] **B3** — extract `agents/queries.ts` — Kimi-2.7 — `codebase-health/b3`
+- [x] **B1** — extract `deacon-inspect.ts` — GPT-5.5 — merged #2117
+- [x] **B2** — extract `container-ops.ts` — GLM-5.2 — merged #2119
+- [x] **B3** — extract `agents/queries.ts` — Kimi-2.7 — merged #2118
 - [ ] **B (later waves)** — api-recovery/review/merge/auto-resume · workspace-data/review-pipeline/merge-ops · termination/delivery/state · `Harness` interface
 - [ ] **C** — evals + frozen kernel (PRDs TBD)
 - [ ] **D** — process gates (PRDs TBD)
+- [ ] **E** — de-leak core: Tier 1 de-hardcode `myn` (ready) · Tier 2 de-core DB machinery (direction TBD) — see [`E-de-leak-core.md`](./codebase-health/E-de-leak-core.md)
 
 ---
 

--- a/docs/codebase-health/E-de-leak-core.md
+++ b/docs/codebase-health/E-de-leak-core.md
@@ -1,0 +1,56 @@
+# Epic E — De-leak core: project-specifics out of Overdeck core
+
+**Status:** identified + documented 2026-06-28 (`main@ddfa3ef7e`). Tier 1 ready to schedule; Tier 2 direction pending operator.
+**Roadmap:** [`docs/CODEBASE-HEALTH-ROADMAP.md`](../CODEBASE-HEALTH-ROADMAP.md)
+
+---
+
+## Problem
+
+Overdeck core (the `pan` CLI + the dashboard server) orchestrates coding agents and workspaces for **any** project. But some **project-specific** logic — concretely, the Mind Your Now (MYN) project's Postgres/Flyway database setup — is **hardcoded into core files**. Two consequences:
+
+1. Features that should be generic only work for MYN (e.g. `pan db seed` would drop/create a database literally named `myn` for *any* project).
+2. Core carries domain knowledge (Postgres, Flyway internals) it has no business knowing.
+
+This is the same class of problem as the god-files (wrong-layer / over-broad core); here the flavor is **domain leakage** rather than file size.
+
+## Findings (audit 2026-06-28)
+
+All 46 `myn` references in `src/` were reviewed. **Most are benign** — comments, `e.g.` examples, `--project` help text, and a Rally integration vendor header (`X-RallyIntegrationVendor: 'Mind Your Now'`, which is a legitimate per-user API value). **No action needed on those.**
+
+**Real leakage — hardcoded `myn` database name in executable code (two files):**
+
+1. `src/cli/commands/db.ts` — five hardcoded references:
+   - `:305` — ``DROP DATABASE IF EXISTS myn; CREATE DATABASE myn;`` (core CLI creating the MYN database)
+   - `:288`, `:318`, `:337`, `:410` — `psql ... -d myn ...` (seed / verify / status)
+2. `src/dashboard/server/routes/workspaces.ts:2898` — passes the literal `'myn'` into `repairFlywayIfNeeded()` (a ~100-line Postgres/Flyway schema-history repair routine at `:1190–1290`).
+
+**Root enabler:** `src/lib/workspace-config.ts` — the workspace `database` config has `container_name` and `migrations`, but **no `name` field**. There is nowhere to declare the database name, so the code hardcodes `myn`. (The rest of the DB config is already generic: `migrations.type: 'flyway' | 'liquibase' | 'prisma' | 'typeorm' | 'custom'`, `migrations.command`, `seed_file`, `container_name` with a `{{PROJECT}}` placeholder.)
+
+## Disposition — two tiers
+
+### Tier 1 — De-hardcode (low risk, clearly correct, do regardless)
+
+- Add a `name` field (and any other missing fields) to the `database` config in `src/lib/workspace-config.ts`.
+- Thread it through and replace the ~6 hardcoded `myn` literals in `db.ts` and `workspaces.ts` with the configured name.
+- **Result:** the existing DB features become project-agnostic and config-driven. Removes the leak without changing where the logic lives.
+
+### Tier 2 — De-core the DB machinery (architectural; direction TBD)
+
+The Flyway/Postgres surgery (reading `flyway_schema_history`, checksum sync, `DROP`/`CREATE DATABASE`) is project-**type**-specific and should not live in a core route/CLI. Two options:
+
+- **(a) Config-driven command** — core simply invokes the project-declared seed/migrate command (`migrations.command` / `seed_file` already exist). The project owns the SQL/Flyway specifics; core stays generic. *Lower effort; the hooks largely exist.*
+- **(b) Plugin / extension** — DB-provisioning becomes an optional module that loads only for projects that opt in; core has zero Postgres/Flyway knowledge. *More work; cleanest separation.*
+
+**Decision pending operator.** Recommendation: do Tier 1 now; for Tier 2 start with **(a) config-driven command** (smaller, reversible), keeping **(b) plugin** as a later evolution if a true plugin system is built.
+
+## Acceptance criteria (Tier 1)
+
+- No hardcoded `myn` remains in `db.ts` or `workspaces.ts`; the DB name is read from project config.
+- A project whose config declares a different DB name drives `pan db` + workspace Flyway-repair correctly (verified via config, with no implicit dependence on a database named `myn`).
+- `npm run typecheck`, `npm run lint`, `npm run build`, and tests pass.
+
+## Notes
+
+- Execution follows the same handoff-orchestration model as Epics A/B (supervised non-pipeline agents; orchestrator verifies + merges). See the roadmap's "Execution model" section.
+- Tier 2's "plugin/extension" option presumes a plugin system Overdeck does not yet have; if pursued, that scaffolding is itself a prerequisite work item.


### PR DESCRIPTION
Documents **Epic E — de-leak core**: MYN-specific Postgres/Flyway logic (incl. a hardcoded `myn` DB name) is baked into core CLI/dashboard files. Full audit + two-tier plan in `docs/codebase-health/E-de-leak-core.md`. Also marks Epic B wave-1 (B1/B2/B3) complete in the roadmap. Docs-only.