### PR TITLE
fix(agents): fleet 24h cost/token tiles use canonical costs summary (PAN-2439)

### DIFF
--- a/src/dashboard/frontend/src/components/Agents/FleetAgentsView.test.tsx
+++ b/src/dashboard/frontend/src/components/Agents/FleetAgentsView.test.tsx
@@ -45,12 +45,11 @@ function renderFleetView(props: { onNavigateToIssues?: () => void } = {}) {
       mutations: { retry: false },
     },
   });
-  client.setQueryData(['cost-stream', undefined, 500], {
-    events: [],
-    byIssue: {
-      'pan-1': [{ ts: '2026-05-18T00:00:00.000Z', model: 'opus', provider: 'anthropic', cost: 12.34, tokens: 456_000 }],
+  client.setQueryData(['agents-fleet-cost-summary'], {
+    today: {
+      totalCost: 12.34,
+      totalTokens: 456_000,
     },
-    count: 1,
   });
 
   return render(
@@ -99,6 +98,14 @@ describe('FleetAgentsView', () => {
           count: 1,
         }), { status: 200 });
       }
+      if (url.startsWith('/api/costs/summary')) {
+        return new Response(JSON.stringify({
+          today: {
+            totalCost: 12.34,
+            totalTokens: 456_000,
+          },
+        }), { status: 200 });
+      }
       return new Response(JSON.stringify({}), { status: 200 });
     }));
   });
