### PR TITLE
test(infra): stub hook bundle freshness guard in pre-push fixture (PAN-2703)

### DIFF
--- a/tests/unit/scripts/pre-push-hook.test.ts
+++ b/tests/unit/scripts/pre-push-hook.test.ts
@@ -21,6 +21,9 @@ function makeHookFixture(): { root: string; hook: string } {
   writeFileSync(join(root, 'scripts', 'guard-state-plane-branches.sh'), '#!/usr/bin/env bash\nexit 0\n', {
     mode: 0o755,
   });
+  writeFileSync(join(root, 'scripts', 'guard-hook-bundle-freshness.sh'), '#!/usr/bin/env bash\nexit 0\n', {
+    mode: 0o755,
+  });
   return { root, hook };
 }
 


### PR DESCRIPTION
Fixes red main.

`main` CI `test` has been red since `a9abceec` (PAN-2699), which added
`bash scripts/guard-hook-bundle-freshness.sh` at `.husky/pre-push:60` without
updating the hook's own test fixture.

`makeHookFixture()` stubs each script-backed guard in a temp root. The new guard
was never stubbed, so bash exits 127 there; the hook runs under `set -e`, exits
non-zero, and `runHook()` returns `ok: false` — failing the assertion at
`tests/unit/scripts/pre-push-hook.test.ts:97`.

This adds the missing stub, matching the existing idiom. The guard call in
`.husky/pre-push` and the assertion are both left intact — the guard is the
point of PAN-2699.

## Gates
- `npx vitest run tests/unit/scripts/pre-push-hook.test.ts` → 4 passed (was 1 failed / 3 passed)
- `npm run typecheck` → green
- `npm run lint` → green

Independently root-caused by strikes PAN-2701 and PAN-2690, which both hit this
failure and correctly refused to push without green gates.

Closes PAN-2703

🤖 Generated with [Claude Code](https://claude.com/claude-code)