### PR TITLE
docs(codebase-health): mark epics A/B/C/E-Tier1 done on roadmap

### DIFF
--- a/docs/CODEBASE-HEALTH-ROADMAP.md
+++ b/docs/CODEBASE-HEALTH-ROADMAP.md
@@ -52,7 +52,7 @@ PRDs: [`docs/codebase-health/`](./codebase-health/). **Epic A complete** — com
 
 ### Epic B — Carve deep modules + unify the harness abstraction
 
-Decompose the god files into deep modules (narrow interface, hidden complexity) and replace the ~46 harness branch sites with a single `Harness` interface (extend the existing `src/lib/runtimes/AgentRuntimeSync`) plus one implementation per harness. **Prereq: Epic A (done).**
+Decompose the god files into deep modules (narrow interface, hidden complexity) and replace the remaining ~117 harness conditionals with a single `Harness` interface (extend the existing `src/lib/runtimes/AgentRuntimeSync`) plus one implementation per harness. **Prereq: Epic A (done).**
 
 **Sequencing decision:** B is far riskier than A — the highest-value seams (deacon auto-resume/merge, the harness migration, the `agents.ts` spawn path) touch the exact code behind our worst failure modes. So B proceeds in **waves, safest-first**: each wave extracts the *single lowest-risk seam* in a god file, behavior-preserving, compiler+test-verified, to prove the extraction pattern before the scary seams. Analysis maps for each file live in the agents' reports; the per-file full seam ladder is in each PRD's appendix.
 
@@ -64,11 +64,30 @@ Decompose the god files into deep modules (narrow interface, hidden complexity) 
 | **B2** | Extract container/docker routes | `routes/workspaces.ts` (6,638) → `routes/workspaces/container-ops.ts` | LOW | GLM-5.2 | `codebase-health/b2` |
 | **B3** | Extract read-only agent queries | `agents.ts` (5,824) → `agents/queries.ts` | LOW | Kimi-2.7 | `codebase-health/b3` |
 
