### PR TITLE
fix(cli): allow close-out after merging newer main (PAN-2716)

### DIFF
--- a/src/lib/lifecycle/workflows.ts
+++ b/src/lib/lifecycle/workflows.ts
@@ -624,6 +624,37 @@ async function verifySquashMergedPrByBranch(
       return stepOk(step, [`${prLabel} is squash-merged and ${branchRef} matches the merged PR head`]);
     }
 
+    // A workspace may merge a newer main after its PR head was pushed. Ignore
+    // those merge commits and allow close-out when every post-PR commit is
+    // already on origin/main; only branch-unique work is unsafe to discard.
+    let commitsNotOnMain: string[] | null = null;
+    try {
+      const { stdout: commitsRaw } = await execAsync(
+        `git log --no-merges --format=%H ${mergedPr.headRefOid}..${tipSha}`,
+        { cwd: ctx.projectPath, encoding: 'utf-8' },
+      );
+      const commits = commitsRaw.split('\n').map((sha) => sha.trim()).filter(Boolean);
+      const unmerged: string[] = [];
+      for (const commit of commits) {
+        try {
+          await execAsync(
+            `git merge-base --is-ancestor ${commit} origin/main`,
+            { cwd: ctx.projectPath, encoding: 'utf-8' },
+          );
+        } catch {
+          unmerged.push(commit);
+        }
+      }
+      if (unmerged.length === 0) {
+        const prLabel = typeof mergedPr.number === 'number' ? `PR #${mergedPr.number}` : 'GitHub PR';
+        return stepOk(step, [
+          `${prLabel} is squash-merged; all ${commits.length} post-PR non-merge commit(s) on ${branchRef} are already on origin/main`,
+        ]);
+      }
+
+      commitsNotOnMain = unmerged;
+    } catch { /* containment check failure falls through to the state-plane policy */ }
+
     // PAN-2406 / state-plane policy rule 3: commits after the merged head that
     // touch ONLY legacy state-plane paths under .pan/ are pipeline exhaust —
     // e.g. 'chore: record merge status' — and must not block close-out.
@@ -657,6 +688,9 @@ async function verifySquashMergedPrByBranch(
     } catch { /* diff failure falls through to the strict rejection below */ }
 
     const prLabel = typeof mergedPr.number === 'number' ? `PR #${mergedPr.number}` : 'merged GitHub PR';
