### PR TITLE
feat(runtimes): Harness behavior interface (Phase 1 keystone)

### DIFF
--- a/docs/codebase-health/B-harness-interface.md
+++ b/docs/codebase-health/B-harness-interface.md
@@ -51,3 +51,78 @@ No bandaids; behavior-preserving; full-suite verify (NOT a subset); verify again
 
 ---
 <!-- Executor: append the design doc (behavior→method map, interface shape, per-runtime notes, Phase-2 partition) below this line as you go. -->
+
+## Phase 1 Design Doc
+
+### Behavior Inventory
+
+The current `harness === ...` / `harness !== ...` branches fall into these behavior groups:
+
+| Behavior | Old branch shape | New runtime behavior field |
+| --- | --- | --- |
+| Launch command family | `harness === 'ohmypi'` builds `omp --mode rpc`; `harness === 'codex'` delegates to Codex work TUI; otherwise Claude Code | `launchCommandKind`, `workAgentMode`, `executableName` |
+| Delivery transport | Claude Code prefers PTY supervisor/Channels/tmux; ohmypi uses RPC FIFO; Codex uses `codex exec resume`; conversations sometimes preserve explicit tmux fallback | `deliveryKind`, `usesRpcFifo`, `usesCodexHome` |
+| Readiness signal | Codex waits for TUI prompt; Claude Code waits for session signal; ohmypi waits for `ready.json` | `readinessKind`, `readyTimeoutSeconds` |
+| Transcript/session storage | Claude JSONL under `~/.claude/projects`; ohmypi JSONL under per-agent sessions; Codex rollout JSONL under per-agent `codex-home` | `transcriptKind`, `sessionIdSource`, existing `getSessionPath()` |
+| Context/feed naming | Claude, Pi, Codex context-layer/feed names differ | `contextLayerKind`, `feedKind` |
+| Capability gates | PTY supervisor, Channels MCP, streaming, patch projection, prompt-time memory | `supportsPtySupervisor`, `supportsChannelsBridge`, `supportsConversationStreaming`, `supportsPatchProjection`, `injectsPromptTimeMemory` |
+| Process liveness | Expected executable in the tmux pane process tree | `processNames` |
+| Display/status labels | User-facing runtime names and timeout/error labels | `displayName`, `executableName`, `readyTimeoutSeconds` |
+| Validation/normalization | Accept `claude-code`/`ohmypi`/`codex`; normalize legacy `pi` to ohmypi behavior where old state can appear | `getHarnessBehavior(harness)` plus existing `normalizeHarness()`/registry dispatch |
+
+### Interface Shape
+
+Phase 1 extends the existing `src/lib/runtimes/` seam, not a parallel abstraction:
+
+- `src/lib/runtimes/types.ts` now defines `HarnessName`, `HarnessBehavior`, and the small literal unions that describe behavior choices.
+- `AgentRuntimeSync` and `AgentRuntime` both expose `getHarnessBehavior(): HarnessBehavior`.
+- `src/lib/runtimes/behavior.ts` exports immutable behavior constants for `claude-code`, `ohmypi`, and `codex`, plus `getHarnessBehavior(harness)` for old call sites that have only a harness string.
+- `src/lib/runtimes/index.ts` re-exports the behavior API alongside the registry and runtime classes.
+
+The behavior constants intentionally preserve today's quirks:
+
+| Runtime | Key preserved behavior |
+| --- | --- |
+| `claude-code` | executable/process `claude`; Claude JSONL transcripts; launcher session id; Claude context/feed names; PTY supervisor and Channels-capable; no conversation streaming flag; 30s default readiness. |
+| `ohmypi` | executable/process `omp`; RPC FIFO delivery; `ready.json` readiness; session id from transcript JSONL; Pi context/feed names; streaming enabled; no PTY supervisor/Channels; prompt-time memory enabled; 120s readiness. |
+| legacy `pi` | `getHarnessBehavior('pi')` returns the exact `ohmypi` behavior object so old persisted state and old branch sites normalize behavior-preservingly. |
+| `codex` | executable/process `codex`; Codex work TUI mode; `codex exec resume` delivery; TUI prompt readiness; rollout JSONL transcripts; thread id session source; Codex context/feed names; PTY supervisor-capable but Channels-off; Codex home required; 30s readiness. |
+
+### Phase 1 Validation Migrations
+
+Only three representative `src/lib/agents.ts` call sites were migrated:
+
+1. `hasAgentRuntimeInSubtree()` now gets expected process names from `getHarnessBehavior(harness).processNames`.
+2. `waitForPromptReady()` now routes Codex through `getHarnessBehavior(harness).readinessKind === 'codex-tui-prompt'`.
+3. `decideSupervisorForWorkAgent()` now uses `supportsPtySupervisor`; missing `state.harness` remains ineligible as before (`harness-unknown`).
+
+Targeted verification for these migrations:
+
+- `npm run typecheck`
+- `npx vitest run --configLoader runner src/lib/runtimes/__tests__/registry-dispatch.test.ts`
+- `npx vitest run --configLoader runner src/lib/__tests__/agents-spawn-supervisor.test.ts`
+
+### Phase 2 Migration Partition
+
+Use this table for the fan-out. Each agent should touch only its assigned file(s), replace local branches with `getHarnessBehavior(...)`/runtime methods, and update nearby tests that introspect the old branch text.
+
+| Phase 2 slice | File(s) | Remaining branches | Behavior fields / methods to use | Notes |
+| --- | --- | ---: | --- | --- |
+| conversations-heavy | `src/dashboard/server/routes/conversations.ts` | 21 | `deliveryKind`, `readinessKind`, `transcriptKind`, `sessionIdSource`, `supportsConversationStreaming`, `supportsPatchProjection`, `usesCodexHome`, `contextLayerKind`, `displayName` | Highest-risk slice. Preserve explicit conversation `deliveryMethod` fallback semantics; do not collapse `harnessChanged = harness !== currentHarness` because that is equality detection, not behavior dispatch. |
+| agents-followup | `src/lib/agents.ts`, `src/lib/agents/activity.ts`, `src/lib/agents/delivery.ts` | 19 total across these files after Phase 1 (`agents.ts` has 16) | `launchCommandKind`, `workAgentMode`, `deliveryKind`, `usesRpcFifo`, `usesCodexHome`, `contextLayerKind`, `sessionIdSource`, `readyTimeoutSeconds`, `displayName` | Continue from the three migrated examples. Preserve `state.harness` missing/unknown edge cases in eligibility checks. |
+| ws-rpc | `src/dashboard/server/ws-rpc.ts` | 7 | `launchCommandKind`, `usesRpcFifo`, `usesCodexHome`, `transcriptKind`, `displayName` | Mirrors route-agent spawning/status decisions; keep legacy `pi` handling behavior-identical. |
+| launcher-generator | `src/lib/launcher-generator.ts` | 5 | `launchCommandKind`, `workAgentMode`, `usesRpcFifo`, `usesCodexHome`, `executableName` | This is command construction. Replace branch predicates only after verifying generated launcher snapshots or existing launcher tests. |
+| settings-policy | `src/lib/settings-api.ts`, `src/lib/harness-policy.ts`, `src/lib/config-yaml.ts`, `src/cli/commands/start.ts`, `src/cli/commands/handoff.ts`, `src/dashboard/server/routes/issues.ts` | 15 | `getHarnessBehavior()` for display/capabilities where applicable; keep explicit valid-harness sets or add a dedicated runtime validation helper if needed | Validation branches are not all behavior dispatch. Do not replace allowed-value checks with behavior defaults that would accept unknown harnesses. |
+| conversation-service | `src/dashboard/server/services/conversation-service.ts`, `src/dashboard/server/services/conversation-lifecycle.ts`, `src/dashboard/server/routes/jsonl-resolver.ts` | 10 | `transcriptKind`, `sessionIdSource`, `supportsConversationStreaming`, existing `getSessionPath()` | Parser selection and lifecycle filtering. Preserve legacy `pi` file detection fallbacks. |
+| frontend-feed-stream | `src/dashboard/frontend/src/components/chat/useConversationMessagesStream.ts`, `src/dashboard/frontend/src/components/sessionFeed/useConversationFeed.ts`, `src/dashboard/server/routes/context.ts`, `src/cli/commands/context-layers.ts` | 11 | `supportsConversationStreaming`, `supportsPatchProjection`, `feedKind`, `contextLayerKind`, `displayName` | If importing server-side runtime code into frontend is inappropriate, create a small shared pure behavior module or generated contract; do not duplicate constants by hand. |
+| memory-planning-longtail | `src/lib/conversations/smart-compaction.ts`, `src/lib/memory/pipeline.ts`, `src/lib/memory/transcript-source.ts`, `src/lib/graceful-restart.ts`, `src/lib/planning/spawn-planning-session.ts` | 8 | `deliveryKind`, `transcriptKind`, `sessionIdSource`, `executableName`, `supportsPtySupervisor`, `usesRpcFifo`, `usesCodexHome` | Long-tail runtime behavior. Keep source filters that are intentionally data queries if replacing them would obscure query semantics. |
+| records-normalization | `src/lib/overdeck/conversations.ts`, `src/lib/overdeck/agent-rollback-state.ts`, `src/lib/pan-dir/record.ts` | 5 | Existing normalization helpers; add a validation helper only if it remains explicit about allowed persisted strings | These branches are canonical state normalization/equality, not necessarily runtime behavior. Be conservative. |
+| tests-introspection | `src/lib/cost-parsers/__tests__/ohmypi-parser.test.ts`, `src/lib/__tests__/harness-policy.test.ts`, `src/dashboard/frontend/src/components/Settings/__tests__/SettingsPage.test.ts`, `src/lib/runtimes/__tests__/registry-dispatch.test.ts` | 7 | Update assertions to the new source location when the referenced production branch moves | Required by FR-5. Do this in the same PR as the production migration that moves the referenced logic. |
+
+Post-Phase-1 inventory from this worktree:
+
+```bash
+git grep -nE "harness === |harness !== " -- 'src/**/*.ts' | cut -d: -f1 | sort | uniq -c | sort -nr
+```
+
+The largest remaining files are `conversations.ts` (21), `agents.ts` (16), `ws-rpc.ts` (7), `launcher-generator.ts` (5), `settings-api.ts` (4), `harness-policy.ts` (4), and `conversation-service.ts` (4). The new runtime behavior file and registry test intentionally contain a few harness comparisons to implement and verify the central dispatch itself.

