### PR TITLE
PAN-2602

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,6 +403,11 @@ Work agents cannot start without beads tasks in the workspace. The start-agent e
 returns 422 if the canonical Dolt resolver reports no issue beads. Planning must create beads via
 `bd create` before handing off to implementation.
 
+The verification gate also blocks completion while the issue has open beads: `runVerificationForIssue`
+calls `checkOpenBeadsPromise` after the vBRIEF acceptance-criteria check, and a non-empty result (or a
+timeout, which is unknown-not-zero per PAN-1812) produces `failedCheck: 'open-beads'`. Finally,
+merge-time and close-out sweeps remove remaining open beads from terminal issues so that a closed
+issue never carries open beads.
 ## postMergeLifecycle Idempotency (enforced by a test, not by this note)
 
 `postMergeLifecycle` must run **at most once per merge**. If it can re-trigger

--- a/configuration/beads.mdx
+++ b/configuration/beads.mdx
@@ -30,3 +30,46 @@ other machines.
 
 `.beads/issues.jsonl` is a validated `--all` recovery export only. Do not read it
 as current task state or edit/merge its lines.
+
+## `pan beads sweep`
+
+Sweep orphaned open beads on issues that are already closed on the tracker. This
+is useful for backfills and for cleaning up after bypass merges that did not run
+the normal merge-time sweep.
+
+```bash
+pan beads sweep --all-closed              # enumerate closed issues with orphaned beads
+pan beads sweep --all-closed --dry-run    # preview would-close counts without mutating
+pan beads sweep PAN-1234 PAN-1235         # sweep specific issue IDs
+pan beads sweep PAN-1234 --reason "custom reason"
+```
+
+`--all-closed` groups beads by issue label, checks the tracker state for each
+candidate through the same GitHub issue-view door used by `pan close`, and sweeps
+only closed issues. Open issues with orphaned beads are listed separately so they
+can be routed back into the pipeline.
+
+The default close reason derives from the GitHub close state:
+
+| Close state | Default reason |
+| --- | --- |
+| completed | `issue closed (completed); orphaned bead swept` |
+| not_planned | `issue closed (not planned); bead cancelled` |
+
+## Handoff issue association
+
+`pan handoff` can associate a spawned conversation with an explicit issue:
+
+```bash
+pan handoff --issue PAN-1234 self "investigate the failing test"
+```
+
+The issue association is resolved with the following precedence:
+
+1. **Explicit `--issue`** — used exactly as given.
+2. **Parent conversation issue** — inherited from the conversation that starts the handoff.
+3. **Current git branch issue** — parsed from a feature branch such as `feature/pan-1234`.
+4. **None** — the handoff runs without an issue association.
+
+This precedence lets an operator override the branch or parent context when
+spawning a targeted investigation.

--- a/docs/BEADS.md
+++ b/docs/BEADS.md
@@ -147,3 +147,30 @@ re-requesting review.
 This check is intentionally placed **after** the vBRIEF acceptance-criteria gate
 and **before** the empty-changeset guard. A timeout is treated as unknown, not
 proof of zero open beads, so the gate fails closed per PAN-1812.
+
+## Dashboard bead signals
+
+The Command Deck surfaces beads as resource signals alongside branches, workspaces,
+and sessions. The dashboard does not read beads directly from Dolt; it consumes
+the same resolver through a background rollup service.
+
+- **`beadTotals`** — `BeadsRollupService` computes a per-project snapshot of total,
+  closed, and in-progress bead counts and caches it in memory. Resource discovery
+  attaches the relevant row to each issue. `BeadsRail` and the issue resource strip
+  display this as a `beads` icon plus counts.
+- **`branchAheadOfMain`** — When a `feature/*` or `bypass/*` branch is not an
+  ancestor of `main`, resource discovery sets `branchAheadOfMain: true`. This is
+  one of the artifact signals used to decide whether an issue has unmerged work.
+- **`conversation` resource source** — Non-archived conversations linked to an issue
+  (`loadConversations`) are treated as a live resource signal independent of tmux
+  or agent sessions. They keep an issue visible in the Command Deck even when no
+  agent is running.
+- **`stalled` bucket** — Pipeline grouping uses the artifact signals above (ahead
+  branch, linked conversations, in-progress beads, or partially-closed beads) plus
+  the absence of a live agent and 14 days of inactivity to place an issue in the
+  `stalled` bucket. Stalled issues are shown after `needs-you` and are excluded
+  from ordinary phase buckets.
+
+The rollup service refreshes on a background interval and on `beads.freshness_changed`
+events, so the Command Deck stays consistent with the canonical Dolt state without
+issuing a resolver call per rendered issue.

--- a/docs/BEADS.md
+++ b/docs/BEADS.md
@@ -99,3 +99,51 @@ in `src/lib/beads/resolver.ts`; new mutations belong in
 The CI allowlist is intentionally identical to the recovery/diagnostic and
 legacy-unmigrated rows above. `npm run lint:beads-access` plants no behavioral
 exceptions for application reads or agent mutations.
+
+## Terminal-issue bead sweep
+
+A terminal issue — one that is merged or closed on the tracker — must never carry
+open beads. Overdeck enforces this invariant in two places:
+
+- **Merge time:** `postMergeLifecycle` sweeps any remaining `open` or
+  `in_progress` beads with the reason `issue merged; remaining open beads swept`.
+- **Close-out time:** `closeOut` sweeps orphaned beads before workspace teardown.
+
+The sweep reasons are categorical. A reason ending in `...orphaned bead swept`
+denotes work that was overtaken by the issue's terminal transition; a reason
+ending in `...bead cancelled` denotes work that is no longer planned.
+
+For backfills and ad-hoc cleanup, use `pan beads sweep`:
+
+```bash
+pan beads sweep --all-closed              # enumerate and sweep closed issues
+pan beads sweep --all-closed --dry-run    # preview, do not mutate
+pan beads sweep PAN-1234 PAN-1235         # sweep specific issues
+pan beads sweep PAN-1234 --reason "custom reason"
+```
+
+`--all-closed` performs exactly one `getAllBeads()` read, groups beads by issue
+label, checks tracker state through the same `gh issue view` door used by
+`pan close`, and sweeps only GitHub-closed issues. GitHub-open issues with
+orphaned beads are skipped and listed as `Open with orphaned beads` so they can
+be routed back into the pipeline rather than silently closed.
+
+The default close reason derives from the GitHub close state:
+
+| Tracker close state | Default reason |
+| --- | --- |
+| completed | `issue closed (completed); orphaned bead swept` |
+| not_planned | `issue closed (not planned); bead cancelled` |
+
+## Verification gate open-beads check
+
+Before a work agent can advance to review, the verification gate reads the
+issue's open beads through the canonical resolver. If any open beads remain, or
+if the resolver cannot answer within its timeout, verification fails with
+`failedCheck: 'open-beads'`. The feedback names the open bead ids and instructs
+the agent to close each one with `pan beads close <id> --reason <reason>` before
+re-requesting review.
+
+This check is intentionally placed **after** the vBRIEF acceptance-criteria gate
+and **before** the empty-changeset guard. A timeout is treated as unknown, not
+proof of zero open beads, so the gate fails closed per PAN-1812.

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -18,7 +18,7 @@
 1035 src/lib/cloister/deacon-auto-resume.ts
 1179 src/lib/cloister/deacon-swarm.ts
 3631 src/lib/cloister/deacon.ts
-1454 src/lib/cloister/merge-agent.ts
+1466 src/lib/cloister/merge-agent.ts
 1749 src/lib/cloister/specialists.ts
 1194 src/lib/conversations/smart-compaction.ts
 1742 src/lib/database/schema.ts

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -1,7 +1,7 @@
 1013 src/cli/commands/doctor.ts
 1060 src/cli/commands/done.ts
 1521 src/cli/commands/start.ts
-1448 src/cli/index.ts
+1449 src/cli/index.ts
 1012 src/dashboard/frontend/src/components/AwaitingMergePage.tsx
 1374 src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.tsx
 1540 src/dashboard/frontend/src/components/CommandDeck/index.tsx
@@ -24,7 +24,7 @@
 1742 src/lib/database/schema.ts
 1364 src/lib/model-capabilities.ts
 1113 src/lib/overdeck/agents.ts
-1539 src/lib/overdeck/conversations.ts
+1540 src/lib/overdeck/conversations.ts
 1050 src/lib/overdeck/memory.ts
 1002 src/lib/overdeck/merge.ts
 1164 src/lib/review-status.ts

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -3,7 +3,7 @@
 1521 src/cli/commands/start.ts
 1449 src/cli/index.ts
 1012 src/dashboard/frontend/src/components/AwaitingMergePage.tsx
-1374 src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.tsx
+1392 src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.tsx
 1540 src/dashboard/frontend/src/components/CommandDeck/index.tsx
 1106 src/dashboard/frontend/src/components/PlanDialog.tsx
 1536 src/dashboard/frontend/src/components/chat/ConversationPanel.tsx

--- a/src/cli/commands/__tests__/beads-sweep.test.ts
+++ b/src/cli/commands/__tests__/beads-sweep.test.ts
@@ -1,0 +1,199 @@
+import { Command } from 'commander';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetAllBeads = vi.hoisted(() => vi.fn());
+const mockSweepOrphanedBeads = vi.hoisted(() => vi.fn());
+const mockReadGitHubCloseState = vi.hoisted(() => vi.fn());
+const mockResolveProjectFromIssueSync = vi.hoisted(() => vi.fn());
+const mockGetProjectSync = vi.hoisted(() => vi.fn());
+const mockCwd = vi.hoisted(() => vi.fn(() => '/test-project'));
+
+vi.mock('../../../lib/beads/resolver.js', () => ({
+  createBeadsResolver: vi.fn(() => ({
+    getAllBeads: mockGetAllBeads,
+  })),
+}));
+
+vi.mock('../../../lib/lifecycle/orphaned-beads-sweep.js', () => ({
+  sweepOrphanedBeads: mockSweepOrphanedBeads,
+}));
+
+vi.mock('../close.js', () => ({
+  readGitHubCloseState: mockReadGitHubCloseState,
+}));
+
+vi.mock('../../../lib/projects.js', () => ({
+  resolveProjectFromIssueSync: mockResolveProjectFromIssueSync,
+  getProjectSync: mockGetProjectSync,
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    existsSync: vi.fn().mockReturnValue(true),
+    readFileSync: vi.fn().mockReturnValue(''),
+  };
+});
+
+import { registerBeadsCommands } from '../beads.js';
+
+describe('pan beads sweep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(process, 'cwd').mockImplementation(mockCwd);
+    process.exitCode = undefined;
+
+    mockResolveProjectFromIssueSync.mockImplementation((issueId: string) => ({
+      projectKey: 'overdeck',
+      projectName: 'Overdeck',
+      projectPath: '/test-project',
+      linearTeam: issueId.split('-')[0].toUpperCase(),
+    }));
+    mockGetProjectSync.mockImplementation(() => ({
+      name: 'Overdeck',
+      path: '/test-project',
+      github_repo: 'eltmon/overdeck',
+    }));
+  });
+
+  function createProgram(): Command {
+    const program = new Command();
+    registerBeadsCommands(program);
+    return program;
+  }
+
+  it('dry-run prints per-issue would-close counts and reasons without mutating', async () => {
+    mockGetAllBeads.mockResolvedValue({
+      ok: true,
+      value: [
+        { id: 'bead-1', title: 'Orphan 1', status: 'open', labels: ['pan-2602'] },
+        { id: 'bead-2', title: 'Orphan 2', status: 'in_progress', labels: ['pan-2602'] },
+      ],
+    });
+    mockReadGitHubCloseState.mockResolvedValue({ state: 'closed', reason: 'completed' });
+    mockSweepOrphanedBeads.mockResolvedValue({ ok: true, closedIds: ['bead-1', 'bead-2'], skipped: 0 });
+
+    const logs: string[] = [];
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((msg: string) => { logs.push(msg); });
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'script', 'beads', 'sweep', '--all-closed', '--dry-run']);
+
+    expect(mockGetAllBeads).toHaveBeenCalledTimes(1);
+    expect(mockSweepOrphanedBeads).toHaveBeenCalledWith({
+      beadsCwd: '/test-project',
+      issueId: 'pan-2602',
+      reason: 'issue closed (completed); orphaned bead swept',
+      dryRun: true,
+    });
+
+    const reportLine = logs.find((line) => line.includes('Would sweep'));
+    expect(reportLine).toContain('pan-2602');
+    expect(reportLine).toContain('2 bead(s)');
+    expect(reportLine).toContain('issue closed (completed); orphaned bead swept');
+
+    const totalLine = logs.find((line) => line.includes('Total:'));
+    expect(totalLine).toContain('1 processed, 0 skipped, 0 failed');
+
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('skips GitHub-open issues with orphaned beads and lists them separately', async () => {
+    mockGetAllBeads.mockResolvedValue({
+      ok: true,
+      value: [
+        { id: 'bead-1', title: 'Open orphan', status: 'open', labels: ['pan-2603'] },
+      ],
+    });
+    mockReadGitHubCloseState.mockResolvedValue({ state: 'open', reason: null });
+
+    const logs: string[] = [];
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((msg: string) => { logs.push(msg); });
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'script', 'beads', 'sweep', '--all-closed']);
+
+    expect(mockSweepOrphanedBeads).not.toHaveBeenCalled();
+
+    const skippedLine = logs.find((line) => line.includes('Open with orphaned beads'));
+    expect(skippedLine).toContain('pan-2603');
+
+    const totalLine = logs.find((line) => line.includes('Total:'));
+    expect(totalLine).toContain('0 processed, 1 skipped, 0 failed');
+
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('uses not-planned default reason for issues closed as not planned', async () => {
+    mockGetAllBeads.mockResolvedValue({
+      ok: true,
+      value: [
+        { id: 'bead-1', title: 'Cancelled orphan', status: 'open', labels: ['pan-2604'] },
+      ],
+    });
+    mockReadGitHubCloseState.mockResolvedValue({ state: 'closed', reason: 'not_planned' });
+    mockSweepOrphanedBeads.mockResolvedValue({ ok: true, closedIds: ['bead-1'], skipped: 0 });
+
+    const logs: string[] = [];
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((msg: string) => { logs.push(msg); });
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'script', 'beads', 'sweep', '--all-closed']);
+
+    expect(mockSweepOrphanedBeads).toHaveBeenCalledWith({
+      beadsCwd: '/test-project',
+      issueId: 'pan-2604',
+      reason: 'issue closed (not planned); bead cancelled',
+      dryRun: undefined,
+    });
+
+    const reportLine = logs.find((line) => line.includes('Swept'));
+    expect(reportLine).toContain('issue closed (not planned); bead cancelled');
+
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('--reason overrides the default close reason', async () => {
+    mockGetAllBeads.mockResolvedValue({
+      ok: true,
+      value: [
+        { id: 'bead-1', title: 'Orphan', status: 'open', labels: ['pan-2605'] },
+      ],
+    });
+    mockReadGitHubCloseState.mockResolvedValue({ state: 'closed', reason: 'completed' });
+    mockSweepOrphanedBeads.mockResolvedValue({ ok: true, closedIds: ['bead-1'], skipped: 0 });
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'script', 'beads', 'sweep', '--all-closed', '--reason', 'custom reason']);
+
+    expect(mockSweepOrphanedBeads).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'custom reason' }),
+    );
+  });
+
+  it('refuses to sweep explicit open issues and reports failure', async () => {
+    mockReadGitHubCloseState.mockResolvedValue({ state: 'open', reason: null });
+
+    const logs: string[] = [];
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((msg: string) => { logs.push(msg); });
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'script', 'beads', 'sweep', 'pan-2606']);
+
+    expect(mockSweepOrphanedBeads).not.toHaveBeenCalled();
+
+    const totalLine = logs.find((line) => line.includes('Total:'));
+    expect(totalLine).toContain('0 processed, 1 skipped, 0 failed');
+
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+});

--- a/src/cli/commands/__tests__/handoff.test.ts
+++ b/src/cli/commands/__tests__/handoff.test.ts
@@ -137,4 +137,50 @@ describe('handoffCommand', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
     expect(forkMocks.forkConversationViaServer).not.toHaveBeenCalled();
   });
+
+  it('prints the issue association returned by the fork server', async () => {
+    conversationMocks.getConversationById.mockReturnValue({
+      id: 123,
+      name: 'source-conv',
+      title: 'Source conversation',
+      cwd: '/workspace',
+      claudeSessionId: 'session-id',
+    });
+    forkMocks.forkConversationViaServer.mockResolvedValue({
+      id: 789,
+      name: 'new-conv',
+      tmuxSession: 'conv-new',
+      issueId: 'PAN-9005',
+      sessionAlive: true,
+    });
+    const { handoffCommand } = await import('../handoff.js');
+
+    await handoffCommand('123', [], {});
+
+    const output = logSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+    expect(output).toContain('Issue: PAN-9005');
+  });
+
+  it('annotates an explicit --issue in the handoff output', async () => {
+    conversationMocks.getConversationById.mockReturnValue({
+      id: 123,
+      name: 'source-conv',
+      title: 'Source conversation',
+      cwd: '/workspace',
+      claudeSessionId: 'session-id',
+    });
+    forkMocks.forkConversationViaServer.mockResolvedValue({
+      id: 789,
+      name: 'new-conv',
+      tmuxSession: 'conv-new',
+      issueId: 'PAN-9004',
+      sessionAlive: true,
+    });
+    const { handoffCommand } = await import('../handoff.js');
+
+    await handoffCommand('123', [], { issue: 'PAN-9004' });
+
+    const output = logSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+    expect(output).toContain('Issue: PAN-9004 (from --issue)');
+  });
 });

--- a/src/cli/commands/__tests__/handoff.test.ts
+++ b/src/cli/commands/__tests__/handoff.test.ts
@@ -95,4 +95,46 @@ describe('handoffCommand', () => {
       handoffAuthorModel: undefined,
     });
   });
+
+  it('validates and forwards --issue to the fork server', async () => {
+    conversationMocks.getConversationById.mockReturnValue({
+      id: 123,
+      name: 'source-conv',
+      title: 'Source conversation',
+      cwd: '/workspace',
+      claudeSessionId: 'session-id',
+    });
+    forkMocks.forkConversationViaServer.mockResolvedValue({
+      id: 789,
+      name: 'new-conv',
+      tmuxSession: 'conv-new',
+      sessionAlive: true,
+    });
+    const { handoffCommand } = await import('../handoff.js');
+
+    await handoffCommand('123', ['continue'], { issue: 'PAN-9004' });
+
+    expect(forkMocks.forkConversationViaServer).toHaveBeenCalledWith(
+      'source-conv',
+      expect.objectContaining({ issueId: 'PAN-9004', focus: 'continue' }),
+    );
+  });
+
+  it('rejects an invalid --issue and does not fork', async () => {
+    conversationMocks.getConversationById.mockReturnValue({
+      id: 123,
+      name: 'source-conv',
+      title: 'Source conversation',
+      cwd: '/workspace',
+      claudeSessionId: 'session-id',
+    });
+    const { handoffCommand } = await import('../handoff.js');
+
+    await expect(handoffCommand('123', [], { issue: 'not-an-issue' })).rejects.toThrow('process.exit');
+
+    const output = logSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+    expect(output).toContain('Invalid --issue: not-an-issue. Expected an issue ID like PAN-123.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(forkMocks.forkConversationViaServer).not.toHaveBeenCalled();
+  });
 });

--- a/src/cli/commands/beads.ts
+++ b/src/cli/commands/beads.ts
@@ -16,6 +16,11 @@ import { registerBeadsReconcileCommand } from './admin/beads-reconcile.js';
 import { standardizeBeadsConfig } from '../../lib/beads/config-standardize.js';
 import { formatMutationBatchFailure, runMutationBatch, type BdMutationClient } from '../../lib/beads/writer.js';
 import { assertSupportedBdVersion, readInstalledBdVersion } from '../../lib/beads/version.js';
+import { createBeadsResolver, type BeadRecord } from '../../lib/beads/resolver.js';
+import { sweepOrphanedBeads } from '../../lib/lifecycle/orphaned-beads-sweep.js';
+import { readGitHubCloseState } from '../commands/close.js';
+import { parseIssueIdSync, type ParsedIssueId } from '../../lib/issue-id.js';
+import { resolveProjectFromIssueSync, getProjectSync } from '../../lib/projects.js';
 
 const execAsync = promisify(exec);
 
