### PR TITLE
fix(beads): guard mutation-batch bootstrap — probe store before bd bootstrap (PAN-2613)

### DIFF
--- a/src/lib/beads/writer.ts
+++ b/src/lib/beads/writer.ts
@@ -76,10 +76,18 @@ async function readRemoteHead(client: BdMutationClient): Promise<string | null> 
   }
 }
 
+async function ensureStoreReady(client: BdMutationClient): Promise<void> {
+  try {
+    await client.run(['context', '--json']);
+  } catch {
+    await client.run(['bootstrap', '--yes', '--json']);
+  }
+}
+
 /**
  * The only canonical beads mutation transaction boundary.
  *
- * A batch owns one project lock and one bootstrap/pull/commit/export/push
+ * A batch owns one project lock and one store-ready/pull/commit/export/push
  * cycle. A failed callback is deliberately left unpushed for operator
  * recovery because bd does not expose a universally safe embedded-mode
  * rollback primitive.
@@ -102,7 +110,7 @@ export async function runMutationBatch<T>(
   return withLock(`beads mutation: ${context.reason}`, async () => {
     let value: T;
     try {
-      await client.run(['bootstrap', '--yes', '--json']);
+      await ensureStoreReady(client);
       await client.run(['dolt', 'pull']);
       recordBeadsPull(telemetryKey, await readHead(client), await readRemoteHead(client));
       value = await mutate(client);

--- a/tests/unit/lib/beads/writer.test.ts
+++ b/tests/unit/lib/beads/writer.test.ts
@@ -17,6 +17,19 @@ function harness(failOn?: string) {
   return { calls, execute, exportSnapshot, withLock };
 }
 
+function missingStoreHarness() {
+  const h = harness('context --json');
+  h.execute.mockImplementation(async (args: readonly string[]) => {
+    const command = args.join(' ');
+    h.calls.push(command);
+    if (command === 'context --json') throw new Error('no beads store');
+    if (command === 'vc status') return 'Branch: main\nCommit: abcdef1234567890abcdef1234567890abcdef12\n';
+    if (command.includes('remote show')) return JSON.stringify({ head: '1234567890123456789012345678901234567890' });
+    return '';
+  });
+  return h;
+}
+
 describe('runMutationBatch', () => {
   it('locks, pulls, performs multiple operations, commits, exports, and pushes once', async () => {
     const h = harness();
@@ -33,7 +46,7 @@ describe('runMutationBatch', () => {
     expect(h.withLock).toHaveBeenCalledOnce();
     expect(h.calls).toEqual([
       'lock',
-      'bootstrap --yes --json',
+      'context --json',
       'dolt pull',
       'vc status',
       'dolt remote show origin --json',
@@ -43,6 +56,24 @@ describe('runMutationBatch', () => {
       'export-snapshot',
       'dolt push',
       'vc status',
+    ]);
+    expect(h.calls).not.toContain('bootstrap --yes --json');
+  });
+
+  it('bootstraps only when the existing-store probe fails', async () => {
+    const h = missingStoreHarness();
+    const result = await runMutationBatch(
+      { project: { workspacePath: '/tmp/project' }, reason: 'create planned beads' },
+      (bd) => bd.mutate(['create', 'one']),
+      h,
+    );
+
+    expect(result).toMatchObject({ ok: true });
+    expect(h.calls.slice(0, 4)).toEqual([
+      'lock',
+      'context --json',
+      'bootstrap --yes --json',
+      'dolt pull',
     ]);
   });
 


### PR DESCRIPTION
Fixes #2613 (P0: every beads mutation batch fails once refs/dolt/data is published).

`runMutationBatch` ran `bd bootstrap --yes --json` unconditionally as step 1 of every mutation. bd 1.1.0's `detectBootstrapAction` plans a clone whenever `sync.remote` is configured or origin has `refs/dolt/data` — without ever checking for an existing database — so the clone dies with `Error 1007: database exists` and poisons every batch (first hit: PAN-2607 `pan plan finalize`).

This change probes the store with `bd context --json` and only invokes `bd bootstrap` when the probe fails (store missing/unconfigured), restoring bootstrap to its intended role: empty/missing DB recovery only.

- `src/lib/beads/writer.ts`: `ensureStoreReady()` guard
- `tests/unit/lib/beads/writer.test.ts`: covers probe-success (no bootstrap) and probe-failure (bootstrap runs) paths

Strike agent reported gates green on the branch. Once merged, the primary checkout needs `npm run build` for the linked `pan` CLI to pick it up; PAN-2607's blocked `pan plan finalize` can then re-run.

Note: main CI is currently red for unrelated runner tooling (PAN-2614 — bd/dolt/rg missing on the runner); per the red-main rule this needs an operator landing decision rather than an admin bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)