### PR TITLE
fix(cloister): drain queued codex mail at turn end (PAN-2701)

### DIFF
--- a/src/lib/agents/messaging.ts
+++ b/src/lib/agents/messaging.ts
@@ -50,12 +50,12 @@ import {
   getProviderExportsForModel,
 } from './provider-env.js';
 
-function queueAgentMail(agentId: string, message: string): void {
+function queueAgentMail(agentId: string, message: string, pendingTurnEndDelivery = false): void {
   const mailDir = join(getAgentDir(agentId), 'mail');
   mkdirSync(mailDir, { recursive: true });
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
   writeFileSync(
-    join(mailDir, `${timestamp}.md`),
+    join(mailDir, `${timestamp}${pendingTurnEndDelivery ? '.pending' : ''}.md`),
     `# Message\n\n${message}\n`
   );
 }
@@ -368,13 +368,21 @@ export async function messageAgent(
   // mirror 'idle' via Stop/SessionStart hook), not a tmux pane-scrape.
   const promptReady = await waitForAgentIdle(normalizedId, 5000);
   if (!promptReady) {
+    if (expectedHarness === 'codex') {
+      queueAgentMail(normalizedId, message, true);
+      logAgentLifecycleSync(normalizedId, 'messageAgent queued mail for codex turn-end delivery: agent busy');
+      console.log(`[agents] Queued message for ${normalizedId}; codex agent is mid-turn`);
+      await appendTellInterventionForUserSource(normalizedId, caller);
+      return;
+    }
     console.warn(`[agents] ${normalizedId} not at idle prompt after 5s — sending message anyway`);
   }
 
   const deliveryMethod = resilientDeliveryMethod(agentState?.deliveryMethod);
   await deliverAgentMessage(normalizedId, message, `messageAgent:${caller}`, deliveryMethod);
 
-  // Also save to mail queue
+  // Save a durable backup. Unlike `.pending.md` busy-turn mail, the Codex hook
+  // does not replay ordinary `.md` backups because they have already landed.
   queueAgentMail(normalizedId, message);
   await appendTellInterventionForUserSource(normalizedId, caller);
 }

--- a/sync-sources/hooks/codex-notify-hook
+++ b/sync-sources/hooks/codex-notify-hook
@@ -16,7 +16,7 @@
 
 import { join } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
-import { writeFileSync, mkdirSync, existsSync, readFileSync, statSync, unlinkSync, appendFileSync } from 'node:fs';
+import { writeFileSync, mkdirSync, existsSync, readFileSync, statSync, unlinkSync, appendFileSync, readdirSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 
 const agentId = process.env.OVERDECK_AGENT_ID;
@@ -62,6 +62,40 @@ try {
 try {
   writeFileSync(join(agentDir, 'turn-completed'), timestamp + '\n');
 } catch { /* ignore */ }
+
+// PAN-2701: a paste sent while Codex is mid-turn remains unsubmitted in its
+// input box. messageAgent therefore queues busy-turn messages in mail/. At the
+// idle boundary, submit the oldest message and delete it only after both tmux
+// operations succeed. One message per turn keeps ordering deterministic; the
+// next turn completion drains the next file.
+try {
+  const mailDir = join(agentDir, 'mail');
+  const mailFile = readdirSync(mailDir)
+    .filter((name) => name.endsWith('.pending.md'))
+    .sort()[0];
+  if (mailFile) {
+    const mailPath = join(mailDir, mailFile);
+    const queued = readFileSync(mailPath, 'utf8').replace(/^# Message\r?\n\r?\n/, '').replace(/\r?\n$/, '');
+    const tmpFile = join(tmpdir(), `codex-mail-${agentId}-${process.pid}-${Date.now()}`);
+    let delivered = false;
+    try {
+      writeFileSync(tmpFile, queued);
+      const load = spawnSync('tmux', ['-L', 'overdeck', 'load-buffer', tmpFile], { stdio: 'ignore' });
+      const paste = load.status === 0
+        ? spawnSync('tmux', ['-L', 'overdeck', 'paste-buffer', '-t', agentId], { stdio: 'ignore' })
+        : undefined;
+      if (paste?.status === 0) {
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 300);
+        const submit = spawnSync('tmux', ['-L', 'overdeck', 'send-keys', '-t', agentId, 'C-m'], { stdio: 'ignore' });
+        delivered = submit.status === 0;
+      }
+    } catch { /* best-effort */ }
+    try { unlinkSync(tmpFile); } catch { /* ignore */ }
+    if (delivered) {
+      try { unlinkSync(mailPath); } catch { /* retry on the next turn */ }
+    }
+  }
+} catch { /* no queue or best-effort failure — never crash the hook */ }
 
 // PAN-2675: interactive convoy reviewer (codex harness) finished a turn. If it
 // wrote its report and hasn't signaled yet, deliver REVIEWER_READY to the

--- a/tests/scripts/codex-notify-hook.test.ts
+++ b/tests/scripts/codex-notify-hook.test.ts
@@ -174,3 +174,86 @@ describe('codex-notify-hook REVIEWER_READY signal (PAN-2675)', () => {
     expect(existsSync(tmuxLog)).toBe(false)
   })
 })
+
+describe('codex-notify-hook queued mail drain (PAN-2701)', () => {
+  let tempRoot: string
+  let overdeckHome: string
+  let mockBin: string
+  let hookPath: string
+  let tmuxLog: string
+  let agentDir: string
+
+  function runHook(sendExit = 0): void {
+    writeFileSync(
+      join(mockBin, 'tmux'),
+      `#!/bin/bash\nprintf '%s\\n' "$*" >> "$MOCK_TMUX_LOG"\n` +
+        `if [ "$3" = "load-buffer" ]; then cat "$4" >> "$MOCK_TMUX_LOG"; printf '\\n' >> "$MOCK_TMUX_LOG"; fi\n` +
+        `case "$*" in *send-keys*) exit ${sendExit};; esac\nexit 0\n`,
+      'utf-8',
+    )
+    chmodSync(join(mockBin, 'tmux'), 0o755)
+    spawnSync('node', [hookPath], {
+      input: '{}',
+      env: {
+        ...process.env,
+        OVERDECK_HOME: overdeckHome,
+        OVERDECK_AGENT_ID: 'agent-pan-2701',
+        MOCK_TMUX_LOG: tmuxLog,
+        PATH: `${mockBin}:${process.env.PATH ?? ''}`,
+      },
+      timeout: 10_000,
+    })
+  }
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'codex-mail-drain-'))
+    overdeckHome = join(tempRoot, 'home')
+    mockBin = join(tempRoot, 'bin')
+    hookPath = join(tempRoot, 'codex-notify-hook')
+    tmuxLog = join(tempRoot, 'tmux.log')
+    agentDir = join(overdeckHome, 'agents', 'agent-pan-2701')
+    mkdirSync(join(agentDir, 'mail'), { recursive: true })
+    mkdirSync(mockBin, { recursive: true })
+    copyFileSync(SOURCE_HOOK, hookPath)
+    chmodSync(hookPath, 0o755)
+  })
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true })
+  })
+
+  it('submits only the oldest queued message and deletes it after confirmed submit', () => {
+    const oldest = join(agentDir, 'mail', '2026-07-15T11-17-00-000Z.pending.md')
+    const newest = join(agentDir, 'mail', '2026-07-15T11-28-00-000Z.pending.md')
+    writeFileSync(oldest, '# Message\n\nfirst feedback\n')
+    writeFileSync(newest, '# Message\n\nsecond feedback\n')
+
+    runHook()
+
+    const log = readFileSync(tmuxLog, 'utf-8')
+    expect(log).toContain('first feedback')
+    expect(log).toContain('paste-buffer -t agent-pan-2701')
+    expect(log).toContain('send-keys -t agent-pan-2701 C-m')
+    expect(existsSync(oldest)).toBe(false)
+    expect(existsSync(newest)).toBe(true)
+  })
+
+  it('keeps queued mail when submit fails so the next turn can retry', () => {
+    const mail = join(agentDir, 'mail', '2026-07-15T11-17-00-000Z.pending.md')
+    writeFileSync(mail, '# Message\n\nretry me\n')
+
+    runHook(1)
+
+    expect(existsSync(mail)).toBe(true)
+  })
+
+  it('does not replay ordinary backup mail that may already have landed', () => {
+    const backup = join(agentDir, 'mail', '2026-07-15T11-17-00-000Z.md')
+    writeFileSync(backup, '# Message\n\nalready delivered\n')
+
+    runHook()
+
+    expect(existsSync(tmuxLog)).toBe(false)
+    expect(existsSync(backup)).toBe(true)
+  })
+})

