### PR TITLE
PAN-2713

### DIFF
--- a/docs/DEFINITION-OF-DONE.md
+++ b/docs/DEFINITION-OF-DONE.md
@@ -3,7 +3,7 @@
 An Overdeck issue is **done** when every row in this table is green — not when the PR merges,
 and not when the tracker issue closes. Each row names its **mechanical owner**: the code that
 performs it and the surface where its result is visible. A row with no live owner is a pipeline
-gap — file an issue for it (that is how PAN-2713 exists). "Is anything missed?" is answered by
+gap — file an issue for it. "Is anything missed?" is answered by
 the `pan close` DoD gate (PAN-2715), never by reasoning from memory.
 
 | # | Step | Mechanical owner | Visible at |
@@ -14,7 +14,7 @@ the `pan close` DoD gate (PAN-2715), never by reasoning from memory.
 | 4 | Merged to main (squash PR, revertible history) | merge door: `triggerMerge` → merge specialist (`merge-agent.ts`) | PR `MERGED`, `mergeStatus: merged` |
 | 5 | Post-merge handoff: work/planning agents paused, workspace Docker stack + networks stopped, `verifying-on-main` label | `postMergeLifecycle()` (`merge-agent.ts`) — at-most-once per merge (PAN-328 in-flight guard) | issue labels, agent states |
 | 6 | Verified on main (post-merge verification of the merged commit) | deacon verify-on-main flow | `verifying_on_main` → verified |
-| 7 | **Deployed: the live dashboard runs a build that includes the merge** | **GAP — PAN-2713** (interim: flywheel doctrine / manual `npm run build` + `pan restart`) | server build commit vs origin/main |
+| 7 | **Deployed: the live dashboard runs a build that includes the merge** | staleness-gated Step 0 (`merge-agent.ts`) + Deacon deploy patrol (`deploy-patrol.ts`), guarded by `getDeployBlockReason()` | `/api/health` `buildCommit` + stale-build chip |
 | 8 | Close-out: worktree removed, branches per `close_out` config, vBRIEF `plan.status: completed`, planning artifacts archived, tracker issue CLOSED + `closed-out` label, review status cleared, Docker `_devnet` teardown verified | `pan close <id>` / dashboard Close Out (`closeOut`); closed-issue reaper (`reapIssueResidue`) as backstop | issue state, `workspaces/` dir |
 
 ## Rules of the table
@@ -24,7 +24,7 @@ the `pan close` DoD gate (PAN-2715), never by reasoning from memory.
   closed-out while the live server ran a build from three merges earlier — every fix inert.
 - **Every row must name a live owner.** Doctrine ("the flywheel usually does X") is not an
   owner; only code with a trigger is. When you find an ownerless step, drive it manually for
-  velocity AND file the gap issue — same discipline as the flywheel's backstop-as-symptom rule
+  velocity and file the gap issue — the flywheel follows the same backstop-as-symptom rule
   (`roles/flywheel.md`).
 - **Enforcement is the gate, not this doc.** `pan close` verifies the rows mechanically
   (PAN-2715) and reports any miss instead of completing silently. Changing the DoD means

--- a/docs/OVERDECK_DEV_SOP.md
+++ b/docs/OVERDECK_DEV_SOP.md
@@ -53,6 +53,33 @@ The supervisor also polls the Qwen TTS daemon every 10 seconds when TTS is enabl
 
 The latest restart outcome is written to `${OVERDECK_HOME}/restart-status.json`. `pan status` renders that state, including failures and watchdog give-up alarms.
 
+## Automatic deployment after merges
+
+Production builds embed their Git commit and build time. Deacon compares that commit with
+`origin/main` every fifth patrol cycle, counting only commits that touch build inputs such as
+`src/`, `packages/`, `package.json`, `bun.lock`, and `tsdown.config.ts`. `/api/health` exposes the
+running `buildCommit`; the app header shows `build stale ×N` when newer build-input commits exist.
+
+The post-merge lifecycle and Deacon share the same deploy safety window. They defer while
+verification, merging, another restart, a pending post-merge lifecycle, or `pan dev` is active.
+Deacon also waits for the merge debounce interval, so a merge train produces one rebuild and
+restart instead of one per merge.
+
+Configure the behavior in Cloister config:
+
+```yaml
+deploy:
+  auto_deploy: true       # default: rebuild and restart when the safety window clears
+  debounce_minutes: 5     # default: wait for origin/main to settle
+```
+
+Set `deploy.auto_deploy: false` for signal-only mode. Staleness remains visible in system health
+and the header, but Deacon does not start a deployment. Detached deployment output is appended to
+`~/.overdeck/logs/auto-deploy.log`.
+
+`pan reload` remains the manual deployment door. It builds first, preserves the running dashboard
+when the build fails, restarts the Node 22 bundle after a successful build, and waits for health.
+
 ## Dashboard recovery guardian
 
 The local recovery model has two tiers. The `overdeck-supervisor.service` systemd user unit keeps the supervisor sidecar alive, and the supervisor keeps the dashboard alive by polling health and running `pan restart --dashboard` when the dashboard is down. Systemd owns only the supervisor, not the dashboard process, so dashboard recovery still flows through the existing watchdog logic and avoids a second owner fighting the restart path.

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -17,7 +17,7 @@
 1031 src/lib/cloister/deacon-auto-resume.ts
 1148 src/lib/cloister/deacon-swarm.ts
 3631 src/lib/cloister/deacon.ts
-1475 src/lib/cloister/merge-agent.ts
+1470 src/lib/cloister/merge-agent.ts
 1749 src/lib/cloister/specialists.ts
 1194 src/lib/conversations/smart-compaction.ts
 1742 src/lib/database/schema.ts

--- a/src/dashboard/frontend/src/App/AppChrome.tsx
+++ b/src/dashboard/frontend/src/App/AppChrome.tsx
@@ -9,6 +9,7 @@ import { CodexAuthBanner } from '../components/CodexAuthBanner';
 import { SetupChecklistBanner } from '../components/SetupChecklistBanner';
 import { SyncRequiredBanner } from '../components/SyncRequiredBanner';
 import { SystemHealthPill } from '../components/SystemHealthPill';
+import { StaleBuildChip } from '../components/StaleBuildChip';
 import { triggerEmergencyStop, EMERGENCY_STOP_HOTKEY_LABEL } from '../components/EmergencyStopOverlay';
 import type { Tab } from '../components/Header';
 import type { TrackerStatusItem } from './api';
@@ -216,6 +217,7 @@ export function AppChrome({
           )}
           <StoppedAgentsBanner variant="pill" />
           <LowCostModePill onOpenSettings={onOpenSettings} />
