### PR TITLE
PAN-2611

### DIFF
--- a/docs/BEADS.md
+++ b/docs/BEADS.md
@@ -18,6 +18,14 @@ one physical local home at `${OVERDECK_HOME}/state/<project>/.beads/`. Main,
 feature worktrees, and workspaces contain `.beads/redirect` files pointing to
 that home. Server mode (`dolt sql-server`, `.beads/dolt/`) is not used.
 
+Redirects are always one hop: `bd` refuses redirect chains and falls back to the
+redirect target's own directory, so a redirect must never point at another
+redirecting directory. Worktree creation writes the canonical home path directly
+into `.beads/redirect`; post-Dolt-cutover the project root `.beads/` is itself a
+redirect, and pointing a worktree at it would create a chain. During close-out,
+the `teardown:sync-beads` step validates and refreshes the recovery export from
+that canonical home, not from inside the workspace.
+
 All reads use the beads resolver. All writes use `runMutationBatch`, exposed to
 agents as `pan beads …`. A mutation batch acquires the project lock, bootstraps,
 pulls, applies all operations in Dolt batch mode, commits once, validates one

--- a/src/lib/lifecycle/teardown-workspace.ts
+++ b/src/lib/lifecycle/teardown-workspace.ts
@@ -25,6 +25,7 @@ import { findAllWorkspacePaths, findWorkspacePath } from './archive-planning.js'
 import { getContainersReferencingWorkspacePath } from '../workspace-manager.js';
 import { DEVCONTAINER_DIRNAME } from '../workspace/devcontainer-renderer.js';
 import { exportBeadsJsonl } from '../beads/export.js';
+import { resolveCanonicalBeadsHome } from '../beads/home.js';
 import { createBeadsResolver } from '../beads/resolver.js';
 import { runMutationBatch } from '../beads/writer.js';
 
@@ -270,8 +271,12 @@ async function syncWorkspaceBeadsImpl(
     return stepSkipped(step, ['No .beads directory in workspace']);
   }
 
