### PR TITLE
fix(ci): install bd/dolt/ripgrep on runner + hard-fail beads-access audit without rg (PAN-2614)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,10 @@ jobs:
 
       - name: Install beads, Dolt, and ripgrep
         run: |
-          npm install -g @beads/bd@1.1.0
+          BD_VERSION=1.1.0
+          curl -fsSL -o /tmp/bd.tar.gz "https://github.com/gastownhall/beads/releases/download/v${BD_VERSION}/beads_${BD_VERSION}_linux_amd64.tar.gz"
+          tar -xzf /tmp/bd.tar.gz -C /tmp
+          sudo install /tmp/bd /usr/local/bin/bd
 
           DOLT_VERSION=1.84.0
           curl -fsSL -o /tmp/dolt.tar.gz "https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}/dolt-linux-amd64.tar.gz"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,14 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Install ripgrep
+        run: |
+          RG_VERSION=15.1.0
+          curl -fsSL -o /tmp/ripgrep.tar.gz "https://github.com/BurntSushi/ripgrep/releases/download/${RG_VERSION}/ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          tar -xzf /tmp/ripgrep.tar.gz -C /tmp
+          sudo install "/tmp/ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl/rg" /usr/local/bin/rg
+          rg --version
+
       - name: Build
         run: npm run build
 
@@ -148,6 +156,24 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Install beads, Dolt, and ripgrep
+        run: |
+          npm install -g @beads/bd@1.1.0
+
+          DOLT_VERSION=1.84.0
+          curl -fsSL -o /tmp/dolt.tar.gz "https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}/dolt-linux-amd64.tar.gz"
+          tar -xzf /tmp/dolt.tar.gz -C /tmp
+          sudo install /tmp/dolt-linux-amd64/bin/dolt /usr/local/bin/dolt
+
+          RG_VERSION=15.1.0
+          curl -fsSL -o /tmp/ripgrep.tar.gz "https://github.com/BurntSushi/ripgrep/releases/download/${RG_VERSION}/ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          tar -xzf /tmp/ripgrep.tar.gz -C /tmp
+          sudo install "/tmp/ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl/rg" /usr/local/bin/rg
+
+          bd --version
+          dolt version
+          rg --version
 
       - name: Build
         run: npm run build

--- a/scripts/lint-beads-access.sh
+++ b/scripts/lint-beads-access.sh
@@ -4,10 +4,26 @@ set -euo pipefail
 root="${1:-.}"
 cd "$root"
 
