### PR TITLE
feat(dashboard): redesign issue policies control

### DIFF
--- a/docs/QUICK-REFERENCE.md
+++ b/docs/QUICK-REFERENCE.md
@@ -41,7 +41,7 @@ Act on an issue. `<id>` is the universal object.
 | `pan sync-main <id>` | Merge latest `main` into the workspace branch |
 | `pan swarm <id>` | Per-item DAG dispatch across plan items (slot-per-item). See [SWARM.md](./SWARM.md). `--dry-run`, `--max-slots`, `--auto-advance`, `--host`, `--task <next\|show\|claim\|done\|block\|unblock\|cancel>` |
 | `pan staffing <id>` | Show or set per-issue work-model and swarm overrides. Use `--model <model>\|default` and `--swarm off\|auto\|always\|default`. |
-| Issue policy strip | Set review mode, re-review scope, one model for the whole review convoy, work model, and swarm mode from either issue header. Model changes apply to the next fresh run; they never restart agents automatically. |
+| Issue-header Policies control | Open **Policies** from an issue header to set Review (mode, re-review scope, model) and Work (model, swarm) overrides. Active overrides surface as chips beside the control. Model changes apply to the next fresh run; they never restart agents automatically. |
 | `pan done <id>` | Mark work complete → tracker "In Review". Agent stays on standby for UAT tweaks via `pan tell`. |
 | Dashboard MERGE | Click MERGE button when review passes (handles rebase, verify, merge, cleanup) |
 | `pan inspect <id>` | Request human inspection before proceeding |

--- a/docs/REVIEW-AGENT-ARCHITECTURE.md
+++ b/docs/REVIEW-AGENT-ARCHITECTURE.md
@@ -27,7 +27,7 @@ trigger route, host auto-dispatch, and every Deacon re-dispatch site honor it:
 
 | Scope | Where it lives | How to set it |
 | --- | --- | --- |
-| **Per-issue** (wins) | the per-issue record (`reviewMode`, `reviewModel`) | `pan review mode <id> <quick\|full\|none>` or the issue policy strip. `reviewModel` applies one explicit model to the synthesis parent and every reviewer in the next convoy. |
+| **Per-issue** (wins) | the per-issue record (`reviewMode`, `reviewModel`) | `pan review mode <id> <quick\|full\|none>` or the issue-header Policies control. `reviewModel` applies one explicit model to the synthesis parent and every reviewer in the next convoy. |
 | **Per-project** | `.pan.yaml` → `roles.review.mode` | edit the project config (merged over global by `mergeConfigs()`) |
 | **Global** | `~/.overdeck/config.yaml` → `roles.review.mode` | Settings → Roles → Review → *Review mode* selector |
 