@@ -138,6 +145,38 @@ describe('FleetAgentsView', () => {
     expect(within(tiles[3] as HTMLElement).getByText('456K')).toBeInTheDocument();
     expect(within(tiles[4] as HTMLElement).getByText('3h 0m')).toBeInTheDocument();
     expect(tiles[2]).toHaveAttribute('title', 'Open /costs for canonical 24h spend numbers');
+  });
+
+  it('uses canonical cost summary totals instead of issue-attributed stream buckets', () => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, staleTime: Infinity },
+        mutations: { retry: false },
+      },
+    });
+    client.setQueryData(['agents-fleet-cost-summary'], {
+      today: {
+        totalCost: 27.89,
+        totalTokens: 789_000,
+      },
+    });
+    client.setQueryData(['cost-stream', undefined, 500], {
+      events: [{ ts: '2026-05-18T00:00:00.000Z', model: 'opus', provider: 'anthropic', cost: 0, tokens: 0 }],
+      byIssue: {},
+      count: 1,
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <DialogProvider>
+          <FleetAgentsView />
+        </DialogProvider>
+      </QueryClientProvider>,
+    );
+
+    const tiles = Array.from(document.querySelectorAll('[data-component="metric-tile"]'));
+    expect(within(tiles[2] as HTMLElement).getByText('$27.9')).toBeInTheDocument();
+    expect(within(tiles[3] as HTMLElement).getByText('789K')).toBeInTheDocument();
   });
 
   it('renders stuck agents with the destructive override and stuck verb badge', () => {
@@ -224,10 +263,14 @@ describe('FleetAgentsView', () => {
     });
     client.setQueryData(['cost-stream', undefined, 500], {
       events: [],
-      byIssue: {
-        'pan-1': [{ ts: '2026-05-18T00:00:00.000Z', model: 'opus', provider: 'anthropic', cost: 12.34, tokens: 456_000 }],
+      byIssue: {},
+      count: 0,
+    });
+    client.setQueryData(['agents-fleet-cost-summary'], {
+      today: {
+        totalCost: 12.34,
+        totalTokens: 456_000,
       },
-      count: 1,
     });
 
     render(

--- a/src/dashboard/frontend/src/components/Agents/FleetAgentsView.tsx
+++ b/src/dashboard/frontend/src/components/Agents/FleetAgentsView.tsx
@@ -1,6 +1,6 @@
+import { useQuery } from '@tanstack/react-query';
 import { Component, useEffect, useMemo, useState, type ReactNode } from 'react';
 
-import { useCostStream, type CostEvent } from '../../hooks/useCostStream';
 import { isAgentProblemStatus, isAgentRunningStatus } from '../../lib/pipeline-state';
 import { isAwaitingInput } from '../../lib/pendingInput';
 import { useSharedTick } from '../../lib/useSharedTick';
@@ -44,6 +44,19 @@ type FilterOption = {
 type AgentsViewMode = 'grid' | 'table' | 'timeline';
 const VIEW_MODES: AgentsViewMode[] = ['grid', 'table', 'timeline'];
 
+type CostSummaryResponse = {
+  today?: {
+    totalCost?: number;
+    totalTokens?: number;
+  };
+};
+
+async function fetchCostSummary(): Promise<CostSummaryResponse> {
+  const res = await fetch('/api/costs/summary');
+  if (!res.ok) throw new Error('Failed to fetch cost summary');
+  return res.json();
+}
+
 function readViewMode(): AgentsViewMode {
   if (typeof window === 'undefined') return 'grid';
   const params = new URLSearchParams(window.location.search);
@@ -60,13 +73,6 @@ function replaceViewUrl(view: AgentsViewMode) {
     url.searchParams.set('view', view);
   }
   window.history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`);
-}
-
-function sumIssueCostEvents(events: CostEvent[] | undefined) {
-  return (events ?? []).reduce(
-    (totals, event) => ({ cost: totals.cost + event.cost, tokens: totals.tokens + event.tokens }),
-    { cost: 0, tokens: 0 },
-  );
 }
 
 function agentRole(agent: Agent): AgentCardRole {
@@ -288,7 +294,11 @@ export function FleetAgentsView({ onNavigateToIssues }: { onNavigateToIssues?: (
   const openIssue = useDashboardStore((state) => state.openIssue);
   const [filter, setFilter] = useState(readFilterState);
   const [viewMode, setViewMode] = useState<AgentsViewMode>(readViewMode);
-  const { eventsByIssue } = useCostStream({ limit: 500 });
+  const { data: costSummary } = useQuery({
+    queryKey: ['agents-fleet-cost-summary'],
+    queryFn: fetchCostSummary,
+    refetchInterval: 30_000,
+  });
 
   useEffect(() => {
     const handlePopState = () => {
@@ -359,17 +369,8 @@ export function FleetAgentsView({ onNavigateToIssues }: { onNavigateToIssues?: (
       const sum = finiteDurations.reduce((total, t) => total + Math.max(0, now.getTime() - t), 0);
       return sum / finiteDurations.length;
     })();
-    const costIssueIds = new Set(fleetAgents.map((agent) => issueKey(agent.issueId)).filter(Boolean));
-    const { cost24h, tokens24h } = Array.from(costIssueIds).reduce(
-      (totals, issueId) => {
-        const issueTotals = sumIssueCostEvents(eventsByIssue[issueId] ?? eventsByIssue[issueId.toUpperCase()]);
-        return {
-          cost24h: totals.cost24h + issueTotals.cost,
-          tokens24h: totals.tokens24h + issueTotals.tokens,
-        };
-      },
-      { cost24h: 0, tokens24h: 0 },
-    );
+    const cost24h = costSummary?.today?.totalCost ?? 0;
+    const tokens24h = costSummary?.today?.totalTokens ?? 0;
 
     return [
       { id: 'running', eyebrow: 'Running', value: runningAgents.length, sub: 'live agents', icon: <MetricIcon label="▶" />, signal: 'info' as const },
@@ -387,7 +388,7 @@ export function FleetAgentsView({ onNavigateToIssues }: { onNavigateToIssues?: (
       { id: 'runtime', eyebrow: 'Avg runtime', value: formatDuration(avgRuntime), sub: 'running agents', icon: <MetricIcon label="⏱" />, signal: 'review' as const },
       { id: 'queue', eyebrow: 'Queue', value: queuedAgents.length, sub: 'starting agents', icon: <MetricIcon label="…" />, signal: 'warning' as const },
     ];
-  }, [eventsByIssue, fleetAgents, now]);
+  }, [costSummary, fleetAgents, now]);
 
   function updateFilter(next: AgentsFilterState) {
     setFilter(next);

--- a/src/dashboard/server/routes/costs.ts
+++ b/src/dashboard/server/routes/costs.ts
@@ -61,7 +61,15 @@ const getCostsSummaryRoute = HttpRouter.add(
         const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
         const monthAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
 
-        type Entry = { issueId?: string; cost?: number; input?: number; output?: number; model?: string };
+        type Entry = {
+          issueId?: string;
+          cost?: number;
+          input?: number;
+          output?: number;
+          cacheRead?: number;
+          cacheWrite?: number;
+          model?: string;
+        };
         const scope = (entries: Entry[]) =>
           projectPrefix
             ? entries.filter((e) => typeof e.issueId === 'string' && e.issueId.toUpperCase().startsWith(`${projectPrefix}-`))
@@ -73,7 +81,10 @@ const getCostsSummaryRoute = HttpRouter.add(
 
         const summarize = (entries: Entry[]) => ({
           totalCost: entries.reduce((sum, e) => sum + (e.cost || 0), 0),
-          totalTokens: entries.reduce((sum, e) => sum + ((e.input || 0) + (e.output || 0)), 0),
+          totalTokens: entries.reduce(
+            (sum, e) => sum + ((e.input || 0) + (e.output || 0) + (e.cacheRead || 0) + (e.cacheWrite || 0)),
+            0,
+          ),
           entryCount: entries.length,
           byModel: entries.reduce<Record<string, number>>((acc, e) => {
             if (e.model) acc[e.model] = (acc[e.model] || 0) + (e.cost || 0);


### PR DESCRIPTION
Strike for PAN-2439. The Agents fleet header computed 24h COST/TOKENS from issue-attributed cost-stream buckets (broken by the attribution gap tracked in PAN-2387), reading $0/0 with 8 agents live. Now reads the canonical /api/costs/summary today totals — one read door. Tests updated + new canonical-vs-bucket test.

Gates run by merge owner: typecheck ✓ lint ✓ FleetAgentsView tests 21/21 ✓

Closes #2439

🤖 Generated with [Claude Code](https://claude.com/claude-code)