### PR TITLE
fix(cloister): deliver messages to idle codex agents (PAN-2725)

### DIFF
--- a/src/lib/agents/messaging.ts
+++ b/src/lib/agents/messaging.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { Effect } from 'effect';
 import { emitActivityEntrySync } from '../activity-logger.js';
@@ -61,6 +61,15 @@ function queueAgentMail(agentId: string, message: string, pendingTurnEndDelivery
 }
 
 const USER_MESSAGE_INTERVENTION_SOURCES = new Set(['pan-tell', 'dashboard:user-message']);
+
+function claimCodexIdleTurn(agentId: string): boolean {
+  try {
+    unlinkSync(join(getAgentDir(agentId), 'turn-completed'));
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 async function appendTellInterventionForUserSource(normalizedId: string, caller: string): Promise<void> {
   if (!USER_MESSAGE_INTERVENTION_SOURCES.has(caller)) return;
@@ -363,10 +372,13 @@ export async function messageAgent(
     throw new Error(`Agent ${normalizedId} session is dead and resume failed: ${resumeResult.error}`);
   }
 
-  // Wait for the agent to be idle at the prompt before sending — reduces dropped
-  // Enter when Claude Code is still rendering. PAN-1594: hook-driven (runtime
-  // mirror 'idle' via Stop/SessionStart hook), not a tmux pane-scrape.
-  const promptReady = await waitForAgentIdle(normalizedId, 5000);
+  // Codex's notify hook writes turn-completed at every idle boundary. Claiming
+  // that marker makes the idle signal one-shot: the next message starts a turn,
+  // and further messages queue until the hook reports the next completion.
+  // Claude Code continues to use its hook-driven runtime mirror (PAN-1594).
+  const promptReady = expectedHarness === 'codex'
+    ? claimCodexIdleTurn(normalizedId)
+    : await waitForAgentIdle(normalizedId, 5000);
   if (!promptReady) {
     if (expectedHarness === 'codex') {
       queueAgentMail(normalizedId, message, true);

--- a/tests/unit/lib/agents/message-agent.test.ts
+++ b/tests/unit/lib/agents/message-agent.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { Effect } from 'effect';
-import { existsSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 
 const mocks = vi.hoisted(() => ({
   getAgentStateSync: vi.fn(),
@@ -115,6 +115,7 @@ describe('messageAgent', () => {
   });
 
   afterEach(() => {
+    rmSync('/tmp/agent-pan-2262', { recursive: true, force: true });
     rmSync('/tmp/agent-pan-2701', { recursive: true, force: true });
   });
 
@@ -150,8 +151,6 @@ describe('messageAgent', () => {
       workspace: '/repo',
       harness: 'codex',
     });
-    mocks.waitForAgentIdle.mockResolvedValue(false);
-
     await messageAgent('agent-pan-2701', 'review feedback', 'pan-tell');
 
     expect(mocks.deliverAgentMessage).not.toHaveBeenCalled();
@@ -171,13 +170,37 @@ describe('messageAgent', () => {
       workspace: '/repo',
       harness: 'codex',
     });
+    mkdirSync('/tmp/agent-pan-2701', { recursive: true });
+    writeFileSync('/tmp/agent-pan-2701/turn-completed', new Date().toISOString());
 
     await messageAgent('agent-pan-2701', 'operator message', 'pan-tell');
 
     expect(mocks.deliverAgentMessage).toHaveBeenCalledOnce();
+    expect(existsSync('/tmp/agent-pan-2701/turn-completed')).toBe(false);
     const files = readdirSync('/tmp/agent-pan-2701/mail');
     expect(files).toHaveLength(1);
     expect(files[0]).toMatch(/\.md$/);
     expect(files[0]).not.toContain('.pending.md');
+  });
+
+  it('queues a second codex message until the current turn completes', async () => {
+    mocks.getAgentStateSync.mockReturnValue({
+      id: 'agent-pan-2701',
+      issueId: 'PAN-2701',
+      status: 'running',
+      workspace: '/repo',
+      harness: 'codex',
+    });
+    mkdirSync('/tmp/agent-pan-2701', { recursive: true });
+    writeFileSync('/tmp/agent-pan-2701/turn-completed', new Date().toISOString());
+
+    await messageAgent('agent-pan-2701', 'first message', 'pan-tell');
+    await messageAgent('agent-pan-2701', 'second message', 'pan-tell');
+
+    expect(mocks.deliverAgentMessage).toHaveBeenCalledOnce();
+    const pending = readdirSync('/tmp/agent-pan-2701/mail')
+      .filter((file) => file.endsWith('.pending.md'));
+    expect(pending).toHaveLength(1);
+    expect(readFileSync(`/tmp/agent-pan-2701/mail/${pending[0]}`, 'utf-8')).toContain('second message');
   });
 });


### PR DESCRIPTION
Messages to an **idle** codex agent dead-lettered: every `pan tell` / verdict
feedback queued as turn-end mail that never drained.

`waitForAgentIdle` is Claude Code's hook-driven runtime mirror (PAN-1594); codex
has no such mirror, so it returned false even for a genuinely idle agent. PAN-2701
then correctly queued the message as `.pending.md` for turn-end delivery — but an
idle agent has no next turn, so the codex notify hook never drained it. The
message was lost.

`messageAgent` now derives codex idleness from the marker codex actually writes:
`claimCodexIdleTurn` unlinks `turn-completed` (written by the notify hook at every
idle boundary). Claiming it succeeds → the agent is idle → deliver directly.
Claiming it fails → mid-turn → queue as pending mail and let PAN-2701's hook drain
it at turn end. Claiming makes the idle signal one-shot, so a second concurrent
message cannot also read "idle" and race.

Claude Code keeps the PAN-1594 path unchanged.

## Gates (verified by the flywheel on the rebased branch)
- `tests/unit/lib/agents/message-agent.test.ts` → 4 passed
- `src/lib/agents/__tests__/tier-supervisor.test.ts` → 11 passed
- `npm run typecheck` → green
- `npm run lint` → green

Note: the strike reported a red full suite ("supervisor expectation drift") and
declined to push. That drift came from its **pre-rebase base** — it predated
PAN-2724 (`847414f572`), which changed `tier-supervisor.ts`. Rebased onto current
main, the supervisor suite passes 11/11. CI on this PR is the authoritative gate.

Authored by strike-pan-2725; rebased and landed by the flywheel.

Closes PAN-2725

🤖 Generated with [Claude Code](https://claude.com/claude-code)