+  const canonicalHome = resolveCanonicalBeadsHome(workspacePath);
+
   try {
-    const result = await exportBeadsJsonl(workspacePath);
+    const result = canonicalHome
+      ? await exportBeadsJsonl(dirname(canonicalHome), { beadsDir: canonicalHome })
+      : await exportBeadsJsonl(workspacePath);
     return stepOk(step, [`Validated ${result.state.recordCount} canonical beads records for ${issueLower}`]);
   } catch (err) {
     return stepFailed(step, `Failed to sync workspace beads: ${(err as Error).message}`);

--- a/src/lib/workspace-manager/worktree-ops.ts
+++ b/src/lib/workspace-manager/worktree-ops.ts
@@ -5,6 +5,7 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 import { TemplatePlaceholders, replacePlaceholdersSync } from '../workspace-config.js';
 import { PRE_WORKTREE_METADATA_DIRS } from './types.js';
+import { resolveCanonicalBeadsHome } from '../beads/home.js';
 
 const execAsync = promisify(exec);
 
@@ -108,12 +109,16 @@ export async function createWorktree(
     // Configure beads role so agents don't get "beads.role not configured" warnings
     await execAsync('git config beads.role contributor', { cwd: targetPath }).catch(() => {});
 
-    // Point the worktree's .beads/ at the source repo's shared Dolt database via a redirect file.
+    // Point the worktree's .beads/ at the canonical beads home via a one-hop redirect.
+    // bd refuses redirect chains and falls back to the redirect target's own directory,
+    // so the redirect must point directly at the canonical store — never at another
+    // redirecting directory. Post-Dolt-cutover the canonical home is the state worktree;
+    // when it cannot be resolved we fall back to the project-root .beads relative path.
     // Without this, `bd` in the worktree spins up its own empty database with no issue_prefix
     // configured, so the first `bd create` errors with "database not initialized: issue_prefix
-    // config is missing". The redirect keeps all worktrees reading/writing the canonical beads
-    // store alongside main. Mirrors the pattern in src/lib/vbrief/beads.ts.
-    const sourceBeadsDir = join(repoPath, '.beads');
+    // config is missing". Mirrors the pattern in src/lib/vbrief/beads.ts.
+    const canonicalHome = resolveCanonicalBeadsHome(targetPath);
+    const sourceBeadsDir = canonicalHome ?? join(repoPath, '.beads');
     if (existsSync(sourceBeadsDir)) {
       const worktreeBeadsDir = join(targetPath, '.beads');
       const redirectPath = join(worktreeBeadsDir, 'redirect');
@@ -121,8 +126,8 @@ export async function createWorktree(
         try {
           mkdirSync(worktreeBeadsDir, { recursive: true });
           // bd resolves the redirect path relative to the worktree root (the parent of .beads/)
-          const relPath = relative(targetPath, sourceBeadsDir);
-          writeFileSync(redirectPath, relPath, 'utf-8');
+          const redirectContent = canonicalHome ?? relative(targetPath, sourceBeadsDir);
+          writeFileSync(redirectPath, redirectContent, 'utf-8');
         } catch {
           // Non-fatal — if redirect creation fails, bd falls back to its usual bootstrap path.
         }

--- a/tests/unit/lib/lifecycle/teardown-workspace.test.ts
+++ b/tests/unit/lib/lifecycle/teardown-workspace.test.ts
@@ -47,10 +47,20 @@ vi.mock('../../../../src/lib/shadow-state.js', () => ({
   removeShadowState: vi.fn().mockReturnValue({ success: true }),
 }));
 
+vi.mock('../../../../src/lib/beads/export.js', () => ({
+  exportBeadsJsonl: vi.fn(),
+}));
+
+vi.mock('../../../../src/lib/beads/home.js', () => ({
+  resolveCanonicalBeadsHome: vi.fn(),
+}));
+
 import { Effect } from 'effect';
 import { teardownWorkspace as teardownWorkspaceProgram } from '../../../../src/lib/lifecycle/teardown-workspace.js';
 import { sessionExists } from '../../../../src/lib/tmux.js';
 import { AGENTS_DIR } from '../../../../src/lib/paths.js';
+import { exportBeadsJsonl } from '../../../../src/lib/beads/export.js';
+import { resolveCanonicalBeadsHome } from '../../../../src/lib/beads/home.js';
 
 const teardownWorkspace = (...args: Parameters<typeof teardownWorkspaceProgram>) =>
   Effect.runPromise(teardownWorkspaceProgram(...args));
@@ -345,5 +355,88 @@ describe('teardown-workspace', () => {
     const content = readFileSync(join(beadsDir, 'issues.jsonl'), 'utf-8');
     expect(content).toContain('PAN-100');
     expect(content).toContain('PAN-200');
+  });
+
+  describe('sync-beads routing', () => {
+    beforeEach(() => {
+      vi.mocked(exportBeadsJsonl).mockReset();
+      vi.mocked(resolveCanonicalBeadsHome).mockReset();
+      vi.mocked(exportBeadsJsonl).mockResolvedValue({
+        path: '/state/overdeck/.beads/issues.jsonl',
+        statePath: '/state/overdeck/.beads/export-state.json',
+        state: {
+          universe: 'all',
+          sourceDoltHead: 'abc1234',
+          recordCount: 3,
+          exportedAt: new Date().toISOString(),
+        },
+      });
+    });
+
+    it('routes export to the canonical beads home when one resolves', async () => {
+      const wsPath = join(testDir, 'workspaces', 'pan-100');
+      mkdirSync(join(wsPath, '.beads'), { recursive: true });
+      vi.mocked(resolveCanonicalBeadsHome).mockReturnValue('/state/overdeck/.beads');
+
+      const results = await teardownWorkspace(
+        { issueId: 'PAN-100', projectPath: testDir },
+        { deleteWorkspace: true },
+      );
+
+      const syncResult = results.find(r => r.step === 'teardown:sync-beads');
+      expect(syncResult).toBeDefined();
+      expect(syncResult!.success).toBe(true);
+      expect(exportBeadsJsonl).toHaveBeenCalledWith('/state/overdeck', { beadsDir: '/state/overdeck/.beads' });
+    });
+
+    it('falls back to the workspace path when no canonical home resolves', async () => {
+      const wsPath = join(testDir, 'workspaces', 'pan-100');
+      mkdirSync(join(wsPath, '.beads'), { recursive: true });
+      vi.mocked(resolveCanonicalBeadsHome).mockReturnValue(null);
+
+      const results = await teardownWorkspace(
+        { issueId: 'PAN-100', projectPath: testDir },
+        { deleteWorkspace: true },
+      );
+
+      const syncResult = results.find(r => r.step === 'teardown:sync-beads');
+      expect(syncResult).toBeDefined();
+      expect(syncResult!.success).toBe(true);
+      expect(exportBeadsJsonl).toHaveBeenCalledWith(wsPath);
+      expect(exportBeadsJsonl).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips sync when the workspace has no .beads directory', async () => {
+      const wsPath = join(testDir, 'workspaces', 'pan-100');
+      mkdirSync(wsPath, { recursive: true });
+      vi.mocked(resolveCanonicalBeadsHome).mockReturnValue('/state/overdeck/.beads');
+
+      const results = await teardownWorkspace(
+        { issueId: 'PAN-100', projectPath: testDir },
+        { deleteWorkspace: true },
+      );
+
+      const syncResult = results.find(r => r.step === 'teardown:sync-beads');
+      expect(syncResult).toBeDefined();
+      expect(syncResult!.skipped).toBe(true);
+      expect(exportBeadsJsonl).not.toHaveBeenCalled();
+    });
+
+    it('fails the step when exportBeadsJsonl rejects', async () => {
+      const wsPath = join(testDir, 'workspaces', 'pan-100');
+      mkdirSync(join(wsPath, '.beads'), { recursive: true });
+      vi.mocked(resolveCanonicalBeadsHome).mockReturnValue('/state/overdeck/.beads');
+      vi.mocked(exportBeadsJsonl).mockRejectedValue(new Error('bd vc status did not report a Dolt commit.'));
+
+      const results = await teardownWorkspace(
+        { issueId: 'PAN-100', projectPath: testDir },
+        { deleteWorkspace: true },
+      );
+
+      const syncResult = results.find(r => r.step === 'teardown:sync-beads');
+      expect(syncResult).toBeDefined();
+      expect(syncResult!.success).toBe(false);
+      expect(syncResult!.error).toContain('bd vc status did not report a Dolt commit.');
+    });
   });
 });

--- a/tests/unit/lib/workspace-manager/worktree-ops.test.ts
+++ b/tests/unit/lib/workspace-manager/worktree-ops.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join, relative } from 'path';
+import { tmpdir } from 'os';
+
+// Use vi.hoisted to avoid initialization order issues
+const { mockExecAsync } = vi.hoisted(() => ({
+  mockExecAsync: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+}));
+
+vi.mock('child_process', () => ({
+  exec: vi.fn(),
+  execFile: vi.fn(),
+}));
+vi.mock('util', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('util')>();
+  return {
+    ...actual,
+    promisify: () => mockExecAsync,
+  };
+});
+
+vi.mock('../../../../src/lib/beads/home.js', () => ({
+  resolveCanonicalBeadsHome: vi.fn(),
+}));
+
+import { createWorktree } from '../../../../src/lib/workspace-manager/worktree-ops.js';
+import { resolveCanonicalBeadsHome } from '../../../../src/lib/beads/home.js';
+
+describe('createWorktree redirect', () => {
+  let repoPath: string;
+  let targetPath: string;
+  let canonicalHome: string;
+
+  beforeEach(() => {
+    vi.mocked(resolveCanonicalBeadsHome).mockReset();
+    mockExecAsync.mockReset();
+    mockExecAsync.mockResolvedValue({ stdout: '', stderr: '' });
+
+    repoPath = mkdtempSync(join(tmpdir(), 'overdeck-worktree-repo-'));
+    targetPath = mkdtempSync(join(tmpdir(), 'overdeck-worktree-target-'));
+    canonicalHome = join(tmpdir(), 'overdeck-canonical-home-');
+  });
+
+  afterEach(() => {
+    if (existsSync(repoPath)) rmSync(repoPath, { recursive: true, force: true });
+    if (existsSync(targetPath)) rmSync(targetPath, { recursive: true, force: true });
+    if (existsSync(canonicalHome)) rmSync(canonicalHome, { recursive: true, force: true });
+  });
+
+  it('writes the absolute canonical beads home path when resolution succeeds', async () => {
+    mkdirSync(canonicalHome, { recursive: true });
+    mkdirSync(join(repoPath, '.beads'), { recursive: true });
+    vi.mocked(resolveCanonicalBeadsHome).mockReturnValue(canonicalHome);
+
+    const result = await createWorktree(repoPath, targetPath, 'feature/pan-100');
+
+    expect(result.success).toBe(true);
+    const redirectPath = join(targetPath, '.beads', 'redirect');
+    expect(existsSync(redirectPath)).toBe(true);
+    expect(readFileSync(redirectPath, 'utf-8')).toBe(canonicalHome);
+  });
+
+  it('falls back to a relative project-root .beads path when no canonical home resolves', async () => {
+    mkdirSync(join(repoPath, '.beads'), { recursive: true });
+    vi.mocked(resolveCanonicalBeadsHome).mockReturnValue(null);
+
+    const result = await createWorktree(repoPath, targetPath, 'feature/pan-100');
+
+    expect(result.success).toBe(true);
+    const redirectPath = join(targetPath, '.beads', 'redirect');
+    expect(existsSync(redirectPath)).toBe(true);
+    expect(readFileSync(redirectPath, 'utf-8')).toBe(relative(targetPath, join(repoPath, '.beads')));
+  });
+
+  it('preserves a pre-existing redirect file', async () => {
+    mkdirSync(join(repoPath, '.beads'), { recursive: true });
+    mkdirSync(join(targetPath, '.beads'), { recursive: true });
+    const redirectPath = join(targetPath, '.beads', 'redirect');
+    const existingContent = '/some/pre-existing/path';
+    writeFileSync(redirectPath, existingContent, 'utf-8');
+    vi.mocked(resolveCanonicalBeadsHome).mockReturnValue(canonicalHome);
+
+    const result = await createWorktree(repoPath, targetPath, 'feature/pan-100');
+
+    expect(result.success).toBe(true);
+    expect(readFileSync(redirectPath, 'utf-8')).toBe(existingContent);
+  });
+});


### PR DESCRIPTION
**Issue:** #2611

## Acceptance Criteria

- [ ] Re-route teardown:sync-beads export to the canonical beads home
- [ ] createWorktree writes a one-hop redirect to the canonical beads home
- [ ] Unit tests locking the sync-beads canonical-home routing
- [ ] Unit tests locking the one-hop redirect writer
- [ ] Document the one-hop redirect invariant and close-out export path in docs/BEADS.md

## Implementation Tasks

- [x] Unit tests locking the one-hop redirect writer
- [x] Unit tests locking the sync-beads canonical-home routing
- [x] Document the one-hop redirect invariant and close-out export path in docs/BEADS.md
- [x] createWorktree writes a one-hop redirect to the canonical beads home
- [x] Re-route teardown:sync-beads export to the canonical beads home

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worktree Beads redirects now point directly to the canonical Beads home when available.
  * Beads synchronization uses the canonical home for recovery exports, with a workspace fallback when needed.
  * Existing redirect files are preserved during worktree setup.

* **Documentation**
  * Clarified that redirects use a single hop and that close-out synchronization validates exports from the canonical Beads home.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->