### PR TITLE
fix(uat-train): gate reconciler to primary dashboard + resolve real project root (PAN-2289)

### DIFF
--- a/src/dashboard/server/main.ts
+++ b/src/dashboard/server/main.ts
@@ -420,8 +420,11 @@ startSubstrateBugPoller();
 // PAN-1737 UAT batch trains: keep one assembled, testable batch ready at all
 // times (gated per-tick on flywheel.merge_train_enabled; no-op without an
 // active flywheel run).
-startUatTrainReconciler();
-console.log('[overdeck] UAT batch-train reconciler started');
+if (startUatTrainReconciler()) {
+  console.log('[overdeck] UAT batch-train reconciler started');
+} else {
+  console.log('[overdeck] UAT batch-train reconciler skipped — non-primary dashboard process');
+}
 
 // Start cleanup for orphaned conversation attachments (1 min interval)
 const attachmentCleanupTimer = setInterval(() => {

--- a/src/dashboard/server/services/__tests__/uat-train.test.ts
+++ b/src/dashboard/server/services/__tests__/uat-train.test.ts
@@ -3,16 +3,39 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Effect } from 'effect';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getUatCandidatePayload, getUatGenerationsPayload } from '../uat-train.js';
+import {
+  canStartUatTrainReconciler,
+  getUatCandidatePayload,
+  getUatGenerationsPayload,
+  resolveUatProjectRoot,
+} from '../uat-train.js';
 import type { UatGeneration } from '../../../../lib/overdeck/merge-types.js';
 
 const mocks = vi.hoisted(() => ({
+  findProjectByPathSync: vi.fn(),
+  getDashboardIdentity: vi.fn(),
   readCurrentFlywheelStatusForDashboard: vi.fn(),
   listUatGenerationsSync: vi.fn(),
   probeUatStack: vi.fn(),
   findVBriefByIssue: vi.fn(),
   readVBriefDocument: vi.fn(),
 }));
+
+vi.mock('../../../../lib/projects.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../../../lib/projects.js')>();
+  return {
+    ...original,
+    findProjectByPathSync: mocks.findProjectByPathSync,
+  };
+});
+
+vi.mock('../../identity.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../identity.js')>();
+  return {
+    ...original,
+    getDashboardIdentity: mocks.getDashboardIdentity,
+  };
+});
 
 vi.mock('../flywheel-actions.js', () => ({
   readCurrentFlywheelStatusForDashboard: mocks.readCurrentFlywheelStatusForDashboard,
@@ -84,6 +107,8 @@ describe('getUatGenerationsPayload', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.findProjectByPathSync.mockReturnValue(null);
+    mocks.getDashboardIdentity.mockReturnValue({ repoRoot: process.cwd(), mode: 'primary' });
     mocks.probeUatStack.mockResolvedValue({ status: 'absent', frontendUrl: 'https://uat-pan-otter-0610.pan.localhost' });
   });
 
@@ -149,6 +174,8 @@ describe('getUatGenerationsPayload', () => {
 describe('getUatCandidatePayload', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.findProjectByPathSync.mockReturnValue(null);
+    mocks.getDashboardIdentity.mockReturnValue({ repoRoot: process.cwd(), mode: 'primary' });
   });
 
   it('returns the newest ready generation as the active UAT candidate', async () => {
@@ -163,7 +190,7 @@ describe('getUatCandidatePayload', () => {
       status: 'ready',
     });
     expect(mocks.listUatGenerationsSync).toHaveBeenCalledWith({
-      projectRoot: process.cwd(),
+      projectRoot: resolveUatProjectRoot(),
       statuses: ['ready'],
       limit: 1,
     });
@@ -173,5 +200,36 @@ describe('getUatCandidatePayload', () => {
     mocks.listUatGenerationsSync.mockReturnValue([]);
 
     await expect(getUatCandidatePayload()).resolves.toBeNull();
+  });
+});
+
+describe('UAT train project root and startup gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findProjectByPathSync.mockReturnValue(null);
+  });
+
+  it('resolves feature workspace cwd back to the project root', () => {
+    expect(resolveUatProjectRoot('/repo/workspaces/feature-pan-2148')).toBe('/repo');
+    expect(resolveUatProjectRoot('/repo/workspaces/feature-pan-2148/workspaces/uat-pan-cobalt-0703')).toBe('/repo');
+  });
+
+  it('prefers the registered project root when the registry matches the cwd', () => {
+    mocks.findProjectByPathSync.mockReturnValue({ path: '/registered/repo' });
+
+    expect(resolveUatProjectRoot('/registered/repo/workspaces/feature-pan-2148')).toBe('/registered/repo');
+  });
+
+  it('lets only the primary dashboard process start the UAT reconciler', () => {
+    mocks.findProjectByPathSync.mockReturnValue({ path: '/repo' });
+
+    mocks.getDashboardIdentity.mockReturnValue({ repoRoot: '/repo', mode: 'primary' });
+    expect(canStartUatTrainReconciler()).toBe(true);
+
+    mocks.getDashboardIdentity.mockReturnValue({ repoRoot: '/repo/workspaces/feature-pan-2148', mode: 'primary' });
+    expect(canStartUatTrainReconciler()).toBe(false);
+
+    mocks.getDashboardIdentity.mockReturnValue({ repoRoot: '/repo', mode: 'peer' });
+    expect(canStartUatTrainReconciler()).toBe(false);
   });
 });