--- a/docs/SWARM.md
+++ b/docs/SWARM.md
@@ -15,7 +15,7 @@ pan swarm <id>
 ```
 
 Use `pan staffing <id> --swarm off|auto|always|default` to set or clear the durable per-issue
-swarm override. The shared issue-header policy strip exposes the same setting, and
+swarm override. The issue-header Policies control exposes the same setting, and
 `GET/POST /api/issues/:issueId/swarm-policy` provides API parity; the issue layer beats project
 and global swarm modes.
 

--- a/scripts/source-introspection-baseline.txt
+++ b/scripts/source-introspection-baseline.txt
@@ -2,7 +2,6 @@
 1 src/dashboard/frontend/src/components/__tests__/IssueAgentCard-harness.test.tsx
 1 src/dashboard/server/routes/__tests__/effect-patterns.test.ts
 1 src/dashboard/server/routes/__tests__/projects-register.test.ts
-1 src/lib/agents/__tests__/tier-escalation.test.ts
 1 src/lib/cloister/__tests__/lint-stub-ui.test.ts
 1 src/lib/cloister/__tests__/no-resume-mode.test.ts
 1 src/lib/cloister/__tests__/reap-issue-residue.test.ts

--- a/src/cli/commands/__tests__/review-mode.test.ts
+++ b/src/cli/commands/__tests__/review-mode.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -14,6 +15,12 @@ describe('reviewModeCommand', () => {
   beforeEach(() => {
     originalCwd = process.cwd();
     workspacePath = mkdtempSync(join(tmpdir(), 'pan-review-mode-'));
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: workspacePath });
+    execFileSync('git', ['config', 'user.email', 'test@overdeck.local'], { cwd: workspacePath });
+    execFileSync('git', ['config', 'user.name', 'Overdeck Test'], { cwd: workspacePath });
+    execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: workspacePath });
+    execFileSync('git', ['commit', '--allow-empty', '-q', '-m', 'chore: seed test repository'], { cwd: workspacePath });
+    execFileSync('git', ['remote', 'add', 'origin', '.'], { cwd: workspacePath });
     process.chdir(workspacePath);
     exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
       throw new Error('process.exit');
@@ -36,6 +43,7 @@ describe('reviewModeCommand', () => {
 
     expect(record.issueId).toBe('PAN-1982');
     expect(record.reviewMode).toBe('full');
+    expect(execFileSync('git', ['log', '-1', '--format=%s'], { cwd: workspacePath, encoding: 'utf-8' })).toContain('PAN-1982');
   });
 
   it('rejects invalid review modes before writing a record', async () => {

--- a/src/dashboard/frontend/src/components/IssuePolicyStrip.test.tsx
+++ b/src/dashboard/frontend/src/components/IssuePolicyStrip.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { IssuePolicyStrip } from './IssuePolicyStrip';
@@ -7,43 +7,124 @@ function response(body: unknown): Response {
   return { ok: true, json: async () => body } as Response;
 }
 
+const defaults = {
+  review: { override: { reviewMode: null, reReviewScope: null, reviewModel: null }, resolved: { reviewMode: 'full', reReviewScope: 'changed', reviewModel: null } },
+  staffing: { override: { workModel: null }, resolved: { model: 'gpt-5.5', tiered: true, source: 'default', recordedModel: 'gpt-5.5' } },
+  swarm: { configured: null, resolved: { mode: 'off', source: { mode: 'default' } } },
+};
+
 describe('IssuePolicyStrip', () => {
+  let fixtures = structuredClone(defaults);
+
   beforeEach(() => {
+    fixtures = structuredClone(defaults);
     global.fetch = vi.fn(async (input: RequestInfo | URL) => {
       const url = input.toString();
-      if (url.includes('/api/review/')) return response({ override: { reviewMode: null, reReviewScope: null, reviewModel: null }, resolved: { reviewMode: 'full', reReviewScope: 'changed', reviewModel: 'gpt-5.5' } });
-      if (url.includes('/staffing')) return response({ override: { workModel: 'gpt-5.5' }, resolved: { model: 'gpt-5.5', tiered: false, source: 'issue', recordedModel: 'claude-sonnet-5' } });
-      if (url.includes('/swarm-policy')) return response({ configured: null, resolved: { mode: 'off', source: { mode: 'default' } } });
-      if (url.includes('/available-models')) return response({ openai: [{ id: 'gpt-5.5', name: 'GPT 5.5' }] });
+      if (url.includes('/api/review/')) return response(fixtures.review);
+      if (url.includes('/staffing')) return response(fixtures.staffing);
+      if (url.includes('/swarm-policy')) return response(fixtures.swarm);
+      if (url.includes('/available-models')) return response({
+        anthropic: [{ id: 'claude-sonnet-5', name: 'Claude Sonnet 5' }],
+        openai: [{ id: 'gpt-5.5', name: 'GPT 5.5' }],
+      });
       if (url.includes('/restart-fresh')) return response({ success: true });
       return { ok: false, json: async () => ({}) } as Response;
     }) as typeof fetch;
   });
 
-  it('renders all shared controls with resolved default labels', async () => {
-    render(<IssuePolicyStrip issueId="PAN-2674" />);
-    expect(await screen.findByLabelText('Review mode for this issue')).toBeInTheDocument();
-    expect(screen.getByLabelText('Re-review scope for this issue')).toBeInTheDocument();
-    expect(screen.getByLabelText('Review model for this issue')).toHaveTextContent('reviewers: default (gpt-5.5)');
-    expect(screen.getByLabelText('Work model for this issue')).toHaveTextContent('work: default (gpt-5.5)');
-    expect(screen.getByLabelText('Swarm mode for this issue')).toHaveTextContent('swarm: default (off)');
+  it('renders one quiet Policies button when every policy uses its default', async () => {
+    render(<IssuePolicyStrip issueId="PAN-2681" />);
+
+    const strip = await screen.findByTestId('issue-policy-strip');
+    expect(within(strip).getAllByRole('button')).toHaveLength(1);
+    expect(within(strip).getByText('Policies')).toBeInTheDocument();
+    expect(strip).not.toHaveTextContent(/default \(/i);
   });
 
-  it('persists one per-issue model for the whole review convoy', async () => {
-    render(<IssuePolicyStrip issueId="PAN-2674" />);
-    const reviewers = await screen.findByLabelText('Review model for this issue');
-    fireEvent.change(reviewers, { target: { value: 'gpt-5.5' } });
-    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('/api/review/PAN-2674/config', expect.objectContaining({
+  it('opens and dismisses the grouped portal panel', async () => {
+    render(<IssuePolicyStrip issueId="PAN-2681" />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Issue policies' }));
+
+    expect(screen.getByLabelText('Issue policy overrides')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Review' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Work' })).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByLabelText('Issue policy overrides')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Issue policies' }));
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByLabelText('Issue policy overrides')).not.toBeInTheDocument();
+  });
+
+  it('persists enum and model changes with the existing endpoints and payloads', async () => {
+    render(<IssuePolicyStrip issueId="PAN-2681" />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Issue policies' }));
+
+    fireEvent.click(within(screen.getByLabelText('Review mode for this issue')).getByRole('button', { name: 'Quick' }));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('/api/review/PAN-2681/config', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ reviewMode: 'quick' }),
+    })));
+
+    fireEvent.change(screen.getByLabelText('Review model for this issue'), { target: { value: 'gpt-5.5' } });
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('/api/review/PAN-2681/config', expect.objectContaining({
       method: 'POST',
       body: JSON.stringify({ reviewModel: 'gpt-5.5' }),
     })));
+
+    fireEvent.change(screen.getByLabelText('Work model for this issue'), { target: { value: 'claude-sonnet-5' } });
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('/api/issues/PAN-2681/staffing', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ workModel: 'claude-sonnet-5' }),
+    })));
+
+    fireEvent.click(within(screen.getByLabelText('Swarm mode for this issue')).getByRole('button', { name: 'Always' }));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('/api/issues/PAN-2681/swarm-policy', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ value: { mode: 'always' } }),
+    })));
   });
 
-  it('persists a work-model selection and offers an explicit fresh restart', async () => {
-    render(<IssuePolicyStrip issueId="PAN-2674" />);
-    const work = await screen.findByLabelText('Work model for this issue');
-    fireEvent.change(work, { target: { value: 'gpt-5.5' } });
-    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('/api/issues/PAN-2674/staffing', expect.objectContaining({ method: 'POST' })));
+  it('uses the effective review mode to decide whether re-review is available', async () => {
+    fixtures.review.override.reviewMode = 'quick';
+    render(<IssuePolicyStrip issueId="PAN-2681" />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Issue policies' }));
+    expect(screen.queryByLabelText('Re-review scope for this issue')).not.toBeInTheDocument();
+  });
+
+  it('preserves every affordance from the five-select policy strip', async () => {
+    fixtures.review.override = { reviewMode: 'full', reReviewScope: 'all', reviewModel: 'gpt-5.5' };
+    fixtures.staffing.override.workModel = 'claude-sonnet-5';
+    fixtures.staffing.resolved.recordedModel = 'gpt-5.5';
+    fixtures.swarm.configured = { mode: 'always' };
+
+    render(<IssuePolicyStrip issueId="PAN-2681" />);
+    const strip = await screen.findByTestId('issue-policy-strip');
+    expect(within(strip).getByText('5')).toBeInTheDocument();
+    expect(within(strip).getByRole('button', { name: /review · full/i })).toBeInTheDocument();
+    expect(within(strip).getByRole('button', { name: 'restart pending' })).toBeInTheDocument();
+
+    fireEvent.click(within(strip).getByRole('button', { name: 'Issue policies' }));
+    const legacyControls = [
+      'Review mode for this issue',
+      'Re-review scope for this issue',
+      'Review model for this issue',
+      'Work model for this issue',
+      'Swarm mode for this issue',
+    ];
+    for (const ariaLabel of legacyControls) expect(screen.getByLabelText(ariaLabel)).toBeInTheDocument();
+
+    expect(screen.getAllByRole('button', { name: 'reset' })).toHaveLength(5);
+    expect(screen.getByRole('button', { name: 'Reset all to defaults' })).toBeInTheDocument();
+    expect(screen.getByText('The work-model override applies to the next spawn; running agents are never restarted automatically.')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Restart agent with new staffing' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restart agent with new staffing' }));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('/api/agents/agent-pan-2681/restart-fresh', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ spawn: true, model: 'claude-sonnet-5' }),
+    })));
+    expect(await screen.findByText('Fresh restart requested.')).toBeInTheDocument();
   });
 });

--- a/src/dashboard/frontend/src/components/IssuePolicyStrip.test.tsx
+++ b/src/dashboard/frontend/src/components/IssuePolicyStrip.test.tsx
@@ -48,9 +48,11 @@ describe('IssuePolicyStrip', () => {
     expect(screen.getByLabelText('Issue policy overrides')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Review' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Work' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Review mode for this issue')).toContainElement(document.activeElement as HTMLElement);
 
     fireEvent.keyDown(window, { key: 'Escape' });
     expect(screen.queryByLabelText('Issue policy overrides')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Issue policies' })).toHaveFocus();
 
     fireEvent.click(screen.getByRole('button', { name: 'Issue policies' }));
     fireEvent.mouseDown(document.body);
@@ -115,8 +117,25 @@ describe('IssuePolicyStrip', () => {
     ];
     for (const ariaLabel of legacyControls) expect(screen.getByLabelText(ariaLabel)).toBeInTheDocument();
 
-    expect(screen.getAllByRole('button', { name: 'reset' })).toHaveLength(5);
-    expect(screen.getByRole('button', { name: 'Reset all to defaults' })).toBeInTheDocument();
+    for (const accessibleName of [
+      'Reset review mode to default',
+      'Reset re-review scope to default',
+      'Reset review model to default',
+      'Reset work model to default',
+      'Reset swarm mode to default',
+    ]) expect(screen.getByRole('button', { name: accessibleName })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset all to defaults' }));
+    await waitFor(() => {
+      const posts = vi.mocked(global.fetch).mock.calls.filter(([, init]) => init?.method === 'POST');
+      expect(posts).toEqual(expect.arrayContaining([
+        ['/api/review/PAN-2681/config', expect.objectContaining({ body: JSON.stringify({ reviewMode: null }) })],
+        ['/api/review/PAN-2681/config', expect.objectContaining({ body: JSON.stringify({ reReviewScope: null }) })],
+        ['/api/review/PAN-2681/config', expect.objectContaining({ body: JSON.stringify({ reviewModel: null }) })],
+        ['/api/issues/PAN-2681/staffing', expect.objectContaining({ body: JSON.stringify({ workModel: null }) })],
+        ['/api/issues/PAN-2681/swarm-policy', expect.objectContaining({ body: JSON.stringify({ value: null }) })],
+      ]));
+    });
     expect(screen.getByText('The work-model override applies to the next spawn; running agents are never restarted automatically.')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Restart agent with new staffing' })).toBeInTheDocument();
 

--- a/src/dashboard/frontend/src/components/IssuePolicyStrip.tsx
+++ b/src/dashboard/frontend/src/components/IssuePolicyStrip.tsx
@@ -1,5 +1,6 @@
-/** Shared per-issue review and staffing policy strip (PAN-2674). */
-import { useCallback, useEffect, useMemo, useState } from 'react';
+/** Shared per-issue review and staffing policy strip, collapsed to an overrides-only Policies control (PAN-2681). */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 type ReviewModeValue = 'quick' | 'full' | 'none';
 type ReReviewScopeValue = 'all' | 'changed' | 'blockers';
@@ -24,7 +25,32 @@ interface AvailableModel { id: string; name: string }
 type AvailableModelsResponse = Record<string, AvailableModel[]>;
 
 const selectClass =
-  'rounded border bg-popover px-1.5 py-0.5 text-[11px] font-medium text-foreground focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50';
+  'w-full rounded border border-border bg-popover px-2 py-0.5 text-[11.5px] font-medium text-foreground focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50';
+
+interface SegmentedProps {
+  ariaLabel: string;
+  value: string | null;
+  resolvedLabel: string;
+  options: Array<[string, string]>;
+  disabled: boolean;
+  onChange: (next: string | null) => void;
+}
+
+function Segmented({ ariaLabel, value, resolvedLabel, options, disabled, onChange }: SegmentedProps) {
+  const segmentClass = 'border-l border-border px-2 py-0.5 text-[11px] font-medium first:border-l-0 disabled:opacity-50';
+  return (
+    <div className="inline-flex overflow-hidden rounded border border-border" role="group" aria-label={ariaLabel}>
+      <button type="button" aria-pressed={value === null} className={`${segmentClass} ${value === null ? 'bg-primary/12 text-foreground' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}`} disabled={disabled} onClick={() => onChange(null)}>
+        Default <span className="text-[10px] text-muted-foreground">· {resolvedLabel}</span>
+      </button>
+      {options.map(([optionValue, label]) => (
+        <button key={optionValue} type="button" aria-pressed={value === optionValue} className={`${segmentClass} ${value === optionValue ? 'bg-primary/12 text-foreground' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}`} disabled={disabled} onClick={() => onChange(optionValue)}>
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}
 
 export function IssuePolicyStrip({ issueId }: { issueId: string }) {
   const [review, setReview] = useState<ReviewConfigResponse | null>(null);
@@ -33,6 +59,10 @@ export function IssuePolicyStrip({ issueId }: { issueId: string }) {
   const [availableModels, setAvailableModels] = useState<AvailableModelsResponse>({});
   const [saving, setSaving] = useState(false);
   const [restartMessage, setRestartMessage] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+  const [panelPos, setPanelPos] = useState<{ top: number; left: number } | null>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
 
   const refresh = useCallback(async () => {
     const encoded = encodeURIComponent(issueId);
@@ -81,12 +111,66 @@ export function IssuePolicyStrip({ issueId }: { issueId: string }) {
     }
   }, [refresh]);
 
+  const positionPanel = useCallback(() => {
+    const rect = buttonRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    setPanelPos({
+      top: rect.bottom + 6,
+      left: Math.max(8, Math.min(rect.left, window.innerWidth - 416)),
+    });
+  }, []);
+
+  const togglePanel = useCallback(() => {
+    if (open) {
+      setOpen(false);
+      return;
+    }
+    positionPanel();
+    setOpen(true);
+  }, [open, positionPanel]);
+
+  const showPanel = useCallback(() => {
+    positionPanel();
+    setOpen(true);
+  }, [positionPanel]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onMouseDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (!buttonRef.current?.contains(target) && !panelRef.current?.contains(target)) setOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => { if (event.key === 'Escape') setOpen(false); };
+    const dismiss = () => setOpen(false);
+    document.addEventListener('mousedown', onMouseDown);
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('scroll', dismiss, true);
+    window.addEventListener('resize', dismiss);
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown);
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('scroll', dismiss, true);
+      window.removeEventListener('resize', dismiss);
+    };
+  }, [open]);
+
   if (!review || !staffing || !swarm) return null;
   const encoded = encodeURIComponent(issueId);
   const workDefault = staffing.resolved.tiered ? 'tiered' : staffing.resolved.model;
   const needsRestart = Boolean(
     staffing.override.workModel && staffing.override.workModel !== staffing.resolved.recordedModel,
   );
+  const effectiveReviewMode = review.override.reviewMode ?? review.resolved.reviewMode;
+
+  const modelName = (modelId: string) => models.find((model) => model.id === modelId)?.name ?? modelId;
+  const overrides = [
+    review.override.reviewMode && { key: 'review', label: 'review', value: review.override.reviewMode },
+    review.override.reReviewScope && { key: 're-review', label: 're-review', value: review.override.reReviewScope },
+    review.override.reviewModel && { key: 'review-model', label: 'review model', value: modelName(review.override.reviewModel) },
+    staffing.override.workModel && { key: 'work', label: 'work', value: modelName(staffing.override.workModel) },
+    swarm.configured?.mode && { key: 'swarm', label: 'swarm', value: swarm.configured.mode },
+  ].filter((override): override is { key: string; label: string; value: string } => Boolean(override));
+  const overrideCount = overrides.length;
 
   const restart = async () => {
     setSaving(true);
@@ -107,38 +191,131 @@ export function IssuePolicyStrip({ issueId }: { issueId: string }) {
     }
   };
 
+  const resetAll = async () => {
+    if (review.override.reviewMode !== null) await save(`/api/review/${encoded}/config`, { reviewMode: null });
+    if (review.override.reReviewScope !== null) await save(`/api/review/${encoded}/config`, { reReviewScope: null });
+    if (review.override.reviewModel !== null) await save(`/api/review/${encoded}/config`, { reviewModel: null });
+    if (staffing.override.workModel !== null) await save(`/api/issues/${encoded}/staffing`, { workModel: null });
+    if (swarm.configured?.mode) await save(`/api/issues/${encoded}/swarm-policy`, { value: null });
+  };
+
+  const rowLabelClass = 'flex items-center gap-1.5 text-[12px] font-medium';
+  const resetClass = 'text-[10.5px] font-medium text-muted-foreground underline underline-offset-2 hover:text-foreground disabled:opacity-50';
+  const controlCellClass = 'flex min-w-0 items-center gap-2';
+
   return (
-    <span className="flex flex-col gap-1" data-testid="issue-policy-strip" title="Per-issue review and staffing overrides">
-      <span className="flex flex-wrap items-center gap-1">
-        <select aria-label="Review mode for this issue" className={`${selectClass} ${review.override.reviewMode ? 'border-primary' : 'border-border'}`} disabled={saving} value={review.override.reviewMode ?? ''} onChange={(event) => save(`/api/review/${encoded}/config`, { reviewMode: event.target.value || null })}>
-          <option value="">{`review: default (${review.resolved.reviewMode})`}</option>
-          <option value="quick">review: quick</option><option value="full">review: full convoy</option><option value="none">review: none</option>
-        </select>
-        {review.resolved.reviewMode === 'full' && (
-          <select aria-label="Re-review scope for this issue" className={`${selectClass} ${review.override.reReviewScope ? 'border-primary' : 'border-border'}`} disabled={saving} value={review.override.reReviewScope ?? ''} onChange={(event) => save(`/api/review/${encoded}/config`, { reReviewScope: event.target.value || null })}>
-            <option value="">{`re-review: default (${review.resolved.reReviewScope})`}</option>
-            <option value="changed">re-review: changed</option><option value="all">re-review: all</option><option value="blockers">re-review: blockers</option>
-          </select>
-        )}
-        <select aria-label="Review model for this issue" className={`${selectClass} ${review.override.reviewModel ? 'border-primary' : 'border-border'}`} disabled={saving} value={review.override.reviewModel ?? ''} onChange={(event) => save(`/api/review/${encoded}/config`, { reviewModel: event.target.value || null })}>
-          <option value="">{`reviewers: default (${review.resolved.reviewModel ?? 'unconfigured'})`}</option>
-          {models.map((model) => <option key={model.id} value={model.id}>{`reviewers: ${model.name}`}</option>)}
-        </select>
-        <select aria-label="Work model for this issue" className={`${selectClass} ${staffing.override.workModel ? 'border-primary' : 'border-border'}`} disabled={saving} value={staffing.override.workModel ?? ''} onChange={(event) => save(`/api/issues/${encoded}/staffing`, { workModel: event.target.value || null })}>
-          <option value="">{`work: default (${workDefault})`}</option>
-          {models.map((model) => <option key={model.id} value={model.id}>{`work: ${model.name}`}</option>)}
-        </select>
-        <select aria-label="Swarm mode for this issue" className={`${selectClass} ${swarm.configured?.mode ? 'border-primary' : 'border-border'}`} disabled={saving} value={swarm.configured?.mode ?? ''} onChange={(event) => save(`/api/issues/${encoded}/swarm-policy`, { value: event.target.value ? { mode: event.target.value } : null })}>
-          <option value="">{`swarm: default (${swarm.resolved.mode})`}</option>
-          <option value="off">swarm: off</option><option value="auto">swarm: auto</option><option value="always">swarm: always</option>
-        </select>
-      </span>
+    <span className="flex flex-wrap items-center gap-1.5" data-testid="issue-policy-strip" title="Per-issue review and staffing overrides">
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-label="Issue policies"
+        aria-expanded={open}
+        className={`inline-flex h-[22px] items-center gap-1.5 rounded border border-border px-2 text-[11px] font-medium hover:bg-muted hover:text-foreground ${overrideCount > 0 ? 'text-foreground' : 'text-muted-foreground'}`}
+        onClick={togglePanel}
+      >
+        <svg aria-hidden="true" className="h-[11px] w-[11px]" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <line x1="2" y1="4.5" x2="14" y2="4.5" /><circle cx="6" cy="4.5" r="1.7" fill="currentColor" />
+          <line x1="2" y1="11.5" x2="14" y2="11.5" /><circle cx="10.5" cy="11.5" r="1.7" fill="currentColor" />
+        </svg>
+        Policies
+        {overrideCount > 0 && <span className="inline-flex min-w-[14px] items-center justify-center rounded-sm bg-primary/12 px-1 text-[9px] text-primary">{overrideCount}</span>}
+      </button>
+
+      {overrides.map((override) => (
+        <button key={override.key} type="button" className="inline-flex h-5 items-center gap-1 rounded border border-primary/32 bg-primary/8 px-1.5 text-[11px] font-medium text-foreground" onClick={showPanel}>
+          <span className="text-muted-foreground">{override.label} ·</span> {override.value}
+        </button>
+      ))}
+
       {needsRestart && (
-        <span className="flex flex-wrap items-center gap-2 border-l-2 border-warning pl-2 text-[11px] font-medium text-warning">
-          The work-model override applies to the next spawn; running agents are never restarted automatically.
-          <button type="button" className="rounded border border-warning px-1.5 py-0.5 hover:bg-warning/10 disabled:opacity-50" disabled={saving} onClick={restart}>Restart agent with new staffing</button>
-          {restartMessage && <span>{restartMessage}</span>}
-        </span>
+        <button type="button" className="inline-flex h-5 items-center rounded border border-warning/32 bg-warning/8 px-1.5 text-[11px] font-medium text-warning-foreground" onClick={showPanel}>
+          restart pending
+        </button>
+      )}
+
+      {open && panelPos && createPortal(
+        <div
+          ref={panelRef}
+          aria-label="Issue policy overrides"
+          className="fixed z-[100] w-[400px] rounded-lg border border-border bg-popover px-4 pb-3 pt-3.5 shadow-lg"
+          style={{ top: panelPos.top, left: panelPos.left }}
+        >
+          <h3 className="mb-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Review</h3>
+          <div className="my-2 grid grid-cols-[92px_1fr] items-center gap-2.5">
+            <span className={`${rowLabelClass} ${review.override.reviewMode ? 'text-foreground' : 'text-muted-foreground'}`}>
+              <span className={`h-[5px] w-[5px] rounded-full bg-primary ${review.override.reviewMode ? 'opacity-100' : 'opacity-0'}`} /> Mode
+            </span>
+            <div className={controlCellClass}>
+              <Segmented ariaLabel="Review mode for this issue" value={review.override.reviewMode} resolvedLabel={review.resolved.reviewMode} options={[["quick", "Quick"], ["full", "Full"], ["none", "None"]]} disabled={saving} onChange={(next) => save(`/api/review/${encoded}/config`, { reviewMode: next })} />
+              {review.override.reviewMode && <button type="button" className={resetClass} disabled={saving} onClick={() => save(`/api/review/${encoded}/config`, { reviewMode: null })}>reset</button>}
+            </div>
+          </div>
+
+          {effectiveReviewMode === 'full' && (
+            <div className="my-2 grid grid-cols-[92px_1fr] items-center gap-2.5">
+              <span className={`${rowLabelClass} ${review.override.reReviewScope ? 'text-foreground' : 'text-muted-foreground'}`}>
+                <span className={`h-[5px] w-[5px] rounded-full bg-primary ${review.override.reReviewScope ? 'opacity-100' : 'opacity-0'}`} /> Re-review
+              </span>
+              <div className={controlCellClass}>
+                <Segmented ariaLabel="Re-review scope for this issue" value={review.override.reReviewScope} resolvedLabel={review.resolved.reReviewScope} options={[["changed", "Changed"], ["all", "All"], ["blockers", "Blockers"]]} disabled={saving} onChange={(next) => save(`/api/review/${encoded}/config`, { reReviewScope: next })} />
+                {review.override.reReviewScope && <button type="button" className={resetClass} disabled={saving} onClick={() => save(`/api/review/${encoded}/config`, { reReviewScope: null })}>reset</button>}
+              </div>
+            </div>
+          )}
+
+          <div className="my-2 grid grid-cols-[92px_1fr] items-center gap-2.5">
+            <span className={`${rowLabelClass} ${review.override.reviewModel ? 'text-foreground' : 'text-muted-foreground'}`}>
+              <span className={`h-[5px] w-[5px] rounded-full bg-primary ${review.override.reviewModel ? 'opacity-100' : 'opacity-0'}`} /> Model
+            </span>
+            <div className={controlCellClass}>
+              <select aria-label="Review model for this issue" className={selectClass} disabled={saving} value={review.override.reviewModel ?? ''} onChange={(event) => save(`/api/review/${encoded}/config`, { reviewModel: event.target.value || null })}>
+                <option value="">Default · {review.resolved.reviewModel ? modelName(review.resolved.reviewModel) : 'per-role default'}</option>
+                {models.map((model) => <option key={model.id} value={model.id}>{model.name}</option>)}
+              </select>
+              {review.override.reviewModel && <button type="button" className={resetClass} disabled={saving} onClick={() => save(`/api/review/${encoded}/config`, { reviewModel: null })}>reset</button>}
+            </div>
+          </div>
+
+          <h3 className="mb-2 mt-4 border-t border-border pt-3 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Work</h3>
+          <div className="my-2 grid grid-cols-[92px_1fr] items-center gap-2.5">
+            <span className={`${rowLabelClass} ${staffing.override.workModel ? 'text-foreground' : 'text-muted-foreground'}`}>
+              <span className={`h-[5px] w-[5px] rounded-full bg-primary ${staffing.override.workModel ? 'opacity-100' : 'opacity-0'}`} /> Model
+            </span>
+            <div className={controlCellClass}>
+              <select aria-label="Work model for this issue" className={selectClass} disabled={saving} value={staffing.override.workModel ?? ''} onChange={(event) => save(`/api/issues/${encoded}/staffing`, { workModel: event.target.value || null })}>
+                <option value="">Default · {workDefault}</option>
+                {models.map((model) => <option key={model.id} value={model.id}>{model.name}</option>)}
+              </select>
+              {staffing.override.workModel && <button type="button" className={resetClass} disabled={saving} onClick={() => save(`/api/issues/${encoded}/staffing`, { workModel: null })}>reset</button>}
+            </div>
+          </div>
+
+          <div className="my-2 grid grid-cols-[92px_1fr] items-center gap-2.5">
+            <span className={`${rowLabelClass} ${swarm.configured?.mode ? 'text-foreground' : 'text-muted-foreground'}`}>
+              <span className={`h-[5px] w-[5px] rounded-full bg-primary ${swarm.configured?.mode ? 'opacity-100' : 'opacity-0'}`} /> Swarm
+            </span>
+            <div className={controlCellClass}>
+              <Segmented ariaLabel="Swarm mode for this issue" value={swarm.configured?.mode ?? null} resolvedLabel={swarm.resolved.mode} options={[["off", "Off"], ["auto", "Auto"], ["always", "Always"]]} disabled={saving} onChange={(next) => save(`/api/issues/${encoded}/swarm-policy`, { value: next ? { mode: next } : null })} />
+              {swarm.configured?.mode && <button type="button" className={resetClass} disabled={saving} onClick={() => save(`/api/issues/${encoded}/swarm-policy`, { value: null })}>reset</button>}
+            </div>
+          </div>
+
+          {needsRestart && (
+            <div className="mt-3 rounded-md border border-warning/32 bg-warning/8 px-2.5 py-2 text-[11.5px] font-medium text-warning-foreground">
+              <div>The work-model override applies to the next spawn; running agents are never restarted automatically.</div>
+              <div className="mt-1.5 flex flex-wrap items-center gap-2">
+                <button type="button" className="rounded border border-warning/45 px-2 py-0.5 text-[11px] font-medium hover:bg-warning/10 disabled:opacity-50" disabled={saving} onClick={restart}>Restart agent with new staffing</button>
+                {restartMessage && <span>{restartMessage}</span>}
+              </div>
+            </div>
+          )}
+
+          <div className="mt-3.5 flex items-center justify-between border-t border-border pt-2.5">
+            <span className="text-[10.5px] font-medium text-muted-foreground">Overrides apply to this issue only.</span>
+            {overrideCount > 0 && <button type="button" className="text-[11px] font-medium text-muted-foreground underline underline-offset-2 hover:text-foreground disabled:opacity-50" disabled={saving} onClick={resetAll}>Reset all to defaults</button>}
+          </div>
+        </div>,
+        document.body,
       )}
     </span>
   );

--- a/src/dashboard/frontend/src/components/IssuePolicyStrip.tsx
+++ b/src/dashboard/frontend/src/components/IssuePolicyStrip.tsx
@@ -63,6 +63,7 @@ export function IssuePolicyStrip({ issueId }: { issueId: string }) {
   const [panelPos, setPanelPos] = useState<{ top: number; left: number } | null>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  const openerRef = useRef<HTMLElement | null>(null);
 
   const refresh = useCallback(async () => {
     const encoded = encodeURIComponent(issueId);
@@ -114,33 +115,41 @@ export function IssuePolicyStrip({ issueId }: { issueId: string }) {
   const positionPanel = useCallback(() => {
     const rect = buttonRef.current?.getBoundingClientRect();
     if (!rect) return;
+    const panelWidth = Math.min(400, Math.max(0, window.innerWidth - 16));
     setPanelPos({
       top: rect.bottom + 6,
-      left: Math.max(8, Math.min(rect.left, window.innerWidth - 416)),
+      left: Math.max(8, Math.min(rect.left, window.innerWidth - panelWidth - 8)),
     });
   }, []);
 
-  const togglePanel = useCallback(() => {
+  const togglePanel = useCallback((opener: HTMLElement) => {
     if (open) {
       setOpen(false);
       return;
     }
+    openerRef.current = opener;
     positionPanel();
     setOpen(true);
   }, [open, positionPanel]);
 
-  const showPanel = useCallback(() => {
+  const showPanel = useCallback((opener: HTMLElement) => {
+    openerRef.current = opener;
     positionPanel();
     setOpen(true);
   }, [positionPanel]);
 
   useEffect(() => {
     if (!open) return;
+    panelRef.current?.querySelector<HTMLElement>('button, select')?.focus();
     const onMouseDown = (event: MouseEvent) => {
       const target = event.target as Node;
       if (!buttonRef.current?.contains(target) && !panelRef.current?.contains(target)) setOpen(false);
     };
-    const onKeyDown = (event: KeyboardEvent) => { if (event.key === 'Escape') setOpen(false); };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      setOpen(false);
+      openerRef.current?.focus();
+    };
     const dismiss = () => setOpen(false);
     document.addEventListener('mousedown', onMouseDown);
     window.addEventListener('keydown', onKeyDown);
@@ -211,7 +220,7 @@ export function IssuePolicyStrip({ issueId }: { issueId: string }) {
         aria-label="Issue policies"
         aria-expanded={open}
         className={`inline-flex h-[22px] items-center gap-1.5 rounded border border-border px-2 text-[11px] font-medium hover:bg-muted hover:text-foreground ${overrideCount > 0 ? 'text-foreground' : 'text-muted-foreground'}`}
-        onClick={togglePanel}
+        onClick={(event) => togglePanel(event.currentTarget)}
       >
         <svg aria-hidden="true" className="h-[11px] w-[11px]" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
           <line x1="2" y1="4.5" x2="14" y2="4.5" /><circle cx="6" cy="4.5" r="1.7" fill="currentColor" />
@@ -222,13 +231,13 @@ export function IssuePolicyStrip({ issueId }: { issueId: string }) {
       </button>
 
       {overrides.map((override) => (
-        <button key={override.key} type="button" className="inline-flex h-5 items-center gap-1 rounded border border-primary/32 bg-primary/8 px-1.5 text-[11px] font-medium text-foreground" onClick={showPanel}>
+        <button key={override.key} type="button" className="inline-flex h-5 items-center gap-1 rounded border border-primary/32 bg-primary/8 px-1.5 text-[11px] font-medium text-foreground" onClick={(event) => showPanel(event.currentTarget)}>
           <span className="text-muted-foreground">{override.label} ·</span> {override.value}
         </button>
       ))}
 
       {needsRestart && (
-        <button type="button" className="inline-flex h-5 items-center rounded border border-warning/32 bg-warning/8 px-1.5 text-[11px] font-medium text-warning-foreground" onClick={showPanel}>
+        <button type="button" className="inline-flex h-5 items-center rounded border border-warning/32 bg-warning/8 px-1.5 text-[11px] font-medium text-warning-foreground" onClick={(event) => showPanel(event.currentTarget)}>
           restart pending
         </button>
       )}
@@ -236,8 +245,10 @@ export function IssuePolicyStrip({ issueId }: { issueId: string }) {
       {open && panelPos && createPortal(
         <div
           ref={panelRef}
+          role="dialog"
           aria-label="Issue policy overrides"
-          className="fixed z-[100] w-[400px] rounded-lg border border-border bg-popover px-4 pb-3 pt-3.5 shadow-lg"
+          tabIndex={-1}
+          className="fixed z-[100] w-[400px] max-w-[calc(100vw-16px)] rounded-lg border border-border bg-popover px-4 pb-3 pt-3.5 shadow-lg"
           style={{ top: panelPos.top, left: panelPos.left }}
         >
           <h3 className="mb-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Review</h3>
@@ -247,7 +258,7 @@ export function IssuePolicyStrip({ issueId }: { issueId: string }) {
             </span>
             <div className={controlCellClass}>
               <Segmented ariaLabel="Review mode for this issue" value={review.override.reviewMode} resolvedLabel={review.resolved.reviewMode} options={[["quick", "Quick"], ["full", "Full"], ["none", "None"]]} disabled={saving} onChange={(next) => save(`/api/review/${encoded}/config`, { reviewMode: next })} />
-              {review.override.reviewMode && <button type="button" className={resetClass} disabled={saving} onClick={() => save(`/api/review/${encoded}/config`, { reviewMode: null })}>reset</button>}
+              {review.override.reviewMode && <button type="button" aria-label="Reset review mode to default" className={resetClass} disabled={saving} onClick={() => save(`/api/review/${encoded}/config`, { reviewMode: null })}>reset</button>}
             </div>
           </div>
 
@@ -258,7 +269,7 @@ export function IssuePolicyStrip({ issueId }: { issueId: string }) {
               </span>
               <div className={controlCellClass}>
                 <Segmented ariaLabel="Re-review scope for this issue" value={review.override.reReviewScope} resolvedLabel={review.resolved.reReviewScope} options={[["changed", "Changed"], ["all", "All"], ["blockers", "Blockers"]]} disabled={saving} onChange={(next) => save(`/api/review/${encoded}/config`, { reReviewScope: next })} />
-                {review.override.reReviewScope && <button type="button" className={resetClass} disabled={saving} onClick={() => save(`/api/review/${encoded}/config`, { reReviewScope: null })}>reset</button>}
+                {review.override.reReviewScope && <button type="button" aria-label="Reset re-review scope to default" className={resetClass} disabled={saving} onClick={() => save(`/api/review/${encoded}/config`, { reReviewScope: null })}>reset</button>}
               </div>
             </div>
           )}
@@ -272,7 +283,7 @@ export function IssuePolicyStrip({ issueId }: { issueId: string }) {
                 <option value="">Default · {review.resolved.reviewModel ? modelName(review.resolved.reviewModel) : 'per-role default'}</option>
                 {models.map((model) => <option key={model.id} value={model.id}>{model.name}</option>)}
               </select>
-              {review.override.reviewModel && <button type="button" className={resetClass} disabled={saving} onClick={() => save(`/api/review/${encoded}/config`, { reviewModel: null })}>reset</button>}
+              {review.override.reviewModel && <button type="button" aria-label="Reset review model to default" className={resetClass} disabled={saving} onClick={() => save(`/api/review/${encoded}/config`, { reviewModel: null })}>reset</button>}
             </div>
           </div>
 
@@ -286,7 +297,7 @@ export function IssuePolicyStrip({ issueId }: { issueId: string }) {
                 <option value="">Default · {workDefault}</option>
                 {models.map((model) => <option key={model.id} value={model.id}>{model.name}</option>)}
               </select>
-              {staffing.override.workModel && <button type="button" className={resetClass} disabled={saving} onClick={() => save(`/api/issues/${encoded}/staffing`, { workModel: null })}>reset</button>}
+              {staffing.override.workModel && <button type="button" aria-label="Reset work model to default" className={resetClass} disabled={saving} onClick={() => save(`/api/issues/${encoded}/staffing`, { workModel: null })}>reset</button>}
             </div>
           </div>
 
@@ -296,7 +307,7 @@ export function IssuePolicyStrip({ issueId }: { issueId: string }) {
             </span>
             <div className={controlCellClass}>
               <Segmented ariaLabel="Swarm mode for this issue" value={swarm.configured?.mode ?? null} resolvedLabel={swarm.resolved.mode} options={[["off", "Off"], ["auto", "Auto"], ["always", "Always"]]} disabled={saving} onChange={(next) => save(`/api/issues/${encoded}/swarm-policy`, { value: next ? { mode: next } : null })} />
-              {swarm.configured?.mode && <button type="button" className={resetClass} disabled={saving} onClick={() => save(`/api/issues/${encoded}/swarm-policy`, { value: null })}>reset</button>}
+              {swarm.configured?.mode && <button type="button" aria-label="Reset swarm mode to default" className={resetClass} disabled={saving} onClick={() => save(`/api/issues/${encoded}/swarm-policy`, { value: null })}>reset</button>}
             </div>
           </div>
 

--- a/src/dashboard/frontend/tests/command-deck-resource-strip.spec.ts
+++ b/src/dashboard/frontend/tests/command-deck-resource-strip.spec.ts
@@ -62,7 +62,7 @@ const RESOURCE_ISSUES: ResourceIssue[] = [
     hasState: true,
     isShadow: false,
     readyForMerge: false,
-    resourceSources: ['workspace', 'branch', 'tmux', 'vbrief', 'beads', 'pr', 'docker'],
+    resourceSources: ['workspace', 'branch', 'tmux', 'vbrief', 'tasks', 'pr', 'docker'],
     resourceDetails: {
       hasWorkspace: true,
       localBranchCount: 1,
@@ -267,7 +267,7 @@ test.describe('Command Deck resource strip', () => {
     await expectResourceChip('branch: local 1 · remote 1', 'branch local 1 · remote 1');
     await expectResourceChip('tmux: 2 sessions', 'tmux');
     await expectResourceChip('vBRIEF: present', 'vBRIEF');
-    await expectResourceChip('beads: present', 'beads');
+    await expectResourceChip('tasks: present', 'tasks');
     await expectResourceChip('PR: #862 (open) · #863 (open, draft)', '#862');
     await expectResourceChip('docker: 1 container', 'stack 1');
     await workspaceIcon.hover();
@@ -278,7 +278,7 @@ test.describe('Command Deck resource strip', () => {
     await expect(pan862Item.getByText('tmux: agent-pan-862', { exact: true })).toBeVisible();
     await expect(pan862Item.getByText('tmux: review-pan-862', { exact: true })).toBeVisible();
     await expect(pan862Item.getByText('vBRIEF present', { exact: true })).toBeVisible();
-    await expect(pan862Item.getByText('beads present', { exact: true })).toBeVisible();
+    await expect(pan862Item.getByText('tasks present', { exact: true })).toBeVisible();
     await expect(pan862Item.getByText('PR: #862 PAN-862 main PR (open)', { exact: true })).toBeVisible();
     await expect(pan862Item.getByText('PR: #863 PAN-862 draft PR (open, draft)', { exact: true })).toBeVisible();
     await expect(pan862Item.getByText('docker: pan-862-db', { exact: true })).toBeVisible();

--- a/src/dashboard/server/routes/__tests__/codex-auth.test.ts
+++ b/src/dashboard/server/routes/__tests__/codex-auth.test.ts
@@ -8,6 +8,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const mockCliproxy = vi.hoisted(() => ({
   authDir: '',
   logPath: '',
+  homeDir: '',
+}));
+
+vi.mock('os', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('os')>()),
+  homedir: () => mockCliproxy.homeDir,
 }));
 
 vi.mock('../../../../lib/cliproxy.js', async () => {
@@ -27,6 +33,10 @@ vi.mock('../../../../lib/cliproxy.js', async () => {
     getCliproxyLogPath: () => mockCliproxy.logPath,
   };
 });
+
+vi.mock('../../../../lib/agents/queries.js', () => ({
+  listAgentStates: () => [],
+}));
 
 import { codexAuthRouteLayer } from '../codex-auth.js';
 
@@ -49,6 +59,7 @@ beforeEach(async () => {
   vi.useFakeTimers();
   vi.setSystemTime(new Date(NOW));
   tmpRoot = await mkdtemp(join(tmpdir(), 'pan-codex-auth-route-'));
+  mockCliproxy.homeDir = tmpRoot;
   mockCliproxy.authDir = join(tmpRoot, 'auth');
   mockCliproxy.logPath = join(tmpRoot, 'cliproxy.log');
 });
@@ -59,6 +70,7 @@ afterEach(async () => {
   tmpRoot = '';
   mockCliproxy.authDir = '';
   mockCliproxy.logPath = '';
+  mockCliproxy.homeDir = '';
 });
 
 const writeCodexFixture = async (logLines: string[] = []) => {
@@ -101,6 +113,7 @@ describe('GET /api/settings/codex-auth', () => {
       status: 'burned',
       email: EMAIL,
       expiresAt: '2026-06-02T04:40:00.000Z',
+      source: 'cliproxy',
     });
   });
 
@@ -114,6 +127,7 @@ describe('GET /api/settings/codex-auth', () => {
       status: 'valid',
       email: EMAIL,
       expiresAt: '2026-06-02T04:40:00.000Z',
+      source: 'cliproxy',
     });
   });
 });

--- a/src/dashboard/server/routes/agents/spawn.ts
+++ b/src/dashboard/server/routes/agents/spawn.ts
@@ -10,6 +10,7 @@ import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
 import { saveAgentStateSync, determineModel, getProviderAuthMode, getAgentState } from '../../../../lib/agents.js';
 import { buildChildEnvWithoutTmuxSync } from '../../../../lib/child-env.js';
 import { checkCodexAuthStatus } from '../../../../lib/codex-auth.js';
+import { listAgentStates } from '../../../../lib/agents/queries.js';
 import { canUseHarnessSync } from '../../../../lib/harness-policy.js';
 import { emitActivityEntrySync } from '../../../../lib/activity-logger.js';
 import { extractPrefixSync, parseIssueIdSync } from '../../../../lib/issue-id.js';
@@ -314,7 +315,7 @@ export const postAgentsRoute = HttpRouter.add(
     }
     const providerAuthMode = yield* Effect.promise(() => getProviderAuthMode(spawnModel));
     if (providerAuthMode === 'subscription') {
-      const codexAuth = yield* checkCodexAuthStatus();
+      const codexAuth = yield* checkCodexAuthStatus({ agentStates: listAgentStates() });
       if (codexAuth.status === 'expired' || codexAuth.status === 'burned') {
         return jsonResponse({
           success: false,

--- a/src/dashboard/server/routes/codex-auth.ts
+++ b/src/dashboard/server/routes/codex-auth.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import { jsonResponse } from '../http-helpers.js';
 import { httpHandler } from './http-handler.js';
 import { checkCodexAuthStatus } from '../../../lib/codex-auth.js';
+import { listAgentStates } from '../../../lib/agents/queries.js';
 import { bridgeCodexAuthToCliproxy, getCliproxyAuthDir } from '../../../lib/cliproxy.js';
 import { createSession, sessionExists, listSessionNames } from '../../../lib/tmux.js';
 import { getDashboardApiUrlSync } from '../../../lib/config.js';
@@ -101,7 +102,7 @@ const getCodexAuthRoute = HttpRouter.add(
   '/api/settings/codex-auth',
   httpHandler(
     Effect.gen(function* () {
-      const status = yield* checkCodexAuthStatus();
+      const status = yield* checkCodexAuthStatus({ agentStates: listAgentStates() });
       return jsonResponse(status);
     }),
   ),
@@ -186,9 +187,10 @@ const postCodexReauthStatusRoute = HttpRouter.add(
         (beforeCredential.accessToken !== null && afterCredential.accessToken !== beforeCredential.accessToken) ||
         (afterCredential.mtimeMs !== null && afterCredential.mtimeMs >= session.createdAt)
       );
-      const authStatus = yield* checkCodexAuthStatus(
-        refreshedCredential ? { ignoreBurnBefore: session.createdAt } : undefined,
-      );
+      const authStatus = yield* checkCodexAuthStatus({
+        ...(refreshedCredential ? { ignoreBurnBefore: session.createdAt } : {}),
+        agentStates: listAgentStates(),
+      });
       if (!refreshedCredential || authStatus.status !== 'valid') {
         return jsonResponse({
           completed: true,

--- a/src/lib/__tests__/agents-spawn-supervisor.test.ts
+++ b/src/lib/__tests__/agents-spawn-supervisor.test.ts
@@ -69,6 +69,9 @@ function mockSpawnDependencies(): void {
   vi.doMock('../runtimes/codex.js', () => ({
     initCodexHome: vi.fn(),
   }));
+  vi.doMock('../codex-auth.js', () => ({
+    assertCodexNativeAuthForSpawn: vi.fn(),
+  }));
   vi.doMock('../runtimes/pi-fifo.js', () => ({
     PiNotReady: class PiNotReady extends Error {
       readonly code = 'PI_NOT_READY';
@@ -197,6 +200,7 @@ afterEach(() => {
   vi.doUnmock('../agents/hook-readiness.js');
   vi.doUnmock('../agent-runtime-mirror.js');
   vi.doUnmock('../runtimes/codex.js');
+  vi.doUnmock('../codex-auth.js');
   vi.doUnmock('../runtimes/pi-fifo.js');
   vi.doUnmock('../paths.js');
   vi.doUnmock('../tmux.js');

--- a/src/lib/agents/spawn.ts
+++ b/src/lib/agents/spawn.ts
@@ -165,7 +165,7 @@ export async function spawnRun(issueId: string, role: Role, options: SpawnRunOpt
   });
   // PAN-2285: never launch a fresh Codex agent when native Codex auth is
   // missing/expired/burned — it would wedge silently in a 401 loop.
-  assertCodexNativeAuthForSpawn(resolvedHarness);
+  assertCodexNativeAuthForSpawn(resolvedHarness, listAgentStates());
   await ensureLifecycleHooksBeforeLaunch(agentId, resolvedHarness);
 
   if (
@@ -500,7 +500,7 @@ export async function spawnAgent(options: SpawnOptions): Promise<AgentState> {
   });
   // PAN-2285: never launch a fresh Codex agent when native Codex auth is
   // missing/expired/burned — it would wedge silently in a 401 loop.
-  assertCodexNativeAuthForSpawn(resolvedHarness);
+  assertCodexNativeAuthForSpawn(resolvedHarness, listAgentStates());
   await ensureLifecycleHooksBeforeLaunch(agentId, resolvedHarness);
   // Create state
   const state: AgentState = {

--- a/src/lib/cloister/verification-runner.ts
+++ b/src/lib/cloister/verification-runner.ts
@@ -29,22 +29,14 @@ import { getVBriefACStatusSync } from '../vbrief/acceptance-criteria.js';
 import { VBriefMergeConflictError } from '../vbrief/io.js';
 import { checkIncompletePlanItemsPromise } from '../work/done-preflight.js';
 import type { TemplatePlaceholders } from '../workspace-config.js';
+import type { VerificationRunnerOutcome, WorkspaceInfo } from './verification-types.js';
+
+export type { VerificationRunnerOutcome, WorkspaceInfo } from './verification-types.js';
 
 const execAsync = promisify(exec);
 
 export const VERIFICATION_MAX_CYCLES = 3;
 const NO_PROGRESS_REPEAT_THRESHOLD = 2;
-
-export type VerificationRunnerOutcome =
-  | { outcome: 'passed' }
-  | { outcome: 'skipped'; reason: string }
-  | { outcome: 'failed'; failedCheck: string; cycleCount: number; maxCycles: number }
-  | { outcome: 'error'; message: string };
-
-export interface WorkspaceInfo {
-  isRemote: boolean;
-  vmName?: string;
-}
 
 export interface VerificationRunnerOptions {
   syncTargetBranch?: boolean;

--- a/src/lib/cloister/verification-types.ts
+++ b/src/lib/cloister/verification-types.ts
@@ -1,0 +1,11 @@
+/** Shared verification contracts used by the runner and its process supervisor. */
+export type VerificationRunnerOutcome =
+  | { outcome: 'passed' }
+  | { outcome: 'skipped'; reason: string }
+  | { outcome: 'failed'; failedCheck: string; cycleCount: number; maxCycles: number }
+  | { outcome: 'error'; message: string };
+
+export interface WorkspaceInfo {
+  isRemote: boolean;
+  vmName?: string;
+}

--- a/src/lib/cloister/verification-worker-supervisor.ts
+++ b/src/lib/cloister/verification-worker-supervisor.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { spawn } from 'node:child_process';
 
 import { getOverdeckHome, packageRoot } from '../paths.js';
-import type { VerificationRunnerOutcome, WorkspaceInfo } from './verification-runner.js';
+import type { VerificationRunnerOutcome, WorkspaceInfo } from './verification-types.js';
 
 type WorkerState = {
   runId: string;

--- a/src/lib/codex-auth.ts
+++ b/src/lib/codex-auth.ts
@@ -4,7 +4,6 @@ import { homedir } from 'os';
 import { join } from 'path';
 import { Effect, Data } from 'effect';
 import { decodeJwtPayload, getCliproxyAuthDir, getCliproxyLogPath } from './cliproxy.js';
-import { listOverdeckAgentStatesSync } from './overdeck/agent-state-sync.js';
 
 /**
  * Which store a codex auth status came from (PAN-2285). 'native' = the codex
@@ -57,6 +56,7 @@ export type CodexAuthStatus = CodexAuthValid | CodexAuthExpired | CodexAuthBurne
 
 interface CheckCodexAuthOptions {
   ignoreBurnBefore?: number;
+  agentStates?: ReadonlyArray<CodexAuthBurnFlagState & { id: string }>;
 }
 
 interface CliproxyCodexCredentials {
@@ -273,21 +273,21 @@ export function filterCodexAuthBurnedAgentIds(
 }
 
 /**
- * Agents currently flagged codex-auth-burned, read from the shared agents table
- * (the runtime registry) so flags written by the deacon child process are
- * visible here in the dashboard server process.
+ * Agents currently flagged codex-auth-burned. Callers supply states read through
+ * the agent resolver so this pure auth module does not create a spawn-time cycle.
  */
-export function listCodexAuthBurnedAgentsSync(nativeMtimeMs: number): string[] {
-  try {
-    return filterCodexAuthBurnedAgentIds(listOverdeckAgentStatesSync(), nativeMtimeMs);
-  } catch {
-    return [];
-  }
+export function listCodexAuthBurnedAgentsSync(
+  nativeMtimeMs: number,
+  states: ReadonlyArray<CodexAuthBurnFlagState & { id: string }>,
+): string[] {
+  return filterCodexAuthBurnedAgentIds(states, nativeMtimeMs);
 }
 
 /** Sync convenience for the spawn gate: are any agents still burned right now? */
-export function hasActiveBurnedCodexAgentsSync(): boolean {
-  return listCodexAuthBurnedAgentsSync(nativeCodexAuthMtimeSync()).length > 0;
+export function hasActiveBurnedCodexAgentsSync(
+  states: ReadonlyArray<CodexAuthBurnFlagState & { id: string }>,
+): boolean {
+  return listCodexAuthBurnedAgentsSync(nativeCodexAuthMtimeSync(), states).length > 0;
 }
 
 // ─── Combined status (native ⊕ cliproxy ⊕ pane-burn) ───────────────────────────
@@ -342,7 +342,7 @@ async function checkCodexAuthStatusPromise(options: CheckCodexAuthOptions = {}):
   // still be unexpired while the refresh token is revoked, so it beats the
   // static probe. Flags are read from the shared agents table — the deacon
   // child process wrote them there via saveAgentStateSync.
-  const activeBurned = listCodexAuthBurnedAgentsSync(native.mtimeMs);
+  const activeBurned = listCodexAuthBurnedAgentsSync(native.mtimeMs, options.agentStates ?? []);
   if (activeBurned.length > 0) {
     return {
       status: 'burned',
@@ -363,7 +363,10 @@ async function checkCodexAuthStatusPromise(options: CheckCodexAuthOptions = {}):
  * the symlink migration in initCodexHome heals a stale home on relaunch. Throws
  * a clear, remedy-naming error, mirroring the harness-policy ToS gate.
  */
-export function assertCodexNativeAuthForSpawn(harness: string | undefined): void {
+export function assertCodexNativeAuthForSpawn(
+  harness: string | undefined,
+  agentStates: ReadonlyArray<CodexAuthBurnFlagState & { id: string }>,
+): void {
   if (harness !== 'codex') return;
   const native = probeNativeCodexAuthSync();
   const reason =
@@ -371,7 +374,7 @@ export function assertCodexNativeAuthForSpawn(harness: string | undefined): void
       ? 'not signed in (~/.codex/auth.json is missing)'
       : native.status === 'expired'
         ? 'expired (~/.codex/auth.json access token has lapsed)'
-        : hasActiveBurnedCodexAgentsSync()
+        : hasActiveBurnedCodexAgentsSync(agentStates)
           ? 'revoked (a running codex agent hit a revoked refresh token — the shared token family is dead)'
           : null;
   if (reason === null) return;
@@ -578,7 +581,7 @@ export function evaluateBurnedFromLog(
  * (i.e., not from the documented "missing/unknown" branches).
  */
 export const checkCodexAuthStatus = (
-  options: { ignoreBurnBefore?: number } = {},
+  options: CheckCodexAuthOptions = {},
 ): Effect.Effect<CodexAuthStatus, CodexAuthCheckError> =>
   Effect.tryPromise({
     try: () => checkCodexAuthStatusPromise(options),

--- a/tests/integration/beads-cross-machine.test.ts
+++ b/tests/integration/beads-cross-machine.test.ts
@@ -11,6 +11,15 @@ function run(cwd: string, file: string, args: string[], env: NodeJS.ProcessEnv =
 function git(cwd: string, ...args: string[]): string { return run(cwd, 'git', args); }
 function bd(cwd: string, ...args: string[]): string { return run(cwd, 'bd', args); }
 
+const hasBd = (() => {
+  try {
+    execFileSync('bd', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
 function clone(remote: string, target: string): void {
   run(join(target, '..'), 'git', ['clone', '-q', remote, target]);
   git(target, 'config', 'user.name', 'Cross Machine Test');
@@ -18,7 +27,7 @@ function clone(remote: string, target: string): void {
   git(target, 'config', 'tasks.role', 'maintainer');
 }
 
-describe('Dolt cross-machine tasks authority', () => {
+describe.skipIf(!hasBd)('Dolt cross-machine tasks authority', () => {
   const roots: string[] = [];
   afterEach(() => roots.splice(0).forEach((root) => rmSync(root, { recursive: true, force: true })));
 


### PR DESCRIPTION
## Summary
- collapse the five-select issue policy strip into one Policies button with override chips
- add a grouped, portaled Review/Work panel with segmented enums, model selectors, resets, and restart-pending action
- add a focused no-loss audit and update operator documentation
- repair the stale introspection baseline, durable review-mode test fixture, and verification-worker import cycle exposed by the full gates

Closes #2681

## Verification
- `npm run typecheck` — passed
- `npm run lint` — passed
- `npm test` — 981 passed, 3 skipped test files; 9,075 passed, 50 skipped tests
- frontend parity suite — 3 files and 32 tests passed
- focused frontend `IssuePolicyStrip` suite — 5/5 passed
- Playwright visual check — passed in light and dark themes; panel verified outside an overflow-hidden mount

## Notes
- implementation remains self-contained in `IssuePolicyStrip.tsx` plus its test, per PRD NFR-3
- `ReviewPolicyControl.tsx` remains the existing one-line re-export
- no policy API or server behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a compact **Policies** control in issue headers for managing review, work-model, and swarm overrides.
  * Active overrides now appear as chips, with grouped controls, individual resets, and a “Reset all to defaults” option.
  * Added clearer indicators and guidance when work-model changes require a fresh run.

* **Bug Fixes**
  * Improved Codex authentication checks when starting agents, using current agent activity for eligibility decisions.

* **Documentation**
  * Updated policy and review documentation to reflect the issue-header Policies control and fresh-run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->