### PR TITLE
refactor(dashboard): Phase-2 harness migration — conversation-service

### DIFF
--- a/src/dashboard/server/routes/jsonl-resolver.ts
+++ b/src/dashboard/server/routes/jsonl-resolver.ts
@@ -30,6 +30,8 @@ import { Effect } from 'effect';
 import { getAgentRuntimeState, getAgentStateSync } from '../../../lib/agents.js';
 import { encodeClaudeProjectDir, getOverdeckHome } from '../../../lib/paths.js';
 import { getAgentWorkspace } from '../../../lib/agent-enrichment.js';
+import { getHarnessBehavior } from '../../../lib/runtimes/behavior.js';
+import type { HarnessName } from '../../../lib/runtimes/types.js';
 
 export interface ResolveJsonlPathOptions {
   /** Override the ~/.overdeck/agents directory (test hook). */
@@ -46,6 +48,10 @@ async function pathExists(p: string): Promise<boolean> {
 
 async function readOptional(p: string): Promise<string | null> {
   return readFile(p, 'utf-8').catch(() => null);
+}
+
+function behaviorForHarness(harness: string | null | undefined) {
+  return getHarnessBehavior(harness as HarnessName | null | undefined);
 }
 
 /**
@@ -345,10 +351,11 @@ export async function resolveJsonlPath(
   // Dispatch on the recorded harness so a stale session.id from an earlier
   // claude-code run of the same agent id can't shadow the codex transcript.
   const harness = await resolveAgentHarness(agentId, opts);
-  if (harness === 'codex') {
+  const behavior = behaviorForHarness(harness);
+  if (behavior.transcriptKind === 'codex-rollout-jsonl') {
     return resolveCodexRolloutPath(agentId, opts);
   }
-  if (harness === 'pi' || harness === 'ohmypi') {
+  if (behavior.transcriptKind === 'ohmypi-jsonl') {
     return resolvePiSessionPath(agentId, opts);
   }
 

--- a/src/dashboard/server/services/conversation-lifecycle.ts
+++ b/src/dashboard/server/services/conversation-lifecycle.ts
@@ -33,6 +33,8 @@ import {
 import { listSessionNames, isHarnessProcessAlive, listPaneValues } from '../../../lib/tmux.js';
 import { isRespawnPending } from './pending-respawn.js';
 import { encodeClaudeProjectDir, sessionFilePath, getOverdeckHome } from '../../../lib/paths.js';
+import { getHarnessBehavior } from '../../../lib/runtimes/behavior.js';
+import type { HarnessName } from '../../../lib/runtimes/types.js';
 import { cleanupUnreferencedConversationAttachments, runInBatches } from './conversation-attachments.js';
 
 const POLL_INTERVAL_MS = 10_000;
@@ -51,6 +53,10 @@ const BACKFILL_ROLES = new Set(['work', 'review', 'test', 'ship']);
 // Tmux session prefixes that are NOT specialist agents and must be left alone
 // by the backfill pass even if they happen to be missing a row.
 const NON_AGENT_PREFIXES = ['conv-', 'inspect-', 'planning-'];
+
+function behaviorForHarness(harness: string | null | undefined) {
+  return getHarnessBehavior(harness as HarnessName | null | undefined);
+}
 
 /**
  * PAN-2099: read the last `maxBytes` of a file without loading the whole thing.
@@ -274,13 +280,13 @@ async function backfillOrphanedSpecialistConversations(aliveSessions: string[]):
  */
 async function detectOrphanedClaudeCodeSessions(activeConvs: Conversation[]): Promise<void> {
   // Group by cwd so we readdir each project dir at most once per tick.
-  // Pi conversations don't use ~/.claude/projects; harness === 'pi' is filtered out.
-  // Legacy rows with harness === null predate the harness column and were all claude-code.
+  // Non-Claude conversations don't use ~/.claude/projects.
+  // Legacy rows with a null harness predate the harness column and were all claude-code.
   const cwdGroups = new Map<string, Conversation[]>();
   for (const conv of activeConvs) {
     if (!conv.cwd) continue;
     if (!conv.claudeSessionId) continue;
-    if (conv.harness === 'ohmypi' || conv.harness === 'codex') continue;
+    if (behaviorForHarness(conv.harness).transcriptKind !== 'claude-jsonl') continue;
     const list = cwdGroups.get(conv.cwd) ?? [];
     list.push(conv);
     cwdGroups.set(conv.cwd, list);

--- a/src/dashboard/server/services/conversation-service.ts
+++ b/src/dashboard/server/services/conversation-service.ts
@@ -14,6 +14,7 @@ import type { ChatMessage, CompactBoundary, ContextUsage, ProposedPlan, WorkLogE
 import { calculateCostSync, getPricingSync, type AIProvider } from '../../../lib/cost.js';
 import { MODEL_CAPABILITIES, resolveModelIdSync } from '../../../lib/model-capabilities.js';
 import { encodeClaudeProjectDir } from '../../../lib/paths.js';
+import { getHarnessBehavior } from '../../../lib/runtimes/behavior.js';
 import { parseCodexConversationMessages } from './codex-conversation-parser.js';
 import { summarizeToolInputForWorkLog } from './format-tool-input.js';
 import { isPiSessionFile, parsePiConversationMessages } from './pi-conversation-parser.js';
@@ -993,17 +994,15 @@ export async function summarizeConversationActivity(
 ): Promise<ConversationActivitySummary> {
   const fileStats = await stat(sessionFile);
   const cacheKey = `${options.harness ?? 'claude-code'}:${sessionFile}`;
+  const behavior = getHarnessBehavior(options.harness as Parameters<typeof getHarnessBehavior>[0]);
   const cached = activitySummaryCache.get(cacheKey);
   if (cached && cached.mtimeMs === fileStats.mtimeMs && cached.size === fileStats.size) {
     return cached.summary;
   }
 
-  const parsed = options.harness === 'codex'
-    ? await parseCodexConversationMessages(sessionFile)
-    : options.harness === 'ohmypi' || isOhmypiSessionFile(sessionFile)
-      ? await parseOhmypiConversationMessages(sessionFile)
-      : options.harness === 'pi' || isPiSessionFile(sessionFile)
-      ? await parsePiConversationMessages(sessionFile)
+  const parsed = behavior.transcriptKind === 'codex-rollout-jsonl' ? await parseCodexConversationMessages(sessionFile)
+    : behavior.transcriptKind === 'ohmypi-jsonl' || isOhmypiSessionFile(sessionFile) ? await parseOhmypiConversationMessages(sessionFile)
+    : isPiSessionFile(sessionFile) ? await parsePiConversationMessages(sessionFile)
       // Parse from the last compact boundary instead of the full file — avoids
       // re-reading potentially megabytes of history on every list enrichment tick.
       // Pass an empty priorState so pendingToolUse stays populated rather than being
@@ -1049,7 +1048,7 @@ export async function summarizeConversationActivity(
         currentTool = entry.toolTitle;
       }
     }
-    if (!currentTool && options.harness === 'codex') {
+    if (!currentTool && behavior.transcriptKind === 'codex-rollout-jsonl') {
       for (const entry of workLog) {
         if (entry.tone === 'tool' && !entry.result && (entry.sequence ?? -1) > maxSequence) {
           maxSequence = entry.sequence ?? -1;


### PR DESCRIPTION
Phase-2 harness slice (conversation-service). Replaces `harness ===` behavior branches in conversation-service.ts / conversation-lifecycle.ts / jsonl-resolver.ts with `getHarnessBehavior()` (transcriptKind, sessionIdSource, getSessionPath), preserving legacy `pi` file detection. Remaining `harness===` is a `typeof` type-guard (not a behavior branch). Verified tc+lint; CI full suite gates merge. GPT-5.5 handoff.