### PR TITLE
fix(dashboard): strike agents visible in issue tree — reducer projection + regression test (PAN-2258)

### DIFF
--- a/packages/contracts/src/event-reducers.ts
+++ b/packages/contracts/src/event-reducers.ts
@@ -447,7 +447,17 @@ export function applyEvent(state: ReadModelState, event: DomainEvent): ReadModel
     }
 
     case 'agent.status_changed': {
-      const agent = state.agentsById[event.payload.agentId]
+      const agent = state.agentsById[event.payload.agentId] ?? (
+        event.payload.role === 'strike' && event.payload.issueId
+          ? {
+              id: event.payload.agentId,
+              issueId: event.payload.issueId,
+              status: event.payload.status,
+              role: 'strike' as const,
+              startedAt: event.timestamp,
+            }
+          : undefined
+      )
       if (!agent) return { ...state, sequence: Math.max(state.sequence, event.sequence) }
       const nextTurnDiffSummariesByAgentId = isTerminalTurnDiffSummaryStatus(event.payload.status)
         ? omitTurnDiffSummariesForAgent(state.turnDiffSummariesByAgentId, event.payload.agentId)
@@ -500,6 +510,9 @@ export function applyEvent(state: ReadModelState, event: DomainEvent): ReadModel
           [event.payload.agentId]: nextAgent,
         },
         turnDiffSummariesByAgentId: nextTurnDiffSummariesByAgentId,
+        agentIdBySessionId: event.payload.sessionId
+          ? { ...state.agentIdBySessionId, [event.payload.sessionId]: event.payload.agentId }
+          : state.agentIdBySessionId,
       }
     }
 

--- a/packages/contracts/src/events.test.ts
+++ b/packages/contracts/src/events.test.ts
@@ -304,6 +304,32 @@ describe("Agent lifecycle events", () => {
 
       expect(second.agentsById["agent-pan-1908"]).toEqual(first.agentsById["agent-pan-1908"])
     })
+
+    it("materializes a strike session under its issue from a role-bearing status event", () => {
+      const changed = applyEvent(INITIAL_READ_MODEL_STATE, decodeDomainEvent({
+        type: "agent.status_changed" as const,
+        sequence: 1,
+        timestamp: "2026-06-15T12:01:00.000Z",
+        payload: {
+          agentId: "strike-pan-2258",
+          issueId: "PAN-2258",
+          status: "running",
+          role: "strike",
+          sessionId: "session-strike-pan-2258",
+          hasLiveTmuxSession: true,
+        },
+      }))
+
+      expect(changed.agentsById["strike-pan-2258"]).toMatchObject({
+        id: "strike-pan-2258",
+        issueId: "PAN-2258",
+        status: "running",
+        role: "strike",
+        sessionId: "session-strike-pan-2258",
+        hasLiveTmuxSession: true,
+      })
+      expect(changed.agentIdBySessionId["session-strike-pan-2258"]).toBe("strike-pan-2258")
+    })
   })
 
   describe("agent.stopped", () => {


### PR DESCRIPTION
Strike fix for PAN-2258: packages/contracts event-reducers had zero strike handling, so the frontend store never materialized a strike session chip under its issue (server side was fully strike-aware). Adds the reducer projection for role=strike plus the reducer-level regression test PAN-1506 lacked — an agent domain event with role strike must yield a session under the issue in the reduced store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event replay so agent status changes now restore missing strike-related agent state more reliably.
  * Session-to-agent linking is now kept in sync when status updates include a session ID, helping preserve correct agent associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->