### PR TITLE
fix(config): E Tier 1 — de-hardcode the myn database name

### DIFF
--- a/docs/codebase-health/E-tier1-dehardcode-myn.md
+++ b/docs/codebase-health/E-tier1-dehardcode-myn.md
@@ -1,0 +1,48 @@
+# E Tier 1 — De-hardcode the `myn` database name (config-driven)
+
+**Epic:** E · **Branch:** `codebase-health/e-tier1` (off `main`) · **Executor:** GPT-5.5 (handoff), supervised by conv #182
+**Mode:** orchestrated handoff — **do NOT run `pan done`, do NOT open a PR.** Commit on this branch; the orchestrator reviews + merges.
+**Background:** read `docs/codebase-health/E-de-leak-core.md` first (the audit + rationale).
+
+---
+
+## Problem
+Core hardcodes the MYN database name `myn` (and a MYN-schema-specific probe) so the DB features only work for MYN. Verified current locations:
+- `src/cli/commands/db.ts`: `:288 :305 :318 :337 :410` — `psql ... -d myn ...` and `DROP DATABASE IF EXISTS myn; CREATE DATABASE myn;`
+- `src/dashboard/server/routes/workspaces/container-ops.ts`: `:320 :493 :497 :507 :514 :530` — `-d myn`, `DROP DATABASE IF EXISTS myn`, `terminate_backend ... datname='myn'`, seed into `myn`, **and a MYN-schema probe `SELECT count(*) FROM customer`** (`:530`).
+
+## Goal (Tier 1 = de-hardcode, config-driven; behavior-preserving for MYN via config)
+1. **Schema:** in `src/lib/workspace-config.ts`, add to the workspace `database` config: `name: string` (the database name) and `seedVerifyQuery?: string` (optional post-seed sanity query; replaces the hardcoded `SELECT count(*) FROM customer`).
+2. **Code:** replace every hardcoded `'myn'` **database name** in `db.ts` and `container-ops.ts` with the configured `database.name` resolved from the project config (the same `projectConfig.workspace.database` already read nearby). Replace the `customer`-table probe with `database.seedVerifyQuery` — **skip the probe entirely if `seedVerifyQuery` is unset**. **No hardcoded `'myn'` fallback** — if a project has `database` config but no `name`, throw a clear config error.
+3. **Behavior preservation for MYN:** locate the MYN project entry in the Overdeck project config (`grep -rn "myn" projects.yaml` and any `*.yaml` under the repo / config dir). Set `database.name: myn` and `seedVerifyQuery: "SELECT count(*) FROM customer"` there so MYN's flow is byte-identical. **Implementation checkpoint:** if `projects.yaml` (or the MYN entry) is NOT in this repo (it may be machine-local under `~/.overdeck/`), do **not** guess — STOP and report to the orchestrator, who will set MYN's local config before merge. Proceed with the code+schema changes regardless.
+
+## Requirements
+**FR-1** `WorkspaceDatabaseConfig` has `name: string` + `seedVerifyQuery?: string` (with doc comments).
+**FR-2** Zero hardcoded `'myn'` database-name remains in `db.ts` / `container-ops.ts` (`grep -rin "\bmyn\b" src/cli/commands/db.ts src/dashboard/server/routes/workspaces/container-ops.ts` returns nothing except possibly comments). The DB name comes from `database.name`.
+**FR-3** The `customer`-table probe is replaced by `seedVerifyQuery` (skipped when unset). No hardcoded table names remain.
+**FR-4** No silent `'myn'` fallback — missing `database.name` (when `database` config exists) throws a clear error.
+**FR-5** `npm run typecheck` + `npm run lint` + `npm run build` pass; db/container tests pass.
+
+**NFR-1** Surgical; only the schema field + the substitutions + (if in-repo) the MYN config entry. No unrelated changes.
+**NFR-2** No new explicit `any` (A1 ratchet). No `execSync` (use the existing `execAsync`).
+**NFR-3** The MYN-specific Flyway *repair logic itself* (the broader "should this be in core at all" question) is **Tier 2 — out of scope here.** Tier 1 only removes the hardcoded name + schema-coupled probe.
+
+## Verification
+```
+npm run typecheck && npm run lint && npm run build
+npx vitest run --configLoader runner $(grep -rl "db\b\|database\|container" tests/unit | tr '\n' ' ')
+grep -rin "\bmyn\b" src/cli/commands/db.ts src/dashboard/server/routes/workspaces/container-ops.ts   # expect: nothing (or comments only)
+```
+
+## Acceptance criteria
+- `database.name` + `seedVerifyQuery` in the config schema; both used in `db.ts` + `container-ops.ts`.
+- No hardcoded `myn` DB-name or `customer` table reference in those two files.
+- Missing `database.name` errors clearly (no silent fallback).
+- MYN config entry set (if in-repo) OR reported to orchestrator (if machine-local).
+- typecheck/lint/build green; tests pass.
+
+## Intersecting rules (restated)
+No bandaids; surgical; A1 ratchet (no new `any`); no `execSync`; worktree discipline (branch = `codebase-health/e-tier1`; never `git checkout <branch>` / `git stash`); conventional commits, never `--no-verify`; **do NOT run `pan done` or open a PR** — report blockers (esp. the MYN-config-location checkpoint) to the orchestrator.
+
+## Out of scope (Tier 2, later)
+Moving the Flyway/Postgres repair machinery out of core (config-driven command vs plugin) — that's the documented Tier 2 decision in `E-de-leak-core.md`.

