### PR TITLE
fix(beads): skip bootstrap in runMutationBatch when the embedded dolt store exists (PAN-2610)

### DIFF
--- a/src/cli/commands/beads.ts
+++ b/src/cli/commands/beads.ts
@@ -14,7 +14,7 @@ import { promisify } from 'util';
 import { platform } from 'os';
 import { registerBeadsReconcileCommand } from './admin/beads-reconcile.js';
 import { standardizeBeadsConfig } from '../../lib/beads/config-standardize.js';
-import { runMutationBatch, type BdMutationClient } from '../../lib/beads/writer.js';
+import { formatMutationBatchFailure, runMutationBatch, type BdMutationClient } from '../../lib/beads/writer.js';
 import { assertSupportedBdVersion, readInstalledBdVersion } from '../../lib/beads/version.js';
 
 const execAsync = promisify(exec);
@@ -129,7 +129,7 @@ async function compactCommand(options: CompactOptions): Promise<void> {
       { project: { workspacePath: cwd }, reason: `compact beads older than ${days} days` },
       (bd) => bd.mutate(['admin', 'compact', '--days', String(days)]),
     );
-    if (!compacted.ok) throw new Error(compacted.message);
+    if (!compacted.ok) throw new Error(formatMutationBatchFailure(compacted));
 
     spinner.succeed(`Compacted ${count} beads older than ${days} days`);
 
