### PR TITLE
fix(dashboard): correct Effect.catchAll misuse in route handlers — status POSTs no longer 500 (PAN-2329)

### DIFF
--- a/src/dashboard/server/routes/__tests__/request-review-nudge.test.ts
+++ b/src/dashboard/server/routes/__tests__/request-review-nudge.test.ts
@@ -12,6 +12,8 @@ const {
   listProjectsMock,
   restoreTrackedBeadsExportMock,
   loadWorkspaceMetadataMock,
+  messageAgentMock,
+  saveAgentRuntimeStateMock,
   transitionIssueToInReviewMock,
   spawnReviewRoleForIssueMock,
 } = vi.hoisted(() => {
@@ -38,6 +40,8 @@ const {
     listProjectsMock: vi.fn(),
     restoreTrackedBeadsExportMock: vi.fn(),
     loadWorkspaceMetadataMock: vi.fn(),
+    messageAgentMock: vi.fn(),
+    saveAgentRuntimeStateMock: vi.fn(),
     transitionIssueToInReviewMock: vi.fn(),
     spawnReviewRoleForIssueMock: vi.fn(),
   };
@@ -89,6 +93,8 @@ vi.mock('../../../../lib/agents.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../../lib/agents.js')>();
   return {
     ...actual,
+    messageAgent: messageAgentMock,
+    saveAgentRuntimeState: saveAgentRuntimeStateMock,
     transitionIssueToInReview: transitionIssueToInReviewMock,
   };
 });
@@ -140,6 +146,29 @@ async function postRequestReview(issueId: string, options: { query?: string; bod
   return { status: response.status, body: JSON.parse(text), appendedEvents };
 }
 
+async function postReviewStatus(issueId: string, body: Record<string, unknown>) {
+  const appendedEvents: Record<string, unknown>[] = [];
+  const request = HttpServerRequest.fromWeb(new Request(
+    `http://localhost/api/review/${issueId}/status`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+  ));
+
+  const response = await Effect.runPromise(
+    Effect.scoped(
+      Effect.flatMap(HttpRouter.toHttpEffect(workspacesRouteLayer), (app) =>
+        Effect.provideService(app, HttpServerRequest.HttpServerRequest, request)
+      ).pipe(Effect.provide(eventStoreLayerFor(appendedEvents))),
+    ),
+  );
+  const responseBody = response.body as { body?: Uint8Array } | null;
+  const text = responseBody?.body ? new TextDecoder().decode(responseBody.body) : '{}';
+  return { status: response.status, body: JSON.parse(text), appendedEvents };
+}
+
 function passedStatus(overrides: Record<string, unknown> = {}) {
   return {
     reviewStatus: 'passed',
@@ -168,6 +197,8 @@ describe('POST /api/review/:id/request nudge and drift gate', () => {
     listProjectsMock.mockReturnValue([{ config: { path: '/tmp/overdeck' } }]);
     loadWorkspaceMetadataMock.mockReturnValue(null);
     restoreTrackedBeadsExportMock.mockReturnValue(Effect.succeed(undefined));
+    messageAgentMock.mockResolvedValue(undefined);
+    saveAgentRuntimeStateMock.mockReturnValue(undefined);
     transitionIssueToInReviewMock.mockResolvedValue(undefined);
     spawnReviewRoleForIssueMock.mockReturnValue(Effect.succeed({ success: true, message: 'spawned' }));
     setReviewStatusMock.mockImplementation((_issueId, update) => update);
@@ -359,5 +390,53 @@ describe('POST /api/review/:id/request nudge and drift gate', () => {
     expect(result.body).toMatchObject({ success: true, alreadyPassed: true });
     expect(console.warn).not.toHaveBeenCalledWith(expect.stringContaining('HEAD lookup failed'));
     expect(setReviewStatusMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/review/:id/status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    messageAgentMock.mockRejectedValue(new Error('agent is not running'));
+    saveAgentRuntimeStateMock.mockReturnValue(undefined);
+    resolveProjectFromIssueMock.mockReturnValue(null);
+    setReviewStatusMock.mockImplementation((issueId, update) => ({
+      issueId,
+      reviewStatus: 'passed',
+      testStatus: 'pending',
+      mergeStatus: 'pending',
+      readyForMerge: false,
+      ...update,
+    }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('persists passed test verdicts even when the optional work-agent notification fails', async () => {
+    const result = await postReviewStatus('PAN-2329', { testStatus: 'passed' });
+
+    expect(result.status).toBe(200);
+    expect(result.body).toMatchObject({
+      issueId: 'PAN-2329',
+      testStatus: 'passed',
+      readyForMerge: false,
+    });
+    expect(setReviewStatusMock).toHaveBeenCalledWith('PAN-2329', { testStatus: 'passed' });
+    expect(setReviewStatusMock).toHaveBeenCalledWith('PAN-2329', { readyForMerge: true });
+    expect(messageAgentMock).toHaveBeenCalledWith(
+      'agent-pan-2329',
+      expect.stringContaining('ALL CHECKS PASSED for PAN-2329'),
+    );
+    expect(result.appendedEvents).toEqual([
+      expect.objectContaining({
+        type: 'pipeline.test-completed',
+        payload: { issueId: 'PAN-2329', passed: true },
+      }),
+    ]);
   });
 });

--- a/src/dashboard/server/routes/artifacts.ts
+++ b/src/dashboard/server/routes/artifacts.ts
@@ -290,7 +290,7 @@ const getArtifactThumbnailRoute = HttpRouter.add(
     }
 
     const response = yield* HttpServerResponse.file(result.path).pipe(
-      Effect.catchAll(() => Effect.succeed(HttpServerResponse.text('', { status: 204 }))),
+      Effect.catch(() => Effect.succeed(HttpServerResponse.text('', { status: 204 }))),
     );
     return HttpServerResponse.setHeader(response, 'Cache-Control', 'public, max-age=31536000, immutable');
   })),

--- a/src/dashboard/server/routes/workspaces.ts
+++ b/src/dashboard/server/routes/workspaces.ts
@@ -1659,7 +1659,7 @@ const postWorkspaceReviewStatusRoute = HttpRouter.add(
           `ALL CHECKS PASSED for ${issueId}. Review: passed. Tests: passed. Your work is complete — ready for merge. You may stop working on this issue.`
         )).pipe(
           Effect.tap(() => Effect.sync(() => console.log(`[review-status] Notified ${notifyAgentId} that all checks passed`))),
-          Effect.catchAll((err) => Effect.sync(() => console.log(
+          Effect.catch((err) => Effect.sync(() => console.log(
             `[review-status] Could not notify work agent for ${issueId} (may not be running): ${err instanceof Error ? err.message : String(err)}`
           ))),
         );

--- a/tests/fixtures/synced-skills.txt
+++ b/tests/fixtures/synced-skills.txt
@@ -30,6 +30,7 @@ pan-admin-config
 pan-admin-hooks
 pan-admin-tldr
 pan-admin-tracker
+pan-agent-activity
 pan-approve
 pan-close
 pan-code-review


### PR DESCRIPTION
Strike fix for PAN-2329. Replaces the invalid `Effect.catchAll(...)` usage (which threw 'Effect.catchAll is not a function' on status POSTs, breaking test/review status recording fleet-wide) with the correct Effect pattern; adds a regression test. Clean-merges onto main; main CI is green.

Closes #2329

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review status handling so passing checks now reliably mark items as ready for merge and continue processing even if notification steps fail.
  * Made artifact thumbnail requests fall back more gracefully when an image can’t be generated, avoiding broken responses.

* **Tests**
  * Added coverage for review status updates, event emission, and failure scenarios to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->