### PR TITLE
fix(dashboard): reconcile stale failing_checks blockers (PAN-2712)

### DIFF
--- a/src/dashboard/server/services/merge-blocker-reconcile-service.ts
+++ b/src/dashboard/server/services/merge-blocker-reconcile-service.ts
@@ -6,10 +6,10 @@
  * 1. Ready rows with no known blockers can go stale (CONFLICTING / CI-red) when a
  *    webhook is delayed or dropped. Polling those rows writes newly discovered
  *    blockers before a human clicks MERGE.
- * 2. Rows that already carry merge_conflict / not_mergeable blockers can become
- *    clean again after a resolver rebases the branch. Re-checking those rows on a
- *    slower cadence lets refreshMergeStateFromGitHub clear stale flags even when
- *    no webhook arrives.
+ * 2. Rows that already carry merge_conflict / not_mergeable / failing_checks
+ *    blockers can become clean again after a rebase or successful CI run.
+ *    Re-checking those rows on a slower cadence lets refreshMergeStateFromGitHub
+ *    clear stale flags even when no webhook arrives.
  *
  * Bounded + cheap: each issue has a throttle. Ready/no-blocker rows use the PAN-1620
  * 3-minute cadence; already-blocked mergeability rows use a 10-minute cadence.
@@ -39,7 +39,11 @@ const POLL_INTERVAL_MS = 60_000;
 const RECHECK_INTERVAL_MS = 180_000;
 /** Re-check already-flagged mergeability blockers less often; they are not mergeable yet. */
 const STALE_BLOCKER_RECHECK_INTERVAL_MS = 10 * 60_000;
-const MERGEABILITY_BLOCKERS = new Set<BlockerReason['type']>(['merge_conflict', 'not_mergeable']);
+const MERGEABILITY_BLOCKERS = new Set<BlockerReason['type']>([
+  'merge_conflict',
+  'not_mergeable',
+  'failing_checks',
+]);
 const MAX_REFRESH_CONCURRENCY = 4;
 
 const serviceState: ServiceState = {

--- a/src/lib/overdeck/review-status-sync.ts
+++ b/src/lib/overdeck/review-status-sync.ts
@@ -463,6 +463,7 @@ export function getMergeBlockerReconcileCandidatesSync(): MergeBlockerReconcileC
     WHERE ready_for_merge = 1
       OR blocker_reasons LIKE '%merge_conflict%'
       OR blocker_reasons LIKE '%not_mergeable%'
+      OR blocker_reasons LIKE '%failing_checks%'
   `).all() as Array<{
     issue_id: string;
     pr_url: string | null;

--- a/tests/unit/dashboard/server/services/merge-blocker-reconcile-service.test.ts
+++ b/tests/unit/dashboard/server/services/merge-blocker-reconcile-service.test.ts
@@ -117,10 +117,7 @@ describe('merge-blocker reconcile service', () => {
     await Promise.resolve();
   });
 
-  it('skips rows with only non-mergeability blockers', async () => {
-    // The selective DB query should never return this row, but the service
-    // must still behave correctly if it does: only mergeability blockers trigger
-    // a re-verification.
+  it('re-verifies failing_checks blockers even when they make the row not ready', async () => {
     mockGetMergeBlockerReconcileCandidates.mockReturnValue(candidatesEffect([
       candidate({
         issueId: 'PAN-2',
@@ -133,7 +130,7 @@ describe('merge-blocker reconcile service', () => {
 
     await __reconcileOnceForTests();
 
-    expect(mockRefreshMergeStateFromGitHub).not.toHaveBeenCalled();
+    expect(mockRefreshMergeStateFromGitHub).toHaveBeenCalledWith('PAN-2', 'eltmon/overdeck', 2);
   });
 
   it('keeps ready-with-no-blockers behavior unchanged', async () => {

--- a/tests/unit/lib/overdeck/review-status-reconcile-candidates.test.ts
+++ b/tests/unit/lib/overdeck/review-status-reconcile-candidates.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getMergeBlockerReconcileCandidatesSync } from '../../../../src/lib/overdeck/review-status-sync.js';
+import {
+  setupOverdeckTestDb,
+  teardownOverdeckTestDb,
+  type OverdeckTestDb,
+} from '../../../helpers/overdeck-test-db.js';
+
+describe('merge-blocker reconcile candidates', () => {
+  let odb: OverdeckTestDb;
+
+  beforeEach(() => { odb = setupOverdeckTestDb(); });
+  afterEach(() => { teardownOverdeckTestDb(odb); });
+
+  it('includes a not-ready row carrying a failing_checks blocker', () => {
+    odb.raw().prepare(`
+      INSERT INTO review_status
+        (issue_id, review_status, test_status, pr_url, blocker_reasons, updated_at, ready_for_merge)
+      VALUES (?, 'passed', 'passed', ?, ?, ?, 0)
+    `).run(
+      'PAN-2712',
+      'https://github.com/eltmon/overdeck/pull/2712',
+      JSON.stringify([{ type: 'failing_checks', summary: 'Required checks are failing' }]),
+      Date.now(),
+    );
+
+    expect(getMergeBlockerReconcileCandidatesSync()).toEqual([
+      expect.objectContaining({ issueId: 'PAN-2712', readyForMerge: false }),
+    ]);
+  });
+});


### PR DESCRIPTION
A `failing_checks` blocker could never be cleared by the reconcile poller — the
backstop that exists precisely so stale GitHub-native blockers clear when no
webhook arrives. The row stayed pinned at `ready_for_merge=0` forever with every
other gate passing, silently out of the merge gate.

The circularity was the bug: the blocker itself sets `readyForMerge = false`
(`review-status.ts:401-407`, PAN-905), which disqualified the row from the only
polling path that would have re-examined it.

Fixed at both layers — either alone is inert:

- `merge-blocker-reconcile-service.ts:41` — `failing_checks` joins
  `MERGEABILITY_BLOCKERS`, so it gets the 10-minute stale recheck cadence.
- `review-status-sync.ts:463` — the candidate SQL also selects
  `blocker_reasons LIKE '%failing_checks%'`, so the row is returned at all.

The existing test `skips rows with only non-mergeability blockers` encoded the
buggy behavior and is inverted to
`re-verifies failing_checks blockers even when they make the row not ready`.

## Gates (verified by the flywheel)
- Focused suites: 5 passed (2 files)
- `npm run typecheck` → green
- `npm run lint` → green

## Live evidence
PAN-2683 sat `review/test/inspect/verification=passed`, `merge=pending`,
`ready_for_merge=0` on a `failing_checks` blocker latched at 13:08:19Z during the
PAN-2703 red-main window. Its PR checks went all-SUCCESS after a re-run, yet
`updated_at` never moved — the row was never enqueued.

Together with PAN-2710 (nothing re-triggers poisoned PR checks on red→green) this
formed a permanent trap that silently freezes the merge gate at scale.

Authored by strike-pan-2712; rebased and landed by the flywheel (its own rebase
was denied by the permission reviewer, which had left the diff reverting 142
lines of docs/FLYWHEEL-STATE.md — dropped by the rebase).

Closes PAN-2712

🤖 Generated with [Claude Code](https://claude.com/claude-code)