### PR TITLE
fix(cli): allow transient state worktree writes (PAN-2722)

### DIFF
--- a/src/lib/__tests__/state-home.test.ts
+++ b/src/lib/__tests__/state-home.test.ts
@@ -207,16 +207,33 @@ describe('state home', () => {
     expect(git(path, ['branch', '--show-current'])).toBe('overdeck-state');
   });
 
-  it('refuses destructive repair of a dirty state worktree', async () => {
+  it('treats a dirty state worktree on overdeck-state as healthy', async () => {
     const parent = pushUnmarkedStateBranch();
     pushCompletionMarker(parent);
     const path = stateWorktreePath(project, { projectKey: 'fixture' });
     await ensureStateWorktree(project, { projectKey: 'fixture' });
     writeFileSync(join(path, 'dirty.txt'), 'preserve me\n');
 
+    await expect(ensureStateWorktree(project, { projectKey: 'fixture' })).resolves.toEqual({
+      status: 'healthy',
+      path,
+    });
+  });
+
+  it('refuses destructive repair of a dirty wrong-branch state worktree', async () => {
+    const parent = pushUnmarkedStateBranch();
+    pushCompletionMarker(parent);
+    const path = stateWorktreePath(project, { projectKey: 'fixture' });
+    mkdirSync(join(overdeckHome, 'state'), { recursive: true });
+    git(repo, ['branch', 'wrong-state-branch', 'main']);
+    git(repo, ['worktree', 'add', '--quiet', path, 'wrong-state-branch']);
+    writeFileSync(join(path, 'dirty.txt'), 'preserve me\n');
+
     await expect(ensureStateWorktree(project, { projectKey: 'fixture' })).resolves.toMatchObject({
       status: 'dirty',
       path,
     });
+    expect(git(path, ['branch', '--show-current'])).toBe('wrong-state-branch');
+    expect(git(path, ['status', '--porcelain'])).toContain('dirty.txt');
   });
 });

--- a/src/lib/state-home.ts
+++ b/src/lib/state-home.ts
@@ -237,17 +237,16 @@ export async function ensureStateWorktree(
   }
 
   let branch: string;
-  let dirty: string;
   try {
     branch = await git(path, ['branch', '--show-current']);
-    dirty = await git(path, ['status', '--porcelain']);
   } catch (error) {
     return { status: 'error', path, detail: error instanceof Error ? error.message : String(error) };
   }
-  if (dirty) return { status: 'dirty', path, detail: 'state worktree has uncommitted changes; refusing destructive repair' };
   if (branch === STATE_BRANCH) return { status: 'healthy', path };
 
   try {
+    const dirty = await git(path, ['status', '--porcelain']);
+    if (dirty) return { status: 'dirty', path, detail: 'state worktree has uncommitted changes; refusing destructive repair' };
     await git(repoPath, ['worktree', 'remove', path]);
     await rm(path, { recursive: true, force: true });
     await addStateWorktree(repoPath, path);


### PR DESCRIPTION
`ensureStateWorktree` refused to start pipeline work whenever the `overdeck-state`
worktree was **transiently** dirty — even when the worktree was healthy and no
repair would be attempted. Any concurrent agent mid-spec-write tripped it, so
`pan start` failed nondeterministically.

The dirty guard exists to protect the **destructive repair** path (`worktree
remove` + `rm -rf` + re-add) and is right to refuse there. But it was ordered
*before* the healthy check, so when `branch === STATE_BRANCH` — nothing to repair
— a dirty tree still blocked the start.

`src/lib/state-home.ts`: the healthy check now runs first; `dirty` is computed
lazily inside the repair path where it actually matters (also saving a `git
status` on every start).

## Tests
- `refuses destructive repair of a dirty state worktree` → re-scoped to
  `treats a dirty state worktree on overdeck-state as healthy` (the corrected behavior)
- **new**: `refuses destructive repair of a dirty wrong-branch state worktree` —
  the original protection is preserved for the case it is actually for

## Gates (verified by the flywheel)
- `npx vitest run src/lib/__tests__/state-home.test.ts` → 11 passed
- `npm run typecheck` → green
- `npm run lint` → green

## Live evidence
`pan start PAN-1234` died with a migration error while the worktree was clean and
on `overdeck-state`. My own `pan start PAN-2598 --fresh` had just written one spec
file; the write door drained it seconds later
(`8dc19bf8e6 chore(state): reconcile 1 pending spec/record update(s)`) — and
PAN-1234 died in that window. Retrying moments later succeeded, proving a race.
Six agents were writing state concurrently.

Distinct from PAN-2692 (`71db76939e`), which fixed writes *stranding* past CLI
exit and is working. Draining on exit cannot help while a write is legitimately
in flight — same symptom, different bug. This is likely the residual cause of the
"blocked pipeline starts" seen repeatedly on 2026-07-15.

Authored by strike-pan-2722.

Closes PAN-2722

🤖 Generated with [Claude Code](https://claude.com/claude-code)