@@ -40,6 +45,223 @@ interface CompactOptions {
   days?: number;
   dryRun?: boolean;
   json?: boolean;
+}
+
+interface SweepOptions {
+  allClosed?: boolean;
+  dryRun?: boolean;
+  reason?: string;
+}
+
+interface SweepIssueReport {
+  issue: string;
+  closedCount: number;
+  reason: string;
+}
+
+interface SweepReport {
+  processed: SweepIssueReport[];
+  skippedOpen: string[];
+  failed: { issue: string; reason: string }[];
+}
+
+const SWEEPABLE_STATUSES = new Set(['open', 'in_progress']);
+
+function isSweepable(status: string): boolean {
+  return SWEEPABLE_STATUSES.has(status);
+}
+
+function findIssueLabel(bead: BeadRecord): ParsedIssueId | null {
+  for (const label of bead.labels) {
+    const parsed = parseIssueIdSync(label);
+    if (parsed) return parsed;
+  }
+  return null;
+}
+
+function groupBeadsByIssue(beads: BeadRecord[]): Map<string, BeadRecord[]> {
+  const groups = new Map<string, BeadRecord[]>();
+  for (const bead of beads) {
+    const issue = findIssueLabel(bead);
+    if (!issue) continue;
+    const existing = groups.get(issue.raw);
+    if (existing) {
+      existing.push(bead);
+    } else {
+      groups.set(issue.raw, [bead]);
+    }
+  }
+  return groups;
+}
+
+function parseGitHubRepo(repo: string | undefined): { owner: string; repo: string } | null {
+  if (!repo) return null;
+  const parts = repo.split('/');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+  return { owner: parts[0], repo: parts[1] };
+}
+
+function defaultSweepReason(closeReason: 'completed' | 'not_planned' | null): string {
+  if (closeReason === 'not_planned') {
+    return 'issue closed (not planned); bead cancelled';
+  }
+  return 'issue closed (completed); orphaned bead swept';
+}
+
+async function resolveGitHubCloseState(issueId: string): Promise<
+  | { ok: true; state: 'open' | 'closed'; reason: 'completed' | 'not_planned' | null }
+  | { ok: false; reason: string }
+> {
+  const resolved = resolveProjectFromIssueSync(issueId);
+  if (!resolved) {
+    return { ok: false, reason: 'could not resolve project from issue ID' };
+  }
+  const project = getProjectSync(resolved.projectKey);
+  const repo = parseGitHubRepo(project?.github_repo);
+  if (!repo) {
+    return { ok: false, reason: 'project does not have a github_repo configured' };
+  }
+  const parsed = parseIssueIdSync(issueId);
+  if (!parsed) {
+    return { ok: false, reason: 'could not parse issue ID' };
+  }
+  try {
+    const state = await readGitHubCloseState(repo.owner, repo.repo, parsed.number);
+    return { ok: true, ...state };
+  } catch (error: any) {
+    return { ok: false, reason: error.message ?? String(error) };
+  }
+}
+
+async function sweepIssue(issueId: string, options: SweepOptions): Promise<
+  | { kind: 'processed'; report: SweepIssueReport }
+  | { kind: 'skipped-open' }
+  | { kind: 'failed'; reason: string }
+> {
+  const trackerState = await resolveGitHubCloseState(issueId);
+  if (!trackerState.ok) {
+    return { kind: 'failed', reason: trackerState.reason };
+  }
+
+  if (trackerState.state === 'open') {
+    return { kind: 'skipped-open' };
+  }
+
+  const reason = options.reason ?? defaultSweepReason(trackerState.reason);
+  const result = await sweepOrphanedBeads({
+    beadsCwd: process.cwd(),
+    issueId,
+    reason,
+    dryRun: options.dryRun,
+  });
+
+  if (!result.ok) {
+    return { kind: 'failed', reason: result.error ?? 'sweep failed' };
+  }
+
+  return {
+    kind: 'processed',
+    report: { issue: issueId, closedCount: result.closedIds.length, reason },
+  };
+}
+
+async function enumerateClosedOrphanIssues(): Promise<
+  | { ok: true; issueIds: string[]; openWithOrphans: string[] }
+  | { ok: false; reason: string }
+> {
+  const resolver = createBeadsResolver(process.cwd());
+  const readResult = await resolver.getAllBeads();
+  if (!readResult.ok) {
+    return { ok: false, reason: readResult.reason };
+  }
+
+  const groups = groupBeadsByIssue(readResult.value);
+  const issueIds: string[] = [];
+  const openWithOrphans: string[] = [];
+
+  for (const [issueId, beads] of groups) {
+    if (!beads.some((bead) => isSweepable(bead.status))) continue;
+
+    const trackerState = await resolveGitHubCloseState(issueId);
+    if (!trackerState.ok) {
+      // Treat unresolvable tracker state as a failed candidate rather than
+      // aborting the entire enumeration.
+      continue;
+    }
+
+    if (trackerState.state === 'closed') {
+      issueIds.push(issueId);
+    } else {
+      openWithOrphans.push(issueId);
+    }
+  }
+
+  return { ok: true, issueIds, openWithOrphans };
+}
+
+async function sweepCommand(issueIds: string[], options: SweepOptions): Promise<void> {
+  const report: SweepReport = { processed: [], skippedOpen: [], failed: [] };
+
+  if (issueIds.length === 0 && !options.allClosed) {
+    console.error(chalk.red('Error: pass issue IDs or use --all-closed to enumerate closed issues with orphaned beads'));
+    process.exitCode = 1;
+    return;
+  }
+
+  let targetIssueIds = issueIds;
+  if (options.allClosed) {
+    const spinner = ora('Enumerating issues with orphaned beads...').start();
+    const enumeration = await enumerateClosedOrphanIssues();
+    if (!enumeration.ok) {
+      spinner.fail(`Enumeration failed: ${enumeration.reason}`);
+      process.exitCode = 1;
+      return;
+    }
+    spinner.succeed(`Found ${enumeration.issueIds.length} closed issue(s) with orphaned beads`);
+    if (enumeration.openWithOrphans.length > 0) {
+      report.skippedOpen = enumeration.openWithOrphans;
+    }
+    targetIssueIds = enumeration.issueIds;
+  }
+
+  for (const issueId of targetIssueIds) {
+    const outcome = await sweepIssue(issueId, options);
+    if (outcome.kind === 'processed') {
+      report.processed.push(outcome.report);
+    } else if (outcome.kind === 'skipped-open') {
+      report.skippedOpen.push(issueId);
+    } else {
+      report.failed.push({ issue: issueId, reason: outcome.reason });
+    }
+  }
+
+  // Per-issue report
+  for (const item of report.processed) {
+    const action = options.dryRun ? 'Would sweep' : 'Swept';
+    console.log(`${action} ${chalk.cyan(item.issue)}: ${item.closedCount} bead(s) — ${item.reason}`);
+  }
+  if (report.skippedOpen.length > 0) {
+    console.log(chalk.yellow(`\nOpen with orphaned beads (route back into pipeline): ${report.skippedOpen.join(', ')}`));
+  }
+  if (report.failed.length > 0) {
+    console.log(chalk.red('\nFailures:'));
+    for (const item of report.failed) {
+      console.log(chalk.red(`  ${item.issue}: ${item.reason}`));
+    }
+  }
+
+  // Totals
+  const totals = {
+    processed: report.processed.length,
+    skipped: report.skippedOpen.length,
+    failed: report.failed.length,
+  };
+  console.log('');
+  console.log(`Total: ${totals.processed} processed, ${totals.skipped} skipped, ${totals.failed} failed`);
+
+  if (report.failed.length > 0) {
+    process.exitCode = 1;
+  }
 }
 
 /**
@@ -299,6 +521,16 @@ export function registerBeadsCommands(program: Command): void {
     .action((ids: string[]) => mutate(`delete ${ids.join(', ')}`, async (bd) => {
       for (const id of ids) await bd.mutate(['delete', id, '--yes']);
     }));
+
+  beads
+    .command('sweep [issueIds...]')
+    .description('Sweep orphaned open beads on GitHub-closed issues')
+    .option('--all-closed', 'Enumerate all closed issues with orphaned beads')
+    .option('--dry-run', 'Show what would be swept without mutating beads')
+    .option('--reason <reason>', 'Override the default close reason')
+    .action(async (issueIds: string[], options: SweepOptions) => {
+      await sweepCommand(issueIds, options);
+    });
 
   beads
     .command('compact')

--- a/src/cli/commands/beads.ts
+++ b/src/cli/commands/beads.ts
@@ -166,7 +166,7 @@ async function sweepIssue(issueId: string, options: SweepOptions): Promise<
 }
 
 async function enumerateClosedOrphanIssues(): Promise<
-  | { ok: true; issueIds: string[]; openWithOrphans: string[] }
+  | { ok: true; issueIds: string[]; openWithOrphans: string[]; unresolved: string[] }
   | { ok: false; reason: string }
 > {
   const resolver = createBeadsResolver(process.cwd());
@@ -178,14 +178,23 @@ async function enumerateClosedOrphanIssues(): Promise<
   const groups = groupBeadsByIssue(readResult.value);
   const issueIds: string[] = [];
   const openWithOrphans: string[] = [];
+  const unresolved: string[] = [];
 
-  for (const [issueId, beads] of groups) {
-    if (!beads.some((bead) => isSweepable(bead.status))) continue;
+  const candidates = [...groups.entries()].filter(([, beads]) =>
+    beads.some((bead) => isSweepable(bead.status)),
+  );
 
-    const trackerState = await resolveGitHubCloseState(issueId);
+  const trackerStates = await Promise.all(
+    candidates.map(async ([issueId]) => ({
+      issueId,
+      trackerState: await resolveGitHubCloseState(issueId),
+    })),
+  );
+
+  for (const { issueId, trackerState } of trackerStates) {
     if (!trackerState.ok) {
-      // Treat unresolvable tracker state as a failed candidate rather than
-      // aborting the entire enumeration.
+      // Surface tracker-resolution failures so they are not silently dropped.
+      unresolved.push(issueId);
       continue;
     }
 
@@ -196,7 +205,7 @@ async function enumerateClosedOrphanIssues(): Promise<
     }
   }
 
-  return { ok: true, issueIds, openWithOrphans };
+  return { ok: true, issueIds, openWithOrphans, unresolved };
 }
 
 async function sweepCommand(issueIds: string[], options: SweepOptions): Promise<void> {
@@ -220,6 +229,9 @@ async function sweepCommand(issueIds: string[], options: SweepOptions): Promise<
     spinner.succeed(`Found ${enumeration.issueIds.length} closed issue(s) with orphaned beads`);
     if (enumeration.openWithOrphans.length > 0) {
       report.skippedOpen = enumeration.openWithOrphans;
+    }
+    if (enumeration.unresolved.length > 0) {
+      report.failed.push(...enumeration.unresolved.map((issue) => ({ issue, reason: 'could not resolve tracker state' })));
     }
     targetIssueIds = enumeration.issueIds;
   }

--- a/src/cli/commands/beads.ts
+++ b/src/cli/commands/beads.ts
@@ -71,6 +71,14 @@ function isSweepable(status: string): boolean {
   return SWEEPABLE_STATUSES.has(status);
 }
 
+function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
 function findIssueLabel(bead: BeadRecord): ParsedIssueId | null {
   for (const label of bead.labels) {
     const parsed = parseIssueIdSync(label);
@@ -184,12 +192,19 @@ async function enumerateClosedOrphanIssues(): Promise<
     beads.some((bead) => isSweepable(bead.status)),
   );
 
-  const trackerStates = await Promise.all(
-    candidates.map(async ([issueId]) => ({
-      issueId,
-      trackerState: await resolveGitHubCloseState(issueId),
-    })),
-  );
+  const trackerStates: Array<{
+    issueId: string;
+    trackerState: Awaited<ReturnType<typeof resolveGitHubCloseState>>;
+  }> = [];
+  for (const batch of chunk(candidates, 5)) {
+    const batchResults = await Promise.all(
+      batch.map(async ([issueId]) => ({
+        issueId,
+        trackerState: await resolveGitHubCloseState(issueId),
+      })),
+    );
+    trackerStates.push(...batchResults);
+  }
 
   for (const { issueId, trackerState } of trackerStates) {
     if (!trackerState.ok) {

--- a/src/cli/commands/close.ts
+++ b/src/cli/commands/close.ts
@@ -53,7 +53,7 @@ async function readGitHubCanonicalState(owner: string, repo: string, number: num
     `${owner}/${repo}`,
     '--json',
     'state,labels',
-  ], { encoding: 'utf-8' });
+  ], { encoding: 'utf-8', timeout: 10000 });
   const parsed = JSON.parse(stdout) as { state?: string; labels?: Array<string | { name?: string }> };
   const labels = (parsed.labels ?? [])
     .map(label => typeof label === 'string' ? label : label.name)
@@ -82,7 +82,7 @@ export async function readGitHubCloseState(owner: string, repo: string, number: 
     `${owner}/${repo}`,
     '--json',
     'state,stateReason',
-  ], { encoding: 'utf-8' });
+  ], { encoding: 'utf-8', timeout: 10000 });
   const parsed = JSON.parse(stdout) as { state?: string; stateReason?: string | null };
   const stateLower = (parsed.state ?? 'open').toLowerCase();
   const reasonLower = parsed.stateReason?.toLowerCase();

--- a/src/cli/commands/close.ts
+++ b/src/cli/commands/close.ts
@@ -61,6 +61,37 @@ async function readGitHubCanonicalState(owner: string, repo: string, number: num
   return mapGitHubStateToCanonical(parsed.state ?? 'open', labels);
 }
 
+export interface GitHubCloseState {
+  state: 'open' | 'closed';
+  reason: 'completed' | 'not_planned' | null;
+}
+
+/**
+ * Read the raw close state of a GitHub issue, including its close reason.
+ *
+ * This is the same `gh issue view` door used by closeOutCommand; it is exported
+ * so other CLI commands (e.g. `pan beads sweep`) can look up tracker state
+ * without reaching past the tracker door.
+ */
+export async function readGitHubCloseState(owner: string, repo: string, number: number): Promise<GitHubCloseState> {
+  const { stdout } = await execFileAsync('gh', [
+    'issue',
+    'view',
+    String(number),
+    '--repo',
+    `${owner}/${repo}`,
+    '--json',
+    'state,stateReason',
+  ], { encoding: 'utf-8' });
+  const parsed = JSON.parse(stdout) as { state?: string; stateReason?: string | null };
+  const stateLower = (parsed.state ?? 'open').toLowerCase();
+  const reasonLower = parsed.stateReason?.toLowerCase();
+  return {
+    state: stateLower === 'closed' ? 'closed' : 'open',
+    reason: reasonLower === 'not_planned' ? 'not_planned' : reasonLower === 'completed' ? 'completed' : null,
+  };
+}
+
 export async function closeOutCommand(id: string, options: CloseOutOptions): Promise<void> {
   const issueId = resolveBareNumericIdSync(id);
   if (!issueId) {

--- a/src/cli/commands/fork-client.ts
+++ b/src/cli/commands/fork-client.ts
@@ -50,6 +50,7 @@ export interface ForkResultConv {
   handoffDocPath?: string | null;
   sessionAlive?: boolean;
   status?: string;
+  issueId?: string | null;
 }
 
 export class ForkServerError extends Error {}

--- a/src/cli/commands/fork-client.ts
+++ b/src/cli/commands/fork-client.ts
@@ -31,6 +31,7 @@ export interface ForkViaServerOptions {
   summaryHarness?: RuntimeName;
   title?: string;
   focus?: string;
+  issueId?: string;
   handoffAuthor?: 'source' | 'external';
   handoffAuthorModel?: string;
   handoffAuthorHarness?: RuntimeName;
@@ -86,6 +87,7 @@ export async function forkConversationViaServer(
   if (opts.summaryHarness) body['summaryHarness'] = opts.summaryHarness;
   if (opts.title) body['title'] = opts.title;
   if (opts.focus) body['focus'] = opts.focus;
+  if (opts.issueId) body['issueId'] = opts.issueId;
   if (opts.handoffAuthor) body['handoffAuthor'] = opts.handoffAuthor;
   if (opts.handoffAuthorModel) body['handoffAuthorModel'] = opts.handoffAuthorModel;
   if (opts.handoffAuthorHarness) body['handoffAuthorHarness'] = opts.handoffAuthorHarness;

--- a/src/cli/commands/handoff.ts
+++ b/src/cli/commands/handoff.ts
@@ -139,6 +139,7 @@ export async function handoffCommand(
   console.log(chalk.gray(`  Session: ${newConv.tmuxSession}${newConv.sessionAlive ? ' (live)' : ''}`));
   console.log(chalk.gray(`  Model: ${newConv.model || 'default'}`));
   console.log(chalk.gray(`  Harness: ${newConv.harness || 'claude-code'}`));
+  console.log(chalk.gray(`  Issue: ${newConv.issueId ?? 'none'}${options.issue ? ' (from --issue)' : ''}`));
   if (newConv.handoffDocPath) {
     console.log(chalk.gray(`  Handoff doc: ${newConv.handoffDocPath}`));
   }

--- a/src/cli/commands/handoff.ts
+++ b/src/cli/commands/handoff.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import { existsSync } from 'fs';
 import { getConversationById, getConversationByName } from '../../lib/overdeck/conversations.js';
 import { resolveCurrentConversation } from '../../lib/conversations/current.js';
+import { parseIssueIdSync } from '../../lib/issue-id.js';
 import { forkConversationViaServer, ForkServerError, isForkResultInProgress } from './fork-client.js';
 import { sessionFilePath } from '../../lib/paths.js';
 
@@ -9,6 +10,7 @@ interface HandoffOptions {
   model?: string;
   harness?: string;
   cwd?: string;
+  issue?: string;
   author?: string;
   authorModel?: string;
   authorHarness?: string;
@@ -79,6 +81,15 @@ export async function handoffCommand(
     console.log(chalk.yellow(`Invalid --author: ${options.author}. Expected source or external.`));
     process.exit(1);
   }
+  let issueId: string | undefined;
+  if (options.issue !== undefined) {
+    const parsed = parseIssueIdSync(options.issue.trim());
+    if (!parsed) {
+      console.log(chalk.yellow(`Invalid --issue: ${options.issue}. Expected an issue ID like PAN-123.`));
+      process.exit(1);
+    }
+    issueId = parsed.raw;
+  }
   console.log(chalk.gray(`Creating handoff from conversation: ${conv.name} (${conv.title || 'untitled'})`));
   console.log(chalk.gray(`  Author: ${author}${author === 'external' ? ` (model=${options.authorModel ?? 'default'}, harness=provider-default)` : ' (in-source agent)'}`));
   if (focus) {
@@ -94,6 +105,7 @@ export async function handoffCommand(
     newConv = await forkConversationViaServer(conv.name, {
       model: options.model,
       cwd: options.cwd,
+      issueId,
       forkMode: 'handoff',
       focus,
       handoffAuthor: author,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -490,6 +490,7 @@ program
   .option('--model <model>', 'Model for the handoff-forked (new) conversation')
   .option('--harness <harness>', 'Ignored: harness is provider-default-only (PAN-1984)')
   .option('--cwd <path>', 'Working directory for the new conversation')
+  .option('--issue <id>', 'Issue ID to associate with the new conversation')
   .option('--author <author>', 'Who authors the handoff doc: external (default) or source', 'external')
   .option('--author-model <model>', 'Model for the external authoring session (only when --author=external)')
   .option('--author-harness <harness>', 'Ignored: author harness is provider-default-only (PAN-1984)')

--- a/src/dashboard/frontend/src/App.test.tsx
+++ b/src/dashboard/frontend/src/App.test.tsx
@@ -122,6 +122,8 @@ vi.mock('./lib/store', () => ({
   selectDashboardLifecycle: (state: { dashboardLifecycle: { active: boolean } }) => state.dashboardLifecycle,
   selectAgentsWithPendingAskUserQuestion: (state: { agentsWithPendingAskUserQuestion?: unknown[] }) =>
     state.agentsWithPendingAskUserQuestion ?? [],
+  selectAgentsWithPendingProposedPlan: (state: { agentsWithPendingProposedPlan?: unknown[] }) =>
+    state.agentsWithPendingProposedPlan ?? [],
 }));
 vi.mock('./lib/refresh-dashboard-state', () => ({
   refreshDashboardState: mockRefreshDashboardState,

--- a/src/dashboard/frontend/src/components/CommandDeck/CommandDeck.test.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/CommandDeck.test.tsx
@@ -221,6 +221,7 @@ function renderCommandDeck(props?: Partial<React.ComponentProps<typeof CommandDe
                 hasVbrief: false,
                 hasBeads: false,
                 dockerContainerCount: 0,
+                conversations: [],
               },
             },
           ],

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.test.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.test.tsx
@@ -1109,7 +1109,7 @@ describe('FeatureItem', () => {
 
   it('shows cleanup affordances for orphaned resources', () => {
     const onCleanupOrphanedResources = vi.fn();
-    renderFeature(
+    const { container } = renderFeature(
       <FeatureItem
         feature={makeFeature({
           issueId: 'PAN-777',
@@ -1133,6 +1133,16 @@ describe('FeatureItem', () => {
         onCleanupOrphanedResources={onCleanupOrphanedResources}
       />,
     );
+
+    const strip = container.querySelector('.featureResourceStrip');
+    expect(strip).toBeTruthy();
+    if (strip) fireEvent.mouseEnter(strip);
+
+    const cleanupButton = screen.getByTitle('Clean up orphaned workspace resources');
+    fireEvent.click(cleanupButton);
+
+    expect(onCleanupOrphanedResources).toHaveBeenCalledTimes(1);
+    expect(onCleanupOrphanedResources).toHaveBeenCalledWith('PAN-777');
   });
 
   it('renders issue-linked conversations as child rows with links to /conv/<id>', () => {

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.test.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.test.tsx
@@ -28,6 +28,7 @@ vi.mock('lucide-react', async (importOriginal) => {
     Container: () => <svg data-testid="container" />,
     Radio: () => <svg data-testid="radio" />,
     Workflow: () => <svg data-testid="workflow" />,
+    MessageSquare: () => <svg data-testid="message-square" />,
   };
 });
 
@@ -152,6 +153,7 @@ function makeFeature(overrides?: Partial<ProjectFeature>): ProjectFeature {
       hasBeads: false,
       dockerContainerCount: 0,
       dockerContainerNames: [],
+      conversations: [],
     },
     ...overrides,
   };
@@ -919,6 +921,7 @@ describe('FeatureItem', () => {
             hasVbrief: false,
             hasBeads: false,
             dockerContainerCount: 2,
+            conversations: [],
           },
           sessions: [
             makeSession({ sessionId: 'agent-pan-821', type: 'work', status: 'stopped', presence: 'inactive' }),
@@ -971,6 +974,7 @@ describe('FeatureItem', () => {
             hasVbrief: false,
             hasBeads: false,
             dockerContainerCount: 2,
+            conversations: [],
           },
           sessions: [
             makeSession({ sessionId: 'agent-pan-821', type: 'work', status: 'stopped', presence: 'inactive' }),
@@ -1121,6 +1125,7 @@ describe('FeatureItem', () => {
             hasVbrief: false,
             hasBeads: false,
             dockerContainerCount: 0,
+            conversations: [],
           },
         })}
         isSelected={false}
@@ -1128,9 +1133,71 @@ describe('FeatureItem', () => {
         onCleanupOrphanedResources={onCleanupOrphanedResources}
       />,
     );
+  });
 
-    fireEvent.mouseEnter(screen.getByTitle('workspace: allocated').parentElement!);
-    fireEvent.click(screen.getByRole('button', { name: 'Cleanup' }));
-    expect(onCleanupOrphanedResources).toHaveBeenCalledWith('PAN-777');
+  it('renders issue-linked conversations as child rows with links to /conv/<id>', () => {
+    renderFeature(
+      <FeatureItem
+        feature={makeFeature({
+          sessions: [],
+          resourceSources: ['conversation'],
+          resourceDetails: {
+            hasWorkspace: false,
+            localBranchCount: 0,
+            remoteBranchCount: 0,
+            tmuxSessionCount: 0,
+            prs: [],
+            hasVbrief: false,
+            hasBeads: false,
+            dockerContainerCount: 0,
+            conversations: [
+              { id: 42, name: 'conv-pan-821', title: 'My conv', status: 'active' },
+              { id: 43, name: 'conv-pan-821-2', title: null, status: 'ended' },
+            ],
+          },
+        })}
+        isSelected={false}
+        onSelect={() => {}}
+      />,
+    );
+
+    const activeLink = screen.getByTestId('conversation-42');
+    expect(activeLink).toHaveAttribute('href', '/conv/42');
+    expect(activeLink).toHaveTextContent('My conv');
+
+    const endedLink = screen.getByTestId('conversation-43');
+    expect(endedLink).toHaveAttribute('href', '/conv/43');
+    expect(endedLink).toHaveTextContent('Conversation');
+  });
+
+  it('shows the expand caret for an issue with conversations but no sessions', () => {
+    renderFeature(
+      <FeatureItem
+        feature={makeFeature({
+          stateLabel: 'Done',
+          sessions: [],
+          resourceSources: ['conversation'],
+          resourceDetails: {
+            hasWorkspace: false,
+            localBranchCount: 0,
+            remoteBranchCount: 0,
+            tmuxSessionCount: 0,
+            prs: [],
+            hasVbrief: false,
+            hasBeads: false,
+            dockerContainerCount: 0,
+            conversations: [{ id: 7, name: 'conv-pan-821', title: 'Only conv', status: 'active' }],
+          },
+        })}
+        isSelected={false}
+        onSelect={() => {}}
+      />,
+    );
+
+    expect(screen.queryByTestId('conversation-7')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Expand sessions' }));
+    const link = screen.getByTestId('conversation-7');
+    expect(link).toHaveAttribute('href', '/conv/7');
+    expect(link).toHaveTextContent('Only conv');
   });
 });

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.tsx
@@ -3,7 +3,7 @@ import { useLiveFlash } from '../../../lib/useLiveFlash';
 import {
   Loader2, AlertTriangle, CheckCircle2, Circle, Eye, Layers, GitMerge,
   ChevronRight, ChevronDown, FolderOpen, FileText, Trash2, GitBranch,
-  BookText, Bug, Container, Radio, Workflow,
+  BookText, Bug, Container, Radio, Workflow, MessageSquare,
 } from 'lucide-react';
 import type { SessionNode as SessionNodeType } from '@overdeck/contracts';
 import type { ProjectFeature, ProjectFeatureResourceIdentifiers, ResourceSource } from './ProjectNode';
@@ -1015,6 +1015,10 @@ export function FeatureItem({ feature, isSelected, onSelect, selectedSessionId, 
     [visibleSessions],
   );
 
+  const issueConversations = feature.resourceDetails?.conversations ?? [];
+  const hasConversations = issueConversations.length > 0;
+  const hasExpandableChildren = hasVisibleSessions || hasConversations;
+
   const workSession = feature.sessions?.find((s) => s.type === 'work');
   const workSessionId = workSession?.sessionId ?? bestSessionId ?? null;
 
@@ -1108,7 +1112,7 @@ export function FeatureItem({ feature, isSelected, onSelect, selectedSessionId, 
         data-issue-id={feature.issueId}
       >
         <div className={styles.featureItemRow}>
-          {hasVisibleSessions ? (
+          {hasExpandableChildren ? (
             <button
               className={styles.featureItemCaret}
               onClick={handleToggleExpanded}
@@ -1260,7 +1264,7 @@ export function FeatureItem({ feature, isSelected, onSelect, selectedSessionId, 
       {expanded && (
         <ShipDoorTreeRow issueId={feature.issueId} onSelect={() => onSelect?.()} />
       )}
-      {expanded && hasVisibleSessions && (
+      {expanded && hasExpandableChildren && (
         <div className={styles.sessionList}>
           {(() => {
             const reviewerChildren = visibleSessions.filter(s => s.type === 'reviewer');
@@ -1271,7 +1275,7 @@ export function FeatureItem({ feature, isSelected, onSelect, selectedSessionId, 
 
             return (
               <>
-                {sortedNonReviewers.map(session => {
+                {hasVisibleSessions && sortedNonReviewers.map(session => {
                   if (session.type === 'review') {
                     return (
                       <ReviewGroup
@@ -1313,6 +1317,20 @@ export function FeatureItem({ feature, isSelected, onSelect, selectedSessionId, 
                     />
                   );
                 })}
+                {hasConversations && issueConversations.map(conv => (
+                  <a
+                    key={`conv-${conv.id}`}
+                    href={`/conv/${conv.id}`}
+                    className={styles.sessionNode}
+                    data-testid={`conversation-${conv.id}`}
+                    title={conv.title ?? conv.name}
+                  >
+                    <MessageSquare size={12} style={{ color: 'var(--muted-foreground)', flexShrink: 0 }} />
+                    <span style={{ fontSize: 12, fontWeight: 500 }}>{conv.title || 'Conversation'}</span>
+                    <span style={{ fontSize: 11, color: 'var(--muted-foreground)' }}>{conv.status}</span>
+                    <span style={{ fontSize: 10, color: 'var(--muted-foreground)', fontVariantNumeric: 'tabular-nums' }}>#{conv.id}</span>
+                  </a>
+                ))}
               </>
             );
           })()}

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ProjectNode.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ProjectNode.tsx
@@ -5,7 +5,7 @@ import { FeatureItem, sessionMatchesFilter, type TreeSessionFilter } from './Fea
 import type { Harness } from '../../shared/ModelPicker';
 import styles from '../styles/command-deck.module.css';
 
-export type ResourceSource = 'tracker' | 'tmux' | 'workspace' | 'branch' | 'pr' | 'vbrief' | 'beads' | 'docker' | 'remote-agent';
+export type ResourceSource = 'tracker' | 'tmux' | 'workspace' | 'branch' | 'pr' | 'vbrief' | 'beads' | 'docker' | 'remote-agent' | 'conversation';
 
 export interface ProjectFeatureResourceDetails {
   hasWorkspace: boolean;
@@ -29,6 +29,8 @@ export interface ProjectFeatureResourceDetails {
   workspaceMissing?: boolean;
   /** PAN-1676: remote (fly.io) work agent for this issue, when one is active. */
   remoteAgent?: { vmName: string; status: string; model: string; startedAt: string } | null;
+  /** Non-archived conversations explicitly linked to this issue (PAN-2602). */
+  conversations: Array<{ id: number; name: string; title: string | null; status: string }>;
 }
 
 export interface ProjectFeatureResourceIdentifiers {

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ProjectNode.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ProjectNode.tsx
@@ -25,6 +25,8 @@ export interface ProjectFeatureResourceDetails {
   actualBranch?: string | null;
   /** PAN-1523: true when workspace HEAD differs from expected feature/<id> branch. */
   branchDrifted?: boolean;
+  /** PAN-2602: true when a feature/* or bypass/* branch for the issue has unmerged commits not on main. */
+  branchAheadOfMain?: boolean;
   /** PAN-1523: true when workspace path is configured but missing on disk. */
   workspaceMissing?: boolean;
   /** PAN-1676: remote (fly.io) work agent for this issue, when one is active. */
@@ -69,6 +71,8 @@ export interface ProjectFeature {
   sessions?: readonly SessionNode[];
   resourceSources?: ResourceSource[];
   resourceDetails?: ProjectFeatureResourceDetails;
+  /** PAN-2602: per-issue bead rollup totals from the cached bulk rollup. */
+  beadTotals?: { total: number; closed: number; inProgress: number; lastUpdated: string | null } | null;
 }
 
 interface ProjectNodeProps {

--- a/src/dashboard/frontend/src/components/CommandDeck/__tests__/pipeline-helpers.test.ts
+++ b/src/dashboard/frontend/src/components/CommandDeck/__tests__/pipeline-helpers.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProjectFeature } from '../ProjectTree/ProjectNode';
+import {
+  groupPipelineEntries,
+  isStalledFeature,
+  lastActivityAt,
+  pipelineChipFor,
+} from '../pipeline-helpers';
+
+const DAYS = 24 * 60 * 60 * 1000;
+
+function makeFeature(overrides: Partial<ProjectFeature> = {}): ProjectFeature {
+  return {
+    issueId: 'PAN-1',
+    title: 'Test issue',
+    projectName: 'overdeck',
+    branch: 'feature/pan-1',
+    status: 'idle',
+    stateLabel: 'open',
+    agentStatus: null,
+    hasPlanning: false,
+    hasPrd: false,
+    hasState: true,
+    isShadow: false,
+    sessions: [],
+    resourceDetails: {
+      hasWorkspace: true,
+      localBranchCount: 0,
+      remoteBranchCount: 0,
+      tmuxSessionCount: 0,
+      prs: [],
+      hasVbrief: false,
+      hasBeads: true,
+      dockerContainerCount: 0,
+      conversations: [],
+    },
+    ...overrides,
+  };
+}
+
+function makeBucket(feature: ProjectFeature) {
+  return { feature, reviewStatus: undefined, phase: 'work' as const };
+}
+
+describe('isStalledFeature', () => {
+  it('returns true when the issue has an artifact signal but no live agent', () => {
+    const feature = makeFeature({
+      resourceDetails: { ...makeFeature().resourceDetails!, branchAheadOfMain: true },
+    });
+    expect(isStalledFeature(feature, undefined)).toBe(true);
+  });
+
+  it('returns true when there is partial bead progress and no live agent', () => {
+    const feature = makeFeature({
+      beadTotals: { total: 4, closed: 2, inProgress: 0, lastUpdated: new Date(Date.now() - 30 * DAYS).toISOString() },
+    });
+    expect(isStalledFeature(feature, undefined)).toBe(true);
+  });
+
+  it('returns true when there is an in-progress bead and no live agent', () => {
+    const feature = makeFeature({
+      beadTotals: { total: 3, closed: 0, inProgress: 1, lastUpdated: new Date(Date.now() - 30 * DAYS).toISOString() },
+    });
+    expect(isStalledFeature(feature, undefined)).toBe(true);
+  });
+
+  it('returns true when there is a linked conversation and no live agent', () => {
+    const feature = makeFeature({
+      resourceDetails: {
+        ...makeFeature().resourceDetails!,
+        conversations: [{ id: 1, name: 'conv-1', title: 'Investigate', status: 'active' }],
+      },
+    });
+    expect(isStalledFeature(feature, undefined)).toBe(true);
+  });
+
+  it('returns false when there is no artifact signal', () => {
+    const feature = makeFeature({
+      resourceDetails: { ...makeFeature().resourceDetails!, branchAheadOfMain: false, hasBeads: false },
+      beadTotals: null,
+    });
+    expect(isStalledFeature(feature, undefined)).toBe(false);
+  });
+
+  it('returns false when a work session is active', () => {
+    const feature = makeFeature({
+      beadTotals: { total: 4, closed: 2, inProgress: 0, lastUpdated: new Date(Date.now() - 30 * DAYS).toISOString() },
+      agentStatus: 'active',
+    });
+    expect(isStalledFeature(feature, undefined)).toBe(false);
+  });
+
+  it('returns false when a live agent session is present', () => {
+    const feature = makeFeature({
+      beadTotals: { total: 4, closed: 2, inProgress: 0, lastUpdated: new Date(Date.now() - 30 * DAYS).toISOString() },
+      sessions: [
+        {
+          id: 'agent-pan-1',
+          type: 'work',
+          presence: 'active',
+          model: 'claude-sonnet-5',
+          startedAt: new Date(Date.now() - 1 * DAYS).toISOString(),
+        } as any,
+      ],
+    });
+    expect(isStalledFeature(feature, undefined)).toBe(false);
+  });
+});
+
+describe('lastActivityAt', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-13T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('includes beadTotals.lastUpdated when no sessions or review updates exist', () => {
+    const entry = makeBucket(
+      makeFeature({
+        beadTotals: { total: 2, closed: 1, inProgress: 0, lastUpdated: '2026-06-13T00:00:00Z' },
+      }),
+    );
+    expect(lastActivityAt(entry)).toBe(new Date('2026-06-13T00:00:00Z').getTime());
+  });
+});
+
+describe('groupPipelineEntries stalled bucket', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-13T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('places an artifact-bearing, agent-less, stale feature in the stalled group', () => {
+    const feature = makeFeature({
+      beadTotals: { total: 4, closed: 2, inProgress: 0, lastUpdated: '2026-05-13T00:00:00Z' },
+    });
+    const groups = groupPipelineEntries([makeBucket(feature)]);
+
+    expect(groups.map(g => g.key)).toEqual(['stalled']);
+    expect(groups[0].phase).toBe('stalled');
+    expect(groups[0].entries[0].phase).toBe('stalled');
+    expect(pipelineChipFor(groups[0].entries[0]).label).toBe('stalled — has work, no live agent');
+  });
+
+  it('keeps a recently-active artifact-bearing feature out of stalled', () => {
+    const feature = makeFeature({
+      beadTotals: { total: 4, closed: 2, inProgress: 0, lastUpdated: '2026-07-12T00:00:00Z' },
+    });
+    const groups = groupPipelineEntries([makeBucket(feature)]);
+
+    expect(groups.map(g => g.key)).toEqual(['work']);
+    expect(groups.some(g => g.key === 'stalled')).toBe(false);
+  });
+
+  it('keeps a live-agent feature out of stalled even when artifact signals exist', () => {
+    const feature = makeFeature({
+      beadTotals: { total: 4, closed: 2, inProgress: 0, lastUpdated: '2026-05-13T00:00:00Z' },
+      sessions: [
+        {
+          id: 'agent-pan-1',
+          type: 'work',
+          presence: 'active',
+          model: 'claude-sonnet-5',
+          startedAt: '2026-07-12T00:00:00Z',
+        } as any,
+      ],
+    });
+    const groups = groupPipelineEntries([makeBucket(feature)]);
+
+    expect(groups.map(g => g.key)).toEqual(['work']);
+    expect(groups.some(g => g.key === 'stalled')).toBe(false);
+  });
+
+  it('prefers needs-you over stalled when both apply', () => {
+    const feature = makeFeature({
+      readyForMerge: true,
+      beadTotals: { total: 4, closed: 2, inProgress: 0, lastUpdated: '2026-05-13T00:00:00Z' },
+    });
+    const groups = groupPipelineEntries([makeBucket(feature)]);
+
+    expect(groups.map(g => g.key)).toEqual(['needs-you']);
+    expect(groups.some(g => g.key === 'stalled')).toBe(false);
+  });
+
+  it('does not duplicate a stalled feature into its original phase group', () => {
+    const feature = makeFeature({
+      beadTotals: { total: 4, closed: 2, inProgress: 0, lastUpdated: '2026-05-13T00:00:00Z' },
+    });
+    const groups = groupPipelineEntries([makeBucket(feature)]);
+
+    expect(groups.filter(g => g.key === 'stalled')).toHaveLength(1);
+    expect(groups.filter(g => g.key === 'work')).toHaveLength(0);
+  });
+});

--- a/src/dashboard/frontend/src/components/CommandDeck/pipeline-helpers.ts
+++ b/src/dashboard/frontend/src/components/CommandDeck/pipeline-helpers.ts
@@ -3,15 +3,17 @@ import type { PipelineIssuePhase } from '../../lib/pipeline-state';
 import { compactModelName } from '../../lib/model-names';
 import type { ProjectFeature } from './ProjectTree/ProjectNode';
 
+export type PipelineBucketPhase = PipelineIssuePhase | 'needs-you' | 'stalled';
+
 export interface BucketedFeature {
   feature: ProjectFeature;
   reviewStatus: ReviewStatusSnapshot | undefined;
-  phase: PipelineIssuePhase;
+  phase: PipelineBucketPhase;
 }
 
 export interface PipelineGroup {
   key: string;
-  phase: PipelineIssuePhase | 'needs-you';
+  phase: PipelineBucketPhase;
   title: string;
   subtitle: string;
   entries: BucketedFeature[];
@@ -48,6 +50,50 @@ export function hasWorkSession(feature: ProjectFeature): boolean {
 
 export function hasActiveAgentSignal(feature: ProjectFeature): boolean {
   return hasActiveWorkSession(feature) || ACTIVE_AGENT_STATUSES.has(feature.agentStatus ?? '');
+}
+
+const STALLED_INACTIVITY_MS = 14 * 24 * 60 * 60 * 1000;
+
+function hasAdmittedArtifactSignal(feature: ProjectFeature): boolean {
+  const details = feature.resourceDetails;
+  if (details?.branchAheadOfMain) return true;
+  if (details?.conversations && details.conversations.length > 0) return true;
+
+  const totals = feature.beadTotals;
+  if (totals) {
+    if (totals.inProgress > 0) return true;
+    if (totals.closed > 0 && totals.closed < totals.total) return true;
+  }
+  return false;
+}
+
+function featureLastActivity(feature: ProjectFeature, reviewStatus: ReviewStatusSnapshot | undefined): number {
+  const sessionTimes = (feature.sessions ?? [])
+    .flatMap(session => [session.startedAt, session.endedAt].filter(Boolean))
+    .map(iso => new Date(iso!).getTime())
+    .filter(t => !Number.isNaN(t));
+  const reviewTime = reviewStatus?.updatedAt ? new Date(reviewStatus.updatedAt).getTime() : NaN;
+  const beadUpdated = feature.beadTotals?.lastUpdated
+    ? new Date(feature.beadTotals.lastUpdated).getTime()
+    : NaN;
+  const times = [
+    ...sessionTimes,
+    ...(Number.isNaN(reviewTime) ? [] : [reviewTime]),
+    ...(Number.isNaN(beadUpdated) ? [] : [beadUpdated]),
+  ];
+  return times.length > 0 ? Math.max(...times) : 0;
+}
+
+function isStaleActivity(feature: ProjectFeature, reviewStatus: ReviewStatusSnapshot | undefined): boolean {
+  const last = featureLastActivity(feature, reviewStatus);
+  if (last === 0) return true;
+  return Date.now() - last >= STALLED_INACTIVITY_MS;
+}
+
+export function isStalledFeature(feature: ProjectFeature, reviewStatus: ReviewStatusSnapshot | undefined): boolean {
+  if (!hasAdmittedArtifactSignal(feature)) return false;
+  if (hasActiveAgentSignal(feature)) return false;
+  return isStaleActivity(feature, reviewStatus);
 }
 
 export function isBlockedFeature(feature: ProjectFeature, reviewStatus: ReviewStatusSnapshot | undefined): boolean {
@@ -97,6 +143,18 @@ export function pipelineChipFor(entry: BucketedFeature): PipelineChipSpec {
     return {
       key: 'waiting',
       label: 'waiting on you',
+      textClass: 'text-amber-600',
+      bgClass: 'bg-amber-500/14',
+      dotClass: 'bg-amber-500',
+      ringClass: 'border-amber-500',
+      animate: false,
+    };
+  }
+
+  if (phase === 'stalled') {
+    return {
+      key: 'stalled',
+      label: 'stalled — has work, no live agent',
       textClass: 'text-amber-600',
       bgClass: 'bg-amber-500/14',
       dotClass: 'bg-amber-500',
@@ -192,6 +250,10 @@ export function sublineFor(entry: BucketedFeature): string {
     return stuckReason(reviewStatus);
   }
 
+  if (phase === 'stalled') {
+    return 'work artifacts present but no live agent';
+  }
+
   if (reviewStatus?.testStatus === 'testing') return 'tests running now';
   if (reviewStatus?.reviewStatus === 'reviewing') return 'reviewer checking the finished work';
   if (reviewStatus?.reviewStatus === 'passed') {
@@ -276,20 +338,14 @@ export function formatPipelineCost(cost: number | undefined): string {
 }
 
 export function lastActivityAt(entry: BucketedFeature): number {
-  const sessionTimes = (entry.feature.sessions ?? [])
-    .flatMap(session => [session.startedAt, session.endedAt].filter(Boolean))
-    .map(iso => new Date(iso!).getTime())
-    .filter(t => !Number.isNaN(t));
-  const reviewTime = entry.reviewStatus?.updatedAt ? new Date(entry.reviewStatus.updatedAt).getTime() : NaN;
-  const times = [...sessionTimes, ...(Number.isNaN(reviewTime) ? [] : [reviewTime])];
-  return times.length > 0 ? Math.max(...times) : 0;
+  return featureLastActivity(entry.feature, entry.reviewStatus);
 }
 
 export function sortByLastActivity(entries: readonly BucketedFeature[]): BucketedFeature[] {
   return [...entries].sort((a, b) => lastActivityAt(b) - lastActivityAt(a));
 }
 
-export function stageDisplayName(phase: PipelineIssuePhase): { title: string; subtitle: string } {
+export function stageDisplayName(phase: PipelineBucketPhase): { title: string; subtitle: string } {
   switch (phase) {
     case 'ship': return { title: 'Lining up to ship', subtitle: 'ready to merge' };
     case 'review': return { title: 'Being reviewed', subtitle: 'quality checks' };
@@ -298,6 +354,8 @@ export function stageDisplayName(phase: PipelineIssuePhase): { title: string; su
     case 'ready': return { title: 'Ready', subtitle: 'queued for pickup' };
     case 'todo': return { title: 'Todo', subtitle: 'not started' };
     case 'verifying': return { title: 'Verifying', subtitle: 'on main' };
+    case 'stalled': return { title: 'Stalled / fell off the pipeline', subtitle: 'started work with nobody on it' };
+    case 'needs-you': return { title: 'Needs you', subtitle: 'waiting on a human decision' };
     default: return { title: phase, subtitle: '' };
   }
 }
@@ -316,10 +374,30 @@ export function groupPipelineEntries(entries: readonly BucketedFeature[]): Pipel
     });
   }
 
-  const phaseOrder: PipelineIssuePhase[] = ['ship', 'review', 'work', 'plan', 'ready', 'todo', 'verifying'];
+  const stalledEntries = sortByLastActivity(
+    entries.filter(e =>
+      isStalledFeature(e.feature, e.reviewStatus) &&
+      !isNeedsYouFeature(e.feature, e.reviewStatus),
+    ),
+  );
+  if (stalledEntries.length > 0) {
+    groups.push({
+      key: 'stalled',
+      phase: 'stalled',
+      title: 'Stalled / fell off the pipeline',
+      subtitle: 'started work with nobody on it',
+      entries: stalledEntries.map(e => ({ ...e, phase: 'stalled' })),
+    });
+  }
+
+  const phaseOrder: PipelineBucketPhase[] = ['ship', 'review', 'work', 'plan', 'ready', 'todo', 'verifying'];
   for (const phase of phaseOrder) {
     const phaseEntries = sortByLastActivity(
-      entries.filter(e => e.phase === phase && !isNeedsYouFeature(e.feature, e.reviewStatus)),
+      entries.filter(e =>
+        e.phase === phase &&
+        !isNeedsYouFeature(e.feature, e.reviewStatus) &&
+        !isStalledFeature(e.feature, e.reviewStatus),
+      ),
     );
     if (phaseEntries.length === 0) continue;
     const { title, subtitle } = stageDisplayName(phase);

--- a/src/dashboard/frontend/src/components/Stage/cockpit/IssueMissionControl.tsx
+++ b/src/dashboard/frontend/src/components/Stage/cockpit/IssueMissionControl.tsx
@@ -456,6 +456,7 @@ function IssueTreeLane({
       hasVbrief: actions.state.hasPlan,
       hasBeads: actions.state.hasBeads,
       dockerContainerCount: 0,
+      conversations: [],
     },
   }), [actions.state.hasBeads, actions.state.hasPlan, issueId, projectName, review.data, sessions, title])
 

--- a/src/dashboard/server/main.ts
+++ b/src/dashboard/server/main.ts
@@ -15,6 +15,7 @@ import { startSharedIssueService, getSharedIssueService } from './services/issue
 import { startAgentEnrichmentService, stopAgentEnrichmentService } from './services/agent-enrichment-service.js';
 import { startMergeBlockerReconcileService } from './services/merge-blocker-reconcile-service.js';
 import { startAgentOutputService, stopAgentOutputService } from './services/agent-output-service.js';
+import { createBeadsRollupService } from './services/beads-rollup-service.js';
 import { createBeadsSyncService } from './services/beads-sync-service.js';
 import { startConversationLifecycleService, stopConversationLifecycleService } from './services/conversation-lifecycle.js';
 import { startRestartAnnouncer, stopRestartAnnouncer } from './services/restart-announcer.js';
@@ -484,6 +485,8 @@ console.log(conversationSearchWatcher
   ? '[overdeck] Conversation search watcher started'
   : '[overdeck] Conversation search watcher skipped (conversationSearch.enabled=false)');
 
+let stopBeadsRollupService: (() => void) | undefined;
+
 void (async () => {
   const store = await initEventStore();
   const beadsSync = createBeadsSyncService({
@@ -491,6 +494,14 @@ void (async () => {
   });
   void beadsSync.run().catch((err) => console.warn('[beads-sync] service stopped:', err?.message ?? err));
   console.log('[overdeck] BeadsSyncService started');
+
+  const beadsRollup = createBeadsRollupService({
+    subscribe: (listener) => store.subscribe((event) => listener(event as any)),
+  });
+  beadsRollup.start();
+  stopBeadsRollupService = beadsRollup.stop;
+  console.log('[overdeck] BeadsRollupService started');
+
   store.subscribe((event) => {
     if (event.type === 'agent.stopped' || event.type === 'agent.heartbeat_dead') {
       const agentId = typeof (event.payload as { agentId?: unknown }).agentId === 'string'
@@ -571,6 +582,7 @@ const handleShutdownSignal = async (signal: NodeJS.Signals) => {
   stopTranscriptPoller();
   stopCostReconcileService();
   stopRestartAnnouncer();
+  stopBeadsRollupService?.();
   await stopDeaconChild().catch((err) => console.warn('[deacon-supervisor] child shutdown failed:', err));
   await Effect.runPromise(flushAllPendingAutoCommits()).catch((err) => console.warn('[pan-dir/auto-commit] shutdown flush failed:', err));
   await stopConversationSearchWatcher().catch((err) => console.warn('[conversation-search] watcher shutdown failed:', err));

--- a/src/dashboard/server/main.ts
+++ b/src/dashboard/server/main.ts
@@ -485,8 +485,6 @@ console.log(conversationSearchWatcher
   ? '[overdeck] Conversation search watcher started'
   : '[overdeck] Conversation search watcher skipped (conversationSearch.enabled=false)');
 
-let stopBeadsRollupService: (() => void) | undefined;
-
 void (async () => {
   const store = await initEventStore();
   const beadsSync = createBeadsSyncService({

--- a/src/dashboard/server/main.ts
+++ b/src/dashboard/server/main.ts
@@ -15,8 +15,8 @@ import { startSharedIssueService, getSharedIssueService } from './services/issue
 import { startAgentEnrichmentService, stopAgentEnrichmentService } from './services/agent-enrichment-service.js';
 import { startMergeBlockerReconcileService } from './services/merge-blocker-reconcile-service.js';
 import { startAgentOutputService, stopAgentOutputService } from './services/agent-output-service.js';
-import { createBeadsRollupService } from './services/beads-rollup-service.js';
 import { createBeadsSyncService } from './services/beads-sync-service.js';
+import { startBeadsRollupService, stopBeadsRollupService } from './services/beads-rollup-singleton.js';
 import { startConversationLifecycleService, stopConversationLifecycleService } from './services/conversation-lifecycle.js';
 import { startRestartAnnouncer, stopRestartAnnouncer } from './services/restart-announcer.js';
 import { startSubstrateBugPoller, stopSubstrateBugPoller } from './services/substrate-bug-poller.js';
@@ -495,11 +495,9 @@ void (async () => {
   void beadsSync.run().catch((err) => console.warn('[beads-sync] service stopped:', err?.message ?? err));
   console.log('[overdeck] BeadsSyncService started');
 
-  const beadsRollup = createBeadsRollupService({
+  startBeadsRollupService({
     subscribe: (listener) => store.subscribe((event) => listener(event as any)),
   });
-  beadsRollup.start();
-  stopBeadsRollupService = beadsRollup.stop;
   console.log('[overdeck] BeadsRollupService started');
 
   store.subscribe((event) => {
@@ -582,8 +580,8 @@ const handleShutdownSignal = async (signal: NodeJS.Signals) => {
   stopTranscriptPoller();
   stopCostReconcileService();
   stopRestartAnnouncer();
-  stopBeadsRollupService?.();
-  await stopDeaconChild().catch((err) => console.warn('[deacon-supervisor] child shutdown failed:', err));
+  stopBeadsRollupService();
+  await stopDeaconChild().catch((err) => console.warn('[deacon-supervisor] child shutdown failed:', err?.message ?? err));
   await Effect.runPromise(flushAllPendingAutoCommits()).catch((err) => console.warn('[pan-dir/auto-commit] shutdown flush failed:', err));
   await stopConversationSearchWatcher().catch((err) => console.warn('[conversation-search] watcher shutdown failed:', err));
   closeConversationSearchService();

--- a/src/dashboard/server/services/__tests__/beads-rollup-service.test.ts
+++ b/src/dashboard/server/services/__tests__/beads-rollup-service.test.ts
@@ -21,6 +21,8 @@ function rollupToObject(rollup: BeadRollup) {
   };
 }
 
+const testProject = { key: 'proj', beadsCwd: '/state', issuePrefixes: ['pan'] };
+
 describe('beads rollup service', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -41,7 +43,7 @@ describe('beads rollup service', () => {
     } as BeadsReadResult<BeadRecord[]>);
 
     const service = createBeadsRollupService({
-      projects: () => [{ key: 'proj', beadsCwd: '/state' }],
+      projects: () => [testProject],
       createResolver: () => ({ getAllBeads } as any),
       now: () => Date.parse('2026-07-12T12:00:00Z'),
     });
@@ -68,7 +70,7 @@ describe('beads rollup service', () => {
     } as BeadsReadResult<BeadRecord[]>);
 
     const service = createBeadsRollupService({
-      projects: () => [{ key: 'proj', beadsCwd: '/state' }],
+      projects: () => [testProject],
       createResolver: () => ({ getAllBeads } as any),
     });
 
@@ -80,6 +82,25 @@ describe('beads rollup service', () => {
     expect(state!.rollups.has('workspace:pan-9002')).toBe(false);
   });
 
+  it('excludes non-issue labels such as vBRIEF phase labels', async () => {
+    const getAllBeads = vi.fn().mockResolvedValue({
+      ok: true,
+      value: [makeBead({ id: 'b1', labels: ['pan-9003', 'phase-1'], status: 'open' })],
+    } as BeadsReadResult<BeadRecord[]>);
+
+    const service = createBeadsRollupService({
+      projects: () => [testProject],
+      createResolver: () => ({ getAllBeads } as any),
+    });
+
+    service.start();
+    await vi.runAllTimersAsync();
+
+    const state = service.getProjectRollups('proj');
+    expect(state!.rollups.has('pan-9003')).toBe(true);
+    expect(state!.rollups.has('phase-1')).toBe(false);
+  });
+
   it('refreshes on beads.freshness_changed with a trailing-edge debounce', async () => {
     const getAllBeads = vi.fn().mockResolvedValue({
       ok: true,
@@ -88,7 +109,7 @@ describe('beads rollup service', () => {
 
     const listeners: Array<(event: { type: string; payload?: Record<string, unknown> }) => void> = [];
     const service = createBeadsRollupService({
-      projects: () => [{ key: 'proj', beadsCwd: '/state' }],
+      projects: () => [testProject],
       createResolver: () => ({ getAllBeads } as any),
       subscribe: (listener) => {
         listeners.push(listener);
@@ -131,7 +152,7 @@ describe('beads rollup service', () => {
 
     const listeners: Array<(event: { type: string; payload?: Record<string, unknown> }) => void> = [];
     const service = createBeadsRollupService({
-      projects: () => [{ key: 'proj', beadsCwd: '/state' }],
+      projects: () => [testProject],
       createResolver: () => ({ getAllBeads } as any),
       subscribe: (listener) => {
         listeners.push(listener);

--- a/src/dashboard/server/services/__tests__/beads-rollup-service.test.ts
+++ b/src/dashboard/server/services/__tests__/beads-rollup-service.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createBeadsRollupService, type BeadRollup } from '../beads-rollup-service.js';
+import type { BeadRecord, BeadsReadResult } from '../../../../lib/beads/resolver.js';
+
+function makeBead(overrides: Partial<BeadRecord> & { id: string }): BeadRecord {
+  return {
+    title: '',
+    status: 'open',
+    labels: [],
+    ...overrides,
+  };
+}
+
+function rollupToObject(rollup: BeadRollup) {
+  return {
+    total: rollup.total,
+    closed: rollup.closed,
+    inProgress: rollup.inProgress,
+    lastUpdated: rollup.lastUpdated,
+  };
+}
+
+describe('beads rollup service', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('computes rollups from one getAllBeads call and groups by issue label', async () => {
+    const getAllBeads = vi.fn().mockResolvedValue({
+      ok: true,
+      value: [
+        makeBead({ id: 'b1', labels: ['pan-9001'], status: 'closed', updated_at: '2026-07-10T00:00:00Z' }),
+        makeBead({ id: 'b2', labels: ['pan-9001'], status: 'in_progress', updated_at: '2026-07-11T00:00:00Z' }),
+        makeBead({ id: 'b3', labels: ['pan-9001'], status: 'open', updated_at: '2026-07-09T00:00:00Z' }),
+      ],
+    } as BeadsReadResult<BeadRecord[]>);
+
+    const service = createBeadsRollupService({
+      projects: () => [{ key: 'proj', beadsCwd: '/state' }],
+      createResolver: () => ({ getAllBeads } as any),
+      now: () => Date.parse('2026-07-12T12:00:00Z'),
+    });
+
+    service.start();
+    await vi.runAllTimersAsync();
+
+    expect(getAllBeads).toHaveBeenCalledTimes(1);
+    const state = service.getProjectRollups('proj');
+    expect(state).not.toBeNull();
+    expect(state!.stale).toBe(false);
+    expect(rollupToObject(state!.rollups.get('pan-9001')!)).toEqual({
+      total: 3,
+      closed: 1,
+      inProgress: 1,
+      lastUpdated: '2026-07-11T00:00:00Z',
+    });
+  });
+
+  it('maps workspace:pan-N labels to the bare issue label', async () => {
+    const getAllBeads = vi.fn().mockResolvedValue({
+      ok: true,
+      value: [makeBead({ id: 'b1', labels: ['workspace:pan-9002'], status: 'open' })],
+    } as BeadsReadResult<BeadRecord[]>);
+
+    const service = createBeadsRollupService({
+      projects: () => [{ key: 'proj', beadsCwd: '/state' }],
+      createResolver: () => ({ getAllBeads } as any),
+    });
+
+    service.start();
+    await vi.runAllTimersAsync();
+
+    const state = service.getProjectRollups('proj');
+    expect(state!.rollups.has('pan-9002')).toBe(true);
+    expect(state!.rollups.has('workspace:pan-9002')).toBe(false);
+  });
+
+  it('refreshes on beads.freshness_changed with a trailing-edge debounce', async () => {
+    const getAllBeads = vi.fn().mockResolvedValue({
+      ok: true,
+      value: [makeBead({ id: 'b1', labels: ['pan-9003'], status: 'open' })],
+    } as BeadsReadResult<BeadRecord[]>);
+
+    const listeners: Array<(event: { type: string; payload?: Record<string, unknown> }) => void> = [];
+    const service = createBeadsRollupService({
+      projects: () => [{ key: 'proj', beadsCwd: '/state' }],
+      createResolver: () => ({ getAllBeads } as any),
+      subscribe: (listener) => {
+        listeners.push(listener);
+        return () => {
+          const index = listeners.indexOf(listener);
+          if (index >= 0) listeners.splice(index, 1);
+        };
+      },
+    });
+
+    service.start();
+    await vi.runAllTimersAsync();
+    expect(getAllBeads).toHaveBeenCalledTimes(1);
+
+    for (let i = 0; i < 5; i += 1) {
+      for (const listener of listeners) {
+        listener({ type: 'beads.freshness_changed', payload: { projectKey: 'proj', localHead: 'head-' + i } });
+      }
+    }
+
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(getAllBeads).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(2);
+    expect(getAllBeads).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps previous rollups and marks stale when getAllBeads fails', async () => {
+    const getAllBeads = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        value: [makeBead({ id: 'b1', labels: ['pan-9004'], status: 'open' })],
+      } as BeadsReadResult<BeadRecord[]>)
+      .mockResolvedValueOnce({
+        ok: false,
+        reason: 'timeout',
+        transient: true,
+        error: new Error('timeout'),
+      } as BeadsReadResult<BeadRecord[]>);
+
+    const listeners: Array<(event: { type: string; payload?: Record<string, unknown> }) => void> = [];
+    const service = createBeadsRollupService({
+      projects: () => [{ key: 'proj', beadsCwd: '/state' }],
+      createResolver: () => ({ getAllBeads } as any),
+      subscribe: (listener) => {
+        listeners.push(listener);
+        return () => {
+          const index = listeners.indexOf(listener);
+          if (index >= 0) listeners.splice(index, 1);
+        };
+      },
+    });
+
+    service.start();
+    await vi.runAllTimersAsync();
+    expect(service.getProjectRollups('proj')!.stale).toBe(false);
+
+    for (const listener of listeners) {
+      listener({ type: 'beads.freshness_changed', payload: { projectKey: 'proj' } });
+    }
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    const state = service.getProjectRollups('proj');
+    expect(state!.stale).toBe(true);
+    expect(state!.rollups.get('pan-9004')!.total).toBe(1);
+  });
+
+  it('returns null for an unknown project', () => {
+    const service = createBeadsRollupService({
+      projects: () => [],
+    });
+    expect(service.getProjectRollups('unknown')).toBeNull();
+  });
+});

--- a/src/dashboard/server/services/beads-rollup-service.ts
+++ b/src/dashboard/server/services/beads-rollup-service.ts
@@ -1,0 +1,165 @@
+import { listProjectsSync } from '../../../lib/projects.js';
+import { resolveStateReadHomeSync } from '../../../lib/state-read-home.js';
+import { createBeadsResolver, type BeadRecord, type BeadsResolver } from '../../../lib/beads/resolver.js';
+
+export interface BeadRollup {
+  total: number;
+  closed: number;
+  inProgress: number;
+  lastUpdated: string | null;
+}
+
+export interface ProjectRollupState {
+  rollups: Map<string, BeadRollup>;
+  stale: boolean;
+}
+
+export interface BeadsRollupServiceDependencies {
+  projects?: () => Array<{ key: string; beadsCwd: string }>;
+  createResolver?: (beadsCwd: string) => BeadsResolver;
+  subscribe?: (listener: (event: { type: string; payload?: Record<string, unknown> }) => void) => (() => void) | void;
+  now?: () => number;
+  debounceMs?: number;
+}
+
+const DEBOUNCE_MS = 2_000;
+
+function defaultProjects() {
+  return listProjectsSync().map(({ key, config }) => ({
+    key,
+    beadsCwd: resolveStateReadHomeSync(config).root,
+  }));
+}
+
+function defaultCreateResolver(beadsCwd: string): BeadsResolver {
+  return createBeadsResolver(beadsCwd, {
+    retry: { acquisitionTimeoutMs: 5_000 },
+  });
+}
+
+function extractIssueLabels(labels: string[]): string[] {
+  const result = new Set<string>();
+  for (const label of labels) {
+    const normalized = label.toLowerCase();
+    if (/^[a-z]+-\d+$/.test(normalized)) {
+      result.add(normalized);
+    }
+    const workspaceMatch = /^workspace:([a-z]+-\d+)$/.exec(normalized);
+    if (workspaceMatch) {
+      result.add(workspaceMatch[1]!);
+    }
+  }
+  return Array.from(result);
+}
+
+function maxUpdated(a: string | null, b: string | null): string | null {
+  if (!a) return b;
+  if (!b) return a;
+  return a > b ? a : b;
+}
+
+function computeRollups(beads: BeadRecord[]): Map<string, BeadRollup> {
+  const groups = new Map<string, BeadRollup>();
+  for (const bead of beads) {
+    const issueLabels = extractIssueLabels(bead.labels);
+    if (issueLabels.length === 0) continue;
+    const status = typeof bead.status === 'string' ? bead.status.toLowerCase() : 'open';
+    const updatedAt = typeof bead.updated_at === 'string'
+      ? bead.updated_at
+      : typeof bead.updatedAt === 'string'
+        ? bead.updatedAt
+        : null;
+    for (const label of issueLabels) {
+      const existing = groups.get(label);
+      if (existing) {
+        existing.total += 1;
+        if (status === 'closed') existing.closed += 1;
+        else if (status === 'in_progress') existing.inProgress += 1;
+        existing.lastUpdated = maxUpdated(existing.lastUpdated, updatedAt);
+      } else {
+        groups.set(label, {
+          total: 1,
+          closed: status === 'closed' ? 1 : 0,
+          inProgress: status === 'in_progress' ? 1 : 0,
+          lastUpdated: updatedAt,
+        });
+      }
+    }
+  }
+  return groups;
+}
+
+export function createBeadsRollupService(dependencies: BeadsRollupServiceDependencies = {}) {
+  const projects = dependencies.projects ?? defaultProjects;
+  const createResolver = dependencies.createResolver ?? defaultCreateResolver;
+  const subscribe = dependencies.subscribe;
+  const now = dependencies.now ?? Date.now;
+  const debounceMs = dependencies.debounceMs ?? DEBOUNCE_MS;
+
+  const stateByProject = new Map<string, ProjectRollupState>();
+  const debounceTimers = new Map<string, NodeJS.Timeout>();
+  let unsubscribe: (() => void) | undefined;
+  let stopped = false;
+
+  async function refreshProject(projectKey: string, beadsCwd: string): Promise<void> {
+    const resolver = createResolver(beadsCwd);
+    const result = await resolver.getAllBeads();
+    if (result.ok) {
+      stateByProject.set(projectKey, { rollups: computeRollups(result.value), stale: false });
+    } else {
+      const previous = stateByProject.get(projectKey);
+      stateByProject.set(projectKey, {
+        rollups: previous?.rollups ?? new Map<string, BeadRollup>(),
+        stale: true,
+      });
+    }
+  }
+
+  function scheduleRefresh(projectKey: string): void {
+    const existing = debounceTimers.get(projectKey);
+    if (existing) clearTimeout(existing);
+    debounceTimers.set(
+      projectKey,
+      setTimeout(() => {
+        debounceTimers.delete(projectKey);
+        const project = projects().find((p) => p.key === projectKey);
+        if (project) {
+          void refreshProject(project.key, project.beadsCwd);
+        }
+      }, debounceMs),
+    );
+  }
+
+  function start(): void {
+    if (stopped) return;
+    for (const project of projects()) {
+      void refreshProject(project.key, project.beadsCwd);
+    }
+    if (subscribe) {
+      unsubscribe = subscribe((event) => {
+        if (event.type !== 'beads.freshness_changed') return;
+        const payload = event.payload ?? {};
+        const projectKey = typeof payload.projectKey === 'string' ? payload.projectKey : undefined;
+        if (projectKey) scheduleRefresh(projectKey);
+      }) as (() => void) | undefined;
+    }
+  }
+
+  function stop(): void {
+    stopped = true;
+    for (const timer of debounceTimers.values()) {
+      clearTimeout(timer);
+    }
+    debounceTimers.clear();
+    if (unsubscribe) {
+      unsubscribe();
+      unsubscribe = undefined;
+    }
+  }
+
+  function getProjectRollups(projectKey: string): ProjectRollupState | null {
+    return stateByProject.get(projectKey) ?? null;
+  }
+
+  return { start, stop, getProjectRollups };
+}

--- a/src/dashboard/server/services/beads-rollup-service.ts
+++ b/src/dashboard/server/services/beads-rollup-service.ts
@@ -14,8 +14,14 @@ export interface ProjectRollupState {
   stale: boolean;
 }
 
+export interface RollupProject {
+  key: string;
+  beadsCwd: string;
+  issuePrefixes: string[];
+}
+
 export interface BeadsRollupServiceDependencies {
-  projects?: () => Array<{ key: string; beadsCwd: string }>;
+  projects?: () => RollupProject[];
   createResolver?: (beadsCwd: string) => BeadsResolver;
   subscribe?: (listener: (event: { type: string; payload?: Record<string, unknown> }) => void) => (() => void) | void;
   now?: () => number;
@@ -24,10 +30,20 @@ export interface BeadsRollupServiceDependencies {
 
 const DEBOUNCE_MS = 2_000;
 
-function defaultProjects() {
+function normalizeIssuePrefixes(config: { issue_prefix?: string; issue_prefixes?: string[] }): string[] {
+  const prefixes = new Set<string>();
+  if (config.issue_prefix) prefixes.add(config.issue_prefix.toLowerCase());
+  for (const prefix of config.issue_prefixes ?? []) {
+    prefixes.add(prefix.toLowerCase());
+  }
+  return Array.from(prefixes);
+}
+
+function defaultProjects(): RollupProject[] {
   return listProjectsSync().map(({ key, config }) => ({
     key,
     beadsCwd: resolveStateReadHomeSync(config).root,
+    issuePrefixes: normalizeIssuePrefixes(config),
   }));
 }
 
@@ -37,16 +53,20 @@ function defaultCreateResolver(beadsCwd: string): BeadsResolver {
   });
 }
 
-function extractIssueLabels(labels: string[]): string[] {
+function extractIssueLabels(labels: string[], issuePrefixes: string[]): string[] {
   const result = new Set<string>();
   for (const label of labels) {
     const normalized = label.toLowerCase();
-    if (/^[a-z]+-\d+$/.test(normalized)) {
+    const bareMatch = /^([a-z]+)-(\d+)$/.exec(normalized);
+    if (bareMatch && issuePrefixes.includes(bareMatch[1]!)) {
       result.add(normalized);
     }
     const workspaceMatch = /^workspace:([a-z]+-\d+)$/.exec(normalized);
     if (workspaceMatch) {
-      result.add(workspaceMatch[1]!);
+      const wsBareMatch = /^([a-z]+)-(\d+)$/.exec(workspaceMatch[1]!);
+      if (wsBareMatch && issuePrefixes.includes(wsBareMatch[1]!)) {
+        result.add(workspaceMatch[1]!);
+      }
     }
   }
   return Array.from(result);
@@ -58,10 +78,10 @@ function maxUpdated(a: string | null, b: string | null): string | null {
   return a > b ? a : b;
 }
 
-function computeRollups(beads: BeadRecord[]): Map<string, BeadRollup> {
+function computeRollups(beads: BeadRecord[], issuePrefixes: string[]): Map<string, BeadRollup> {
   const groups = new Map<string, BeadRollup>();
   for (const bead of beads) {
-    const issueLabels = extractIssueLabels(bead.labels);
+    const issueLabels = extractIssueLabels(bead.labels, issuePrefixes);
     if (issueLabels.length === 0) continue;
     const status = typeof bead.status === 'string' ? bead.status.toLowerCase() : 'open';
     const updatedAt = typeof bead.updated_at === 'string'
@@ -101,14 +121,14 @@ export function createBeadsRollupService(dependencies: BeadsRollupServiceDepende
   let unsubscribe: (() => void) | undefined;
   let stopped = false;
 
-  async function refreshProject(projectKey: string, beadsCwd: string): Promise<void> {
-    const resolver = createResolver(beadsCwd);
+  async function refreshProject(project: RollupProject): Promise<void> {
+    const resolver = createResolver(project.beadsCwd);
     const result = await resolver.getAllBeads();
     if (result.ok) {
-      stateByProject.set(projectKey, { rollups: computeRollups(result.value), stale: false });
+      stateByProject.set(project.key, { rollups: computeRollups(result.value, project.issuePrefixes), stale: false });
     } else {
-      const previous = stateByProject.get(projectKey);
-      stateByProject.set(projectKey, {
+      const previous = stateByProject.get(project.key);
+      stateByProject.set(project.key, {
         rollups: previous?.rollups ?? new Map<string, BeadRollup>(),
         stale: true,
       });
@@ -124,7 +144,7 @@ export function createBeadsRollupService(dependencies: BeadsRollupServiceDepende
         debounceTimers.delete(projectKey);
         const project = projects().find((p) => p.key === projectKey);
         if (project) {
-          void refreshProject(project.key, project.beadsCwd);
+          void refreshProject(project);
         }
       }, debounceMs),
     );
@@ -133,7 +153,7 @@ export function createBeadsRollupService(dependencies: BeadsRollupServiceDepende
   function start(): void {
     if (stopped) return;
     for (const project of projects()) {
-      void refreshProject(project.key, project.beadsCwd);
+      void refreshProject(project);
     }
     if (subscribe) {
       unsubscribe = subscribe((event) => {

--- a/src/dashboard/server/services/beads-rollup-singleton.ts
+++ b/src/dashboard/server/services/beads-rollup-singleton.ts
@@ -1,0 +1,21 @@
+import type { BeadsRollupServiceDependencies } from './beads-rollup-service.js';
+import { createBeadsRollupService, type ProjectRollupState } from './beads-rollup-service.js';
+
+let service: ReturnType<typeof createBeadsRollupService> | null = null;
+
+export function startBeadsRollupService(dependencies: BeadsRollupServiceDependencies = {}): void {
+  if (service) return;
+  service = createBeadsRollupService(dependencies);
+  service.start();
+}
+
+export function stopBeadsRollupService(): void {
+  service?.stop();
+  service = null;
+}
+
+export function getBeadsRollupService(): { getProjectRollups(projectKey: string): ProjectRollupState | null } {
+  return service ?? {
+    getProjectRollups: () => null,
+  };
+}

--- a/src/dashboard/server/services/beads-sync-service.ts
+++ b/src/dashboard/server/services/beads-sync-service.ts
@@ -36,6 +36,7 @@ export interface BeadsSyncServiceDependencies {
   intervalMs?: number;
   withLock?: typeof withBdProcessLock;
   remoteDoltHead?: (projectPath: string) => Promise<string | null>;
+  localDoltHead?: (beadsCwd: string) => Promise<string | null>;
 }
 
 function parseHead(status: string): string | null {
@@ -62,6 +63,21 @@ async function defaultRemoteDoltHead(projectPath: string): Promise<string | null
   }
 }
 
+/**
+ * Cheap local-head probe that runs OUTSIDE the bd process lock. Combined with
+ * the remote-head probe, this lets syncOnce skip the expensive locked pull
+ * only when BOTH heads are verifiably unchanged — so a local write that moves
+ * the Dolt head still triggers a sync.
+ */
+async function defaultLocalDoltHead(beadsCwd: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('bd', ['vc', 'status'], { cwd: beadsCwd, encoding: 'utf8', timeout: 10_000 });
+    return parseHead(stdout);
+  } catch {
+    return null;
+  }
+}
+
 function defaultProjects() {
   return listProjectsSync().map(({ key, config }) => ({
     key,
@@ -80,25 +96,34 @@ export function createBeadsSyncService(dependencies: BeadsSyncServiceDependencie
   const intervalMs = dependencies.intervalMs ?? DEFAULT_INTERVAL_MS;
   const withLock = dependencies.withLock ?? withBdProcessLock;
   const remoteDoltHead = dependencies.remoteDoltHead ?? defaultRemoteDoltHead;
+  const localDoltHead = dependencies.localDoltHead ?? defaultLocalDoltHead;
   const lastRemoteHead = new Map<string, string>();
+  const lastObservedHead = new Map<string, string>();
   let stopped = false;
   let failures = 0;
 
   async function syncOnce(): Promise<void> {
     for (const project of projects()) {
       try {
-        // Skip the expensive locked pull when the remote Dolt head is
-        // verifiably unchanged. Unknown (null) fails open into the pull.
+        // Skip the expensive locked pull only when BOTH the remote Dolt head
+        // and the local Dolt head are verifiably unchanged. Unknown (null)
+        // fails open into the pull. This is what lets local writes (which
+        // advance the head before the poll) emit beads.freshness_changed.
         const remoteHead = await remoteDoltHead(project.path);
-        if (remoteHead && remoteHead === lastRemoteHead.get(project.key)) continue;
+        const localHead = await localDoltHead(project.beadsCwd);
+        const previousHead = lastObservedHead.get(project.key);
+        const remoteUnchanged = remoteHead && remoteHead === lastRemoteHead.get(project.key);
+        const localUnchanged = localHead && localHead === previousHead;
+        if (remoteUnchanged && localUnchanged) continue;
+
         await withLock('background beads pull for ' + project.key, async () => {
-          const before = parseHead(await execute(['vc', 'status'], project.beadsCwd));
           await execute(['dolt', 'pull'], project.beadsCwd);
           const after = parseHead(await execute(['vc', 'status'], project.beadsCwd));
           const lastSyncedAt = new Date(now()).toISOString();
           healthByProject.set(project.key, { localHead: after, lastSyncedAt, lastError: null });
           recordBeadsPull(project.key, after, after, new Date(lastSyncedAt));
-          if (after && after !== before) {
+          lastObservedHead.set(project.key, after);
+          if (after && previousHead !== undefined && after !== previousHead) {
             emit({
               type: 'beads.freshness_changed',
               timestamp: lastSyncedAt,

--- a/src/dashboard/server/services/resource-discovery-signals.ts
+++ b/src/dashboard/server/services/resource-discovery-signals.ts
@@ -1,0 +1,32 @@
+import type { BeadRollup } from './beads-rollup-service.js';
+
+export const RECENCY_DAYS = 14;
+const RECENCY_MS = RECENCY_DAYS * 24 * 60 * 60 * 1000;
+
+export interface BeadTotals {
+  total: number;
+  closed: number;
+  inProgress: number;
+  lastUpdated: string | null;
+}
+
+export function isWithinRecencyMs(timestamp: number): boolean {
+  return Number.isFinite(timestamp) && (Date.now() - timestamp) < RECENCY_MS;
+}
+
+export function isWithinRecencyDate(dateString: string | null): boolean {
+  if (!dateString) return false;
+  const parsed = Date.parse(dateString);
+  return Number.isFinite(parsed) && (Date.now() - parsed) < RECENCY_MS;
+}
+
+export function getBeadTotalsForIssue(issueId: string, rollups: Map<string, BeadRollup>): BeadTotals | null {
+  const rollup = rollups.get(issueId.toLowerCase());
+  if (!rollup) return null;
+  return {
+    total: rollup.total,
+    closed: rollup.closed,
+    inProgress: rollup.inProgress,
+    lastUpdated: rollup.lastUpdated,
+  };
+}

--- a/src/dashboard/server/services/resource-discovery.ts
+++ b/src/dashboard/server/services/resource-discovery.ts
@@ -434,10 +434,14 @@ async function isBranchAheadOfMain(branchName: string, projectPath: string): Pro
       timeout: 10000,
     });
     return false;
-  } catch {
-    // Non-zero exit (or any failure) means the branch is not an ancestor of main,
-    // i.e. it has unmerged work. Fail closed on errors: treat as not ahead.
-    return true;
+  } catch (err) {
+    // Exit code 1 means the branch is not an ancestor of main, i.e. it has
+    // unmerged work. Any other failure (timeout, missing ref, real error) is
+    // an error state; fail closed by treating the branch as merged.
+    if (err !== null && typeof err === 'object' && 'code' in err && err.code === 1) {
+      return true;
+    }
+    return false;
   }
 }
 
@@ -682,11 +686,11 @@ async function computeResourceAllocatedIssues(): Promise<InternalDiscoveredIssue
       issue.resourceDetails.workspaceMissing = gitInfo.workspaceMissing;
     }));
 
-    for (const branch of branches.local) {
+    await Promise.all(branches.local.map(async (branch) => {
       const issueId = parseIssueIdFromTextSync(branch);
-      if (!issueId) continue;
+      if (!issueId) return;
       const issue = ensureIssue(issueId, project);
-      if (!issue) continue;
+      if (!issue) return;
       issue.resourceSources.add('branch');
       if (!issue.resourceDetails.localBranches.includes(branch)) {
         issue.resourceDetails.localBranches.push(branch);
@@ -694,13 +698,13 @@ async function computeResourceAllocatedIssues(): Promise<InternalDiscoveredIssue
       if (await isBranchAheadOfMain(branch, projectPath)) {
         issue.resourceDetails.branchAheadOfMain = true;
       }
-    }
+    }));
 
-    for (const branch of branches.remote) {
+    await Promise.all(branches.remote.map(async (branch) => {
       const issueId = parseIssueIdFromTextSync(branch);
-      if (!issueId) continue;
+      if (!issueId) return;
       const issue = ensureIssue(issueId, project);
-      if (!issue) continue;
+      if (!issue) return;
       issue.resourceSources.add('branch');
       if (!issue.resourceDetails.remoteBranches.includes(branch)) {
         issue.resourceDetails.remoteBranches.push(branch);
@@ -708,7 +712,7 @@ async function computeResourceAllocatedIssues(): Promise<InternalDiscoveredIssue
       if (await isBranchAheadOfMain(branch, projectPath)) {
         issue.resourceDetails.branchAheadOfMain = true;
       }
-    }
+    }));
   }));
 
   for (const [issueId, prs] of pullRequests) {

--- a/src/dashboard/server/services/resource-discovery.ts
+++ b/src/dashboard/server/services/resource-discovery.ts
@@ -64,7 +64,7 @@ export interface ResourceDetails {
   /** Remote (fly.io) work agent for this issue, when one is active (PAN-1676). */
   remoteAgent: { vmName: string; status: string; model: string; startedAt: string } | null;
   /** Non-archived conversations explicitly linked to this issue. */
-  conversations: Array<{ title: string | null; status: string }>;
+  conversations: Array<{ id: number; name: string; title: string | null; status: string }>;
 }
 
 export interface ResourceDetailIdentifiers {
@@ -240,7 +240,7 @@ function summarizeResourceDetails(details: InternalResourceDetails): ResourceDet
     branchAheadOfMain: details.branchAheadOfMain,
     workspaceMissing: details.workspaceMissing,
     remoteAgent: details.remoteAgent,
-    conversations: details.conversations.map((conv) => ({ title: conv.title, status: conv.status })),
+    conversations: details.conversations.map((conv) => ({ id: conv.id, name: conv.name, title: conv.title, status: conv.status })),
   };
 }
 
@@ -945,7 +945,7 @@ export function sanitizeResourceAllocatedIssues(issues: ResourceAllocatedIssue[]
       branchAheadOfMain: issue.resourceDetails.branchAheadOfMain,
       workspaceMissing: issue.resourceDetails.workspaceMissing,
       remoteAgent: issue.resourceDetails.remoteAgent ?? null,
-      conversations: issue.resourceDetails.conversations.map((conv) => ({ title: conv.title, status: conv.status })),
+      conversations: issue.resourceDetails.conversations.map((conv) => ({ id: conv.id, name: conv.name, title: conv.title, status: conv.status })),
     },
   }));
 }

--- a/src/dashboard/server/services/resource-discovery.ts
+++ b/src/dashboard/server/services/resource-discovery.ts
@@ -425,7 +425,6 @@ async function loadProjectBranches(projectPath: string): Promise<{ local: string
     return { local: [], remote: [] };
   }
 }
-
 async function loadBranchesAheadOfMain(projectPath: string): Promise<Set<string>> {
   const ahead = new Set<string>();
   const run = async (patterns: string[]) => {
@@ -441,7 +440,7 @@ async function loadBranchesAheadOfMain(projectPath: string): Promise<Set<string>
         if (branch) ahead.add(branch);
       }
     } catch {
-      // ignore: fail closed by treating all branches as merged
+      // fail closed by treating all branches as merged
     }
   };
   await Promise.all([

--- a/src/dashboard/server/services/resource-discovery.ts
+++ b/src/dashboard/server/services/resource-discovery.ts
@@ -1,8 +1,16 @@
 import { execFile } from 'node:child_process';
-import { readdir } from 'node:fs/promises';
+import { readdir, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { Effect } from 'effect';
+
+import type { BeadTotals } from './resource-discovery-signals.js';
+import {
+  getBeadTotalsForIssue,
+  isWithinRecencyDate,
+  isWithinRecencyMs,
+} from './resource-discovery-signals.js';
+import { getBeadsRollupService } from './beads-rollup-singleton.js';
 
 import { getAgentRuntimeState } from '../../../lib/agents.js';
 import { listConversations, type LegacyConversation as Conversation } from '../../../lib/overdeck/conversations.js';
@@ -22,6 +30,9 @@ import { parseIssueIdFromTextSync } from '../../../lib/resource-utils.js';
 const execFileAsync = promisify(execFile);
 const RESOURCE_DISCOVERY_TTL_MS = 30_000;
 const RECENT_ACTIVITY_WINDOW_MS = 5_000;
+
+export { RECENCY_DAYS } from './resource-discovery-signals.js';
+export type { BeadTotals } from './resource-discovery-signals.js';
 
 export type ResourceSource = 'tracker' | 'tmux' | 'workspace' | 'branch' | 'pr' | 'vbrief' | 'beads' | 'docker' | 'remote-agent' | 'conversation';
 
@@ -90,6 +101,7 @@ export interface ResourceAllocatedIssue {
   rawTrackerState?: string;
   resourceSources: ResourceSource[];
   resourceDetails: ResourceDetails;
+  beadTotals: BeadTotals | null;
 }
 
 interface InternalResourceDetails {
@@ -99,6 +111,7 @@ interface InternalResourceDetails {
   remoteBranches: string[];
   prs: GhPullRequest[];
   vbriefPath: string | null;
+  vbriefMtime: number | null;
   beadsPath: string | null;
   dockerContainers: string[];
   actualBranch: string | null;
@@ -126,6 +139,7 @@ interface MutableResourceIssue {
   lastActivity: number | null;
   resourceSources: Set<ResourceSource>;
   resourceDetails: InternalResourceDetails;
+  beadTotals: BeadTotals | null;
 }
 
 interface InternalDiscoveredIssue extends Omit<ResourceAllocatedIssue, 'resourceSources' | 'resourceDetails'> {
@@ -434,6 +448,7 @@ interface WorkspaceScanResult {
   hasState: boolean;
   hasVbrief: boolean;
   vbriefPath: string | null;
+  vbriefMtime: number | null;
   hasBeads: boolean;
 }
 
@@ -454,6 +469,15 @@ async function scanWorkspace(
     ? await Effect.runPromise(findSpecByIssue(projectRoot, issueId)).catch(() => null)
     : null;
   const vbriefPath = specEntry ? specEntry.path : null;
+  let vbriefMtime: number | null = null;
+  if (vbriefPath) {
+    try {
+      const stats = await stat(vbriefPath);
+      vbriefMtime = stats.mtimeMs;
+    } catch {
+      vbriefMtime = null;
+    }
+  }
 
   return {
     workspacePath,
@@ -462,6 +486,7 @@ async function scanWorkspace(
     hasState: panEntries.has(PAN_CONTINUE_FILENAME),
     hasVbrief: vbriefPath !== null,
     vbriefPath,
+    vbriefMtime,
     hasBeads: issueId !== null && beadsPresence.set.has(issueId),
   };
 }
@@ -531,6 +556,7 @@ async function computeResourceAllocatedIssues(): Promise<InternalDiscoveredIssue
         remoteBranches: [],
         prs: [],
         vbriefPath: null,
+        vbriefMtime: null,
         beadsPath: null,
         dockerContainers: [],
         actualBranch: null,
@@ -540,6 +566,7 @@ async function computeResourceAllocatedIssues(): Promise<InternalDiscoveredIssue
         remoteAgent: null,
         conversations: [],
       },
+      beadTotals: null,
     };
     issueMap.set(upper, created);
     return created;
@@ -643,6 +670,7 @@ async function computeResourceAllocatedIssues(): Promise<InternalDiscoveredIssue
       if (workspace.vbriefPath) {
         issue.resourceSources.add('vbrief');
         issue.resourceDetails.vbriefPath = workspace.vbriefPath;
+        issue.resourceDetails.vbriefMtime = workspace.vbriefMtime;
       }
       if (workspace.hasBeads) {
         issue.resourceSources.add('beads');
@@ -727,6 +755,25 @@ async function computeResourceAllocatedIssues(): Promise<InternalDiscoveredIssue
     }
   }
 
+  // PAN-2602: bead rollups give a second signal for issues that have bead work in
+  // flight even when the tracker label is stale or missing. Load the cached rollup
+  // state once per discovery pass and attach totals to each issue.
+  const beadsRollupService = getBeadsRollupService();
+  const projectKeyByName = new Map<string, string>();
+  for (const project of projects) {
+    projectKeyByName.set(project.config.name ?? project.key, project.key);
+  }
+  const getIssueBeadTotals = (issue: MutableResourceIssue): BeadTotals | null => {
+    const projectKey = projectKeyByName.get(issue.projectName);
+    if (!projectKey) return null;
+    const state = beadsRollupService.getProjectRollups(projectKey);
+    if (!state) return null;
+    return getBeadTotalsForIssue(issue.issueId, state.rollups);
+  };
+  for (const issue of issueMap.values()) {
+    issue.beadTotals = getIssueBeadTotals(issue);
+  }
+
   // PRD acceptance (PAN-862): the tree shows ONLY issues with real in-flight work.
   // PAN-1966 (durable-signal membership): an active tracker LABEL is NOT sufficient
   // on its own — labels drift (an issue can stay `in-progress`/`in-review` after its
@@ -739,6 +786,9 @@ async function computeResourceAllocatedIssues(): Promise<InternalDiscoveredIssue
   // PAN-2054: a CLOSED/done/canceled issue is terminal — the operator (or close-out)
   // has declared it finished. Any workspace, feature branch, or *paused* work-agent
   // tmux session left behind is stale close-out residue, not active pipeline work.
+  // PAN-2602 (pipeline-signal-union): non-terminal issues also qualify when they have
+  // a branch ahead of main, an active linked conversation, recently-active partial
+  // bead completion, beads currently in progress, or a recently-touched vBRIEF spec.
   const discoveredIssues = [...issueMap.values()]
     .filter((issue) => issue.resourceSources.size > 0)
     // PAN-2054: drop terminal (closed/done/canceled) issues from the active resource
@@ -748,12 +798,40 @@ async function computeResourceAllocatedIssues(): Promise<InternalDiscoveredIssue
     // (isLiveResource → true) lingers forever as "merged — awaiting close-out". An
     // OPEN PR is the one terminal-state case that still warrants attention.
     .filter((issue) => !isTerminalTrackerState(issue.trackerState) || hasOpenPr(issue))
-    .filter(
-      (issue) =>
-        issue.readyForMerge
-        || isLiveResource(issue)
-        || (isActiveTrackerState(issue.trackerState) && issue.branch != null),
-    )
+    .filter((issue) => {
+      if (issue.readyForMerge) return true;
+      if (isLiveResource(issue)) return true;
+      if (isActiveTrackerState(issue.trackerState) && issue.branch != null) return true;
+
+      // New PAN-2602 signals are gated on non-terminal tracker state so the
+      // PAN-2054 exclusion above remains authoritative.
+      if (!isTerminalTrackerState(issue.trackerState)) {
+        if (issue.resourceDetails.branchAheadOfMain) return true;
+        if (issue.resourceSources.has('conversation')) return true;
+
+        const beadTotals = issue.beadTotals;
+        if (beadTotals) {
+          if (
+            beadTotals.closed > 0
+            && beadTotals.closed < beadTotals.total
+            && isWithinRecencyDate(beadTotals.lastUpdated)
+          ) {
+            return true;
+          }
+          if (beadTotals.inProgress > 0) return true;
+        }
+
+        if (
+          issue.resourceSources.has('vbrief')
+          && issue.resourceDetails.vbriefMtime !== null
+          && isWithinRecencyMs(issue.resourceDetails.vbriefMtime)
+        ) {
+          return true;
+        }
+      }
+
+      return false;
+    })
     .map((issue) => {
         const hasTmux = issue.resourceDetails.tmuxSessions.length > 0;
         const hasRecentHeartbeat = hasRecentActivity(issue.lastActivity);
@@ -786,6 +864,7 @@ async function computeResourceAllocatedIssues(): Promise<InternalDiscoveredIssue
           rawTrackerState: issue.rawTrackerState,
           resourceSources: new Set([...issue.resourceSources].sort()),
           resourceDetails: issue.resourceDetails,
+          beadTotals: issue.beadTotals,
         } satisfies InternalDiscoveredIssue;
       });
 

--- a/src/dashboard/server/services/resource-discovery.ts
+++ b/src/dashboard/server/services/resource-discovery.ts
@@ -426,23 +426,29 @@ async function loadProjectBranches(projectPath: string): Promise<{ local: string
   }
 }
 
-async function isBranchAheadOfMain(branchName: string, projectPath: string): Promise<boolean> {
-  try {
-    await execFileAsync('git', ['merge-base', '--is-ancestor', branchName, 'main'], {
-      cwd: projectPath,
-      encoding: 'utf-8',
-      timeout: 10000,
-    });
-    return false;
-  } catch (err) {
-    // Exit code 1 means the branch is not an ancestor of main, i.e. it has
-    // unmerged work. Any other failure (timeout, missing ref, real error) is
-    // an error state; fail closed by treating the branch as merged.
-    if (err !== null && typeof err === 'object' && 'code' in err && err.code === 1) {
-      return true;
+async function loadBranchesAheadOfMain(projectPath: string): Promise<Set<string>> {
+  const ahead = new Set<string>();
+  const run = async (patterns: string[]) => {
+    if (patterns.length === 0) return;
+    try {
+      const { stdout } = await execFileAsync('git', ['for-each-ref', '--format=%(refname:short)', ...patterns, '--no-merged=main'], {
+        cwd: projectPath,
+        encoding: 'utf-8',
+        timeout: 10000,
+      });
+      for (const line of stdout.split('\n')) {
+        const branch = line.trim();
+        if (branch) ahead.add(branch);
+      }
+    } catch {
+      // ignore: fail closed by treating all branches as merged
     }
-    return false;
-  }
+  };
+  await Promise.all([
+    run(['refs/heads/feature/*', 'refs/heads/bypass/*']),
+    run(['refs/remotes/origin/feature/*', 'refs/remotes/origin/bypass/*']),
+  ]);
+  return ahead;
 }
 
 interface WorkspaceScanResult {
@@ -659,6 +665,7 @@ async function computeResourceAllocatedIssues(): Promise<InternalDiscoveredIssue
       loadProjectBranches(projectPath),
       readIssuesWithBeads(projectPath),
     ]);
+    const aheadBranches = await loadBranchesAheadOfMain(projectPath);
 
     await Promise.all(workspaceEntries.map(async (entry) => {
       if (!entry.isDirectory() || !entry.name.startsWith('feature-')) return;
@@ -686,33 +693,22 @@ async function computeResourceAllocatedIssues(): Promise<InternalDiscoveredIssue
       issue.resourceDetails.workspaceMissing = gitInfo.workspaceMissing;
     }));
 
-    await Promise.all(branches.local.map(async (branch) => {
+    for (const [branch, key] of [
+      ...branches.local.map((b) => [b, 'localBranches'] as const),
+      ...branches.remote.map((b) => [b, 'remoteBranches'] as const),
+    ]) {
       const issueId = parseIssueIdFromTextSync(branch);
-      if (!issueId) return;
+      if (!issueId) continue;
       const issue = ensureIssue(issueId, project);
-      if (!issue) return;
+      if (!issue) continue;
       issue.resourceSources.add('branch');
-      if (!issue.resourceDetails.localBranches.includes(branch)) {
-        issue.resourceDetails.localBranches.push(branch);
+      if (!issue.resourceDetails[key].includes(branch)) {
+        issue.resourceDetails[key].push(branch);
       }
-      if (await isBranchAheadOfMain(branch, projectPath)) {
+      if (aheadBranches.has(branch)) {
         issue.resourceDetails.branchAheadOfMain = true;
       }
-    }));
-
-    await Promise.all(branches.remote.map(async (branch) => {
-      const issueId = parseIssueIdFromTextSync(branch);
-      if (!issueId) return;
-      const issue = ensureIssue(issueId, project);
-      if (!issue) return;
-      issue.resourceSources.add('branch');
-      if (!issue.resourceDetails.remoteBranches.includes(branch)) {
-        issue.resourceDetails.remoteBranches.push(branch);
-      }
-      if (await isBranchAheadOfMain(branch, projectPath)) {
-        issue.resourceDetails.branchAheadOfMain = true;
-      }
-    }));
+    }
   }));
 
   for (const [issueId, prs] of pullRequests) {

--- a/src/dashboard/server/services/resource-discovery.ts
+++ b/src/dashboard/server/services/resource-discovery.ts
@@ -45,6 +45,8 @@ export interface ResourceDetails {
   actualBranch: string | null;
   /** True when the workspace HEAD differs from the expected feature/<id> branch. */
   branchDrifted: boolean;
+  /** True when a feature/* or bypass/* branch for the issue has unmerged commits not on main. */
+  branchAheadOfMain: boolean;
   /** True when the workspace path is configured but missing on disk. */
   workspaceMissing: boolean;
   /** Remote (fly.io) work agent for this issue, when one is active (PAN-1676). */
@@ -98,6 +100,7 @@ interface InternalResourceDetails {
   dockerContainers: string[];
   actualBranch: string | null;
   branchDrifted: boolean;
+  branchAheadOfMain: boolean;
   workspaceMissing: boolean;
   remoteAgent: { vmName: string; status: string; model: string; startedAt: string } | null;
 }
@@ -216,6 +219,7 @@ function summarizeResourceDetails(details: InternalResourceDetails): ResourceDet
     dockerContainerCount: details.dockerContainers.length,
     actualBranch: details.actualBranch,
     branchDrifted: details.branchDrifted,
+    branchAheadOfMain: details.branchAheadOfMain,
     workspaceMissing: details.workspaceMissing,
     remoteAgent: details.remoteAgent,
   };
@@ -357,7 +361,7 @@ async function loadOpenPullRequests(): Promise<Map<string, GhPullRequest[]>> {
 
 async function loadProjectBranches(projectPath: string): Promise<{ local: string[]; remote: string[] }> {
   try {
-    const [localResult, remoteResult] = await Promise.all([
+    const [localFeature, remoteFeature, localBypass, remoteBypass] = await Promise.all([
       execFileAsync('git', ['for-each-ref', 'refs/heads/feature/*', '--format=%(refname:short)'], {
         cwd: projectPath,
         encoding: 'utf-8',
@@ -368,14 +372,45 @@ async function loadProjectBranches(projectPath: string): Promise<{ local: string
         encoding: 'utf-8',
         timeout: 10000,
       }).catch(() => ({ stdout: '' })),
+      execFileAsync('git', ['for-each-ref', 'refs/heads/bypass/*', '--format=%(refname:short)'], {
+        cwd: projectPath,
+        encoding: 'utf-8',
+        timeout: 10000,
+      }).catch(() => ({ stdout: '' })),
+      execFileAsync('git', ['for-each-ref', 'refs/remotes/origin/bypass/*', '--format=%(refname:short)'], {
+        cwd: projectPath,
+        encoding: 'utf-8',
+        timeout: 10000,
+      }).catch(() => ({ stdout: '' })),
     ]);
 
     return {
-      local: localResult.stdout.split('\n').map((line) => line.trim()).filter(Boolean),
-      remote: remoteResult.stdout.split('\n').map((line) => line.trim()).filter(Boolean),
+      local: [
+        ...localFeature.stdout.split('\n').map((line) => line.trim()).filter(Boolean),
+        ...localBypass.stdout.split('\n').map((line) => line.trim()).filter(Boolean),
+      ],
+      remote: [
+        ...remoteFeature.stdout.split('\n').map((line) => line.trim()).filter(Boolean),
+        ...remoteBypass.stdout.split('\n').map((line) => line.trim()).filter(Boolean),
+      ],
     };
   } catch {
     return { local: [], remote: [] };
+  }
+}
+
+async function isBranchAheadOfMain(branchName: string, projectPath: string): Promise<boolean> {
+  try {
+    await execFileAsync('git', ['merge-base', '--is-ancestor', branchName, 'main'], {
+      cwd: projectPath,
+      encoding: 'utf-8',
+      timeout: 10000,
+    });
+    return false;
+  } catch {
+    // Non-zero exit (or any failure) means the branch is not an ancestor of main,
+    // i.e. it has unmerged work. Fail closed on errors: treat as not ahead.
+    return true;
   }
 }
 
@@ -487,6 +522,7 @@ async function computeResourceAllocatedIssues(): Promise<InternalDiscoveredIssue
         dockerContainers: [],
         actualBranch: null,
         branchDrifted: false,
+        branchAheadOfMain: false,
         workspaceMissing: false,
         remoteAgent: null,
       },
@@ -595,6 +631,9 @@ async function computeResourceAllocatedIssues(): Promise<InternalDiscoveredIssue
       if (!issue.resourceDetails.localBranches.includes(branch)) {
         issue.resourceDetails.localBranches.push(branch);
       }
+      if (await isBranchAheadOfMain(branch, projectPath)) {
+        issue.resourceDetails.branchAheadOfMain = true;
+      }
     }
 
     for (const branch of branches.remote) {
@@ -605,6 +644,9 @@ async function computeResourceAllocatedIssues(): Promise<InternalDiscoveredIssue
       issue.resourceSources.add('branch');
       if (!issue.resourceDetails.remoteBranches.includes(branch)) {
         issue.resourceDetails.remoteBranches.push(branch);
+      }
+      if (await isBranchAheadOfMain(branch, projectPath)) {
+        issue.resourceDetails.branchAheadOfMain = true;
       }
     }
   }));
@@ -789,6 +831,7 @@ export function sanitizeResourceAllocatedIssues(issues: ResourceAllocatedIssue[]
       dockerContainerCount: issue.resourceDetails.dockerContainerCount,
       actualBranch: issue.resourceDetails.actualBranch,
       branchDrifted: issue.resourceDetails.branchDrifted,
+      branchAheadOfMain: issue.resourceDetails.branchAheadOfMain,
       workspaceMissing: issue.resourceDetails.workspaceMissing,
       remoteAgent: issue.resourceDetails.remoteAgent ?? null,
     },

--- a/src/dashboard/server/services/resource-discovery.ts
+++ b/src/dashboard/server/services/resource-discovery.ts
@@ -5,6 +5,7 @@ import { promisify } from 'node:util';
 import { Effect } from 'effect';
 
 import { getAgentRuntimeState } from '../../../lib/agents.js';
+import { listConversations, type LegacyConversation as Conversation } from '../../../lib/overdeck/conversations.js';
 import {
   PAN_CONTINUE_FILENAME,
   PAN_DIRNAME,
@@ -22,7 +23,7 @@ const execFileAsync = promisify(execFile);
 const RESOURCE_DISCOVERY_TTL_MS = 30_000;
 const RECENT_ACTIVITY_WINDOW_MS = 5_000;
 
-export type ResourceSource = 'tracker' | 'tmux' | 'workspace' | 'branch' | 'pr' | 'vbrief' | 'beads' | 'docker' | 'remote-agent';
+export type ResourceSource = 'tracker' | 'tmux' | 'workspace' | 'branch' | 'pr' | 'vbrief' | 'beads' | 'docker' | 'remote-agent' | 'conversation';
 
 export interface ResourcePullRequest {
   number: number;
@@ -51,6 +52,8 @@ export interface ResourceDetails {
   workspaceMissing: boolean;
   /** Remote (fly.io) work agent for this issue, when one is active (PAN-1676). */
   remoteAgent: { vmName: string; status: string; model: string; startedAt: string } | null;
+  /** Non-archived conversations explicitly linked to this issue. */
+  conversations: Array<{ title: string | null; status: string }>;
 }
 
 export interface ResourceDetailIdentifiers {
@@ -103,6 +106,7 @@ interface InternalResourceDetails {
   branchAheadOfMain: boolean;
   workspaceMissing: boolean;
   remoteAgent: { vmName: string; status: string; model: string; startedAt: string } | null;
+  conversations: Array<{ id: number; name: string; title: string | null; status: string; tmuxSession: string | null }>;
 }
 
 interface MutableResourceIssue {
@@ -222,6 +226,7 @@ function summarizeResourceDetails(details: InternalResourceDetails): ResourceDet
     branchAheadOfMain: details.branchAheadOfMain,
     workspaceMissing: details.workspaceMissing,
     remoteAgent: details.remoteAgent,
+    conversations: details.conversations.map((conv) => ({ title: conv.title, status: conv.status })),
   };
 }
 
@@ -304,6 +309,14 @@ async function loadTrackerIssues(): Promise<Map<string, TrackerIssueRecord>> {
 async function loadTmuxSessions(): Promise<string[]> {
   try {
     return (await Effect.runPromise(listSessionNames())).map((name) => name.trim()).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function loadConversations(): Conversation[] {
+  try {
+    return listConversations();
   } catch {
     return [];
   }
@@ -525,6 +538,7 @@ async function computeResourceAllocatedIssues(): Promise<InternalDiscoveredIssue
         branchAheadOfMain: false,
         workspaceMissing: false,
         remoteAgent: null,
+        conversations: [],
       },
     };
     issueMap.set(upper, created);
@@ -553,6 +567,24 @@ async function computeResourceAllocatedIssues(): Promise<InternalDiscoveredIssue
     if (!issue.resourceDetails.tmuxSessions.includes(sessionName)) {
       issue.resourceDetails.tmuxSessions.push(sessionName);
     }
+  }
+
+  // Non-archived conversations explicitly linked to an issue are a distinct
+  // resource signal from tmux/agent sessions (PAN-2602). They indicate active
+  // operator attention even when no agent session is running.
+  const conversations = loadConversations();
+  for (const conv of conversations) {
+    if (!conv.issueId || conv.archivedAt) continue;
+    const issue = ensureIssue(conv.issueId);
+    if (!issue) continue;
+    issue.resourceSources.add('conversation');
+    issue.resourceDetails.conversations.push({
+      id: conv.id,
+      name: conv.name,
+      title: conv.title,
+      status: conv.status,
+      tmuxSession: conv.tmuxSession,
+    });
   }
 
   // Remote (fly.io) work agents have no local tmux session — surface them
@@ -834,6 +866,7 @@ export function sanitizeResourceAllocatedIssues(issues: ResourceAllocatedIssue[]
       branchAheadOfMain: issue.resourceDetails.branchAheadOfMain,
       workspaceMissing: issue.resourceDetails.workspaceMissing,
       remoteAgent: issue.resourceDetails.remoteAgent ?? null,
+      conversations: issue.resourceDetails.conversations.map((conv) => ({ title: conv.title, status: conv.status })),
     },
   }));
 }

--- a/src/lib/cloister/merge-agent.ts
+++ b/src/lib/cloister/merge-agent.ts
@@ -447,6 +447,18 @@ export async function postMergeLifecycle(
       console.warn(`[merge-agent] Beads compaction failed: ${err}`);
     }
 
+    // 2b. Sweep any remaining open beads (backstop for bypass/admin merges that skip verification).
+    try {
+      const { sweepOrphanedBeads } = await import('../lifecycle/orphaned-beads-sweep.js');
+      const sweepResult = await sweepOrphanedBeads({ beadsCwd: projectPath, issueId, reason: 'issue merged; remaining open beads swept' });
+      if (sweepResult.ok && sweepResult.closedIds.length > 0) {
+        console.log(`[merge-agent] ✓ Swept ${sweepResult.closedIds.length} open bead(s) for ${issueId}`);
+        logActivity('beads_sweep_complete', `Swept ${sweepResult.closedIds.length} open bead(s) for ${issueId}`);
+      }
+    } catch (err) {
+      console.warn(`[merge-agent] Beads sweep failed: ${err}`);
+    }
+
     // 3. Pause work/planning agents and kill their tmux panes to free resources.
     try {
       const { setAgentPaused, getAgentState } = await import('../agents.js');

--- a/src/lib/cloister/verification-runner.ts
+++ b/src/lib/cloister/verification-runner.ts
@@ -23,6 +23,7 @@ import { messageAgent, setAgentPaused, stopAgent } from '../agents.js';
 import { findProjectByPathSync } from '../projects.js';
 import { getVBriefACStatusSync } from '../vbrief/beads.js';
 import { VBriefMergeConflictError } from '../vbrief/io.js';
+import { checkOpenBeadsPromise } from '../work/done-preflight.js';
 import type { TemplatePlaceholders } from '../workspace-config.js';
 
 const execAsync = promisify(exec);
@@ -642,6 +643,51 @@ async function runVerificationForIssuePromise(
         }
       } catch (feedbackErr: any) {
         console.error(`[${logPrefix}] Failed to write AC verification feedback for ${issueId}:`, feedbackErr);
+      }
+
+      return { outcome: 'failed', failedCheck, cycleCount: newCycleCount, maxCycles: VERIFICATION_MAX_CYCLES };
+    }
+
+    // Open-beads gate: a terminal issue must not carry open beads. Fail closed
+    // if the canonical resolver cannot answer (PAN-1812).
+    const openBeadsBlockers = await checkOpenBeadsPromise(workspacePath, issueId);
+    if (openBeadsBlockers.length > 0) {
+      const newCycleCount = currentCycles + 1;
+      const failedCheck = 'open-beads';
+      const beadIds = openBeadsBlockers
+        .map((line) => line.match(/^\s+-\s+(\S+)/)?.[1])
+        .filter((id): id is string => Boolean(id));
+      const summary = `Open beads check FAILED — ${beadIds.length} open bead(s) remain:\n\n${openBeadsBlockers.join('\n')}`;
+
+      setStateDerivedVerificationFailure(issueId, failedCheck, summary, newCycleCount, currentStatus);
+      if (shouldEscalateVerificationFailure(currentStatus, failedCheck, newCycleCount)) {
+        await escalateVerificationStuck(issueId, failedCheck, newCycleCount, summary, logPrefix);
+      }
+
+      const feedbackBody = shouldEscalateVerificationFailure(currentStatus, failedCheck, newCycleCount)
+        ? `VERIFICATION STUCK for ${issueId} (attempt ${newCycleCount}/${VERIFICATION_MAX_CYCLES}):\n\nFailed check: ${failedCheck}\n\n${summary}\n\n${buildFinalFailureInstructions(issueId)}`
+        : `VERIFICATION FAILED for ${issueId} (attempt ${newCycleCount}/${VERIFICATION_MAX_CYCLES}):\n\nFailed check: ${failedCheck}\n\n${summary}\n\n## REQUIRED: Close all open beads BEFORE resubmitting\n\n1. Review the open beads listed above\n2. Complete any remaining work and close each bead with \`pan beads close <id> --reason <reason>\`\n3. Commit and push ALL changes\n4. ONLY THEN resubmit: pan review request ${issueId} -m "Closed open beads"\n\nDo NOT resubmit until all open beads are closed.`;
+
+      try {
+        const fileResult = await Effect.runPromise(writeFeedbackFile({
+          issueId,
+          workspacePath,
+          specialist: 'verification-gate',
+          outcome: 'failed',
+          summary: `Open beads check FAILED — ${beadIds.length} open bead(s) remain (attempt ${newCycleCount}/${VERIFICATION_MAX_CYCLES})`,
+          markdownBody: feedbackBody,
+        }));
+        if (fileResult.success) {
+          const msg = shouldEscalateVerificationFailure(currentStatus, failedCheck, newCycleCount)
+            ? `VERIFICATION STUCK for ${issueId}.\nFailed check: ${failedCheck} after ${newCycleCount}/${VERIFICATION_MAX_CYCLES} attempts.\n\nMUST READ: ${fileResult.filePath}\n\nYou are paused for operator intervention. Do not re-request review automatically.`
+            : `VERIFICATION FAILED for ${issueId}.\nFailed check: ${failedCheck} — ${beadIds.length} open bead(s) remain.\n\nMUST READ: ${fileResult.filePath}\n\nUse your Read tool to open this file, read every line, close all open beads with pan beads close, commit and push every change, then request a new review with pan review request. Do NOT stop at the prompt — keep working until pan review request completes successfully.`;
+          await deliverVerificationFeedback(issueId, msg, {
+            failedCheck,
+            feedbackPath: fileResult.filePath,
+          }, logPrefix);
+        }
+      } catch (feedbackErr: any) {
+        console.error(`[${logPrefix}] Failed to write open-beads verification feedback for ${issueId}:`, feedbackErr);
       }
 
       return { outcome: 'failed', failedCheck, cycleCount: newCycleCount, maxCycles: VERIFICATION_MAX_CYCLES };

--- a/src/lib/lifecycle/orphaned-beads-sweep.ts
+++ b/src/lib/lifecycle/orphaned-beads-sweep.ts
@@ -1,0 +1,82 @@
+import { createBeadsResolver } from '../beads/resolver.js';
+import { formatMutationBatchFailure, runMutationBatch } from '../beads/writer.js';
+
+export interface SweepResult {
+  ok: boolean;
+  closedIds: string[];
+  skipped: number;
+  error?: string;
+}
+
+export interface SweepOrphanedBeadsOptions {
+  beadsCwd: string;
+  issueId: string;
+  reason: string;
+  dryRun?: boolean;
+}
+
+const SWEEPABLE_STATUSES = new Set(['open', 'in_progress']);
+
+function isSweepable(status: string): boolean {
+  return SWEEPABLE_STATUSES.has(status);
+}
+
+export async function sweepOrphanedBeads(options: SweepOrphanedBeadsOptions): Promise<SweepResult> {
+  const { beadsCwd, issueId, reason, dryRun } = options;
+
+  const resolver = createBeadsResolver(beadsCwd);
+  const readResult = await resolver.getBeadsForIssue(issueId);
+
+  if (!readResult.ok) {
+    return {
+      ok: false,
+      closedIds: [],
+      skipped: 0,
+      error: readResult.reason,
+    };
+  }
+
+  const beads = readResult.value;
+  const toClose = beads.filter((bead) => isSweepable(bead.status));
+  const skipped = beads.length - toClose.length;
+
+  if (toClose.length === 0) {
+    return {
+      ok: true,
+      closedIds: [],
+      skipped,
+    };
+  }
+
+  if (dryRun) {
+    return {
+      ok: true,
+      closedIds: toClose.map((bead) => bead.id),
+      skipped,
+    };
+  }
+
+  const batchResult = await runMutationBatch(
+    { project: { workspacePath: beadsCwd }, reason: `sweep orphaned beads for ${issueId}` },
+    async (client) => {
+      for (const bead of toClose) {
+        await client.mutate(['close', bead.id, '--reason', reason]);
+      }
+    },
+  );
+
+  if (!batchResult.ok) {
+    return {
+      ok: false,
+      closedIds: [],
+      skipped: 0,
+      error: formatMutationBatchFailure(batchResult),
+    };
+  }
+
+  return {
+    ok: true,
+    closedIds: toClose.map((bead) => bead.id),
+    skipped,
+  };
+}

--- a/src/lib/lifecycle/workflows.ts
+++ b/src/lib/lifecycle/workflows.ts
@@ -196,7 +196,12 @@ export function closeOut(
       ? 'issue closed (not planned); bead cancelled'
       : 'issue closed (completed); orphaned bead swept';
     const sweepResult = yield* Effect.promise(() =>
-      sweepOrphanedBeads({ beadsCwd: ctx.projectPath, issueId: ctx.issueId, reason: sweepReason }),
+      sweepOrphanedBeads({ beadsCwd: ctx.projectPath, issueId: ctx.issueId, reason: sweepReason }).catch((err) => ({
+        ok: false,
+        closedIds: [],
+        skipped: 0,
+        error: err instanceof Error ? err.message : String(err),
+      })),
     );
     if (sweepResult.ok) {
       if (sweepResult.closedIds.length > 0) {

--- a/src/lib/lifecycle/workflows.ts
+++ b/src/lib/lifecycle/workflows.ts
@@ -27,6 +27,7 @@ import { archivePlanning, findWorkspacePath } from './archive-planning.js';
 import { closeIssue, type CloseIssueOptions } from './close-issue.js';
 import { teardownWorkspace } from './teardown-workspace.js';
 import { compactBeads } from './compact-beads.js';
+import { sweepOrphanedBeads } from './orphaned-beads-sweep.js';
 import { loadCloisterConfig } from '../cloister/config.js';
 import { extractNumberSync, extractPrefixSync } from '../issue-id.js';
 import { recordFeatureRegistryLifecycle } from '../registry/feature-registry-population.js';
@@ -190,7 +191,24 @@ export function closeOut(
       return buildResult('close-out', ctx.issueId, allSteps, start);
     }
 
-    // 4+5. Teardown workspace + agent state
+    // 4. Sweep any orphaned beads before teardown removes the workspace/.beads redirect.
+    const sweepReason = opts.reason && /not\s*planned|cancelled/i.test(opts.reason)
+      ? 'issue closed (not planned); bead cancelled'
+      : 'issue closed (completed); orphaned bead swept';
+    const sweepResult = yield* Effect.promise(() =>
+      sweepOrphanedBeads({ beadsCwd: ctx.projectPath, issueId: ctx.issueId, reason: sweepReason }),
+    );
+    if (sweepResult.ok) {
+      if (sweepResult.closedIds.length > 0) {
+        allSteps.push(stepOk('close-out:sweep-orphaned-beads', [`Closed ${sweepResult.closedIds.length} orphaned bead(s); skipped ${sweepResult.skipped}`]));
+      } else {
+        allSteps.push(stepSkipped('close-out:sweep-orphaned-beads', [`No orphaned beads to sweep; skipped ${sweepResult.skipped}`]));
+      }
+    } else {
+      allSteps.push(stepSkipped('close-out:sweep-orphaned-beads', [`Bead sweep failed (non-fatal): ${sweepResult.error ?? 'unknown error'}`]));
+    }
+
+    // 5+6. Teardown workspace + agent state
     const closeOutConfig = (yield* Effect.promise(() => Effect.runPromise(loadCloisterConfig()))).close_out;
     const teardownSteps = yield* teardownWorkspace(ctx, {
       deleteWorkspace: closeOutConfig?.remove_workspace ?? false,

--- a/src/lib/overdeck/conversation-forks.ts
+++ b/src/lib/overdeck/conversation-forks.ts
@@ -8,6 +8,7 @@ import { Effect } from 'effect';
 import { HttpServerResponse } from 'effect/unstable/http';
 
 import { jsonResponse } from '../../dashboard/server/http-helpers.js';
+import { parseIssueIdSync } from '../issue-id.js';
 import {
   createConversation,
   getConversationByName,
@@ -174,6 +175,7 @@ export function buildForkRequest(params: ForkRequest): ForkRequest {
     parentConversationName: params.parentConversationName,
     sessionId: params.sessionId,
     forkMode: params.forkMode,
+    ...(params.issueId !== undefined ? { issueId: params.issueId } : {}),
     ...(params.summaryModel !== undefined ? { summaryModel: params.summaryModel } : {}),
     localSummaryOnly: params.localSummaryOnly,
     ...(params.includeThinkingInSummary !== undefined ? { includeThinkingInSummary: params.includeThinkingInSummary } : {}),
@@ -634,6 +636,14 @@ export async function handleConversationSummaryFork(
       return jsonResponse({ error: focusResult.error }, { status: 400 });
     }
     const handoffFocus = focusResult.focus;
+    const requestedIssueId = body['issueId'];
+    let explicitIssueId: string | undefined;
+    if (requestedIssueId !== undefined) {
+      if (typeof requestedIssueId !== 'string' || !parseIssueIdSync(requestedIssueId.trim())) {
+        return jsonResponse({ error: 'Invalid issueId' }, { status: 400 });
+      }
+      explicitIssueId = requestedIssueId.trim();
+    }
     const requestedHandoffAuthor = body['handoffAuthor'];
     let handoffAuthor: HandoffAuthor = 'external';
     if (requestedHandoffAuthor !== undefined) {
@@ -705,7 +715,7 @@ export async function handleConversationSummaryFork(
       name: newName,
       tmuxSession: newTmux,
       cwd: cwd || conv.cwd || process.cwd(),
-      issueId: conv.issueId ?? undefined,
+      issueId: explicitIssueId ?? conv.issueId ?? undefined,
       title: customTitle || defaultTitle,
       titleSource: 'manual',
       titleSeed: forkMode === 'plain'
@@ -723,6 +733,7 @@ export async function handleConversationSummaryFork(
       parentConversationName: conv.name,
       sessionId,
       forkMode,
+      ...(explicitIssueId !== undefined ? { issueId: explicitIssueId } : {}),
       ...(summaryModel !== undefined ? { summaryModel } : {}),
       localSummaryOnly,
       includeThinkingInSummary,

--- a/src/lib/overdeck/conversation-forks.ts
+++ b/src/lib/overdeck/conversation-forks.ts
@@ -9,6 +9,12 @@ import { HttpServerResponse } from 'effect/unstable/http';
 
 import { jsonResponse } from '../../dashboard/server/http-helpers.js';
 import { parseIssueIdSync } from '../issue-id.js';
+import { issueIdFromBranch } from '../webhook-handlers.js';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
 import {
   createConversation,
   getConversationByName,
@@ -597,6 +603,18 @@ export async function recoverStuckForks(): Promise<number> {
   return recovered;
 }
 
+async function detectIssueIdFromBranch(cwd: string): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      cwd,
+      encoding: 'utf-8',
+    });
+    return issueIdFromBranch(stdout.trim()) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function handleConversationSummaryFork(
   name: string,
   body: Record<string, unknown>,
@@ -689,6 +707,10 @@ export async function handleConversationSummaryFork(
         error: `Handoff cwd is not inside a git repository: ${effectiveCwd}. Run the handoff from a git working tree.`,
       }, { status: 400 });
     }
+    const branchIssueId =
+      explicitIssueId === undefined && conv.issueId == null
+        ? await detectIssueIdFromBranch(effectiveCwd)
+        : undefined;
     const { sessionId } = await Effect.runPromise(reserveSummaryForkSession(effectiveCwd));
     const timestamp = new Date().toISOString().slice(0, 10).replace(/-/g, '');
     const suffix = randomUUID().slice(0, 4);
@@ -715,7 +737,7 @@ export async function handleConversationSummaryFork(
       name: newName,
       tmuxSession: newTmux,
       cwd: cwd || conv.cwd || process.cwd(),
-      issueId: explicitIssueId ?? conv.issueId ?? undefined,
+      issueId: explicitIssueId ?? conv.issueId ?? branchIssueId ?? undefined,
       title: customTitle || defaultTitle,
       titleSource: 'manual',
       titleSeed: forkMode === 'plain'

--- a/src/lib/overdeck/conversations.ts
+++ b/src/lib/overdeck/conversations.ts
@@ -625,6 +625,7 @@ export interface ForkRequest {
   parentConversationName: string;
   sessionId: string;
   forkMode: 'summary' | 'plain' | 'handoff';
+  issueId?: string;
   summaryModel?: string;
   localSummaryOnly: boolean;
   includeThinkingInSummary?: boolean;

--- a/src/lib/webhook-handlers.ts
+++ b/src/lib/webhook-handlers.ts
@@ -52,7 +52,7 @@ export interface WebhookPayload {
 }
 
 export function issueIdFromBranch(ref: string): string | null {
-  const match = ref.match(/(?:feature|strike)\/([a-z]+-\d+)$/i);
+  const match = ref.match(/(?:feature|strike|bypass)\/([a-z]+-\d+)$/i);
   return match ? match[1].toUpperCase() : null;
 }
 

--- a/src/lib/work/done-preflight.ts
+++ b/src/lib/work/done-preflight.ts
@@ -52,7 +52,9 @@ async function listBeadsByStatus(
   const result = await createBeadsResolver(workspacePath).getBeadsForIssue(issueId);
   if (!result.ok) throw result.error;
   return JSON.stringify(result.value.filter((bead) => bead.status === status));
-}async function checkOpenBeadsPromise(workspacePath: string, issueId: string, preloadedBeads?: BeadRecord[] | null): Promise<string[]> {
+}
+
+export async function checkOpenBeadsPromise(workspacePath: string, issueId: string, preloadedBeads?: BeadRecord[] | null): Promise<string[]> {
   let stdout: string;
   try {
     stdout = await listBeadsByStatus(workspacePath, issueId, 'open', preloadedBeads);

--- a/sync-sources/skills/pan-handoff/SKILL.md
+++ b/sync-sources/skills/pan-handoff/SKILL.md
@@ -65,7 +65,12 @@ pan handoff source-conv --cwd /path/to/project
 pan handoff source-conv --model claude-opus-4-7 wire the Stripe webhook into checkout
 pan handoff source-conv --author external --author-model claude-haiku-4-5 cheap clean handoff
 pan handoff source-conv --author source uses-source-agent-and-pollutes-its-context
+pan handoff source-conv --issue PAN-1234 continue the API wiring
 ```
+
+## Issue association
+
+Use `--issue <id>` to attach the new conversation to a specific issue (e.g. `PAN-1234`). The flag is validated; an invalid ID rejects the request and creates no conversation. When `--issue` is omitted, the new conversation inherits the source conversation's issue association, if any.
 
 ## When to use
 

--- a/tests/cloister/verification-runner.test.ts
+++ b/tests/cloister/verification-runner.test.ts
@@ -24,6 +24,7 @@ const {
   getVBriefACStatusSyncMock,
   resolveIssueFeedbackTargetMock,
   surfaceIssueFeedbackNeedsYouMock,
+  checkOpenBeadsPromiseMock,
 } = vi.hoisted(() => ({
   execMock: vi.fn<[string, any?], Promise<{ stdout: string; stderr: string }>>()
     .mockResolvedValue({ stdout: 'Already up to date\n', stderr: '' }),
@@ -40,6 +41,7 @@ const {
   getVBriefACStatusSyncMock: vi.fn().mockReturnValue({ allCompleted: true, totalPending: 0, totalCount: 0, items: [] }),
   resolveIssueFeedbackTargetMock: vi.fn(),
   surfaceIssueFeedbackNeedsYouMock: vi.fn(),
+  checkOpenBeadsPromiseMock: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock('child_process', () => {
@@ -119,6 +121,10 @@ vi.mock('fs', async (importOriginal) => {
 vi.mock('../../src/lib/vbrief/beads.js', () => ({
   getVBriefACStatus: vi.fn().mockReturnValue(Effect.succeed({ allCompleted: true, totalPending: 0, totalCount: 0, items: [] })),
   getVBriefACStatusSync: getVBriefACStatusSyncMock,
+}));
+
+vi.mock('../../src/lib/work/done-preflight.js', () => ({
+  checkOpenBeadsPromise: checkOpenBeadsPromiseMock,
 }));
 
 // Import under test after mocks
@@ -512,6 +518,108 @@ describe('runVerificationForIssue', () => {
         'state_derived_verification_hold',
         expect.any(Object),
       );
+    });
+  });
+
+  describe('open-beads gate', () => {
+    beforeEach(() => {
+      runQualityGatesMock.mockReturnValue(Effect.succeed(makePassedResults()));
+      getVBriefACStatusSyncMock.mockReturnValue({
+        allCompleted: true,
+        totalPending: 0,
+        totalCount: 0,
+        items: [],
+      });
+    });
+
+    it('fails verification with failedCheck open-beads and names the bead ids', async () => {
+      checkOpenBeadsPromiseMock.mockResolvedValue([
+        '  Open beads (2):',
+        '    - bead-1 First open bead',
+        '    - bead-2 Second open bead',
+      ]);
+
+      const result = await Effect.runPromise(runVerificationForIssue(issueId, workspacePath, workspaceInfo, 'test'));
+
+      expect(result).toMatchObject({
+        outcome: 'failed',
+        failedCheck: 'open-beads',
+        cycleCount: 1,
+      });
+      expect(setReviewStatusMock).toHaveBeenCalledWith(
+        issueId,
+        expect.objectContaining({
+          verificationStatus: 'failed',
+          verificationNotes: expect.stringContaining('Open beads check FAILED'),
+          verificationCycleCount: 1,
+        }),
+      );
+      expect(writeFeedbackFileMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          issueId,
+          workspacePath,
+          specialist: 'verification-gate',
+          outcome: 'failed',
+          summary: expect.stringContaining('2 open bead(s) remain'),
+          markdownBody: expect.stringContaining('bead-1'),
+        })
+      );
+      expect(messageAgentMock).toHaveBeenCalledWith(
+        `agent-${issueId.toLowerCase()}`,
+        expect.stringContaining('Failed check: open-beads'),
+      );
+    });
+
+    it('fails closed when the beads read times out', async () => {
+      checkOpenBeadsPromiseMock.mockResolvedValue([
+        '  Open beads check timed out after 10s — cannot verify whether open beads exist; retry or resolve bead store lock contention',
+      ]);
+
+      const result = await Effect.runPromise(runVerificationForIssue(issueId, workspacePath, workspaceInfo, 'test'));
+
+      expect(result).toMatchObject({
+        outcome: 'failed',
+        failedCheck: 'open-beads',
+      });
+    });
+
+    it('passes when there are zero open beads', async () => {
+      checkOpenBeadsPromiseMock.mockResolvedValue([]);
+
+      const result = await Effect.runPromise(runVerificationForIssue(issueId, workspacePath, workspaceInfo, 'test'));
+
+      expect(result.outcome).toBe('passed');
+      expect(setReviewStatusMock).toHaveBeenCalledWith(
+        issueId,
+        expect.objectContaining({ verificationStatus: 'passed' }),
+      );
+    });
+
+    it('escalates to needs-you on the third consecutive open-beads failure', async () => {
+      checkOpenBeadsPromiseMock.mockResolvedValue([
+        '  Open beads (1):',
+        '    - bead-1 Stuck open bead',
+      ]);
+      getReviewStatusMock.mockReturnValue({ verificationCycleCount: VERIFICATION_MAX_CYCLES - 1 });
+
+      const result = await Effect.runPromise(runVerificationForIssue(issueId, workspacePath, workspaceInfo, 'test'));
+
+      expect(result).toMatchObject({
+        outcome: 'failed',
+        failedCheck: 'open-beads',
+        cycleCount: VERIFICATION_MAX_CYCLES,
+      });
+      expect(markWorkspaceStuckMock).toHaveBeenCalledWith(
+        issueId,
+        'verification_stuck',
+        expect.objectContaining({ failedCheck: 'open-beads' }),
+      );
+      expect(setAgentPausedMock).toHaveBeenCalledWith(
+        `agent-${issueId.toLowerCase()}`,
+        expect.stringContaining('needs-you: verification stuck'),
+        true,
+      );
+      expect(stopAgentMock).toHaveBeenCalledWith(`agent-${issueId.toLowerCase()}`);
     });
   });
 

--- a/tests/dashboard/beads-freshness.test.ts
+++ b/tests/dashboard/beads-freshness.test.ts
@@ -5,25 +5,94 @@ import { createBeadsSyncService, getBeadsSyncHealth } from '../../src/dashboard/
 describe('beads dashboard freshness', () => {
   afterEach(() => vi.useRealTimers());
 
-  it('pulls off the request path and emits only when the Dolt head advances', async () => {
+  it('emits only when the Dolt head advances across polls', async () => {
     const emit = vi.fn();
     const heads = ['a'.repeat(40), 'b'.repeat(40)];
     const execute = vi.fn(async (args: readonly string[]) => {
       if (args.join(' ') === 'vc status') return `Commit: ${heads.shift() ?? 'b'.repeat(40)}\n`;
       return '';
     });
+    const remoteDoltHead = vi.fn().mockResolvedValueOnce('remote-a').mockResolvedValueOnce('remote-b');
+    const localDoltHead = vi.fn().mockResolvedValueOnce('a'.repeat(40)).mockResolvedValueOnce('b'.repeat(40));
     const withLock = vi.fn(async (_caller, fn) => fn());
     const service = createBeadsSyncService({
-      projects: () => [{ key: 'fixture', path: '/repo', beadsCwd: '/state' }],
+      projects: () => [{ key: 'remote-advance', path: '/repo', beadsCwd: '/state' }],
       execute,
       emit,
       withLock,
+      remoteDoltHead,
+      localDoltHead,
       now: () => Date.parse('2026-07-12T12:00:00Z'),
     });
+
+    // First poll establishes the baseline; no event because there is no previous head.
     await service.syncOnce();
-    expect(execute.mock.calls.map(([args]) => args.join(' '))).toEqual(['vc status', 'dolt pull', 'vc status']);
-    expect(emit).toHaveBeenCalledWith(expect.objectContaining({ type: 'beads.freshness_changed' }));
-    expect(getBeadsSyncHealth('fixture')).toMatchObject({ lastError: null, localHead: 'b'.repeat(40) });
+    expect(emit).not.toHaveBeenCalled();
+    expect(getBeadsSyncHealth('remote-advance')).toMatchObject({ lastError: null, localHead: 'a'.repeat(40) });
+
+    // Second poll sees a remote change that pulls in a new head; event fires.
+    await service.syncOnce();
+    expect(emit).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'beads.freshness_changed',
+      payload: expect.objectContaining({ projectKey: 'remote-advance', localHead: 'b'.repeat(40) }),
+    }));
+    expect(getBeadsSyncHealth('remote-advance')).toMatchObject({ lastError: null, localHead: 'b'.repeat(40) });
+  });
+
+  it('emits when the head advanced locally before the poll', async () => {
+    const emit = vi.fn();
+    const heads = ['a'.repeat(40), 'b'.repeat(40)];
+    const execute = vi.fn(async (args: readonly string[]) => {
+      if (args.join(' ') === 'vc status') return `Commit: ${heads.shift() ?? 'b'.repeat(40)}\n`;
+      return '';
+    });
+    const remoteDoltHead = vi.fn().mockResolvedValue('remote-a');
+    const localDoltHead = vi.fn()
+      .mockResolvedValueOnce('a'.repeat(40))
+      .mockResolvedValueOnce('b'.repeat(40));
+    const withLock = vi.fn(async (_caller, fn) => fn());
+    const service = createBeadsSyncService({
+      projects: () => [{ key: 'local-advance', path: '/repo', beadsCwd: '/state' }],
+      execute,
+      emit,
+      withLock,
+      remoteDoltHead,
+      localDoltHead,
+      now: () => Date.parse('2026-07-12T12:00:00Z'),
+    });
+
+    await service.syncOnce();
+    expect(emit).not.toHaveBeenCalled();
+
+    await service.syncOnce();
+    expect(emit).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'beads.freshness_changed',
+      payload: expect.objectContaining({ projectKey: 'local-advance', localHead: 'b'.repeat(40) }),
+    }));
+  });
+
+  it('does not emit when the head is unchanged since the previous poll', async () => {
+    const emit = vi.fn();
+    const execute = vi.fn(async (args: readonly string[]) => {
+      if (args.join(' ') === 'vc status') return `Commit: ${'a'.repeat(40)}\n`;
+      return '';
+    });
+    const remoteDoltHead = vi.fn().mockResolvedValue(null);
+    const localDoltHead = vi.fn().mockResolvedValue('a'.repeat(40));
+    const withLock = vi.fn(async (_caller, fn) => fn());
+    const service = createBeadsSyncService({
+      projects: () => [{ key: 'no-movement', path: '/repo', beadsCwd: '/state' }],
+      execute,
+      emit,
+      withLock,
+      remoteDoltHead,
+      localDoltHead,
+      now: () => Date.parse('2026-07-12T12:00:00Z'),
+    });
+
+    await service.syncOnce();
+    await service.syncOnce();
+    expect(emit).not.toHaveBeenCalled();
   });
 
   it('uses fake-timer backoff and exposes a complete stale consequence on failure', async () => {

--- a/tests/unit/cli/fork-client.test.ts
+++ b/tests/unit/cli/fork-client.test.ts
@@ -87,4 +87,19 @@ describe('forkConversationViaServer', () => {
       timedOut: false,
     });
   });
+
+  it('forwards issueId in the request body when provided', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ conversation: { id: 4, name: 'issue-fork', tmuxSession: 'conv-4', forkStatus: null } }))
+      .mockResolvedValue(jsonResponse({ id: 4, name: 'issue-fork', tmuxSession: 'conv-4', forkStatus: null }));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const resultPromise = forkConversationViaServer('source', { forkMode: 'handoff', issueId: 'PAN-9005', focus: 'drive' }, { timeoutMs: 1_000, pollMs: 500 });
+    await vi.advanceTimersByTimeAsync(500);
+    await resultPromise;
+
+    const init = fetchMock.mock.calls[0][1] as { body: string };
+    const body = JSON.parse(init.body);
+    expect(body).toMatchObject({ forkMode: 'handoff', issueId: 'PAN-9005', focus: 'drive' });
+  });
 });

--- a/tests/unit/dashboard/server/routes/conversations-fork-pipeline.test.ts
+++ b/tests/unit/dashboard/server/routes/conversations-fork-pipeline.test.ts
@@ -34,7 +34,7 @@ const {
   generateSummaryForFork,
 } = await import('../../../../../src/lib/conversations/summary-fork.js');
 
-const { runForkPipeline } = forksModule;
+const { runForkPipeline, buildForkRequest } = forksModule;
 
 describe('runForkPipeline fallback resilience', () => {
   let TEST_HOME: string;
@@ -205,5 +205,26 @@ describe('runForkPipeline fallback resilience', () => {
     );
     const fork = getConversationByName('fork-conv')!;
     expect(fork.forkFallbackReason).toBeTruthy();
+  });
+});
+
+describe('buildForkRequest', () => {
+  it('carries an explicit issueId when provided', () => {
+    const req = buildForkRequest({
+      parentConversationName: 'parent',
+      sessionId: 'session-uuid',
+      forkMode: 'handoff',
+      issueId: 'PAN-2602',
+    });
+    expect(req.issueId).toBe('PAN-2602');
+  });
+
+  it('omits issueId when not provided', () => {
+    const req = buildForkRequest({
+      parentConversationName: 'parent',
+      sessionId: 'session-uuid',
+      forkMode: 'summary',
+    });
+    expect(req.issueId).toBeUndefined();
   });
 });

--- a/tests/unit/dashboard/server/services/resource-discovery.test.ts
+++ b/tests/unit/dashboard/server/services/resource-discovery.test.ts
@@ -552,7 +552,7 @@ describe('resource-discovery conversation signal', () => {
     expect(issue).toBeDefined();
     expect(issue!.resourceSources).toContain('conversation');
     expect(issue!.resourceDetails.conversations).toEqual([
-      { title: 'Conversation title', status: 'active' },
+      { id: 1, name: 'conv-pan-9003', title: 'Conversation title', status: 'active' },
     ]);
   });
 

--- a/tests/unit/dashboard/server/services/resource-discovery.test.ts
+++ b/tests/unit/dashboard/server/services/resource-discovery.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   },
   listProjectsSync: vi.fn(),
   listSessionNames: vi.fn(),
+  listConversations: vi.fn(),
   loadReadyForMergeFlags: vi.fn(),
   openPullRequests: [] as unknown[],
   resolveAgentGitInfo: vi.fn(),
@@ -45,6 +46,10 @@ vi.mock('../../../../../src/dashboard/server/services/tracker-config.js', () => 
   getGitHubConfig: mocks.getGitHubConfig,
 }));
 
+vi.mock('../../../../../src/lib/overdeck/conversations.js', () => ({
+  listConversations: mocks.listConversations,
+}));
+
 vi.mock('../../../../../src/dashboard/server/services/issue-service-singleton.js', () => ({
   getSharedIssueService: vi.fn(async () => mocks.issueService),
 }));
@@ -72,6 +77,7 @@ beforeEach(() => {
     { key: 'overdeck', config: { name: 'overdeck', path: '/tmp/overdeck', issue_prefix: 'PAN' } },
   ]);
   mocks.listSessionNames.mockReturnValue(Effect.succeed([]));
+  mocks.listConversations.mockReturnValue([]);
   mocks.openPullRequests = [];
   mocks.resolveAgentGitInfo.mockResolvedValue({
     actualBranch: null,
@@ -126,6 +132,7 @@ describe('resource-discovery grouping', () => {
           dockerContainerCount: 0,
           dockerContainerNames: [],
           branchAheadOfMain: false,
+          conversations: [],
         },
       },
       {
@@ -161,6 +168,7 @@ describe('resource-discovery grouping', () => {
           dockerContainerCount: 0,
           dockerContainerNames: [],
           branchAheadOfMain: false,
+          conversations: [],
         },
       },
       {
@@ -201,6 +209,7 @@ describe('resource-discovery grouping', () => {
           dockerContainerCount: 1,
           dockerContainerNames: ['pan-100-db'],
           branchAheadOfMain: false,
+          conversations: [],
         },
       },
     ];
@@ -253,6 +262,7 @@ describe('resource-discovery sanitization', () => {
           dockerContainerCount: 1,
           dockerContainerNames: ['pan-300-db'],
           branchAheadOfMain: false,
+          conversations: [],
         },
       },
     ]);
@@ -458,6 +468,84 @@ describe('resource-discovery branch-ahead signal', () => {
 
     const discovered = await discoverResourceAllocatedIssues();
     expect(discovered.map((entry) => entry.issueId)).toEqual([]);
+  });
+});
+
+describe('resource-discovery conversation signal', () => {
+  beforeEach(() => {
+    resetResourceAllocatedIssuesCacheForTests();
+  });
+
+  function makeConversation(overrides: Partial<{ issueId: string | null; archivedAt: string | null; status: string }>): unknown {
+    return {
+      id: 1,
+      name: 'conv-pan-9003',
+      tmuxSession: 'conv-pan-9003',
+      status: 'active',
+      cwd: '/tmp/overdeck',
+      issueId: 'PAN-9003',
+      createdAt: '2026-07-01T00:00:00Z',
+      endedAt: null,
+      lastAttachedAt: null,
+      claudeSessionId: null,
+      title: 'Conversation title',
+      titleSource: null,
+      titleSeed: null,
+      totalCost: 0,
+      totalTokens: 0,
+      archivedAt: null,
+      model: null,
+      effort: null,
+      forkStatus: null,
+      forkError: null,
+      harness: null,
+      deliveryMethod: null,
+      spawnError: null,
+      handoffDocPath: null,
+      handoffTargetConvId: null,
+      forkFallbackReason: null,
+      clearedToConvId: null,
+      forkRequest: null,
+      forkRetryCount: 0,
+      ...overrides,
+    };
+  }
+
+  it('tags a non-archived conversation with an issueId as a conversation resource source', async () => {
+    mocks.issueService.getIssues.mockReturnValue([
+      { identifier: 'PAN-9003', title: 'Conv issue', state: 'in_progress', rawTrackerState: 'In Progress' },
+    ]);
+    mocks.listConversations.mockReturnValue([makeConversation({})]);
+
+    const discovered = await discoverResourceAllocatedIssues();
+    const issue = discovered.find((entry) => entry.issueId === 'PAN-9003');
+
+    expect(issue).toBeDefined();
+    expect(issue!.resourceSources).toContain('conversation');
+    expect(issue!.resourceDetails.conversations).toEqual([
+      { title: 'Conversation title', status: 'active' },
+    ]);
+  });
+
+  it('ignores conversations with a null issueId', async () => {
+    mocks.listConversations.mockReturnValue([makeConversation({ issueId: null })]);
+
+    const discovered = await discoverResourceAllocatedIssues();
+    expect(discovered.map((entry) => entry.issueId)).toEqual([]);
+  });
+
+  it('ignores archived conversations even when they carry an issueId', async () => {
+    mocks.issueService.getIssues.mockReturnValue([
+      { identifier: 'PAN-9003', title: 'Conv issue', state: 'in_progress', rawTrackerState: 'In Progress' },
+    ]);
+    mocks.listConversations.mockReturnValue([makeConversation({ archivedAt: '2026-07-10T00:00:00Z' })]);
+
+    const discovered = await discoverResourceAllocatedIssues();
+    const issue = discovered.find((entry) => entry.issueId === 'PAN-9003');
+
+    expect(issue).toBeDefined();
+    expect(issue!.resourceSources).not.toContain('conversation');
+    expect(issue!.resourceDetails.conversations).toEqual([]);
   });
 });
 

--- a/tests/unit/dashboard/server/services/resource-discovery.test.ts
+++ b/tests/unit/dashboard/server/services/resource-discovery.test.ts
@@ -445,7 +445,9 @@ describe('resource-discovery branch-ahead signal', () => {
         if (branch === 'feature/pan-9001') {
           callback(null, { stdout: '' });
         } else {
-          callback(new Error('not an ancestor'), { stdout: '' });
+          const err = new Error('not an ancestor') as Error & { code: number };
+          err.code = 1;
+          callback(err, { stdout: '' });
         }
         return;
       }

--- a/tests/unit/dashboard/server/services/resource-discovery.test.ts
+++ b/tests/unit/dashboard/server/services/resource-discovery.test.ts
@@ -125,6 +125,7 @@ describe('resource-discovery grouping', () => {
           hasBeads: false,
           dockerContainerCount: 0,
           dockerContainerNames: [],
+          branchAheadOfMain: false,
         },
       },
       {
@@ -159,6 +160,7 @@ describe('resource-discovery grouping', () => {
           hasBeads: false,
           dockerContainerCount: 0,
           dockerContainerNames: [],
+          branchAheadOfMain: false,
         },
       },
       {
@@ -198,6 +200,7 @@ describe('resource-discovery grouping', () => {
           hasBeads: true,
           dockerContainerCount: 1,
           dockerContainerNames: ['pan-100-db'],
+          branchAheadOfMain: false,
         },
       },
     ];
@@ -249,6 +252,7 @@ describe('resource-discovery sanitization', () => {
           hasBeads: false,
           dockerContainerCount: 1,
           dockerContainerNames: ['pan-300-db'],
+          branchAheadOfMain: false,
         },
       },
     ]);
@@ -382,6 +386,78 @@ describe('resource-discovery session prefix allowlist', () => {
     expect(isDiscoverableAgentSession('conv-371')).toBe(false);
     expect(isDiscoverableAgentSession('overdeck')).toBe(false);
     expect(isDiscoverableAgentSession('0')).toBe(false);
+  });
+});
+
+describe('resource-discovery branch-ahead signal', () => {
+  beforeEach(() => {
+    resetResourceAllocatedIssuesCacheForTests();
+    mocks.execFile.mockImplementation((command: string, args: string[], _options: unknown, callback: (error: Error | null, result?: { stdout: string }) => void) => {
+      if (command === 'git' && args[0] === 'for-each-ref') {
+        const ref = args[1] ?? '';
+        if (ref.includes('feature/*')) {
+          callback(null, { stdout: 'feature/pan-9001\nfeature/pan-9002\n' });
+        } else if (ref.includes('bypass/*')) {
+          callback(null, { stdout: 'bypass/pan-9002\n' });
+        } else {
+          callback(null, { stdout: '' });
+        }
+        return;
+      }
+      if (command === 'git' && args[0] === 'merge-base') {
+        const branch = args[2];
+        // pan-9001 is fully merged into main; everything else is ahead.
+        if (branch === 'feature/pan-9001') {
+          callback(null, { stdout: '' });
+        } else {
+          callback(new Error('not an ancestor'), { stdout: '' });
+        }
+        return;
+      }
+      if (command === 'gh' && args[0] === 'pr') {
+        callback(null, { stdout: JSON.stringify(mocks.openPullRequests) });
+        return;
+      }
+      callback(null, { stdout: '' });
+    });
+  });
+
+  it('records branchAheadOfMain true for a bypass branch with unmerged work', async () => {
+    mocks.issueService.getIssues.mockReturnValue([
+      { identifier: 'PAN-9002', title: 'Bypass', state: 'in_progress', rawTrackerState: 'In Progress' },
+    ]);
+
+    const discovered = await discoverResourceAllocatedIssues();
+    const issue = discovered.find((entry) => entry.issueId === 'PAN-9002');
+
+    expect(issue).toBeDefined();
+    expect(issue!.resourceSources).toContain('branch');
+    expect(issue!.resourceDetails.branchAheadOfMain).toBe(true);
+    expect(issue!.resourceDetails.localBranchCount).toBe(2);
+  });
+
+  it('records branchAheadOfMain false for a feature branch fully merged into main', async () => {
+    mocks.issueService.getIssues.mockReturnValue([
+      { identifier: 'PAN-9001', title: 'Merged', state: 'in_progress', rawTrackerState: 'In Progress' },
+    ]);
+
+    const discovered = await discoverResourceAllocatedIssues();
+    const issue = discovered.find((entry) => entry.issueId === 'PAN-9001');
+
+    expect(issue).toBeDefined();
+    expect(issue!.resourceSources).toContain('branch');
+    expect(issue!.resourceDetails.branchAheadOfMain).toBe(false);
+  });
+
+  it('does not change the membership filter when only branch details change', async () => {
+    resetResourceAllocatedIssuesCacheForTests();
+    // Re-use the branch mock but give the issue a non-active tracker state.
+    mocks.issueService.getIssues.mockReturnValue([
+      { identifier: 'PAN-9003', title: 'Inactive with branch', state: 'open', rawTrackerState: 'OPEN' },
+    ]);
+
+    const discovered = await discoverResourceAllocatedIssues();
+    expect(discovered.map((entry) => entry.issueId)).toEqual([]);
   });
 });
 

--- a/tests/unit/dashboard/server/services/resource-discovery.test.ts
+++ b/tests/unit/dashboard/server/services/resource-discovery.test.ts
@@ -429,26 +429,24 @@ describe('resource-discovery branch-ahead signal', () => {
     resetResourceAllocatedIssuesCacheForTests();
     mocks.execFile.mockImplementation((command: string, args: string[], _options: unknown, callback: (error: Error | null, result?: { stdout: string }) => void) => {
       if (command === 'git' && args[0] === 'for-each-ref') {
-        const ref = args[1] ?? '';
-        if (ref.includes('feature/*')) {
-          callback(null, { stdout: 'feature/pan-9001\nfeature/pan-9002\nfeature/pan-9003\n' });
-        } else if (ref.includes('bypass/*')) {
-          callback(null, { stdout: 'bypass/pan-9002\n' });
-        } else {
-          callback(null, { stdout: '' });
+        const patterns = args.filter((a) => a.includes('feature/*') || a.includes('bypass/*'));
+        const isNoMerged = args.includes('--no-merged=main');
+        const hasFeature = patterns.some((p) => p.includes('feature/*'));
+        const hasBypass = patterns.some((p) => p.includes('bypass/*'));
+        const isRemote = patterns.some((p) => p.includes('refs/remotes/'));
+        const prefix = isRemote ? 'origin/' : '';
+        const branches: string[] = [];
+        if (hasFeature) {
+          if (isNoMerged) {
+            branches.push(`${prefix}feature/pan-9002`, `${prefix}feature/pan-9003`);
+          } else {
+            branches.push(`${prefix}feature/pan-9001`, `${prefix}feature/pan-9002`, `${prefix}feature/pan-9003`);
+          }
         }
-        return;
-      }
-      if (command === 'git' && args[0] === 'merge-base') {
-        const branch = args[2];
-        // pan-9001 is fully merged into main; everything else is ahead.
-        if (branch === 'feature/pan-9001') {
-          callback(null, { stdout: '' });
-        } else {
-          const err = new Error('not an ancestor') as Error & { code: number };
-          err.code = 1;
-          callback(err, { stdout: '' });
+        if (hasBypass) {
+          branches.push(`${prefix}bypass/pan-9002`);
         }
+        callback(null, { stdout: branches.join('\n') + (branches.length ? '\n' : '') });
         return;
       }
       if (command === 'gh' && args[0] === 'pr') {

--- a/tests/unit/dashboard/server/services/resource-discovery.test.ts
+++ b/tests/unit/dashboard/server/services/resource-discovery.test.ts
@@ -3,7 +3,9 @@ import { Effect } from 'effect';
 
 const mocks = vi.hoisted(() => ({
   execFile: vi.fn(),
+  findSpecByIssue: vi.fn(),
   getAgentRuntimeState: vi.fn(),
+  getBeadsRollupService: vi.fn(),
   getGitHubConfig: vi.fn(),
   issueService: {
     getIssues: vi.fn(),
@@ -13,16 +15,27 @@ const mocks = vi.hoisted(() => ({
   listConversations: vi.fn(),
   loadReadyForMergeFlags: vi.fn(),
   openPullRequests: [] as unknown[],
+  readdir: vi.fn(),
   resolveAgentGitInfo: vi.fn(),
   resolveProjectFromIssueSync: vi.fn(),
+  stat: vi.fn(),
 }));
 
 vi.mock('node:child_process', () => ({
   execFile: mocks.execFile,
 }));
 
+vi.mock('node:fs/promises', () => ({
+  readdir: mocks.readdir,
+  stat: mocks.stat,
+}));
+
 vi.mock('../../../../../src/lib/agents.js', () => ({
   getAgentRuntimeState: mocks.getAgentRuntimeState,
+}));
+
+vi.mock('../../../../../src/dashboard/server/services/beads-rollup-singleton.js', () => ({
+  getBeadsRollupService: mocks.getBeadsRollupService,
 }));
 
 vi.mock('../../../../../src/lib/projects.js', () => ({
@@ -48,6 +61,10 @@ vi.mock('../../../../../src/dashboard/server/services/tracker-config.js', () => 
 
 vi.mock('../../../../../src/lib/overdeck/conversations.js', () => ({
   listConversations: mocks.listConversations,
+}));
+
+vi.mock('../../../../../src/lib/pan-dir/specs.js', () => ({
+  findSpecByIssue: mocks.findSpecByIssue,
 }));
 
 vi.mock('../../../../../src/dashboard/server/services/issue-service-singleton.js', () => ({
@@ -79,6 +96,10 @@ beforeEach(() => {
   mocks.listSessionNames.mockReturnValue(Effect.succeed([]));
   mocks.listConversations.mockReturnValue([]);
   mocks.openPullRequests = [];
+  mocks.getBeadsRollupService.mockReturnValue({ getProjectRollups: () => null });
+  mocks.readdir.mockResolvedValue([]);
+  mocks.stat.mockRejectedValue(new Error('no such file'));
+  mocks.findSpecByIssue.mockReturnValue(Effect.fail('no spec'));
   mocks.resolveAgentGitInfo.mockResolvedValue({
     actualBranch: null,
     branchDrifted: false,
@@ -134,6 +155,7 @@ describe('resource-discovery grouping', () => {
           branchAheadOfMain: false,
           conversations: [],
         },
+        beadTotals: null,
       },
       {
         issueId: 'AAA-1',
@@ -170,6 +192,7 @@ describe('resource-discovery grouping', () => {
           branchAheadOfMain: false,
           conversations: [],
         },
+        beadTotals: null,
       },
       {
         issueId: 'PAN-100',
@@ -211,6 +234,7 @@ describe('resource-discovery grouping', () => {
           branchAheadOfMain: false,
           conversations: [],
         },
+        beadTotals: null,
       },
     ];
 
@@ -264,6 +288,7 @@ describe('resource-discovery sanitization', () => {
           branchAheadOfMain: false,
           conversations: [],
         },
+        beadTotals: null,
       },
     ]);
 
@@ -406,7 +431,7 @@ describe('resource-discovery branch-ahead signal', () => {
       if (command === 'git' && args[0] === 'for-each-ref') {
         const ref = args[1] ?? '';
         if (ref.includes('feature/*')) {
-          callback(null, { stdout: 'feature/pan-9001\nfeature/pan-9002\n' });
+          callback(null, { stdout: 'feature/pan-9001\nfeature/pan-9002\nfeature/pan-9003\n' });
         } else if (ref.includes('bypass/*')) {
           callback(null, { stdout: 'bypass/pan-9002\n' });
         } else {
@@ -459,7 +484,7 @@ describe('resource-discovery branch-ahead signal', () => {
     expect(issue!.resourceDetails.branchAheadOfMain).toBe(false);
   });
 
-  it('does not change the membership filter when only branch details change', async () => {
+  it('admits an inactive issue when a branch is ahead of main (PAN-2602)', async () => {
     resetResourceAllocatedIssuesCacheForTests();
     // Re-use the branch mock but give the issue a non-active tracker state.
     mocks.issueService.getIssues.mockReturnValue([
@@ -467,7 +492,11 @@ describe('resource-discovery branch-ahead signal', () => {
     ]);
 
     const discovered = await discoverResourceAllocatedIssues();
-    expect(discovered.map((entry) => entry.issueId)).toEqual([]);
+    const issue = discovered.find((entry) => entry.issueId === 'PAN-9003');
+
+    expect(issue).toBeDefined();
+    expect(issue!.resourceSources).toContain('branch');
+    expect(issue!.resourceDetails.branchAheadOfMain).toBe(true);
   });
 });
 
@@ -534,18 +563,132 @@ describe('resource-discovery conversation signal', () => {
     expect(discovered.map((entry) => entry.issueId)).toEqual([]);
   });
 
-  it('ignores archived conversations even when they carry an issueId', async () => {
+  it('admits an inactive issue when it has a linked conversation (PAN-2602)', async () => {
     mocks.issueService.getIssues.mockReturnValue([
-      { identifier: 'PAN-9003', title: 'Conv issue', state: 'in_progress', rawTrackerState: 'In Progress' },
+      { identifier: 'PAN-9003', title: 'Conv issue inactive', state: 'open', rawTrackerState: 'OPEN' },
     ]);
-    mocks.listConversations.mockReturnValue([makeConversation({ archivedAt: '2026-07-10T00:00:00Z' })]);
+    mocks.listConversations.mockReturnValue([makeConversation({})]);
 
     const discovered = await discoverResourceAllocatedIssues();
-    const issue = discovered.find((entry) => entry.issueId === 'PAN-9003');
 
-    expect(issue).toBeDefined();
-    expect(issue!.resourceSources).not.toContain('conversation');
-    expect(issue!.resourceDetails.conversations).toEqual([]);
+    expect(discovered.map((entry) => entry.issueId)).toEqual(['PAN-9003']);
+    expect(discovered[0]?.resourceSources).toContain('conversation');
+  });
+});
+
+describe('resource-discovery bead rollup signal', () => {
+  beforeEach(() => {
+    resetResourceAllocatedIssuesCacheForTests();
+    mocks.issueService.getIssues.mockReturnValue([
+      { identifier: 'PAN-9004', title: 'Bead rollup issue', state: 'open', rawTrackerState: 'OPEN' },
+    ]);
+  });
+
+  function setBeadRollups(
+    rollups: Record<string, { total: number; closed: number; inProgress: number; lastUpdated: string | null }>,
+  ) {
+    mocks.getBeadsRollupService.mockReturnValue({
+      getProjectRollups: () => ({ rollups: new Map(Object.entries(rollups)), stale: false }),
+    });
+  }
+
+  it('admits an inactive issue with recent partial bead completion', async () => {
+    setBeadRollups({
+      'pan-9004': { total: 3, closed: 1, inProgress: 0, lastUpdated: '2026-07-12T00:00:00Z' },
+    });
+
+    const discovered = await discoverResourceAllocatedIssues();
+
+    expect(discovered.map((entry) => entry.issueId)).toEqual(['PAN-9004']);
+    expect(discovered[0]?.beadTotals).toEqual({
+      total: 3,
+      closed: 1,
+      inProgress: 0,
+      lastUpdated: '2026-07-12T00:00:00Z',
+    });
+  });
+
+  it('excludes an inactive issue when beads are fully closed', async () => {
+    setBeadRollups({
+      'pan-9004': { total: 3, closed: 3, inProgress: 0, lastUpdated: '2026-07-12T00:00:00Z' },
+    });
+
+    const discovered = await discoverResourceAllocatedIssues();
+
+    expect(discovered.map((entry) => entry.issueId)).toEqual([]);
+  });
+
+  it('excludes an inactive issue when partial bead completion is stale', async () => {
+    setBeadRollups({
+      'pan-9004': { total: 3, closed: 1, inProgress: 0, lastUpdated: '2026-06-20T00:00:00Z' },
+    });
+
+    const discovered = await discoverResourceAllocatedIssues();
+
+    expect(discovered.map((entry) => entry.issueId)).toEqual([]);
+  });
+
+  it('admits an inactive issue with in-progress beads', async () => {
+    setBeadRollups({
+      'pan-9004': { total: 2, closed: 0, inProgress: 1, lastUpdated: '2026-06-20T00:00:00Z' },
+    });
+
+    const discovered = await discoverResourceAllocatedIssues();
+
+    expect(discovered.map((entry) => entry.issueId)).toEqual(['PAN-9004']);
+    expect(discovered[0]?.beadTotals?.inProgress).toBe(1);
+  });
+
+  it('does not admit a terminal issue even with recent partial bead completion', async () => {
+    mocks.issueService.getIssues.mockReturnValue([
+      { identifier: 'PAN-9004', title: 'Bead rollup issue', state: 'closed', rawTrackerState: 'CLOSED' },
+    ]);
+    setBeadRollups({
+      'pan-9004': { total: 3, closed: 1, inProgress: 0, lastUpdated: '2026-07-12T00:00:00Z' },
+    });
+
+    const discovered = await discoverResourceAllocatedIssues();
+
+    expect(discovered.map((entry) => entry.issueId)).toEqual([]);
+  });
+});
+
+describe('resource-discovery vbrief recency signal', () => {
+  beforeEach(() => {
+    resetResourceAllocatedIssuesCacheForTests();
+    mocks.issueService.getIssues.mockReturnValue([
+      { identifier: 'PAN-9005', title: 'Vbrief recency issue', state: 'open', rawTrackerState: 'OPEN' },
+    ]);
+    mocks.findSpecByIssue.mockReturnValue(Effect.succeed({ path: '/state/specs/pan-9005.vbrief.json' }));
+  });
+
+  it('admits an inactive issue when its vBRIEF spec was touched recently', async () => {
+    mocks.readdir.mockImplementation(async (path: string, options?: { withFileTypes?: boolean }) => {
+      if (typeof path === 'string' && path.endsWith('/workspaces') && options?.withFileTypes) {
+        return [{ name: 'feature-pan-9005', isDirectory: () => true }];
+      }
+      return [];
+    });
+    mocks.stat.mockResolvedValue({ mtimeMs: Date.parse('2026-07-12T00:00:00Z') } as any);
+
+    const discovered = await discoverResourceAllocatedIssues();
+
+    expect(discovered.map((entry) => entry.issueId)).toEqual(['PAN-9005']);
+    expect(discovered[0]?.resourceSources).toContain('vbrief');
+  });
+
+  it('excludes an inactive issue when its vBRIEF spec is stale', async () => {
+    mocks.readdir.mockImplementation(async (path: string, options?: { withFileTypes?: boolean }) => {
+      if (typeof path === 'string' && path.endsWith('/workspaces') && options?.withFileTypes) {
+        return [{ name: 'feature-pan-9005', isDirectory: () => true }];
+      }
+      return [];
+    });
+    mocks.stat.mockResolvedValue({ mtimeMs: Date.parse('2026-06-20T00:00:00Z') } as any);
+
+    const discovered = await discoverResourceAllocatedIssues();
+
+    expect(discovered.map((entry) => entry.issueId)).toEqual([]);
   });
 });
 

--- a/tests/unit/lib/cloister/postmerge-auto-retro.test.ts
+++ b/tests/unit/lib/cloister/postmerge-auto-retro.test.ts
@@ -23,6 +23,7 @@ const mockCreateResetMarker = vi.hoisted(() => vi.fn(async (input: unknown) => (
 const mockSetReviewStatusSync = vi.hoisted(() => vi.fn());
 const mockIsGitHubAppConfigured = vi.hoisted(() => vi.fn(() => false));
 const mockListPullRequestsForHead = vi.hoisted(() => vi.fn(() => Effect.succeed([])));
+const mockSweepOrphanedBeads = vi.hoisted(() => vi.fn().mockResolvedValue({ ok: true, closedIds: [], skipped: 0 }));
 const mockExec = vi.hoisted(() => vi.fn((cmd: string, optionsOrCb?: any, maybeCb?: any) => {
   const callback = typeof optionsOrCb === 'function' ? optionsOrCb : maybeCb;
   if (typeof callback === 'function') {
@@ -142,6 +143,10 @@ vi.mock('../../../../src/lib/git-utils.js', () => ({
 vi.mock('../../../../src/lib/github-app.js', () => ({
   isGitHubAppConfigured: mockIsGitHubAppConfigured,
   listPullRequestsForHead: mockListPullRequestsForHead,
+}));
+
+vi.mock('../../../../src/lib/lifecycle/orphaned-beads-sweep.js', () => ({
+  sweepOrphanedBeads: mockSweepOrphanedBeads,
 }));
 
 import { postMergeLifecycle, resetPostMergeState } from '../../../../src/lib/cloister/merge-agent.js';

--- a/tests/unit/lib/cloister/postmerge-cleanup-async.test.ts
+++ b/tests/unit/lib/cloister/postmerge-cleanup-async.test.ts
@@ -24,6 +24,7 @@ const mockRunRelease = vi.hoisted(() =>
 
 // ── Track cleanup side effects ────────────────────────────────────────────────
 const mockCompactBeads = vi.hoisted(() => vi.fn(() => Effect.succeed({ success: true, skipped: false, details: ['compacted'] })));
+const mockSweepOrphanedBeads = vi.hoisted(() => vi.fn().mockResolvedValue({ ok: true, closedIds: [], skipped: 0 }));
 const mockCleanupMergedLabels = vi.hoisted(() => vi.fn(() => Effect.succeed({ success: true, skipped: true, details: ['skipped'] })));
 const mockSetAgentPaused = vi.hoisted(() => vi.fn(() => Effect.succeed(null)));
 const mockCreateResetMarker = vi.hoisted(() => vi.fn(async (input: unknown) => ({ id: 'reset-1', ...(input as Record<string, unknown>) })));
@@ -169,6 +170,10 @@ vi.mock('../../../../src/lib/lifecycle/compact-beads.js', () => ({
   compactBeads: mockCompactBeads,
 }));
 
+vi.mock('../../../../src/lib/lifecycle/orphaned-beads-sweep.js', () => ({
+  sweepOrphanedBeads: mockSweepOrphanedBeads,
+}));
+
 vi.mock('../../../../src/lib/lifecycle/label-cleanup.js', () => ({
   cleanupMergedLabels: mockCleanupMergedLabels,
 }));
@@ -230,6 +235,11 @@ describe('postMergeLifecycle — release trigger does not block cleanup', () => 
 
     // Cleanup must have proceeded before release resolves.
     expect(mockCompactBeads).toHaveBeenCalled();
+    expect(mockSweepOrphanedBeads).toHaveBeenCalledWith({
+      beadsCwd: PROJECT_PATH,
+      issueId: ISSUE_ID,
+      reason: 'issue merged; remaining open beads swept',
+    });
     expect(mockSetAgentPaused).toHaveBeenCalled();
     expect(mockCreateResetMarker).toHaveBeenCalled();
 

--- a/tests/unit/lib/lifecycle/orphaned-beads-sweep.test.ts
+++ b/tests/unit/lib/lifecycle/orphaned-beads-sweep.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockGetBeadsForIssue,
+  mockMutate,
+  mockRunMutationBatch,
+  mockFormatFailure,
+} = vi.hoisted(() => ({
+  mockGetBeadsForIssue: vi.fn(),
+  mockMutate: vi.fn(),
+  mockRunMutationBatch: vi.fn(),
+  mockFormatFailure: vi.fn(),
+}));
+
+vi.mock('../../../../src/lib/beads/resolver.js', () => ({
+  createBeadsResolver: vi.fn(() => ({
+    getBeadsForIssue: mockGetBeadsForIssue,
+  })),
+}));
+
+vi.mock('../../../../src/lib/beads/writer.js', () => ({
+  runMutationBatch: mockRunMutationBatch,
+  formatMutationBatchFailure: mockFormatFailure,
+}));
+
+import { sweepOrphanedBeads } from '../../../../src/lib/lifecycle/orphaned-beads-sweep.js';
+
+describe('sweepOrphanedBeads', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRunMutationBatch.mockImplementation(async (_ctx, fn) => {
+      const client = { run: vi.fn(), mutate: mockMutate };
+      await fn(client);
+      return { ok: true, value: undefined, localHead: null };
+    });
+    mockFormatFailure.mockReturnValue('batch failed');
+  });
+
+  it('closes open and in_progress beads through a single runMutationBatch and returns their ids', async () => {
+    mockGetBeadsForIssue.mockResolvedValue({
+      ok: true,
+      value: [
+        { id: 'bead-open-1', status: 'open', title: 'Open 1' },
+        { id: 'bead-progress-1', status: 'in_progress', title: 'Progress 1' },
+        { id: 'bead-open-2', status: 'open', title: 'Open 2' },
+        { id: 'bead-closed-1', status: 'closed', title: 'Closed 1' },
+      ],
+    });
+
+    const result = await sweepOrphanedBeads({
+      beadsCwd: '/workspace',
+      issueId: 'PAN-2602',
+      reason: 'orphaned',
+    });
+
+    expect(result).toEqual({ ok: true, closedIds: ['bead-open-1', 'bead-progress-1', 'bead-open-2'], skipped: 1 });
+    expect(mockRunMutationBatch).toHaveBeenCalledTimes(1);
+    expect(mockRunMutationBatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        project: { workspacePath: '/workspace' },
+        reason: 'sweep orphaned beads for PAN-2602',
+      }),
+      expect.any(Function),
+    );
+    expect(mockMutate).toHaveBeenCalledTimes(3);
+    expect(mockMutate).toHaveBeenNthCalledWith(1, ['close', 'bead-open-1', '--reason', 'orphaned']);
+    expect(mockMutate).toHaveBeenNthCalledWith(2, ['close', 'bead-progress-1', '--reason', 'orphaned']);
+    expect(mockMutate).toHaveBeenNthCalledWith(3, ['close', 'bead-open-2', '--reason', 'orphaned']);
+  });
+
+  it('returns ok:false and closes nothing when the beads read fails', async () => {
+    mockGetBeadsForIssue.mockResolvedValue({
+      ok: false,
+      reason: 'beads read timed out',
+      transient: true,
+      error: new Error('timeout'),
+    });
+
+    const result = await sweepOrphanedBeads({
+      beadsCwd: '/workspace',
+      issueId: 'PAN-2602',
+      reason: 'orphaned',
+    });
+
+    expect(result).toEqual({ ok: false, closedIds: [], skipped: 0, error: 'beads read timed out' });
+    expect(mockRunMutationBatch).not.toHaveBeenCalled();
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it('returns ok:true with empty closedIds and performs no mutation when all beads are already closed', async () => {
+    mockGetBeadsForIssue.mockResolvedValue({
+      ok: true,
+      value: [
+        { id: 'bead-closed-1', status: 'closed', title: 'Closed 1' },
+        { id: 'bead-closed-2', status: 'closed', title: 'Closed 2' },
+      ],
+    });
+
+    const result = await sweepOrphanedBeads({
+      beadsCwd: '/workspace',
+      issueId: 'PAN-2602',
+      reason: 'orphaned',
+    });
+
+    expect(result).toEqual({ ok: true, closedIds: [], skipped: 2 });
+    expect(mockRunMutationBatch).not.toHaveBeenCalled();
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it('returns would-close ids without invoking the writer when dryRun is true', async () => {
+    mockGetBeadsForIssue.mockResolvedValue({
+      ok: true,
+      value: [
+        { id: 'bead-open-1', status: 'open', title: 'Open 1' },
+        { id: 'bead-closed-1', status: 'closed', title: 'Closed 1' },
+      ],
+    });
+
+    const result = await sweepOrphanedBeads({
+      beadsCwd: '/workspace',
+      issueId: 'PAN-2602',
+      reason: 'orphaned',
+      dryRun: true,
+    });
+
+    expect(result).toEqual({ ok: true, closedIds: ['bead-open-1'], skipped: 1 });
+    expect(mockRunMutationBatch).not.toHaveBeenCalled();
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it('returns ok:false when the mutation batch fails', async () => {
+    mockGetBeadsForIssue.mockResolvedValue({
+      ok: true,
+      value: [{ id: 'bead-open-1', status: 'open', title: 'Open 1' }],
+    });
+    mockRunMutationBatch.mockResolvedValue({
+      ok: false,
+      conflict: false,
+      needsOperatorRecovery: true,
+      localHead: null,
+      message: 'mutation failed',
+      cause: new Error('boom'),
+    });
+
+    const result = await sweepOrphanedBeads({
+      beadsCwd: '/workspace',
+      issueId: 'PAN-2602',
+      reason: 'orphaned',
+    });
+
+    expect(result).toEqual({ ok: false, closedIds: [], skipped: 0, error: 'batch failed' });
+    expect(mockFormatFailure).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/lib/lifecycle/workflows.test.ts
+++ b/tests/unit/lib/lifecycle/workflows.test.ts
@@ -11,11 +11,18 @@ import { tmpdir } from 'os';
 vi.setConfig({ testTimeout: 30_000 });
 
 // Use vi.hoisted to avoid initialization order issues
-const { mockExecAsync, mockClearReviewStatus, mockResetPostMergeState, mockMarkRecordPipelineClosedOutSync } = vi.hoisted(() => ({
+const {
+  mockExecAsync,
+  mockClearReviewStatus,
+  mockResetPostMergeState,
+  mockMarkRecordPipelineClosedOutSync,
+  mockSweepOrphanedBeads,
+} = vi.hoisted(() => ({
   mockExecAsync: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
   mockClearReviewStatus: vi.fn(),
   mockResetPostMergeState: vi.fn(),
   mockMarkRecordPipelineClosedOutSync: vi.fn(),
+  mockSweepOrphanedBeads: vi.fn().mockResolvedValue({ ok: true, closedIds: [], skipped: 0 }),
 }));
 
 vi.mock('child_process', () => ({
@@ -71,6 +78,10 @@ vi.mock('../../../../src/lib/pan-dir/record.js', async (importOriginal) => {
     markRecordPipelineClosedOutSync: mockMarkRecordPipelineClosedOutSync,
   };
 });
+
+vi.mock('../../../../src/lib/lifecycle/orphaned-beads-sweep.js', () => ({
+  sweepOrphanedBeads: mockSweepOrphanedBeads,
+}));
 
 vi.mock('../../../../src/lib/cloister/merge-agent.js', () => ({
   resetPostMergeState: mockResetPostMergeState,
@@ -566,6 +577,52 @@ describe('workflows', () => {
       expect(commands.some(command => command.includes('--add-label "closed-out"'))).toBe(true);
       expect(commands.some(command => command.includes('--remove-label "verifying-on-main"'))).toBe(true);
       expect(commands.some(command => command.includes('--remove-label "needs-close-out"'))).toBe(true);
+    });
+
+    it('sweeps orphaned beads after vBRIEF completion and before teardown', async () => {
+      mockSweepOrphanedBeads.mockResolvedValueOnce({ ok: true, closedIds: ['bead-1', 'bead-2'], skipped: 1 });
+      const ctx = { issueId: 'PAN-100', projectPath: testDir };
+      const result = await closeOut(ctx, { tracker: successfulTracker() });
+
+      const vbriefIdx = result.steps.findIndex(s => s.step === 'close-out:vbrief-completed');
+      const sweepIdx = result.steps.findIndex(s => s.step === 'close-out:sweep-orphaned-beads');
+      const teardownIdx = result.steps.findIndex(s => s.step === 'teardown:checkpoint-refs');
+      expect(vbriefIdx).toBeGreaterThanOrEqual(0);
+      expect(sweepIdx).toBeGreaterThanOrEqual(0);
+      expect(teardownIdx).toBeGreaterThanOrEqual(0);
+      expect(vbriefIdx).toBeLessThan(sweepIdx);
+      expect(sweepIdx).toBeLessThan(teardownIdx);
+      expect(result.steps[sweepIdx]?.success).toBe(true);
+      expect(result.steps[sweepIdx]?.details?.[0]).toContain('2 orphaned bead(s)');
+    });
+
+    it('uses the cancelled reason when opts.reason indicates not-planned/cancelled close', async () => {
+      const ctx = { issueId: 'PAN-100', projectPath: testDir };
+      await closeOut(ctx, { tracker: successfulTracker(), reason: 'not planned' });
+      expect(mockSweepOrphanedBeads).toHaveBeenLastCalledWith(
+        expect.objectContaining({ reason: 'issue closed (not planned); bead cancelled' }),
+      );
+    });
+
+    it('uses the completed reason by default', async () => {
+      const ctx = { issueId: 'PAN-100', projectPath: testDir };
+      await closeOut(ctx, { tracker: successfulTracker() });
+      expect(mockSweepOrphanedBeads).toHaveBeenLastCalledWith(
+        expect.objectContaining({ reason: 'issue closed (completed); orphaned bead swept' }),
+      );
+    });
+
+    it('continues close-out when the bead sweep fails', async () => {
+      mockSweepOrphanedBeads.mockResolvedValueOnce({ ok: false, closedIds: [], skipped: 0, error: 'beads read timed out' });
+      const ctx = { issueId: 'PAN-100', projectPath: testDir };
+      const result = await closeOut(ctx, { tracker: successfulTracker() });
+
+      expect(result.success).toBe(true);
+      const sweepStep = result.steps.find(s => s.step === 'close-out:sweep-orphaned-beads');
+      expect(sweepStep?.success).toBe(true);
+      expect(sweepStep?.skipped).toBe(true);
+      expect(sweepStep?.details?.[0]).toContain('Bead sweep failed (non-fatal)');
+      expect(sweepStep?.details?.[0]).toContain('beads read timed out');
     });
   });
 

--- a/tests/unit/lib/webhook-handlers.test.ts
+++ b/tests/unit/lib/webhook-handlers.test.ts
@@ -96,9 +96,10 @@ function makePayload(overrides: Partial<WebhookPayload> = {}): WebhookPayload {
 }
 
 describe('issueIdFromBranch', () => {
-  it('parses feature and strike issue refs only', () => {
+  it('parses feature, strike, and bypass issue refs', () => {
     expect(issueIdFromBranch('feature/pan-123')).toBe('PAN-123');
     expect(issueIdFromBranch('strike/pan-123')).toBe('PAN-123');
+    expect(issueIdFromBranch('bypass/pan-2564')).toBe('PAN-2564');
     expect(issueIdFromBranch('main')).toBeNull();
     expect(issueIdFromBranch('uat/pan-slate-0625')).toBeNull();
   });


### PR DESCRIPTION
**Issue:** #2602

## Acceptance Criteria

- [ ] Fix beads.freshness_changed to fire on local writes (compare against previous poll head)
- [ ] Per-issue bead rollup service: one bulk getAllBeads() → {total, closed, inProgress, lastUpdated} cache refreshed on beads.freshness_changed
- [ ] Discovery computes branch-ahead-of-main for feature/* AND bypass/* branches
- [ ] Discovery tags issueId-linked conversations as a 'conversation' resource source
- [ ] Extend the discovery membership filter with the gated union of work-artifact signals
- [ ] pan handoff --issue <id>: thread an explicit issue association to the spawned conversation
- [ ] Auto-detect the handoff issue association from the target cwd's branch (feature/, strike/, bypass/)
- [ ] Command Deck: render issueId-linked conversations as child rows under their issue node
- [ ] sweepOrphanedBeads(): close remaining open/in_progress beads for a terminal issue with a reason category
- [ ] closeOut step: sweep orphaned beads after vBRIEF completion, before workspace teardown
- [ ] postMergeLifecycle step: sweep remaining open beads at merge, adjacent to compactBeads
- [ ] pan beads sweep: one-shot backfill closing orphaned beads on GitHub-closed issues (--dry-run)
- [ ] Verification gate: explicit 'open-beads' check that blocks completion while the issue has open beads
- [ ] Command Deck 'stalled' bucket: in-pipeline artifacts, no live agent, no recent activity
- [ ] Document the in-pipeline union signal, bead sweep, verification gate, and handoff --issue

## Implementation Tasks

- [x] Command Deck 'stalled' bucket: in-pipeline artifacts, no live agent, no recent activity
- [x] Document the in-pipeline union signal, bead sweep, verification gate, and handoff --issue
- [x] Command Deck: render issueId-linked conversations as child rows under their issue node
- [x] Extend the discovery membership filter with the gated union of work-artifact signals
- [x] pan beads sweep: one-shot backfill closing orphaned beads on GitHub-closed issues (--dry-run)
- [x] postMergeLifecycle step: sweep remaining open beads at merge, adjacent to compactBeads
- [x] closeOut step: sweep orphaned beads after vBRIEF completion, before workspace teardown
- [x] Auto-detect the handoff issue association from the target cwd's branch (feature/, strike/, bypass/)
- [x] Discovery tags issueId-linked conversations as a 'conversation' resource source
- [x] Verification gate: explicit 'open-beads' check that blocks completion while the issue has open beads
- [x] sweepOrphanedBeads(): close remaining open/in_progress beads for a terminal issue with a reason category
- [x] pan handoff --issue <id>: thread an explicit issue association to the spawned conversation
- [x] Discovery computes branch-ahead-of-main for feature/* AND bypass/* branches
- [x] Per-issue bead rollup service: one bulk getAllBeads() → {total, closed, inProgress, lastUpdated} cache refreshed on beads.freshness_changed
- [x] Fix beads.freshness_changed to fire on local writes (compare against previous poll head)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `beads sweep` to clean up orphaned work items on closed issues, with targeted scans, previews, and custom reasons.
  * Handoffs can now be associated with a specified issue and display that association.
  * Dashboard issue views now surface linked conversations, bead summaries, branch status, and stalled work.
* **Bug Fixes**
  * Verification and lifecycle close-out now prevent closed issues from retaining open beads.
  * Improved freshness detection for bead updates.
* **Documentation**
  * Added guidance for bead cleanup and handoff issue association.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->