+if ! command -v rg >/dev/null 2>&1; then
+  echo "beads access audit failed: ripgrep (rg) is required but was not found in PATH" >&2
+  exit 2
+fi
+
 violations=""
 append_matches() {
   local output
-  output="$("$@" 2>/dev/null || true)"
+  local status
+  set +e
+  output="$("$@" 2>&1)"
+  status=$?
+  set -e
+  if [[ $status -eq 1 ]]; then
+    return
+  fi
+  if [[ $status -ne 0 ]]; then
+    printf 'beads access audit failed: rg command failed with exit %s:\n%s\n' "$status" "$output" >&2
+    exit 2
+  fi
   if [[ -n "$output" ]]; then
     violations+="$output"$'\n'
   fi
@@ -34,7 +50,8 @@ append_matches rg -n --glob '*.ts' \
 
 # Production code, active prompts, and skill entrypoints may not teach or run
 # raw mutations. Writer/bootstrap/recovery adapters are the only executors.
-mutation_matches="$(rg -n \
+set +e
+mutation_rg_matches="$(rg -n \
   --glob '*.ts' --glob 'SKILL.md' --glob 'work.md' \
   --glob '!**/__tests__/**' --glob '!**/*.test.ts' \
   --glob '!src/lib/beads/writer.ts' \
@@ -43,8 +60,18 @@ mutation_matches="$(rg -n \
   --glob '!src/lib/beads/bd-shim.ts' \
   --glob '!src/lib/remote-workspace.ts' \
   --glob '!src/lib/remote/fly-provider.ts' \
-  "\\bbd +(create|update|close|delete|import|init|migrate|batch|dep +(add|remove)|dolt +(push|commit|reset)|config +(set|unset)|admin +compact)\\b" src sync-sources/skills 2>/dev/null \
-  | grep -Eiv "(:[0-9]+:[[:space:]]*(//|\\*)|never|do not|don't|replaces|without asking|must be run once|only sanctioned|not need to run)" || true)"
+  "\\bbd +(create|update|close|delete|import|init|migrate|batch|dep +(add|remove)|dolt +(push|commit|reset)|config +(set|unset)|admin +compact)\\b" src sync-sources/skills 2>&1)"
+mutation_rg_status=$?
+set -e
+if [[ $mutation_rg_status -eq 1 ]]; then
+  mutation_matches=""
+elif [[ $mutation_rg_status -ne 0 ]]; then
+  printf 'beads access audit failed: rg command failed with exit %s:\n%s\n' "$mutation_rg_status" "$mutation_rg_matches" >&2
+  exit 2
+else
+  mutation_matches="$(printf '%s\n' "$mutation_rg_matches" \
+    | grep -Eiv "(:[0-9]+:[[:space:]]*(//|\\*)|never|do not|don't|replaces|without asking|must be run once|only sanctioned|not need to run)" || true)"
+fi
 if [[ -n "$mutation_matches" ]]; then violations+="$mutation_matches"$'\n'; fi
 
 if [[ -n "$violations" ]]; then

--- a/tests/unit/scripts/lint-beads-access.test.ts
+++ b/tests/unit/scripts/lint-beads-access.test.ts
@@ -16,8 +16,12 @@ function fixture(path: string, content: string): string {
   return root;
 }
 
-function run(root: string): void {
-  execFileSync('bash', [script, root], { encoding: 'utf8', stdio: 'pipe' });
+function run(root: string, env: NodeJS.ProcessEnv = {}): void {
+  execFileSync('/usr/bin/bash', [script, root], {
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+    stdio: 'pipe',
+  });
 }
 
 afterEach(() => roots.splice(0).forEach((root) => rmSync(root, { recursive: true, force: true })));
@@ -34,8 +38,23 @@ describe('beads access audit', () => {
   it('allows the recovery/export adapter and canonical doors', () => {
     const root = fixture('src/lib/beads/export.ts', "readFileSync('.beads/issues.jsonl')");
     mkdirSync(join(root, 'src/lib/beads'), { recursive: true });
+    mkdirSync(join(root, 'sync-sources/skills'), { recursive: true });
     writeFileSync(join(root, 'src/lib/beads/resolver.ts'), "execFile('bd', ['list'])");
     writeFileSync(join(root, 'src/lib/beads/writer.ts'), "execFile('bd', ['close', id])");
     expect(() => run(root)).not.toThrow();
+  });
+
+  it('fails clearly when ripgrep is unavailable', () => {
+    const root = fixture('src/ok.ts', 'export const ok = true;');
+    const emptyPath = join(root, 'empty-bin');
+    mkdirSync(emptyPath);
+
+    try {
+      run(root, { PATH: emptyPath });
+      throw new Error('expected beads access audit to fail without rg');
+    } catch (error) {
+      const stderr = (error as { stderr?: Buffer | string }).stderr?.toString() ?? '';
+      expect(stderr).toContain('ripgrep (rg) is required');
+    }
   });
 });


### PR DESCRIPTION
Fixes red main (PAN-2614): the CI \`test\` job lacked \`bd\`/\`dolt\`/\`ripgrep\`, so two tests from the PAN-2564 Dolt cutover failed on the runner (pass locally):

- \`beads-cross-machine.test.ts\` — \`spawnSync bd ENOENT\`
- \`lint-beads-access.test.ts\` — audit silently exited 0 (rg missing → \`2>/dev/null || true\` swallowed it)

Changes:
- ci.yml: install ripgrep (build + test jobs), bd@1.1.0 + dolt 1.84.0 (test job), with version-verify.
- lint-beads-access.sh: hard-fail (exit 2) when rg absent; distinguish rg exit 1 (no matches, ok) from rg errors (exit ≥2, fatal) — fixes the silently-vacuous audit.
- Added missing-tool test case.

Strike branch authored by strike-pan-2614; landed via flywheel-orchestrator after review (diff verified, matches PAN-2614 fix spec). CI on this PR validates the tool-install commands empirically.

Closes PAN-2614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)