### PR TITLE
PAN-2364

### DIFF
--- a/docs/SWARM.md
+++ b/docs/SWARM.md
@@ -55,7 +55,7 @@ Two dispatchable items whose `files_scope` overlaps are serialized. Deacon may d
    `classifyInFlightSlots()` classifies slots as `running`, `ready-to-merge`, `failed`, or `stalled`. It checks a slot's durable completion marker first (see [Durable Slot Completion](#durable-slot-completion) below); a matching marker makes the slot `ready-to-merge` with signal `durable-completion` regardless of session state. Otherwise a pane exit code of 0 makes a slot ready to merge. A missing session, missing agent, non-zero pane exit, or unknown dead-pane exit makes it failed. A live pane with no branch-tip commit progress and no pane-output progress past the stall threshold becomes stalled.
 
 5. Verify and merge ready slots.
-   `mergeReadySlots()` calls `verifyAndMergeSlot()`. On success it writes the item `done` through `applyTaskOperationToPlanFile()`. On merge conflicts it records a failed-merge recovery block.
+   `mergeReadySlots()` calls `verifyAndMergeSlot()` for each slot that is not blocked. On success it writes the item `done` through `applyTaskOperationToPlanFile()`. On merge conflicts it records a per-slot failed-merge recovery block; the coordinator then skips that slot on subsequent passes while continuing to merge and dispatch the remaining slots.
 
 6. Garbage collect merged slots.
    `gcMergedSlots()` removes merged slot worktrees and branches after the slot has been incorporated into the parent feature branch.
@@ -64,7 +64,7 @@ Two dispatchable items whose `files_scope` overlaps are serialized. Deacon may d
    `dispatchNextWave()` calls `getDispatchableItems(doc, mergedItemIds)`, filters to slot-eligible items, applies file-overlap serialization, checks global capacity, allocates the lowest free slot index, claims the vBRIEF item through the write door, and spawns `agent-<issue>-slot-N`.
 
 8. Recover failed or stalled slots.
-   Failed merge and stalled-slot records pause automatic advancement for that issue until `pan swarm recover` applies an operator-selected action.
+   Failed merge and stalled-slot records are stored per slot. A block pauses automatic advancement for that specific slot only; the coordinator keeps working on the rest of the issue. `pan swarm status` lists all blocked slots and labels them `failed-merge-blocked` so they are not misreported as `ready-to-merge`. Recovery is applied slot-by-slot with `pan swarm recover <id> <slotIndex>`.
 
 ## CLI
 
@@ -94,11 +94,11 @@ pan swarm recover PAN-2203 1 --action drop
 pan swarm recover PAN-2203 1 --action handoff
 ```
 
-`pan swarm recover <id> <slotIndex> --action retry|drop|handoff` calls the same recovery path used by Deacon:
+`pan swarm recover <id> <slotIndex> --action retry|drop|handoff` targets a single blocked slot. Failed-merge and stalled-slot blocks are stored per-slot, so one blocked slot does not halt the rest of the swarm. The coordinator continues merging and dispatching other slots while any slot remains blocked.
 
 | Action | Effect |
 | --- | --- |
-| `retry` | Unblocks the item, clears the failed-slot block, and redispatches through `dispatchNextWave()`. |
+| `retry` | Archives the conflicted slot attempt (renames its branch and worktree to a superseded attempt record) so the old attempt cannot re-assert, unblocks the item, clears the per-slot block, and redispatches a fresh attempt through `dispatchNextWave()`. |
 | `drop` | Marks the item done through the vBRIEF write door and clears the block. Use only when the operator has verified the slot output is no longer needed. |
 | `handoff` | Keeps advancement paused and records an operator handoff note for manual resolution. |
 
@@ -132,7 +132,7 @@ Pane exit alone is not enough. A model can leave a pane alive while making no pr
 - the branch-tip commit time for the slot branch; and
 - the captured pane output digest.
 
-If neither changes before the stall threshold elapses, the slot becomes `stalled`. Deacon records a recovery block and stops advancing that issue until the operator chooses `retry`, `drop`, or `handoff`.
+If neither changes before the stall threshold elapses, the slot becomes `stalled`. Deacon records a per-slot recovery block and stops advancing that specific slot until the operator chooses `retry`, `drop`, or `handoff` for that slot. Other slots continue normally.
 
 The default stall threshold is 30 minutes. It can be overridden with `PAN_SWARM_STALL_THRESHOLD_MS` for test or operational tuning.
 

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -16,7 +16,7 @@
 1520 src/dashboard/server/services/issue-data-service.ts
 1321 src/dashboard/server/ws-rpc.ts
 1035 src/lib/cloister/deacon-auto-resume.ts
-1075 src/lib/cloister/deacon-swarm.ts
+1152 src/lib/cloister/deacon-swarm.ts
 3622 src/lib/cloister/deacon.ts
 1409 src/lib/cloister/merge-agent.ts
 2135 src/lib/cloister/service.ts

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -16,7 +16,7 @@
 1520 src/dashboard/server/services/issue-data-service.ts
 1321 src/dashboard/server/ws-rpc.ts
 1035 src/lib/cloister/deacon-auto-resume.ts
-1152 src/lib/cloister/deacon-swarm.ts
+1179 src/lib/cloister/deacon-swarm.ts
 3622 src/lib/cloister/deacon.ts
 1409 src/lib/cloister/merge-agent.ts
 2135 src/lib/cloister/service.ts

--- a/src/cli/commands/swarm.ts
+++ b/src/cli/commands/swarm.ts
@@ -529,6 +529,7 @@ export interface SwarmStatusCommandDeps {
     slots: Parameters<typeof classifyInFlightSlots>[0],
     workspacePath: string,
   ) => Promise<ClassifiedSwarmSlot[]>;
+  getFailedMergeBlocks: typeof getFailedMergeBlocks;
   getReviewStatusSync: typeof getReviewStatusSync;
   listSessionNamesSync: () => string[];
   getConcurrencyLimits: typeof getConcurrencyLimits;
@@ -541,6 +542,7 @@ const defaultStatusDeps: SwarmStatusCommandDeps = {
   findSpecByIssue,
   reconcileSlotState,
   classifyInFlightSlots: (slots, workspacePath) => classifyInFlightSlots(slots, undefined, { workspacePath }),
+  getFailedMergeBlocks,
   getReviewStatusSync,
   listSessionNamesSync,
   getConcurrencyLimits,
@@ -571,6 +573,8 @@ export async function swarmStatusCommand(
   const lifecycleBySlot = new Map(classified.map(slot => [slot.slotIndex, slot.lifecycle]));
   const branchMergedBySlot = new Map(reconciled.branches.map(branch => [branch.slotIndex, branch.merged]));
   const liveSessions = new Set(safeListSessionNames(deps));
+  const blockedSlots = deps.getFailedMergeBlocks(issue, workspacePath);
+  const blockedSlotIndexes = new Set(blockedSlots.map(block => block.slotIndex));
 
   deps.console.log(chalk.bold(`Swarm status for ${issue}`));
 
@@ -599,13 +603,40 @@ export async function swarmStatusCommand(
   );
 
   const rows = [
-    ...reconciled.merged.map(slot => ({ ...slot, lifecycle: 'merged' })),
-    ...reconciled.inFlight.map(slot => ({ ...slot, lifecycle: lifecycleBySlot.get(slot.slotIndex) ?? 'running' })),
-  ].sort((a, b) => a.slotIndex - b.slotIndex);
+    ...reconciled.merged.map(slot => ({ ...slot, lifecycle: 'merged' as const })),
+    ...reconciled.inFlight.map(slot => ({
+      ...slot,
+      lifecycle: blockedSlotIndexes.has(slot.slotIndex)
+        ? 'failed-merge-blocked'
+        : (lifecycleBySlot.get(slot.slotIndex) ?? 'running'),
+    })),
+  ];
+
+  for (const block of blockedSlots) {
+    if (!rows.some(row => row.slotIndex === block.slotIndex)) {
+      rows.push({
+        itemId: block.itemId,
+        slotIndex: block.slotIndex,
+        status: 'in_flight',
+        branch: block.branch,
+        agentId: undefined,
+        lifecycle: 'failed-merge-blocked',
+      });
+    }
+  }
+
+  rows.sort((a, b) => a.slotIndex - b.slotIndex);
 
   if (rows.length === 0) {
     deps.console.log('Slots: none — nothing is dispatched right now, and no merged slot state remains.');
     return { ok: true };
+  }
+
+  if (blockedSlots.length > 0) {
+    deps.console.log(
+      `Blocked slots: ${blockedSlots.map(b => `slot ${b.slotIndex} (item ${b.itemId})`).join(', ')} — `
+      + 'awaiting `pan swarm recover`. Other slots continue around them.',
+    );
   }
 
   deps.console.log('Slots:');

--- a/src/cli/commands/swarm.ts
+++ b/src/cli/commands/swarm.ts
@@ -194,7 +194,7 @@ export async function swarmRecoverCommand(
     return { ok: false, actions: [] };
   }
 
-  const actions = await deps.recoverFailedMergeSlot(issue, workspacePath, loaded.doc, action);
+  const actions = await deps.recoverFailedMergeSlot(issue, workspacePath, slotIndex, loaded.doc, action);
   for (const line of actions) deps.console.log(line);
 
   return { ok: true, actions, workspacePath };

--- a/src/cli/commands/swarm.ts
+++ b/src/cli/commands/swarm.ts
@@ -16,6 +16,7 @@ import {
   clearFailedMergeBlock,
   coordinateSwarmSlots,
   getFailedMergeBlock,
+  getFailedMergeBlocks,
   recoverFailedMergeSlot,
   type ClassifiedSwarmSlot,
   type SwarmRecoveryAction,
@@ -177,7 +178,7 @@ export async function swarmRecoverCommand(
   }
 
   const workspacePath = await deps.ensureWorkspace(issue, loaded.project);
-  const block = deps.getFailedMergeBlock(issue, workspacePath);
+  const block = deps.getFailedMergeBlock(issue, slotIndex, workspacePath);
   if (!block) {
     if (action === 'retry') {
       const actions = await deps.coordinateSwarmSlots({ issueId: issue });
@@ -190,10 +191,6 @@ export async function swarmRecoverCommand(
       }
     }
     deps.console.error(chalk.red(`No failed-merge slot is recorded for ${issue}.`));
-    return { ok: false, actions: [] };
-  }
-  if (block.slotIndex !== slotIndex) {
-    deps.console.error(chalk.red(`Recorded failed-merge slot for ${issue} is slot ${block.slotIndex}, not slot ${slotIndex}.`));
     return { ok: false, actions: [] };
   }
 
@@ -325,6 +322,7 @@ export interface SwarmResetCommandDeps extends SwarmStopCommandDeps {
   runGitCommand: (command: string, cwd: string) => Promise<unknown>;
   clearAllSlotAssignments: typeof clearAllSlotAssignments;
   clearFailedMergeBlock: typeof clearFailedMergeBlock;
+  getFailedMergeBlocks: typeof getFailedMergeBlocks;
   removeAgentSync: (agentId: string) => void;
 }
 
@@ -334,6 +332,7 @@ const defaultResetDeps: SwarmResetCommandDeps = {
   runGitCommand: (command, cwd) => execAsync(command, { cwd }),
   clearAllSlotAssignments,
   clearFailedMergeBlock,
+  getFailedMergeBlocks,
   removeAgentSync,
 };
 
@@ -410,7 +409,9 @@ export async function swarmResetCommand(
   }
 
   deps.clearAllSlotAssignments(workspacePath, issue);
-  deps.clearFailedMergeBlock(issue, workspacePath);
+  for (const block of deps.getFailedMergeBlocks(issue, workspacePath)) {
+    deps.clearFailedMergeBlock(issue, block.slotIndex, workspacePath);
+  }
 
   // No stale running registration may survive: mark live-status rows stopped.
   let stoppedRows = 0;

--- a/src/cli/commands/swarm.ts
+++ b/src/cli/commands/swarm.ts
@@ -48,6 +48,7 @@ export interface SwarmCommandDeps {
   ensureWorkspace: (issueId: string, project: ResolvedProjectLike) => Promise<string>;
   coordinateSwarmSlots: typeof coordinateSwarmSlots;
   getFailedMergeBlock: typeof getFailedMergeBlock;
+  getFailedMergeBlocks: typeof getFailedMergeBlocks;
   recoverFailedMergeSlot: typeof recoverFailedMergeSlot;
   console: ConsoleLike;
 }
@@ -100,6 +101,7 @@ const defaultDeps: SwarmCommandDeps = {
   ensureWorkspace: ensureFeatureWorkspace,
   coordinateSwarmSlots,
   getFailedMergeBlock,
+  getFailedMergeBlocks,
   recoverFailedMergeSlot,
   console,
 };
@@ -190,7 +192,17 @@ export async function swarmRecoverCommand(
         return { ok: true, actions, workspacePath };
       }
     }
-    deps.console.error(chalk.red(`No failed-merge slot is recorded for ${issue}.`));
+    const otherBlocks = deps.getFailedMergeBlocks(issue, workspacePath);
+    if (otherBlocks.length > 0) {
+      const lines = otherBlocks
+        .map(b => `  slot ${b.slotIndex} (item ${b.itemId}): ${b.note}`)
+        .join('\n');
+      deps.console.error(
+        chalk.red(`No failed-merge block for ${issue} slot ${slotIndex}. Currently blocked slots:\n${lines}`),
+      );
+    } else {
+      deps.console.error(chalk.red(`No failed-merge slot is recorded for ${issue}.`));
+    }
     return { ok: false, actions: [] };
   }
 
@@ -632,13 +644,6 @@ export async function swarmStatusCommand(
     return { ok: true };
   }
 
-  if (blockedSlots.length > 0) {
-    deps.console.log(
-      `Blocked slots: ${blockedSlots.map(b => `slot ${b.slotIndex} (item ${b.itemId})`).join(', ')} — `
-      + 'awaiting `pan swarm recover`. Other slots continue around them.',
-    );
-  }
-
   deps.console.log('Slots:');
   for (const row of rows) {
     const branch = row.branch ?? `feature/${issueLower}-slot-${row.slotIndex}`;
@@ -647,10 +652,24 @@ export async function swarmStatusCommand(
       : branchMergedBySlot.get(row.slotIndex) ? 'merged' : 'unmerged';
     const sessionName = row.agentId ?? `agent-${issueLower}-slot-${row.slotIndex}`;
     const sessionState = liveSessions.has(sessionName) ? 'session alive' : 'session dead';
+    const lifecycle = row.lifecycle === 'failed-merge-blocked'
+      ? 'failed-merge (blocked)'
+      : row.lifecycle;
     deps.console.log(
-      `  slot ${row.slotIndex} · item ${row.itemId} · ${row.lifecycle} · branch ${branch} (${branchState}) · ${sessionState}`,
+      `  slot ${row.slotIndex} · item ${row.itemId} · ${lifecycle} · branch ${branch} (${branchState}) · ${sessionState}`,
     );
   }
+
+  if (blockedSlots.length > 0) {
+    deps.console.log('Blocked slots:');
+    for (const block of blockedSlots) {
+      deps.console.log(
+        `  slot ${block.slotIndex} (item ${block.itemId}): ${block.note}. `
+        + `Recover with \`pan swarm recover ${issue} ${block.slotIndex} --action retry|drop|handoff\`.`,
+      );
+    }
+  }
+
   return { ok: true };
 }
 

