### PR TITLE
fix(webhooks): keep smee relay alive (PAN-2306)

### DIFF
--- a/src/dashboard/frontend/src/components/SystemHealthPill.test.tsx
+++ b/src/dashboard/frontend/src/components/SystemHealthPill.test.tsx
@@ -89,6 +89,12 @@ function createSnapshot(severity: SystemHealthSnapshot['severity']): SystemHealt
     reasons: severity === 'critical' ? ['Available RAM below critical threshold'] : [],
     agents: [],
     leakedSpecialists: severity === 'critical' ? [{ name: 'specialist-pan-1', currentIssue: 'PAN-1', reason: 'parent agent missing' }] : [],
+    smeeRelay: {
+      configured: true,
+      running: severity !== 'warning',
+      status: severity === 'warning' ? 'stopped' : 'running',
+      message: severity === 'warning' ? 'Configured but not running' : 'Running',
+    },
     topConsumers: severity === 'critical'
       ? [
           {
@@ -214,6 +220,7 @@ describe('SystemHealthPill', () => {
     expect(screen.getByText('System health')).toBeInTheDocument();
     expect(screen.getByText('Top consumers')).toBeInTheDocument();
     expect(screen.getByText('Overdeck')).toBeInTheDocument();
+    expect(screen.getByText('Webhook relay')).toBeInTheDocument();
     expect(screen.getByText(/Overcommit 40.0%/)).toBeInTheDocument();
     expect(screen.getByText('Remove')).toBeInTheDocument();
     expect(screen.getAllByText('Kill').length).toBeGreaterThan(0);

--- a/src/dashboard/frontend/src/components/SystemHealthPill.tsx
+++ b/src/dashboard/frontend/src/components/SystemHealthPill.tsx
@@ -228,6 +228,12 @@ export function SystemHealthPill({ compact = false }: { compact?: boolean }) {
               <div className="text-muted-foreground">Containers</div>
               <div className="mt-1 font-semibold text-foreground">{data.summary.containerCount}</div>
             </div>
+            <div className="rounded-lg border border-border p-2">
+              <div className="text-muted-foreground">Webhook relay</div>
+              <div className={`mt-1 font-semibold ${data.smeeRelay.running || !data.smeeRelay.configured ? 'text-foreground' : 'text-warning-foreground'}`}>
+                {data.smeeRelay.message}
+              </div>
+            </div>
           </div>
 
           {data.reasons.length > 0 && (

--- a/src/dashboard/frontend/src/types.ts
+++ b/src/dashboard/frontend/src/types.ts
@@ -366,6 +366,12 @@ export interface SystemHealthSnapshot {
   agents: SystemHealthAgentProcess[];
   leakedSpecialists: SystemHealthLeakedSpecialist[];
   topConsumers: SystemHealthConsumer[];
+  smeeRelay: {
+    configured: boolean;
+    running: boolean;
+    status: 'not_configured' | 'running' | 'stopped' | 'unknown';
+    message: string;
+  };
 }
 
 export interface StartAgentGuardrailWarning {

--- a/src/dashboard/server/main.ts
+++ b/src/dashboard/server/main.ts
@@ -62,6 +62,7 @@ import { getOverdeckDatabasePath } from '../../lib/overdeck/paths.js';
 import { ProjectsLive } from '../../lib/overdeck/config.js';
 import { RecordsLive, TmuxLive } from '../../lib/overdeck/infra.js';
 import { getAgentSessionsSync } from '../../lib/tmux.js';
+import { isSmeeConfiguredSync, startSmeeProcessSync } from '../../lib/smee.js';
 
 declare const Bun: unknown;
 
@@ -476,6 +477,20 @@ void (async () => {
 // Start CLIProxy watchdog — auto-restarts the sidecar if it crashes
 startCliproxyWatchdog();
 console.log('[overdeck] CLIProxy watchdog started (30s interval)');
+
+if (isPeerDashboard) {
+  console.log('[overdeck] smee-client webhook relay skipped — peer dashboard (OVERDECK_DISABLE_DEACON=1)');
+} else if (isSmeeConfiguredSync()) {
+  try {
+    startSmeeProcessSync();
+    console.log('[overdeck] smee-client webhook relay ensured');
+  } catch (err) {
+    console.warn('[overdeck] Failed to ensure smee-client webhook relay:', err instanceof Error ? err.message : String(err));
+    emitActivityEntrySync({ source: 'dashboard', level: 'warn', message: `Failed to ensure smee-client webhook relay: ${err instanceof Error ? err.message : String(err)}` });
+  }
+} else {
+  console.log('[overdeck] smee-client webhook relay not configured');
+}
 
 // Clean up pollers on graceful shutdown
 const emitShutdownActivity = () => {

--- a/src/dashboard/server/services/system-health-service.ts
+++ b/src/dashboard/server/services/system-health-service.ts
@@ -11,6 +11,7 @@ import { layer as nodeServicesLayer } from '@effect/platform-node/NodeServices';
 
 import { listRunningAgents, getAgentRuntimeState, type AgentState } from '../../../lib/agents.js';
 import { resolveProjectFromIssueSync } from '../../../lib/projects.js';
+import { isSmeeConfiguredSync, isSmeeProcessRunningSync } from '../../../lib/smee.js';
 import { listPaneValues } from '../../../lib/tmux.js';
 import { DockerStatsCollector, type ContainerStats } from '../../../lib/docker-stats.js';
 import { initEventStore } from '../event-store.js';
@@ -99,6 +100,13 @@ export interface HealthConsumer {
   };
 }
 
+export interface SmeeRelayHealth {
+  configured: boolean;
+  running: boolean;
+  status: 'not_configured' | 'running' | 'stopped' | 'unknown';
+  message: string;
+}
+
 export interface SystemHealthSnapshot {
   severity: SystemHealthSeverity;
   updatedAt: string;
@@ -129,6 +137,7 @@ export interface SystemHealthSnapshot {
   agents: HealthAgentProcess[];
   leakedSpecialists: HealthLeakedSpecialist[];
   topConsumers: HealthConsumer[];
+  smeeRelay: SmeeRelayHealth;
 }
 
 let dockerStatsCollector: DockerStatsCollector | null = null;
@@ -448,6 +457,7 @@ function evaluateSeverity(
     loadPerCore1m: number;
     overcommitPercent: number;
     leakedSpecialistCount: number;
+    smeeRelay: SmeeRelayHealth;
   },
 ): { severity: SystemHealthSeverity; reasons: string[] } {
   const criticalReasons: string[] = [];
@@ -481,6 +491,10 @@ function evaluateSeverity(
     warningReasons.push(`${data.leakedSpecialistCount} leaked specialist session${data.leakedSpecialistCount === 1 ? '' : 's'} detected.`);
   }
 
+  if (data.smeeRelay.configured && !data.smeeRelay.running) {
+    warningReasons.push('smee-client webhook relay is configured but not running.');
+  }
+
   if (criticalReasons.length > 0) {
     return { severity: 'critical', reasons: criticalReasons.concat(warningReasons) };
   }
@@ -488,6 +502,41 @@ function evaluateSeverity(
     return { severity: 'warning', reasons: warningReasons };
   }
   return { severity: 'normal', reasons: [] };
+}
+
+function collectSmeeRelayHealth(): SmeeRelayHealth {
+  try {
+    if (!isSmeeConfiguredSync()) {
+      return {
+        configured: false,
+        running: false,
+        status: 'not_configured',
+        message: 'Not configured',
+      };
+    }
+
+    const running = isSmeeProcessRunningSync();
+    return running
+      ? {
+          configured: true,
+          running: true,
+          status: 'running',
+          message: 'Running',
+        }
+      : {
+          configured: true,
+          running: false,
+          status: 'stopped',
+          message: 'Configured but not running',
+        };
+  } catch (err) {
+    return {
+      configured: false,
+      running: false,
+      status: 'unknown',
+      message: err instanceof Error ? err.message : 'Status check failed',
+    };
+  }
 }
 
 async function collectAgentProcesses(): Promise<HealthAgentProcess[]> {
@@ -591,6 +640,7 @@ async function refreshSystemHealth(snapshot?: DashboardSnapshot): Promise<System
   ]);
 
   const thresholds = defaultThresholds();
+  const smeeRelay = collectSmeeRelayHealth();
   const coreCount = Math.max(cpus().length, 1);
   const loadPerCore1m = Math.round((loadAverage1m / coreCount) * 100) / 100;
   const usedMemoryBytes = Math.max(memory.memTotal - memory.memAvailable, 0);
@@ -603,6 +653,7 @@ async function refreshSystemHealth(snapshot?: DashboardSnapshot): Promise<System
     loadPerCore1m,
     overcommitPercent,
     leakedSpecialistCount: leakedSpecialists.length,
+    smeeRelay,
   });
 
   const containerMemoryBytes = containers.reduce((sum, container) => sum + container.memoryUsage, 0);
@@ -667,6 +718,7 @@ async function refreshSystemHealth(snapshot?: DashboardSnapshot): Promise<System
     agents: sortedAgents,
     leakedSpecialists,
     topConsumers: buildTopConsumers(sortedAgents, containers, leakedSpecialists),
+    smeeRelay,
   };
 
   if (previousSeverity && previousSeverity !== result.severity) {

--- a/src/lib/smee.ts
+++ b/src/lib/smee.ts
@@ -16,10 +16,10 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, unlinkSync, openSync, closeSync, readdirSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { spawn } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 import SmeeClient from 'smee-client';
 import { Effect } from 'effect';
 import { loadConfigSync } from './config.js';
@@ -31,6 +31,7 @@ const SMEE_LOG_PATH = join(homedir(), '.overdeck', 'logs', 'smee.log');
 const MAX_RESTART_ATTEMPTS = 5;
 const BASE_RESTART_DELAY_MS = 1_000;
 const MAX_RESTART_DELAY_MS = 30_000;
+const require = createRequire(import.meta.url);
 
 let activeClient: SmeeClient | null = null;
 let restartTimeout: NodeJS.Timeout | null = null;
@@ -44,6 +45,10 @@ function getSmeeUrl(): string | null {
   } catch {
     return null;
   }
+}
+
+export function isSmeeConfiguredSync(): boolean {
+  return getSmeeUrl() !== null;
 }
 
 function getWebhookTarget(): string {
@@ -145,8 +150,7 @@ export function isSmeeRunningSync(): boolean {
 // ─── CLI process mode (detached subprocess) ──────────────────────────────────
 
 function getSmeeBinaryPath(): string {
-  const moduleDir = dirname(fileURLToPath(import.meta.url));
-  return join(moduleDir, '..', '..', 'node_modules', 'smee-client', 'bin', 'smee.js');
+  return require.resolve('smee-client/bin/smee.js');
 }
 
 function isProcessAlive(pid: number): boolean {


### PR DESCRIPTION
Strike fix for PAN-2306. Bundled getSmeeBinaryPath resolved outside the repo (MODULE_NOT_FOUND); starts the smee relay from server boot (non-fatal, try/caught) instead of only pan up/dev; adds smee health to SystemHealthPill. Isolated (6 files); the strike's red tests were unrelated sandbox-EPERM failures. Verified clean-merge onto main.

Closes #2306