### PR TITLE
fix(no-loss): remove duplicate ship-log matrix entry (PAN-2496 red-main)

### DIFF
--- a/tests/unit/lib/overdeck/no-loss-matrix.ts
+++ b/tests/unit/lib/overdeck/no-loss-matrix.ts
@@ -274,7 +274,6 @@ export const NO_LOSS_MATRIX: MatrixEntry[] = [
   // ── issues.ts ─────────────────────────────────────────────────────────────
   { surface: 'GET /api/issues',                                     kind: 'http', disposition: 'READ',        door: 'IssuesResolver.list' },
   { surface: 'GET /api/issues/:id/analyze',                         kind: 'http', disposition: 'DELETE',      door: 'ad-hoc analysis helper; no pipeline branch reads it' },
-  { surface: 'GET /api/issues/:id/ship-log',                        kind: 'http', disposition: 'READ',        door: 'Ship log / ship view surface' },
   { surface: 'GET /api/issues/:id/beads',                           kind: 'http', disposition: 'RELOCATE',    door: 'Beads (out of remodel scope)' },
   { surface: 'GET /api/issues/:id/planning-state',                  kind: 'http', disposition: 'READ',        door: 'IssuesResolver.get (stage + planRef)' },
   { surface: 'GET /api/issues/:id/ship-log',                        kind: 'http', disposition: 'READ',        door: 'getShipLog + ReviewStatusResolver (merge progress)' },


### PR DESCRIPTION
Removes the duplicate `GET /api/issues/:id/ship-log` NO_LOSS_MATRIX entry created by the PAN-1644 + PAN-2490 UAT merge collision. Greens the `test` job (`no-loss-matrix.test.ts > matrix has no duplicate surface entries`). Fixes PAN-2496.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal coverage tracking for a legacy issue ship-log endpoint entry to reflect a more specific implementation path.
  * No user-facing behavior, UI, or API changes were included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->