### PR TITLE
fix(dashboard): container-aware identity guard — stop crash-loop of workspace-container servers (PAN-2298)

### DIFF
--- a/src/dashboard/server/config.ts
+++ b/src/dashboard/server/config.ts
@@ -70,9 +70,9 @@ export const ServerConfigLayer = Layer.effect(
       throw new ServerConfigError('API_PORT', `Invalid port value: "${portStr}"`);
     }
 
-    // A peer dashboard or workspace checkout must never bind the host dashboard
-    // API port. Workspace/devcontainer peer servers are legitimate only when
-    // they use an explicit non-host port.
+    // A host-side peer dashboard or workspace checkout must never bind the host
+    // dashboard API port. Workspace-container peers use an isolated network
+    // namespace, so the identity guard allows their canonical compose port.
     const identity = getDashboardIdentity();
     const hostDashboardApiPort = readHostDashboardApiPort();
     const overrideAllowed = process.env['OVERDECK_WORKSPACE_DASHBOARD_ALLOW_PRIMARY'] === '1';

--- a/src/dashboard/server/identity.ts
+++ b/src/dashboard/server/identity.ts
@@ -47,12 +47,19 @@ export function shouldRefuseHostDashboardPort(input: {
   readonly mode: DashboardMode;
   readonly port: number;
   readonly hostDashboardApiPort?: number;
+  readonly runningInContainer?: boolean;
 }): boolean {
   const hostDashboardApiPort = input.hostDashboardApiPort ?? readHostDashboardApiPort();
   if (input.port !== hostDashboardApiPort) return false;
-  if (input.mode === 'peer') return true;
 
   const repoRoot = resolve(input.repoRoot);
+  const runningInContainer =
+    input.runningInContainer ?? (existsSync('/.dockerenv') || repoRoot === '/workspaces/overdeck');
+  if (runningInContainer) {
+    return false;
+  }
+  if (input.mode === 'peer') return true;
+
   if (isWorkspaceRepoRoot(repoRoot)) return true;
 
   const workspacesDir = resolve(repoRoot, '..');

--- a/tests/unit/dashboard/identity.test.ts
+++ b/tests/unit/dashboard/identity.test.ts
@@ -9,6 +9,7 @@ describe('dashboard identity port guard', () => {
       mode: 'peer',
       port: 3011,
       hostDashboardApiPort: 3011,
+      runningInContainer: false,
     })).toBe(true);
   });
 
@@ -18,6 +19,7 @@ describe('dashboard identity port guard', () => {
       mode: 'peer',
       port: 4011,
       hostDashboardApiPort: 3011,
+      runningInContainer: false,
     })).toBe(false);
   });
 
@@ -27,6 +29,7 @@ describe('dashboard identity port guard', () => {
       mode: 'primary',
       port: 3011,
       hostDashboardApiPort: 3011,
+      runningInContainer: false,
     })).toBe(true);
   });
 
@@ -34,6 +37,26 @@ describe('dashboard identity port guard', () => {
     expect(shouldRefuseHostDashboardPort({
       repoRoot: '/repo',
       mode: 'primary',
+      port: 3011,
+      hostDashboardApiPort: 3011,
+      runningInContainer: false,
+    })).toBe(false);
+  });
+
+  it('allows a peer dashboard on the host dashboard API port inside a container', () => {
+    expect(shouldRefuseHostDashboardPort({
+      repoRoot: '/repo',
+      mode: 'peer',
+      port: 3011,
+      hostDashboardApiPort: 3011,
+      runningInContainer: true,
+    })).toBe(false);
+  });
+
+  it('allows the canonical workspace container repo root on the host dashboard API port', () => {
+    expect(shouldRefuseHostDashboardPort({
+      repoRoot: '/workspaces/overdeck',
+      mode: 'peer',
       port: 3011,
       hostDashboardApiPort: 3011,
     })).toBe(false);


### PR DESCRIPTION
Fixes PAN-2298 (critical regression from PAN-2252).

## Problem
The PAN-2252 identity guard (`shouldRefuseHostDashboardPort`) refuses the host dashboard API port (3011) for any non-host checkout — but it had **no container awareness**. A workspace-container peer server runs in its own isolated network namespace where binding 3011 does NOT collide with the host's 3011, yet the guard refused it, **crash-looping every workspace-container server**.

## Fix
- `shouldRefuseHostDashboardPort` gains an optional `runningInContainer` input, defaulted from `/.dockerenv` or `repoRoot === '/workspaces/overdeck'`.
- When running in a container, the guard returns `false` (allows the canonical compose port) — the isolated namespace makes the collision impossible.
- `config.ts` comment updated to reflect container-peer legitimacy; +23 lines of unit tests in `identity.test.ts`.

## Verification
- `npm run typecheck`, `npm run lint`, focused identity test — green (strike).
- Full local `npm test` red only in unrelated repo-wide suites (workspace-sandbox artifact) — main CI is green and the diff is isolated to identity/config, so it cannot redden unrelated suites. This PR runs the full CI gate on the isolated branch as the authoritative check; merge gated on CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