--- a/docs/codebase-health/B-harness-interface.md
+++ b/docs/codebase-health/B-harness-interface.md
@@ -1,0 +1,53 @@
+# B — Harness interface (Phase 1: the keystone)
+
+**Epic:** B · **Branch:** `codebase-health/harness-interface` (off `main`) · **Executor:** GPT-5.5 (handoff), supervised by conv #182.
+**Mode:** orchestrated handoff — **do NOT run `pan done`, do NOT open a PR.** Commit per coherent step; the orchestrator reviews + merges. This is the **highest-risk** change in the campaign — be conservative, behavior-preserving, and verify with the FULL test suite.
+
+---
+
+## Problem
+~117 `harness === 'claude-code'` / `harness === 'pi'` / `harness !== …` conditionals are scattered across the codebase, each re-deciding harness-specific behavior inline. Concentrations: `src/dashboard/server/routes/conversations.ts` (21), `src/lib/agents.ts` (19), `src/dashboard/server/ws-rpc.ts` (7), `src/lib/launcher-generator.ts` (5), `src/lib/settings-api.ts` (4), `src/lib/harness-policy.ts` (4), `src/dashboard/server/services/conversation-service.ts` (4), + a long tail. Find them all: `git grep -nE "harness === |harness !== " -- 'src/**/*.ts'`.
+
+There is **already a runtime-abstraction seam**: `src/lib/runtimes/` with per-runtime modules (`claude-code.ts`, `codex.ts`, `ohmypi.ts`, `ohmypi-fifo.ts`, `pi.ts`, `pi-fifo.ts`) and a registry (`index.ts`). **Read that whole directory first** — the goal is to EXTEND this existing interface, not invent a parallel one.
+
+## Goal (Phase 1 — keystone only)
+1. **Analyze** the 117 conditionals and group them into a small set of distinct *behaviors* (e.g. build-launch-command, deliver-message transport, session-id / transcript-path resolution, ToS/auth policy, capability flags, etc.). Produce the behavior list.
+2. **Extend the `src/lib/runtimes/` interface** with a method (or capability field) per behavior, and **implement each per-runtime** so the interface can fully replace the inline branches — behavior IDENTICAL to today's conditionals for every harness.
+3. **Validate** by migrating **2–3 representative call sites** (e.g. a couple in `agents.ts`) onto the new interface and proving behavior is unchanged. **Do NOT migrate all 117 here** — the bulk is Phase 2 (a fan-out the orchestrator will run per-file once this interface lands).
+4. **Write the design doc** (this file — append below the brief): the behavior→method map, the final interface shape, per-runtime implementation notes, and a **Phase-2 migration partition** — a table of `{file → which behaviors/branches → which interface methods to call}` so each fan-out agent has an unambiguous, conflict-free slice.
+
+## Requirements
+**FR-1** The extended interface lives in `src/lib/runtimes/` (extend the existing interface/registry; do not create a competing abstraction). Every new method is implemented for ALL runtimes (claude-code, codex, ohmypi, pi, + fifo variants as applicable).
+**FR-2** Behavior-preserving: for every harness, the interface method returns/does exactly what the corresponding inline `harness === …` branch does today. Where behavior is subtle (see "Harness facts" below), replicate it precisely — do not "clean up" semantics.
+**FR-3** Additive: the 114-ish un-migrated call sites still compile and behave identically (old branches remain until Phase 2). Only the 2–3 validation call sites are migrated here.
+**FR-4** `npm run typecheck` + `npm run lint` + **the FULL `npm test` suite** pass (`npx vitest run --configLoader runner`). The full suite is mandatory — a partial/targeted run is NOT acceptable (a prior decomposition went red on main precisely because only a subset was run). Existing runtime tests in `src/lib/runtimes/__tests__/` must stay green; add tests for new interface methods.
+**FR-5** When you MOVE harness logic, grep for tests that introspect or import the old location and update them in THIS PR (`git grep -n "harness ===" -- tests/`; also check `src/lib/runtimes/__tests__/`).
+
+**NFR-1** No new explicit `any` (A1 ratchet); new `runtimes/` files < 1000 lines (file-size guard). No `execSync` in server-reachable code (async only). Async tmux primitives only.
+**NFR-2** Conservative scope: this PR is interface + per-runtime impl + 2–3 validation migrations + the design doc. Nothing else.
+
+## Harness facts to preserve (from repo rules — replicate, don't redesign)
+- **claude-code** Claude work/conversation agents use the **PTY supervisor** delivery path (`dist/pty-supervisor.js`), `OVERDECK_AGENT_ID`, per-agent `pty-token`; `deliverAgentMessage` tries supervisor → legacy Channels MCP → tmux paste-buffer.
+- **pi** uses an `rpc.in` FIFO transport; **codex** work agents use `work-tui` mode (never `codex exec`).
+- Model routing: kimi → ohmypi, gpt-5.5 → codex, native `claude-*` → claude-code. Pi + Anthropic + subscription auth is ToS-blocked (`harness-policy.ts`).
+- Session-id / transcript resolution differs per harness (pi session id lives in the transcript filename; claude-code in launcher-pinned `--session-id`). Preserve exactly.
+
+## Verification
+```
+git grep -nE "harness === |harness !== " -- 'src/**/*.ts' | wc -l   # baseline before; should drop only by the 2-3 validated sites
+npm run typecheck && npm run lint
+npx vitest run --configLoader runner        # FULL suite, 0 failed — MANDATORY
+```
+
+## Acceptance criteria
+- Extended `runtimes/` interface with per-behavior methods, implemented for every runtime; new unit tests for them green.
+- 2–3 representative call sites migrated and behavior-identical; remaining branches untouched and still green.
+- Full `vitest run` exit 0; typecheck + lint exit 0.
+- Design doc section written with the behavior→method map AND a concrete Phase-2 file-partition table.
+- Report to the orchestrator when green, with the Phase-2 partition, so the migration fan-out can start.
+
+## Intersecting rules (restated)
+No bandaids; behavior-preserving; full-suite verify (NOT a subset); verify against this worktree's post-`main` code; A1 ratchet; file-size guard; async tmux + no execSync; never force `--harness` for CLIProxy models; worktree discipline (branch = `codebase-health/harness-interface`; never `git checkout <branch>`/`git stash`); conventional commits lowercase subject, never `--no-verify`; **do NOT run `pan done` or open a PR** — report blockers/when-green to the orchestrator.
+
+---
+<!-- Executor: append the design doc (behavior→method map, interface shape, per-runtime notes, Phase-2 partition) below this line as you go. -->

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -13,6 +13,7 @@ import { getClaudePermissionFlagsStringSync, resolvePermissionModeSync } from '.
 import { createSessionSync, createSession, killSessionSync, killSession, sendKeys, sendRawKeystroke, sessionExistsSync, sessionExists, listSessions, listSessionsSync, capturePaneSync, capturePane, listPaneValuesSync, listPaneValues, isPaneDead, setOption, exactPaneTarget } from './tmux.js';
 import { initHookSync, checkHookSync, generateFixedPointPromptSync } from './hooks.js';
 import { findLatestRollout, extractThreadIdFromRollout, initCodexHome } from './runtimes/codex.js';
