### PR TITLE
refactor(harness): Phase-2 migration — memory/planning longtail

### DIFF
--- a/src/lib/conversations/smart-compaction.ts
+++ b/src/lib/conversations/smart-compaction.ts
@@ -7,6 +7,7 @@ import { Effect } from 'effect';
 import * as self from './smart-compaction.js';
 import { buildSpawnEnvForModel, getProviderEnvForModel } from '../agents.js';
 import { getClaudePermissionFlagsSync } from '../claude-permissions.js';
+import { getHarnessBehavior } from '../runtimes/behavior.js';
 import type { RuntimeName } from '../runtimes/types.js';
 import { FsError, ProcessSpawnError } from '../errors.js';
 import { recordBackgroundAiCost } from '../background-ai/cost.js';
@@ -36,7 +37,6 @@ function recordSummaryForkCost(model: string, envelope: Record<string, unknown>)
 
 const SUMMARY_TIMEOUT_MS = 60_000;
 const FORK_SUMMARY_TIMEOUT_MS = 300_000;
-
 const DEFAULT_SUMMARY_MODEL = 'claude-haiku-4-5-20251001';
 
 export interface CompactionOptions {
@@ -696,7 +696,7 @@ async function runPiModelSummary(prompt: string, model: string, timeoutMs?: numb
   const useModel = model || DEFAULT_SUMMARY_MODEL;
   console.log(`[claude-invoke] purpose=smart-summary | model=${useModel} | harness=${harness} | source=smart-compaction.ts:runModelSummary | promptChars=${prompt.length} | timeoutMs=${timeoutMs ?? SUMMARY_TIMEOUT_MS}`);
 
-  if (harness === 'ohmypi') {
+  if (getHarnessBehavior(harness).deliveryKind === 'rpc-fifo') {
     // Pi/omp runs in rpc mode and auto-executes tools, so it needs no allowlist.
     const summary = await runPiModelSummary(prompt, useModel, timeoutMs);
     console.log(`[claude-invoke] SUCCESS purpose=smart-summary | model=${useModel} | harness=${harness} | outputChars=${summary.length}`);
@@ -1161,7 +1161,7 @@ export function runModelSummary(
     try: () => runModelSummaryPromise(prompt, model, timeoutMs, harness, allowedTools),
     catch: (cause) =>
       new ProcessSpawnError({
-        command: harness === 'ohmypi' ? 'omp' : 'claude',
+        command: getHarnessBehavior(harness).deliveryKind === 'rpc-fifo' ? getHarnessBehavior(harness).executableName : 'claude',
         args: ['-p', model ?? 'default'],
         message: cause instanceof Error ? cause.message : String(cause),
         cause,

--- a/src/lib/graceful-restart.ts
+++ b/src/lib/graceful-restart.ts
@@ -2,6 +2,7 @@ import { existsSync, statSync } from 'fs';
 import { join } from 'path';
 import { Effect } from 'effect';
 import { sendEscapeKeyAsync, sendKeys } from './tmux.js';
+import { getHarnessBehavior } from './runtimes/behavior.js';
 import type { RuntimeName } from './runtimes/types.js';
 
 export const GRACEFUL_RESTART_GRACE_MS = 60_000;
@@ -13,7 +14,7 @@ export async function sendGracefulRestartWarning(
 ): Promise<void> {
   const warning = 'Restarting in 60s. Update .pan/continue.json now with all progress, decisions, hazards, and resume point.';
   try {
-    if (harness === 'claude-code' || harness === 'codex') {
+    if (harness && !getHarnessBehavior(harness).usesRpcFifo) {
       await sendEscapeKeyAsync(agentId, 2);
       await new Promise((r) => setTimeout(r, 1_000));
     }

--- a/src/lib/planning/spawn-planning-session.ts
+++ b/src/lib/planning/spawn-planning-session.ts
@@ -31,6 +31,7 @@ import { renderPrompt } from '../cloister/prompts.js';
 import { getAgentRuntimeBaseCommand, getProviderExportsForModel, retrieveSpawnTimeMemoryContext, roleAgentDefinitionPath, saveAgentStateSync, getAgentStateSync } from '../agents.js';
 import { loadConfigSync, resolveModel } from '../config-yaml.js';
 import { resolveHarness } from '../harness-resolve.js';
+import { getHarnessBehavior } from '../runtimes/behavior.js';
 import type { RuntimeName } from '../runtimes/types.js';
 import { generateLauncherScriptSync } from '../launcher-generator.js';
 import { BLANKED_PROVIDER_ENV } from '../child-env.js';
@@ -410,8 +411,9 @@ async function claudePlanningSystemPromptFiles(workspacePath: string, harness: '
   }
   files.push(await ensureSessionContextBriefingFile());
 
+  const behavior = getHarnessBehavior(harness);
   // PAN-1566: Pi/ohmypi also receives the rendered global context layer.
-  if (harness === 'ohmypi') {
+  if (behavior.contextLayerKind === 'pi') {
     const { piGlobalContextFile } = await import('../context-layers/index.js');
     const globalFile = piGlobalContextFile();
     if (existsSync(globalFile)) {
@@ -421,7 +423,7 @@ async function claudePlanningSystemPromptFiles(workspacePath: string, harness: '
   // PAN-1574: Codex receives its rendered global context layer (codex-global.md).
   // The per-agent CODEX_HOME/AGENTS.md is set up by initCodexHome at spawn time;
   // this file provides context for the planning session before spawn.
-  if (harness === 'codex') {
+  if (behavior.contextLayerKind === 'codex') {
     const { codexGlobalContextFile } = await import('../context-layers/index.js');
     const globalFile = codexGlobalContextFile();
     if (existsSync(globalFile)) {

--- a/tests/lib/graceful-restart.test.ts
+++ b/tests/lib/graceful-restart.test.ts
@@ -57,4 +57,17 @@ describe('sendGracefulRestartWarning', () => {
     await vi.advanceTimersByTimeAsync(GRACEFUL_RESTART_GRACE_MS);
     await result;
   });
+
+  it('preserves the missing-harness path without sending Escape', async () => {
+    const { GRACEFUL_RESTART_GRACE_MS, sendGracefulRestartWarning } = await import('../../src/lib/graceful-restart.js');
+
+    const result = sendGracefulRestartWarning('agent-pan-1787', undefined, '/tmp/workspace');
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(tmuxMocks.sendEscapeKeyAsync).not.toHaveBeenCalled();
+    expect(tmuxMocks.sendKeys).toHaveBeenCalledWith('agent-pan-1787', expect.stringContaining('Restarting in 60s'));
+
+    await vi.advanceTimersByTimeAsync(GRACEFUL_RESTART_GRACE_MS);
+    await result;
+  });
 });


### PR DESCRIPTION
Phase-2 slice (memory-planning-longtail). Migrates harness branches in smart-compaction.ts, graceful-restart.ts, spawn-planning-session.ts to `getHarnessBehavior()` fields; preserves intentional data-query source filters per the partition Notes; adds a graceful-restart test. Verified tc+lint; CI full suite gates. GPT-5.5 handoff.