### PR TITLE
feat(cli): persist pan start policy flags (PAN-2704)

### DIFF
--- a/src/cli/commands/__tests__/start-policy-overrides.test.ts
+++ b/src/cli/commands/__tests__/start-policy-overrides.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { updateIssueRecord } = vi.hoisted(() => ({
+  updateIssueRecord: vi.fn(async (_project, _issueId, mutator) => {
+    const record: Record<string, unknown> = { swarm: { policy: { inspection: 'required' } } };
+    await mutator(record);
+    return record;
+  }),
+}));
+
+vi.mock('../../../lib/pan-dir/record-update.js', () => ({ updateIssueRecord }));
+
+import { hasStartPolicyOverrides, parseStartPolicyOverrides, persistStartPolicyOverrides } from '../start-policy-overrides.js';
+
+describe('pan start policy overrides', () => {
+  it('parses all supported start-time policy flags', () => {
+    expect(parseStartPolicyOverrides({ model: 'gpt-5.6-sol', swarm: 'off', reviewMode: 'full', reviewModel: 'gpt-5.5' })).toEqual({
+      workModel: 'gpt-5.6-sol', swarmMode: 'off', reviewMode: 'full', reviewModel: 'gpt-5.5',
+    });
+  });
+
+  it.each([
+    [{ swarm: 'sometimes' }, 'Invalid --swarm value'],
+    [{ reviewMode: 'fast' }, 'Invalid --review-mode value'],
+  ])('rejects invalid policy flag values', (options, message) => {
+    expect(() => parseStartPolicyOverrides(options)).toThrow(message);
+  });
+
+  it('leaves inherited policy untouched when flags are omitted', async () => {
+    const overrides = parseStartPolicyOverrides({});
+    expect(hasStartPolicyOverrides(overrides)).toBe(false);
+    await persistStartPolicyOverrides({} as never, 'PAN-2704', overrides);
+    expect(updateIssueRecord).not.toHaveBeenCalled();
+  });
+
+  it('creates or updates the issue record through the canonical writer', async () => {
+    await persistStartPolicyOverrides({} as never, 'PAN-2704', {
+      workModel: 'gpt-5.6-sol', swarmMode: 'off', reviewMode: 'full', reviewModel: 'gpt-5.5',
+    });
+    expect(updateIssueRecord).toHaveBeenCalledWith({}, 'PAN-2704', expect.any(Function));
+    await expect(updateIssueRecord.mock.results[0].value).resolves.toEqual({
+      workModel: 'gpt-5.6-sol', reviewMode: 'full', reviewModel: 'gpt-5.5',
+      swarm: { policy: { inspection: 'required', mode: 'off' } },
+    });
+  });
+});

--- a/src/cli/commands/start-policy-overrides.ts
+++ b/src/cli/commands/start-policy-overrides.ts
@@ -1,0 +1,68 @@
+import type { ReviewMode } from '../../lib/config-yaml.js';
+import { getProjectSync, type ProjectConfig, type ResolvedProject } from '../../lib/projects.js';
+import { normalizeModelOverrideSync } from '../../lib/model-validation.js';
+import { updateIssueRecord } from '../../lib/pan-dir/record-update.js';
+import type { SwarmMode } from '../../lib/swarm-policy.js';
+
+export interface StartPolicyOptions {
+  model?: string;
+  swarm?: string;
+  reviewMode?: string;
+  reviewModel?: string;
+}
+
+export interface StartPolicyOverrides {
+  workModel?: string;
+  swarmMode?: SwarmMode;
+  reviewMode?: ReviewMode;
+  reviewModel?: string;
+}
+
+export function parseStartPolicyOverrides(options: StartPolicyOptions): StartPolicyOverrides {
+  const overrides: StartPolicyOverrides = {};
+  if (options.model !== undefined) overrides.workModel = normalizeModelOverrideSync(options.model);
+  if (options.reviewModel !== undefined) overrides.reviewModel = normalizeModelOverrideSync(options.reviewModel);
+  if (options.swarm !== undefined) {
+    if (!['off', 'auto', 'always'].includes(options.swarm)) {
+      throw new Error(`Invalid --swarm value: ${options.swarm}. Expected 'off', 'auto', or 'always'.`);
+    }
+    overrides.swarmMode = options.swarm as SwarmMode;
+  }
+  if (options.reviewMode !== undefined) {
+    if (!['quick', 'full', 'none'].includes(options.reviewMode)) {
+      throw new Error(`Invalid --review-mode value: ${options.reviewMode}. Expected 'quick', 'full', or 'none'.`);
+    }
+    overrides.reviewMode = options.reviewMode as ReviewMode;
+  }
+  return overrides;
+}
+
+export function hasStartPolicyOverrides(overrides: StartPolicyOverrides): boolean {
+  return Object.values(overrides).some((value) => value !== undefined);
+}
+
+export async function persistStartPolicyOverrides(project: ProjectConfig, issueId: string, overrides: StartPolicyOverrides): Promise<void> {
+  if (!hasStartPolicyOverrides(overrides)) return;
+  await updateIssueRecord(project, issueId, (record) => {
+    if (overrides.workModel !== undefined) record.workModel = overrides.workModel;
+    if (overrides.reviewMode !== undefined) record.reviewMode = overrides.reviewMode;
+    if (overrides.reviewModel !== undefined) record.reviewModel = overrides.reviewModel;
+    if (overrides.swarmMode !== undefined) {
+      record.swarm = { ...record.swarm, policy: { ...record.swarm?.policy, mode: overrides.swarmMode } };
+    }
+  });
+}
+
+export async function applyStartPolicyOptions(
+  resolved: ResolvedProject,
+  issueId: string,
+  options: StartPolicyOptions,
+  dryRun: boolean,
+): Promise<void> {
+  if (dryRun) return;
+  const overrides = parseStartPolicyOverrides(options);
+  if (!hasStartPolicyOverrides(overrides)) return;
+  const project = getProjectSync(resolved.projectKey);
+  if (!project) throw new Error(`Project configuration not found for ${resolved.projectName}`);
+  await persistStartPolicyOverrides(project, issueId, overrides);
+}

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -89,7 +89,7 @@ import { assertCanStartFreshSync, getWorkAgentLifecycleStateSync } from '../../l
 import { normalizeModelOverrideSync } from '../../lib/model-validation.js';
 import { resolvePlanningMode, type PlanningMode } from './planning-mode.js';
 import { requireAutomaticStateMigration } from '../../lib/state-auto-migrate.js';
