### PR TITLE
fix(cloister): re-evaluate stale merge-blockers on deacon patrol (PAN-2143)

### DIFF
--- a/src/lib/cloister/deacon-merge.ts
+++ b/src/lib/cloister/deacon-merge.ts
@@ -400,6 +400,70 @@ export async function reconcileClosedPrReadyForMerge(): Promise<string[]> {
   return actions;
 }
 
+const staleMergeBlockerCooldowns = new Map<string, number>();
+const STALE_MERGE_BLOCKER_COOLDOWN_MS = 2 * 60 * 1000; // 2 minutes
+
+/**
+ * Reconciler: re-evaluate stale merge-blockers so resolved conflicts unstick.
+ *
+ * resolveConflictGate() already clears a stale merge_conflict/not_mergeable
+ * blocker once the branch is mergeable against main again — but it only runs
+ * on-demand from the review-dispatch routes. An issue that picks up a
+ * merge-blocker (so readyForMerge stays false) and then falls out of the active
+ * review flow is therefore never re-evaluated: the blocker persists forever and
+ * the merge train never picks it up. That is the "stuck after review" failure
+ * mode (PAN-2143) — a PR that was conflicting while main moved stays blocked
+ * even after the conflict is resolved.
+ *
+ * This patrol runs resolveConflictGate for every in-pipeline issue still
+ * carrying a merge-blocker. When the branch became mergeable again it clears the
+ * stale blocker (which lets setReviewStatus recompute readyForMerge so the merge
+ * train resumes); when the branch is genuinely conflicting, resolveConflictGate
+ * dispatches the conflict resolver on its existing throttle. A per-issue 2-min
+ * cooldown bounds the git-probe cost; resolveConflictGate also caches its
+ * mergeability probe.
+ */
+export async function reconcileStaleMergeBlockers(): Promise<string[]> {
+  const actions: string[] = [];
+  try {
+    const { resolveConflictGate, buildRealConflictGateDeps } = await import('./conflict-gate.js');
+    const statuses = loadReviewStatuses();
+    const now = Date.now();
+    const deps = buildRealConflictGateDeps();
+
+    for (const [issueId, status] of Object.entries(statuses)) {
+      if (status.mergeStatus === 'merged') continue;
+      const hasMergeBlocker = (status.blockerReasons ?? []).some(
+        (b) => b.type === 'merge_conflict' || b.type === 'not_mergeable',
+      );
+      if (!hasMergeBlocker) continue;
+
+      const cooledUntil = staleMergeBlockerCooldowns.get(issueId);
+      if (cooledUntil && now < cooledUntil) continue;
+      staleMergeBlockerCooldowns.set(issueId, now + STALE_MERGE_BLOCKER_COOLDOWN_MS);
+
+      const resolved = resolveProjectFromIssueSync(issueId);
+      if (!resolved) continue;
+      const workspacePath = join(resolved.projectPath, 'workspaces', `feature-${issueId.toLowerCase()}`);
+      if (!existsSync(workspacePath)) continue;
+
+      try {
+        const result = await resolveConflictGate(issueId, workspacePath, 'main', deps);
+        if (result.clearedStaleBlocker) {
+          const msg = `Cleared stale merge blocker for ${issueId} — branch is mergeable again; readyForMerge will recompute`;
+          actions.push(msg);
+          console.log(`[deacon] ${msg}`);
+        }
+      } catch (gateErr: unknown) {
+        console.warn(`[deacon] reconcileStaleMergeBlockers: ${issueId} conflict-gate failed: ${gateErr instanceof Error ? gateErr.message : String(gateErr)}`);
+      }
+    }
+  } catch (err: unknown) {
+    console.warn(`[deacon] Error in reconcileStaleMergeBlockers: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  return actions;
+}
+
 export async function reconcileMergedButReviewing(): Promise<string[]> {
   const actions: string[] = [];
   try {

--- a/src/lib/cloister/deacon.ts
+++ b/src/lib/cloister/deacon.ts
@@ -32,7 +32,7 @@ import { checkInspectAgentTimeouts } from './deacon-inspect.js';
 import { checkApiErrorAgents } from './deacon-api-recovery.js';
 import { checkOrphanedReviewStatuses, recoverStalledReviewConvoys, checkMissingReviewStatuses, checkStuckReviewing, checkCompletedButUnsignaledReviews, monitorReviewConvoySignals, cleanupOrphanedReviewSessions } from './deacon-review.js';
 import { getAutoCloseOutCanonicalState } from './deacon-canonical-state.js';
-import { checkReadyForMergeStuck as checkReadyForMergeStuckWithDeps, reconcileStaleMergeStatus, reconcileFalseMerged, reconcileClosedPrReadyForMerge, reconcileMergedButReviewing, checkFailedMergeRetry, autoCloseOut, checkFirstCompletionAgents, ciRetryMap, FAILED_MERGE_MAX_RETRIES } from './deacon-merge.js';
+import { checkReadyForMergeStuck as checkReadyForMergeStuckWithDeps, reconcileStaleMergeStatus, reconcileFalseMerged, reconcileClosedPrReadyForMerge, reconcileStaleMergeBlockers, reconcileMergedButReviewing, checkFailedMergeRetry, autoCloseOut, checkFirstCompletionAgents, ciRetryMap, FAILED_MERGE_MAX_RETRIES } from './deacon-merge.js';
 import { recoverOrphanedAgents as recoverOrphanedAgentsWithDeps, handleAgentHeartbeatDeadEvent as handleAgentHeartbeatDeadEventWithDeps, handleAgentStoppedEvent as handleAgentStoppedEventWithDeps, autoResumeStoppedWorkAgents as autoResumeStoppedWorkAgentsWithDeps, reconcileAgentLiveness as reconcileAgentLivenessWithDeps, nudgeStalledResumeWorkAgents, nudgeIdleWorkAgentsWithOpenBeads, cleanupOrphanedPlanningSessions as cleanupOrphanedPlanningSessionsWithDeps } from './deacon-auto-resume.js';
 // Review gated-dispatch behavior moved to deacon-review-status.ts:
 // keep the source guard anchors here: releaseAdvancingSlot, if (dispatchResult.gated),
@@ -139,7 +139,7 @@ const unlinkPath = (path: string): Effect.Effect<void, FsError> =>
 /** Re-exported for symmetry with the additive pattern in the rest of src/lib. */
 export { GitError, ProcessTimeoutError };
 export { checkInspectAgentTimeouts, INSPECT_TIMEOUT_MS } from './deacon-inspect.js';
-export { reconcileStaleMergeStatus, reconcileFalseMerged, reconcileClosedPrReadyForMerge, reconcileMergedButReviewing, checkFailedMergeRetry, autoCloseOut, checkFirstCompletionAgents, ciRetryMap, FAILED_MERGE_MAX_RETRIES } from './deacon-merge.js';
+export { reconcileStaleMergeStatus, reconcileFalseMerged, reconcileClosedPrReadyForMerge, reconcileStaleMergeBlockers, reconcileMergedButReviewing, checkFailedMergeRetry, autoCloseOut, checkFirstCompletionAgents, ciRetryMap, FAILED_MERGE_MAX_RETRIES } from './deacon-merge.js';
 export { nudgeStalledResumeWorkAgents, nudgeIdleWorkAgentsWithOpenBeads, isRapidPostResumeDeath, isPreKickoffLaunchDeath } from './deacon-auto-resume.js';
 
 import { OVERDECK_HOME, AGENTS_DIR, sessionFilePath } from '../paths.js';
@@ -2926,6 +2926,16 @@ export async function runPatrol(): Promise<PatrolResult> {
   const closedPrReadyActions = await reconcileClosedPrReadyForMerge();
   actions.push(...closedPrReadyActions);
   for (const a of closedPrReadyActions) addLog('action', a, state.patrolCycle);
+
+  // PAN-2143: re-evaluate stale merge-blockers. resolveConflictGate clears a
+  // stale merge_conflict/not_mergeable blocker once the branch is mergeable
+  // again, but only runs on-demand from review dispatch — so a blocked issue
+  // that falls out of the review flow stays stuck after review forever. This
+  // patrol re-runs it for every in-pipeline issue still carrying a merge-blocker
+  // so resolved conflicts clear and readyForMerge recomputes.
+  const staleMergeBlockerActions = await reconcileStaleMergeBlockers();
+  actions.push(...staleMergeBlockerActions);
+  for (const a of staleMergeBlockerActions) addLog('action', a, state.patrolCycle);
 
   // Dead-end agent recovery: nudge agents stuck with reviewStatus=blocked/failed after
   // fixing review issues but not re-requesting review. Has 10-min per-issue cooldown and


### PR DESCRIPTION
Fixes PAN-2143 — the 'stuck after review' root cause.

**Problem:** `resolveConflictGate()` clears a stale `merge_conflict`/`not_mergeable` blocker once a branch is mergeable again, but it only ran on-demand from review-dispatch routes. A blocked issue that fell out of the active review flow was never re-evaluated → blocker persisted → `readyForMerge` stayed false forever → merge train never picked it up. Confirmed live on PAN-1884/PAN-2088/PAN-1718.

**Fix:** new deacon patrol `reconcileStaleMergeBlockers()` runs `resolveConflictGate` over every in-pipeline issue still carrying a merge-blocker each cycle (2-min per-issue cooldown). Clears stale blockers when mergeable → `readyForMerge` recomputes → merge train resumes; genuine conflicts get the existing throttled resolver dispatch.

This is the linchpin for autonomous 24/7 throughput — without it, any PR that goes briefly stale against a fast-moving main gets permanently stuck post-review.

**Verified (orchestrator):** typecheck, lint, build, conflict-gate tests (20), and the FULL suite (7,530 passed, 0 failed) all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated check that revisits issues stuck behind merge blockers and attempts to clear them when the problem has resolved.
  * Patrol runs now include an extra recovery step to keep merge progress moving more reliably.

* **Bug Fixes**
  * Improved handling of stale merge conflicts and “not mergeable” states, reducing cases where issues remain blocked longer than necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->