### PR TITLE
fix(dashboard): show signaled reviewers as warm-idle (PAN-2690)

### DIFF
--- a/src/dashboard/server/routes/__tests__/reviewer-tree.test.ts
+++ b/src/dashboard/server/routes/__tests__/reviewer-tree.test.ts
@@ -240,6 +240,27 @@ describe('buildReviewerNodes (PAN-830)', () => {
     expect(nodes.every(n => n.presence === 'idle')).toBe(true);
   });
 
+  it('marks a live reviewer warm-idle after REVIEWER_READY is signaled (PAN-2690)', async () => {
+    const correctness = getReviewerSessionName('correctness', PROJECT_KEY, ISSUE_ID);
+    await mkdir(join(agentsDir, correctness), { recursive: true });
+    await writeFile(join(agentsDir, correctness, 'reviewer-signaled'), '');
+
+    const nodes = await buildReviewerNodes({
+      issueId: ISSUE_ID,
+      projectKey: PROJECT_KEY,
+      workspacePath: WORKSPACE_PATH,
+      tmuxSessionNames: new Set([correctness]),
+      startedAt: '2026-01-01T00:00:00Z',
+      status: 'running',
+      agentsDirOverride: agentsDir,
+    });
+
+    const correctnessNode = nodes.find(n => n.role === 'correctness')!;
+    expect(correctnessNode.status).toBe('running');
+    expect(correctnessNode.presence).toBe('idle');
+    expect(correctnessNode.tmuxSession).toBe(correctness);
+  });
+
   it('marks presence "ended" when no tmux session exists', async () => {
     const nodes = await buildReviewerNodes({
       issueId: ISSUE_ID,

--- a/src/dashboard/server/routes/reviewer-tree.ts
+++ b/src/dashboard/server/routes/reviewer-tree.ts
@@ -352,6 +352,12 @@ export async function buildReviewerNodes(
         : false;
       const inProgressThisRound = isLive && latestReviewRunDir !== null && !latestRunOutputExists;
 
+      // PAN-2690 — codex reviewers stay alive at their prompt after the notify
+      // hook signals REVIEWER_READY. The marker is cleared before every new
+      // convoy round, so its presence means this live session is warm-idle for
+      // the current round rather than actively reviewing.
+      const isWarmIdle = isLive && existsSync(join(agentsRoot, sessionId, 'reviewer-signaled'));
+
       // Determine if the reviewer is genuinely working or just a zombie session.
       // A reviewer is a zombie when: tmux is alive, the latest archived round
       // artifact says completed/failed, AND no newer round directory has
@@ -383,7 +389,7 @@ export async function buildReviewerNodes(
       if (hasApiError) {
         presence = 'idle';
       } else if (isLive && !isZombie) {
-        presence = (opts.status === 'running' || inProgressThisRound) ? 'active' : 'idle';
+        presence = !isWarmIdle && (opts.status === 'running' || inProgressThisRound) ? 'active' : 'idle';
       } else {
         // Zombie or dead — treat as ended so terminal won't try to connect
         presence = isZombie ? 'idle' : 'ended';


### PR DESCRIPTION
Codex convoy reviewers stay alive at their prompt after the notify hook signals
`REVIEWER_READY`, so the dashboard rendered them `active` forever and their
spinners never stopped.

`buildReviewerNodes` now treats a live session carrying the `reviewer-signaled`
marker as warm-idle and renders it `idle` instead of `active`. The session stays
running and resumable — only the presentation changes.

The marker is a sound per-round signal: `src/lib/cloister/review-convoy.ts:153`
removes it at every reviewer spawn, so its presence means "signaled this round"
rather than "signaled at some point".

## Gates
- Rebased onto green main (`3736d5e0a1`)
- Focused tests + typecheck + lint green (verified by the strike)
- `npx vitest run tests/unit/scripts/pre-push-hook.test.ts` → 4 passed

Authored by strike-pan-2690, which correctly refused to push while main was red.

Closes PAN-2690

🤖 Generated with [Claude Code](https://claude.com/claude-code)