### PR TITLE
fix(dashboard): health pill names the actual critical cause, not always '% mem' (PAN-2440)

### DIFF
--- a/src/dashboard/frontend/src/components/SystemHealthPill.test.tsx
+++ b/src/dashboard/frontend/src/components/SystemHealthPill.test.tsx
@@ -233,4 +233,28 @@ describe('SystemHealthPill', () => {
 
     expect(screen.getByTestId('system-health-pill').className).toContain('animate-pulse');
   });
+
+  it('summarizes the critical health cause instead of always showing memory usage', () => {
+    const critical = createSnapshot('critical');
+    hookState.current = {
+      data: {
+        ...critical,
+        summary: {
+          ...critical.summary,
+          availableMemoryBytes: 42 * GIB,
+          memoryUsedPercent: 31,
+          swapUsedPercent: 90,
+        },
+        reasons: ['Swap usage is high (90%).'],
+      },
+      isLoading: false,
+      error: null,
+    };
+
+    renderPill();
+
+    expect(screen.getByTestId('system-health-pill')).toHaveTextContent('critical');
+    expect(screen.getByTestId('system-health-pill')).toHaveTextContent('90% swap');
+    expect(screen.getByTestId('system-health-pill')).not.toHaveTextContent('31% mem');
+  });
 });

--- a/src/dashboard/frontend/src/components/SystemHealthPill.tsx
+++ b/src/dashboard/frontend/src/components/SystemHealthPill.tsx
@@ -27,6 +27,17 @@ function topConsumerLabel(consumer: SystemHealthConsumer): string {
   return consumer.label;
 }
 
+function primaryHealthLabel(data: SystemHealthSnapshot): string {
+  const reasons = data.reasons.join(' ');
+  if (/Available RAM/i.test(reasons)) return `${formatBytes(data.summary.availableMemoryBytes)} avail`;
+  if (/Swap usage/i.test(reasons)) return `${Math.round(data.summary.swapUsedPercent)}% swap`;
+  if (/CPU load/i.test(reasons)) return `${data.summary.loadPerCore1m.toFixed(2)} load/core`;
+  if (/Committed memory/i.test(reasons)) return `${Math.round(data.summary.overcommitPercent)}% commit`;
+  if (/leaked specialist/i.test(reasons)) return `${data.summary.leakedSpecialistCount} leaked`;
+  if (/smee-client/i.test(reasons)) return 'relay down';
+  return `${Math.round(data.summary.memoryUsedPercent)}% mem`;
+}
+
 function KillButton({ consumer, onSelectLeaked }: { consumer: SystemHealthConsumer; onSelectLeaked: () => void }) {
   const confirm = useConfirm();
   const queryClient = useQueryClient();
@@ -173,7 +184,7 @@ export function SystemHealthPill({ compact = false }: { compact?: boolean }) {
           {!compact && (
             <>
               <span className="font-semibold uppercase tracking-wide">{data.severity}</span>
-              <span className="text-muted-foreground">{Math.round(data.summary.memoryUsedPercent)}% mem</span>
+              <span className="text-muted-foreground">{primaryHealthLabel(data)}</span>
             </>
           )}
         </span>

--- a/src/dashboard/server/services/__tests__/system-health-service-classify.test.ts
+++ b/src/dashboard/server/services/__tests__/system-health-service-classify.test.ts
@@ -1,6 +1,36 @@
 import { describe, expect, it } from 'vitest';
 
-import { classifyAgentKind } from '../system-health-service.js';
+import { classifyAgentKind, evaluateSeverity } from '../system-health-service.js';
+
+const GIB = 1024 ** 3;
+
+const thresholds = {
+  memoryAvailableWarningBytes: 4 * GIB,
+  memoryAvailableCriticalBytes: 2 * GIB,
+  swapUsedWarningPercent: 20,
+  swapUsedCriticalPercent: 50,
+  cpuLoadWarningPerCore: 1,
+  cpuLoadCriticalPerCore: 1.5,
+  overcommitWarningPercent: 150,
+  overcommitCriticalPercent: 200,
+};
+
+function severityInput(overrides: Partial<Parameters<typeof evaluateSeverity>[1]> = {}): Parameters<typeof evaluateSeverity>[1] {
+  return {
+    availableMemoryBytes: 16 * GIB,
+    swapUsedPercent: 0,
+    loadPerCore1m: 0.2,
+    overcommitPercent: 40,
+    leakedSpecialistCount: 0,
+    smeeRelay: {
+      configured: false,
+      running: false,
+      status: 'not_configured',
+      message: 'Not configured',
+    },
+    ...overrides,
+  };
+}
 
 describe('classifyAgentKind (PAN-1257)', () => {
   it.each([
@@ -22,5 +52,44 @@ describe('classifyAgentKind (PAN-1257)', () => {
 
   it('classifies legacy specialist prefixes as specialists', () => {
     expect(classifyAgentKind('specialist-foo')).toBe('specialist');
+  });
+});
+
+describe('evaluateSeverity memory thresholds', () => {
+  it('keeps healthy memory usage normal when available RAM is above warning threshold', () => {
+    expect(evaluateSeverity(thresholds, severityInput({
+      availableMemoryBytes: 42 * GIB,
+    }))).toEqual({ severity: 'normal', reasons: [] });
+  });
+
+  it('warns below the available-memory warning threshold', () => {
+    const result = evaluateSeverity(thresholds, severityInput({
+      availableMemoryBytes: Math.floor(3.5 * GIB),
+    }));
+
+    expect(result.severity).toBe('warning');
+    expect(result.reasons).toEqual(['Available RAM is tight (3.5 GB).']);
+  });
+
+  it('marks critical below the available-memory critical threshold', () => {
+    const result = evaluateSeverity(thresholds, severityInput({
+      availableMemoryBytes: Math.floor(1.5 * GIB),
+    }));
+
+    expect(result.severity).toBe('critical');
+    expect(result.reasons).toEqual(['Available RAM is low (1.5 GB).']);
+  });
+
+  it('does not warn exactly at the memory threshold boundaries', () => {
+    expect(evaluateSeverity(thresholds, severityInput({
+      availableMemoryBytes: 4 * GIB,
+    }))).toEqual({ severity: 'normal', reasons: [] });
+
+    const result = evaluateSeverity(thresholds, severityInput({
+      availableMemoryBytes: 2 * GIB,
+    }));
+
+    expect(result.severity).toBe('warning');
+    expect(result.reasons).toEqual(['Available RAM is tight (2 GB).']);
   });
 });

--- a/src/dashboard/server/services/system-health-service.ts
+++ b/src/dashboard/server/services/system-health-service.ts
@@ -449,7 +449,7 @@ function buildLeakedSpecialists(
     }));
 }
 
-function evaluateSeverity(
+export function evaluateSeverity(
   thresholds: SystemHealthThresholds,
   data: {
     availableMemoryBytes: number;


### PR DESCRIPTION
Strike for PAN-2440. The header pill showed 'CRITICAL 31% mem' when severity was driven by swap/CPU/leaks — the label always rendered memoryUsedPercent regardless of cause. Now summarizes the primary reason (e.g. '90% swap', 'relay down'); '% mem' only as fallback. Adds SystemHealthPill + evaluateSeverity threshold tests.

Gates run by merge owner: typecheck ✓ lint ✓ targeted server+frontend tests ✓

Closes #2440

🤖 Generated with [Claude Code](https://claude.com/claude-code)