### PR TITLE
fix(test): add getAllBeads() to mocked beads resolver — fixes RED MAIN (PAN-2643)

### DIFF
--- a/src/dashboard/server/routes/__tests__/auto-promote-chain.integration.test.ts
+++ b/src/dashboard/server/routes/__tests__/auto-promote-chain.integration.test.ts
@@ -21,6 +21,12 @@ vi.mock('../../../../lib/activity-logger.js', () => ({
 
 vi.mock('../../../../lib/beads/resolver.js', () => ({
   createBeadsResolver: (workspacePath: string) => ({
+    getAllBeads: async () => {
+      try {
+        const raw = readFileSync(join(workspacePath, '.beads', 'issues.jsonl'), 'utf8');
+        return { ok: true, value: raw.split('\n').filter(Boolean).map((line) => JSON.parse(line)) };
+      } catch { return { ok: true, value: [] }; }
+    },
     countBeadsForIssue: async (issueId: string) => {
       try {
         const raw = readFileSync(join(workspacePath, '.beads', 'issues.jsonl'), 'utf8');


### PR DESCRIPTION
Strike fix for RED MAIN (PAN-2643). The `auto-promote-chain.integration.test.ts` beads-resolver mock was missing `getAllBeads()`, which the orphan proposed reconciler now calls via the cached bulk-read path → returned undefined → `TypeError: (0, __vite_ssr_import_0__.cre…)`. Adds the mock method (matching the existing `countBeadsForIssue` idiom). typecheck+lint+test green locally.

Fixes #2643

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test coverage by enabling realistic loading of bead data from JSONL files.
  * Added graceful handling for missing or invalid test data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->