+import { getHarnessBehavior } from './runtimes/behavior.js';
 import { startWorkSync, completeWorkSync, getAgentCVSync } from './cv.js';
 import { BLANKED_PROVIDER_ENV } from './child-env.js';
 import type { ModelId, ComplexityLevel } from './settings.js';
@@ -161,7 +162,7 @@ function isNodeNotFound(error: unknown): boolean {
  * be the runtime directly for specialists (`exec claude ...` / `exec pi ...`).
  */
 async function hasAgentRuntimeInSubtree(rootPid: string, harness: RuntimeName = 'claude-code'): Promise<boolean> {
-  const expectedProcessNames = harness === 'ohmypi' ? new Set(['omp']) : harness === 'codex' ? new Set(['codex']) : new Set(['claude']);
+  const expectedProcessNames = new Set(getHarnessBehavior(harness).processNames);
   const queue: string[] = [rootPid];
   const seen = new Set<string>();
   while (queue.length > 0) {
@@ -367,7 +368,7 @@ async function waitForCodexTuiReady(agentId: string, timeoutSec = 30): Promise<b
 }
 
 export async function waitForPromptReady(agentId: string, harness: RuntimeName | undefined, timeoutSec = 30): Promise<boolean> {
-  if (harness === 'codex') return waitForCodexTuiReady(agentId, timeoutSec);
+  if (getHarnessBehavior(harness).readinessKind === 'codex-tui-prompt') return waitForCodexTuiReady(agentId, timeoutSec);
   return waitForReadySignal(agentId, timeoutSec);
 }
 
@@ -1719,7 +1720,8 @@ export function decideSupervisorForWorkAgent(
     return { eligible: false, reason: 'docker-not-supported-yet' };
   }
 
-  if (state.harness !== 'claude-code' && state.harness !== 'codex') {
+  const behavior = state.harness ? getHarnessBehavior(state.harness) : null;
+  if (!behavior?.supportsPtySupervisor) {
     const reason = `harness-${state.harness ?? 'unknown'}`;
     log(false, reason);
     return { eligible: false, reason };

--- a/src/lib/runtimes/__tests__/registry-dispatch.test.ts
+++ b/src/lib/runtimes/__tests__/registry-dispatch.test.ts
@@ -28,12 +28,14 @@ vi.mock('../../paths.js', async (importOriginal) => ({
   encodeClaudeProjectDir: (p: string) => p,
 }))
 
-import { RuntimeRegistry, setGlobalRegistry, getGlobalRegistry } from '../index.js'
-import type { AgentRuntimeSync } from '../types.js'
+import { RuntimeRegistry, setGlobalRegistry, getGlobalRegistry, getHarnessBehavior } from '../index.js'
+import type { AgentRuntimeSync, HarnessBehavior } from '../types.js'
 
-function stubRuntime(name: 'claude-code' | 'pi' | 'ohmypi'): AgentRuntimeSync {
+function stubRuntime(name: 'claude-code' | 'ohmypi' | 'codex'): AgentRuntimeSync {
+  const behavior = getHarnessBehavior(name)
   return {
     name,
+    getHarnessBehavior: () => behavior,
     getSessionPath: () => null,
     getLastActivity: () => null,
     getHeartbeat: () => null,
@@ -72,8 +74,8 @@ describe('RuntimeRegistry.getRuntimeForAgent dispatches by state.harness (PAN-63
     savedRegistry = getGlobalRegistry()
     const fresh = new RuntimeRegistry()
     fresh.register(stubRuntime('claude-code'))
-    fresh.register(stubRuntime('pi'))
     fresh.register(stubRuntime('ohmypi'))
+    fresh.register(stubRuntime('codex'))
     setGlobalRegistry(fresh)
   })
   afterEach(() => {
@@ -88,6 +90,11 @@ describe('RuntimeRegistry.getRuntimeForAgent dispatches by state.harness (PAN-63
   it('returns the ohmypi runtime when state.harness === "ohmypi" (PAN-1989)', () => {
     writeAgentState('agent-ohmypi-1', { harness: 'ohmypi' })
     expect(getGlobalRegistry().getRuntimeForAgent('agent-ohmypi-1')?.name).toBe('ohmypi')
+  })
+
+  it('returns the codex runtime when state.harness === "codex" (PAN-1574)', () => {
+    writeAgentState('agent-codex-1', { harness: 'codex' })
+    expect(getGlobalRegistry().getRuntimeForAgent('agent-codex-1')?.name).toBe('codex')
   })
 
   it('returns the claude-code runtime when state.harness === "claude-code" (AC1)', () => {
@@ -107,6 +114,94 @@ describe('RuntimeRegistry.getRuntimeForAgent dispatches by state.harness (PAN-63
 
   it('returns null when no agent state exists', () => {
     expect(getGlobalRegistry().getRuntimeForAgent('agent-unknown')).toBeNull()
+  })
+})
+
+function pickBehaviorFields(behavior: HarnessBehavior): Record<string, unknown> {
+  return {
+    executableName: behavior.executableName,
+    processNames: behavior.processNames,
+    launchCommandKind: behavior.launchCommandKind,
+    deliveryKind: behavior.deliveryKind,
+    readinessKind: behavior.readinessKind,
+    transcriptKind: behavior.transcriptKind,
+    sessionIdSource: behavior.sessionIdSource,
+    contextLayerKind: behavior.contextLayerKind,
+    feedKind: behavior.feedKind,
+    supportsPtySupervisor: behavior.supportsPtySupervisor,
+    supportsChannelsBridge: behavior.supportsChannelsBridge,
+    supportsConversationStreaming: behavior.supportsConversationStreaming,
+    supportsPatchProjection: behavior.supportsPatchProjection,
+    usesRpcFifo: behavior.usesRpcFifo,
+    usesCodexHome: behavior.usesCodexHome,
+    injectsPromptTimeMemory: behavior.injectsPromptTimeMemory,
+    workAgentMode: behavior.workAgentMode,
+    readyTimeoutSeconds: behavior.readyTimeoutSeconds,
+  }
+}
+
+describe('getHarnessBehavior', () => {
+  it('preserves Claude Code behavior switches', () => {
+    expect(pickBehaviorFields(getHarnessBehavior('claude-code'))).toEqual({
+      executableName: 'claude',
+      processNames: ['claude'],
+      launchCommandKind: 'claude-code',
+      deliveryKind: 'pty-supervisor',
+      readinessKind: 'claude-session-signal',
+      transcriptKind: 'claude-jsonl',
+      sessionIdSource: 'launcher-session-id',
+      contextLayerKind: 'claude',
+      feedKind: 'claude_code',
+      supportsPtySupervisor: true,
+      supportsChannelsBridge: true,
+      supportsConversationStreaming: false,
+      supportsPatchProjection: true,
+      usesRpcFifo: false,
+      usesCodexHome: false,
+      injectsPromptTimeMemory: false,
+      workAgentMode: 'claude-code',
+      readyTimeoutSeconds: 30,
+    })
+  })
+
+  it('normalizes legacy pi to ohmypi behavior switches', () => {
+    expect(getHarnessBehavior('pi')).toBe(getHarnessBehavior('ohmypi'))
+    expect(pickBehaviorFields(getHarnessBehavior('ohmypi'))).toMatchObject({
+      executableName: 'omp',
+      processNames: ['omp'],
+      deliveryKind: 'rpc-fifo',
+      readinessKind: 'ohmypi-ready-file',
+      transcriptKind: 'ohmypi-jsonl',
+      sessionIdSource: 'transcript-jsonl',
+      contextLayerKind: 'pi',
+      feedKind: 'pi',
+      supportsPtySupervisor: false,
+      supportsChannelsBridge: false,
+      supportsConversationStreaming: true,
+      usesRpcFifo: true,
+      readyTimeoutSeconds: 120,
+    })
+  })
+
+  it('preserves Codex behavior switches', () => {
+    expect(pickBehaviorFields(getHarnessBehavior('codex'))).toMatchObject({
+      executableName: 'codex',
+      processNames: ['codex'],
+      launchCommandKind: 'codex-work-tui',
+      deliveryKind: 'codex-exec-resume',
+      readinessKind: 'codex-tui-prompt',
+      transcriptKind: 'codex-rollout-jsonl',
+      sessionIdSource: 'codex-thread-id',
+      contextLayerKind: 'codex',
+      feedKind: 'codex',
+      supportsPtySupervisor: true,
+      supportsChannelsBridge: false,
+      supportsConversationStreaming: true,
+      supportsPatchProjection: true,
+      usesCodexHome: true,
+      workAgentMode: 'codex-work-tui',
+      readyTimeoutSeconds: 30,
+    })
   })
 })
 

--- a/src/lib/runtimes/behavior.ts
+++ b/src/lib/runtimes/behavior.ts
@@ -1,0 +1,83 @@
+import type { HarnessBehavior, HarnessName, RuntimeName } from './types.js';
+
+export const CLAUDE_CODE_BEHAVIOR: HarnessBehavior = {
+  displayName: 'Claude Code',
+  executableName: 'claude',
+  processNames: ['claude'],
+  launchCommandKind: 'claude-code',
+  deliveryKind: 'pty-supervisor',
+  readinessKind: 'claude-session-signal',
+  transcriptKind: 'claude-jsonl',
+  sessionIdSource: 'launcher-session-id',
+  contextLayerKind: 'claude',
+  feedKind: 'claude_code',
+  supportsPtySupervisor: true,
+  supportsChannelsBridge: true,
+  supportsConversationStreaming: false,
+  supportsPatchProjection: true,
+  usesRpcFifo: false,
+  usesCodexHome: false,
+  injectsPromptTimeMemory: false,
+  workAgentMode: 'claude-code',
+  readyTimeoutSeconds: 30,
+};
+
+export const OHMYPI_BEHAVIOR: HarnessBehavior = {
+  displayName: 'Pi',
+  executableName: 'omp',
+  processNames: ['omp'],
+  launchCommandKind: 'ohmypi-rpc',
+  deliveryKind: 'rpc-fifo',
+  readinessKind: 'ohmypi-ready-file',
+  transcriptKind: 'ohmypi-jsonl',
+  sessionIdSource: 'transcript-jsonl',
+  contextLayerKind: 'pi',
+  feedKind: 'pi',
+  supportsPtySupervisor: false,
+  supportsChannelsBridge: false,
+  supportsConversationStreaming: true,
+  supportsPatchProjection: false,
+  usesRpcFifo: true,
+  usesCodexHome: false,
+  injectsPromptTimeMemory: true,
+  workAgentMode: 'ohmypi-rpc',
+  readyTimeoutSeconds: 120,
+};
+
+export const CODEX_BEHAVIOR: HarnessBehavior = {
+  displayName: 'Codex',
+  executableName: 'codex',
+  processNames: ['codex'],
+  launchCommandKind: 'codex-work-tui',
+  deliveryKind: 'codex-exec-resume',
+  readinessKind: 'codex-tui-prompt',
+  transcriptKind: 'codex-rollout-jsonl',
+  sessionIdSource: 'codex-thread-id',
+  contextLayerKind: 'codex',
+  feedKind: 'codex',
+  supportsPtySupervisor: true,
+  supportsChannelsBridge: false,
+  supportsConversationStreaming: true,
+  supportsPatchProjection: true,
+  usesRpcFifo: false,
+  usesCodexHome: true,
+  injectsPromptTimeMemory: false,
+  workAgentMode: 'codex-work-tui',
+  readyTimeoutSeconds: 30,
+};
+
+const BEHAVIORS: Record<RuntimeName, HarnessBehavior> = {
+  'claude-code': CLAUDE_CODE_BEHAVIOR,
+  ohmypi: OHMYPI_BEHAVIOR,
+  codex: CODEX_BEHAVIOR,
+};
+
+export function getHarnessBehavior(harness: HarnessName | undefined | null): HarnessBehavior {
+  if (harness === 'ohmypi' || harness === 'pi') return OHMYPI_BEHAVIOR;
+  if (harness === 'codex') return CODEX_BEHAVIOR;
+  return CLAUDE_CODE_BEHAVIOR;
+}
+
+export function getRuntimeBehavior(runtime: RuntimeName): HarnessBehavior {
+  return BEHAVIORS[runtime];
+}

--- a/src/lib/runtimes/claude-code.ts
+++ b/src/lib/runtimes/claude-code.ts
@@ -15,6 +15,7 @@ import type {
   AgentRuntime,
   AgentRuntimeSync,
   AgentRuntimeError,
+  HarnessBehavior,
   Heartbeat,
   TokenUsage,
   CostBreakdown,
@@ -23,6 +24,7 @@ import type {
   Agent,
   ActivitySource,
 } from './types.js';
+import { CLAUDE_CODE_BEHAVIOR } from './behavior.js';
 import { getAgentStateSync, getAgentDir, spawnAgent as spawnAgentImpl, saveAgentStateSync, saveAgentRuntimeState, determineModel } from '../agents.js';
 import { sessionExistsSync, killSessionSync, sendKeys, getAgentSessionsSync } from '../tmux.js';
 import { parseClaudeSessionSync, getSessionFilesSync, getProjectDirsSync } from '../cost-parsers/jsonl-parser.js';
@@ -45,6 +47,10 @@ interface SessionIndexEntry {
  */
 export class ClaudeCodeRuntimeSync implements AgentRuntimeSync {
   readonly name = 'claude-code' as const;
+
+  getHarnessBehavior(): HarnessBehavior {
+    return CLAUDE_CODE_BEHAVIOR;
+  }
 
   /**
    * Get the project directory for a workspace
@@ -459,6 +465,9 @@ export class ClaudeCodeRuntime implements AgentRuntime {
 
   getSessionPath(agentId: string): string | null {
     return this.inner.getSessionPath(agentId);
+  }
+  getHarnessBehavior(): HarnessBehavior {
+    return this.inner.getHarnessBehavior();
   }
   getLastActivity(agentId: string): Date | null {
     return this.inner.getLastActivity(agentId);

--- a/src/lib/runtimes/codex.ts
+++ b/src/lib/runtimes/codex.ts
@@ -23,6 +23,7 @@ import type {
   AgentRuntime,
   AgentRuntimeSync,
   AgentRuntimeError,
+  HarnessBehavior,
   Heartbeat,
   TokenUsage,
   CostBreakdown,
@@ -30,6 +31,7 @@ import type {
   SpawnConfig,
   Agent,
 } from './types.js'
+import { CODEX_BEHAVIOR } from './behavior.js'
 import { sessionExists, killSession, listSessionsSync, createSession } from '../tmux.js'
 import { TmuxError, ProcessSpawnError, ProcessTimeoutError } from '../errors.js'
 import { parseCodexSessionSync } from '../cost-parsers/codex-parser.js'
@@ -376,6 +378,10 @@ export function findLatestRollout(codexHomeDir: string): string | null {
 export class CodexRuntimeSync implements AgentRuntimeSync {
   readonly name = 'codex' as const
 
+  getHarnessBehavior(): HarnessBehavior {
+    return CODEX_BEHAVIOR
+  }
+
   getSessionPath(agentId: string): string | null {
     const threadId = readThreadId(agentId)
     if (!threadId) return null
@@ -661,6 +667,9 @@ export class CodexRuntime implements AgentRuntime {
 
   getSessionPath(agentId: string): string | null {
     return this.inner.getSessionPath(agentId)
+  }
+  getHarnessBehavior(): HarnessBehavior {
+    return this.inner.getHarnessBehavior()
   }
   getLastActivity(agentId: string): Date | null {
     return this.inner.getLastActivity(agentId)

--- a/src/lib/runtimes/index.ts
+++ b/src/lib/runtimes/index.ts
@@ -6,6 +6,7 @@
  */
 
 export * from './types.js';
+export * from './behavior.js';
 export {
   ClaudeCodeRuntimeSync,
   ClaudeCodeRuntime,

--- a/src/lib/runtimes/ohmypi.ts
+++ b/src/lib/runtimes/ohmypi.ts
@@ -34,6 +34,7 @@ import type {
   AgentRuntime,
   AgentRuntimeSync,
   AgentRuntimeError,
+  HarnessBehavior,
   Heartbeat,
   TokenUsage,
   CostBreakdown,
@@ -41,6 +42,7 @@ import type {
   SpawnConfig,
   Agent,
 } from './types.js'
+import { OHMYPI_BEHAVIOR } from './behavior.js'
 import { sessionExists, killSession, createSession, listSessionsSync } from '../tmux.js'
 import { parseOhmypiSessionSync } from '../cost-parsers/ohmypi-parser.js'
 import { generateLauncherScriptSync } from '../launcher-generator.js'
@@ -146,6 +148,10 @@ export function resolveLatestOhmypiSessionId(agentId: string): string | null {
 
 export class OhmypiRuntimeSync implements AgentRuntimeSync {
   readonly name = 'ohmypi' as const
+
+  getHarnessBehavior(): HarnessBehavior {
+    return OHMYPI_BEHAVIOR
+  }
 
   getSessionPath(agentId: string): string | null {
     const root = ohmypiSessionDirFor(agentId)
@@ -424,6 +430,9 @@ export class OhmypiRuntime implements AgentRuntime {
 
   getSessionPath(agentId: string): string | null {
     return this.inner.getSessionPath(agentId)
+  }
+  getHarnessBehavior(): HarnessBehavior {
+    return this.inner.getHarnessBehavior()
   }
   getLastActivity(agentId: string): Date | null {
     return this.inner.getLastActivity(agentId)

--- a/src/lib/runtimes/pi.ts
+++ b/src/lib/runtimes/pi.ts
@@ -34,6 +34,7 @@ import type {
   AgentRuntime,
   AgentRuntimeSync,
   AgentRuntimeError,
+  HarnessBehavior,
   Heartbeat,
   TokenUsage,
   CostBreakdown,
@@ -41,6 +42,7 @@ import type {
   SpawnConfig,
   Agent,
 } from './types.js'
+import { OHMYPI_BEHAVIOR } from './behavior.js'
 import { sessionExists, killSession, createSession, listSessionsSync } from '../tmux.js'
 import { parsePiSessionSync } from '../cost-parsers/pi-parser.js'
 import { generateLauncherScriptSync } from '../launcher-generator.js'
@@ -138,6 +140,10 @@ function resolveLatestPiSessionId(agentId: string): string | null {
 // RuntimeName union). Class is kept for backward-compat exports only.
 export class PiRuntimeSync {
   readonly name: string = 'pi'
+
+  getHarnessBehavior(): HarnessBehavior {
+    return OHMYPI_BEHAVIOR
+  }
 
   /** Resolve the latest Pi session JSONL for an agent. Pi nests files under
    *  <agentDir>/sessions/<encoded-cwd>/<timestamp>_<id>.jsonl, but we tolerate
@@ -452,6 +458,9 @@ export class PiRuntime {
 
   getSessionPath(agentId: string): string | null {
     return this.inner.getSessionPath(agentId)
+  }
+  getHarnessBehavior(): HarnessBehavior {
+    return this.inner.getHarnessBehavior()
   }
   getLastActivity(agentId: string): Date | null {
     return this.inner.getLastActivity(agentId)

--- a/src/lib/runtimes/types.ts
+++ b/src/lib/runtimes/types.ts
@@ -22,6 +22,12 @@
 export type RuntimeName = 'claude-code' | 'ohmypi' | 'codex';
 
 /**
+ * Legacy harness strings that can still appear in persisted state or older
+ * call sites while PAN-1989 normalization moves them onto current runtimes.
+ */
+export type HarnessName = RuntimeName | 'pi';
+
+/**
  * Health state of an agent
  */
 export type HealthState = 'active' | 'stale' | 'warning' | 'stuck' | 'wedged';
@@ -108,6 +114,42 @@ export interface Agent {
   startedAt: Date;
 }
 
+export type HarnessLaunchCommandKind = 'claude-code' | 'ohmypi-rpc' | 'codex-work-tui';
+export type HarnessDeliveryKind = 'pty-supervisor' | 'rpc-fifo' | 'codex-exec-resume' | 'tmux-paste';
+export type HarnessReadinessKind = 'claude-session-signal' | 'ohmypi-ready-file' | 'codex-tui-prompt';
+export type HarnessTranscriptKind = 'claude-jsonl' | 'ohmypi-jsonl' | 'codex-rollout-jsonl';
+export type HarnessSessionIdSource = 'launcher-session-id' | 'transcript-jsonl' | 'codex-thread-id';
+export type HarnessContextLayerKind = 'claude' | 'pi' | 'codex';
+export type HarnessFeedKind = 'claude_code' | 'pi' | 'codex';
+
+/**
+ * Behavior switches that previously lived as scattered harness conditionals.
+ * These values are intentionally descriptive, not aspirational: each runtime
+ * returns today's behavior so old branches can be replaced without semantics
+ * changing during Phase 2.
+ */
+export interface HarnessBehavior {
+  readonly displayName: string;
+  readonly executableName: string;
+  readonly processNames: readonly string[];
+  readonly launchCommandKind: HarnessLaunchCommandKind;
+  readonly deliveryKind: HarnessDeliveryKind;
+  readonly readinessKind: HarnessReadinessKind;
+  readonly transcriptKind: HarnessTranscriptKind;
+  readonly sessionIdSource: HarnessSessionIdSource;
+  readonly contextLayerKind: HarnessContextLayerKind;
+  readonly feedKind: HarnessFeedKind;
+  readonly supportsPtySupervisor: boolean;
+  readonly supportsChannelsBridge: boolean;
+  readonly supportsConversationStreaming: boolean;
+  readonly supportsPatchProjection: boolean;
+  readonly usesRpcFifo: boolean;
+  readonly usesCodexHome: boolean;
+  readonly injectsPromptTimeMemory: boolean;
+  readonly workAgentMode: 'claude-code' | 'ohmypi-rpc' | 'codex-work-tui';
+  readonly readyTimeoutSeconds: number;
+}
+
 /**
  * Runtime abstraction for agent health monitoring
  *
@@ -119,6 +161,11 @@ export interface AgentRuntimeSync {
    * Runtime identifier
    */
   readonly name: RuntimeName;
+
+  /**
+   * Return the stable behavior matrix for this runtime.
+   */
+  getHarnessBehavior(): HarnessBehavior;
 
   /**
    * Get the path to the session file/directory for an agent
@@ -255,6 +302,7 @@ export type AgentRuntimeError =
  */
 export interface AgentRuntime {
   readonly name: RuntimeName;
+  getHarnessBehavior(): HarnessBehavior;
   getSessionPath(agentId: string): string | null;
   getLastActivity(agentId: string): Date | null;
   getHeartbeat(agentId: string): Heartbeat | null;


### PR DESCRIPTION
**Epic B — Harness interface, Phase 1 (keystone).** Extends the existing `src/lib/runtimes/` seam with a `getHarnessBehavior()` contract (capability fields: launch/delivery/readiness/transcript kinds, supportsPtySupervisor, etc.), implemented per-runtime (claude-code/codex/ohmypi, legacy `pi`→ohmypi), + tests. Migrates 3 validation call sites in agents.ts; **rest of the 117 branches deferred to a Phase-2 fan-out** (conflict-free partition appended to `docs/codebase-health/B-harness-interface.md`). Behavior-preserving. **Verified (orchestrator, full suite): 7,523 tests pass, typecheck + lint green.** GPT-5.5 handoff.