+    if (commitsNotOnMain) {
+      return stepFailed(step, `${branchRef} has ${commitsNotOnMain.length} commit(s) after merged ${prLabel} that are not on origin/main: ${commitsNotOnMain.join(', ')}`);
+    }
     return stepFailed(step, `${branchRef} does not match the head commit of merged ${prLabel}; inspect before closing out.`);
   } catch {
     return null;

--- a/tests/unit/lib/lifecycle/workflows.test.ts
+++ b/tests/unit/lib/lifecycle/workflows.test.ts
@@ -322,6 +322,12 @@ describe('workflows', () => {
         if (command.startsWith('git rev-parse feature/pan-100')) {
           return { stdout: 'newer-branch-tip\n', stderr: '' };
         }
+        if (command.startsWith('git log --no-merges')) {
+          return { stdout: 'unmerged-commit\n', stderr: '' };
+        }
+        if (command === 'git merge-base --is-ancestor unmerged-commit origin/main') {
+          throw new Error('commit is not on main');
+        }
         if (command.startsWith('git diff --name-only')) {
           // PAN-2406 predicate: report a real source file so the state-plane
           // exemption does NOT apply and the strict rejection is exercised.
@@ -342,7 +348,49 @@ describe('workflows', () => {
 
       expect(verifyStep.step).toBe('close-out:verify-merged');
       expect(verifyStep.success).toBe(false);
-      expect(verifyStep.error).toBe('feature/pan-100 does not match the head commit of merged PR #2182; inspect before closing out.');
+      expect(verifyStep.error).toBe('feature/pan-100 has 1 commit(s) after merged PR #2182 that are not on origin/main: unmerged-commit');
+    });
+
+    it('accepts a squash-merged PR when the branch later merged commits already on main', async () => {
+      mockExecAsync.mockImplementation(async (command: string) => {
+        if (command.startsWith('git branch --list')) {
+          return { stdout: '  feature/pan-100\n', stderr: '' };
+        }
+        if (command.startsWith('git merge-base --is-ancestor feature/pan-100 main')) {
+          throw new Error('not an ancestor after squash merge');
+        }
+        if (command.startsWith('git diff main...feature/pan-100')) {
+          return { stdout: 'diff --git a/src/example.ts b/src/example.ts\n', stderr: '' };
+        }
+        if (command.startsWith('gh pr list')) {
+          return {
+            stdout: '[{"number":2182,"mergedAt":"2026-07-02T12:00:00Z","headRefOid":"merged-head","url":"https://github.com/eltmon/overdeck/pull/2182"}]',
+            stderr: '',
+          };
+        }
+        if (command.startsWith('git rev-parse feature/pan-100')) {
+          return { stdout: 'local-tip-after-main-merge\n', stderr: '' };
+        }
+        if (command.startsWith('git log --no-merges')) {
+          return { stdout: 'main-commit-a\nmain-commit-b\n', stderr: '' };
+        }
+        if (command.startsWith('git merge-base --is-ancestor main-commit-')) {
+          return { stdout: '', stderr: '' };
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      const ctx = {
+        issueId: 'PAN-100',
+        projectPath: testDir,
+        github: { owner: 'eltmon', repo: 'overdeck', number: 100 },
+      };
+      const verifyStep = await Effect.runPromise(__testInternals.verifyBranchMerged(ctx));
+
+      expect(verifyStep.success).toBe(true);
+      expect(verifyStep.details).toEqual([
+        'PR #2182 is squash-merged; all 2 post-PR non-merge commit(s) on feature/pan-100 are already on origin/main',
+      ]);
     });
 
     it('rejects local squash-merge success when the remote branch has advanced past the merged PR head', async () => {
@@ -381,6 +429,12 @@ describe('workflows', () => {
         if (command.startsWith('git rev-parse origin/feature/pan-100')) {
           return { stdout: 'advanced-remote-head\n', stderr: '' };
         }
+        if (command.startsWith('git log --no-merges')) {
+          return { stdout: 'remote-unmerged-commit\n', stderr: '' };
+        }
+        if (command === 'git merge-base --is-ancestor remote-unmerged-commit origin/main') {
+          throw new Error('commit is not on main');
+        }
         if (command.startsWith('git log main..origin/feature/pan-100')) {
           throw new Error('should fail immediately on mismatched remote merged PR head');
         }
@@ -396,7 +450,7 @@ describe('workflows', () => {
 
       expect(verifyStep.step).toBe('close-out:verify-merged');
       expect(verifyStep.success).toBe(false);
-      expect(verifyStep.error).toBe('origin/feature/pan-100 does not match the head commit of merged PR #2182; inspect before closing out.');
+      expect(verifyStep.error).toBe('origin/feature/pan-100 has 1 commit(s) after merged PR #2182 that are not on origin/main: remote-unmerged-commit');
     });
 
     it('should abort if archive fails', async () => {


### PR DESCRIPTION
`close-out:verify-merged` compared the local feature branch head to the merged
PR head by **equality**. A workspace that merged a newer `main` into itself after
its PR head was pushed — normal, encouraged behavior — was then permanently
un-closeable despite its work being fully merged and nothing unpushed.

Equality cannot distinguish the two cases it must:

- genuinely unmerged branch-unique work (the real hazard the guard exists for), and
- a newer main merged in locally (benign).

Both failed identically.

`verifySquashMergedPrByBranch` now runs a **containment check**: every non-merge
commit between the merged PR head and the branch tip must already be an ancestor
of `origin/main`. If they all are, the branch carries no unmerged work and
close-out proceeds. If any is not, close-out still refuses — and the error now
names the offending commits instead of the opaque "does not match the head
commit".

The PAN-2406 state-plane exemption path is preserved as a fallthrough, so
pipeline-exhaust commits keep their existing handling.

## Gates (verified by the flywheel)
- `npx vitest run tests/unit/lib/lifecycle/workflows.test.ts` → 30 passed, 1 skipped
- `npm run typecheck` → green
- `npm run lint` → green

## Live case that motivated this
PAN-2683 is merged (PR #2693 → `0f7aaa4e86`) but cannot be closed out:

```
merged PR head:  f1c457d830        local branch:  cf2d1b32a1   (ahead, not behind)
commits in local not in remote: 2 main merges + 73178549f7 — all already on origin/main
```

Zero PAN-2683 work is unpushed. The only ways past the gate today are
`git reset --hard` or branch deletion — both forbidden one-way doors — so its
workspace, worktree, agent state, and Docker stack leak until this lands.

Authored by strike-pan-2716.

Closes PAN-2716

🤖 Generated with [Claude Code](https://claude.com/claude-code)