-
+import { applyStartPolicyOptions } from './start-policy-overrides.js';
 interface IssueOptions {
   model: string;
   /** PAN-636 — explicit coding-agent harness override. Omit to use resolver defaults. */
@@ -844,8 +844,8 @@ export async function issueCommand(id: string, options: IssueOptions): Promise<v
       spinner.text = `Resolved project: ${resolved.projectName} (${resolved.projectPath})`;
       spinner.text = `Reconciling permanent state for ${resolved.projectName}...`;
       await requireAutomaticStateMigration(resolved);
+      await applyStartPolicyOptions(resolved, id, options, options.dryRun === true);
     }
-    // Find workspace (local or remote based on preference)
     const { workspacePath, isRemote } = findWorkspaceWithLocation(id, locationPreference);
 
     // Overflow scale-out (PAN-1676): a FRESH issue (no workspace anywhere, no

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -568,7 +568,7 @@ program
 program
   .command('start <id>')
   .description('Create workspace and spawn agent for an issue')
-  .option('--model <model>', 'Model to use (sonnet/opus/haiku/kimi-k2.5/etc) - defaults to Cloister config')
+  .option('--model <model>', 'Work model to use and persist for later respawns (defaults to Cloister config)').option('--swarm <mode>', 'Per-issue swarm policy: off | auto | always').option('--review-mode <mode>', 'Per-issue review mode: quick | full | none').option('--review-model <model>', 'Per-issue review model override')
   .option('--harness <harness>', 'Coding-agent harness: claude-code | pi | codex (defaults to role/provider settings)')
   .option('--effort <level>', 'Claude Code effort: low | medium | high | xhigh | max (defaults to roles.work.effort)')
   .option('--tier <tier>', 'Remote workspace resiliency tier: ephemeral | durable (defaults to remote.resiliency_tier)')

--- a/sync-sources/skills/pan-start/SKILL.md
+++ b/sync-sources/skills/pan-start/SKILL.md
@@ -29,6 +29,8 @@ pan start PAN-123 --force  # Clear a paused agent gate and start anyway
 pan start PAN-123 --host   # Break-glass: bypass workspace Docker stack-health gate
 pan start PAN-123 --fresh  # Drop the saved session and start a new one (e.g. switch model)
 pan start PAN-123 --harness codex  # Explicitly use the Codex harness
+pan start PAN-123 --model gpt-5.6-sol --swarm off --review-mode full
+pan start PAN-123 --review-model gpt-5.6-sol  # Pin the convoy review model
 pan start PAN-123 --remote --tier durable  # Remote Fly.io workspace with persistent volume
 pan start PAN-123 --remote --tier ephemeral  # Remote Fly.io workspace that winds down on stale heartbeat
 ```
@@ -56,6 +58,11 @@ pan start PAN-1071 --plan skip          # synthesize a minimal vBRIEF and vBRIEF
 The default planning mode comes from `planning.default_mode` in `~/.overdeck/config.yaml`;
 the shipped default is `auto`. The legacy `--auto` flag is deprecated and is now an alias
 for `--plan skip`.
+
+Start-time policy flags are persisted on the issue before planning or work begins. `--model`
+sets the durable work-model override used by later respawns, `--swarm` accepts `off`, `auto`,
+or `always`, `--review-mode` accepts `quick`, `full`, or `none`, and `--review-model` pins the
+model used by the review convoy. Omitted flags leave existing and inherited policy untouched.
 
 If an agent is paused, `pan start <id>` refuses to spawn until you run `pan unpause <id>`.
 Use `--force` only when you intentionally want to clear that pause gate and start anyway.


### PR DESCRIPTION
`pan start` could not pin per-issue policies at start time. Adds persistent
`--model`, `--swarm`, `--review-mode`, and `--review-model` flags, written to the
issue record so later respawns keep the operator's choice.

- `--swarm off|auto|always`, `--review-mode quick|full|none`, `--review-model <model>`
- `--model` now persists the work model for later respawns
- Invalid values fail loudly with the accepted set (no silent fallback)
- `--dry-run` persists nothing
- `sync-sources/skills/pan-start/SKILL.md` updated in the same change, per the
  skills↔CLI convention

## Gates (verified by the flywheel, not just the strike signal)
- `npx vitest run src/cli/commands/__tests__/start-policy-overrides.test.ts` → 5 passed
- `npm run typecheck` → green
- `npm run lint` → green (incl. skills lint cross-checking flags against `pan start --help`)

Authored by strike-pan-2704.

Closes PAN-2704

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added per-issue `pan start` options for work model, swarm policy, review mode, and review model.
  - Overrides are saved before work begins, while omitted options preserve existing settings.
  - Dry-run behavior is supported without persisting changes.
  - Added validation for supported swarm and review-mode values.

- **Documentation**
  - Updated `pan start` guidance with the new options and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->