### PR TITLE
fix(specialists): pass inspect item IDs structurally (PAN-2724)

### DIFF
--- a/src/cli/commands/specialists/done.ts
+++ b/src/cli/commands/specialists/done.ts
@@ -21,6 +21,8 @@ import {
 
 interface DoneOptions {
   status: 'passed' | 'failed' | 'blocked';
+  /** vBRIEF item receiving an inspect verdict. Required for inspect. */
+  item?: string;
   /** PAN-1862 (FR-6): "security=passed,correctness=blocked" per-reviewer verdicts. */
   reviewers?: string;
   notes?: string;
@@ -53,6 +55,38 @@ export async function doneCommand(
     console.error(chalk.red(`Invalid status: ${options.status}`));
     console.error(chalk.dim(`Valid options for ${specialist}: ${validStatuses.join(', ')}`));
     process.exit(1);
+  }
+
+  if (specialist === 'inspect') {
+    if (!options.item) throw new Error('--item is required for inspect verdicts');
+
+    const { resolveProjectFromIssueSync } = await import('../../../lib/projects.js');
+    const { readWorkspacePlanSync } = await import('../../../lib/vbrief/io.js');
+    const { join } = await import('node:path');
+    const project = resolveProjectFromIssueSync(normalizedIssueId);
+    const workspacePath = project && join(project.projectPath, 'workspaces', `feature-${normalizedIssueId.toLowerCase()}`);
+    const plan = workspacePath ? readWorkspacePlanSync(workspacePath) : undefined;
+    if (!plan?.plan.items.some(item => item.id === options.item)) {
+      throw new Error(`Item "${options.item}" does not exist in the vBRIEF for ${normalizedIssueId}`);
+    }
+
+    const baseUrl = (process.env.OVERDECK_DASHBOARD_URL || process.env.DASHBOARD_URL || 'http://localhost:3011').replace(/\/$/, '');
+    const response = await fetch(`${baseUrl}/api/specialists/done`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        specialist,
+        issueId: normalizedIssueId,
+        itemId: options.item,
+        status: options.status,
+        notes: options.notes,
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(`Could not record inspect verdict (${response.status}): ${await response.text()}`);
+    }
+    console.log(chalk.green(`✓ Inspection ${options.status} for ${normalizedIssueId} item ${options.item}`));
+    return;
   }
 
   // Build the atomic update — setReviewStatus handles history, SQLite,

--- a/src/cli/commands/specialists/index.ts
+++ b/src/cli/commands/specialists/index.ts
@@ -58,6 +58,7 @@ export function registerSpecialistsCommands(program: Command): void {
     .command('done <type> <issueId>')
     .description('Signal specialist completion (deterministic status update)')
     .requiredOption('--status <status>', 'Result status: passed, failed, or review-only blocked')
+    .option('--item <itemId>', 'vBRIEF item ID (required for inspect verdicts)')
     .option('--notes <notes>', 'Optional notes about the result')
     .option('--reviewers <verdicts>', 'PAN-1862 (review only): per-reviewer verdicts, e.g. "security=passed,correctness=blocked"')
     .action(doneAndExitCommand);

--- a/src/dashboard/server/routes/specialists/legacy-routes.ts
+++ b/src/dashboard/server/routes/specialists/legacy-routes.ts
@@ -117,11 +117,12 @@ const postSpecialistsDoneRoute = HttpRouter.add(
   httpHandler(Effect.gen(function* () {
     const body = yield* readJsonBody;
     const eventStore = yield* EventStoreService;
-    const { specialist, issueId, status, notes } = body as {
+    const { specialist, issueId, status, notes, itemId } = body as {
       specialist: string;
       issueId: string;
       status: string;
       notes?: string;
+      itemId?: string;
     };
 
     // Validate specialist type
@@ -147,6 +148,18 @@ const postSpecialistsDoneRoute = HttpRouter.add(
     }
 
     const normalizedIssueId = issueId.toUpperCase();
+
+    if (specialist === 'inspect' && status === 'passed') {
+      if (!itemId) {
+        return jsonResponse({ error: 'itemId is required for a passed inspect verdict' }, { status: 400 });
+      }
+      const project = resolveProjectFromIssueSync(normalizedIssueId);
+      const workspacePath = project && join(project.projectPath, 'workspaces', `feature-${normalizedIssueId.toLowerCase()}`);
+      const plan = workspacePath ? readWorkspacePlanSync(workspacePath) : undefined;
+      if (!plan?.plan.items.some(item => item.id === itemId)) {
+        return jsonResponse({ error: `Item "${itemId}" does not exist in the vBRIEF for ${normalizedIssueId}` }, { status: 400 });
+      }
+    }
     console.log(`[specialists/done] ${specialist} signaling ${status} for ${normalizedIssueId}`);
 
     // Resolve any pending specialist completion waiters (PAN-632: event-driven completion).
@@ -302,9 +315,6 @@ const postSpecialistsDoneRoute = HttpRouter.add(
       yield* Effect.promise(async () => {
         try {
           const { onInspectComplete } = await import('../../../../lib/cloister/inspect-agent.js');
-          // Extract taskId from notes (format: "Task <taskId> matches spec...")
-          const taskMatch = notes?.match(/[Bb]ead\s+(\S+)/);
-          const taskId = taskMatch?.[1] || 'unknown';
           // Resolve project to get workspace path
           const project = resolveProjectFromIssueSync(normalizedIssueId);
           if (project) {
@@ -314,7 +324,7 @@ const postSpecialistsDoneRoute = HttpRouter.add(
               `feature-${normalizedIssueId.toLowerCase()}`,
             );
             if (existsSync(workspacePath)) {
-              (await Effect.runPromise(onInspectComplete(project.projectKey, normalizedIssueId, taskId, 'passed', workspacePath)));
+              await Effect.runPromise(onInspectComplete(project.projectKey, normalizedIssueId, itemId!, 'passed', workspacePath));
 
             }
           }

--- a/src/lib/agents/__tests__/tier-supervisor.test.ts
+++ b/src/lib/agents/__tests__/tier-supervisor.test.ts
@@ -9,11 +9,30 @@ vi.mock('../spawn.js', () => ({
 import { spawnRun } from '../spawn.js';
 import {
   DEFAULT_SUPERVISOR_SAMPLE_RATE,
+  buildSupervisorReviewMessage,
   shouldSupervise,
   spawnTierSupervisor,
   supervisorAgentId,
   SUPERVISOR_SUB_ROLE,
 } from '../tier-supervisor.js';
+
+describe('buildSupervisorReviewMessage', () => {
+  it('passes the exact item id structurally instead of encoding it in notes', () => {
+    const message = buildSupervisorReviewMessage({
+      issueId: 'PAN-2724',
+      itemId: 'issue-view-model',
+      itemTitle: 'Issue view model',
+      sha: '1234567890abcdef',
+      acceptanceCriteria: [],
+      diff: 'diff --git a/a b/a',
+      apiUrl: 'http://localhost:3011',
+    });
+
+    expect(message).toContain('pan admin specialists done inspect PAN-2724 --item issue-view-model --status passed');
+    expect(message).toContain('notes are free-form evidence');
+    expect(message).not.toContain('server extracts the bead id');
+  });
+});
 
 function task(id: string, requiresInspection?: boolean) {
   return {

--- a/src/lib/agents/tier-supervisor.ts
+++ b/src/lib/agents/tier-supervisor.ts
@@ -172,7 +172,7 @@ const execFileAsync = promisify(execFile);
 /** One commit-review event as delivered to the standing supervisor. */
 export interface SupervisorReviewEvent {
   issueId: string;
-  /** Beads-tracker id the verdict must reference ("Item <itemId> ..."). */
+  /** vBRIEF item id receiving the verdict. */
   itemId: string;
   itemTitle: string;
   /** Full commit sha being reviewed. */
@@ -188,7 +188,7 @@ export interface SupervisorReviewEvent {
 }
 
 export interface SupervisorVerdict {
-  /** Bead id parsed from the inspect-status notes prefix. */
+  /** vBRIEF item id receiving the verdict. */
   itemId: string;
   /** Supervisor ack clears prior blocking findings; failed/blocked records one. */
   status: 'passed' | 'ack' | 'failed' | 'blocked';
@@ -203,7 +203,7 @@ export interface DeliverCommitForReviewOptions {
   /** The vBRIEF item the commit implements. */
   item: VBriefItem;
   sha: string;
-  /** Beads id for the verdict prefix; defaults to the vBRIEF item id. */
+  /** Item id receiving the verdict; defaults to the vBRIEF item id. */
   itemId?: string;
   /**
    * PRD draft markdown to source traced FR text from. When omitted and the
@@ -383,22 +383,18 @@ ${event.diff}
 
 ## Verdict (REQUIRED — post exactly one)
 
-Land your verdict on the existing inspect-status surface. Your notes MUST begin with "Item ${event.itemId}" — the server extracts the bead id from that prefix.
+Land your verdict on the existing inspect-status surface. Pass the item ID structurally; notes are free-form evidence.
 
 If the diff satisfies the acceptance criteria, post an ack (this persists inspectStatus and saves the bead checkpoint):
 
 \`\`\`bash
-curl -X POST ${event.apiUrl}/api/specialists/done \\
-  -H "Content-Type: application/json" \\
-  -d '{"specialist":"inspect","issueId":"${event.issueId}","status":"passed","notes":"Item ${event.itemId} ack: <one-line summary>"}'
+pan admin specialists done inspect ${event.issueId} --item ${event.itemId} --status passed --notes "<one-line summary>"
 \`\`\`
 
 If any acceptance criterion is not met, post a blocking finding with specific, actionable violations ([file:line] + what is wrong):
 
 \`\`\`bash
-curl -X POST ${event.apiUrl}/api/specialists/done \\
-  -H "Content-Type: application/json" \\
-  -d '{"specialist":"inspect","issueId":"${event.issueId}","status":"failed","notes":"Item ${event.itemId} BLOCKED: <specific violations and required fixes>"}'
+pan admin specialists done inspect ${event.issueId} --item ${event.itemId} --status failed --notes "<specific violations and required fixes>"
 \`\`\`
 
 Rules:

--- a/tests/cli/commands/specialists/done.test.ts
+++ b/tests/cli/commands/specialists/done.test.ts
@@ -2,9 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Effect } from 'effect';
 import { verificationSatisfied } from '../../../../src/lib/review-status.js';
 
-const { mockSetReviewStatus, mockDeliverReviewVerdictFeedback } = vi.hoisted(() => ({
+const { mockSetReviewStatus, mockDeliverReviewVerdictFeedback, mockResolveProject, mockReadWorkspacePlan } = vi.hoisted(() => ({
   mockSetReviewStatus: vi.fn(),
   mockDeliverReviewVerdictFeedback: vi.fn(),
+  mockResolveProject: vi.fn(),
+  mockReadWorkspacePlan: vi.fn(),
 }));
 
 vi.mock('../../../../src/lib/review-status.js', async (importOriginal) => {
@@ -20,6 +22,14 @@ vi.mock('../../../../src/lib/review-status.js', async (importOriginal) => {
 
 vi.mock('../../../../src/lib/cloister/review-verdict-feedback.js', () => ({
   deliverReviewVerdictFeedback: mockDeliverReviewVerdictFeedback,
+}));
+
+vi.mock('../../../../src/lib/projects.js', () => ({
+  resolveProjectFromIssueSync: mockResolveProject,
+}));
+
+vi.mock('../../../../src/lib/vbrief/io.js', () => ({
+  readWorkspacePlanSync: mockReadWorkspacePlan,
 }));
 
 describe('specialists done command', () => {
@@ -42,6 +52,11 @@ describe('specialists done command', () => {
       prCommentPosted: true,
       agentMessageSent: true,
     }));
+    mockResolveProject.mockReturnValue({ projectPath: '/project' });
+    mockReadWorkspacePlan.mockReturnValue({
+      plan: { items: [{ id: 'issue-view-model' }] },
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
   });
 
   afterEach(() => {
@@ -133,6 +148,35 @@ describe('specialists done command', () => {
 
     expect(mockSetReviewStatus).toHaveBeenCalled();
     expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it('requires an exact vBRIEF item for inspect verdicts', async () => {
+    const { doneCommand } = await import('../../../../src/cli/commands/specialists/done.js');
+
+    await expect(doneCommand('inspect', 'pan-1059', { status: 'passed' }))
+      .rejects.toThrow('--item is required for inspect verdicts');
+    await expect(doneCommand('inspect', 'pan-1059', { status: 'passed', item: 'missing' }))
+      .rejects.toThrow('Item "missing" does not exist in the vBRIEF for PAN-1059');
+
+    await doneCommand('inspect', 'pan-1059', {
+      status: 'passed',
+      item: 'issue-view-model',
+      notes: 'This predates this bead and is correct',
+    });
+
+    expect(mockReadWorkspacePlan).toHaveBeenCalledWith('/project/workspaces/feature-pan-1059');
+    expect(fetch).toHaveBeenCalledWith('http://localhost:3011/api/specialists/done', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        specialist: 'inspect',
+        issueId: 'PAN-1059',
+        itemId: 'issue-view-model',
+        status: 'passed',
+        notes: 'This predates this bead and is correct',
+      }),
+    });
+    expect(mockSetReviewStatus).not.toHaveBeenCalled();
   });
 
   it('verificationSatisfied is true after passed override even from failed state (AC10/AC27)', () => {

--- a/tests/unit/dashboard/server/routes/specialists-inspect-item.test.ts
+++ b/tests/unit/dashboard/server/routes/specialists-inspect-item.test.ts
@@ -1,0 +1,118 @@
+import { Effect, Layer, Stream } from 'effect';
+import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { INTERNAL_TOKEN_HEADER, _resetInternalTokenCacheForTests } from '../../../../../src/lib/internal-token.js';
+import { specialistsLegacyRouteLayer } from '../../../../../src/dashboard/server/routes/specialists/legacy-routes.js';
+import { EventStoreService } from '../../../../../src/dashboard/server/services/domain-services.js';
+
+const mocks = vi.hoisted(() => ({
+  resolveProject: vi.fn(),
+  readWorkspacePlan: vi.fn(),
+  onInspectComplete: vi.fn(),
+}));
+
+vi.mock('../../../../../src/lib/projects.js', () => ({
+  resolveProjectFromIssueSync: mocks.resolveProject,
+}));
+
+vi.mock('../../../../../src/lib/vbrief/io.js', () => ({
+  readWorkspacePlanSync: mocks.readWorkspacePlan,
+}));
+
+vi.mock('../../../../../src/lib/cloister/inspect-agent.js', () => ({
+  onInspectComplete: mocks.onInspectComplete,
+}));
+
+vi.mock('../../../../../src/lib/cloister/specialists.js', () => ({
+  getTmuxSessionName: vi.fn(() => 'inspect-agent-test'),
+  updateRunMetadata: vi.fn(),
+  makeSpecialistRegistryKey: vi.fn(() => 'inspect-agent:PAN-2724'),
+}));
+
+vi.mock('../../../../../src/lib/cloister/specialist-handoff-logger.js', () => ({
+  updateSpecialistHandoffStatus: vi.fn(() => Effect.succeed(false)),
+}));
+
+const eventStoreLayer = Layer.succeed(EventStoreService, {
+  append: () => Effect.succeed(1),
+  appendAsync: () => Effect.succeed(1),
+  readFrom: () => Effect.succeed([]),
+  queryByType: () => Effect.succeed([]),
+  getLatestSequence: Effect.succeed(0),
+  streamEvents: Stream.empty,
+});
+
+async function postDone(body: Record<string, unknown>): Promise<{ status: number; body: Record<string, unknown> }> {
+  const request = HttpServerRequest.fromWeb(new Request('http://localhost/api/specialists/done', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      [INTERNAL_TOKEN_HEADER]: 'test-token',
+    },
+    body: JSON.stringify(body),
+  }));
+  const response = await Effect.runPromise(Effect.scoped(
+    Effect.flatMap(HttpRouter.toHttpEffect(specialistsLegacyRouteLayer), app =>
+      Effect.provideService(app, HttpServerRequest.HttpServerRequest, request),
+    ).pipe(Effect.provide(eventStoreLayer)),
+  ));
+  const responseBody = response.body as { body?: Uint8Array } | null;
+  const text = responseBody?.body ? new TextDecoder().decode(responseBody.body) : '{}';
+  return { status: response.status, body: JSON.parse(text) as Record<string, unknown> };
+}
+
+let projectPath: string;
+
+beforeEach(async () => {
+  projectPath = await mkdtemp(join(tmpdir(), 'pan-2724-inspect-'));
+  await mkdir(join(projectPath, 'workspaces', 'feature-pan-2724'), { recursive: true });
+  process.env.OVERDECK_INTERNAL_TOKEN = 'test-token';
+  _resetInternalTokenCacheForTests();
+  mocks.resolveProject.mockReturnValue({ projectPath, projectKey: 'overdeck' });
+  mocks.readWorkspacePlan.mockReturnValue({ plan: { items: [{ id: 'issue-view-model' }] } });
+  mocks.onInspectComplete.mockReturnValue(Effect.succeed(undefined));
+});
+
+afterEach(async () => {
+  delete process.env.OVERDECK_INTERNAL_TOKEN;
+  _resetInternalTokenCacheForTests();
+  await rm(projectPath, { recursive: true, force: true });
+});
+
+describe('POST /api/specialists/done inspect item attribution', () => {
+  it('rejects a passed inspect verdict without itemId', async () => {
+    const result = await postDone({ specialist: 'inspect', issueId: 'PAN-2724', status: 'passed', notes: 'looks good' });
+
+    expect(result).toEqual({ status: 400, body: { error: 'itemId is required for a passed inspect verdict' } });
+  });
+
+  it('rejects an itemId that is not in the issue vBRIEF', async () => {
+    const result = await postDone({ specialist: 'inspect', issueId: 'PAN-2724', itemId: 'by', status: 'passed' });
+
+    expect(result).toEqual({ status: 400, body: { error: 'Item "by" does not exist in the vBRIEF for PAN-2724' } });
+    expect(mocks.readWorkspacePlan).toHaveBeenCalledWith(join(projectPath, 'workspaces', 'feature-pan-2724'));
+  });
+
+  it('checkpoints the exact structured itemId regardless of notes wording', async () => {
+    const result = await postDone({
+      specialist: 'inspect',
+      issueId: 'PAN-2724',
+      itemId: 'issue-view-model',
+      status: 'passed',
+      notes: 'This predates this bead and is correct',
+    });
+
+    expect(result.status).toBe(200);
+    expect(mocks.onInspectComplete).toHaveBeenCalledWith(
+      'overdeck',
+      'PAN-2724',
+      'issue-view-model',
+      'passed',
+      join(projectPath, 'workspaces', 'feature-pan-2724'),
+    );
+  });
+});


### PR DESCRIPTION
Inspect verdicts were attributed to a vBRIEF item by parsing a beads-era
`"Item <id> ..."` prefix out of free-text `--notes`. Replaces that regex with a
structured `--item <itemId>` flag.

- `pan admin specialists done inspect <issue> --item <itemId> --status …` — the
  item is now passed explicitly and posted as `itemId` rather than recovered
  from prose.
- `--item` is **required** for inspect, and validated against the vBRIEF before
  posting: an unknown id fails loudly (`Item "X" does not exist in the vBRIEF
  for <issue>`) instead of silently mis-attributing or dropping the verdict.
- The only callers are the standing-supervisor prompts
  (`tier-supervisor.ts:391/397`); both emit `--item` in this same change, so no
  caller is left on the old shape.
- Beads-era comments on `SupervisorReviewEvent.itemId` / `SupervisorVerdict.itemId`
  updated to vBRIEF vocabulary.

## Gates (verified by the flywheel)
- `tests/cli/commands/specialists/done.test.ts`,
  `src/lib/agents/__tests__/tier-supervisor.test.ts`,
  `tests/unit/dashboard/server/routes/specialists-inspect-item.test.ts` → 21 passed (3 files)
- `npm run typecheck` → green
- `npm run lint` → green

Authored by strike-pan-2724.

Closes PAN-2724

🤖 Generated with [Claude Code](https://claude.com/claude-code)