### PR TITLE
fix(lifecycle): mock gh labels-view in close-out tests (red-main, PAN-2412)

### DIFF
--- a/tests/unit/lib/lifecycle/close-issue.test.ts
+++ b/tests/unit/lib/lifecycle/close-issue.test.ts
@@ -51,6 +51,16 @@ import { closeIssue as closeIssueProgram, POST_MERGE_RESIDUE_LABELS, WORKFLOW_LA
 const closeIssue = (...args: Parameters<typeof closeIssueProgram>) =>
   Effect.runPromise(closeIssueProgram(...args));
 
+function mockCurrentGitHubLabels(labels = ['verifying-on-main', 'needs-close-out', 'merged', 'ready']) {
+  mockExecAsync.mockImplementation(async (...args: any[]) => {
+    const command = String(args[0] ?? '');
+    if (command.includes('gh issue view') && command.includes('--json labels')) {
+      return { stdout: JSON.stringify(labels), stderr: '' };
+    }
+    return { stdout: '', stderr: '' };
+  });
+}
+
 describe('close-issue', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -143,7 +153,7 @@ describe('close-issue', () => {
     });
 
     it('adds closed-out and removes workflow labels in one GitHub edit', async () => {
-      mockExecAsync.mockResolvedValue({ stdout: '', stderr: '' });
+      mockCurrentGitHubLabels();
 
       const ctx = {
         issueId: 'PAN-100',

--- a/tests/unit/lib/lifecycle/workflows.test.ts
+++ b/tests/unit/lib/lifecycle/workflows.test.ts
@@ -134,6 +134,15 @@ function successfulTracker() {
   } as any;
 }
 
+function mockCurrentGitHubLabels(labels = ['verifying-on-main', 'needs-close-out', 'merged', 'ready']) {
+  mockExecAsync.mockImplementation(async (command: string) => {
+    if (command.includes('gh issue view') && command.includes('--json labels')) {
+      return { stdout: JSON.stringify(labels), stderr: '' };
+    }
+    return { stdout: '', stderr: '' };
+  });
+}
+
 describe('workflows', () => {
   let testDir: string;
 
@@ -406,6 +415,9 @@ describe('workflows', () => {
       mkdirSync(wsPath, { recursive: true });
       await writeSpecForIssue(testDir, makeVBrief('PAN-100'), 'active');
       mockExecAsync.mockImplementation(async (command: string) => {
+        if (command.includes('gh issue view') && command.includes('--json labels')) {
+          return { stdout: JSON.stringify(['verifying-on-main', 'needs-close-out', 'merged', 'ready']), stderr: '' };
+        }
         if (command.startsWith('git worktree remove')) {
           rmSync(wsPath, { recursive: true, force: true });
         }
@@ -526,6 +538,7 @@ describe('workflows', () => {
     });
 
     it('should remove verifying labels when applying the closed-out label', async () => {
+      mockCurrentGitHubLabels();
       const ctx = {
         issueId: 'PAN-100',
         projectPath: testDir,


### PR DESCRIPTION
Fixes red main. Test-only: both close-out lifecycle test files now mock the new `gh issue view --json labels` call (added in 2518d740db) so the current labels are seen as present and the `--remove-label` args are generated. Source `close-issue.ts` unchanged — its new behavior is the desired one.

Closes PAN-2412.

Verified: `close-issue.test.ts` + `workflows.test.ts` = 43 passed / 1 skipped; `npm run typecheck` exit 0 (incl. hooks + evals); `npm run lint` green.