### PR TITLE
fix(dashboard): repair frontend tiered-execution build (red-main, PAN-2433)

### DIFF
--- a/src/dashboard/frontend/src/components/KanbanBoard/badges/DifficultyBadge.tsx
+++ b/src/dashboard/frontend/src/components/KanbanBoard/badges/DifficultyBadge.tsx
@@ -1,4 +1,4 @@
-import type { ComplexityLevel } from '../../../../../../lib/cloister/complexity.js';
+import type { ComplexityLevel } from '../types';
 
 const DIFFICULTY_COLORS: Record<ComplexityLevel, string> = {
   trivial: 'badge-bg-success text-success-foreground',

--- a/src/dashboard/frontend/src/components/KanbanBoard/cards/KanbanCards.tsx
+++ b/src/dashboard/frontend/src/components/KanbanBoard/cards/KanbanCards.tsx
@@ -5,7 +5,6 @@ import { ExternalLink, User, Play, Eye, DollarSign, ChevronDown, ChevronRight, S
 import { useDashboardStore, selectReviewStatus } from '../../../lib/store';
 import { Issue, Agent, STATUS_LABELS } from '../../../types';
 import { getFriendlyModelName } from '../../../lib/dashboard-utils';
-import { parseDifficultyLabel } from '../../../../../../lib/cloister/complexity.js';
 import { deriveIssueActionPhase, type PipelinePhase } from '../../../lib/issueActions';
 import { cn } from '../../../lib/utils';
 import { getIssueWorkAgentMap, isAgentSessionAttachable } from '../../../lib/workAgents';
@@ -17,7 +16,15 @@ import { CostBreakdownModal } from '../../CostBreakdownModal';
 import type { WorkspaceData } from '../../CommandDeck/ZoneCOverviewTabs/queries';
 import { DifficultyBadge, TrackerShadowBadges } from '../badges';
 import { avatarGradient, cardAvatarInitials, formatCost, formatRuntime, getCostColor } from '../kanban-utils';
-import type { IssueCost, PlanningState } from '../types';
+import type { ComplexityLevel, IssueCost, PlanningState } from '../types';
+
+const DIFFICULTY_LEVELS: ComplexityLevel[] = ['trivial', 'simple', 'medium', 'complex', 'expert'];
+
+function parseDifficultyLabel(labels: string[]): ComplexityLevel | null {
+  const difficultyLabel = labels.find((label) => label.startsWith('difficulty:'));
+  const level = difficultyLabel?.split(':')[1] as ComplexityLevel | undefined;
+  return level && DIFFICULTY_LEVELS.includes(level) ? level : null;
+}
 
 // Feature card — rich card for Rally Features with progress and expand/collapse
 // Children (user stories) render INSIDE the card

--- a/src/dashboard/frontend/src/components/KanbanBoard/types.ts
+++ b/src/dashboard/frontend/src/components/KanbanBoard/types.ts
@@ -14,4 +14,6 @@ export interface PlanningState {
   planningComplete: boolean;
 }
 
+export type ComplexityLevel = 'trivial' | 'simple' | 'medium' | 'complex' | 'expert';
+
 export type CycleFilter = 'current' | 'all' | 'backlog' | 'canceled';

--- a/src/dashboard/frontend/src/components/vbrief/types.ts
+++ b/src/dashboard/frontend/src/components/vbrief/types.ts
@@ -7,6 +7,7 @@ export type VBriefItemStatus = 'draft' | 'proposed' | 'approved' | 'pending' | '
 export type VBriefPriority = 'critical' | 'high' | 'medium' | 'low';
 export type VBriefDifficulty = 'trivial' | 'simple' | 'medium' | 'complex' | 'expert';
 export type VBriefInspectionPolicy = 'auto' | 'never' | 'fast' | 'deep';
+export type TieredExecutionSource = 'global' | 'issue-override' | 'plan-metadata';
 
 export interface VBriefReference {
   uri: string;
@@ -49,7 +50,7 @@ export interface VBriefPlan {
   metadata?: { tiered_execution?: 'on' | 'off'; [key: string]: unknown };
   /** PAN-2383: computed by the plan read door (effective tiered-execution
    * state + where it came from). Optional until the read-door bead lands. */
-  tieredExecution?: { effective: boolean; source: string; override: 'on' | 'off' | null };
+  tieredExecution?: { effective: boolean; source: TieredExecutionSource; override: 'on' | 'off' | null };
   author?: string;
   uid?: string;
   sequence?: number;


### PR DESCRIPTION
Fixes red main (be8f5b948b). Targeted current-main fix, 4 files:
- `vbrief/types.ts`: add `TieredExecutionSource` union; type `VBriefPlan.tieredExecution.source` as it (fixes PlanCard.tsx TS2345).
- `KanbanCards.tsx` + `DifficultyBadge.tsx` + `KanbanBoard/types.ts`: remove the value-import of `parseDifficultyLabel`/`ComplexityLevel` from `lib/cloister/complexity.js` (which pulled server/lib into the frontend's noUnusedLocals typecheck, surfacing the ~15 TS6133 unused-symbol errors); replace with a local implementation + local type.

Verified: frontend build passes (5810 modules, 3.17s). Closes PAN-2433.