+          <StaleBuildChip />
           <SystemHealthPill />
           <SystemMenu onOpenSettings={onOpenSettings} />
           {/* The Command Deck has the always-on Awareness rail, so the global

--- a/src/dashboard/frontend/src/components/StaleBuildChip.test.tsx
+++ b/src/dashboard/frontend/src/components/StaleBuildChip.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { StaleBuildChip } from './StaleBuildChip';
+import type { SystemHealthSnapshot } from '../types';
+
+const hookState = vi.hoisted(() => ({
+  data: undefined as Pick<SystemHealthSnapshot, 'deployStaleness'> | undefined,
+}));
+
+vi.mock('../hooks/useSystemHealth', () => ({
+  useSystemHealth: () => ({ data: hookState.data }),
+}));
+
+afterEach(() => {
+  cleanup();
+  hookState.data = undefined;
+});
+
+describe('StaleBuildChip', () => {
+  it('renders the number of missed build-input commits in the warning tone', () => {
+    hookState.data = {
+      deployStaleness: {
+        status: 'stale',
+        buildCommit: '1234567890abcdef',
+        originMainSha: 'fedcba0987654321',
+        behindTotal: 5,
+        behindBuildInputs: 2,
+        originMainLastCommitAt: 1_710_000_000_000,
+        computedAt: 1_752_580_800_000,
+      },
+    };
+
+    const chip = render(<StaleBuildChip />).getByText('build stale ×2');
+
+    expect(chip).toHaveClass('text-warning-foreground');
+    expect(chip).toHaveAttribute(
+      'title',
+      'Running build 12345678 · origin/main fedcba09 · 5 total commit(s) behind',
+    );
+  });
+
+  it.each(['fresh', 'unknown'] as const)('renders nothing for %s builds', (status) => {
+    hookState.data = {
+      deployStaleness: {
+        status,
+        buildCommit: 'build-sha',
+        originMainSha: 'origin-sha',
+        behindTotal: 0,
+        behindBuildInputs: 0,
+        originMainLastCommitAt: 1_710_000_000_000,
+        computedAt: 1_752_580_800_000,
+      },
+    };
+
+    const { container } = render(<StaleBuildChip />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when deploy staleness is unavailable', () => {
+    hookState.data = { deployStaleness: null };
+
+    render(<StaleBuildChip />);
+    expect(screen.queryByText(/build stale/)).not.toBeInTheDocument();
+  });
+});

--- a/src/dashboard/frontend/src/components/StaleBuildChip.tsx
+++ b/src/dashboard/frontend/src/components/StaleBuildChip.tsx
@@ -1,0 +1,26 @@
+import { useSystemHealth } from '../hooks/useSystemHealth';
+
+function shortCommit(commit: string | null): string {
+  return commit?.slice(0, 8) || 'unknown';
+}
+
+export function StaleBuildChip() {
+  const { data } = useSystemHealth();
+  const staleness = data?.deployStaleness;
+
+  if (staleness?.status !== 'stale' || (staleness.behindBuildInputs ?? 0) < 1) {
+    return null;
+  }
+
+  const title = [
+    `Running build ${shortCommit(staleness.buildCommit)}`,
+    `origin/main ${shortCommit(staleness.originMainSha)}`,
+    `${staleness.behindTotal ?? 'unknown'} total commit(s) behind`,
+  ].join(' · ');
+
+  return (
+    <span className="text-[11px] font-medium text-warning-foreground" title={title}>
+      build stale ×{staleness.behindBuildInputs}
+    </span>
+  );
+}

--- a/src/dashboard/frontend/src/types.ts
+++ b/src/dashboard/frontend/src/types.ts
@@ -547,6 +547,16 @@ export interface SystemHealthSnapshot {
     status: 'not_configured' | 'running' | 'stopped' | 'unknown';
     message: string;
   };
+  deployStaleness: {
+    status: 'fresh' | 'stale' | 'unknown';
+    buildCommit: string | null;
+    originMainSha: string | null;
+    behindTotal: number | null;
+    behindBuildInputs: number | null;
+    originMainLastCommitAt: number | null;
+    computedAt: number;
+    reason?: string;
+  } | null;
 }
 
 export interface StartAgentGuardrailWarning {

--- a/src/dashboard/server/identity.ts
+++ b/src/dashboard/server/identity.ts
@@ -5,10 +5,11 @@ import { relative, resolve, sep } from 'node:path';
 import { parse as parseToml } from '@iarna/toml';
 
 import { CONFIG_FILE } from '../../lib/paths.js';
+import { getBuildInfo, type BuildInfo } from '../../lib/deploy/build-info.js';
 
 export type DashboardMode = 'primary' | 'peer';
 
-export interface DashboardIdentity {
+export interface DashboardIdentity extends BuildInfo {
   readonly repoRoot: string;
   readonly mode: DashboardMode;
 }
@@ -17,6 +18,7 @@ export function getDashboardIdentity(): DashboardIdentity {
   return {
     repoRoot: resolve(cwd()),
     mode: process.env.OVERDECK_DISABLE_DEACON === '1' ? 'peer' : 'primary',
+    ...getBuildInfo(),
   };
 }
 

--- a/src/dashboard/server/services/__tests__/system-health-service.test.ts
+++ b/src/dashboard/server/services/__tests__/system-health-service.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  _resetDeployStalenessForTests,
+  getDeployStaleness,
+} from '../system-health-service.js';
+import type { BuildStaleness } from '../../../../lib/deploy/staleness.js';
+
+const STALENESS: BuildStaleness = {
+  status: 'stale',
+  buildCommit: 'build-sha',
+  originMainSha: 'origin-sha',
+  behindTotal: 4,
+  behindBuildInputs: 2,
+  originMainLastCommitAt: 1_710_000_000_000,
+  computedAt: 1_752_580_800_000,
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-07-15T12:00:00.000Z'));
+});
+
+afterEach(() => {
+  _resetDeployStalenessForTests();
+  vi.useRealTimers();
+});
+
+describe('deploy staleness health surface', () => {
+  it('returns the build and origin/main comparison fields', async () => {
+    const compute = vi.fn().mockResolvedValue(STALENESS);
+    _resetDeployStalenessForTests(compute);
+
+    await expect(getDeployStaleness()).resolves.toEqual(STALENESS);
+  });
+
+  it('returns null instead of rejecting when Git computation throws', async () => {
+    _resetDeployStalenessForTests(vi.fn().mockRejectedValue(new Error('git unavailable')));
+
+    await expect(getDeployStaleness()).resolves.toBeNull();
+  });
+
+  it('caches the staleness result for 60 seconds', async () => {
+    const compute = vi.fn().mockResolvedValue(STALENESS);
+    _resetDeployStalenessForTests(compute);
+
+    await getDeployStaleness();
+    await vi.advanceTimersByTimeAsync(59_999);
+    await getDeployStaleness();
+
+    expect(compute).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await getDeployStaleness();
+    expect(compute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/dashboard/server/services/system-health-service.ts
+++ b/src/dashboard/server/services/system-health-service.ts
@@ -14,7 +14,13 @@ import { resolveProjectFromIssueSync } from '../../../lib/projects.js';
 import { isSmeeConfiguredSync, isSmeeProcessRunningSync } from '../../../lib/smee.js';
 import { listPaneValues } from '../../../lib/tmux.js';
 import { DockerStatsCollector, type ContainerStats } from '../../../lib/docker-stats.js';
+import { getBuildInfo } from '../../../lib/deploy/build-info.js';
+import {
+  computeBuildStaleness,
+  type BuildStaleness,
+} from '../../../lib/deploy/staleness.js';
 import { initEventStore } from '../event-store.js';
+import { getDashboardIdentity } from '../identity.js';
 
 const execAsync = promisify(exec);
 const DEFAULT_HEALTH_POLL_SECONDS = 15;
@@ -138,6 +144,7 @@ export interface SystemHealthSnapshot {
   leakedSpecialists: HealthLeakedSpecialist[];
   topConsumers: HealthConsumer[];
   smeeRelay: SmeeRelayHealth;
+  deployStaleness: BuildStaleness | null;
 }
 
 let dockerStatsCollector: DockerStatsCollector | null = null;
@@ -155,6 +162,44 @@ let cachedResourceConfig = DEFAULT_RESOURCE_CONFIG;
 let cachedPollSeconds = DEFAULT_HEALTH_POLL_SECONDS;
 let resourceConfigLoadedAt = 0;
 let resourceConfigInflight: Promise<void> | null = null;
+let cachedDeployStaleness: BuildStaleness | null = null;
+let hasCachedDeployStaleness = false;
+let deployStalenessCacheExpiresAt = 0;
+let deployStalenessInflight: Promise<BuildStaleness | null> | null = null;
+let computeBuildStalenessFn = computeBuildStaleness;
+const DEPLOY_STALENESS_TTL_MS = 60_000;
+
+export async function getDeployStaleness(): Promise<BuildStaleness | null> {
+  if (hasCachedDeployStaleness && Date.now() < deployStalenessCacheExpiresAt) {
+    return cachedDeployStaleness;
+  }
+
+  if (!deployStalenessInflight) {
+    deployStalenessInflight = computeBuildStalenessFn({
+      repoRoot: getDashboardIdentity().repoRoot,
+      buildCommit: getBuildInfo().buildCommit,
+    }).catch(() => null).then((result) => {
+      cachedDeployStaleness = result;
+      hasCachedDeployStaleness = true;
+      deployStalenessCacheExpiresAt = Date.now() + DEPLOY_STALENESS_TTL_MS;
+      return result;
+    }).finally(() => {
+      deployStalenessInflight = null;
+    });
+  }
+
+  return deployStalenessInflight;
+}
+
+export function _resetDeployStalenessForTests(
+  compute: typeof computeBuildStaleness = computeBuildStaleness,
+): void {
+  cachedDeployStaleness = null;
+  hasCachedDeployStaleness = false;
+  deployStalenessCacheExpiresAt = 0;
+  deployStalenessInflight = null;
+  computeBuildStalenessFn = compute;
+}
 
 function getDockerStatsCollector(): DockerStatsCollector {
   if (!dockerStatsCollector) {
@@ -665,6 +710,7 @@ async function refreshSystemHealth(snapshot?: DashboardSnapshot): Promise<System
   const overdeckMemoryPercent = toPercent(overdeckMemoryBytes, memory.memTotal);
 
   const sortedAgents = [...agents].sort((a, b) => b.memoryBytes - a.memoryBytes);
+  const deployStaleness = await getDeployStaleness();
 
   // Hysteresis: require HYSTERESIS_POLLS consecutive polls at a new severity
   // before actually transitioning. Prevents flapping when metrics hover near thresholds.
@@ -719,6 +765,7 @@ async function refreshSystemHealth(snapshot?: DashboardSnapshot): Promise<System
     leakedSpecialists,
     topConsumers: buildTopConsumers(sortedAgents, containers, leakedSpecialists),
     smeeRelay,
+    deployStaleness,
   };
 
   if (previousSeverity && previousSeverity !== result.severity) {

--- a/src/dashboard/server/tsdown.config.ts
+++ b/src/dashboard/server/tsdown.config.ts
@@ -1,12 +1,9 @@
-import { execFileSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { resolve } from 'node:path';
+import { promisify } from 'node:util';
 import { defineConfig } from 'tsdown';
 
-const buildCommit = execFileSync('git', ['rev-parse', 'HEAD'], {
-  cwd: resolve(import.meta.dirname, '../../..'),
-  encoding: 'utf8',
-}).trim();
-const builtAt = new Date().toISOString();
+const execFileAsync = promisify(execFile);
 
 function configYamlSingleChunkAssertion() {
   return {
@@ -33,57 +30,66 @@ function configYamlSingleChunkAssertion() {
   };
 }
 
-export default defineConfig({
-  entry: {
-    server: 'main.ts',
-    deacon: 'deacon-main.ts',
-    'dashboard-db-worker': 'services/dashboard-db-worker.ts',
-    'checkpoint-worker': '../../lib/memory/checkpoint-worker.ts',
-    'memory-fts-worker': '../../lib/memory/fts-worker.ts',
-  },
-  outDir: '../../../dist/dashboard',
-  format: 'esm',
-  platform: 'node',
-  shims: true,
-  define: {
-    __OVERDECK_BUILD_COMMIT__: JSON.stringify(buildCommit),
-    __OVERDECK_BUILD_TIME__: JSON.stringify(builtAt),
-  },
-  clean: false,
-  sourcemap: true,
-  outExtensions: () => ({ js: '.js' }),
-  alias: {
-    '@overdeck/contracts': resolve(import.meta.dirname, '../../../packages/contracts/src/index.ts'),
-  },
-  outputOptions: {
-    codeSplitting: {
-      groups: [
-        {
-          name: 'config-yaml',
-          test: (moduleId: string) => moduleId.replaceAll('\\', '/').endsWith('/src/lib/config-yaml.ts'),
-          priority: 10,
-        },
+export default defineConfig(async () => {
+  const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], {
+    cwd: resolve(import.meta.dirname, '../../..'),
+    encoding: 'utf8',
+  });
+  const buildCommit = stdout.trim();
+  const builtAt = new Date().toISOString();
+
+  return {
+    entry: {
+      server: 'main.ts',
+      deacon: 'deacon-main.ts',
+      'dashboard-db-worker': 'services/dashboard-db-worker.ts',
+      'checkpoint-worker': '../../lib/memory/checkpoint-worker.ts',
+      'memory-fts-worker': '../../lib/memory/fts-worker.ts',
+    },
+    outDir: '../../../dist/dashboard',
+    format: 'esm',
+    platform: 'node',
+    shims: true,
+    define: {
+      __OVERDECK_BUILD_COMMIT__: JSON.stringify(buildCommit),
+      __OVERDECK_BUILD_TIME__: JSON.stringify(builtAt),
+    },
+    clean: false,
+    sourcemap: true,
+    outExtensions: () => ({ js: '.js' }),
+    alias: {
+      '@overdeck/contracts': resolve(import.meta.dirname, '../../../packages/contracts/src/index.ts'),
+    },
+    outputOptions: {
+      codeSplitting: {
+        groups: [
+          {
+            name: 'config-yaml',
+            test: (moduleId: string) => moduleId.replaceAll('\\', '/').endsWith('/src/lib/config-yaml.ts'),
+            priority: 10,
+          },
+        ],
+      },
+    },
+    plugins: [configYamlSingleChunkAssertion()],
+    deps: {
+      alwaysBundle: [/^@overdeck\//],
+      neverBundle: [
+        '@homebridge/node-pty-prebuilt-multiarch',
+        'ssh2',
+        // PAN-1645: playwright is loaded only via a runtime `await import('playwright')`
+        // (artifact thumbnails). Bundling it pulls in playwright-core's prebundled
+        // coreBundle.js, which has an internal `require("chromium-bidi/...")` for a
+        // package playwright does not ship — emitting UNRESOLVED_IMPORT warnings that
+        // the workspace docker `init` guard turns into exit 1 (forcing --host).
+        // Externalizing it keeps it resolved from node_modules at runtime and drops
+        // a 5.6 MB browser chunk from the server bundle.
+        'playwright',
+        'playwright-core',
+        /^chromium-bidi/,
+        /^bun:/,
+        /^@effect\/platform-bun/,
       ],
     },
-  },
-  plugins: [configYamlSingleChunkAssertion()],
-  deps: {
-    alwaysBundle: [/^@overdeck\//],
-    neverBundle: [
-      '@homebridge/node-pty-prebuilt-multiarch',
-      'ssh2',
-      // PAN-1645: playwright is loaded only via a runtime `await import('playwright')`
-      // (artifact thumbnails). Bundling it pulls in playwright-core's prebundled
-      // coreBundle.js, which has an internal `require("chromium-bidi/...")` for a
-      // package playwright does not ship — emitting UNRESOLVED_IMPORT warnings that
-      // the workspace docker `init` guard turns into exit 1 (forcing --host).
-      // Externalizing it keeps it resolved from node_modules at runtime and drops
-      // a 5.6 MB browser chunk from the server bundle.
-      'playwright',
-      'playwright-core',
-      /^chromium-bidi/,
-      /^bun:/,
-      /^@effect\/platform-bun/,
-    ],
-  },
+  };
 });

--- a/src/dashboard/server/tsdown.config.ts
+++ b/src/dashboard/server/tsdown.config.ts
@@ -1,5 +1,12 @@
+import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { defineConfig } from 'tsdown';
+
+const buildCommit = execFileSync('git', ['rev-parse', 'HEAD'], {
+  cwd: resolve(import.meta.dirname, '../../..'),
+  encoding: 'utf8',
+}).trim();
+const builtAt = new Date().toISOString();
 
 function configYamlSingleChunkAssertion() {
   return {
@@ -38,6 +45,10 @@ export default defineConfig({
   format: 'esm',
   platform: 'node',
   shims: true,
+  define: {
+    __OVERDECK_BUILD_COMMIT__: JSON.stringify(buildCommit),
+    __OVERDECK_BUILD_TIME__: JSON.stringify(builtAt),
+  },
   clean: false,
   sourcemap: true,
   outExtensions: () => ({ js: '.js' }),

--- a/src/lib/cloister/config.ts
+++ b/src/lib/cloister/config.ts
@@ -324,6 +324,11 @@ export interface OrphanProposedReconcilerConfig {
   minAttemptIntervalMs: number;
 }
 
+export interface DeployConfig {
+  auto_deploy: boolean;
+  debounce_minutes: number;
+}
+
 /**
  * Complete Cloister configuration
  */
@@ -346,6 +351,7 @@ export interface CloisterConfig {
   retention?: RetentionConfig;
   close_out?: CloseOutConfig;
   orphanProposedReconciler?: OrphanProposedReconcilerConfig;
+  deploy: DeployConfig;
 }
 
 /**
@@ -381,6 +387,10 @@ export const DEFAULT_CLOISTER_CONFIG: CloisterConfig = {
   monitoring: {
     check_interval: 60, // 1 minute
     heartbeat_sources: ['jsonl_mtime', 'tmux_activity', 'git_activity'],
+  },
+  deploy: {
+    auto_deploy: true,
+    debounce_minutes: 5,
   },
   concurrency: {
     max_work_agents: 6,

--- a/src/lib/cloister/deacon.ts
+++ b/src/lib/cloister/deacon.ts
@@ -2792,6 +2792,19 @@ export async function runPatrol(): Promise<PatrolResult> {
     console.warn(`[deacon] Failed to process pending lifecycle: ${err.message}`);
   }
 
+  if (state.patrolCycle % 5 === 0) {
+    try {
+      const { runDeployPatrol } = await import('./deploy-patrol.js');
+      await runDeployPatrol({
+        repoRoot: process.cwd(),
+        config: loadCloisterConfigSync().deploy,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      addLog('warn', `Automatic deploy patrol failed: ${message}`, state.patrolCycle);
+    }
+  }
+
   /* PAN-378: Global specialist patrol removed. All specialist work now goes through
    * per-project ephemeral specialists via spawnEphemeralSpecialist(). The global
    * merge-agent, review-agent, and test-agent singletons are no longer used.

--- a/src/lib/cloister/deacon.ts
+++ b/src/lib/cloister/deacon.ts
@@ -2791,20 +2791,7 @@ export async function runPatrol(): Promise<PatrolResult> {
   } catch (err: any) {
     console.warn(`[deacon] Failed to process pending lifecycle: ${err.message}`);
   }
-
-  if (state.patrolCycle % 5 === 0) {
-    try {
-      const { runDeployPatrol } = await import('./deploy-patrol.js');
-      await runDeployPatrol({
-        repoRoot: process.cwd(),
-        config: loadCloisterConfigSync().deploy,
-      });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      addLog('warn', `Automatic deploy patrol failed: ${message}`, state.patrolCycle);
-    }
-  }
-
+  if (state.patrolCycle % 5 === 0) await (await import('./deploy-patrol.js')).runScheduledDeployPatrol();
   /* PAN-378: Global specialist patrol removed. All specialist work now goes through
    * per-project ephemeral specialists via spawnEphemeralSpecialist(). The global
    * merge-agent, review-agent, and test-agent singletons are no longer used.

--- a/src/lib/cloister/deploy-patrol.ts
+++ b/src/lib/cloister/deploy-patrol.ts
@@ -7,7 +7,7 @@ import { getBuildInfo } from '../deploy/build-info.js';
 import { getDeployBlockReason } from '../deploy/deploy-window.js';
 import { computeBuildStaleness, type BuildStaleness } from '../deploy/staleness.js';
 import { OVERDECK_HOME } from '../paths.js';
-import type { DeployConfig } from './config.js';
+import { loadCloisterConfigSync, type DeployConfig } from './config.js';
 
 const OBSERVATION_INTERVAL_MS = 30 * 60 * 1000;
 const DEPLOY_SPAWN_COOLDOWN_MS = 10 * 60 * 1000;
@@ -180,4 +180,16 @@ export async function runDeployPatrol(context: DeployPatrolContext): Promise<voi
 
 export function _resetDeployPatrolForTests(): void {
   clearState();
+}
+
+export async function runScheduledDeployPatrol(): Promise<void> {
+  try {
+    await runDeployPatrol({
+      repoRoot: process.cwd(),
+      config: loadCloisterConfigSync().deploy,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[deacon] Automatic deploy patrol failed: ${message}`);
+  }
 }

--- a/src/lib/cloister/deploy-patrol.ts
+++ b/src/lib/cloister/deploy-patrol.ts
@@ -1,0 +1,183 @@
+import { open, mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+
+import { emitActivityEntrySync, emitActivityTtsSync } from '../activity-logger.js';
+import { getBuildInfo } from '../deploy/build-info.js';
+import { getDeployBlockReason } from '../deploy/deploy-window.js';
+import { computeBuildStaleness, type BuildStaleness } from '../deploy/staleness.js';
+import { OVERDECK_HOME } from '../paths.js';
+import type { DeployConfig } from './config.js';
+
+const OBSERVATION_INTERVAL_MS = 30 * 60 * 1000;
+const DEPLOY_SPAWN_COOLDOWN_MS = 10 * 60 * 1000;
+
+interface DeployPatrolState {
+  lastObservedBehind: number | null;
+  lastObservationAt: number;
+  lastDeferralReason: string | null;
+  lastDeferralAt: number;
+  lastDeploySpawnAt: number;
+  unknownObserved: boolean;
+}
+
+const state: DeployPatrolState = {
+  lastObservedBehind: null,
+  lastObservationAt: 0,
+  lastDeferralReason: null,
+  lastDeferralAt: 0,
+  lastDeploySpawnAt: 0,
+  unknownObserved: false,
+};
+
+type EmitEntry = typeof emitActivityEntrySync;
+type EmitTts = typeof emitActivityTtsSync;
+
+export interface DeployPatrolContext {
+  readonly repoRoot: string;
+  readonly config: DeployConfig;
+  readonly computeStaleness?: () => Promise<BuildStaleness>;
+  readonly getBlockReason?: () => Promise<string | null>;
+  readonly spawnReload?: (request: ReloadRequest) => Promise<void>;
+  readonly emitEntry?: EmitEntry;
+  readonly emitTts?: EmitTts;
+  readonly now?: () => number;
+}
+
+export interface ReloadRequest {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly detached: true;
+}
+
+function shortSha(sha: string | null): string {
+  return sha?.slice(0, 8) || 'unknown';
+}
+
+async function spawnDetachedReload(request: ReloadRequest, now: number): Promise<void> {
+  const logsDir = join(OVERDECK_HOME, 'logs');
+  await mkdir(logsDir, { recursive: true });
+  await writeFile(
+    join(OVERDECK_HOME, 'dashboard-restarting.json'),
+    JSON.stringify({ reason: 'auto-deploy', trigger: 'deacon', timestamp: now }, null, 2),
+    'utf8',
+  );
+
+  const log = await open(join(logsDir, 'auto-deploy.log'), 'a');
+  try {
+    const child = spawn(
+      request.command,
+      [...request.args],
+      {
+        cwd: request.cwd,
+        detached: request.detached,
+        stdio: ['ignore', log.fd, log.fd],
+      },
+    );
+    child.unref();
+  } finally {
+    await log.close();
+  }
+}
+
+function clearState(): void {
+  state.lastObservedBehind = null;
+  state.lastObservationAt = 0;
+  state.lastDeferralReason = null;
+  state.lastDeferralAt = 0;
+  state.lastDeploySpawnAt = 0;
+  state.unknownObserved = false;
+}
+
+export async function runDeployPatrol(context: DeployPatrolContext): Promise<void> {
+  const now = (context.now ?? Date.now)();
+  const emitEntry = context.emitEntry ?? emitActivityEntrySync;
+  const emitTts = context.emitTts ?? emitActivityTtsSync;
+  const staleness = await (context.computeStaleness ?? (() => computeBuildStaleness({
+    repoRoot: context.repoRoot,
+    buildCommit: getBuildInfo().buildCommit,
+  })))();
+
+  if (staleness.status === 'unknown') {
+    if (!state.unknownObserved) {
+      emitEntry({
+        source: 'deploy-script',
+        level: 'warn',
+        message: `Automatic deployment cannot compare the running build with origin/main: ${staleness.reason ?? 'build staleness is unknown'}`,
+      });
+      state.unknownObserved = true;
+    }
+    return;
+  }
+
+  if (staleness.status === 'fresh') {
+    clearState();
+    return;
+  }
+
+  state.unknownObserved = false;
+  const behind = staleness.behindBuildInputs ?? 0;
+  if (
+    state.lastObservedBehind !== behind ||
+    now - state.lastObservationAt >= OBSERVATION_INTERVAL_MS
+  ) {
+    emitEntry({
+      source: 'deploy-script',
+      level: 'warn',
+      message: `The running build ${shortSha(staleness.buildCommit)} is ${behind} build-input commit(s) behind origin/main ${shortSha(staleness.originMainSha)}. ${context.config.auto_deploy ? 'Automatic deployment will start after the merge debounce and safety checks clear.' : 'Automatic deployment is disabled, so operator action is required.'}`,
+    });
+    state.lastObservedBehind = behind;
+    state.lastObservationAt = now;
+  }
+
+  if (!context.config.auto_deploy) return;
+  if (
+    staleness.originMainLastCommitAt !== null &&
+    now - staleness.originMainLastCommitAt < context.config.debounce_minutes * 60 * 1000
+  ) return;
+  if (state.lastDeploySpawnAt > 0 && now - state.lastDeploySpawnAt < DEPLOY_SPAWN_COOLDOWN_MS) return;
+
+  const blockReason = await (context.getBlockReason ?? getDeployBlockReason)();
+  if (blockReason) {
+    if (
+      state.lastDeferralReason !== blockReason ||
+      now - state.lastDeferralAt >= OBSERVATION_INTERVAL_MS
+    ) {
+      emitEntry({
+        source: 'deploy-script',
+        level: 'warn',
+        message: blockReason,
+      });
+      state.lastDeferralReason = blockReason;
+      state.lastDeferralAt = now;
+    }
+    return;
+  }
+
+  const reloadRequest: ReloadRequest = {
+    command: process.execPath,
+    args: [join(context.repoRoot, 'dist/cli/index.js'), 'reload', '--health-timeout', '120000'],
+    cwd: context.repoRoot,
+    detached: true,
+  };
+  await (context.spawnReload ?? ((request) => spawnDetachedReload(request, now)))(reloadRequest);
+  state.lastDeploySpawnAt = now;
+  state.lastDeferralReason = null;
+  state.lastDeferralAt = 0;
+  emitEntry({
+    source: 'deploy-script',
+    level: 'info',
+    message: `Automatic deployment started for origin/main ${shortSha(staleness.originMainSha)}; the dashboard will rebuild and restart with a 120-second health timeout.`,
+  });
+  emitTts({
+    utterance: 'Automatic dashboard deployment started.',
+    priority: 2,
+    source: 'deploy-script',
+    eventType: 'auto_deploy_started',
+  });
+}
+
+export function _resetDeployPatrolForTests(): void {
+  clearState();
+}

--- a/src/lib/cloister/deploy-patrol.ts
+++ b/src/lib/cloister/deploy-patrol.ts
@@ -1,6 +1,7 @@
 import { open, mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
 
 import { emitActivityEntrySync, emitActivityTtsSync } from '../activity-logger.js';
 import { getBuildInfo } from '../deploy/build-info.js';
@@ -55,6 +56,29 @@ function shortSha(sha: string | null): string {
   return sha?.slice(0, 8) || 'unknown';
 }
 
+export async function waitForChildSpawn(
+  child: Pick<ChildProcess, 'once' | 'removeListener' | 'unref'>,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onSpawn = () => {
+      cleanup();
+      child.unref();
+      resolve();
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const cleanup = () => {
+      child.removeListener('spawn', onSpawn);
+      child.removeListener('error', onError);
+    };
+
+    child.once('spawn', onSpawn);
+    child.once('error', onError);
+  });
+}
+
 async function spawnDetachedReload(request: ReloadRequest, now: number): Promise<void> {
   const logsDir = join(OVERDECK_HOME, 'logs');
   await mkdir(logsDir, { recursive: true });
@@ -75,7 +99,7 @@ async function spawnDetachedReload(request: ReloadRequest, now: number): Promise
         stdio: ['ignore', log.fd, log.fd],
       },
     );
-    child.unref();
+    await waitForChildSpawn(child);
   } finally {
     await log.close();
   }

--- a/src/lib/cloister/merge-agent-step0.ts
+++ b/src/lib/cloister/merge-agent-step0.ts
@@ -1,0 +1,42 @@
+import type { BuildStaleness } from '../deploy/staleness.js';
+
+interface Step0Dependencies {
+  readonly computeStaleness: () => Promise<BuildStaleness>;
+  readonly getBlockReason: () => Promise<string | null>;
+  readonly log: (message: string) => void;
+}
+
+export async function shouldRestartForPostMerge(
+  repoRoot: string,
+  dependencies: Partial<Step0Dependencies> = {},
+): Promise<boolean> {
+  const computeStaleness = dependencies.computeStaleness ?? (async () => {
+    const [{ getBuildInfo }, { computeBuildStaleness }] = await Promise.all([
+      import('../deploy/build-info.js'),
+      import('../deploy/staleness.js'),
+    ]);
+    return computeBuildStaleness({ repoRoot, buildCommit: getBuildInfo().buildCommit });
+  });
+  const staleness = await computeStaleness();
+
+  if (staleness.status === 'fresh') {
+    (dependencies.log ?? console.log)(
+      'Running build already contains origin/main build inputs — skipping deploy restart',
+    );
+    return false;
+  }
+
+  if (staleness.status === 'stale') {
+    const getBlockReason = dependencies.getBlockReason ?? (async () =>
+      (await import('../deploy/deploy-window.js')).getDeployBlockReason());
+    const reason = await getBlockReason();
+    if (reason) {
+      (dependencies.log ?? console.log)(
+        `Deploy window unsafe (${reason}) — deferring deploy to the staleness patrol`,
+      );
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/lib/cloister/merge-agent-step0.ts
+++ b/src/lib/cloister/merge-agent-step0.ts
@@ -26,16 +26,14 @@ export async function shouldRestartForPostMerge(
     return false;
   }
 
-  if (staleness.status === 'stale') {
-    const getBlockReason = dependencies.getBlockReason ?? (async () =>
-      (await import('../deploy/deploy-window.js')).getDeployBlockReason());
-    const reason = await getBlockReason();
-    if (reason) {
-      (dependencies.log ?? console.log)(
-        `Deploy window unsafe (${reason}) — deferring deploy to the staleness patrol`,
-      );
-      return false;
-    }
+  const getBlockReason = dependencies.getBlockReason ?? (async () =>
+    (await import('../deploy/deploy-window.js')).getDeployBlockReason());
+  const reason = await getBlockReason();
+  if (reason) {
+    (dependencies.log ?? console.log)(
+      `Deploy window unsafe (${reason}) — deferring deploy to the staleness patrol`,
+    );
+    return false;
   }
 
   return true;

--- a/src/lib/cloister/merge-agent.ts
+++ b/src/lib/cloister/merge-agent.ts
@@ -12,6 +12,7 @@ import { Effect } from 'effect';
 import { capturePane, killSession, listSessionNames, sendKeys, sessionExists } from '../tmux.js';
 import { emitActivityEntrySync, emitActivityTtsSync } from '../activity-logger.js';
 import { loadConfigSync } from '../config-yaml.js';
+import { shouldRestartForPostMerge } from './merge-agent-step0.js';
 
 const execAsync = promisify(exec);
 
@@ -375,13 +376,7 @@ export async function postMergeLifecycle(
       console.warn(`[merge-agent] Could not set mergeStatus: ${err.message}`);
     }
 
-    // Step 0: Write pending lifecycle file and spawn detached deploy script.
-    // The deploy script rebuilds dist/, kills this server, and starts a fresh process.
-    // The fresh process reads the pending file on startup and runs the lifecycle steps
-    // with correct module chunk references (no ERR_MODULE_NOT_FOUND after merge).
-    //
-    // Skip this step when we ARE the fresh process (called from processPendingLifecycle) —
-    // dynamic imports already resolve correctly and spawning again would create an infinite loop.
+    // Step 0: restart only when the running build is stale and the deploy window is safe.
     if (!options?.skipDeploy) {
       const pendingFile = join(OVERDECK_HOME, 'pending-post-merge.json');
       let repoRoot = __dirname.includes('/src/')
@@ -397,7 +392,7 @@ export async function postMergeLifecycle(
       }
       const deployScript = join(repoRoot, 'scripts', 'post-merge-deploy.sh');
 
-      try {
+      if (await shouldRestartForPostMerge(repoRoot)) try {
         const pendingData = JSON.stringify({
           issueId,
           projectPath,

--- a/src/lib/deploy/build-info.ts
+++ b/src/lib/deploy/build-info.ts
@@ -1,0 +1,15 @@
+declare const __OVERDECK_BUILD_COMMIT__: string;
+declare const __OVERDECK_BUILD_TIME__: string;
+
+export interface BuildInfo {
+  readonly buildCommit: string | null;
+  readonly builtAt: string | null;
+}
+
+export function getBuildInfo(): BuildInfo {
+  return {
+    buildCommit:
+      typeof __OVERDECK_BUILD_COMMIT__ === 'string' ? __OVERDECK_BUILD_COMMIT__ : null,
+    builtAt: typeof __OVERDECK_BUILD_TIME__ === 'string' ? __OVERDECK_BUILD_TIME__ : null,
+  };
+}

--- a/src/lib/deploy/deploy-window.ts
+++ b/src/lib/deploy/deploy-window.ts
@@ -3,7 +3,6 @@ import { join } from 'node:path';
 
 import { Effect } from 'effect';
 
-import { isMergeAgentRunning } from '../cloister/merge-agent.js';
 import {
   readDevSupervisorMarker,
   type DevSupervisorMarker,
@@ -11,6 +10,7 @@ import {
 import { getOverdeckHome } from '../paths.js';
 import { loadReviewStatuses, type ReviewStatus } from '../review-status.js';
 import { readRestartLockHolder, type RestartLockHolder } from '../restart-lock.js';
+import { sessionExists } from '../tmux.js';
 
 interface DeployWindowDependencies {
   readonly loadReviewStatuses: () => Record<string, ReviewStatus>;
@@ -22,7 +22,7 @@ interface DeployWindowDependencies {
 
 const defaultDependencies: DeployWindowDependencies = {
   loadReviewStatuses,
-  isMergeAgentRunning,
+  isMergeAgentRunning: () => Effect.runPromise(sessionExists('specialist-merge-agent')),
   pendingPostMergeExists: async () => {
     try {
       await access(join(getOverdeckHome(), 'pending-post-merge.json'));

--- a/src/lib/deploy/deploy-window.ts
+++ b/src/lib/deploy/deploy-window.ts
@@ -7,6 +7,7 @@ import {
   readDevSupervisorMarker,
   type DevSupervisorMarker,
 } from '../dev-supervisor.js';
+import { getFlywheelActiveRunId } from '../overdeck/control-settings.js';
 import { getOverdeckHome } from '../paths.js';
 import { loadReviewStatuses, type ReviewStatus } from '../review-status.js';
 import { readRestartLockHolder, type RestartLockHolder } from '../restart-lock.js';
@@ -14,6 +15,7 @@ import { sessionExists } from '../tmux.js';
 
 interface DeployWindowDependencies {
   readonly loadReviewStatuses: () => Record<string, ReviewStatus>;
+  readonly getFlywheelActiveRunId: () => string | null;
   readonly isMergeAgentRunning: () => Promise<boolean>;
   readonly pendingPostMergeExists: () => Promise<boolean>;
   readonly readRestartLockHolder: () => Promise<RestartLockHolder | null>;
@@ -22,6 +24,7 @@ interface DeployWindowDependencies {
 
 const defaultDependencies: DeployWindowDependencies = {
   loadReviewStatuses,
+  getFlywheelActiveRunId,
   isMergeAgentRunning: () => Effect.runPromise(sessionExists('specialist-merge-agent')),
   pendingPostMergeExists: async () => {
     try {
@@ -46,6 +49,11 @@ export async function getDeployBlockReason(
 
   if (verifyingIssues.length > 0) {
     return `Deployment deferred because verification is in flight for ${verifyingIssues.join(', ')}.`;
+  }
+
+  const activeFlywheelRunId = deps.getFlywheelActiveRunId();
+  if (activeFlywheelRunId) {
+    return `Deployment deferred because flywheel run ${activeFlywheelRunId} owns deployment.`;
   }
 
   if (await deps.isMergeAgentRunning()) {

--- a/src/lib/deploy/deploy-window.ts
+++ b/src/lib/deploy/deploy-window.ts
@@ -1,0 +1,69 @@
+import { access } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { Effect } from 'effect';
+
+import { isMergeAgentRunning } from '../cloister/merge-agent.js';
+import {
+  readDevSupervisorMarker,
+  type DevSupervisorMarker,
+} from '../dev-supervisor.js';
+import { getOverdeckHome } from '../paths.js';
+import { loadReviewStatuses, type ReviewStatus } from '../review-status.js';
+import { readRestartLockHolder, type RestartLockHolder } from '../restart-lock.js';
+
+interface DeployWindowDependencies {
+  readonly loadReviewStatuses: () => Record<string, ReviewStatus>;
+  readonly isMergeAgentRunning: () => Promise<boolean>;
+  readonly pendingPostMergeExists: () => Promise<boolean>;
+  readonly readRestartLockHolder: () => Promise<RestartLockHolder | null>;
+  readonly readDevSupervisorMarker: () => DevSupervisorMarker | null;
+}
+
+const defaultDependencies: DeployWindowDependencies = {
+  loadReviewStatuses,
+  isMergeAgentRunning,
+  pendingPostMergeExists: async () => {
+    try {
+      await access(join(getOverdeckHome(), 'pending-post-merge.json'));
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  readRestartLockHolder: () => Effect.runPromise(readRestartLockHolder()),
+  readDevSupervisorMarker,
+};
+
+export async function getDeployBlockReason(
+  dependencies: Partial<DeployWindowDependencies> = {},
+): Promise<string | null> {
+  const deps = { ...defaultDependencies, ...dependencies };
+  const verifyingIssues = Object.entries(deps.loadReviewStatuses())
+    .filter(([, status]) => status.verificationStatus === 'running')
+    .map(([issueId]) => issueId)
+    .sort();
+
+  if (verifyingIssues.length > 0) {
+    return `Deployment deferred because verification is in flight for ${verifyingIssues.join(', ')}.`;
+  }
+
+  if (await deps.isMergeAgentRunning()) {
+    return 'Deployment deferred because a merge specialist session is active.';
+  }
+
+  if (await deps.pendingPostMergeExists()) {
+    return 'Deployment deferred because the post-merge lifecycle is pending.';
+  }
+
+  const restartLock = await deps.readRestartLockHolder();
+  if (restartLock) {
+    return `Deployment deferred because a restart is already in progress (pid ${restartLock.pid}, ${restartLock.caller}).`;
+  }
+
+  if (deps.readDevSupervisorMarker()) {
+    return 'Deployment deferred because a pan dev session owns the dashboard.';
+  }
+
+  return null;
+}

--- a/src/lib/deploy/staleness.ts
+++ b/src/lib/deploy/staleness.ts
@@ -26,11 +26,17 @@ export type GitExec = (
 ) => Promise<{ readonly stdout: string }>;
 
 const DEFAULT_FETCH_MIN_INTERVAL_MS = 120_000;
+const DEFAULT_GIT_TIMEOUT_MS = 30_000;
 const lastFetchAttemptByRepo = new Map<string, number>();
 
 const defaultExec: GitExec = (command, args, options) =>
   new Promise((resolve, reject) => {
-    execFile(command, [...args], { cwd: options.cwd, encoding: 'utf8' }, (error, stdout) => {
+    execFile(command, [...args], {
+      cwd: options.cwd,
+      encoding: 'utf8',
+      timeout: DEFAULT_GIT_TIMEOUT_MS,
+      killSignal: 'SIGTERM',
+    }, (error, stdout) => {
       if (error) {
         reject(error);
         return;
@@ -38,6 +44,27 @@ const defaultExec: GitExec = (command, args, options) =>
       resolve({ stdout });
     });
   });
+
+async function fetchOriginMain(
+  run: GitExec,
+  repoRoot: string,
+  timeoutMs: number,
+): Promise<void> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      run('git', ['fetch', 'origin', 'main'], { cwd: repoRoot }),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`git fetch timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
 
 function unknown(
   buildCommit: string | null,
@@ -66,6 +93,7 @@ export async function computeBuildStaleness(input: {
   readonly buildCommit: string | null;
   readonly exec?: GitExec;
   readonly fetchMinIntervalMs?: number;
+  readonly fetchTimeoutMs?: number;
 }): Promise<BuildStaleness> {
   const computedAt = Date.now();
   const { repoRoot, buildCommit } = input;
@@ -86,7 +114,7 @@ export async function computeBuildStaleness(input: {
   if (computedAt - lastFetchAttempt >= fetchMinIntervalMs) {
     lastFetchAttemptByRepo.set(repoRoot, computedAt);
     try {
-      await run('git', ['fetch', 'origin', 'main'], { cwd: repoRoot });
+      await fetchOriginMain(run, repoRoot, input.fetchTimeoutMs ?? DEFAULT_GIT_TIMEOUT_MS);
     } catch {
       // A stale local origin/main is still more useful than rejecting the health check.
     }

--- a/src/lib/deploy/staleness.ts
+++ b/src/lib/deploy/staleness.ts
@@ -1,0 +1,128 @@
+import { execFile } from 'node:child_process';
+
+export const BUILD_INPUT_PATHS = [
+  'src',
+  'packages',
+  'package.json',
+  'bun.lock',
+  'tsdown.config.ts',
+] as const;
+
+export interface BuildStaleness {
+  readonly status: 'fresh' | 'stale' | 'unknown';
+  readonly buildCommit: string | null;
+  readonly originMainSha: string | null;
+  readonly behindTotal: number | null;
+  readonly behindBuildInputs: number | null;
+  readonly originMainLastCommitAt: number | null;
+  readonly computedAt: number;
+  readonly reason?: string;
+}
+
+export type GitExec = (
+  command: string,
+  args: readonly string[],
+  options: { readonly cwd: string },
+) => Promise<{ readonly stdout: string }>;
+
+const DEFAULT_FETCH_MIN_INTERVAL_MS = 120_000;
+const lastFetchAttemptByRepo = new Map<string, number>();
+
+const defaultExec: GitExec = (command, args, options) =>
+  new Promise((resolve, reject) => {
+    execFile(command, [...args], { cwd: options.cwd, encoding: 'utf8' }, (error, stdout) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve({ stdout });
+    });
+  });
+
+function unknown(
+  buildCommit: string | null,
+  computedAt: number,
+  reason: string,
+  originMainSha: string | null = null,
+): BuildStaleness {
+  return {
+    status: 'unknown',
+    buildCommit,
+    originMainSha,
+    behindTotal: null,
+    behindBuildInputs: null,
+    originMainLastCommitAt: null,
+    computedAt,
+    reason,
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function computeBuildStaleness(input: {
+  readonly repoRoot: string;
+  readonly buildCommit: string | null;
+  readonly exec?: GitExec;
+  readonly fetchMinIntervalMs?: number;
+}): Promise<BuildStaleness> {
+  const computedAt = Date.now();
+  const { repoRoot, buildCommit } = input;
+  const run = input.exec ?? defaultExec;
+
+  if (!buildCommit) {
+    return unknown(buildCommit, computedAt, 'The running build does not include a commit stamp.');
+  }
+
+  try {
+    await run('git', ['rev-parse', '--verify', `${buildCommit}^{commit}`], { cwd: repoRoot });
+  } catch (error) {
+    return unknown(buildCommit, computedAt, `The build commit is not available in this repository: ${errorMessage(error)}`);
+  }
+
+  const fetchMinIntervalMs = input.fetchMinIntervalMs ?? DEFAULT_FETCH_MIN_INTERVAL_MS;
+  const lastFetchAttempt = lastFetchAttemptByRepo.get(repoRoot) ?? Number.NEGATIVE_INFINITY;
+  if (computedAt - lastFetchAttempt >= fetchMinIntervalMs) {
+    lastFetchAttemptByRepo.set(repoRoot, computedAt);
+    try {
+      await run('git', ['fetch', 'origin', 'main'], { cwd: repoRoot });
+    } catch {
+      // A stale local origin/main is still more useful than rejecting the health check.
+    }
+  }
+
+  let originMainSha: string | null = null;
+  try {
+    originMainSha = (await run('git', ['rev-parse', 'origin/main'], { cwd: repoRoot })).stdout.trim();
+    const range = `${buildCommit}..origin/main`;
+    const [total, buildInputs, lastCommit] = await Promise.all([
+      run('git', ['rev-list', '--count', range], { cwd: repoRoot }),
+      run('git', ['rev-list', '--count', range, '--', ...BUILD_INPUT_PATHS], { cwd: repoRoot }),
+      run('git', ['log', '-1', '--format=%ct', 'origin/main'], { cwd: repoRoot }),
+    ]);
+    const behindTotal = Number.parseInt(total.stdout.trim(), 10);
+    const behindBuildInputs = Number.parseInt(buildInputs.stdout.trim(), 10);
+    const originMainLastCommitAt = Number.parseInt(lastCommit.stdout.trim(), 10) * 1000;
+
+    if (![behindTotal, behindBuildInputs, originMainLastCommitAt].every(Number.isFinite)) {
+      return unknown(buildCommit, computedAt, 'Git returned invalid staleness metadata.', originMainSha);
+    }
+
+    return {
+      status: behindBuildInputs > 0 ? 'stale' : 'fresh',
+      buildCommit,
+      originMainSha,
+      behindTotal,
+      behindBuildInputs,
+      originMainLastCommitAt,
+      computedAt,
+    };
+  } catch (error) {
+    return unknown(buildCommit, computedAt, `Unable to compute build staleness: ${errorMessage(error)}`, originMainSha);
+  }
+}
+
+export function _resetForTests(): void {
+  lastFetchAttemptByRepo.clear();
+}

--- a/tests/unit/dashboard/identity.test.ts
+++ b/tests/unit/dashboard/identity.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, it } from 'vitest';
 
-import { shouldRefuseHostDashboardPort } from '../../../src/dashboard/server/identity.js';
+import { getBuildInfo } from '../../../src/lib/deploy/build-info.js';
+import {
+  getDashboardIdentity,
+  shouldRefuseHostDashboardPort,
+} from '../../../src/dashboard/server/identity.js';
+
+describe('dashboard build identity', () => {
+  it('returns null build metadata when build-time globals are undefined', () => {
+    expect(getBuildInfo()).toEqual({ buildCommit: null, builtAt: null });
+  });
+
+  it('includes build metadata without removing existing identity fields', () => {
+    expect(getDashboardIdentity()).toMatchObject({
+      repoRoot: process.cwd(),
+      mode: expect.stringMatching(/^(primary|peer)$/),
+      buildCommit: null,
+      builtAt: null,
+    });
+  });
+});
 
 describe('dashboard identity port guard', () => {
   it('refuses a peer dashboard on the host dashboard API port', () => {

--- a/tests/unit/lib/cloister/deploy-patrol.test.ts
+++ b/tests/unit/lib/cloister/deploy-patrol.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
 
 import {
   _resetDeployPatrolForTests,
   runDeployPatrol,
+  waitForChildSpawn,
 } from '../../../../src/lib/cloister/deploy-patrol.js';
 import type { BuildStaleness } from '../../../../src/lib/deploy/staleness.js';
 
@@ -119,5 +121,30 @@ describe('runDeployPatrol', () => {
     await runDeployPatrol(unknownCtx);
     expect(unknownCtx.spawnReload).not.toHaveBeenCalled();
     expect(unknownCtx.emitEntry).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('waitForChildSpawn', () => {
+  it('unrefs only after the detached child reports a successful spawn', async () => {
+    const child = new EventEmitter() as EventEmitter & { unref: ReturnType<typeof vi.fn> };
+    child.unref = vi.fn();
+
+    const spawned = waitForChildSpawn(child);
+    child.emit('spawn');
+
+    await expect(spawned).resolves.toBeUndefined();
+    expect(child.unref).toHaveBeenCalledOnce();
+  });
+
+  it('rejects an asynchronous spawn error without leaving an unhandled error event', async () => {
+    const child = new EventEmitter() as EventEmitter & { unref: ReturnType<typeof vi.fn> };
+    child.unref = vi.fn();
+    const error = new Error('spawn failed');
+
+    const spawned = waitForChildSpawn(child);
+    child.emit('error', error);
+
+    await expect(spawned).rejects.toBe(error);
+    expect(child.unref).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/lib/cloister/deploy-patrol.test.ts
+++ b/tests/unit/lib/cloister/deploy-patrol.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  _resetDeployPatrolForTests,
+  runDeployPatrol,
+} from '../../../../src/lib/cloister/deploy-patrol.js';
+import type { BuildStaleness } from '../../../../src/lib/deploy/staleness.js';
+
+const NOW = new Date('2026-07-15T12:00:00.000Z').getTime();
+
+function stale(overrides: Partial<BuildStaleness> = {}): BuildStaleness {
+  return {
+    status: 'stale',
+    buildCommit: 'build123456789',
+    originMainSha: 'origin123456789',
+    behindTotal: 4,
+    behindBuildInputs: 2,
+    originMainLastCommitAt: NOW - 10 * 60 * 1000,
+    computedAt: NOW,
+    ...overrides,
+  };
+}
+
+function context(staleness: BuildStaleness = stale()) {
+  return {
+    repoRoot: '/repo',
+    config: { auto_deploy: true, debounce_minutes: 5 },
+    computeStaleness: vi.fn(async () => staleness),
+    getBlockReason: vi.fn(async () => null),
+    spawnReload: vi.fn(async () => undefined),
+    emitEntry: vi.fn(),
+    emitTts: vi.fn(),
+    now: () => Date.now(),
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  _resetDeployPatrolForTests();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('runDeployPatrol', () => {
+  it('starts one reload and announces it when the safety window is clear', async () => {
+    const ctx = context();
+
+    await runDeployPatrol(ctx);
+
+    expect(ctx.spawnReload).toHaveBeenCalledWith({
+      command: process.execPath,
+      args: ['/repo/dist/cli/index.js', 'reload', '--health-timeout', '120000'],
+      cwd: '/repo',
+      detached: true,
+    });
+    expect(ctx.emitEntry).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('Automatic deployment started'),
+    }));
+    expect(ctx.emitTts).toHaveBeenCalledWith(expect.objectContaining({
+      utterance: 'Automatic dashboard deployment started.',
+    }));
+  });
+
+  it('emits a throttled deferral when the deploy window is blocked', async () => {
+    const ctx = context();
+    ctx.getBlockReason.mockResolvedValue('Deployment deferred because verification is in flight for PAN-1.');
+
+    await runDeployPatrol(ctx);
+    await runDeployPatrol(ctx);
+
+    expect(ctx.spawnReload).not.toHaveBeenCalled();
+    expect(ctx.emitEntry.mock.calls.filter(([entry]) => entry.message.includes('verification'))).toHaveLength(1);
+  });
+
+  it('waits for the merge debounce interval under fake timers', async () => {
+    const ctx = context(stale({ originMainLastCommitAt: NOW - 4 * 60 * 1000 }));
+
+    await runDeployPatrol(ctx);
+    expect(ctx.spawnReload).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await runDeployPatrol(ctx);
+    expect(ctx.spawnReload).toHaveBeenCalledTimes(1);
+  });
+
+  it('remains signal-only when automatic deployment is disabled', async () => {
+    const ctx = context();
+    ctx.config.auto_deploy = false;
+
+    await runDeployPatrol(ctx);
+
+    expect(ctx.emitEntry).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('operator action is required'),
+    }));
+    expect(ctx.spawnReload).not.toHaveBeenCalled();
+  });
+
+  it('suppresses another spawn for ten minutes', async () => {
+    const ctx = context();
+
+    await runDeployPatrol(ctx);
+    await vi.advanceTimersByTimeAsync(9 * 60 * 1000);
+    await runDeployPatrol(ctx);
+
+    expect(ctx.spawnReload).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not repeatedly observe fresh or unknown builds', async () => {
+    const freshCtx = context(stale({ status: 'fresh', behindTotal: 0, behindBuildInputs: 0 }));
+    await runDeployPatrol(freshCtx);
+    expect(freshCtx.spawnReload).not.toHaveBeenCalled();
+    expect(freshCtx.emitEntry).not.toHaveBeenCalled();
+
+    const unknownCtx = context(stale({ status: 'unknown', reason: 'missing stamp' }));
+    await runDeployPatrol(unknownCtx);
+    await runDeployPatrol(unknownCtx);
+    expect(unknownCtx.spawnReload).not.toHaveBeenCalled();
+    expect(unknownCtx.emitEntry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/lib/cloister/merge-agent-step0.test.ts
+++ b/tests/unit/lib/cloister/merge-agent-step0.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { shouldRestartForPostMerge } from '../../../../src/lib/cloister/merge-agent-step0.js';
+import type { BuildStaleness } from '../../../../src/lib/deploy/staleness.js';
+
+function staleness(status: BuildStaleness['status']): BuildStaleness {
+  return {
+    status,
+    buildCommit: 'build-sha',
+    originMainSha: 'origin-sha',
+    behindTotal: status === 'fresh' ? 0 : 2,
+    behindBuildInputs: status === 'fresh' ? 0 : 1,
+    originMainLastCommitAt: 1_710_000_000_000,
+    computedAt: 1_752_580_800_000,
+    ...(status === 'unknown' ? { reason: 'legacy unstamped build' } : {}),
+  };
+}
+
+describe('postMergeLifecycle Step 0 deploy gating', () => {
+  it('skips the restart for a fresh build so lifecycle work can continue in-process', async () => {
+    const log = vi.fn();
+    await expect(shouldRestartForPostMerge('/repo', {
+      computeStaleness: async () => staleness('fresh'),
+      getBlockReason: vi.fn(),
+      log,
+    })).resolves.toBe(false);
+    expect(log).toHaveBeenCalledWith(
+      'Running build already contains origin/main build inputs — skipping deploy restart',
+    );
+  });
+
+  it('defers a stale build when the deploy window is unsafe', async () => {
+    const log = vi.fn();
+    const reason = 'Deployment deferred because verification is in flight for PAN-1.';
+    await expect(shouldRestartForPostMerge('/repo', {
+      computeStaleness: async () => staleness('stale'),
+      getBlockReason: async () => reason,
+      log,
+    })).resolves.toBe(false);
+    expect(log).toHaveBeenCalledWith(
+      `Deploy window unsafe (${reason}) — deferring deploy to the staleness patrol`,
+    );
+  });
+
+  it('preserves the detached restart path for a stale build when the window is clear', async () => {
+    await expect(shouldRestartForPostMerge('/repo', {
+      computeStaleness: async () => staleness('stale'),
+      getBlockReason: async () => null,
+    })).resolves.toBe(true);
+  });
+
+  it('preserves the existing restart behavior for an unknown legacy build', async () => {
+    const getBlockReason = vi.fn();
+    await expect(shouldRestartForPostMerge('/repo', {
+      computeStaleness: async () => staleness('unknown'),
+      getBlockReason,
+    })).resolves.toBe(true);
+    expect(getBlockReason).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/lib/cloister/merge-agent-step0.test.ts
+++ b/tests/unit/lib/cloister/merge-agent-step0.test.ts
@@ -49,12 +49,18 @@ describe('postMergeLifecycle Step 0 deploy gating', () => {
     })).resolves.toBe(true);
   });
 
-  it('preserves the existing restart behavior for an unknown legacy build', async () => {
-    const getBlockReason = vi.fn();
+  it('defers an unknown legacy build when the deploy window is unsafe', async () => {
+    const reason = 'Deployment deferred because flywheel run RUN-42 owns deployment.';
     await expect(shouldRestartForPostMerge('/repo', {
       computeStaleness: async () => staleness('unknown'),
-      getBlockReason,
+      getBlockReason: async () => reason,
+    })).resolves.toBe(false);
+  });
+
+  it('preserves the existing restart behavior for an unknown legacy build when the window is clear', async () => {
+    await expect(shouldRestartForPostMerge('/repo', {
+      computeStaleness: async () => staleness('unknown'),
+      getBlockReason: async () => null,
     })).resolves.toBe(true);
-    expect(getBlockReason).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/lib/deploy/deploy-window.test.ts
+++ b/tests/unit/lib/deploy/deploy-window.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { getDeployBlockReason } from '../../../../src/lib/deploy/deploy-window.js';
+
+function clearDependencies() {
+  return {
+    loadReviewStatuses: vi.fn(() => ({})),
+    isMergeAgentRunning: vi.fn(async () => false),
+    pendingPostMergeExists: vi.fn(async () => false),
+    readRestartLockHolder: vi.fn(async () => null),
+    readDevSupervisorMarker: vi.fn(() => null),
+  };
+}
+
+describe('getDeployBlockReason', () => {
+  it('names every issue with verification in flight before checking later gates', async () => {
+    const deps = clearDependencies();
+    deps.loadReviewStatuses.mockReturnValue({
+      'PAN-20': { issueId: 'PAN-20', verificationStatus: 'running' },
+      'PAN-10': { issueId: 'PAN-10', verificationStatus: 'running' },
+      'PAN-30': { issueId: 'PAN-30', verificationStatus: 'passed' },
+    });
+
+    await expect(getDeployBlockReason(deps)).resolves.toBe(
+      'Deployment deferred because verification is in flight for PAN-10, PAN-20.',
+    );
+    expect(deps.isMergeAgentRunning).not.toHaveBeenCalled();
+  });
+
+  it('blocks while a merge specialist session is active', async () => {
+    const deps = clearDependencies();
+    deps.isMergeAgentRunning.mockResolvedValue(true);
+
+    await expect(getDeployBlockReason(deps)).resolves.toBe(
+      'Deployment deferred because a merge specialist session is active.',
+    );
+  });
+
+  it('blocks while the post-merge lifecycle is pending', async () => {
+    const deps = clearDependencies();
+    deps.pendingPostMergeExists.mockResolvedValue(true);
+
+    await expect(getDeployBlockReason(deps)).resolves.toBe(
+      'Deployment deferred because the post-merge lifecycle is pending.',
+    );
+  });
+
+  it('identifies the process holding the restart lock', async () => {
+    const deps = clearDependencies();
+    deps.readRestartLockHolder.mockResolvedValue({
+      pid: 1234,
+      caller: 'pan reload',
+      acquiredAt: '2026-07-15T12:00:00.000Z',
+    });
+
+    await expect(getDeployBlockReason(deps)).resolves.toBe(
+      'Deployment deferred because a restart is already in progress (pid 1234, pan reload).',
+    );
+  });
+
+  it('blocks while pan dev owns the dashboard', async () => {
+    const deps = clearDependencies();
+    deps.readDevSupervisorMarker.mockReturnValue({
+      pid: 5678,
+      dashboardPort: 5173,
+      apiPort: 3011,
+      startedAt: '2026-07-15T12:00:00.000Z',
+    });
+
+    await expect(getDeployBlockReason(deps)).resolves.toBe(
+      'Deployment deferred because a pan dev session owns the dashboard.',
+    );
+  });
+
+  it('returns null when the full deploy window is clear', async () => {
+    await expect(getDeployBlockReason(clearDependencies())).resolves.toBeNull();
+  });
+});

--- a/tests/unit/lib/deploy/deploy-window.test.ts
+++ b/tests/unit/lib/deploy/deploy-window.test.ts
@@ -5,6 +5,7 @@ import { getDeployBlockReason } from '../../../../src/lib/deploy/deploy-window.j
 function clearDependencies() {
   return {
     loadReviewStatuses: vi.fn(() => ({})),
+    getFlywheelActiveRunId: vi.fn(() => null as string | null),
     isMergeAgentRunning: vi.fn(async () => false),
     pendingPostMergeExists: vi.fn(async () => false),
     readRestartLockHolder: vi.fn(async () => null),
@@ -34,6 +35,16 @@ describe('getDeployBlockReason', () => {
     await expect(getDeployBlockReason(deps)).resolves.toBe(
       'Deployment deferred because a merge specialist session is active.',
     );
+  });
+
+  it('defers deployment to an active flywheel run', async () => {
+    const deps = clearDependencies();
+    deps.getFlywheelActiveRunId.mockReturnValue('RUN-42');
+
+    await expect(getDeployBlockReason(deps)).resolves.toBe(
+      'Deployment deferred because flywheel run RUN-42 owns deployment.',
+    );
+    expect(deps.isMergeAgentRunning).not.toHaveBeenCalled();
   });
 
   it('blocks while the post-merge lifecycle is pending', async () => {

--- a/tests/unit/lib/deploy/staleness.test.ts
+++ b/tests/unit/lib/deploy/staleness.test.ts
@@ -98,4 +98,29 @@ describe('computeBuildStaleness', () => {
     await expect(computeBuildStaleness({ repoRoot: REPO_ROOT, buildCommit: BUILD_COMMIT, exec }))
       .resolves.toMatchObject({ status: 'stale', originMainSha: 'origin-sha', behindBuildInputs: 1 });
   });
+
+  it('bounds a stalled fetch and continues with the local origin/main ref', async () => {
+    const { exec: baseExec, calls } = createExec({ behindBuildInputs: 1 });
+    const exec: GitExec = async (command, args, options) => {
+      if (args[0] === 'fetch') {
+        calls.push([...args]);
+        return new Promise(() => undefined);
+      }
+      return baseExec(command, args, options);
+    };
+
+    const result = computeBuildStaleness({
+      repoRoot: REPO_ROOT,
+      buildCommit: BUILD_COMMIT,
+      exec,
+      fetchTimeoutMs: 1_000,
+    });
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(result).resolves.toMatchObject({
+      status: 'stale',
+      originMainSha: 'origin-sha',
+      behindBuildInputs: 1,
+    });
+  });
 });

--- a/tests/unit/lib/deploy/staleness.test.ts
+++ b/tests/unit/lib/deploy/staleness.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  _resetForTests,
+  BUILD_INPUT_PATHS,
+  computeBuildStaleness,
+  type GitExec,
+} from '../../../../src/lib/deploy/staleness.js';
+
+const REPO_ROOT = '/repo';
+const BUILD_COMMIT = 'build-sha';
+
+function createExec(options: {
+  behindTotal?: number;
+  behindBuildInputs?: number;
+  fetchError?: Error;
+  unknownBuild?: boolean;
+} = {}) {
+  const calls: string[][] = [];
+  const exec: GitExec = async (_command, args) => {
+    calls.push([...args]);
+    if (args[0] === 'fetch' && options.fetchError) throw options.fetchError;
+    if (args[0] === 'rev-parse' && args[1] === '--verify' && options.unknownBuild) {
+      throw new Error('bad object');
+    }
+    if (args[0] === 'rev-parse' && args[1] === 'origin/main') return { stdout: 'origin-sha\n' };
+    if (args[0] === 'rev-list' && args.includes('--')) {
+      return { stdout: `${options.behindBuildInputs ?? 0}\n` };
+    }
+    if (args[0] === 'rev-list') return { stdout: `${options.behindTotal ?? 0}\n` };
+    if (args[0] === 'log') return { stdout: '1710000000\n' };
+    return { stdout: `${BUILD_COMMIT}\n` };
+  };
+  return { exec, calls };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-07-15T12:00:00.000Z'));
+  _resetForTests();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('computeBuildStaleness', () => {
+  it('reports build-input commits behind origin/main', async () => {
+    const { exec, calls } = createExec({ behindTotal: 5, behindBuildInputs: 2 });
+
+    const result = await computeBuildStaleness({ repoRoot: REPO_ROOT, buildCommit: BUILD_COMMIT, exec });
+
+    expect(result).toMatchObject({ status: 'stale', behindTotal: 5, behindBuildInputs: 2 });
+    expect(calls).toContainEqual([
+      'rev-list', '--count', `${BUILD_COMMIT}..origin/main`, '--', ...BUILD_INPUT_PATHS,
+    ]);
+  });
+
+  it('reports fresh when origin/main has no newer build-input commits', async () => {
+    const { exec } = createExec({ behindTotal: 3, behindBuildInputs: 0 });
+
+    await expect(computeBuildStaleness({ repoRoot: REPO_ROOT, buildCommit: BUILD_COMMIT, exec }))
+      .resolves.toMatchObject({
+        status: 'fresh',
+        originMainSha: 'origin-sha',
+        behindTotal: 3,
+        behindBuildInputs: 0,
+        originMainLastCommitAt: 1_710_000_000_000,
+      });
+  });
+
+  it('returns unknown without rejecting for a missing or unknown build commit', async () => {
+    const missing = createExec();
+    const unknown = createExec({ unknownBuild: true });
+
+    await expect(computeBuildStaleness({ repoRoot: REPO_ROOT, buildCommit: null, exec: missing.exec }))
+      .resolves.toMatchObject({ status: 'unknown', buildCommit: null, reason: expect.any(String) });
+    expect(missing.calls).toHaveLength(0);
+
+    await expect(computeBuildStaleness({ repoRoot: REPO_ROOT, buildCommit: BUILD_COMMIT, exec: unknown.exec }))
+      .resolves.toMatchObject({ status: 'unknown', buildCommit: BUILD_COMMIT, reason: expect.any(String) });
+  });
+
+  it('throttles fetches while continuing to read local refs', async () => {
+    const { exec, calls } = createExec();
+
+    await computeBuildStaleness({ repoRoot: REPO_ROOT, buildCommit: BUILD_COMMIT, exec });
+    await vi.advanceTimersByTimeAsync(1_000);
+    await computeBuildStaleness({ repoRoot: REPO_ROOT, buildCommit: BUILD_COMMIT, exec });
+
+    expect(calls.filter(([command]) => command === 'fetch')).toHaveLength(1);
+    expect(calls.filter(([command, ref]) => command === 'rev-parse' && ref === 'origin/main')).toHaveLength(2);
+  });
+
+  it('uses the last-fetched origin/main when fetch fails', async () => {
+    const { exec } = createExec({ fetchError: new Error('offline'), behindBuildInputs: 1 });
+
+    await expect(computeBuildStaleness({ repoRoot: REPO_ROOT, buildCommit: BUILD_COMMIT, exec }))
+      .resolves.toMatchObject({ status: 'stale', originMainSha: 'origin-sha', behindBuildInputs: 1 });
+  });
+});

--- a/tests/unit/lib/pan-444-post-merge-step0.test.ts
+++ b/tests/unit/lib/pan-444-post-merge-step0.test.ts
@@ -32,6 +32,7 @@ const mockSetReviewStatusSync = vi.hoisted(() => vi.fn());
 const mockLoadConfigSync = vi.hoisted(() => vi.fn(() => ({ config: { knowledge: { postMergeAutoRetro: false } } })));
 const mockIsGitHubAppConfigured = vi.hoisted(() => vi.fn(() => false));
 const mockListPullRequestsForHead = vi.hoisted(() => vi.fn(() => Effect.succeed([])));
+const mockShouldRestartForPostMerge = vi.hoisted(() => vi.fn(async () => true));
 const mockExec = vi.hoisted(() => vi.fn((cmd: string, optionsOrCb?: any, maybeCb?: any) => {
   const callback = typeof optionsOrCb === 'function' ? optionsOrCb : maybeCb;
   if (typeof callback === 'function') {
@@ -116,6 +117,10 @@ vi.mock('../../../src/lib/cloister/specialists.js', () => ({
   isRunning: vi.fn().mockResolvedValue(false),
 }));
 
+vi.mock('../../../src/lib/cloister/merge-agent-step0.js', () => ({
+  shouldRestartForPostMerge: mockShouldRestartForPostMerge,
+}));
+
 vi.mock('../../../src/lib/projects.js', () => ({
   resolveProjectFromIssue: vi.fn().mockReturnValue(null),
   resolveProjectFromIssueSync: vi.fn().mockReturnValue(null),
@@ -172,6 +177,7 @@ describe('postMergeLifecycle — step 0 deploy handoff', () => {
     mockExecAsync.mockImplementation(defaultExecAsync);
     mockIsGitHubAppConfigured.mockReturnValue(false);
     mockListPullRequestsForHead.mockReturnValue(Effect.succeed([]));
+    mockShouldRestartForPostMerge.mockResolvedValue(true);
     resetPostMergeState(ISSUE_ID);
     mockWriteFile.mockResolvedValue(undefined);
     mockSpawn.mockReturnValue(mockSpawnChild);

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,5 +1,12 @@
+import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { defineConfig } from 'tsdown';
+
+const buildCommit = execFileSync('git', ['rev-parse', 'HEAD'], {
+  cwd: import.meta.dirname,
+  encoding: 'utf8',
+}).trim();
+const builtAt = new Date().toISOString();
 
 export default defineConfig({
   entry: {
@@ -16,6 +23,10 @@ export default defineConfig({
   sourcemap: true,
   target: 'node18',
   shims: true,
+  define: {
+    __OVERDECK_BUILD_COMMIT__: JSON.stringify(buildCommit),
+    __OVERDECK_BUILD_TIME__: JSON.stringify(builtAt),
+  },
   outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
   alias: {
     '@overdeck/contracts': resolve(import.meta.dirname, 'packages/contracts/src/index.ts'),


### PR DESCRIPTION
**Issue:** #2713

## Acceptance Criteria

- [ ] Stamp build commit into bundles and expose it on /api/health
- [ ] Shared build-staleness module (behind origin/main by N, filtered to build inputs)
- [ ] Expose deployStaleness on /api/system/health with TTL caching
- [ ] Header chip: 'build stale ×N' when the running build is behind on build inputs
- [ ] getDeployBlockReason(): the shared deploy safety-window guard
- [ ] Deacon staleness patrol: observe, debounce, and auto-deploy via detached pan reload
- [ ] Gate postMergeLifecycle Step 0 on staleness and the deploy window
- [ ] Docs: DoD row 7 gains its mechanical owner; SOP documents auto-deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic deployment after merges when builds are stale and deployment conditions are safe.
  * Added build staleness details to system health information.
  * Added a warning chip showing when the running build is behind build-related changes.
  * Added deployment settings for enabling automatic deployment and configuring merge debounce time.
  * Documented automatic deployment behavior and configuration.

* **Bug Fixes**
  * Prevented deployments during verification, restarts, active development sessions, or other unsafe conditions.
  * Preserved manual reload behavior when automatic deployment is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->