### PR TITLE
fix(cloister): break feedback-target ↔ review-verdict-feedback cycle — RED MAIN fix (PAN-2471)

### DIFF
--- a/src/lib/cloister/feedback-target.ts
+++ b/src/lib/cloister/feedback-target.ts
@@ -11,6 +11,7 @@ export type IssueFeedbackTarget =
 
 export interface ResolveIssueFeedbackTargetOptions {
   itemId?: string;
+  revivePipelinePausedAgent?: (agentId: string, issueId: string) => Promise<boolean>;
 }
 
 async function isLiveSession(agentId: string): Promise<boolean> {
@@ -105,7 +106,7 @@ export async function resolveIssueFeedbackTarget(
   // pipeline's to clear when it has actionable feedback to deliver: unpause and
   // resume the whole-issue agent so the feedback lands. Operator pauses (pan pause,
   // any non-"needs-you:" reason) are never touched.
-  const revived = await revivePipelinePausedAgent(wholeIssueAgentId, normalizedIssue);
+  const revived = await opts.revivePipelinePausedAgent?.(wholeIssueAgentId, normalizedIssue);
   if (revived) return { agentId: wholeIssueAgentId };
 
   const suffix = requestedItemId ? ` for item ${requestedItemId}` : '';
@@ -113,33 +114,6 @@ export async function resolveIssueFeedbackTarget(
     needsYou: true,
     reason: `No live feedback target for ${normalizedIssue}${suffix}: ${wholeIssueAgentId} is not running and no assigned swarm slot has a live tmux session.`,
   };
-}
-
-/**
- * PAN-2461: unpause + resume an agent that the PIPELINE paused (pausedReason
- * starts with "needs-you:") so feedback can be delivered to it. Returns true
- * when the agent is live again. Operator pauses are left untouched.
- */
-async function revivePipelinePausedAgent(agentId: string, issueId: string): Promise<boolean> {
-  try {
-    const { getAgentStateSync, clearAgentPausedSync } = await import('../agents/agent-state.js');
-    const state = getAgentStateSync(agentId);
-    if (!state) return false;
-    if (state.paused !== true || !state.pausedReason?.startsWith('needs-you:')) return false;
-
-    console.log(`[feedback-target] ${agentId} is pipeline-paused (${state.pausedReason}) — unpausing to deliver feedback for ${issueId}`);
-    clearAgentPausedSync(agentId);
-    const { resumeAgent } = await import('../agents.js');
-    const result = await resumeAgent(agentId);
-    if (!result.success) {
-      console.warn(`[feedback-target] Failed to revive ${agentId}: ${result.error}`);
-      return false;
-    }
-    return isLiveSession(agentId);
-  } catch (err) {
-    console.warn(`[feedback-target] revivePipelinePausedAgent(${agentId}) failed: ${err instanceof Error ? err.message : String(err)}`);
-    return false;
-  }
 }
 
 export function surfaceIssueFeedbackNeedsYou(

--- a/src/lib/cloister/review-verdict-feedback.ts
+++ b/src/lib/cloister/review-verdict-feedback.ts
@@ -6,10 +6,11 @@ import { promisify } from 'node:util';
 
 import { Effect } from 'effect';
 
-import { messageAgent } from '../agents.js';
+import { clearAgentPausedSync, getAgentStateSync, messageAgent, resumeAgent } from '../agents.js';
 import { resolveProjectFromIssueSync } from '../projects.js';
 import { getReviewStatusSync } from '../review-status.js';
 import { PAN_DIRNAME } from '../pan-dir/types.js';
+import { sessionExists } from '../tmux.js';
 import { writeFeedbackFile } from './feedback-writer.js';
 import { resolveIssueFeedbackTarget, surfaceIssueFeedbackNeedsYou } from './feedback-target.js';
 
@@ -124,7 +125,10 @@ async function deliverReviewVerdictFeedbackPromise(
   if (fileResult.success && fileResult.filePath) {
     const message = `SPECIALIST FEEDBACK: review-agent reported ${opts.verdict.toUpperCase()} for ${issueId}.\n\nMUST READ: ${fileResult.filePath}\n\nUse your Read tool to open this file, read every line, then fix ALL review findings. Do NOT stop at the prompt.`;
     try {
-      const target = await resolveIssueFeedbackTarget(issueId, { itemId: opts.slotItemId });
+      const target = await resolveIssueFeedbackTarget(issueId, {
+        itemId: opts.slotItemId,
+        revivePipelinePausedAgent,
+      });
       if ('agentId' in target) {
         try {
           await messageAgent(target.agentId, message);
@@ -156,6 +160,31 @@ async function deliverReviewVerdictFeedbackPromise(
     prCommentPosted,
     agentMessageSent,
   };
+}
+
+/**
+ * PAN-2461: unpause + resume an agent that the PIPELINE paused (pausedReason
+ * starts with "needs-you:") so feedback can be delivered to it. Operator pauses
+ * are left untouched.
+ */
+async function revivePipelinePausedAgent(agentId: string, issueId: string): Promise<boolean> {
+  try {
+    const state = getAgentStateSync(agentId);
+    if (!state) return false;
+    if (state.paused !== true || !state.pausedReason?.startsWith('needs-you:')) return false;
+
+    console.log(`[review-verdict-feedback] ${agentId} is pipeline-paused (${state.pausedReason}) — unpausing to deliver feedback for ${issueId}`);
+    clearAgentPausedSync(agentId);
+    const result = await resumeAgent(agentId);
+    if (!result.success) {
+      console.warn(`[review-verdict-feedback] Failed to revive ${agentId}: ${result.error}`);
+      return false;
+    }
+    return Effect.runPromise(sessionExists(agentId));
+  } catch (err) {
+    console.warn(`[review-verdict-feedback] revivePipelinePausedAgent(${agentId}) failed: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
 }
 
 // ─── Effect variant (PAN-1249) ───────────────────────────────────────────────

--- a/tests/unit/lib/cloister/deacon-swarm-verdict-routing.test.ts
+++ b/tests/unit/lib/cloister/deacon-swarm-verdict-routing.test.ts
@@ -127,7 +127,7 @@ describe('swarm verdict feedback routing', () => {
     }));
 
     expect(result.agentMessageSent).toBe(true);
-    expect(mockResolveIssueFeedbackTarget).toHaveBeenCalledWith('PAN-2203', { itemId: 'wi-b' });
+    expect(mockResolveIssueFeedbackTarget).toHaveBeenCalledWith('PAN-2203', expect.objectContaining({ itemId: 'wi-b' }));
     expect(mockMessageAgent).toHaveBeenCalledWith(
       'agent-pan-2203-slot-2',
       expect.stringContaining('MUST READ: /tmp/workspace/.pan/feedback/001-review-agent-changes-requested.md'),
@@ -183,7 +183,7 @@ describe('swarm verdict feedback routing', () => {
     }));
 
     expect(result.agentMessageSent).toBe(true);
-    expect(mockResolveIssueFeedbackTarget).toHaveBeenCalledWith('PAN-2203', { itemId: 'wi-c' });
+    expect(mockResolveIssueFeedbackTarget).toHaveBeenCalledWith('PAN-2203', expect.objectContaining({ itemId: 'wi-c' }));
     expect(mockMessageAgent).toHaveBeenCalledWith(
       'agent-pan-2203-slot-1',
       expect.stringContaining('MUST READ: /tmp/workspace/.pan/feedback/001-review-agent-changes-requested.md'),


### PR DESCRIPTION
Fixes RED MAIN: the lint circular-dependency guard failing on a new cycle introduced by PAN-2469's verdict-routing/drift-logging work. Breaks the `feedback-target.ts ↔ review-verdict-feedback.ts` cycle via dependency inversion — **no baseline changes** (`✓ circular-dependency guard passed, no new cycles`). typecheck + full lint + focused vitest (5 tests) pass. Closes PAN-2471.

Strike agent `strike-pan-2471`, RUN-58 red-main P0.