@@ -232,7 +232,7 @@ export function registerBeadsCommands(program: Command): void {
 
   const mutate = async <T>(reason: string, fn: (bd: BdMutationClient) => Promise<T>): Promise<T> => {
     const result = await runMutationBatch({ project: { workspacePath: process.cwd() }, reason }, fn);
-    if (!result.ok) throw new Error(result.message);
+    if (!result.ok) throw new Error(formatMutationBatchFailure(result));
     return result.value;
   };
 

--- a/src/cli/commands/workspace-beads.ts
+++ b/src/cli/commands/workspace-beads.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { promisify } from 'util';
 import { findProjectByPathSync, type ProjectConfig } from '../../lib/projects.js';
 import { ensureStateWorktree, resolveStateHome } from '../../lib/state-home.js';
-import { runMutationBatch } from '../../lib/beads/writer.js';
+import { formatMutationBatchFailure, runMutationBatch } from '../../lib/beads/writer.js';
 import { resolveCanonicalBeadsHome } from '../../lib/beads/home.js';
 import { assertSupportedBdVersion, readInstalledBdVersion } from '../../lib/beads/version.js';
 
@@ -71,7 +71,7 @@ export async function initializeWorkspaceBeads(workspacePath: string, issueId: s
         { project: { workspacePath }, reason: `create implementation bead for ${issueId.toUpperCase()}` },
         (bd) => bd.mutate(['create', '--title', title, '--priority', '1', '--type', 'task', '--labels', issueLabel]),
       );
-      if (!batch.ok) return { success: false, error: batch.message };
+      if (!batch.ok) return { success: false, error: formatMutationBatchFailure(batch) };
       const stdout = batch.value;
 
       // Parse the created bead ID

--- a/src/lib/beads/export.ts
+++ b/src/lib/beads/export.ts
@@ -33,7 +33,7 @@ async function defaultExecute(args: readonly string[], cwd: string): Promise<str
 }
 
 function doltHead(status: string): string | null {
-  return /^Commit:\s*([0-9a-f]{7,40})\s*$/im.exec(status)?.[1] ?? null;
+  return /^Commit:\s*([0-9a-v]{7,40})\s*$/im.exec(status)?.[1] ?? null;
 }
 
 function recordsFromJsonl(raw: string): Array<Record<string, unknown>> {

--- a/src/lib/beads/export.ts
+++ b/src/lib/beads/export.ts
@@ -7,6 +7,7 @@ import { promisify } from 'node:util';
 import { resolveSharedBeadsDir } from '../bd-process-lock.js';
 
 const execFileAsync = promisify(execFile);
+const BD_EXEC_MAX_BUFFER = 64 * 1024 * 1024;
 
 export interface BeadsExportState {
   universe: 'all';
@@ -28,7 +29,7 @@ export interface ExportBeadsResult {
 }
 
 async function defaultExecute(args: readonly string[], cwd: string): Promise<string> {
-  const { stdout } = await execFileAsync('bd', [...args], { cwd, encoding: 'utf8', timeout: 120_000 });
+  const { stdout } = await execFileAsync('bd', [...args], { cwd, encoding: 'utf8', timeout: 120_000, maxBuffer: BD_EXEC_MAX_BUFFER });
   return stdout;
 }
 

--- a/src/lib/beads/export.ts
+++ b/src/lib/beads/export.ts
@@ -33,7 +33,7 @@ async function defaultExecute(args: readonly string[], cwd: string): Promise<str
 }
 
 function doltHead(status: string): string | null {
-  return /^Commit:\s*([0-9a-v]{7,40})\s*$/im.exec(status)?.[1] ?? null;
+  return /^\s*Commit:\s*([0-9a-v]{7,40})\s*$/im.exec(status)?.[1] ?? null;
 }
 
 function recordsFromJsonl(raw: string): Array<Record<string, unknown>> {

--- a/src/lib/beads/reconcile.ts
+++ b/src/lib/beads/reconcile.ts
@@ -122,7 +122,7 @@ export async function reconcileBeads(options: ReconcileBeadsOptions) {
     const jsonlPath = join(options.stateRoot, '.beads', 'issues.jsonl');
     const stateJsonl = existsSync(jsonlPath) ? parseJsonl(await readFile(jsonlPath, 'utf8')) : [];
     const inventory = compareBeadsSources({ 'local-dolt': local, 'remote-dolt': remote, 'state-jsonl': stateJsonl });
-    const head = (raw: string) => /^Commit:\s*([0-9a-v]{7,40})\s*$/im.exec(raw)?.[1] ?? '';
+    const head = (raw: string) => /^\s*Commit:\s*([0-9a-v]{7,40})\s*$/im.exec(raw)?.[1] ?? '';
     const reportPath = join(notesDir, `beads-reconcile-${date}.md`);
     const report = reportMarkdown(options, inventory, { local: head(localHead), remote: head(remoteHead) });
     await writeFile(reportPath, report);

--- a/src/lib/beads/reconcile.ts
+++ b/src/lib/beads/reconcile.ts
@@ -122,7 +122,7 @@ export async function reconcileBeads(options: ReconcileBeadsOptions) {
     const jsonlPath = join(options.stateRoot, '.beads', 'issues.jsonl');
     const stateJsonl = existsSync(jsonlPath) ? parseJsonl(await readFile(jsonlPath, 'utf8')) : [];
     const inventory = compareBeadsSources({ 'local-dolt': local, 'remote-dolt': remote, 'state-jsonl': stateJsonl });
-    const head = (raw: string) => /^Commit:\s*([0-9a-f]{7,40})\s*$/im.exec(raw)?.[1] ?? '';
+    const head = (raw: string) => /^Commit:\s*([0-9a-v]{7,40})\s*$/im.exec(raw)?.[1] ?? '';
     const reportPath = join(notesDir, `beads-reconcile-${date}.md`);
     const report = reportMarkdown(options, inventory, { local: head(localHead), remote: head(remoteHead) });
     await writeFile(reportPath, report);

--- a/src/lib/beads/writer.ts
+++ b/src/lib/beads/writer.ts
@@ -1,4 +1,6 @@
 import { execFile } from 'node:child_process';
+import { readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
 import { promisify } from 'node:util';
 
 import { withBdProcessLock, type BdProcessLockOptions } from '../bd-process-lock.js';
@@ -40,6 +42,12 @@ function errorText(error: unknown): string {
   return [record.stderr, record.message, record.stdout].filter((value) => typeof value === 'string').join('\n');
 }
 
+export function formatMutationBatchFailure(result: Extract<MutationBatchResult<unknown>, { ok: false }>): string {
+  if (!('cause' in result)) return result.message;
+  const cause = errorText(result.cause).trim();
+  return cause ? `${result.message}\nCause: ${cause}` : result.message;
+}
+
 function isConflict(error: unknown): boolean {
   return /conflict|non-fast-forward|rejected|diverge/i.test(errorText(error));
 }
@@ -76,6 +84,17 @@ async function readRemoteHead(client: BdMutationClient): Promise<string | null> 
   }
 }
 
+async function hasExistingEmbeddedDoltStore(cwd: string): Promise<boolean> {
+  try {
+    const storePath = join(cwd, '.beads', 'embeddeddolt');
+    const storeStat = await stat(storePath);
+    if (!storeStat.isDirectory()) return false;
+    return (await readdir(storePath)).length > 0;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * The only canonical beads mutation transaction boundary.
  *
@@ -102,7 +121,9 @@ export async function runMutationBatch<T>(
   return withLock(`beads mutation: ${context.reason}`, async () => {
     let value: T;
     try {
-      await client.run(['bootstrap', '--yes', '--json']);
+      if (!(await hasExistingEmbeddedDoltStore(cwd))) {
+        await client.run(['bootstrap', '--yes', '--json']);
+      }
       await client.run(['dolt', 'pull']);
       recordBeadsPull(telemetryKey, await readHead(client), await readRemoteHead(client));
       value = await mutate(client);

--- a/src/lib/beads/writer.ts
+++ b/src/lib/beads/writer.ts
@@ -8,6 +8,7 @@ import { exportBeadsJsonl } from './export.js';
 import { recordBeadsConflict, recordBeadsPull, recordBeadsPush, recordBeadsSyncError } from './telemetry.js';
 
 const execFileAsync = promisify(execFile);
+const BD_EXEC_MAX_BUFFER = 64 * 1024 * 1024;
 
 export interface BeadsMutationProject {
   workspacePath: string;
@@ -42,6 +43,12 @@ function errorText(error: unknown): string {
   return [record.stderr, record.message, record.stdout].filter((value) => typeof value === 'string').join('\n');
 }
 
+function errorDiagnosticText(error: unknown): string {
+  if (!error || typeof error !== 'object') return String(error);
+  const record = error as Record<string, unknown>;
+  return [record.stderr, record.message].filter((value) => typeof value === 'string').join('\n');
+}
+
 export function formatMutationBatchFailure(result: Extract<MutationBatchResult<unknown>, { ok: false }>): string {
   if (!('cause' in result)) return result.message;
   const cause = errorText(result.cause).trim();
@@ -49,7 +56,7 @@ export function formatMutationBatchFailure(result: Extract<MutationBatchResult<u
 }
 
 function isConflict(error: unknown): boolean {
-  return /conflict|non-fast-forward|rejected|diverge/i.test(errorText(error));
+  return /conflict|non-fast-forward|rejected|diverge/i.test(errorDiagnosticText(error));
 }
 
 function parseHead(status: string): string | null {
@@ -57,7 +64,7 @@ function parseHead(status: string): string | null {
 }
 
 async function defaultExecute(args: readonly string[], cwd: string): Promise<string> {
-  const { stdout } = await execFileAsync('bd', [...args], { cwd, encoding: 'utf8', timeout: 120_000 });
+  const { stdout } = await execFileAsync('bd', [...args], { cwd, encoding: 'utf8', timeout: 120_000, maxBuffer: BD_EXEC_MAX_BUFFER });
   return stdout;
 }
 

--- a/src/lib/beads/writer.ts
+++ b/src/lib/beads/writer.ts
@@ -53,7 +53,7 @@ function isConflict(error: unknown): boolean {
 }
 
 function parseHead(status: string): string | null {
-  return /^Commit:\s*([0-9a-v]{7,40})\s*$/im.exec(status)?.[1] ?? null;
+  return /^\s*Commit:\s*([0-9a-v]{7,40})\s*$/im.exec(status)?.[1] ?? null;
 }
 
 async function defaultExecute(args: readonly string[], cwd: string): Promise<string> {

--- a/src/lib/beads/writer.ts
+++ b/src/lib/beads/writer.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { readdir, stat } from 'node:fs/promises';
+import { readFile, readdir, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 
@@ -86,12 +86,23 @@ async function readRemoteHead(client: BdMutationClient): Promise<string | null> 
 
 async function hasExistingEmbeddedDoltStore(cwd: string): Promise<boolean> {
   try {
-    const storePath = join(cwd, '.beads', 'embeddeddolt');
+    const beadsDir = await resolveBeadsDir(cwd);
+    const storePath = join(beadsDir, 'embeddeddolt');
     const storeStat = await stat(storePath);
     if (!storeStat.isDirectory()) return false;
     return (await readdir(storePath)).length > 0;
   } catch {
     return false;
+  }
+}
+
+async function resolveBeadsDir(cwd: string): Promise<string> {
+  const localBeadsDir = join(cwd, '.beads');
+  try {
+    const redirect = (await readFile(join(localBeadsDir, 'redirect'), 'utf8')).trim();
+    return redirect || localBeadsDir;
+  } catch {
+    return localBeadsDir;
   }
 }
 

--- a/src/lib/beads/writer.ts
+++ b/src/lib/beads/writer.ts
@@ -53,7 +53,7 @@ function isConflict(error: unknown): boolean {
 }
 
 function parseHead(status: string): string | null {
-  return /^Commit:\s*([0-9a-f]{7,40})\s*$/im.exec(status)?.[1] ?? null;
+  return /^Commit:\s*([0-9a-v]{7,40})\s*$/im.exec(status)?.[1] ?? null;
 }
 
 async function defaultExecute(args: readonly string[], cwd: string): Promise<string> {

--- a/src/lib/vbrief/beads.ts
+++ b/src/lib/vbrief/beads.ts
@@ -19,7 +19,7 @@ import { extractACFromDocument } from './acceptance-criteria.js';
 import type { AcceptanceCriterion } from './acceptance-criteria.js';
 import { subItemsOf, type VBriefDocument, type VBriefEdge, type VBriefInspectionPolicy, type VBriefItem, type VBriefItemStatus } from './types.js';
 import { createBeadsResolver } from '../beads/resolver.js';
-import { runMutationBatch, type BdMutationClient } from '../beads/writer.js';
+import { formatMutationBatchFailure, runMutationBatch, type BdMutationClient } from '../beads/writer.js';
 import { resolveCanonicalBeadsHome } from '../beads/home.js';
 
 const execFileAsync = promisify(execFile);
@@ -333,7 +333,7 @@ export async function clearBeadsForIssue(
     { project: { workspacePath }, reason: `clear beads for ${issueLabel}`, lockOptions: options },
     (client) => clearBeadsForIssueWithClient(client, workspacePath, issueLabel, options),
   );
-  return batch.ok ? batch.value : { cleared: 0, errors: [batch.message] };
+  return batch.ok ? batch.value : { cleared: 0, errors: [formatMutationBatchFailure(batch)] };
 }
 
 async function clearBeadsForIssueWithClient(
@@ -651,7 +651,7 @@ async function createBeadsFromVBriefPromise(
   );
   return batch.ok
     ? batch.value
-    : { success: false, created: [], errors: [batch.message], beadIds: new Map() };
+    : { success: false, created: [], errors: [formatMutationBatchFailure(batch)], beadIds: new Map() };
 }
 
 /**

--- a/tests/unit/lib/beads/export.test.ts
+++ b/tests/unit/lib/beads/export.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { exportBeadsJsonl } from '../../../../src/lib/beads/export.js';
 
 describe('validated beads JSONL export', () => {
+  const doltHead = 'dmqijeb6';
   const roots: string[] = [];
   afterEach(() => roots.splice(0).forEach((root) => rmSync(root, { recursive: true, force: true })));
 
@@ -15,7 +16,7 @@ describe('validated beads JSONL export', () => {
     const beadsDir = join(root, '.beads');
     mkdirSync(beadsDir);
     const execute = vi.fn(async (args: readonly string[]) => {
-      if (args.join(' ') === 'vc status') return `Branch: main\nCommit: ${'a'.repeat(40)}\n`;
+      if (args.join(' ') === 'vc status') return `Branch: main\nCommit: ${doltHead}\n`;
       if (args[0] === 'export') {
         const output = String(args[args.indexOf('-o') + 1]);
         writeFileSync(output, records.map((record) => JSON.stringify(record)).join('\n') + (records.length ? '\n' : ''));
@@ -30,7 +31,7 @@ describe('validated beads JSONL export', () => {
   it('exports and verifies the same --all record universe and records the source head', async () => {
     const f = fixture([{ id: 'one', title: 'One' }, { id: 'gate', type: 'gate' }]);
     const result = await exportBeadsJsonl(f.root, { beadsDir: f.beadsDir, execute: f.execute, now: () => new Date('2026-07-12T12:00:00Z') });
-    expect(result.state).toEqual({ universe: 'all', sourceDoltHead: 'a'.repeat(40), recordCount: 2, exportedAt: '2026-07-12T12:00:00.000Z' });
+    expect(result.state).toEqual({ universe: 'all', sourceDoltHead: doltHead, recordCount: 2, exportedAt: '2026-07-12T12:00:00.000Z' });
     expect(f.execute).toHaveBeenCalledWith(expect.arrayContaining(['export', '--all']), f.root);
     expect(f.execute).toHaveBeenCalledWith(['list', '--all', '--json', '--limit', '0'], f.root);
   });
@@ -46,7 +47,7 @@ describe('validated beads JSONL export', () => {
   it('refuses an ID-set mismatch without publishing', async () => {
     const f = fixture([{ id: 'one' }]);
     f.execute.mockImplementation(async (args: readonly string[]) => {
-      if (args.join(' ') === 'vc status') return `Commit: ${'a'.repeat(40)}\n`;
+      if (args.join(' ') === 'vc status') return `Commit: ${doltHead}\n`;
       if (args[0] === 'export') { writeFileSync(String(args.at(-1)), '{"id":"different"}\n'); return ''; }
       return JSON.stringify([{ id: 'one' }]);
     });

--- a/tests/unit/lib/beads/export.test.ts
+++ b/tests/unit/lib/beads/export.test.ts
@@ -7,6 +7,7 @@ import { exportBeadsJsonl } from '../../../../src/lib/beads/export.js';
 
 describe('validated beads JSONL export', () => {
   const doltHead = 'dmqijeb6';
+  const status = `\n📊 Version Control Status\n\n  Branch: main\n  Commit: ${doltHead}\n\n`;
   const roots: string[] = [];
   afterEach(() => roots.splice(0).forEach((root) => rmSync(root, { recursive: true, force: true })));
 
@@ -16,7 +17,7 @@ describe('validated beads JSONL export', () => {
     const beadsDir = join(root, '.beads');
     mkdirSync(beadsDir);
     const execute = vi.fn(async (args: readonly string[]) => {
-      if (args.join(' ') === 'vc status') return `Branch: main\nCommit: ${doltHead}\n`;
+      if (args.join(' ') === 'vc status') return status;
       if (args[0] === 'export') {
         const output = String(args[args.indexOf('-o') + 1]);
         writeFileSync(output, records.map((record) => JSON.stringify(record)).join('\n') + (records.length ? '\n' : ''));
@@ -47,7 +48,7 @@ describe('validated beads JSONL export', () => {
   it('refuses an ID-set mismatch without publishing', async () => {
     const f = fixture([{ id: 'one' }]);
     f.execute.mockImplementation(async (args: readonly string[]) => {
-      if (args.join(' ') === 'vc status') return `Commit: ${doltHead}\n`;
+      if (args.join(' ') === 'vc status') return status;
       if (args[0] === 'export') { writeFileSync(String(args.at(-1)), '{"id":"different"}\n'); return ''; }
       return JSON.stringify([{ id: 'one' }]);
     });

--- a/tests/unit/lib/beads/writer.test.ts
+++ b/tests/unit/lib/beads/writer.test.ts
@@ -34,6 +34,22 @@ async function withProjectDir<T>(hasEmbeddedStore: boolean, fn: (cwd: string) =>
   }
 }
 
+async function withRedirectedProjectDir<T>(fn: (cwd: string) => Promise<T>): Promise<T> {
+  const cwd = await mkdtemp(join(tmpdir(), 'beads-writer-project-'));
+  const redirectedBeadsDir = await mkdtemp(join(tmpdir(), 'beads-writer-state-'));
+  try {
+    await mkdir(join(cwd, '.beads'), { recursive: true });
+    await writeFile(join(cwd, '.beads', 'redirect'), `${redirectedBeadsDir}\n`);
+    const storePath = join(redirectedBeadsDir, 'embeddeddolt', 'overdeck');
+    await mkdir(storePath, { recursive: true });
+    await writeFile(join(storePath, 'store'), 'present');
+    return await fn(cwd);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+    await rm(redirectedBeadsDir, { recursive: true, force: true });
+  }
+}
+
 describe('runMutationBatch', () => {
   it('uses an existing embedded Dolt store without bootstrapping, then pulls, commits, exports, and pushes once', async () => {
     const h = harness();
@@ -58,6 +74,29 @@ describe('runMutationBatch', () => {
       'close one --dolt-auto-commit batch',
       'close two --dolt-auto-commit batch',
       'dolt commit -m close planned beads',
+      'export-snapshot',
+      'dolt push',
+      'vc status',
+    ]);
+  });
+
+  it('uses a redirected existing embedded Dolt store without bootstrapping', async () => {
+    const h = harness();
+    const result = await withRedirectedProjectDir((workspacePath) =>
+      runMutationBatch(
+        { project: { workspacePath }, reason: 'close redirected beads' },
+        (bd) => bd.mutate(['close', 'one']),
+        h,
+      ),
+    );
+    expect(result).toMatchObject({ ok: true, value: '' });
+    expect(h.calls).toEqual([
+      'lock',
+      'dolt pull',
+      'vc status',
+      'dolt remote show origin --json',
+      'close one --dolt-auto-commit batch',
+      'dolt commit -m close redirected beads',
       'export-snapshot',
       'dolt push',
       'vc status',

--- a/tests/unit/lib/beads/writer.test.ts
+++ b/tests/unit/lib/beads/writer.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
-import { runMutationBatch } from '../../../../src/lib/beads/writer.js';
+import { formatMutationBatchFailure, runMutationBatch } from '../../../../src/lib/beads/writer.js';
 
 function harness(failOn?: string) {
   const calls: string[] = [];
@@ -17,20 +20,60 @@ function harness(failOn?: string) {
   return { calls, execute, exportSnapshot, withLock };
 }
 
+async function withProjectDir<T>(hasEmbeddedStore: boolean, fn: (cwd: string) => Promise<T>): Promise<T> {
+  const cwd = await mkdtemp(join(tmpdir(), 'beads-writer-'));
+  try {
+    if (hasEmbeddedStore) {
+      const storePath = join(cwd, '.beads', 'embeddeddolt', 'overdeck');
+      await mkdir(storePath, { recursive: true });
+      await writeFile(join(storePath, 'store'), 'present');
+    }
+    return await fn(cwd);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
 describe('runMutationBatch', () => {
-  it('locks, pulls, performs multiple operations, commits, exports, and pushes once', async () => {
+  it('uses an existing embedded Dolt store without bootstrapping, then pulls, commits, exports, and pushes once', async () => {
     const h = harness();
-    const result = await runMutationBatch(
-      { project: { workspacePath: '/tmp/project' }, reason: 'close planned beads' },
-      async (bd) => {
-        await bd.mutate(['close', 'one']);
-        await bd.mutate(['close', 'two']);
-        return 2;
-      },
-      h,
+    const result = await withProjectDir(true, (workspacePath) =>
+      runMutationBatch(
+        { project: { workspacePath }, reason: 'close planned beads' },
+        async (bd) => {
+          await bd.mutate(['close', 'one']);
+          await bd.mutate(['close', 'two']);
+          return 2;
+        },
+        h,
+      ),
     );
     expect(result).toMatchObject({ ok: true, value: 2 });
     expect(h.withLock).toHaveBeenCalledOnce();
+    expect(h.calls).toEqual([
+      'lock',
+      'dolt pull',
+      'vc status',
+      'dolt remote show origin --json',
+      'close one --dolt-auto-commit batch',
+      'close two --dolt-auto-commit batch',
+      'dolt commit -m close planned beads',
+      'export-snapshot',
+      'dolt push',
+      'vc status',
+    ]);
+  });
+
+  it('bootstraps when the embedded Dolt store is absent or empty', async () => {
+    const h = harness();
+    const result = await withProjectDir(false, (workspacePath) =>
+      runMutationBatch(
+        { project: { workspacePath }, reason: 'close planned beads' },
+        (bd) => bd.mutate(['close', 'one']),
+        h,
+      ),
+    );
+    expect(result).toMatchObject({ ok: true, value: '' });
     expect(h.calls).toEqual([
       'lock',
       'bootstrap --yes --json',
@@ -38,7 +81,6 @@ describe('runMutationBatch', () => {
       'vc status',
       'dolt remote show origin --json',
       'close one --dolt-auto-commit batch',
-      'close two --dolt-auto-commit batch',
       'dolt commit -m close planned beads',
       'export-snapshot',
       'dolt push',
@@ -59,6 +101,22 @@ describe('runMutationBatch', () => {
     expect(result).toMatchObject({ ok: false, needsOperatorRecovery: true });
     expect(h.calls).not.toContain('dolt push');
     expect(h.calls.some((call) => call.startsWith('dolt commit'))).toBe(false);
+  });
+
+  it('formats operator recovery failures with the captured cause', async () => {
+    const cause = Object.assign(new Error('operation failed'), {
+      stderr: 'Bootstrap failed: clone from remote: database exists',
+    });
+    const formatted = formatMutationBatchFailure({
+      ok: false,
+      needsOperatorRecovery: true,
+      localHead: null,
+      message: 'The mutation batch failed before push.',
+      cause,
+    });
+
+    expect(formatted).toContain('The mutation batch failed before push.');
+    expect(formatted).toContain('Bootstrap failed: clone from remote: database exists');
   });
 
   it('returns a typed conflict when push is rejected and never force-pushes', async () => {

--- a/tests/unit/lib/beads/writer.test.ts
+++ b/tests/unit/lib/beads/writer.test.ts
@@ -7,11 +7,12 @@ import { formatMutationBatchFailure, runMutationBatch } from '../../../../src/li
 
 function harness(failOn?: string) {
   const calls: string[] = [];
+  const status = '\n📊 Version Control Status\n\n  Branch: main\n  Commit: dmqijeb6\n\n';
   const execute = vi.fn(async (args: readonly string[]) => {
     const command = args.join(' ');
     calls.push(command);
     if (command === failOn) throw new Error(command.includes('push') ? 'non-fast-forward rejected' : 'operation failed');
-    if (command === 'vc status') return 'Branch: main\nCommit: dmqijeb6\n';
+    if (command === 'vc status') return status;
     if (command.includes('remote show')) return JSON.stringify({ head: '1234567890123456789012345678901234567890' });
     return '';
   });

--- a/tests/unit/lib/beads/writer.test.ts
+++ b/tests/unit/lib/beads/writer.test.ts
@@ -11,7 +11,7 @@ function harness(failOn?: string) {
     const command = args.join(' ');
     calls.push(command);
     if (command === failOn) throw new Error(command.includes('push') ? 'non-fast-forward rejected' : 'operation failed');
-    if (command === 'vc status') return 'Branch: main\nCommit: abcdef1234567890abcdef1234567890abcdef12\n';
+    if (command === 'vc status') return 'Branch: main\nCommit: dmqijeb6\n';
     if (command.includes('remote show')) return JSON.stringify({ head: '1234567890123456789012345678901234567890' });
     return '';
   });

--- a/tests/unit/lib/beads/writer.test.ts
+++ b/tests/unit/lib/beads/writer.test.ts
@@ -143,6 +143,26 @@ describe('runMutationBatch', () => {
     expect(h.calls.some((call) => call.startsWith('dolt commit'))).toBe(false);
   });
 
+  it('does not classify maxBuffer failures as conflicts based on partial stdout content', async () => {
+    const h = harness();
+    const cause = Object.assign(new Error('stdout maxBuffer length exceeded'), {
+      stdout: JSON.stringify([{ id: 'PAN-1', title: 'contains the word conflict in bead content' }]),
+    });
+    const result = await withProjectDir(true, (workspacePath) =>
+      runMutationBatch(
+        { project: { workspacePath }, reason: 'export large beads' },
+        (bd) => bd.mutate(['create', 'one']),
+        { ...h, exportSnapshot: vi.fn(async () => { h.calls.push('export-snapshot'); throw cause; }) },
+      ),
+    );
+
+    expect(result).toMatchObject({ ok: false, needsOperatorRecovery: true });
+    expect(result).toHaveProperty('cause', cause);
+    expect(h.calls).not.toContain('dolt push');
+    if (result.ok) throw new Error('expected mutation batch failure');
+    expect(formatMutationBatchFailure(result)).toContain('stdout maxBuffer length exceeded');
+  });
+
   it('formats operator recovery failures with the captured cause', async () => {
     const cause = Object.assign(new Error('operation failed'), {
       stderr: 'Bootstrap failed: clone from remote: database exists',


### PR DESCRIPTION
## Problem

Every beads mutation batch fleet-wide fails since the PAN-2564 cutover published `refs/dolt/data` (+ `sync.remote` for panopticon-cli): `runMutationBatch` runs `bd bootstrap --yes` before every batch, and bd 1.1.0's bootstrap plans a clone whenever a remote is configured/published — **before** its own existing-db check — then `dolt clone` hard-fails with `Error 1007: database exists`. All `pan beads close/create/update`, plan-finalize bead materialization, and vBRIEF AC sync are down; work agents will wedge at done-preflight as they finish beads.

Root cause verified in bd source (`gastownhall/beads cmd/bd/bootstrap.go`); latest bd release (v1.1.0) still has the ordering bug, so the fix lands in our writer.

## Fix

`runMutationBatch` skips the bootstrap step when `<cwd>/.beads/embeddeddolt` exists and is non-empty (async fs, server-reachable code), mirroring bd's own `existingBootstrapDBPlan` check. Fresh clones (no embedded store) still bootstrap. Unit coverage added in `tests/unit/lib/beads/writer.test.ts`.

Gates: typecheck + lint + full test suite green after rebase onto origin/main.

## Urgency

Pipeline blocker: PAN-2598 and PAN-2602 planning finalizes are stuck on this right now; the flywheel orchestrator is not running, so this PR needs a human merge. After merging, rebuild the linked CLI (`npm run build` in the primary checkout) so `pan plan finalize` picks up the fix.

Closes #2610. Duplicate report with full analysis: #2612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)