### PR TITLE
fix(agents): correct cross-wired kickoff delivery — agents no longer receive another issue's brief (PAN-2330)

### DIFF
--- a/src/lib/__tests__/deliver-agent-message.test.ts
+++ b/src/lib/__tests__/deliver-agent-message.test.ts
@@ -45,7 +45,7 @@ vi.mock('../paths.js', async (importOriginal) => {
 
 import { BRIDGE_TOKEN_HEADER, writeBridgeTokenSync } from '../bridge-token.js';
 import { PTY_TOKEN_HEADER, writePtyToken } from '../pty-token.js';
-import { deliverAgentMessage, deliverAgentPermissionDecision, deliverInitialPromptWithRetry, deliverResumeMessageWithTranscriptConfirmation, type AgentState } from '../agents.js';
+import { deliverAgentMessage, deliverAgentPermissionDecision, deliverInitialPromptWithRetry, deliverResumeMessageWithTranscriptConfirmation, getAgentDir, type AgentState } from '../agents.js';
 import { sendKeys } from '../tmux.js';
 
 function writeAgentState(agentId: string, partial: Partial<AgentState>): void {
@@ -296,9 +296,9 @@ describe('initial kickoff transcript confirmation', () => {
     expect(snapshot).not.toHaveBeenCalled();
   });
 
-  it('delivers codex kickoff as a short pointer to .pan/kickoff.md', async () => {
+  it('delivers work-agent codex kickoff as a short pointer to .pan/kickoff.md', async () => {
     const workspace = mkdtempSync(join(tmpdir(), 'pan-codex-kickoff-'));
-    const fullPrompt = 'Full planning instructions for PAN-2275';
+    const fullPrompt = 'Full work instructions for PAN-2275';
     const deliver = vi.fn(async () => ({ ok: true, path: 'tmux' as const }));
     const snapshot = vi.fn(async () => ({ sessionFile: '/tmp/session.jsonl', userRecordCount: 0 }));
 
@@ -310,7 +310,7 @@ describe('initial kickoff transcript confirmation', () => {
         undefined,
         {
           ...baseOptions,
-          getState: vi.fn(async () => ({ ...baseState, harness: 'codex', role: 'plan', workspace })),
+          getState: vi.fn(async () => ({ ...baseState, harness: 'codex', role: 'work', workspace })),
           deliver,
           snapshot,
         },
@@ -325,6 +325,41 @@ describe('initial kickoff transcript confirmation', () => {
       );
       expect(deliver.mock.calls[0]?.[1]).toContain('`.pan/kickoff.md`');
       expect(deliver.mock.calls[0]?.[1]).not.toContain(fullPrompt);
+      expect(snapshot).not.toHaveBeenCalled();
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('does not overwrite a work kickoff when delivering a codex role prompt in the same workspace', async () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'pan-codex-role-kickoff-'));
+    const existingWorkPrompt = 'Full work instructions for PAN-2318';
+    const rolePrompt = 'CODE REVIEW for PAN-2318';
+    const agentId = 'agent-pan-2318-review';
+    const deliver = vi.fn(async () => ({ ok: true, path: 'tmux' as const }));
+    const snapshot = vi.fn(async () => ({ sessionFile: '/tmp/session.jsonl', userRecordCount: 0 }));
+
+    try {
+      mkdirSync(join(workspace, '.pan'), { recursive: true });
+      writeFileSync(join(workspace, '.pan', 'kickoff.md'), existingWorkPrompt, 'utf-8');
+
+      await expect(deliverInitialPromptWithRetry(
+        agentId,
+        rolePrompt,
+        'test:codex-review-kickoff',
+        undefined,
+        {
+          ...baseOptions,
+          getState: vi.fn(async () => ({ ...baseState, id: agentId, harness: 'codex', role: 'review', workspace })),
+          deliver,
+          snapshot,
+        },
+      )).resolves.toMatchObject({ ok: true, path: 'tmux' });
+
+      expect(readFileSync(join(workspace, '.pan', 'kickoff.md'), 'utf-8')).toBe(existingWorkPrompt);
+      expect(readFileSync(join(getAgentDir(agentId), 'kickoff.md'), 'utf-8')).toBe(rolePrompt);
+      expect(deliver.mock.calls[0]?.[1]).toContain(join(getAgentDir(agentId), 'kickoff.md'));
+      expect(deliver.mock.calls[0]?.[1]).not.toContain(rolePrompt);
       expect(snapshot).not.toHaveBeenCalled();
     } finally {
       rmSync(workspace, { recursive: true, force: true });

--- a/src/lib/agents/delivery.ts
+++ b/src/lib/agents/delivery.ts
@@ -411,15 +411,24 @@ export async function deliverInitialPromptWithRetry(
   // deliver a SHORT pointer instead (robust regardless of transport — the same
   // pattern that makes file-backed handoffs reliable). Only codex needs this;
   // claude-code/pi line-based input handle the full prompt fine.
+  //
+  // PAN-2330: keep the workspace-level .pan/kickoff.md owned by the work/strike
+  // agent. Review, test, planning, flywheel, and other role prompts can share
+  // the same workspace; writing those prompts to .pan/kickoff.md overwrites the
+  // work agent's brief and a later resume can make it read the wrong task.
   let deliveredPrompt = prompt;
   let state = await getState(agentId);
   try {
-    if (state?.harness && getHarnessBehavior(state.harness).usesCodexHome && state.workspace) {
-      const kickoffPath = join(state.workspace, '.pan', 'kickoff.md');
+    if (state?.harness && getHarnessBehavior(state.harness).usesCodexHome) {
+      const ownsWorkspaceKickoff = state.workspace && (state.role === 'work' || state.role === 'strike');
+      const kickoffPath = ownsWorkspaceKickoff
+        ? join(state.workspace, '.pan', 'kickoff.md')
+        : join(getAgentDir(normalizedId), 'kickoff.md');
+      const displayPath = ownsWorkspaceKickoff ? '`.pan/kickoff.md`' : `\`${kickoffPath}\``;
       mkdirSync(dirname(kickoffPath), { recursive: true });
       writeFileSync(kickoffPath, prompt, 'utf-8');
       deliveredPrompt =
-        'Your complete task brief has been written to `.pan/kickoff.md` in this workspace. '
+        `Your complete task brief has been written to ${displayPath}. `
         + 'Read that file in full now and execute it exactly — it is your full set of work '
         + 'instructions. Begin immediately and keep working autonomously until done; do not '
         + 'wait for further input.';


### PR DESCRIPTION
Strike fix for PAN-2330. Fixes the message-delivery path so an agent's kickoff/brief can't be delivered to a different issue's workspace (which stalled PAN-2318 with a PAN-2203 planning brief). Adds a regression test. Clean-merges onto green main.

Closes #2330