### PR TITLE
test(review): fix red main — repoint review-agent introspection tests after #2124

### DIFF
--- a/docs/codebase-health/FIX-review-agent-test.md
+++ b/docs/codebase-health/FIX-review-agent-test.md
@@ -1,0 +1,59 @@
+# Fix red main — repoint `review-agent.test.ts` source-introspection tests after #2124
+
+**Branch:** `codebase-health/fix-review-agent-test` (off `main`) · **Executor:** GPT-5.5 (handoff), supervised by conv #182
+**Mode:** orchestrated handoff — **do NOT run `pan done`, do NOT open a PR.** Commit on this branch; the orchestrator reviews + merges.
+
+---
+
+## Root cause (verified)
+`main` is RED. PR #2124 decomposed `src/dashboard/server/routes/workspaces.ts` and **extracted the review routes into submodules**, but `tests/lib/cloister/review-agent.test.ts` still `readFileSync`s `workspaces.ts` and regex-matches for route code that has MOVED. 9 tests now get `null` matches → `expect(...).not.toBeNull()` fails.
+
+**Symbol → new location on `main` (verified with grep):**
+| Symbol | Now lives in |
+|---|---|
+| `postWorkspaceRequestReviewRoute` | `src/dashboard/server/routes/workspaces/review-pipeline.ts` |
+| `shouldTreatAsRerun(existingStatus)` | `…/workspaces/review-pipeline.ts` |
+| `getDirtyWorkspaceErrorForReviewRequest` | `…/workspaces/review-pipeline.ts` |
+| `runVerificationForIssue` usage (request-review) | `…/workspaces/review-pipeline.ts` |
+| gated-dispatch deferral (`reviewResult.gated`, `Review deferred for`) | `…/workspaces/review-pipeline.ts` |
+| `postWorkspaceResetReviewRoute` (old END delimiter) | `…/workspaces/review-control.ts` |
+| `postWorkspaceApproveRoute` / `POST /api/issues/:issueId/approve` | still `workspaces.ts` |
+
+## The 9 failing tests (all in `tests/lib/cloister/review-agent.test.ts`)
+1. `reviewStatus type-safety regression` → `does not write reviewStatus=dispatch_failed` (~L404)
+2. `request-review fresh convoy regression` → `forces review respawn…` (~L435)
+3. `passed-state rerun regression` → `rejects dirty workspaces before rerun dispatch` (~L507)
+4. `passed-state rerun regression` → `uses spawnReviewRoleForIssue in the rerun path` (~L525)
+5. `dispatch failure reviewStatus regression` → `blocks dirty worktrees before verification` (~L749)
+6. `dispatch failure reviewStatus regression` → `yields the verification Effect directly` (~L773)
+7. `dispatch failure reviewStatus regression` → `review request routes treat gated dispatches as deferrals` (~L812)
+8. `dispatch failure reviewStatus regression` → `approve route treats gated dispatches as deferrals` (~L833)
+9. `dispatch failure reviewStatus regression` → `dispatch failure paths set reviewStatus=pending not failed` (~L857)
+
+(Note: a 10th test in the same block, `specialists review restart route returns 409…` at ~L792, reads `specialists.ts` and is NOT failing — leave it alone.)
+
+## Fix approach (behavior-preserving, NO weakening of assertions)
+For each failing test, repoint the `readFileSync(...)` at the module that now contains the code, and fix the block-extraction:
+
+- **Tests 1, 2, 5, 6, 7, 9** (request-review block): read `…/workspaces/review-pipeline.ts`. The old extraction `routeSrc.match(/postWorkspaceRequestReviewRoute[\s\S]*?postWorkspaceResetReviewRoute/)` can no longer span two files. Since `review-pipeline.ts` IS the request-review module, set `requestReviewBlock = <the full review-pipeline.ts source>` (drop the cross-file regex), then keep the existing inner assertions unchanged. If an inner assertion needs a narrower scope, pick an in-module delimiter that actually exists in `review-pipeline.ts`.
+- **Tests 3, 4** (rerun block): read `…/workspaces/review-pipeline.ts`; the `/shouldTreatAsRerun\(existingStatus\)[\s\S]*?rerun:\s*true/` regex still works there — only the file path changes.
+- **Test 8** (approve route): approve stayed in `workspaces.ts`. Keep reading `workspaces.ts`, but VERIFY the `/POST \/api\/issues\/:issueId\/approve[\s\S]*?Fallback \(PAN-1531\): direct server-side rebase/` delimiters still both exist there; if the end-delimiter moved, pick one that exists in the current approve route.
+
+**Do NOT delete or weaken any inner `toContain`/`toMatch`/`toBeNull` assertion.** The route CODE moved verbatim; the asserted strings must still be present in the new module. If any assertion genuinely cannot be satisfied against the new module, STOP and report — that would mean #2124 changed behavior, not just location.
+
+Consider extracting a small top-level helper `readRouteSrc(relPath)` to DRY the repeated `readFileSync(resolve(import.meta.dirname, relPath), 'utf-8')`, but that is optional — minimal repointing is fine.
+
+## Verification (MUST run, in this worktree which has the post-#2124 code)
+```
+npx vitest run tests/lib/cloister/review-agent.test.ts --configLoader runner   # all green, 0 failed
+npm run typecheck && npm run lint
+```
+The first command is the real gate — these tests run against the actual new module layout in this worktree, so green here means the fix is correct.
+
+## Acceptance criteria
+- All 9 tests pass; the non-failing tests in the file still pass; no assertion weakened/removed.
+- `npx vitest run tests/lib/cloister/review-agent.test.ts` exit 0; typecheck + lint exit 0.
+- Diff touches ONLY `tests/lib/cloister/review-agent.test.ts` (+ this PRD).
+
+## Intersecting rules
+No bandaids (repoint to real new locations, don't weaken tests); surgical; worktree discipline (branch = `codebase-health/fix-review-agent-test`); conventional commit lowercase subject (e.g. `test(review): repoint review-agent introspection tests to extracted review modules`), never `--no-verify`; **do NOT run `pan done` or open a PR** — report to the orchestrator when green.

--- a/tests/lib/cloister/review-agent.test.ts
+++ b/tests/lib/cloister/review-agent.test.ts
@@ -401,16 +401,15 @@ describe('pan down integration (PAN-931)', () => {
 // The route must use 'failed' for reviewStatus so the type contract is maintained.
 
 describe('reviewStatus type-safety regression', () => {
-  it('workspaces.ts request-review route does not write reviewStatus=dispatch_failed', async () => {
+  it('review-pipeline.ts request-review route does not write reviewStatus=dispatch_failed', async () => {
     const { readFileSync } = await import('fs');
     const { resolve } = await import('path');
     const routeSrc = readFileSync(
-      resolve(import.meta.dirname, '../../../src/dashboard/server/routes/workspaces.ts'),
+      resolve(import.meta.dirname, '../../../src/dashboard/server/routes/workspaces/review-pipeline.ts'),
       'utf-8',
     );
-
     const requestReviewMatch = routeSrc.match(
-      /postWorkspaceRequestReviewRoute[\s\S]*?postWorkspaceResetReviewRoute/,
+      /const postWorkspaceRequestReviewRoute[\s\S]*?export const reviewPipelineRouteLayer/,
     );
     expect(requestReviewMatch).not.toBeNull();
     const requestReviewBlock = requestReviewMatch![0];
@@ -436,12 +435,11 @@ describe('request-review fresh convoy regression', () => {
     const { readFileSync } = await import('fs');
     const { resolve } = await import('path');
     const routeSrc = readFileSync(
-      resolve(import.meta.dirname, '../../../src/dashboard/server/routes/workspaces.ts'),
+      resolve(import.meta.dirname, '../../../src/dashboard/server/routes/workspaces/review-pipeline.ts'),
       'utf-8',
     );
-
     const requestReviewMatch = routeSrc.match(
-      /postWorkspaceRequestReviewRoute[\s\S]*?postWorkspaceResetReviewRoute/,
+      /const postWorkspaceRequestReviewRoute[\s\S]*?export const reviewPipelineRouteLayer/,
     );
     expect(requestReviewMatch).not.toBeNull();
     const requestReviewBlock = requestReviewMatch![0];
@@ -504,11 +502,11 @@ describe('stale synthesis session detection (PAN-1131)', () => {
 });
 
 describe('passed-state rerun regression', () => {
-  it('workspaces.ts request-review route rejects dirty workspaces before rerun dispatch', async () => {
+  it('review-pipeline.ts request-review route rejects dirty workspaces before rerun dispatch', async () => {
     const { readFileSync } = await import('fs');
     const { resolve } = await import('path');
     const routeSrc = readFileSync(
-      resolve(import.meta.dirname, '../../../src/dashboard/server/routes/workspaces.ts'),
+      resolve(import.meta.dirname, '../../../src/dashboard/server/routes/workspaces/review-pipeline.ts'),
       'utf-8',
     );
 
@@ -522,11 +520,11 @@ describe('passed-state rerun regression', () => {
     expect(rerunBlock).toContain('dirty workspace on rerun path');
   });
 
-  it('workspaces.ts request-review route uses spawnReviewRoleForIssue in the rerun path', async () => {
+  it('review-pipeline.ts request-review route uses spawnReviewRoleForIssue in the rerun path', async () => {
     const { readFileSync } = await import('fs');
     const { resolve } = await import('path');
     const routeSrc = readFileSync(
-      resolve(import.meta.dirname, '../../../src/dashboard/server/routes/workspaces.ts'),
+      resolve(import.meta.dirname, '../../../src/dashboard/server/routes/workspaces/review-pipeline.ts'),
       'utf-8',
     );
 
@@ -746,16 +744,15 @@ describe('deacon gated review deferral', () => {
 // dispatch error (e.g., tmux not ready, file-system issue).
 
 describe('dispatch failure reviewStatus regression', () => {
-  it('workspaces.ts request-review route blocks dirty worktrees before verification', async () => {
+  it('review-pipeline.ts request-review route blocks dirty worktrees before verification', async () => {
     const { readFileSync } = await import('fs');
     const { resolve } = await import('path');
     const routeSrc = readFileSync(
-      resolve(import.meta.dirname, '../../../src/dashboard/server/routes/workspaces.ts'),
+      resolve(import.meta.dirname, '../../../src/dashboard/server/routes/workspaces/review-pipeline.ts'),
       'utf-8',
     );
-
     const requestReviewMatch = routeSrc.match(
-      /postWorkspaceRequestReviewRoute[\s\S]*?postWorkspaceResetReviewRoute/,
+      /const postWorkspaceRequestReviewRoute[\s\S]*?export const reviewPipelineRouteLayer/,
     );
     expect(requestReviewMatch).not.toBeNull();
     const requestReviewBlock = requestReviewMatch![0];
@@ -770,16 +767,15 @@ describe('dispatch failure reviewStatus regression', () => {
     expect(requestReviewBlock).not.toContain('Effect.promise(() => getWorkspaceGitInfo(');
   });
 
-  it('workspaces.ts request-review route yields the verification Effect directly', async () => {
+  it('review-pipeline.ts request-review route yields the verification Effect directly', async () => {
     const { readFileSync } = await import('fs');
     const { resolve } = await import('path');
     const routeSrc = readFileSync(
-      resolve(import.meta.dirname, '../../../src/dashboard/server/routes/workspaces.ts'),
+      resolve(import.meta.dirname, '../../../src/dashboard/server/routes/workspaces/review-pipeline.ts'),
       'utf-8',
     );
-
     const requestReviewMatch = routeSrc.match(
-      /postWorkspaceRequestReviewRoute[\s\S]*?postWorkspaceResetReviewRoute/,
+      /const postWorkspaceRequestReviewRoute[\s\S]*?export const reviewPipelineRouteLayer/,
     );
     expect(requestReviewMatch).not.toBeNull();
     const requestReviewBlock = requestReviewMatch![0];
@@ -809,16 +805,15 @@ describe('dispatch failure reviewStatus regression', () => {
     expect(restartBlock).toContain('{ status: 409 }');
   });
 
-  it('workspaces.ts review request routes treat gated dispatches as deferrals', async () => {
+  it('review-pipeline.ts review request routes treat gated dispatches as deferrals', async () => {
     const { readFileSync } = await import('fs');
     const { resolve } = await import('path');
     const routeSrc = readFileSync(
-      resolve(import.meta.dirname, '../../../src/dashboard/server/routes/workspaces.ts'),
+      resolve(import.meta.dirname, '../../../src/dashboard/server/routes/workspaces/review-pipeline.ts'),
       'utf-8',
     );
-
     const requestReviewMatch = routeSrc.match(
-      /postWorkspaceRequestReviewRoute[\s\S]*?postWorkspaceResetReviewRoute/,
+      /const postWorkspaceRequestReviewRoute[\s\S]*?export const reviewPipelineRouteLayer/,
     );
     expect(requestReviewMatch).not.toBeNull();
     const requestReviewBlock = requestReviewMatch![0];
@@ -854,17 +849,15 @@ describe('dispatch failure reviewStatus regression', () => {
     expect(approveBlock).toContain('setReviewStatusBase(issueId, {');
   });
 
-  it('workspaces.ts dispatch failure paths set reviewStatus=pending not failed', async () => {
+  it('review-pipeline.ts dispatch failure paths set reviewStatus=pending not failed', async () => {
     const { readFileSync } = await import('fs');
     const { resolve } = await import('path');
     const routeSrc = readFileSync(
-      resolve(import.meta.dirname, '../../../src/dashboard/server/routes/workspaces.ts'),
+      resolve(import.meta.dirname, '../../../src/dashboard/server/routes/workspaces/review-pipeline.ts'),
       'utf-8',
     );
-
-    // Extract the request-review route block
     const requestReviewMatch = routeSrc.match(
-      /postWorkspaceRequestReviewRoute[\s\S]*?postWorkspaceResetReviewRoute/,
+      /const postWorkspaceRequestReviewRoute[\s\S]*?export const reviewPipelineRouteLayer/,
     );
     expect(requestReviewMatch).not.toBeNull();
     const requestReviewBlock = requestReviewMatch![0];


### PR DESCRIPTION
**Fixes red main.** #2124 extracted the review routes from `routes/workspaces.ts` into `workspaces/review-pipeline.ts` (request-review, rerun, gated-deferral, verification) and `workspaces/review-control.ts` (reset), but `tests/lib/cloister/review-agent.test.ts` kept grepping `workspaces.ts` for that code → 9 tests got null matches → red `test` job on main and on every branch since. Repoints the 9 introspection tests at the modules that now hold the code; **no assertions weakened** (route code moved verbatim). Brief: `docs/codebase-health/FIX-review-agent-test.md`. Verified: `vitest run review-agent.test.ts` 51/51, typecheck + lint green. GPT-5.5 handoff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a codebase health note describing recent review-route test failures and the recommended fix path.
* **Tests**
  * Updated review-agent test coverage to reflect the current review route locations.
  * Strengthened checks around rerun behavior, dirty-worktree handling, dispatch failures, and review status outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->