--- a/src/lib/cloister/deacon-swarm.ts
+++ b/src/lib/cloister/deacon-swarm.ts
@@ -64,7 +64,7 @@ import {
 import { gcMergedSlots } from './deacon-swarm-gc.js';
 import { createMinimalIssueRecord, writeSwarmFinalizedAt, clearSwarmSlotCompletion } from './deacon-swarm-record.js';
 import { fireTieredCommitHooks } from './swarm-tiered-hooks.js';
-import { applySupersededSlotHighWater, requeueFailedSwarmSlots } from './swarm-failed-slot.js';
+import { applySupersededSlotHighWater, archiveFailedSwarmSlot, requeueFailedSwarmSlots } from './swarm-failed-slot.js';
 
 export { gcOrphanedSlots } from './deacon-swarm-orphan-gc.js';
 export { gcMergedSlots } from './deacon-swarm-gc.js';
@@ -715,6 +715,7 @@ export function clearFailedMergeBlock(issueId: string, slotIndex: number, worksp
 export async function recoverFailedMergeSlot(
   issueId: string,
   workspacePath: string,
+  slotIndex: number,
   doc: VBriefDocument,
   action: SwarmRecoveryAction,
   deps: Pick<
@@ -729,11 +730,23 @@ export async function recoverFailedMergeSlot(
     | 'shouldDispatch'
     | 'getMaxSlotIndex'
     | 'listSlotAssignments'
+    | 'runGitCommand'
   > = defaultDeps,
 ): Promise<string[]> {
   const normalizedIssueId = issueId.toUpperCase();
-  const block = getFailedMergeBlocks(normalizedIssueId, workspacePath)[0];
-  if (!block) return [`[swarm] no failed-merge slot for ${normalizedIssueId}`];
+  const block = getFailedMergeBlock(normalizedIssueId, slotIndex, workspacePath);
+  if (!block) {
+    const otherBlocks = getFailedMergeBlocks(normalizedIssueId, workspacePath);
+    if (otherBlocks.length === 0) {
+      return [`[swarm] no failed-merge slot for ${normalizedIssueId}`];
+    }
+    const lines = otherBlocks
+      .map(b => `  slot ${b.slotIndex} (item ${b.itemId}): ${b.note}`)
+      .join('\n');
+    return [
+      `[swarm] no failed-merge block for ${normalizedIssueId} slot ${slotIndex}. Currently blocked slots:\n${lines}`,
+    ];
+  }
 
   const planPath = join(workspacePath, '.pan', 'spec.vbrief.json');
   if (action === 'handoff') {
@@ -754,6 +767,20 @@ export async function recoverFailedMergeSlot(
     return [`[swarm] dropped failed-merge slot ${block.slotIndex} (item ${block.itemId}) for ${normalizedIssueId}`];
   }
 
+  // retry: archive the conflicted attempt so it cannot re-assert, then unblock
+  // and dispatch a fresh attempt.
+  await archiveFailedSwarmSlot(
+    normalizedIssueId,
+    workspacePath,
+    {
+      itemId: block.itemId,
+      slotIndex: block.slotIndex,
+      status: 'in_flight',
+      branch: block.branch,
+      agentId: block.branch ? `agent-${normalizedIssueId.toLowerCase()}-slot-${block.slotIndex}` : undefined,
+    },
+    { runGitCommand: deps.runGitCommand, clearSlotAssignment: deps.clearSlotAssignment },
+  );
   await deps.applyTaskOperationToPlanFile(planPath, {
     type: 'unblock',
     itemId: block.itemId,

--- a/src/lib/cloister/deacon-swarm.ts
+++ b/src/lib/cloister/deacon-swarm.ts
@@ -264,7 +264,7 @@ function defaultShouldDispatch(issueId: string): boolean {
   return !(hold?.stuck || hold?.deaconIgnored);
 }
 
-export type SwarmSlotLifecycle = 'running' | 'ready-to-merge' | 'failed' | 'stalled' | 'awaiting-completion-signal';
+export type SwarmSlotLifecycle = 'running' | 'ready-to-merge' | 'failed' | 'stalled' | 'awaiting-completion-signal' | 'failed-merge-blocked';
 
 export interface ClassifyInFlightSlotsOptions {
   workspacePath?: string;

--- a/src/lib/cloister/deacon-swarm.ts
+++ b/src/lib/cloister/deacon-swarm.ts
@@ -790,19 +790,19 @@ export function recordStalledSlotRecovery(issueId: string, slots: ClassifiedSwar
   const actions: string[] = [];
   const normalizedIssueId = issueId.toUpperCase();
 
-  const stalled = slots.find(slot => slot.lifecycle === 'stalled');
-  if (!stalled) return actions;
+  for (const slot of slots.filter(s => s.lifecycle === 'stalled')) {
+    if (getFailedMergeBlock(normalizedIssueId, slot.slotIndex, workspacePath)) continue;
 
-  if (getFailedMergeBlock(normalizedIssueId, stalled.slotIndex, workspacePath)) return actions;
+    recordFailedMergeBlock({
+      issueId: normalizedIssueId,
+      itemId: slot.itemId,
+      slotIndex: slot.slotIndex,
+      branch: slot.branch,
+      note: `Slot ${slot.slotIndex} stalled with no branch commit or pane output progress`,
+    }, workspacePath);
+    actions.push(`[swarm] stalled slot ${slot.slotIndex} (item ${slot.itemId}) for ${normalizedIssueId}: recovery required`);
+  }
 
-  recordFailedMergeBlock({
-    issueId: normalizedIssueId,
-    itemId: stalled.itemId,
-    slotIndex: stalled.slotIndex,
-    branch: stalled.branch,
-    note: `Slot ${stalled.slotIndex} stalled with no branch commit or pane output progress`,
-  }, workspacePath);
-  actions.push(`[swarm] stalled slot ${stalled.slotIndex} (item ${stalled.itemId}) for ${normalizedIssueId}: recovery required`);
   return actions;
 }
 

--- a/src/lib/cloister/deacon-swarm.ts
+++ b/src/lib/cloister/deacon-swarm.ts
@@ -19,6 +19,7 @@ import {
   writeIssueRecordForWorkspaceSync,
   getIssueRecordPathForWorkspace,
   type PanIssueRecord,
+  type PanIssueSwarmFailedMergeBlock,
   type PanIssueSwarmSlotCompletion,
 } from '../pan-dir/record.js';
 import { findSpecByIssue } from '../pan-dir/specs.js';
@@ -325,9 +326,10 @@ export async function coordinateSwarmSlots(
       actions.push(`[swarm] deferred ${issueId}: advance backoff active`);
       continue;
     }
-    const failedMergeBlock = getFailedMergeBlock(issueId, workspace.workspacePath);
-    if (failedMergeBlock) {
-      actions.push(`[swarm] blocked ${issueId}: failed-merge slot ${failedMergeBlock.slotIndex} (item ${failedMergeBlock.itemId})`);
+    const failedMergeBlocks = getFailedMergeBlocks(issueId, workspace.workspacePath);
+    if (failedMergeBlocks.length > 0) {
+      const block = failedMergeBlocks[0];
+      actions.push(`[swarm] blocked ${issueId}: failed-merge slot ${block.slotIndex} (item ${block.itemId})`);
       continue;
     }
 
@@ -633,13 +635,48 @@ export function isSwarmAdvanceCoolingDown(issueId: string, now = Date.now()): bo
   return record !== undefined && record.cooldownUntil > now;
 }
 
-export function getFailedMergeBlock(issueId: string, workspacePath?: string): FailedMergeBlock | undefined {
+export function getFailedMergeBlock(
+  issueId: string,
+  slotIndex: number,
+  workspacePath?: string,
+): FailedMergeBlock | undefined {
   const normalized = issueId.toUpperCase();
   if (workspacePath) {
-    const durable = readIssueRecordForWorkspaceSync(workspacePath, normalized)?.swarm?.failedMergeBlock;
-    if (durable) return { ...durable, issueId: durable.issueId.toUpperCase() };
+    const swarm = readIssueRecordForWorkspaceSync(workspacePath, normalized)?.swarm;
+    const keyed = swarm?.failedMergeBlocks?.[String(slotIndex)];
+    if (keyed) return { ...keyed, issueId: keyed.issueId.toUpperCase() };
+    const legacy = swarm?.failedMergeBlock;
+    if (legacy && legacy.slotIndex === slotIndex) {
+      return { ...legacy, issueId: legacy.issueId.toUpperCase() };
+    }
   }
-  return failedMergeBlocks.get(normalized);
+  return failedMergeBlocks.get(`${normalized}:${slotIndex}`);
+}
+
+export function getFailedMergeBlocks(issueId: string, workspacePath?: string): FailedMergeBlock[] {
+  const normalized = issueId.toUpperCase();
+  const bySlot = new Map<number, FailedMergeBlock>();
+
+  if (workspacePath) {
+    const swarm = readIssueRecordForWorkspaceSync(workspacePath, normalized)?.swarm;
+    if (swarm?.failedMergeBlock) {
+      const legacy = swarm.failedMergeBlock;
+      bySlot.set(legacy.slotIndex, { ...legacy, issueId: legacy.issueId.toUpperCase() });
+    }
+    if (swarm?.failedMergeBlocks) {
+      for (const [key, block] of Object.entries(swarm.failedMergeBlocks)) {
+        bySlot.set(Number(key), { ...block, issueId: block.issueId.toUpperCase() });
+      }
+    }
+  }
+
+  for (const [key, block] of failedMergeBlocks.entries()) {
+    if (key.startsWith(`${normalized}:`) && !bySlot.has(block.slotIndex)) {
+      bySlot.set(block.slotIndex, { ...block });
+    }
+  }
+
+  return [...bySlot.values()].sort((a, b) => a.slotIndex - b.slotIndex);
 }
 
 export function getSwarmFinalizedAt(issueId: string, workspacePath?: string): string | undefined {
@@ -652,14 +689,18 @@ export function recordSwarmFinalizedAt(issueId: string, workspacePath: string, f
 
 export function recordFailedMergeBlock(block: FailedMergeBlock, workspacePath?: string): void {
   const normalizedBlock = { ...block, issueId: block.issueId.toUpperCase() };
-  failedMergeBlocks.set(normalizedBlock.issueId, normalizedBlock);
-  if (workspacePath) writeSwarmFailedMergeBlock(workspacePath, normalizedBlock.issueId, normalizedBlock);
+  failedMergeBlocks.set(`${normalizedBlock.issueId}:${normalizedBlock.slotIndex}`, normalizedBlock);
+  if (workspacePath) {
+    writeSwarmFailedMergeBlock(workspacePath, normalizedBlock.issueId, normalizedBlock.slotIndex, normalizedBlock);
+  }
 }
 
-export function clearFailedMergeBlock(issueId: string, workspacePath?: string): void {
+export function clearFailedMergeBlock(issueId: string, slotIndex: number, workspacePath?: string): void {
   const normalizedIssueId = issueId.toUpperCase();
-  failedMergeBlocks.delete(normalizedIssueId);
-  if (workspacePath) writeSwarmFailedMergeBlock(workspacePath, normalizedIssueId, undefined);
+  failedMergeBlocks.delete(`${normalizedIssueId}:${slotIndex}`);
+  if (workspacePath) {
+    writeSwarmFailedMergeBlock(workspacePath, normalizedIssueId, slotIndex, undefined);
+  }
 }
 
 export async function recoverFailedMergeSlot(
@@ -682,7 +723,7 @@ export async function recoverFailedMergeSlot(
   > = defaultDeps,
 ): Promise<string[]> {
   const normalizedIssueId = issueId.toUpperCase();
-  const block = getFailedMergeBlock(normalizedIssueId, workspacePath);
+  const block = getFailedMergeBlocks(normalizedIssueId, workspacePath)[0];
   if (!block) return [`[swarm] no failed-merge slot for ${normalizedIssueId}`];
 
   const planPath = join(workspacePath, '.pan', 'spec.vbrief.json');
@@ -699,7 +740,7 @@ export async function recoverFailedMergeSlot(
       writerId: 'deacon-swarm',
       reason: 'Dropped failed swarm slot after operator recovery',
     }, workspacePath);
-    clearFailedMergeBlock(normalizedIssueId, workspacePath);
+    clearFailedMergeBlock(normalizedIssueId, block.slotIndex, workspacePath);
     deps.clearSlotAssignment(workspacePath, normalizedIssueId, block.slotIndex, block.itemId);
     return [`[swarm] dropped failed-merge slot ${block.slotIndex} (item ${block.itemId}) for ${normalizedIssueId}`];
   }
@@ -710,7 +751,7 @@ export async function recoverFailedMergeSlot(
     writerId: 'deacon-swarm',
     reason: 'Retrying failed swarm slot after merge conflict',
   }, workspacePath);
-  clearFailedMergeBlock(normalizedIssueId, workspacePath);
+  clearFailedMergeBlock(normalizedIssueId, block.slotIndex, workspacePath);
   const retryDoc = {
     ...doc,
     plan: {
@@ -736,10 +777,11 @@ export async function recoverFailedMergeSlot(
 export function recordStalledSlotRecovery(issueId: string, slots: ClassifiedSwarmSlot[], workspacePath?: string): string[] {
   const actions: string[] = [];
   const normalizedIssueId = issueId.toUpperCase();
-  if (getFailedMergeBlock(normalizedIssueId, workspacePath)) return actions;
 
   const stalled = slots.find(slot => slot.lifecycle === 'stalled');
   if (!stalled) return actions;
+
+  if (getFailedMergeBlock(normalizedIssueId, stalled.slotIndex, workspacePath)) return actions;
 
   recordFailedMergeBlock({
     issueId: normalizedIssueId,
@@ -755,16 +797,35 @@ export function recordStalledSlotRecovery(issueId: string, slots: ClassifiedSwar
 function writeSwarmFailedMergeBlock(
   workspacePath: string,
   issueId: string,
+  slotIndex: number,
   block: FailedMergeBlock | undefined,
 ): void {
   const normalizedIssueId = issueId.toUpperCase();
   const existing = readIssueRecordForWorkspaceSync(workspacePath, normalizedIssueId);
   const record = existing ?? createMinimalIssueRecord(normalizedIssueId);
+  const existingSwarm = record.swarm ?? {};
+  const existingBlocks = existingSwarm.failedMergeBlocks ?? {};
+
+  // PAN-2364: fold a legacy singular block into the per-slot map and clear the
+  // singular field on first write to the new keyed storage.
+  const foldedBlocks: Record<string, PanIssueSwarmFailedMergeBlock> = { ...existingBlocks };
+  if (existingSwarm.failedMergeBlock) {
+    foldedBlocks[String(existingSwarm.failedMergeBlock.slotIndex)] = existingSwarm.failedMergeBlock;
+  }
+
+  const nextBlocks = { ...foldedBlocks };
+  if (block) {
+    nextBlocks[String(slotIndex)] = block;
+  } else {
+    delete nextBlocks[String(slotIndex)];
+  }
+
   writeIssueRecordForWorkspaceSync(workspacePath, normalizedIssueId, {
     ...record,
     swarm: {
-      ...(record.swarm ?? {}),
-      failedMergeBlock: block,
+      ...existingSwarm,
+      failedMergeBlocks: nextBlocks,
+      failedMergeBlock: undefined,
     },
   });
 }

--- a/src/lib/cloister/deacon-swarm.ts
+++ b/src/lib/cloister/deacon-swarm.ts
@@ -327,10 +327,13 @@ export async function coordinateSwarmSlots(
       continue;
     }
     const failedMergeBlocks = getFailedMergeBlocks(issueId, workspace.workspacePath);
+    const blockedSlotIndexes = new Set(failedMergeBlocks.map(block => block.slotIndex));
+    const blockedItemIds = new Set(failedMergeBlocks.map(block => block.itemId));
     if (failedMergeBlocks.length > 0) {
-      const block = failedMergeBlocks[0];
-      actions.push(`[swarm] blocked ${issueId}: failed-merge slot ${block.slotIndex} (item ${block.itemId})`);
-      continue;
+      const slots = failedMergeBlocks
+        .map(block => `slot ${block.slotIndex} (item ${block.itemId})`)
+        .join(', ');
+      actions.push(`[swarm] blocked slots for ${issueId}: ${slots} — other slots continue; run \`pan swarm recover ${issueId} <slot>\``);
     }
 
     try {
@@ -374,15 +377,15 @@ export async function coordinateSwarmSlots(
         actions.push(`[swarm] ${issueId} slot ${slot.slotIndex} ${slot.lifecycle}${slot.signal ? ` signal: ${slot.signal}` : ''}`);
         if (slot.actions) actions.push(...slot.actions);
       }
-      const requeue = await requeueFailedSwarmSlots(issueId, workspace.workspacePath, classified, doc, reconciled, deps);
+      const requeue = await requeueFailedSwarmSlots(issueId, workspace.workspacePath, classified, doc, reconciled, deps, blockedSlotIndexes);
       actions.push(...requeue.actions);
       actions.push(...recordStalledSlotRecovery(issueId, classified, workspace.workspacePath)); // stalled slots remain operator-recoverable
-      actions.push(...await mergeReadySlots(issueId, workspace.workspacePath, doc, classified, deps));
+      actions.push(...await mergeReadySlots(issueId, workspace.workspacePath, doc, classified, deps, blockedSlotIndexes));
       actions.push(...await gcMergedSlots(issueId, workspace.workspacePath, reconciled.merged, deps));
       actions.push(...await gcOrphanedSlots(issueId, workspace.workspacePath, reconciled, deps));
       actions.push(...await finalizeSwarmIssueIfComplete(issueId, workspace.workspacePath, spec.document, deps));
       if (dispatchEligible) {
-        actions.push(...await dispatchNextWave(issueId, workspace.workspacePath, requeue.doc, reconciled, analyzeSwarmReadiness(requeue.doc), deps));
+        actions.push(...await dispatchNextWave(issueId, workspace.workspacePath, requeue.doc, reconciled, analyzeSwarmReadiness(requeue.doc), deps, blockedSlotIndexes, blockedItemIds));
       }
       recordSwarmAdvanceSuccess(issueId);
     } catch (err) {
@@ -539,6 +542,7 @@ export async function mergeReadySlots(
   doc: VBriefDocument,
   slots: ClassifiedSwarmSlot[],
   deps: Pick<CoordinateSwarmSlotsDeps, 'verifyAndMergeSlot' | 'applyTaskOperationToPlanFile' | 'fireTieredCommitHooks'> = defaultDeps,
+  blockedSlotIndexes: Set<number> = new Set(),
 ): Promise<string[]> {
   const actions: string[] = [];
   const itemsById = new Map(doc.plan.items.map(item => [item.id, item]));
@@ -546,6 +550,11 @@ export async function mergeReadySlots(
 
   for (const slot of slots) {
     if (slot.lifecycle !== 'ready-to-merge') continue;
+
+    if (blockedSlotIndexes.has(slot.slotIndex)) {
+      actions.push(`[swarm] skipped merge slot ${slot.slotIndex} (item ${slot.itemId}) for ${issueId}: failed-merge block — awaiting \`pan swarm recover\``);
+      continue;
+    }
 
     const item = itemsById.get(slot.itemId);
     if (!item) {
@@ -752,6 +761,9 @@ export async function recoverFailedMergeSlot(
     reason: 'Retrying failed swarm slot after merge conflict',
   }, workspacePath);
   clearFailedMergeBlock(normalizedIssueId, block.slotIndex, workspacePath);
+  const remainingBlocks = getFailedMergeBlocks(normalizedIssueId, workspacePath);
+  const blockedSlotIndexes = new Set(remainingBlocks.map(b => b.slotIndex));
+  const blockedItemIds = new Set(remainingBlocks.map(b => b.itemId));
   const retryDoc = {
     ...doc,
     plan: {
@@ -770,7 +782,7 @@ export async function recoverFailedMergeSlot(
       pending: [],
       branches: [],
       agents: [],
-    }, analyzeSwarmReadiness(retryDoc), deps),
+    }, analyzeSwarmReadiness(retryDoc), deps, blockedSlotIndexes, blockedItemIds),
   ];
 }
 
@@ -861,12 +873,15 @@ export async function dispatchNextWave(
     | 'getMaxSlotIndex'
     | 'listSlotAssignments'
   > & Partial<Pick<CoordinateSwarmSlotsDeps, 'listSessionNames' | 'slotWorktreeExists'>> = defaultDeps,
+  blockedSlotIndexes: Set<number> = new Set(),
+  blockedItemIds: Set<string> = new Set(),
 ): Promise<string[]> {
   const actions: string[] = [];
   const mergedItemIds = new Set(reconciled.merged.map(slot => slot.itemId));
   const slotEligibleIds = new Set(readiness.items.filter(item => item.slotEligible).map(item => item.id));
   const configuredMaxSlotIndex = Math.max(1, Math.floor((deps.getMaxSlotIndex ?? defaultGetMaxSlotIndex)()));
   const occupiedSlotIndexes = new Set([
+    ...blockedSlotIndexes, // PAN-2364: blocked slots count as occupied so other slots cannot collide with them
     ...reconciled.inFlight.map(slot => slot.slotIndex),
     // Local branches hold their index until GC; archived indexes are added below.
     ...reconciled.branches.map(branch => branch.slotIndex),
@@ -889,6 +904,7 @@ export async function dispatchNextWave(
   const planPath = join(workspacePath, '.pan', 'spec.vbrief.json');
 
   for (const item of getDispatchableItems(doc, mergedItemIds)) {
+    if (blockedItemIds.has(item.id)) continue;
     if (!slotEligibleIds.has(item.id)) continue;
     if (inFlightItemIds.has(item.id)) continue;
 

--- a/src/lib/cloister/swarm-failed-slot.ts
+++ b/src/lib/cloister/swarm-failed-slot.ts
@@ -85,10 +85,15 @@ export async function requeueFailedSwarmSlots(
   doc: VBriefDocument,
   reconciled: SlotReconcileResult,
   deps: FailedSlotArchiveDeps & { applyTaskOperationToPlanFile: (path: string, operation: PersistedTaskOperation, workspace?: string) => Promise<unknown> },
+  blockedSlotIndexes: Set<number> = new Set(),
 ): Promise<{ doc: VBriefDocument; actions: string[] }> {
   let nextDoc = doc;
   const actions: string[] = [];
   for (const slot of classified.filter(candidate => candidate.lifecycle === 'failed')) {
+    if (blockedSlotIndexes.has(slot.slotIndex)) {
+      actions.push(`[swarm] skipped requeue slot ${slot.slotIndex} (item ${slot.itemId}) for ${issueId}: failed-merge block — awaiting operator recovery`);
+      continue;
+    }
     const admission = decideAutonomousRedrive(slot.agentId ? getAgentStateSync(slot.agentId) ?? {} : {}, { owesRework: true });
     if (admission.decision === 'defer') { actions.push(`[swarm] deferred failed slot ${slot.slotIndex}: ${admission.reason}`); continue; }
     const attempt = await archiveFailedSwarmSlot(issueId, workspacePath, slot, deps);

--- a/src/lib/pan-dir/record.ts
+++ b/src/lib/pan-dir/record.ts
@@ -102,6 +102,11 @@ export interface PanIssueSwarmSlotCompletion {
 
 export interface PanIssueSwarmRecord {
   finalizedAt?: string;
+  /**
+   * @deprecated Read for migration only; new blocks live in `failedMergeBlocks`
+   * keyed by `String(slotIndex)`. `writeSwarmFailedMergeBlock` folds this into
+   * the map and clears it on first write.
+   */
   failedMergeBlock?: PanIssueSwarmFailedMergeBlock;
   slotAssignments?: PanIssueSwarmSlotAssignment[];
   supersededAttempts?: PanIssueSwarmSupersededAttempt[];
@@ -110,6 +115,12 @@ export interface PanIssueSwarmRecord {
    * a slot durable-ready; merge/requeue clears the key (clearSwarmSlotCompletion).
    */
   slotCompletions?: Record<string, PanIssueSwarmSlotCompletion>;
+  /**
+   * PAN-2364: failed-merge and stalled-slot recovery blocks keyed by
+   * `String(slotIndex)`. The legacy singular `failedMergeBlock` above is folded
+   * into this map on first write.
+   */
+  failedMergeBlocks?: Record<string, PanIssueSwarmFailedMergeBlock>;
 }
 
 export interface PanIssueRecoveryTrip {

--- a/tests/unit/cli/commands/swarm.test.ts
+++ b/tests/unit/cli/commands/swarm.test.ts
@@ -225,7 +225,7 @@ describe('pan swarm command', () => {
     const result = await swarmRecoverCommand('PAN-2203', '1', { action: 'retry' }, deps);
 
     expect(result.ok).toBe(true);
-    expect(deps.getFailedMergeBlock).toHaveBeenCalledWith('PAN-2203', '/repo/workspaces/feature-pan-2203');
+    expect(deps.getFailedMergeBlock).toHaveBeenCalledWith('PAN-2203', 1, '/repo/workspaces/feature-pan-2203');
     expect(deps.recoverFailedMergeSlot).toHaveBeenCalledWith(
       'PAN-2203',
       '/repo/workspaces/feature-pan-2203',
@@ -613,6 +613,7 @@ describe('pan swarm reset (PAN-2214)', () => {
       resolveProjectFromIssueSync: vi.fn(() => ({ projectName: 'overdeck', projectPath: '/repo' })),
       clearAllSlotAssignments: vi.fn(),
       clearFailedMergeBlock: vi.fn(),
+      getFailedMergeBlocks: vi.fn(() => [{ issueId: 'PAN-2203', itemId: 'wi-1', slotIndex: 1, note: 'conflict' }]),
       runGitCommand: vi.fn(async (command: string) => {
         gitCalls.push(command);
         if (command.startsWith('git for-each-ref')) {
@@ -708,7 +709,7 @@ describe('pan swarm reset (PAN-2214)', () => {
 
     expect(result.ok).toBe(true);
     expect(deps.clearAllSlotAssignments).toHaveBeenCalledWith('/repo/workspaces/feature-pan-2203', 'PAN-2203');
-    expect(deps.clearFailedMergeBlock).toHaveBeenCalledWith('PAN-2203', '/repo/workspaces/feature-pan-2203');
+    expect(deps.clearFailedMergeBlock).toHaveBeenCalledWith('PAN-2203', 1, '/repo/workspaces/feature-pan-2203');
     // The running row is stopped twice at most (once via stop's enumeration, once via the
     // final sweep) — the essential guarantee is it is stopped and the stopped row is not touched.
     expect(deps.stopAgentSync).toHaveBeenCalledWith('agent-pan-2203-slot-1');

--- a/tests/unit/cli/commands/swarm.test.ts
+++ b/tests/unit/cli/commands/swarm.test.ts
@@ -474,6 +474,7 @@ describe('pan swarm status (PAN-2214)', () => {
     hold?: { deaconIgnored?: boolean; deaconIgnoredReason?: string; stuck?: boolean; stuckReason?: string } | null;
     reconciled?: Record<string, unknown>;
     classified?: Array<Record<string, unknown>>;
+    getFailedMergeBlocks?: () => Array<Record<string, unknown>>;
     sessionNames?: string[];
     liveSlotCount?: number;
   } = {}): SwarmStatusCommandDeps {
@@ -500,6 +501,7 @@ describe('pan swarm status (PAN-2214)', () => {
         ...options.reconciled,
       })) as unknown as SwarmStatusCommandDeps['reconcileSlotState'],
       classifyInFlightSlots: vi.fn(async () => (options.classified ?? []) as never),
+      getFailedMergeBlocks: vi.fn(() => (options.getFailedMergeBlocks ? options.getFailedMergeBlocks() : [])),
       getReviewStatusSync: vi.fn(() => options.hold ?? null) as unknown as SwarmStatusCommandDeps['getReviewStatusSync'],
       listSessionNamesSync: vi.fn(() => options.sessionNames ?? []),
       getConcurrencyLimits: vi.fn(() => ({
@@ -563,6 +565,37 @@ describe('pan swarm status (PAN-2214)', () => {
     expect(loggedText(deps)).toContain('Hold: none — the Deacon is actively coordinating this issue on every patrol.');
   });
 
+  it('PAN-2364: lists blocked slots separately and overrides ready-to-merge mislabel', async () => {
+    const deps = makeStatusDeps({
+      reconciled: {
+        inFlight: [
+          { itemId: 'wi-1', slotIndex: 1, status: 'in_flight', branch: 'feature/pan-2203-slot-1', agentId: 'agent-pan-2203-slot-1' },
+          { itemId: 'wi-2', slotIndex: 2, status: 'in_flight', branch: 'feature/pan-2203-slot-2', agentId: 'agent-pan-2203-slot-2' },
+        ],
+        branches: [
+          { slotIndex: 1, branch: 'feature/pan-2203-slot-1', merged: false },
+          { slotIndex: 2, branch: 'feature/pan-2203-slot-2', merged: false },
+        ],
+      },
+      classified: [
+        { itemId: 'wi-1', slotIndex: 1, lifecycle: 'ready-to-merge' },
+        { itemId: 'wi-2', slotIndex: 2, lifecycle: 'running' },
+      ],
+      getFailedMergeBlocks: vi.fn(() => [
+        { issueId: 'PAN-2203', itemId: 'wi-1', slotIndex: 1, note: 'merge conflict' },
+      ]),
+    });
+
+    const result = await swarmStatusCommand('PAN-2203', deps);
+
+    expect(result.ok).toBe(true);
+    const output = loggedText(deps);
+    expect(output).toContain('Blocked slots: slot 1 (item wi-1)');
+    expect(output).toContain('slot 1 · item wi-1 · failed-merge-blocked');
+    expect(output).not.toContain('slot 1 · item wi-1 · ready-to-merge');
+    expect(output).toContain('slot 2 · item wi-2 · running');
+  });
+
   it('is read-only: no record writes, git mutations, or spawns are possible through its deps', async () => {
     const deps = makeStatusDeps({
       reconciled: {
@@ -584,6 +617,7 @@ describe('pan swarm status (PAN-2214)', () => {
       'countRunningSwarmSlotsForIssue',
       'findSpecByIssue',
       'getConcurrencyLimits',
+      'getFailedMergeBlocks',
       'getReviewStatusSync',
       'listSessionNamesSync',
       'reconcileSlotState',

--- a/tests/unit/cli/commands/swarm.test.ts
+++ b/tests/unit/cli/commands/swarm.test.ts
@@ -74,6 +74,7 @@ function makeDeps(doc: VBriefDocument): SwarmCommandDeps {
       '[swarm] dispatched implementation slot 1 (item wi-1) for PAN-2203',
     ]),
     getFailedMergeBlock: vi.fn(() => ({ issueId: 'PAN-2203', itemId: 'wi-1', slotIndex: 1, note: 'conflict' })),
+    getFailedMergeBlocks: vi.fn(() => []),
     recoverFailedMergeSlot: vi.fn(async () => ['[swarm] retrying failed-merge slot 1 (item wi-1) for PAN-2203']),
     console: {
       log: vi.fn(),
@@ -248,6 +249,29 @@ describe('pan swarm command', () => {
     expect(result.ok).toBe(true);
     expect(deps.coordinateSwarmSlots).toHaveBeenCalledWith({ issueId: 'PAN-2203' });
     expect(deps.recoverFailedMergeSlot).not.toHaveBeenCalled();
+  });
+
+  it('recover against a slot with no block lists the currently blocked slots and exits nonzero', async () => {
+    const deps = makeDeps(makeDoc([makeEligibleItem('wi-1', 'src/a.ts')]));
+    deps.getFailedMergeBlock = vi.fn(() => undefined);
+    deps.getFailedMergeBlocks = vi.fn(() => [
+      { issueId: 'PAN-2203', itemId: 'wi-1', slotIndex: 1, note: 'slot 1 conflict' },
+      { issueId: 'PAN-2203', itemId: 'wi-3', slotIndex: 3, note: 'slot 3 conflict' },
+    ]);
+    deps.coordinateSwarmSlots = vi.fn(async () => []);
+
+    const result = await swarmRecoverCommand('PAN-2203', '2', { action: 'retry' }, deps);
+
+    expect(result.ok).toBe(false);
+    expect(deps.recoverFailedMergeSlot).not.toHaveBeenCalled();
+    expect(deps.console.error).toHaveBeenCalledWith(
+      expect.stringContaining('No failed-merge block for PAN-2203 slot 2'),
+    );
+    const errorCall = vi.mocked(deps.console.error).mock.calls.find(call =>
+      String(call[0]).includes('No failed-merge block for PAN-2203 slot 2'),
+    )?.[0];
+    expect(String(errorCall)).toContain('slot 1 (item wi-1): slot 1 conflict');
+    expect(String(errorCall)).toContain('slot 3 (item wi-3): slot 3 conflict');
   });
 
   it('recover reads a failed slot persisted by Deacon instead of a CLI-local map', async () => {
@@ -581,19 +605,22 @@ describe('pan swarm status (PAN-2214)', () => {
         { itemId: 'wi-1', slotIndex: 1, lifecycle: 'ready-to-merge' },
         { itemId: 'wi-2', slotIndex: 2, lifecycle: 'running' },
       ],
-      getFailedMergeBlocks: vi.fn(() => [
+      getFailedMergeBlocks: () => [
         { issueId: 'PAN-2203', itemId: 'wi-1', slotIndex: 1, note: 'merge conflict' },
-      ]),
+        { issueId: 'PAN-2203', itemId: 'wi-3', slotIndex: 3, note: 'another conflict' },
+      ],
     });
 
     const result = await swarmStatusCommand('PAN-2203', deps);
 
     expect(result.ok).toBe(true);
     const output = loggedText(deps);
-    expect(output).toContain('Blocked slots: slot 1 (item wi-1)');
-    expect(output).toContain('slot 1 · item wi-1 · failed-merge-blocked');
+    expect(output).toContain('slot 1 · item wi-1 · failed-merge (blocked)');
     expect(output).not.toContain('slot 1 · item wi-1 · ready-to-merge');
     expect(output).toContain('slot 2 · item wi-2 · running');
+    expect(output).toContain('Blocked slots:');
+    expect(output).toContain('slot 1 (item wi-1): merge conflict. Recover with `pan swarm recover PAN-2203 1 --action retry|drop|handoff`.');
+    expect(output).toContain('slot 3 (item wi-3): another conflict. Recover with `pan swarm recover PAN-2203 3 --action retry|drop|handoff`.');
   });
 
   it('is read-only: no record writes, git mutations, or spawns are possible through its deps', async () => {

--- a/tests/unit/cli/commands/swarm.test.ts
+++ b/tests/unit/cli/commands/swarm.test.ts
@@ -229,6 +229,7 @@ describe('pan swarm command', () => {
     expect(deps.recoverFailedMergeSlot).toHaveBeenCalledWith(
       'PAN-2203',
       '/repo/workspaces/feature-pan-2203',
+      1,
       doc,
       'retry',
     );
@@ -293,7 +294,7 @@ describe('pan swarm command', () => {
       const result = await swarmRecoverCommand('PAN-2203', '1', { action: 'retry' }, deps);
 
       expect(result.ok).toBe(true);
-      expect(deps.recoverFailedMergeSlot).toHaveBeenCalledWith('PAN-2203', workspace, doc, 'retry');
+      expect(deps.recoverFailedMergeSlot).toHaveBeenCalledWith('PAN-2203', workspace, 1, doc, 'retry');
     } finally {
       rmSync(workspace, { recursive: true, force: true });
       resetSwarmLoopSafetyForTests();

--- a/tests/unit/lib/cloister/deacon-swarm-completion.test.ts
+++ b/tests/unit/lib/cloister/deacon-swarm-completion.test.ts
@@ -261,7 +261,7 @@ describe('deacon-swarm completion classification', () => {
     });
 
     expect(recordStalledSlotRecovery('PAN-2203', classified)).toEqual([]);
-    expect(getFailedMergeBlock('PAN-2203')).toBeUndefined();
+    expect(getFailedMergeBlock('PAN-2203', 1)).toBeUndefined();
   });
 
   it('infers ready-to-merge on the second unchanged idle observation in auto mode', async () => {

--- a/tests/unit/lib/cloister/deacon-swarm-hold.test.ts
+++ b/tests/unit/lib/cloister/deacon-swarm-hold.test.ts
@@ -178,6 +178,7 @@ type DispatchDeps = Pick<
   | 'spawnRun'
   | 'getMaxSlotIndex'
   | 'listSlotAssignments'
+  | 'runGitCommand'
 >;
 
 function dispatchDeps(overrides: Partial<DispatchDeps> = {}): DispatchDeps {
@@ -191,6 +192,7 @@ function dispatchDeps(overrides: Partial<DispatchDeps> = {}): DispatchDeps {
     spawnRun: vi.fn(async () => undefined),
     getMaxSlotIndex: vi.fn(() => 5),
     listSlotAssignments: vi.fn(() => []),
+    runGitCommand: vi.fn(async () => undefined),
     ...overrides,
   };
 }
@@ -273,7 +275,7 @@ describe('per-spawn freeze/hold re-check (PAN-2214 slot-20 regression)', () => {
     const doc = makeDoc('PAN-107', 1);
     const deps = dispatchDeps();
 
-    const actions = await recoverFailedMergeSlot('PAN-107', workspacePath, doc, 'retry', deps);
+    const actions = await recoverFailedMergeSlot('PAN-107', workspacePath, 1, doc, 'retry', deps);
 
     expect(deps.spawnRun).not.toHaveBeenCalled();
     expect(actions).toContain('[swarm] dispatch-halted wi-1: freeze/hold active');

--- a/tests/unit/lib/cloister/deacon-swarm-hold.test.ts
+++ b/tests/unit/lib/cloister/deacon-swarm-hold.test.ts
@@ -279,3 +279,121 @@ describe('per-spawn freeze/hold re-check (PAN-2214 slot-20 regression)', () => {
     expect(actions).toContain('[swarm] dispatch-halted wi-1: freeze/hold active');
   });
 });
+
+type CoordinateDeps = CoordinateSwarmSlotsDeps;
+
+function makeCoordinateDeps(
+  issueId: string,
+  projectPath: string,
+  workspacePath: string,
+  overrides: Partial<CoordinateDeps> = {},
+): CoordinateDeps {
+  return {
+    listFeatureWorkspaces: () => [{ issueId, projectPath, workspacePath }],
+    reconcileSlotState: vi.fn(async (reconcileIssueId: string) => ({
+      issueId: reconcileIssueId,
+      merged: [],
+      inFlight: [],
+      pending: [],
+      branches: [],
+      agents: [],
+    })),
+    listSessionNames: vi.fn(async () => []),
+    isPaneDead: vi.fn(async () => false),
+    getPaneExitStatus: vi.fn(async () => null),
+    getAgentRuntimeState: vi.fn(async () => ({ resolution: 'done' })),
+    getPaneOutputDigest: vi.fn(async () => ''),
+    getBranchTipCommitTime: vi.fn(async () => null),
+    getSlotBranchAheadCount: vi.fn(async () => 0),
+    isSlotWorktreeClean: vi.fn(async () => true),
+    sendCompletionNudge: vi.fn(async () => {}),
+    slotWorktreeExists: vi.fn(() => false),
+    verifyAndMergeSlot: vi.fn(async () => ({
+      verified: true,
+      merged: true,
+      conflicts: false,
+      evidence: { verifyCommands: [], expectedOutputs: [], commandOutputs: [] },
+    })),
+    applyTaskOperationToPlanFile: vi.fn(async () => null),
+    fireTieredCommitHooks: vi.fn(async () => []),
+    recordSlotAssignment: vi.fn(),
+    clearSlotAssignment: vi.fn(),
+    runGitCommand: vi.fn(async () => null),
+    registeredSlotCapacityAvailable: vi.fn(() => true),
+    tryReserveSwarmSlot: vi.fn(() => true),
+    releaseSwarmSlot: vi.fn(),
+    spawnRun: vi.fn(async () => null),
+    getIssueHold: vi.fn(() => null),
+    readStatusOverrides: vi.fn(() => undefined),
+    readSlotCompletion: vi.fn(() => undefined),
+    getFinalizedAt: vi.fn(() => undefined),
+    setFinalizedAt: vi.fn(),
+    shouldDispatch: vi.fn(() => true),
+    getMaxSlotIndex: vi.fn(() => 4),
+    listSlotAssignments: vi.fn(() => []),
+    requestIssueReview: vi.fn(async () => ({ success: true, message: 'dispatched' })),
+    ...overrides,
+  };
+}
+
+describe('PAN-2364 coordinator continues around blocked slots', () => {
+  it('emits a per-issue blocked-slots line listing every blocked slot', async () => {
+    const { coordinateSwarmSlots, recordFailedMergeBlock } = await import('../../../../src/lib/cloister/deacon-swarm.js');
+    const projectPath = setupWorkspace('pan-200', 'PAN-200');
+    const workspacePath = join(projectPath, 'workspaces', 'feature-pan-200');
+    recordFailedMergeBlock({ issueId: 'PAN-200', itemId: 'wi-1', slotIndex: 1, note: 'slot 1 conflict' }, workspacePath);
+    recordFailedMergeBlock({ issueId: 'PAN-200', itemId: 'wi-3', slotIndex: 3, note: 'slot 3 conflict' }, workspacePath);
+    mocks.getReviewStatusSync.mockReturnValue(null);
+    const deps = makeCoordinateDeps('PAN-200', projectPath, workspacePath);
+
+    const actions = await coordinateSwarmSlots({}, deps);
+
+    expect(actions).toContain('[swarm] blocked slots for PAN-200: slot 1 (item wi-1), slot 3 (item wi-3) — other slots continue; run `pan swarm recover PAN-200 <slot>`');
+  });
+
+  it('merges a ready-to-merge slot while another slot is blocked', async () => {
+    const { coordinateSwarmSlots, recordFailedMergeBlock } = await import('../../../../src/lib/cloister/deacon-swarm.js');
+    const projectPath = setupWorkspace('pan-201', 'PAN-201');
+    const workspacePath = join(projectPath, 'workspaces', 'feature-pan-201');
+    recordFailedMergeBlock({ issueId: 'PAN-201', itemId: 'wi-1', slotIndex: 1, note: 'slot 1 conflict' }, workspacePath);
+    mocks.getReviewStatusSync.mockReturnValue(null);
+    const deps = makeCoordinateDeps('PAN-201', projectPath, workspacePath, {
+      reconcileSlotState: vi.fn(async () => ({
+        issueId: 'PAN-201',
+        merged: [],
+        inFlight: [
+          { itemId: 'wi-1', slotIndex: 1, status: 'in_flight', branch: 'feature/pan-201-slot-1', agentId: 'agent-pan-201-slot-1' },
+          { itemId: 'wi-2', slotIndex: 2, status: 'in_flight', branch: 'feature/pan-201-slot-2', agentId: 'agent-pan-201-slot-2' },
+        ],
+        pending: [],
+        branches: [],
+        agents: [],
+      })),
+    });
+
+    const actions = await coordinateSwarmSlots({}, deps);
+
+    expect(actions).toContain('[swarm] skipped merge slot 1 (item wi-1) for PAN-201: failed-merge block — awaiting `pan swarm recover`');
+    expect(actions).toContain('[swarm] merged slot 2 (item wi-2) for PAN-201');
+    expect(deps.verifyAndMergeSlot).toHaveBeenCalledTimes(1);
+    expect(deps.verifyAndMergeSlot).toHaveBeenCalledWith(
+      { issueId: 'PAN-201', featureWorkspace: workspacePath },
+      2,
+      expect.objectContaining({ id: 'wi-2' }),
+    );
+  });
+
+  it('dispatches a new item to a non-blocked slot index', async () => {
+    const { coordinateSwarmSlots, recordFailedMergeBlock } = await import('../../../../src/lib/cloister/deacon-swarm.js');
+    const projectPath = setupWorkspace('pan-202', 'PAN-202');
+    const workspacePath = join(projectPath, 'workspaces', 'feature-pan-202');
+    recordFailedMergeBlock({ issueId: 'PAN-202', itemId: 'wi-1', slotIndex: 1, note: 'slot 1 conflict' }, workspacePath);
+    mocks.getReviewStatusSync.mockReturnValue(null);
+    const deps = makeCoordinateDeps('PAN-202', projectPath, workspacePath);
+
+    const actions = await coordinateSwarmSlots({}, deps);
+
+    expect(actions).toContain('[swarm] dispatched implementation slot 2 (item wi-2) for PAN-202');
+    expect(deps.spawnRun).toHaveBeenCalledWith('PAN-202', 'work', expect.objectContaining({ slotIndex: 2, slotItemId: 'wi-2' }));
+  });
+});

--- a/tests/unit/lib/cloister/deacon-swarm-recovery.test.ts
+++ b/tests/unit/lib/cloister/deacon-swarm-recovery.test.ts
@@ -208,6 +208,7 @@ describe('deacon-swarm failed-merge recovery', () => {
     expect(record?.swarm?.supersededAttempts).toEqual(
       expect.arrayContaining([expect.objectContaining({ slotIndex: 1, itemId: 'wi-a' })]),
     );
+    expect(fakeDeps.clearSlotAssignment).toHaveBeenCalledWith(workspacePath, 'PAN-2203', 1, 'wi-a');
     expect(getFailedMergeBlock('PAN-2203', 1, workspacePath)).toBeUndefined();
   });
 
@@ -241,6 +242,48 @@ describe('deacon-swarm failed-merge recovery', () => {
     expect(fakeDeps.applyTaskOperationToPlanFile).not.toHaveBeenCalled();
     expect(fakeDeps.spawnRun).not.toHaveBeenCalled();
     expect(getFailedMergeBlock('PAN-2203', 1, workspacePath)?.note).toContain('Operator handoff required');
+  });
+
+  it('PAN-2364: recover drop on slot 3 marks only that item done and leaves slot 1 block intact', async () => {
+    recordFailedMergeBlock({ issueId: 'PAN-2203', itemId: 'wi-a', slotIndex: 1, note: 'slot 1 conflict' }, workspacePath);
+    recordFailedMergeBlock({ issueId: 'PAN-2203', itemId: 'wi-c', slotIndex: 3, note: 'slot 3 conflict' }, workspacePath);
+    const fakeDeps = recoveryDeps();
+
+    await expect(recoverFailedMergeSlot('PAN-2203', workspacePath, 3, doc(item('wi-c', 'blocked')), 'drop', fakeDeps))
+      .resolves.toEqual(['[swarm] dropped failed-merge slot 3 (item wi-c) for PAN-2203']);
+
+    expect(fakeDeps.applyTaskOperationToPlanFile).toHaveBeenCalledWith(
+      join(workspacePath, '.pan', 'spec.vbrief.json'),
+      {
+        type: 'done',
+        itemId: 'wi-c',
+        writerId: 'deacon-swarm',
+        reason: 'Dropped failed swarm slot after operator recovery',
+      },
+      workspacePath,
+    );
+    expect(fakeDeps.applyTaskOperationToPlanFile).toHaveBeenCalledTimes(1);
+    expect(getFailedMergeBlock('PAN-2203', 3, workspacePath)).toBeUndefined();
+    expect(getFailedMergeBlock('PAN-2203', 1, workspacePath)).toEqual(expect.objectContaining({
+      itemId: 'wi-a',
+      slotIndex: 1,
+    }));
+  });
+
+  it('PAN-2364: recover handoff updates only the targeted slot block note and leaves others untouched', async () => {
+    recordFailedMergeBlock({ issueId: 'PAN-2203', itemId: 'wi-a', slotIndex: 1, note: 'slot 1 conflict' }, workspacePath);
+    recordFailedMergeBlock({ issueId: 'PAN-2203', itemId: 'wi-c', slotIndex: 3, note: 'slot 3 conflict' }, workspacePath);
+    const fakeDeps = recoveryDeps();
+
+    await recoverFailedMergeSlot('PAN-2203', workspacePath, 1, doc(), 'handoff', fakeDeps);
+
+    expect(fakeDeps.applyTaskOperationToPlanFile).not.toHaveBeenCalled();
+    expect(fakeDeps.spawnRun).not.toHaveBeenCalled();
+    expect(getFailedMergeBlock('PAN-2203', 1, workspacePath)?.note).toContain('Operator handoff required');
+    expect(getFailedMergeBlock('PAN-2203', 3, workspacePath)).toEqual(expect.objectContaining({
+      itemId: 'wi-c',
+      note: 'slot 3 conflict',
+    }));
   });
 
   it('stores and returns multiple per-slot blocks independently', () => {

--- a/tests/unit/lib/cloister/deacon-swarm-recovery.test.ts
+++ b/tests/unit/lib/cloister/deacon-swarm-recovery.test.ts
@@ -25,7 +25,7 @@ import {
   type ClassifiedSwarmSlot,
   type CoordinateSwarmSlotsDeps,
 } from '../../../../src/lib/cloister/deacon-swarm.js';
-import { writeIssueRecordForWorkspaceSync } from '../../../../src/lib/pan-dir/record.js';
+import { readIssueRecordForWorkspaceSync, writeIssueRecordForWorkspaceSync } from '../../../../src/lib/pan-dir/record.js';
 import { requeueFailedSwarmSlots } from '../../../../src/lib/cloister/swarm-failed-slot.js';
 import type { VBriefDocument, VBriefItem } from '../../../../src/lib/vbrief/types.js';
 
@@ -200,6 +200,14 @@ describe('deacon-swarm failed-merge recovery', () => {
       slotIndex: 1,
       slotItemId: 'wi-a',
     }));
+    expect(fakeDeps.runGitCommand).toHaveBeenCalledWith(
+      expect.stringContaining('git branch -m'),
+      workspacePath,
+    );
+    const record = readIssueRecordForWorkspaceSync(workspacePath, 'PAN-2203');
+    expect(record?.swarm?.supersededAttempts).toEqual(
+      expect.arrayContaining([expect.objectContaining({ slotIndex: 1, itemId: 'wi-a' })]),
+    );
     expect(getFailedMergeBlock('PAN-2203', 1, workspacePath)).toBeUndefined();
   });
 

--- a/tests/unit/lib/cloister/deacon-swarm-recovery.test.ts
+++ b/tests/unit/lib/cloister/deacon-swarm-recovery.test.ts
@@ -132,6 +132,7 @@ function recoveryDeps(): Pick<
   | 'releaseSwarmSlot'
   | 'spawnRun'
   | 'shouldDispatch'
+  | 'runGitCommand'
 > {
   return {
     applyTaskOperationToPlanFile: vi.fn(async () => undefined),
@@ -142,6 +143,7 @@ function recoveryDeps(): Pick<
     releaseSwarmSlot: vi.fn(),
     spawnRun: vi.fn(async () => undefined),
     shouldDispatch: vi.fn(() => true),
+    runGitCommand: vi.fn(async () => undefined),
   };
 }
 
@@ -178,7 +180,7 @@ describe('deacon-swarm failed-merge recovery', () => {
     await recordConflict();
     const fakeDeps = recoveryDeps();
 
-    await expect(recoverFailedMergeSlot('PAN-2203', workspacePath, doc(item('wi-a', 'blocked')), 'retry', fakeDeps))
+    await expect(recoverFailedMergeSlot('PAN-2203', workspacePath, 1,doc(item('wi-a', 'blocked')), 'retry', fakeDeps))
       .resolves.toEqual([
         '[swarm] retrying failed-merge slot 1 (item wi-a) for PAN-2203',
         '[swarm] dispatched implementation slot 1 (item wi-a) for PAN-2203',
@@ -205,7 +207,7 @@ describe('deacon-swarm failed-merge recovery', () => {
     await recordConflict();
     const fakeDeps = recoveryDeps();
 
-    await expect(recoverFailedMergeSlot('PAN-2203', workspacePath, doc(), 'drop', fakeDeps))
+    await expect(recoverFailedMergeSlot('PAN-2203', workspacePath, 1,doc(), 'drop', fakeDeps))
       .resolves.toEqual(['[swarm] dropped failed-merge slot 1 (item wi-a) for PAN-2203']);
 
     expect(fakeDeps.applyTaskOperationToPlanFile).toHaveBeenCalledWith(
@@ -225,7 +227,7 @@ describe('deacon-swarm failed-merge recovery', () => {
     await recordConflict();
     const fakeDeps = recoveryDeps();
 
-    await expect(recoverFailedMergeSlot('PAN-2203', workspacePath, doc(), 'handoff', fakeDeps))
+    await expect(recoverFailedMergeSlot('PAN-2203', workspacePath, 1,doc(), 'handoff', fakeDeps))
       .resolves.toEqual(['[swarm] handoff paused PAN-2203 slot 1 (item wi-a)']);
 
     expect(fakeDeps.applyTaskOperationToPlanFile).not.toHaveBeenCalled();

--- a/tests/unit/lib/cloister/deacon-swarm-recovery.test.ts
+++ b/tests/unit/lib/cloister/deacon-swarm-recovery.test.ts
@@ -1,15 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
+  clearFailedMergeBlock,
   getFailedMergeBlock,
+  getFailedMergeBlocks,
   mergeReadySlots,
+  recordFailedMergeBlock,
   recoverFailedMergeSlot,
   resetSwarmLoopSafetyForTests,
   type ClassifiedSwarmSlot,
   type CoordinateSwarmSlotsDeps,
 } from '../../../../src/lib/cloister/deacon-swarm.js';
+import { writeIssueRecordForWorkspaceSync } from '../../../../src/lib/pan-dir/record.js';
 import type { VBriefDocument, VBriefItem } from '../../../../src/lib/vbrief/types.js';
 
 function item(id = 'wi-a', status: VBriefItem['status'] = 'running'): VBriefItem {
@@ -120,7 +124,7 @@ describe('deacon-swarm failed-merge recovery', () => {
     await expect(mergeReadySlots('PAN-2203', workspacePath, doc(), [readySlot()], mergeDeps()))
       .resolves.toEqual(['[swarm] failed-merge slot 1 (item wi-a) for PAN-2203']);
 
-    expect(getFailedMergeBlock('PAN-2203', workspacePath)).toEqual(expect.objectContaining({
+    expect(getFailedMergeBlock('PAN-2203', 1, workspacePath)).toEqual(expect.objectContaining({
       issueId: 'PAN-2203',
       itemId: 'wi-a',
       slotIndex: 1,
@@ -152,7 +156,7 @@ describe('deacon-swarm failed-merge recovery', () => {
       slotIndex: 1,
       slotItemId: 'wi-a',
     }));
-    expect(getFailedMergeBlock('PAN-2203', workspacePath)).toBeUndefined();
+    expect(getFailedMergeBlock('PAN-2203', 1, workspacePath)).toBeUndefined();
   });
 
   it('drops a failed-merge slot by marking the item done and clearing the block', async () => {
@@ -172,7 +176,7 @@ describe('deacon-swarm failed-merge recovery', () => {
       },
       workspacePath,
     );
-    expect(getFailedMergeBlock('PAN-2203', workspacePath)).toBeUndefined();
+    expect(getFailedMergeBlock('PAN-2203', 1, workspacePath)).toBeUndefined();
   });
 
   it('handoff keeps auto-advance paused with an operator note', async () => {
@@ -184,6 +188,85 @@ describe('deacon-swarm failed-merge recovery', () => {
 
     expect(fakeDeps.applyTaskOperationToPlanFile).not.toHaveBeenCalled();
     expect(fakeDeps.spawnRun).not.toHaveBeenCalled();
-    expect(getFailedMergeBlock('PAN-2203', workspacePath)?.note).toContain('Operator handoff required');
+    expect(getFailedMergeBlock('PAN-2203', 1, workspacePath)?.note).toContain('Operator handoff required');
+  });
+
+  it('stores and returns multiple per-slot blocks independently', () => {
+    recordFailedMergeBlock({ issueId: 'PAN-2203', itemId: 'wi-a', slotIndex: 1, note: 'slot 1 conflict' }, workspacePath);
+    recordFailedMergeBlock({ issueId: 'PAN-2203', itemId: 'wi-c', slotIndex: 3, note: 'slot 3 conflict' }, workspacePath);
+
+    const blocks = getFailedMergeBlocks('PAN-2203', workspacePath);
+    expect(blocks).toHaveLength(2);
+    expect(blocks.map(b => b.slotIndex)).toEqual([1, 3]);
+    expect(getFailedMergeBlock('PAN-2203', 1, workspacePath)?.itemId).toBe('wi-a');
+    expect(getFailedMergeBlock('PAN-2203', 3, workspacePath)?.itemId).toBe('wi-c');
+  });
+
+  it('folds a legacy singular block into the per-slot map on first write and clears the singular field', () => {
+    writeIssueRecordForWorkspaceSync(workspacePath, 'PAN-2203', {
+      issueId: 'PAN-2203',
+      schemaVersion: 2,
+      feedback: [],
+      swarm: {
+        failedMergeBlock: {
+          issueId: 'PAN-2203',
+          itemId: 'wi-legacy',
+          slotIndex: 2,
+          note: 'legacy singular block',
+        },
+      },
+      pipeline: {
+        issueId: 'PAN-2203',
+        reviewStatus: 'pending',
+        testStatus: 'pending',
+        mergeStatus: 'pending',
+        readyForMerge: false,
+        updatedAt: '2026-07-01T00:00:00.000Z',
+      },
+      closeOut: { usage: { byStage: {}, totals: {} }, merges: [], ranOn: 'test' },
+    });
+
+    expect(getFailedMergeBlocks('PAN-2203', workspacePath)).toEqual([
+      expect.objectContaining({ slotIndex: 2, itemId: 'wi-legacy' }),
+    ]);
+
+    recordFailedMergeBlock({ issueId: 'PAN-2203', itemId: 'wi-a', slotIndex: 1, note: 'slot 1 conflict' }, workspacePath);
+
+    const record = JSON.parse(readFileSync(join(workspacePath, '.pan', 'records', 'pan-2203.json'), 'utf-8'));
+    expect(record.swarm.failedMergeBlock).toBeUndefined();
+    expect(record.swarm.failedMergeBlocks).toEqual(expect.objectContaining({
+      '1': expect.objectContaining({ itemId: 'wi-a' }),
+      '2': expect.objectContaining({ itemId: 'wi-legacy' }),
+    }));
+  });
+
+  it('clearFailedMergeBlock removes only the targeted slot', () => {
+    recordFailedMergeBlock({ issueId: 'PAN-2203', itemId: 'wi-a', slotIndex: 1, note: 'slot 1 conflict' }, workspacePath);
+    recordFailedMergeBlock({ issueId: 'PAN-2203', itemId: 'wi-c', slotIndex: 3, note: 'slot 3 conflict' }, workspacePath);
+
+    clearFailedMergeBlock('PAN-2203', 1, workspacePath);
+
+    expect(getFailedMergeBlock('PAN-2203', 1, workspacePath)).toBeUndefined();
+    expect(getFailedMergeBlock('PAN-2203', 3, workspacePath)).toEqual(expect.objectContaining({
+      itemId: 'wi-c',
+      slotIndex: 3,
+    }));
+    expect(getFailedMergeBlocks('PAN-2203', workspacePath)).toEqual([
+      expect.objectContaining({ slotIndex: 3, itemId: 'wi-c' }),
+    ]);
+  });
+
+  it('durable blocks survive resetSwarmLoopSafetyForTests clearing the in-memory map', () => {
+    recordFailedMergeBlock({ issueId: 'PAN-2203', itemId: 'wi-a', slotIndex: 1, note: 'slot 1 conflict' }, workspacePath);
+
+    resetSwarmLoopSafetyForTests();
+
+    expect(getFailedMergeBlocks('PAN-2203', workspacePath)).toEqual([
+      expect.objectContaining({ slotIndex: 1, itemId: 'wi-a' }),
+    ]);
+    expect(getFailedMergeBlock('PAN-2203', 1, workspacePath)).toEqual(expect.objectContaining({
+      itemId: 'wi-a',
+      slotIndex: 1,
+    }));
   });
 });

--- a/tests/unit/lib/cloister/deacon-swarm-recovery.test.ts
+++ b/tests/unit/lib/cloister/deacon-swarm-recovery.test.ts
@@ -2,6 +2,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+
+const mocks = vi.hoisted(() => ({
+  listProjectsSync: vi.fn(),
+  resolveProjectFromIssueSync: vi.fn(),
+}));
+
+vi.mock('../../../../src/lib/projects.js', () => ({
+  listProjectsSync: mocks.listProjectsSync,
+  findProjectByPathSync: () => null,
+  resolveProjectFromIssueSync: mocks.resolveProjectFromIssueSync,
+}));
+
 import {
   clearFailedMergeBlock,
   getFailedMergeBlock,
@@ -14,7 +26,12 @@ import {
   type CoordinateSwarmSlotsDeps,
 } from '../../../../src/lib/cloister/deacon-swarm.js';
 import { writeIssueRecordForWorkspaceSync } from '../../../../src/lib/pan-dir/record.js';
+import { requeueFailedSwarmSlots } from '../../../../src/lib/cloister/swarm-failed-slot.js';
 import type { VBriefDocument, VBriefItem } from '../../../../src/lib/vbrief/types.js';
+
+beforeEach(() => {
+  mocks.resolveProjectFromIssueSync.mockReturnValue(null);
+});
 
 function item(id = 'wi-a', status: VBriefItem['status'] = 'running'): VBriefItem {
   return {
@@ -61,6 +78,31 @@ function readySlot(): ClassifiedSwarmSlot {
     agentId: 'agent-pan-2203-slot-1',
     lifecycle: 'ready-to-merge',
     exitStatus: 0,
+  };
+}
+
+function readySlotAt(index: number, itemId: string): ClassifiedSwarmSlot {
+  return {
+    itemId,
+    slotIndex: index,
+    status: 'in_flight',
+    branch: `feature/pan-2203-slot-${index}`,
+    agentId: `agent-pan-2203-slot-${index}`,
+    lifecycle: 'ready-to-merge',
+    exitStatus: 0,
+  };
+}
+
+function failedSlotAt(index: number, itemId: string): ClassifiedSwarmSlot {
+  return {
+    itemId,
+    slotIndex: index,
+    status: 'in_flight',
+    branch: `feature/pan-2203-slot-${index}`,
+    agentId: `agent-pan-2203-slot-${index}`,
+    lifecycle: 'failed',
+    reason: 'pane-exit-nonzero',
+    exitStatus: 1,
   };
 }
 
@@ -268,5 +310,55 @@ describe('deacon-swarm failed-merge recovery', () => {
       itemId: 'wi-a',
       slotIndex: 1,
     }));
+  });
+
+  it('PAN-2364: mergeReadySlots skips a blocked ready-to-merge slot every pass', async () => {
+    recordFailedMergeBlock({ issueId: 'PAN-2203', itemId: 'wi-b', slotIndex: 2, note: 'slot 2 conflict' }, workspacePath);
+    const fakeDeps = mergeDeps();
+
+    await expect(mergeReadySlots(
+      'PAN-2203',
+      workspacePath,
+      doc(item('wi-b')),
+      [readySlotAt(2, 'wi-b')],
+      fakeDeps,
+      new Set([2]),
+    )).resolves.toEqual([
+      '[swarm] skipped merge slot 2 (item wi-b) for PAN-2203: failed-merge block — awaiting `pan swarm recover`',
+    ]);
+
+    expect(fakeDeps.verifyAndMergeSlot).not.toHaveBeenCalled();
+  });
+
+  it('PAN-2364: requeueFailedSwarmSlots skips a blocked failed slot without archiving', async () => {
+    recordFailedMergeBlock({ issueId: 'PAN-2203', itemId: 'wi-b', slotIndex: 2, note: 'slot 2 conflict' }, workspacePath);
+    const fakeDeps = {
+      ...recoveryDeps(),
+      runGitCommand: vi.fn(async () => undefined),
+    };
+
+    const { doc: nextDoc, actions } = await requeueFailedSwarmSlots(
+      'PAN-2203',
+      workspacePath,
+      [failedSlotAt(2, 'wi-b')],
+      doc(item('wi-b')),
+      {
+        issueId: 'PAN-2203',
+        merged: [],
+        inFlight: [failedSlotAt(2, 'wi-b')],
+        pending: [],
+        branches: [],
+        agents: [],
+      },
+      fakeDeps,
+      new Set([2]),
+    );
+
+    expect(actions).toEqual([
+      '[swarm] skipped requeue slot 2 (item wi-b) for PAN-2203: failed-merge block — awaiting operator recovery',
+    ]);
+    expect(fakeDeps.runGitCommand).not.toHaveBeenCalled();
+    expect(fakeDeps.applyTaskOperationToPlanFile).not.toHaveBeenCalled();
+    expect(nextDoc.plan.items.find(i => i.id === 'wi-b')?.status).toBe('running');
   });
 });

--- a/tests/unit/lib/cloister/deacon-swarm-stall.test.ts
+++ b/tests/unit/lib/cloister/deacon-swarm-stall.test.ts
@@ -168,7 +168,7 @@ describe('deacon-swarm stalled-slot detection and duplicate-spawn guard', () => 
     expect(recordStalledSlotRecovery('PAN-2203', classified)).toEqual([
       '[swarm] stalled slot 1 (item wi-a) for PAN-2203: recovery required',
     ]);
-    expect(getFailedMergeBlock('PAN-2203')).toEqual(expect.objectContaining({
+    expect(getFailedMergeBlock('PAN-2203', 1)).toEqual(expect.objectContaining({
       itemId: 'wi-a',
       slotIndex: 1,
       note: expect.stringContaining('stalled'),

--- a/tests/unit/lib/cloister/deacon-swarm-stall.test.ts
+++ b/tests/unit/lib/cloister/deacon-swarm-stall.test.ts
@@ -3,6 +3,8 @@ import {
   classifyInFlightSlots,
   dispatchNextWave,
   getFailedMergeBlock,
+  getFailedMergeBlocks,
+  recordFailedMergeBlock,
   recordStalledSlotRecovery,
   resetSwarmLoopSafetyForTests,
   type CoordinateSwarmSlotsDeps,
@@ -173,6 +175,44 @@ describe('deacon-swarm stalled-slot detection and duplicate-spawn guard', () => 
       slotIndex: 1,
       note: expect.stringContaining('stalled'),
     }));
+  });
+
+  it('PAN-2364: records a block for every stalled slot in one pass', () => {
+    const classified = [
+      { ...slot(), lifecycle: 'stalled' as const, reason: 'no-progress-timeout' as const, stalledForMs: STALL_THRESHOLD_MS + 1 },
+      { ...slot({ itemId: 'wi-b', slotIndex: 2, branch: 'feature/pan-2203-slot-2', agentId: 'agent-pan-2203-slot-2' }), lifecycle: 'stalled' as const, reason: 'no-progress-timeout' as const, stalledForMs: STALL_THRESHOLD_MS + 1 },
+    ];
+
+    expect(recordStalledSlotRecovery('PAN-2203', classified)).toEqual([
+      '[swarm] stalled slot 1 (item wi-a) for PAN-2203: recovery required',
+      '[swarm] stalled slot 2 (item wi-b) for PAN-2203: recovery required',
+    ]);
+    expect(getFailedMergeBlock('PAN-2203', 1)).toEqual(expect.objectContaining({ itemId: 'wi-a', slotIndex: 1 }));
+    expect(getFailedMergeBlock('PAN-2203', 2)).toEqual(expect.objectContaining({ itemId: 'wi-b', slotIndex: 2 }));
+  });
+
+  it('PAN-2364: only records blocks for newly stalled slots when others already hold blocks', () => {
+    recordFailedMergeBlock({ issueId: 'PAN-2203', itemId: 'wi-a', slotIndex: 1, note: 'Slot 1 stalled with no branch commit or pane output progress' });
+    const classified = [
+      { ...slot(), lifecycle: 'stalled' as const, reason: 'no-progress-timeout' as const, stalledForMs: STALL_THRESHOLD_MS + 1 },
+      { ...slot({ itemId: 'wi-b', slotIndex: 2, branch: 'feature/pan-2203-slot-2', agentId: 'agent-pan-2203-slot-2' }), lifecycle: 'stalled' as const, reason: 'no-progress-timeout' as const, stalledForMs: STALL_THRESHOLD_MS + 1 },
+    ];
+
+    expect(recordStalledSlotRecovery('PAN-2203', classified)).toEqual([
+      '[swarm] stalled slot 2 (item wi-b) for PAN-2203: recovery required',
+    ]);
+    expect(getFailedMergeBlock('PAN-2203', 1)).toEqual(expect.objectContaining({ itemId: 'wi-a', slotIndex: 1 }));
+    expect(getFailedMergeBlock('PAN-2203', 2)).toEqual(expect.objectContaining({ itemId: 'wi-b', slotIndex: 2 }));
+  });
+
+  it('PAN-2364: repeated passes over the same stalled slot are idempotent and do not rewrite the block', () => {
+    const classified = [{ ...slot(), lifecycle: 'stalled' as const, reason: 'no-progress-timeout' as const, stalledForMs: STALL_THRESHOLD_MS + 1 }];
+
+    expect(recordStalledSlotRecovery('PAN-2203', classified)).toEqual([
+      '[swarm] stalled slot 1 (item wi-a) for PAN-2203: recovery required',
+    ]);
+    expect(recordStalledSlotRecovery('PAN-2203', classified)).toEqual([]);
+    expect(getFailedMergeBlocks('PAN-2203')).toHaveLength(1);
   });
 
   it('keeps a fresh slot running within the threshold', async () => {


### PR DESCRIPTION
**Issue:** #2364

## Acceptance Criteria

- [ ] Store failed-merge blocks per-slot in the record and in-memory map
- [ ] Coordinator continues merging and dispatching around blocked slots
- [ ] recordStalledSlotRecovery blocks every stalled slot, not just the first
- [ ] recover retry archives the conflicted attempt so it cannot re-assert; recover is slot-scoped
- [ ] pan swarm status lists all blocked slots and stops mislabeling them ready-to-merge
- [ ] Update docs/SWARM.md recovery sections to per-slot isolation semantics

## Implementation Tasks

- [x] Update docs/SWARM.md recovery sections to per-slot isolation semantics
- [x] pan swarm status lists all blocked slots and stops mislabeling them ready-to-merge
- [x] recover retry archives the conflicted attempt so it cannot re-assert; recover is slot-scoped
- [x] recordStalledSlotRecovery blocks every stalled slot, not just the first
- [x] Coordinator continues merging and dispatching around blocked slots
- [x] Store failed-merge blocks per-slot in the record and in-memory map

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Swarm coordination now tracks failed-merge blocks independently for each slot.
  * Status displays blocked slots, recovery notes, and specific recovery instructions.
  * Recovery actions can retry, drop, or hand off individual blocked slots without pausing other work.
  * Retrying a blocked slot archives the conflicted attempt and dispatches a fresh one.

* **Bug Fixes**
  * Prevented blocked slots from being incorrectly shown as ready to merge or re-dispatched.
  * Improved recovery for multiple stalled or conflicted slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->