### PR TITLE
fix(cloister): reactive readyForMerge convergence for the no-blocker stuck-after-review strand (PAN-2198)

### DIFF
--- a/src/lib/cloister/deacon-merge.ts
+++ b/src/lib/cloister/deacon-merge.ts
@@ -8,7 +8,7 @@ import { AGENTS_DIR } from '../paths.js';
 import { emitActivityEntrySync } from '../activity-logger.js';
 import { getAgentRuntimeStateSync, getAgentStateSync, listRunningAgentsSync, type AgentState } from '../agents.js';
 import { withConcurrencyLimit } from '../concurrency.js';
-import { loadReviewStatuses, setReviewStatusSync } from '../review-status.js';
+import { loadReviewStatuses, setReviewStatusSync, reviewGatesPassedSync } from '../review-status.js';
 import { resolveProjectFromIssueSync } from '../projects.js';
 import { resolveGitHubIssueSync } from '../tracker-utils.js';
 import { sessionExistsSync, sendKeys } from '../tmux.js';
@@ -460,6 +460,45 @@ export async function reconcileStaleMergeBlockers(): Promise<string[]> {
     }
   } catch (err: unknown) {
     console.warn(`[deacon] Error in reconcileStaleMergeBlockers: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  return actions;
+}
+
+/**
+ * Reconciler (PAN-2198): periodic twin of the boot-only fixStuckReadyForMerge,
+ * for the NO-BLOCKER strand of "stuck after review".
+ *
+ * readyForMerge is re-derived on every setReviewStatusSync write. When the last
+ * write left it false and there is NO merge-blocker, nothing re-derives it until
+ * the next write — so a PR whose review+test+verify all passed but whose
+ * readyForMerge was left false (e.g. a verdict that landed via a write path that
+ * didn't recompute, or a gate that was transiently non-final) converges ONLY on
+ * server restart (PAN-1758: "readyForMerge only flips via the startup repair
+ * sweep"). This patrol re-derives it on the 60s deacon tick instead.
+ *
+ * Blocker strands are deliberately excluded — those are owned by
+ * reconcileStaleMergeBlockers, and excluding them also avoids fighting the
+ * setReviewStatus deriver's hasBlockers override (which would flip readyForMerge
+ * straight back to false). Loop-safe: it writes ONLY readyForMerge (no
+ * review/test status transition, so no review/test re-dispatch events fire), and
+ * is idempotent — once flipped true, the readyForMerge!==false guard excludes the
+ * issue, so steady state is zero writes. Flipping readyForMerge=true only makes
+ * the issue merge-ELIGIBLE; the merge train / MERGE button remains the trigger.
+ */
+export function reconcileStuckReadyForMerge(): string[] {
+  const actions: string[] = [];
+  try {
+    for (const [issueId, status] of Object.entries(loadReviewStatuses())) {
+      if (status.readyForMerge !== false) continue;
+      if ((status.blockerReasons?.length ?? 0) > 0) continue; // blocker strand → reconcileStaleMergeBlockers
+      if (!reviewGatesPassedSync(status)) continue;
+      setReviewStatusSync(issueId, { readyForMerge: true });
+      const msg = `Restored readyForMerge for ${issueId} — review+test+verify passed, no blocker (was stuck false)`;
+      actions.push(msg);
+      console.log(`[deacon] ${msg}`);
+    }
+  } catch (err: unknown) {
+    console.warn(`[deacon] Error in reconcileStuckReadyForMerge: ${err instanceof Error ? err.message : String(err)}`);
   }
   return actions;
 }

--- a/src/lib/cloister/deacon.ts
+++ b/src/lib/cloister/deacon.ts
@@ -32,7 +32,7 @@ import { checkInspectAgentTimeouts } from './deacon-inspect.js';
 import { checkApiErrorAgents } from './deacon-api-recovery.js';
 import { checkOrphanedReviewStatuses, recoverStalledReviewConvoys, checkMissingReviewStatuses, checkStuckReviewing, checkCompletedButUnsignaledReviews, monitorReviewConvoySignals, cleanupOrphanedReviewSessions } from './deacon-review.js';
 import { getAutoCloseOutCanonicalState } from './deacon-canonical-state.js';
-import { checkReadyForMergeStuck as checkReadyForMergeStuckWithDeps, reconcileStaleMergeStatus, reconcileFalseMerged, reconcileClosedPrReadyForMerge, reconcileStaleMergeBlockers, reconcileMergedButReviewing, checkFailedMergeRetry, autoCloseOut, checkFirstCompletionAgents, ciRetryMap, FAILED_MERGE_MAX_RETRIES } from './deacon-merge.js';
+import { checkReadyForMergeStuck as checkReadyForMergeStuckWithDeps, reconcileStaleMergeStatus, reconcileFalseMerged, reconcileClosedPrReadyForMerge, reconcileStaleMergeBlockers, reconcileStuckReadyForMerge, reconcileMergedButReviewing, checkFailedMergeRetry, autoCloseOut, checkFirstCompletionAgents, ciRetryMap, FAILED_MERGE_MAX_RETRIES } from './deacon-merge.js';
 import { recoverOrphanedAgents as recoverOrphanedAgentsWithDeps, handleAgentHeartbeatDeadEvent as handleAgentHeartbeatDeadEventWithDeps, handleAgentStoppedEvent as handleAgentStoppedEventWithDeps, autoResumeStoppedWorkAgents as autoResumeStoppedWorkAgentsWithDeps, applyBootReconciliationDecision as applyBootReconciliationDecisionWithDeps, reconcileAgentLiveness as reconcileAgentLivenessWithDeps, nudgeStalledResumeWorkAgents, nudgeIdleWorkAgentsWithOpenBeads, cleanupOrphanedPlanningSessions as cleanupOrphanedPlanningSessionsWithDeps } from './deacon-auto-resume.js';
 // Review gated-dispatch behavior moved to deacon-review-status.ts:
 // keep the source guard anchors here: releaseAdvancingSlot, if (dispatchResult.gated),
@@ -139,7 +139,7 @@ const unlinkPath = (path: string): Effect.Effect<void, FsError> =>
 /** Re-exported for symmetry with the additive pattern in the rest of src/lib. */
 export { GitError, ProcessTimeoutError };
 export { checkInspectAgentTimeouts, INSPECT_TIMEOUT_MS } from './deacon-inspect.js';
-export { reconcileStaleMergeStatus, reconcileFalseMerged, reconcileClosedPrReadyForMerge, reconcileStaleMergeBlockers, reconcileMergedButReviewing, checkFailedMergeRetry, autoCloseOut, checkFirstCompletionAgents, ciRetryMap, FAILED_MERGE_MAX_RETRIES } from './deacon-merge.js';
+export { reconcileStaleMergeStatus, reconcileFalseMerged, reconcileClosedPrReadyForMerge, reconcileStaleMergeBlockers, reconcileStuckReadyForMerge, reconcileMergedButReviewing, checkFailedMergeRetry, autoCloseOut, checkFirstCompletionAgents, ciRetryMap, FAILED_MERGE_MAX_RETRIES } from './deacon-merge.js';
 export { nudgeStalledResumeWorkAgents, nudgeIdleWorkAgentsWithOpenBeads, isRapidPostResumeDeath, isPreKickoffLaunchDeath } from './deacon-auto-resume.js';
 
 import { OVERDECK_HOME, AGENTS_DIR, sessionFilePath } from '../paths.js';
@@ -2939,6 +2939,13 @@ export async function runPatrol(): Promise<PatrolResult> {
   const staleMergeBlockerActions = await reconcileStaleMergeBlockers();
   actions.push(...staleMergeBlockerActions);
   for (const a of staleMergeBlockerActions) addLog('action', a, state.patrolCycle);
+
+  // PAN-2198: re-derive readyForMerge for the no-blocker "stuck after review" strand
+  // (review+test+verify passed, no blocker, but readyForMerge stuck false) so it
+  // converges on the deacon tick instead of only on the server-restart repair sweep.
+  const stuckReadyActions = reconcileStuckReadyForMerge();
+  actions.push(...stuckReadyActions);
+  for (const a of stuckReadyActions) addLog('action', a, state.patrolCycle);
 
   // Dead-end agent recovery: nudge agents stuck with reviewStatus=blocked/failed after
   // fixing review issues but not re-requesting review. Has 10-min per-issue cooldown and

--- a/src/lib/review-status.ts
+++ b/src/lib/review-status.ts
@@ -133,7 +133,7 @@ export function verificationSatisfied(status: Pick<ReviewStatus, 'verificationSt
  * failed, UAT ok, merge not started). Extracted so both setReviewStatusSync and the
  * journal→DB reconcile in getReviewStatusSync derive readyForMerge identically.
  */
-function reviewGatesPassedSync(
+export function reviewGatesPassedSync(
   s: Pick<ReviewStatus, 'reviewStatus' | 'testStatus' | 'verificationStatus' | 'uatStatus' | 'mergeStatus'>,
 ): boolean {
   return (

--- a/tests/unit/lib/cloister/deacon-stuck-readyformerge.test.ts
+++ b/tests/unit/lib/cloister/deacon-stuck-readyformerge.test.ts
@@ -1,0 +1,92 @@
+/**
+ * PAN-2198: reconcileStuckReadyForMerge — periodic re-derive of readyForMerge for
+ * the NO-BLOCKER "stuck after review" strand (review+test+verify passed, no merge
+ * blocker, but readyForMerge left false). Previously converged only on the
+ * server-restart repair sweep (fixStuckReadyForMerge); this patrol does it on the tick.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { setupOverdeckTestDb, teardownOverdeckTestDb, type OverdeckTestDb } from '../../../helpers/overdeck-test-db.js';
+
+let odb: OverdeckTestDb;
+
+vi.mock('../../../../src/lib/pipeline-notifier.js', () => ({
+  notifyPipeline: vi.fn(),
+  notifyPipelineSync: vi.fn(),
+}));
+vi.mock('../../../../src/lib/activity-logger.js', () => ({
+  emitActivityEntry: vi.fn(),
+  emitActivityEntrySync: vi.fn(),
+  emitActivityTts: vi.fn(),
+  emitActivityTtsSync: vi.fn(),
+}));
+
+beforeEach(() => {
+  odb = setupOverdeckTestDb();
+});
+afterEach(() => {
+  teardownOverdeckTestDb(odb);
+});
+
+import { reconcileStuckReadyForMerge } from '../../../../src/lib/cloister/deacon-merge.js';
+import { loadReviewStatuses } from '../../../../src/lib/review-status.js';
+
+const seed = (cols: Record<string, string | number>) => {
+  const keys = Object.keys(cols);
+  const placeholders = keys.map(() => '?').join(', ');
+  odb.raw()
+    .prepare(`INSERT INTO review_status (${keys.join(', ')}) VALUES (${placeholders})`)
+    .run(...keys.map((k) => cols[k]));
+};
+
+describe('reconcileStuckReadyForMerge (PAN-2198)', () => {
+  it('flips readyForMerge for the no-blocker stuck strand, and is idempotent', () => {
+    seed({
+      issue_id: 'PAN-STUCK',
+      review_status: 'passed',
+      test_status: 'passed',
+      verification_status: 'passed',
+      merge_status: 'pending',
+      updated_at: '2026-06-30T00:00:00Z',
+      ready_for_merge: 0,
+    });
+
+    const actions = reconcileStuckReadyForMerge();
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toContain('PAN-STUCK');
+    expect(loadReviewStatuses()['PAN-STUCK'].readyForMerge).toBe(true);
+
+    // Second tick: already flipped → no action (steady state = zero writes)
+    expect(reconcileStuckReadyForMerge()).toHaveLength(0);
+  });
+
+  it('leaves a blocker-strand issue untouched (owned by reconcileStaleMergeBlockers)', () => {
+    seed({
+      issue_id: 'PAN-BLOCKED',
+      review_status: 'passed',
+      test_status: 'passed',
+      verification_status: 'passed',
+      merge_status: 'pending',
+      blocker_reasons: JSON.stringify([{ type: 'merge_conflict', detail: 'main moved' }]),
+      updated_at: '2026-06-30T00:00:00Z',
+      ready_for_merge: 0,
+    });
+
+    expect(reconcileStuckReadyForMerge()).toHaveLength(0);
+    expect(loadReviewStatuses()['PAN-BLOCKED'].readyForMerge).toBeFalsy();
+  });
+
+  it('leaves an issue whose gates have not passed untouched', () => {
+    seed({
+      issue_id: 'PAN-REVIEWING',
+      review_status: 'reviewing',
+      test_status: 'pending',
+      verification_status: 'pending',
+      merge_status: 'pending',
+      updated_at: '2026-06-30T00:00:00Z',
+      ready_for_merge: 0,
+    });
+
+    expect(reconcileStuckReadyForMerge()).toHaveLength(0);
+    expect(loadReviewStatuses()['PAN-REVIEWING'].readyForMerge).toBeFalsy();
+  });
+});


### PR DESCRIPTION
Part of #2198 (epic: post-approval pipeline convergence). Implements the minimal "no-blocker strand" fix designed in #2198 and #2143.

## Problem
Approved PRs (review+test+verify passed, **no** merge-blocker) frequently stall before merge. `readyForMerge` is re-derived on every `setReviewStatusSync` write, but when the *last* write left it `false` with no blocker, nothing re-derives it until the next write — so it converges **only on the server-restart repair sweep** (`fixStuckReadyForMerge`). That's the no-blocker facet of "stuck after review" (#2198 / #1758: "readyForMerge only flips via the startup repair sweep"). Hit live on PAN-1762 today (review APPROVED, every gate green, PR mergeable, but `readyForMerge` stuck false until a manual intervention).

## Fix
`reconcileStuckReadyForMerge()` — a 60s deacon-tick patrol (the periodic twin of the boot-only `fixStuckReadyForMerge`) that re-derives `readyForMerge` for in-review issues whose gates passed and carry no blocker. Blocker strands stay owned by `reconcileStaleMergeBlockers` (#2143).

- Reuses the canonical `reviewGatesPassedSync` predicate (now `export`ed) instead of re-implementing it — zero drift across derivation sites.
- **Loop-safe** (the #1758 "37 re-dispatches" caution): writes **only** `readyForMerge`, which emits no `review.approved`/`test.passed` lifecycle events (those fire only on review/test status *transitions*) — so it triggers no review/test re-dispatch. Idempotent: once flipped `true`, the `readyForMerge !== false` guard excludes the issue next tick → steady state is zero writes. Flipping `readyForMerge=true` only makes the issue merge-*eligible*; the merge train / MERGE button remains the trigger.

## Tests
`tests/unit/lib/cloister/deacon-stuck-readyformerge.test.ts`: the no-blocker stuck strand flips (and is idempotent); a `merge_conflict` blocker strand is left untouched (owned by `reconcileStaleMergeBlockers`); a not-yet-approved issue is untouched. `npm run typecheck` + `eslint` green.

## Out of scope (tracked in #2198)
Collapsing the 3 derivation sites behind one shared deriver; folding all reconcilers into one merge-readiness pass; optional event-driven invalidation; the `forceReview`-can't-yank-merge-ready guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a case where some issues could remain stuck as not ready to merge even after all checks had passed.
  * The system now automatically re-evaluates eligible issues during patrol and updates their merge readiness when appropriate.
  * Issues with blocking reasons or incomplete checks are left unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->