### PR TITLE
fix(no-loss): register ship-log route in no_loss_matrix (PAN-2490 red-main)

### DIFF
--- a/tests/unit/lib/overdeck/no-loss-matrix.ts
+++ b/tests/unit/lib/overdeck/no-loss-matrix.ts
@@ -271,6 +271,7 @@ export const NO_LOSS_MATRIX: MatrixEntry[] = [
   // ── issues.ts ─────────────────────────────────────────────────────────────
   { surface: 'GET /api/issues',                                     kind: 'http', disposition: 'READ',        door: 'IssuesResolver.list' },
   { surface: 'GET /api/issues/:id/analyze',                         kind: 'http', disposition: 'DELETE',      door: 'ad-hoc analysis helper; no pipeline branch reads it' },
+  { surface: 'GET /api/issues/:id/ship-log',                        kind: 'http', disposition: 'READ',        door: 'Ship log / ship view surface' },
   { surface: 'GET /api/issues/:id/beads',                           kind: 'http', disposition: 'RELOCATE',    door: 'Beads (out of remodel scope)' },
   { surface: 'GET /api/issues/:id/planning-state',                  kind: 'http', disposition: 'READ',        door: 'IssuesResolver.get (stage + planRef)' },
   { surface: 'GET /api/issues/:id/pr',                              kind: 'http', disposition: 'READ',        door: 'IssuesResolver.get(.pr) + live GitHub for CI' },


### PR DESCRIPTION
Completes the red-main fix: adds `GET /api/issues/:id/ship-log` to `NO_LOSS_MATRIX` (tests/unit/lib/overdeck/no-loss-matrix.ts). Pairs with 14e35a1987 (issues-no-loss expectedRoutes + 29→30) to green the `test` job. Additive — registers an intentionally-added route in the no-loss ledger. Fixes PAN-2490.