-Merged: B1 #2117, B2 #2119, B3 #2118 — combined `main` CI green. PRDs: [`docs/codebase-health/`](./codebase-health/) (`B1-*`, `B2-*`, `B3-*`). Later waves tackle api-recovery/review/merge/auto-resume (deacon), workspace-data/review-pipeline/merge-ops (route), termination/delivery/state (agents), then the `Harness` interface migration.
+Merged: B1 #2117, B2 #2119, B3 #2118 — combined `main` CI green. PRDs: [`docs/codebase-health/`](./codebase-health/) (`B1-*`, `B2-*`, `B3-*`).
+
+**Backend god-file decomposition — ✅ COMPLETE (merged 2026-06-28):**
+
+| File | Result | PRs | Status |
+|---|---|---|---|
+| `src/lib/cloister/deacon.ts` | Decomposed into 8 modules | #2117, #2122 | ✅ merged |
+| `src/lib/agents.ts` | Decomposed into 4 modules | #2118, #2123 | ✅ merged |
+| `src/dashboard/server/routes/workspaces.ts` | Decomposed into `workspaces/{workspace-data,stash-clean,review-pipeline,review-control,container-ops,merge-ops}.ts` | #2117, #2119, #2124, #2126 | ✅ merged |
+
+**Frontend god-file decomposition — ✅ COMPLETE (merged 2026-06-28):**
+
+| File | Result | PR | Status |
+|---|---|---|---|
+| `SettingsPage.tsx` (4,200 lines) | Split into 6 seams: autosave + conversation-search hooks, voice / conversation-search / provider-management / TTS sections | #2127 | ✅ merged |
+| `KanbanBoard.tsx` (3,017 lines) | Split into 6 seams: utils, badges, dialogs, drag-drop hook, cards+columns, filter-bar | #2128 | ✅ merged |
+
+**Remaining B work:** the god-file decomposition waves are done. The `Harness` interface migration remains in progress on `codebase-health/harness-interface`; it consolidates the remaining harness conditionals behind the existing `src/lib/runtimes/` seam. Remaining large files outside this wave include `config-yaml.ts` (~3k) and `App.tsx` (~1.9k).
 
 ### Epic C — Fitness functions (evals + a frozen kernel)
 
 Adopt [`evalite`](https://github.com/mattpocock/evalite) for agent-behavior regression tests wired into CI; define and freeze a kernel (state doors, spawn, lifecycle) behind extra tests so entropy can't creep back.
+
+**Foundation status:** ✅ merged 2026-06-28 in #2121 — evalite harness, `npm run eval`, and the first eval landed. The remaining C work is expanding coverage around the frozen kernel and wiring the eval gate into the right CI path.
 
 ### Epic D — Process
 
@@ -77,6 +96,22 @@ One large migration at a time (finished before the next); a `/grilling` design-r
 ### Epic E — De-leak core (project-specifics out of Overdeck core)
 
 Core (`pan` CLI + dashboard server) must serve **any** project, but MYN-specific Postgres/Flyway database logic — including a hardcoded `myn` database name — is baked into core files. Same disease as the god files (wrong-layer logic), different flavor (domain leakage). **Tier 1:** de-hardcode `myn` → drive the DB name from project config (add a `name` field; replace ~6 hardcoded literals in `cli/commands/db.ts` and `routes/workspaces.ts`). **Tier 2 (direction TBD):** move the Flyway/Postgres machinery out of core — either invoke a project-declared command, or extract a plugin/extension. Full audit + plan: [`docs/codebase-health/E-de-leak-core.md`](./codebase-health/E-de-leak-core.md).
+
+**Tier 1 status:** ✅ merged 2026-06-28 in #2125 — the database name is now config-driven through `database.name`, and workspace config carries `seedVerifyQuery`. Tier 2 remains: move the MYN Flyway/Postgres repair machinery out of core, either behind a project-declared command or a plugin/extension seam.
+
+---
+
+## Red-main incident — resolved 2026-06-28
+
+The workspaces decomposition in #2124 moved review routes out of `routes/workspaces.ts` into `routes/workspaces/review-pipeline.ts` and `routes/workspaces/review-control.ts`. Nine source-introspection tests in `tests/lib/cloister/review-agent.test.ts` still grepped `workspaces.ts` for that code, so the `test` job went red on `main`.
+
+Fix: #2129 repointed all nine tests to the new route files without weakening assertions. The same root cause also hit the merge-ops branch; the approve-route introspection was repointed inline in commit `d4e9181c2`.
+
+Lessons:
+
+- Run the FULL test suite before merge, not just typecheck/lint/build.
+- Verify against `origin/main` HEAD, not a stale local checkout; the local checkout was 51 commits behind.
+- When decomposing a file, repoint its source-introspection tests in the same PR.
 
 ---
 
@@ -99,10 +134,14 @@ These changes modify the agents' **own substrate** — lint rules, the build, th
 - [x] **B1** — extract `deacon-inspect.ts` — GPT-5.5 — merged #2117
 - [x] **B2** — extract `container-ops.ts` — GLM-5.2 — merged #2119
 - [x] **B3** — extract `agents/queries.ts` — Kimi-2.7 — merged #2118
-- [ ] **B (later waves)** — api-recovery/review/merge/auto-resume · workspace-data/review-pipeline/merge-ops · termination/delivery/state · `Harness` interface
-- [ ] **C** — evals + frozen kernel (PRDs TBD)
+- [x] **B (backend god files)** — deacon full decomp (#2122) · agents full decomp (#2123) · workspaces final decomp (#2124) · merge-ops seam (#2126)
+- [x] **B (frontend god files)** — `SettingsPage.tsx` (#2127) · `KanbanBoard.tsx` (#2128)
+- [ ] **B (later waves)** — `Harness` interface consolidation in progress on `codebase-health/harness-interface`
+- [x] **C** — evalite foundation + `npm run eval` + first eval — merged #2121
+- [ ] **C (later)** — frozen kernel eval coverage + CI gate placement
 - [ ] **D** — process gates (PRDs TBD)
-- [ ] **E** — de-leak core: Tier 1 de-hardcode `myn` (ready) · Tier 2 de-core DB machinery (direction TBD) — see [`E-de-leak-core.md`](./codebase-health/E-de-leak-core.md)
+- [x] **E Tier 1** — de-hardcode `myn` via config-driven `database.name` + `seedVerifyQuery` — merged #2125
+- [ ] **E Tier 2** — de-core MYN Flyway/Postgres repair machinery (direction TBD) — see [`E-de-leak-core.md`](./codebase-health/E-de-leak-core.md)
 
 ---
 

--- a/docs/codebase-health/HOUSEKEEP-roadmap-update.md
+++ b/docs/codebase-health/HOUSEKEEP-roadmap-update.md
@@ -1,0 +1,32 @@
+# Housekeeping — bring the roadmap doc current (batch done 2026-06-28)
+
+**Branch:** `codebase-health/housekeep-roadmap` · **Executor:** GPT-5.5 (handoff), supervised by conv #182.
+**Mode:** orchestrated handoff — **do NOT run `pan done`, do NOT open a PR.** Commit on this branch; the orchestrator reviews + merges.
+
+## Task
+Update `docs/CODEBASE-HEALTH-ROADMAP.md` (read it first) so it reflects what actually landed on `main` today. Mark the completed epics DONE with PR numbers, add the red-main incident + lessons, and list what remains. Keep the doc's existing structure/voice; this is a status refresh, not a rewrite.
+
+## Facts to record (all merged to origin/main 2026-06-28, CI green)
+- **Epic A (ratchets) — DONE:** no-explicit-any ratchet (#2113), ts-reset (#2114), file-size guard (#2115).
+- **Epic B (deep-module decomposition) — backend god files DONE:**
+  - `src/lib/cloister/deacon.ts` → 8 modules (#2122)
+  - `src/lib/agents.ts` → 4 modules (#2123)
+  - `src/dashboard/server/routes/workspaces.ts` → 6 modules: `workspaces/{workspace-data,stash-clean,review-pipeline,review-control,container-ops,merge-ops}.ts` (wave-1 #2117/#2119, wave-2 #2122–#2124, merge-ops #2126)
+- **Epic B — frontend god files DONE:**
+  - `SettingsPage.tsx` (4,200 lines) → 6 seams: autosave + conversation-search hooks, voice / conversation-search / provider-management / tts sections (#2127)
+  - `KanbanBoard.tsx` (3,017 lines) → 6 seams: utils, badges, dialogs, drag-drop hook, cards+columns, filter-bar (#2128)
+- **Epic C (evals) — foundation DONE:** evalite harness + `npm run eval` + first eval (#2121).
+- **Epic E Tier 1 — DONE:** `myn` database name de-hardcoded → config-driven `database.name` + `seedVerifyQuery` in workspace config (#2125).
+- **Red-main incident (resolved, #2129):** the workspaces decomposition (#2124) moved review routes into `routes/workspaces/review-pipeline.ts` / `review-control.ts`, breaking 9 source-introspection tests in `tests/lib/cloister/review-agent.test.ts` that grepped `workspaces.ts` for that code. Fixed by repointing the tests (no assertions weakened). **Lessons:** run the FULL test suite before merge (not just typecheck/lint/build); verify against `origin/main` HEAD, not a stale local checkout; when decomposing a file, repoint its source-introspection tests in the same PR.
+
+## Remaining (mark as not-yet-done / in-progress)
+- **Epic B — Harness interface:** ~117 `harness ===/!==` conditionals → consolidate behind the existing `src/lib/runtimes/` seam (IN PROGRESS, `codebase-health/harness-interface`).
+- Remaining large files: `config-yaml.ts` (~3k), `App.tsx` (~1.9k).
+- **Epic E Tier 2:** move the MYN Flyway/Postgres repair machinery out of core (config-command vs plugin).
+- **Epic D:** process gates (one-migration-at-a-time, design gate).
+
+## Verify / acceptance
+- `docs/CODEBASE-HEALTH-ROADMAP.md` reflects the above; internal cross-references stay valid.
+- Diff touches ONLY `docs/CODEBASE-HEALTH-ROADMAP.md` (+ this brief). No code changes → no build needed, but run `npm run lint` if the repo lints markdown (skip if it doesn't).
+- Conventional commit, lowercase subject (e.g. `docs(codebase-health): mark epics a/b/c/e-tier1 done`). Never `--no-verify`.
+- **Do NOT run `pan done` or open a PR** — report when committed.


### PR DESCRIPTION
Roadmap status refresh: Epics A, B (all god files), C, E-Tier1 marked DONE with PR numbers + red-main lessons + remaining work. Docs-only.