--- a/tests/unit/lib/agents/message-agent.test.ts
+++ b/tests/unit/lib/agents/message-agent.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { Effect } from 'effect';
+import { existsSync, readdirSync, readFileSync, rmSync } from 'node:fs';
 
 const mocks = vi.hoisted(() => ({
   getAgentStateSync: vi.fn(),
@@ -113,6 +114,10 @@ describe('messageAgent', () => {
     mocks.deliverAgentMessage.mockResolvedValue({ ok: true });
   });
 
+  afterEach(() => {
+    rmSync('/tmp/agent-pan-2701', { recursive: true, force: true });
+  });
+
   it('delivers to a troubled agent when its tmux session is live', async () => {
     mocks.getAgentStateSync.mockReturnValue({
       id: 'agent-pan-2262',
@@ -135,5 +140,44 @@ describe('messageAgent', () => {
       'agent-pan-2262',
       expect.stringContaining('queued mail without resume'),
     );
+  });
+
+  it('queues a message instead of pasting into a mid-turn codex agent', async () => {
+    mocks.getAgentStateSync.mockReturnValue({
+      id: 'agent-pan-2701',
+      issueId: 'PAN-2701',
+      status: 'running',
+      workspace: '/repo',
+      harness: 'codex',
+    });
+    mocks.waitForAgentIdle.mockResolvedValue(false);
+
+    await messageAgent('agent-pan-2701', 'review feedback', 'pan-tell');
+
+    expect(mocks.deliverAgentMessage).not.toHaveBeenCalled();
+    const mailDir = '/tmp/agent-pan-2701/mail';
+    expect(existsSync(mailDir)).toBe(true);
+    const files = readdirSync(mailDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/\.pending\.md$/);
+    expect(readFileSync(`${mailDir}/${files[0]}`, 'utf-8')).toContain('review feedback');
+  });
+
+  it('marks direct codex delivery as backup mail rather than pending mail', async () => {
+    mocks.getAgentStateSync.mockReturnValue({
+      id: 'agent-pan-2701',
+      issueId: 'PAN-2701',
+      status: 'running',
+      workspace: '/repo',
+      harness: 'codex',
+    });
+
+    await messageAgent('agent-pan-2701', 'operator message', 'pan-tell');
+
+    expect(mocks.deliverAgentMessage).toHaveBeenCalledOnce();
+    const files = readdirSync('/tmp/agent-pan-2701/mail');
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/\.md$/);
+    expect(files[0]).not.toContain('.pending.md');
   });
 });


### PR DESCRIPTION
A paste sent while Codex is mid-turn stays unsubmitted in its input box, so
verdict feedback and `pan tell` messages silently dead-lettered.

`messageAgent` now queues busy-turn codex messages as `mail/<ts>.pending.md`
instead of pasting into a mid-turn session, and the codex notify hook drains the
oldest pending message at the idle boundary using the sanctioned tmux sequence
(`load-buffer` → `paste-buffer` → 300ms settle → `C-m`), deleting the file only
after both operations succeed. One message per turn keeps ordering
deterministic; the next turn completion drains the next file.

Ordinary `.md` mail backups are not replayed — they have already landed.

## Gates
- Rebased onto green main (`3736d5e0a1`)
- Focused regression tests: 12 passed
- `npx vitest run tests/unit/scripts/pre-push-hook.test.ts` → 4 passed
- typecheck + lint green

Authored by strike-pan-2701, which correctly refused to push while main was red.

Closes PAN-2701

🤖 Generated with [Claude Code](https://claude.com/claude-code)