--- a/src/cli/commands/db.ts
+++ b/src/cli/commands/db.ts
@@ -39,12 +39,35 @@ function findFullProjectByTeam(teamPrefix: string): ExtendedProjectConfig | null
   ) || null;
 }
 
+function requireDatabaseName(dbConfig: DatabaseConfig | undefined): string {
+  if (!dbConfig) {
+    throw new Error('No database configuration found in projects.yaml');
+  }
+  const name = dbConfig.name?.trim();
+  if (!name) {
+    throw new Error('Missing required database.name in projects.yaml database config');
+  }
+  return name;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function sqlIdentifier(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function sqlString(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
 export function registerDbCommands(program: Command): void {
   const db = program.command('db').description('Database seeding and management');
 
   db.command('snapshot')
     .description('Create a database snapshot from an external source')
-    .option('--project <key>', 'Project key (e.g., myn)')
+    .option('--project <key>', 'Project key')
     .option('--output <path>', 'Output file path')
     .option('--sanitize', 'Run sanitization script after snapshot')
     .action(snapshotCommand);
@@ -133,6 +156,7 @@ async function snapshotCommand(options: {
   ${projectConfig.key}:
     workspace:
       database:
+        name: myapp
         snapshot_command: "kubectl exec -n prod pod/postgres -- pg_dump -U app mydb"
         # or
         external_db:
@@ -253,6 +277,7 @@ async function seedCommand(
     }
 
     const dbConfig = projectConfig.workspace.database;
+    const databaseName = requireDatabaseName(dbConfig);
     const seedFile = options.file || dbConfig?.seed_file;
 
     if (!seedFile || !existsSync(seedFile)) {
@@ -285,7 +310,7 @@ async function seedCommand(
     if (!options.force) {
       try {
         const { stdout } = await execAsync(
-          `docker exec ${containerName} psql -U postgres -d myn -c "SELECT count(*) FROM flyway_schema_history" -t 2>/dev/null`
+          `docker exec ${shellQuote(containerName)} psql -U postgres -d ${shellQuote(databaseName)} -c "SELECT count(*) FROM flyway_schema_history" -t 2>/dev/null`
         );
         const count = parseInt(stdout.trim(), 10);
         if (count > 0) {
@@ -302,7 +327,7 @@ async function seedCommand(
       spinner.text = 'Dropping existing database...';
       try {
         await execAsync(
-          `docker exec ${containerName} psql -U postgres -c "DROP DATABASE IF EXISTS myn; CREATE DATABASE myn;"`
+          `docker exec ${shellQuote(containerName)} psql -U postgres -c "DROP DATABASE IF EXISTS ${sqlIdentifier(databaseName)}; CREATE DATABASE ${sqlIdentifier(databaseName)};"`
         );
       } catch (error: any) {
         spinner.warn(`Could not drop database: ${error.message}`);
@@ -311,11 +336,11 @@ async function seedCommand(
 
     // Copy seed file to container and execute
     spinner.text = 'Copying seed file to container...';
-    await execAsync(`docker cp "${seedFile}" ${containerName}:/tmp/seed.sql`);
+    await execAsync(`docker cp ${shellQuote(seedFile)} ${shellQuote(`${containerName}:/tmp/seed.sql`)}`);
 
     spinner.text = 'Executing seed...';
     try {
-      await execAsync(`docker exec ${containerName} psql -U postgres -d myn -f /tmp/seed.sql`, {
+      await execAsync(`docker exec ${shellQuote(containerName)} psql -U postgres -d ${shellQuote(databaseName)} -f /tmp/seed.sql`, {
         timeout: 600000, // 10 minute timeout for large seeds
       });
     } catch (error: any) {
@@ -327,14 +352,14 @@ async function seedCommand(
     }
 
     // Clean up
-    await execAsync(`docker exec ${containerName} rm /tmp/seed.sql`);
+    await execAsync(`docker exec ${shellQuote(containerName)} rm /tmp/seed.sql`);
 
     spinner.succeed('Database seeded successfully');
 
     // Show migration status
     try {
       const { stdout } = await execAsync(
-        `docker exec ${containerName} psql -U postgres -d myn -c "SELECT version, description FROM flyway_schema_history ORDER BY installed_rank DESC LIMIT 3" -t`
+        `docker exec ${shellQuote(containerName)} psql -U postgres -d ${shellQuote(databaseName)} -c "SELECT version, description FROM flyway_schema_history ORDER BY installed_rank DESC LIMIT 3" -t`
       );
       console.log(chalk.dim('\nRecent migrations:'));
       stdout
@@ -389,6 +414,8 @@ async function statusCommand(workspaceOrIssue?: string): Promise<void> {
       return;
     }
 
+    const databaseName = requireDatabaseName(projectConfig?.workspace?.database);
+
     spinner.text = `Checking container ${containerName}...`;
 
     // Check if container is running
@@ -407,7 +434,7 @@ async function statusCommand(workspaceOrIssue?: string): Promise<void> {
     // Check flyway version
     try {
       const { stdout: version } = await execAsync(
-        `docker exec ${containerName} psql -U postgres -d myn -c "SELECT version, description FROM flyway_schema_history ORDER BY installed_rank DESC LIMIT 1" -t`
+        `docker exec ${shellQuote(containerName)} psql -U postgres -d ${shellQuote(databaseName)} -c "SELECT version, description FROM flyway_schema_history ORDER BY installed_rank DESC LIMIT 1" -t`
       );
       const [ver, desc] = version.trim().split('|').map((s) => s.trim());
       console.log(chalk.green(`  Flyway: V${ver} - ${desc}`));
@@ -418,7 +445,7 @@ async function statusCommand(workspaceOrIssue?: string): Promise<void> {
     // Check table count
     try {
       const { stdout: tableCount } = await execAsync(
-        `docker exec ${containerName} psql -U postgres -d myn -c "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public'" -t`
+        `docker exec ${shellQuote(containerName)} psql -U postgres -d ${shellQuote(databaseName)} -c "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public'" -t`
       );
       console.log(chalk.dim(`  Tables: ${tableCount.trim()}`));
     } catch {
@@ -428,7 +455,7 @@ async function statusCommand(workspaceOrIssue?: string): Promise<void> {
     // Check database size
     try {
       const { stdout: dbSize } = await execAsync(
-        `docker exec ${containerName} psql -U postgres -d myn -c "SELECT pg_size_pretty(pg_database_size('myn'))" -t`
+        `docker exec ${shellQuote(containerName)} psql -U postgres -d ${shellQuote(databaseName)} -c "SELECT pg_size_pretty(pg_database_size('${sqlString(databaseName)}'))" -t`
       );
       console.log(chalk.dim(`  Size: ${dbSize.trim()}`));
     } catch {
@@ -598,11 +625,17 @@ async function configCommand(project?: string): Promise<void> {
     console.log(chalk.dim('\nAdd to projects.yaml under workspace:'));
     console.log(chalk.dim(`
   database:
+    name: myapp
     seed_file: /path/to/seed.sql
     snapshot_command: "kubectl exec -n prod pod/postgres -- pg_dump -U app db"
     container_name: "{{PROJECT}}-postgres-1"
 `));
     return;
+  }
+
+  console.log(`  Database: ${dbConfig.name || chalk.red('(missing database.name)')}`);
+  if (dbConfig.seedVerifyQuery) {
+    console.log(`  Seed verify query: ${dbConfig.seedVerifyQuery}`);
   }
 
   if (dbConfig.seed_file) {

--- a/src/dashboard/server/routes/workspaces/container-ops.ts
+++ b/src/dashboard/server/routes/workspaces/container-ops.ts
@@ -28,6 +28,7 @@ import {
   listProjectsSync,
 } from '../../../../lib/projects.js';
 import { DEVCONTAINER_DIRNAME } from '../../../../lib/workspace/devcontainer-renderer.js';
+import type { DatabaseConfig } from '../../../../lib/workspace-config.js';
 import { jsonResponse } from '../../http-helpers.js';
 import { httpHandler } from '../http-handler.js';
 import {
@@ -40,6 +41,29 @@ import {
 } from '../workspaces.js';
 
 const execAsync = promisify(exec);
+
+function requireDatabaseName(dbConfig: DatabaseConfig | undefined): string {
+  if (!dbConfig) {
+    throw new Error('No database configuration found in projects.yaml');
+  }
+  const name = dbConfig.name?.trim();
+  if (!name) {
+    throw new Error('Missing required database.name in projects.yaml database config');
+  }
+  return name;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function sqlIdentifier(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function sqlString(value: string): string {
+  return value.replace(/'/g, "''");
+}
 
 // ─── Route: POST /api/workspaces/:issueId/containerize ───────────────────────
 
@@ -312,12 +336,13 @@ const postWorkspaceContainerActionRoute = HttpRouter.add(
         pConfig?.workspace?.database?.migrations?.type === 'flyway' &&
         projectName
       ) {
+        const databaseName = requireDatabaseName(pConfig.workspace.database);
         const pgContainer = `${projectName}-postgres-1`;
         try {
           const result = yield* Effect.promise(() => repairFlywayIfNeeded(
             issueId,
             pgContainer,
-            'myn',
+            databaseName,
             pConfig,
             workspacePath!
           ));
@@ -419,6 +444,7 @@ const postWorkspaceRefreshDbRoute = HttpRouter.add(
         { status: 400 }
       );
     }
+    const databaseName = requireDatabaseName(dbConfig);
 
     const seedFile = join(projectConfig.path, dbConfig.seed_file);
     if (!existsSync(seedFile)) {
@@ -490,28 +516,28 @@ const postWorkspaceRefreshDbRoute = HttpRouter.add(
     }
 
     yield* Effect.promise(() => execAsync(
-      `docker exec "${pgContainer}" psql -U postgres -d postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'myn' AND pid <> pg_backend_pid();"`,
+      `docker exec ${shellQuote(pgContainer)} psql -U postgres -d postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${sqlString(databaseName)}' AND pid <> pg_backend_pid();"`,
       { encoding: 'utf-8', timeout: 10000 }
     ));
     yield* Effect.promise(() => execAsync(
-      `docker exec "${pgContainer}" psql -U postgres -d postgres -c "DROP DATABASE IF EXISTS myn;"`,
+      `docker exec ${shellQuote(pgContainer)} psql -U postgres -d postgres -c "DROP DATABASE IF EXISTS ${sqlIdentifier(databaseName)};"`,
       { encoding: 'utf-8', timeout: 10000 }
     ));
     yield* Effect.promise(() => execAsync(
-      `docker exec "${pgContainer}" psql -U postgres -d postgres -c "CREATE DATABASE myn OWNER postgres;"`,
+      `docker exec ${shellQuote(pgContainer)} psql -U postgres -d postgres -c "CREATE DATABASE ${sqlIdentifier(databaseName)} OWNER postgres;"`,
       { encoding: 'utf-8', timeout: 10000 }
     ));
 
     console.log(`[refresh-db] Loading seed file: ${seedFile}`);
     yield* Effect.promise(() => execAsync(
-      `docker exec -i "${pgContainer}" psql -U postgres -d myn < "${seedFile}"`,
+      `docker exec -i ${shellQuote(pgContainer)} psql -U postgres -d ${shellQuote(databaseName)} < ${shellQuote(seedFile)}`,
       { encoding: 'utf-8', timeout: 600000 }
     ));
 
     const repairResult = yield* Effect.promise(() => repairFlywayIfNeeded(
       issueId,
       pgContainer,
-      'myn',
+      databaseName,
       projectConfig,
       workspacePath,
       (msg) => console.log(`[refresh-db] ${msg}`)
@@ -524,23 +550,23 @@ const postWorkspaceRefreshDbRoute = HttpRouter.add(
       console.log(`[refresh-db] Could not start API container (may need manual start)`);
     }
 
-    let customerCount = 0;
-    try {
-      const { stdout } = yield* Effect.promise(() => execAsync(
-        `docker exec "${pgContainer}" psql -U postgres -d myn -t -A -c "SELECT count(*) FROM customer;"`,
-        { encoding: 'utf-8', timeout: 10000 }
-      ));
-      customerCount = parseInt(stdout.trim(), 10) || 0;
-    } catch {}
+    let seedVerifyResult: string | undefined;
+    if (dbConfig.seedVerifyQuery) {
+      try {
+        const { stdout } = yield* Effect.promise(() => execAsync(
+          `docker exec ${shellQuote(pgContainer)} psql -U postgres -d ${shellQuote(databaseName)} -t -A -c ${shellQuote(dbConfig.seedVerifyQuery)}`,
+          { encoding: 'utf-8', timeout: 10000 }
+        ));
+        seedVerifyResult = stdout.trim();
+      } catch {}
+    }
 
-    console.log(
-      `[refresh-db] DB refresh complete for ${issueId}: ${customerCount} customers`
-    );
+    console.log(`[refresh-db] DB refresh complete for ${issueId}`);
 
     return jsonResponse({
       success: true,
       message: `Database refreshed successfully`,
-      customerCount,
+      seedVerifyResult,
     });
   }))
 );

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -12,7 +12,7 @@ import { Effect } from 'effect';
 import { ConfigError, ConfigParseError, FsError } from './errors.js';
 import { OVERDECK_HOME } from './paths.js';
 import { extractPrefixSync, parseIssueIdSync } from './issue-id.js';
-import type { QualityGateConfig, RepoConfig } from './workspace-config.js';
+import type { DatabaseConfig, QualityGateConfig, RepoConfig } from './workspace-config.js';
 import type { AutoResumeConfig } from './cloister/auto-resume-config.js';
 
 export const PROJECTS_CONFIG_FILE = join(OVERDECK_HOME, 'projects.yaml');
@@ -48,7 +48,7 @@ export interface WorkspaceConfig {
   dns?: { domain: string; entries: string[]; sync_method?: 'wsl2hosts' | 'hosts_file' | 'dnsmasq' };
   ports?: Record<string, { range: [number, number] }>;
   docker?: { traefik?: string; compose_template?: string };
-  database?: { seed_file?: string; container_name?: string; [key: string]: any };
+  database?: DatabaseConfig;
   agent?: { template_dir: string; templates?: Array<{ source: string; target: string }>; copy_dirs?: string[]; symlinks?: string[] };
   env?: { template?: string; secrets_file?: string };
   services?: Array<{ name: string; path: string; start_command: string; docker_command?: string; health_url?: string; port?: number }>;

--- a/src/lib/workspace-config.ts
+++ b/src/lib/workspace-config.ts
@@ -127,9 +127,13 @@ export interface QualityGateConfig {
   container_name?: string;
 }
 
-export interface DatabaseConfig {
+export interface DatabaseConfig extends Record<string, unknown> {
+  /** Database name used by workspace database commands */
+  name: string;
   /** Path to seed file for database initialization */
   seed_file?: string;
+  /** Optional SQL query to verify a seed after loading */
+  seedVerifyQuery?: string;
   /** Command to run after loading seed (e.g., sanitization script) */
   seed_command?: string;
   /** Command to create snapshots from external source (e.g., kubectl exec pg_dump) */


### PR DESCRIPTION
**PRD:** `docs/codebase-health/E-tier1-dehardcode-myn.md` (Epic E). Removes hardcoded `myn` DB-name + the MYN-schema `SELECT count(*) FROM customer` probe from `cli/commands/db.ts` + `routes/workspaces/container-ops.ts`; adds `database.name` + `database.seedVerifyQuery` to the workspace config and reads them (no silent fallback). `rg '\bmyn\b|customer'` on those two files now returns nothing. **Orchestrator set MYN's machine-local `~/.overdeck/projects.yaml` `database.name: myn` + seedVerifyQuery to preserve MYN behavior** (the agent correctly flagged it couldn't edit machine-local config). **Verified (agent):** typecheck/lint/build + 640 tests pass. GPT-5.5 handoff.