--- a/src/dashboard/server/services/uat-train.ts
+++ b/src/dashboard/server/services/uat-train.ts
@@ -10,6 +10,7 @@
  * is single-flight per project, so ticks never pile up.
  */
 import { stat } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { Effect } from 'effect';
 import { layer as nodeServicesLayer } from '@effect/platform-node/NodeServices';
 import {
@@ -39,6 +40,8 @@ import {
 } from '../../../lib/overdeck/merge-sync.js';
 import { extractACFromDocument } from '../../../lib/vbrief/acceptance-criteria.js';
 import { findVBriefByIssue, readVBriefDocument } from '../../../lib/vbrief/vbrief-index.js';
+import { findProjectByPathSync } from '../../../lib/projects.js';
+import { getDashboardIdentity } from '../identity.js';
 import { readCurrentFlywheelStatusForDashboard } from './flywheel-actions.js';
 
 const RECONCILE_INTERVAL_MS = 60_000;
@@ -55,8 +58,22 @@ interface AcceptanceCriteriaCacheEntry {
 
 const acceptanceCriteriaByIssue = new Map<string, AcceptanceCriteriaCacheEntry>();
 
+export function resolveUatProjectRoot(cwdPath = process.cwd()): string {
+  const registeredProject = findProjectByPathSync(cwdPath);
+  if (registeredProject) return resolve(registeredProject.path);
+
+  const normalized = resolve(cwdPath);
+  const workspaceMatch = normalized.match(/^(.*)\/workspaces\/feature-[^/]+(?:\/.*)?$/i);
+  return workspaceMatch?.[1] ? resolve(workspaceMatch[1]) : normalized;
+}
+
 function projectRoot(): string {
-  return process.cwd();
+  return resolveUatProjectRoot();
+}
+
+export function canStartUatTrainReconciler(): boolean {
+  const identity = getDashboardIdentity();
+  return identity.mode === 'primary' && resolve(identity.repoRoot) === projectRoot();
 }
 
 /** Ready set in merge order, or null when no flywheel run is active. */
@@ -137,8 +154,9 @@ export async function runUatTrainReconcile(options: { force?: boolean } = {}): P
 
 let reconcilerTimer: ReturnType<typeof setInterval> | null = null;
 
-export function startUatTrainReconciler(): void {
-  if (reconcilerTimer) return;
+export function startUatTrainReconciler(): boolean {
+  if (!canStartUatTrainReconciler()) return false;
+  if (reconcilerTimer) return true;
   reconcilerTimer = setInterval(() => {
     void runUatTrainReconcile().catch((err) => {
       console.warn('[uat-train] reconcile tick failed:', err instanceof Error ? err.message : err);
@@ -148,6 +166,7 @@ export function startUatTrainReconciler(): void {
   void runUatTrainReconcile().catch((err) => {
     console.warn('[uat-train] initial reconcile failed:', err instanceof Error ? err.message : err);
   });
+  return true;
 }
 
 export function stopUatTrainReconciler(): void {


### PR DESCRIPTION
Fixes PAN-2289.

## Problem
The UAT batch-train reconciler resolved `projectRoot()` as `process.cwd()`. In a non-primary dashboard process (a workspace-container peer, or a nested `workspaces/feature-*` worktree), that pointed at a non-canonical path, so the engine operated on the wrong worktree — a stale nested UAT worktree could hold the `uat/*` branch and wedge every assembly.

## Fix
- `resolveUatProjectRoot()` resolves the real project root: a registered project's path, or the primary root when cwd is inside a `workspaces/feature-*` worktree.
- `canStartUatTrainReconciler()` gates the reconciler to the **primary** dashboard only (`identity.mode === 'primary'` and matching repo root), so workspace-container peers never run it. `startUatTrainReconciler()` returns a boolean; `main.ts` logs started-vs-skipped.
- +62 lines of unit tests in `uat-train.test.ts`.

## Verification
- Focused uat-train tests + typecheck + lint green (strike agent).
- Full local `npm test` reported broadly red **outside this change** — an environment artifact of the strike workspace, not real: `main` CI is green (`4be4bd41c9`), the diff is isolated to 3 uat-train-scoped files, and it cannot cause failures in unrelated suites. This PR runs the full CI gate on the isolated branch as the authoritative check; merge is gated on that CI being green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
