### PR TITLE
PAN-2568

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,11 @@ The supervisor is Node 22-only because it owns a real PTY through
 `${OVERDECK_HOME}/sockets/pty-<id>.sock` at mode `0600`, accepts authenticated
 HTTP-on-unix POSTs, writes each delivered message into Claude's PTY input, and
 echoes the message into the tmux transcript so operators can see what was sent.
+`src/lib/channels/injection-budget.ts` is the single timing source for the
+supervisor's payload-sized echo, settle, and purge waits and for the delivery
+client deadline that must outlast them. The supervisor accepts at most 262,144
+characters, returns HTTP 400 above that limit, and can therefore purge every
+character it accepted before retrying without stacking duplicate composer text.
 
 `deliverAgentMessage(agentId, message, caller?)` is the single delivery
 primitive. In automatic mode it tries, in order:
@@ -252,6 +257,13 @@ primitive. In automatic mode it tries, in order:
 1. PTY supervisor socket (`path: "supervisor"`)
 2. legacy Claude Code Channels MCP socket for already-wired sessions
 3. tmux paste-buffer fallback
+
+Summary forks add a pane-verified recovery above that transport: when the
+runtime transcript stays silent but the delivered tail remains in the composer,
+the fork pipeline sends at most two standalone Enter keystrokes. If submission
+still cannot be confirmed, it keeps the conversation alive but records
+`forkStatus = 'failed'` with an actionable `forkError` instead of presenting an
+empty transcript as a healthy completed fork.
 
 Docker workspaces remain excluded from supervisor wiring until host/container
 socket sharing is designed; Pi keeps using its `rpc.in` FIFO. H1 lifecycle

--- a/src/lib/__tests__/deliver-agent-message.test.ts
+++ b/src/lib/__tests__/deliver-agent-message.test.ts
@@ -48,6 +48,10 @@ import { BRIDGE_TOKEN_HEADER, writeBridgeTokenSync } from '../bridge-token.js';
 import { PTY_TOKEN_HEADER, writePtyToken } from '../pty-token.js';
 import { deliverAgentMessage, deliverAgentPermissionDecision, deliverInitialPromptWithRetry, deliverResumeMessageWithTranscriptConfirmation, getAgentDir, type AgentState } from '../agents.js';
 import { sendKeys } from '../tmux.js';
+import {
+  SUPERVISOR_CLIENT_MARGIN_MS,
+  supervisorInjectionBudgetMs,
+} from '../channels/injection-budget.js';
 
 function writeAgentState(agentId: string, partial: Partial<AgentState>): void {
   const dir = join(stateDir, agentId);
@@ -542,6 +546,56 @@ describe('channel bridge delivery', () => {
     }
   });
 
+  it('scales the supervisor socket timeout with a 30 KB payload', async () => {
+    const agentId = 'conv-supervisor-large-timeout';
+    await writePtyToken(agentId);
+    const message = 'x'.repeat(30 * 1_024);
+    const expectedTimeout = supervisorInjectionBudgetMs(message.length) + SUPERVISOR_CLIENT_MARGIN_MS;
+    const timeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const server = await startFakeBridge(join(socketDir, `pty-${agentId}.sock`), {
+      status: 200,
+      body: 'ok',
+    });
+
+    try {
+      await expect(deliverAgentMessage(agentId, message, 'large-timeout-test')).resolves.toEqual({
+        ok: true,
+        path: 'supervisor',
+      });
+      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), expectedTimeout);
+    } finally {
+      timeoutSpy.mockRestore();
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
+  it('keeps a 30 KB delivery on the supervisor tier when it responds just under budget', async () => {
+    vi.useFakeTimers();
+    const agentId = 'conv-supervisor-large-delayed';
+    await writePtyToken(agentId);
+    const message = 'x'.repeat(30 * 1_024);
+    const supervisorBudget = supervisorInjectionBudgetMs(message.length);
+    const capture: { lastBody?: string } = {};
+    const server = await startFakeBridge(join(socketDir, `pty-${agentId}.sock`), {
+      status: 200,
+      body: 'ok',
+      delayMs: supervisorBudget - 1,
+      capture,
+    });
+
+    try {
+      const delivered = deliverAgentMessage(agentId, message, 'large-delayed-test');
+      await vi.waitFor(() => expect(capture.lastBody).toBeDefined());
+      await vi.advanceTimersByTimeAsync(supervisorBudget - 1);
+
+      await expect(delivered).resolves.toEqual({ ok: true, path: 'supervisor' });
+      expect(vi.mocked(sendKeys)).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
   it('supervisor missing: falls through to channels when channels are enabled', async () => {
     const agentId = 'agent-supervisor-missing';
     writeAgentState(agentId, { channelsEnabled: true });
@@ -647,11 +701,13 @@ describe('channel bridge delivery', () => {
     writeAgentState(agentId, { channelsEnabled: true });
     await writePtyToken(agentId);
     writeBridgeTokenSync(agentId);
+    const message = 'timeout fallback';
+    const clientTimeout = supervisorInjectionBudgetMs(message.length) + SUPERVISOR_CLIENT_MARGIN_MS;
     const capture: { lastBody?: string } = {};
     const supervisor = await startFakeBridge(join(socketDir, `pty-${agentId}.sock`), {
       status: 200,
       body: 'late',
-      delayMs: 9_000,
+      delayMs: clientTimeout + 1_000,
       capture,
     });
     const channel = await startFakeBridge(join(socketDir, `agent-${agentId}.sock`), {
@@ -660,9 +716,9 @@ describe('channel bridge delivery', () => {
     });
     vi.useFakeTimers();
     try {
-      const delivered = deliverAgentMessage(agentId, 'timeout fallback', 'caller-timeout');
+      const delivered = deliverAgentMessage(agentId, message, 'caller-timeout');
       await vi.waitFor(() => expect(capture.lastBody).toBeDefined());
-      await vi.advanceTimersByTimeAsync(8_100);
+      await vi.advanceTimersByTimeAsync(clientTimeout + 100);
       await expect(delivered).resolves.toEqual({ ok: true, path: 'channels' });
       expect(vi.mocked(sendKeys)).not.toHaveBeenCalled();
       expect(readDeliveryLog(agentId).at(-1)).toMatchObject({ path: 'channel' });

--- a/src/lib/agents/delivery.ts
+++ b/src/lib/agents/delivery.ts
@@ -19,6 +19,10 @@ import { isPaneDead, sendKeys, sessionExists } from '../tmux.js';
 import { BRIDGE_TOKEN_HEADER, readBridgeTokenSync } from '../bridge-token.js';
 import { PTY_TOKEN_HEADER, readPtyToken } from '../pty-token.js';
 import {
+  SUPERVISOR_CLIENT_MARGIN_MS,
+  supervisorInjectionBudgetMs,
+} from '../channels/injection-budget.js';
+import {
   captureTranscriptUserRecordSnapshot,
   hasNewTranscriptUserRecord,
   type TranscriptUserRecordSnapshot,
@@ -208,15 +212,14 @@ export async function deliverAgentMessage(
       supervisorFailure = 'pty-token-missing';
     } else {
       try {
-        // Must exceed the supervisor's worst-case echo-confirmation path
-        // (2 attempts × 2.5s + 2 purges × 150ms ≈ 5.3s, pty-supervisor.ts).
-        // A shorter client timeout abandons the POST mid-retry and fires the
-        // tmux fallback while the supervisor is still writing — re-creating
-        // the duplicate-submit race PAN-1769 fixed.
+        // The client deadline must remain above the supervisor's payload-aware
+        // worst-case injection budget. Abandoning the POST mid-injection would
+        // fire the tmux fallback while the supervisor is still writing and
+        // re-create the duplicate-writer race PAN-1769 fixed.
         await postUnixSocketJson(
           supervisorSocketPath,
           { content: message, meta: { caller } },
-          8_000,
+          supervisorInjectionBudgetMs(message.length) + SUPERVISOR_CLIENT_MARGIN_MS,
           ptyToken,
           PTY_TOKEN_HEADER,
         );

--- a/src/lib/channels/SMOKE_TEST.md
+++ b/src/lib/channels/SMOKE_TEST.md
@@ -8,6 +8,12 @@ this path because it requires an interactive Claude session; the in-process
 unit tests in `__tests__/overdeck-bridge.test.ts` and
 `../__tests__/deliver-agent-message.test.ts` are the automated layer.
 
+The preferred PTY path derives both supervisor waits and the client deadline
+from `injection-budget.ts`: echo and settle windows scale with payload size, and
+the client always waits longer than the supervisor's worst-case injection path.
+Accepted messages are capped at 262,144 characters so a failed echo can always
+purge the complete composer contents before a retry.
+
 ## Prerequisites
 
 - `claude` on PATH and authenticated against an Anthropic provider
@@ -71,6 +77,16 @@ unit tests in `__tests__/overdeck-bridge.test.ts` and
      the PTY supervisor socket for this disposable smoke-test agent, then send a
      second `pan tell` and expect `path: 'channel'` plus the bridge companion
      line.
+
+6. **Fork a large summary into Codex.**
+   - Create a summary fork whose generated summary exceeds 8 KB and targets a
+     Codex conversation.
+   - Confirm the first turn submits without a second delivery: the conversation
+     transcript gains the summary prompt, the terminal composer no longer shows
+     its tail, and the conversation does not retain `forkStatus = 'failed'`.
+   - If the composer keeps the summary after delivery, confirm the fork pipeline
+     sends a standalone Enter. Two unsuccessful nudges must surface an actionable
+     `forkError` while leaving the live terminal available for recovery.
 
 ## Expected log signatures
 

--- a/src/lib/channels/__tests__/injection-budget.test.ts
+++ b/src/lib/channels/__tests__/injection-budget.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+  INPUT_ECHO_CONFIRM_ATTEMPTS,
+  INPUT_PURGE_MAX_CHARS,
+  SUPERVISOR_CLIENT_MARGIN_MS,
+  echoConfirmTimeoutMs,
+  inputSettleMs,
+  purgeSettleMs,
+  supervisorInjectionBudgetMs,
+} from '../injection-budget.js';
+
+describe('injection budget', () => {
+  it('is monotonic as payload length grows', () => {
+    const lengths = [0, 1, 1_024, 8 * 1_024, 30 * 1_024, 1_024 * 1_024, 10 * 1_024 * 1_024];
+    const budgets = lengths.map(supervisorInjectionBudgetMs);
+
+    expect(budgets).toEqual([...budgets].sort((a, b) => a - b));
+  });
+
+  it('preserves the documented floors', () => {
+    expect(echoConfirmTimeoutMs(1_024)).toBe(2_600);
+    expect(supervisorInjectionBudgetMs(0)).toBe(2 * 2_500 + 2 * 150 + 300 + 3_000);
+  });
+
+  it('caps each payload-scaled wait for a 10 MB payload', () => {
+    const tenMb = 10 * 1_024 * 1_024;
+
+    expect(echoConfirmTimeoutMs(tenMb)).toBe(15_000);
+    expect(inputSettleMs(tenMb)).toBe(2_000);
+    expect(purgeSettleMs(tenMb)).toBe(1_000);
+    expect(supervisorInjectionBudgetMs(tenMb)).toBe(37_000);
+  });
+
+  it.each([0, 8 * 1_024, 30 * 1_024, 1_024 * 1_024])(
+    'keeps the client timeout above the supervisor wait sum for %i chars',
+    (length) => {
+      const erased = Math.min(length, INPUT_PURGE_MAX_CHARS);
+      const internalWaitSum =
+        INPUT_ECHO_CONFIRM_ATTEMPTS * echoConfirmTimeoutMs(length) +
+        INPUT_ECHO_CONFIRM_ATTEMPTS * purgeSettleMs(erased) +
+        inputSettleMs(length);
+      const clientTimeout = supervisorInjectionBudgetMs(length) + SUPERVISOR_CLIENT_MARGIN_MS;
+
+      expect(clientTimeout).toBeGreaterThan(internalWaitSum);
+    },
+  );
+});

--- a/src/lib/channels/__tests__/pty-supervisor.test.ts
+++ b/src/lib/channels/__tests__/pty-supervisor.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PTY_TOKEN_HEADER, writePtyToken } from '../../pty-token.js';
 import { createPtySupervisorServer, injectPtyMessage } from '../pty-supervisor.js';
+import { INPUT_PURGE_MAX_CHARS, echoConfirmTimeoutMs, purgeSettleMs } from '../injection-budget.js';
 
 const REPO_ROOT = process.cwd();
 const SUPERVISOR_ENTRY = join(REPO_ROOT, 'dist/pty-supervisor.js');
@@ -293,16 +294,58 @@ describe.skipIf(isBun)('injectPtyMessage', () => {
     const fake = createFakePty();
     // 2 KiB => echoConfirmTimeoutMs = 2500 + 2*100 = 2700ms.
     const content = 'x'.repeat(2 * 1024);
+    const echoTimeout = echoConfirmTimeoutMs(content.length);
+    const settle = purgeSettleMs(content.length + 8);
 
     const delivered = injectPtyMessage(fake.child, 'agent-unit-warn', { content, echo: false });
-    await vi.advanceTimersByTimeAsync(2_700);
+    await vi.advanceTimersByTimeAsync(echoTimeout);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('after 2700ms'),
+      expect.stringContaining(`after ${echoTimeout}ms`),
     );
 
-    await vi.advanceTimersByTimeAsync(3_000);
+    // Second attempt echo timeout + both purge settles + margin.
+    await vi.advanceTimersByTimeAsync(echoTimeout + 2 * settle + 100);
     await expect(delivered).rejects.toThrow(/input echo confirmation failed/);
     warnSpy.mockRestore();
+  });
+
+  it('purges the full 30,000-char written length, not the old 8,192-char cap', async () => {
+    vi.useFakeTimers();
+    const fake = createFakePty();
+    const content = 'x'.repeat(30_000);
+    const purge = '\x7f'.repeat(30_008);
+    const echoTimeout = echoConfirmTimeoutMs(content.length);
+    const settle = purgeSettleMs(content.length + 8);
+
+    const delivered = injectPtyMessage(fake.child, 'agent-unit-purge-full', { content, echo: false });
+    const rejected = expect(delivered).rejects.toThrow(/input echo confirmation failed/);
+
+    await vi.advanceTimersByTimeAsync(echoTimeout);
+    expect(fake.writes).toEqual([content, purge]);
+
+    // Second attempt echo timeout + both purge settles + margin.
+    await vi.advanceTimersByTimeAsync(echoTimeout + 2 * settle + 100);
+    await rejected;
+  });
+
+  it('scales the post-purge settle with the erased length', async () => {
+    vi.useFakeTimers();
+    const fake = createFakePty();
+    const content = 'x'.repeat(30_000);
+    const purge = '\x7f'.repeat(30_008);
+    const echoTimeout = echoConfirmTimeoutMs(content.length);
+    const settle = purgeSettleMs(content.length + 8);
+
+    const delivered = injectPtyMessage(fake.child, 'agent-unit-purge-settle', { content, echo: false });
+
+    await vi.advanceTimersByTimeAsync(echoTimeout + settle - 100);
+    expect(fake.writes).toEqual([content, purge]);
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fake.writes).toEqual([content, purge, content]);
+
+    await vi.runAllTimersAsync();
+    await expect(delivered).rejects.toThrow(/input echo confirmation failed/);
   });
 
   it('returns non-2xx from the supervisor server when echo confirmation fails', async () => {
@@ -399,6 +442,27 @@ describe.skipIf(isBun)('pty-supervisor subprocess', () => {
     const logPath = join(tmpHome, 'logs', 'pty-supervisor-agent-no-echo.log');
     expect(readFileSync(logPath, 'utf8')).toContain('"kind":"echo_confirm_failed"');
   }, 15_000);
+
+  it('rejects socket posts whose content exceeds INPUT_PURGE_MAX_CHARS', async () => {
+    const agentId = 'agent-server-too-long';
+    const token = await writePtyToken(agentId);
+    const fake = createFakePty();
+    const server = createPtySupervisorServer(agentId, fake.child);
+    const socketPath = join(tmpHome, 'sockets', `pty-${agentId}.sock`);
+    mkdirSync(join(tmpHome, 'sockets'), { recursive: true, mode: 0o700 });
+    await new Promise<void>((resolve) => server.listen(socketPath, () => resolve()));
+
+    try {
+      const result = await postToUnixSocket(socketPath, token, {
+        content: 'x'.repeat(INPUT_PURGE_MAX_CHARS + 1),
+        echo: false,
+      });
+      expect(result.status).toBe(400);
+      expect(fake.writes).toEqual([]);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
 
   it('creates the supervisor socket at mode 0600', async () => {
     const { socketPath } = await readySupervisor('agent-mode');

--- a/src/lib/channels/__tests__/pty-supervisor.test.ts
+++ b/src/lib/channels/__tests__/pty-supervisor.test.ts
@@ -188,17 +188,19 @@ describe.skipIf(isBun)('injectPtyMessage', () => {
   it('purges between retries and before rejecting so unconfirmed writes never stack', async () => {
     vi.useFakeTimers();
     const fake = createFakePty();
-    const purge = '\x7f'.repeat('missing echo'.length + 8);
+    const content = 'missing echo';
+    const purge = '\x7f'.repeat(content.length + 8);
 
-    const delivered = injectPtyMessage(fake.child, 'agent-unit-miss', { content: 'missing echo', echo: false });
+    const delivered = injectPtyMessage(fake.child, 'agent-unit-miss', { content, echo: false });
     const rejected = expect(delivered).rejects.toThrow(/input echo confirmation failed/);
-    expect(fake.writes).toEqual(['missing echo']);
-    await vi.advanceTimersByTimeAsync(2_650);
-    expect(fake.writes).toEqual(['missing echo', purge, 'missing echo']);
-    await vi.advanceTimersByTimeAsync(2_650);
+    expect(fake.writes).toEqual([content]);
+    // 12 bytes => echoConfirmTimeoutMs = 2600ms; second write lands after purge settle.
+    await vi.advanceTimersByTimeAsync(2_800);
+    expect(fake.writes).toEqual([content, purge, content]);
+    await vi.advanceTimersByTimeAsync(2_800);
 
     await rejected;
-    expect(fake.writes).toEqual(['missing echo', purge, 'missing echo', purge]);
+    expect(fake.writes).toEqual([content, purge, content, purge]);
     expect(fake.writes).not.toContain('\r');
   });
 
@@ -231,16 +233,76 @@ describe.skipIf(isBun)('injectPtyMessage', () => {
   it('submits exactly one copy when the echo only appears after the purged retry', async () => {
     vi.useFakeTimers();
     const fake = createFakePty();
-    const purge = '\x7f'.repeat('late echo'.length + 8);
+    const content = 'late echo';
+    const purge = '\x7f'.repeat(content.length + 8);
 
-    const delivered = injectPtyMessage(fake.child, 'agent-unit-late', { content: 'late echo', echo: false });
-    await vi.advanceTimersByTimeAsync(2_650);
-    expect(fake.writes).toEqual(['late echo', purge, 'late echo']);
+    const delivered = injectPtyMessage(fake.child, 'agent-unit-late', { content, echo: false });
+    await vi.advanceTimersByTimeAsync(2_800);
+    expect(fake.writes).toEqual([content, purge, content]);
     fake.emit('late echo');
     await vi.advanceTimersByTimeAsync(400);
 
     await expect(delivered).resolves.toBeUndefined();
-    expect(fake.writes).toEqual(['late echo', purge, 'late echo', '\r']);
+    expect(fake.writes).toEqual([content, purge, content, '\r']);
+  });
+
+  it('scales the echo-confirm window so a large payload confirms without purging', async () => {
+    vi.useFakeTimers();
+    const fake = createFakePty();
+    // 36 KiB => echoConfirmTimeoutMs = 2500 + 36*100 = 6100ms.
+    const content = 'x'.repeat(36 * 1024);
+    const echoedPrefix = 'x'.repeat(40);
+
+    const delivered = injectPtyMessage(fake.child, 'agent-unit-large', { content, echo: false });
+    expect(fake.writes).toEqual([content]);
+
+    // The old fixed 2.5s window would have purged by now; the scaled window must not.
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(fake.writes).toEqual([content]);
+
+    // Echo arrives at t=6s, still inside the 6100ms window.
+    fake.emit(echoedPrefix);
+    await vi.advanceTimersByTimeAsync(3_500);
+
+    await expect(delivered).resolves.toBeUndefined();
+    expect(fake.writes).toEqual([content, '\r']);
+  });
+
+  it('keeps the small-message echo timeout near the previous fixed floor', async () => {
+    vi.useFakeTimers();
+    const fake = createFakePty();
+    const content = 'x'.repeat(512);
+    const purge = '\x7f'.repeat(content.length + 8);
+
+    const delivered = injectPtyMessage(fake.child, 'agent-unit-small', { content, echo: false });
+    const rejected = expect(delivered).rejects.toThrow(/input echo confirmation failed/);
+    expect(fake.writes).toEqual([content]);
+
+    // 512 bytes => echoConfirmTimeoutMs = 2500 + 1*100 = 2600ms.
+    await vi.advanceTimersByTimeAsync(2_800);
+    expect(fake.writes).toEqual([content, purge, content]);
+    await vi.advanceTimersByTimeAsync(2_800);
+
+    await rejected;
+    expect(fake.writes).toEqual([content, purge, content, purge]);
+  });
+
+  it('warns with the computed echo-confirm timeout value', async () => {
+    vi.useFakeTimers();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const fake = createFakePty();
+    // 2 KiB => echoConfirmTimeoutMs = 2500 + 2*100 = 2700ms.
+    const content = 'x'.repeat(2 * 1024);
+
+    const delivered = injectPtyMessage(fake.child, 'agent-unit-warn', { content, echo: false });
+    await vi.advanceTimersByTimeAsync(2_700);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('after 2700ms'),
+    );
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    await expect(delivered).rejects.toThrow(/input echo confirmation failed/);
+    warnSpy.mockRestore();
   });
 
   it('returns non-2xx from the supervisor server when echo confirmation fails', async () => {

--- a/src/lib/channels/__tests__/pty-supervisor.test.ts
+++ b/src/lib/channels/__tests__/pty-supervisor.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PTY_TOKEN_HEADER, writePtyToken } from '../../pty-token.js';
-import { createPtySupervisorServer, injectPtyMessage } from '../pty-supervisor.js';
+import { createPtySupervisorServer, createSocketWriteLogQueue, injectPtyMessage } from '../pty-supervisor.js';
 import { INPUT_PURGE_MAX_CHARS, echoConfirmTimeoutMs, purgeSettleMs } from '../injection-budget.js';
 
 const REPO_ROOT = process.cwd();
@@ -17,6 +17,27 @@ let tmpHome: string;
 let proc: ChildProcess | null;
 let stdout = '';
 let stderr = '';
+
+describe('socket write log queue', () => {
+  it('bounds stalled logging and retains metadata instead of full payloads', async () => {
+    const stalledWrite = vi.fn(() => new Promise<void>(() => undefined));
+    const queue = createSocketWriteLogQueue(stalledWrite, 2);
+    const payload = { content: 'x'.repeat(INPUT_PURGE_MAX_CHARS), caller: 'queue-test' };
+
+    expect(queue.enqueue('agent-one', payload)).toBe(true);
+    expect(queue.enqueue('agent-two', payload)).toBe(true);
+    expect(queue.enqueue('agent-three', payload)).toBe(false);
+    await Promise.resolve();
+
+    expect(stalledWrite).toHaveBeenCalledOnce();
+    expect(stalledWrite).toHaveBeenCalledWith({
+      agentId: 'agent-one',
+      contentLength: INPUT_PURGE_MAX_CHARS,
+      caller: 'queue-test',
+    });
+    expect(stalledWrite.mock.calls[0]?.[0]).not.toHaveProperty('content');
+  });
+});
 
 function startSupervisor(agentId: string, command: string, args: string[] = []): ChildProcess {
   proc = spawn(process.execPath, [SUPERVISOR_ENTRY, command, ...args], {
@@ -417,8 +438,9 @@ describe.skipIf(isBun)('pty-supervisor subprocess', () => {
     await waitForProcessOutput(() => stdout.includes(content), 'supervisor did not echo posted content');
     expect(stdout.match(new RegExp(content, 'g'))).toHaveLength(1);
     const logPath = join(tmpHome, 'logs', 'pty-supervisor-agent-echo.log');
-    await vi.waitFor(() => expect(existsSync(logPath)).toBe(true));
-    expect(readFileSync(logPath, 'utf8')).toContain('"kind":"socket_write"');
+    await vi.waitFor(() => {
+      expect(readFileSync(logPath, 'utf8')).toContain('"kind":"socket_write"');
+    });
   });
 
   it('returns non-2xx after one retry when child PTY output never reflects the input', async () => {

--- a/src/lib/channels/__tests__/pty-supervisor.test.ts
+++ b/src/lib/channels/__tests__/pty-supervisor.test.ts
@@ -417,6 +417,7 @@ describe.skipIf(isBun)('pty-supervisor subprocess', () => {
     await waitForProcessOutput(() => stdout.includes(content), 'supervisor did not echo posted content');
     expect(stdout.match(new RegExp(content, 'g'))).toHaveLength(1);
     const logPath = join(tmpHome, 'logs', 'pty-supervisor-agent-echo.log');
+    await vi.waitFor(() => expect(existsSync(logPath)).toBe(true));
     expect(readFileSync(logPath, 'utf8')).toContain('"kind":"socket_write"');
   });
 

--- a/src/lib/channels/injection-budget.ts
+++ b/src/lib/channels/injection-budget.ts
@@ -1,6 +1,7 @@
 /**
  * Payload-size-aware injection budget shared between the PTY supervisor and
- * its delivery client. Keeping both sides' timeouts in one leaf module makes
+ * its delivery client. This is the single timing source for both sides of the
+ * protocol; keeping their waits in one leaf module makes
  * mid-injection abandonment structurally impossible: the client always waits
  * strictly longer than the supervisor's worst-case internal path.
  *

--- a/src/lib/channels/injection-budget.ts
+++ b/src/lib/channels/injection-budget.ts
@@ -1,0 +1,42 @@
+/**
+ * Payload-size-aware injection budget shared between the PTY supervisor and
+ * its delivery client. Keeping both sides' timeouts in one leaf module makes
+ * mid-injection abandonment structurally impossible: the client always waits
+ * strictly longer than the supervisor's worst-case internal path.
+ *
+ * This module must remain a leaf (it imports nothing from src/lib) so the
+ * dashboard build does not gain a new circular-ESM edge.
+ */
+
+export const INPUT_ECHO_CONFIRM_INTERVAL_MS = 50;
+export const INPUT_ECHO_CONFIRM_ATTEMPTS = 2;
+export const INPUT_ECHO_CONFIRM_PREFIX_CHARS = 40;
+export const INPUT_PURGE_MAX_CHARS = 262_144;
+export const SUPERVISOR_CLIENT_MARGIN_MS = 2_000;
+const INJECTION_OVERHEAD_MS = 3_000; // PTY writes, log appends, scheduler slack
+
+/** Echo window for one attempt: 2.5s floor + 100ms per KB, capped at 15s. */
+export function echoConfirmTimeoutMs(contentLength: number): number {
+  return Math.min(2_500 + Math.ceil(contentLength / 1_024) * 100, 15_000);
+}
+
+/** Pause between confirmed echo and the standalone Enter: 300ms floor + 50ms/KB, capped at 2s. */
+export function inputSettleMs(contentLength: number): number {
+  return Math.min(300 + Math.ceil(contentLength / 1_024) * 50, 2_000);
+}
+
+/** Settle after a purge: 150ms floor + 25ms/KB of erased content, capped at 1s. */
+export function purgeSettleMs(erasedChars: number): number {
+  return Math.min(150 + Math.ceil(erasedChars / 1_024) * 25, 1_000);
+}
+
+/** Worst-case wall time injectPtyMessage can spend before responding. */
+export function supervisorInjectionBudgetMs(contentLength: number): number {
+  const clamped = Math.min(contentLength, INPUT_PURGE_MAX_CHARS);
+  return (
+    INPUT_ECHO_CONFIRM_ATTEMPTS * echoConfirmTimeoutMs(contentLength) +
+    INPUT_ECHO_CONFIRM_ATTEMPTS * purgeSettleMs(clamped) +
+    inputSettleMs(contentLength) +
+    INJECTION_OVERHEAD_MS
+  );
+}

--- a/src/lib/channels/pty-supervisor.ts
+++ b/src/lib/channels/pty-supervisor.ts
@@ -129,19 +129,50 @@ function payloadCaller(payload: PtySupervisorPayload): string | undefined {
   return payload.caller ?? payload.meta?.caller;
 }
 
-async function appendSocketWriteLog(agentId: string, payload: PtySupervisorPayload): Promise<void> {
+export interface SocketWriteLogRecord {
+  agentId: string;
+  contentLength: number;
+  caller?: string;
+}
+
+export function createSocketWriteLogQueue(
+  write: (record: SocketWriteLogRecord) => Promise<void>,
+  maxPending = 64,
+): { enqueue: (agentId: string, payload: PtySupervisorPayload) => boolean } {
+  let pending = 0;
+  let tail: Promise<void> = Promise.resolve();
+
+  return {
+    enqueue(agentId, payload) {
+      if (pending >= maxPending) return false;
+      const caller = payloadCaller(payload);
+      const record: SocketWriteLogRecord = {
+        agentId,
+        contentLength: payload.content.length,
+        ...(caller ? { caller } : {}),
+      };
+      pending += 1;
+      tail = tail
+        .then(() => write(record))
+        .catch(() => undefined)
+        .finally(() => { pending -= 1; });
+      return true;
+    },
+  };
+}
+
+async function appendSocketWriteLog(record: SocketWriteLogRecord): Promise<void> {
   try {
-    const logPath = getPtySupervisorLogPath(agentId);
+    const logPath = getPtySupervisorLogPath(record.agentId);
     await mkdir(join(getOverdeckHome(), 'logs'), { recursive: true, mode: 0o700 });
-    const caller = payloadCaller(payload);
     await appendFile(
       logPath,
       `${JSON.stringify({
         ts: new Date().toISOString(),
-        agentId,
+        agentId: record.agentId,
         kind: 'socket_write',
-        contentLength: payload.content.length,
-        ...(caller ? { caller } : {}),
+        contentLength: record.contentLength,
+        ...(record.caller ? { caller: record.caller } : {}),
       })}\n`,
       'utf8',
     );
@@ -149,6 +180,8 @@ async function appendSocketWriteLog(agentId: string, payload: PtySupervisorPaylo
     // non-critical
   }
 }
+
+const socketWriteLogQueue = createSocketWriteLogQueue(appendSocketWriteLog);
 
 /**
  * Record what the PTY actually showed when echo confirmation failed — without
@@ -333,7 +366,7 @@ export async function injectPtyMessage(
     // Delivery is complete once the standalone Enter is written. Logging is
     // best-effort observability and must not hold the supervisor response open
     // past the shared client deadline after the message has already submitted.
-    void appendSocketWriteLog(agentId, payload);
+    socketWriteLogQueue.enqueue(agentId, payload);
   } finally {
     subscription.dispose();
   }

--- a/src/lib/channels/pty-supervisor.ts
+++ b/src/lib/channels/pty-supervisor.ts
@@ -27,16 +27,18 @@ import { pathToFileURL } from 'node:url';
 import { join } from 'node:path';
 import { getOverdeckHome } from '../paths.js';
 import { PTY_TOKEN_HEADER, readPtyToken } from '../pty-token.js';
+import {
+  INPUT_ECHO_CONFIRM_INTERVAL_MS,
+  INPUT_ECHO_CONFIRM_ATTEMPTS,
+  INPUT_ECHO_CONFIRM_PREFIX_CHARS,
+  echoConfirmTimeoutMs,
+  inputSettleMs,
+} from './injection-budget.js';
 
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
 const SHUTDOWN_GRACE_MS = 2_000;
 const MAX_REQUEST_BYTES = 1024 * 1024;
-const INPUT_ECHO_CONFIRM_TIMEOUT_MS = 2_500;
-const INPUT_ECHO_CONFIRM_INTERVAL_MS = 50;
-const INPUT_ECHO_CONFIRM_ATTEMPTS = 2;
-const INPUT_ECHO_CONFIRM_PREFIX_CHARS = 40;
-const INPUT_SETTLE_MS = 300;
 const INPUT_PURGE_MAX_CHARS = 8_192;
 const INPUT_PURGE_SETTLE_MS = 150;
 
@@ -243,9 +245,9 @@ export function isEchoConfirmed(rawOutput: string, prefix: string): boolean {
   return normalized.includes(prefix) || PASTE_PLACEHOLDER_NORMALIZED_RE.test(normalized);
 }
 
-async function waitForPtyEcho(readOutput: () => string, prefix: string): Promise<boolean> {
+async function waitForPtyEcho(readOutput: () => string, prefix: string, timeoutMs: number): Promise<boolean> {
   const confirmed = (): boolean => isEchoConfirmed(readOutput(), prefix);
-  const deadline = Date.now() + INPUT_ECHO_CONFIRM_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (confirmed()) return true;
     await sleep(INPUT_ECHO_CONFIRM_INTERVAL_MS);
@@ -297,10 +299,11 @@ export async function injectPtyMessage(
         await purgePtyInput(child, trimmed.length);
       }
       child.write(trimmed);
-      confirmed = await waitForPtyEcho(() => observedOutput, prefix);
+      const attemptTimeoutMs = echoConfirmTimeoutMs(trimmed.length);
+      confirmed = await waitForPtyEcho(() => observedOutput, prefix, attemptTimeoutMs);
       if (!confirmed && attempt < INPUT_ECHO_CONFIRM_ATTEMPTS) {
         console.warn(
-          `[pty-supervisor] Input echo not confirmed for ${agentId} after ${INPUT_ECHO_CONFIRM_TIMEOUT_MS}ms ` +
+          `[pty-supervisor] Input echo not confirmed for ${agentId} after ${attemptTimeoutMs}ms ` +
           `(attempt ${attempt}/${INPUT_ECHO_CONFIRM_ATTEMPTS}); purging and rewriting content before Enter.`,
         );
       }
@@ -313,11 +316,11 @@ export async function injectPtyMessage(
       await purgePtyInput(child, trimmed.length);
       await appendEchoFailureLog(agentId, payload, normalizePtyText(observedOutput).slice(-200));
       throw new Error(
-        `input echo confirmation failed after ${INPUT_ECHO_CONFIRM_ATTEMPTS} attempts × ${INPUT_ECHO_CONFIRM_TIMEOUT_MS}ms`,
+        `input echo confirmation failed after ${INPUT_ECHO_CONFIRM_ATTEMPTS} attempts × ${echoConfirmTimeoutMs(trimmed.length)}ms`,
       );
     }
 
-    await sleep(INPUT_SETTLE_MS);
+    await sleep(inputSettleMs(trimmed.length));
     child.write('\r');
     if (payload.echo !== false) {
       process.stdout.write(trimmed.endsWith('\n') ? trimmed : `${trimmed}\n`);

--- a/src/lib/channels/pty-supervisor.ts
+++ b/src/lib/channels/pty-supervisor.ts
@@ -33,14 +33,14 @@ import {
   INPUT_ECHO_CONFIRM_PREFIX_CHARS,
   echoConfirmTimeoutMs,
   inputSettleMs,
+  INPUT_PURGE_MAX_CHARS,
+  purgeSettleMs,
 } from './injection-budget.js';
 
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
 const SHUTDOWN_GRACE_MS = 2_000;
 const MAX_REQUEST_BYTES = 1024 * 1024;
-const INPUT_PURGE_MAX_CHARS = 8_192;
-const INPUT_PURGE_SETTLE_MS = 150;
 
 export interface PtySupervisorPayload {
   content: string;
@@ -111,6 +111,7 @@ function parsePayload(value: unknown): PtySupervisorPayload | null {
   if (value === null || typeof value !== 'object') return null;
   const payload = value as Partial<PtySupervisorPayload>;
   if (typeof payload.content !== 'string' || payload.content.length === 0) return null;
+  if (payload.content.length > INPUT_PURGE_MAX_CHARS) return null;
   if (payload.echo !== undefined && typeof payload.echo !== 'boolean') return null;
   if (payload.caller !== undefined && typeof payload.caller !== 'string') return null;
   if (payload.meta !== undefined) {
@@ -262,12 +263,14 @@ async function waitForPtyEcho(readOutput: () => string, prefix: string, timeoutM
  * composer are no-ops, and a collapsed `[Pasted text]` placeholder is deleted
  * atomically by the first DEL. Without this, an unconfirmed-but-landed write
  * stacks with the retry write and the caller's tmux fallback, submitting the
- * same message two or three times (PAN-1769).
+ * same message two or three times (PAN-1769). This invariant holds for payloads
+ * up to INPUT_PURGE_MAX_CHARS; larger payloads are rejected by parsePayload so
+ * "accepted" always implies "purgeable".
  */
 async function purgePtyInput(child: pty.IPty, charCount: number): Promise<void> {
   const count = Math.min(charCount, INPUT_PURGE_MAX_CHARS) + 8;
   child.write('\x7f'.repeat(count));
-  await sleep(INPUT_PURGE_SETTLE_MS);
+  await sleep(purgeSettleMs(count));
 }
 
 export async function injectPtyMessage(

--- a/src/lib/channels/pty-supervisor.ts
+++ b/src/lib/channels/pty-supervisor.ts
@@ -330,7 +330,10 @@ export async function injectPtyMessage(
     if (payload.echo !== false) {
       process.stdout.write(trimmed.endsWith('\n') ? trimmed : `${trimmed}\n`);
     }
-    await appendSocketWriteLog(agentId, payload);
+    // Delivery is complete once the standalone Enter is written. Logging is
+    // best-effort observability and must not hold the supervisor response open
+    // past the shared client deadline after the message has already submitted.
+    void appendSocketWriteLog(agentId, payload);
   } finally {
     subscription.dispose();
   }

--- a/src/lib/channels/pty-supervisor.ts
+++ b/src/lib/channels/pty-supervisor.ts
@@ -13,7 +13,9 @@
  * passed through unchanged. The supervisor proxies stdin/stdout/resize between
  * tmux and Claude, and listens on `${OVERDECK_HOME}/sockets/pty-<agentId>.sock`
  * for authenticated HTTP-on-unix POSTs. Socket-injected messages echo to stdout
- * by default so the tmux transcript shows what Cloister sent. Permission relay
+ * by default so the tmux transcript shows what Cloister sent. Accepted payloads
+ * never exceed the shared purge cap, preserving the invariant that an
+ * unconfirmed write is fully erased before retry. Permission relay
  * is intentionally out of scope; existing Channels MCP remains the bidirectional
  * permission path for agents that opt into it.
  */

--- a/src/lib/overdeck/__tests__/conversation-forks-enter-nudge.test.ts
+++ b/src/lib/overdeck/__tests__/conversation-forks-enter-nudge.test.ts
@@ -75,6 +75,17 @@ describe('injectForkSummary standalone Enter recovery', () => {
     expect(mocks.sendKeysAsync).toHaveBeenCalledOnce();
   });
 
+  it('does not re-deliver when unknown confirmation finds an empty prompt', async () => {
+    vi.spyOn(forks, 'confirmForkPromptAccepted').mockResolvedValue('unknown');
+    mocks.capturePaneText.mockResolvedValue('empty prompt');
+
+    await expect(forks.injectForkSummary(conversation, 'summary verify line', 'summary-fork'))
+      .resolves.toBe('submitted');
+
+    expect(mocks.deliverAgentMessage).toHaveBeenCalledOnce();
+    expect(mocks.sendKeysAsync).not.toHaveBeenCalled();
+  });
+
   it('returns stranded after two nudges without re-delivering onto a full composer', async () => {
     vi.spyOn(forks, 'confirmForkPromptAccepted').mockResolvedValue('unknown');
     mocks.capturePaneText.mockResolvedValue('summary verify line');

--- a/src/lib/overdeck/__tests__/conversation-forks-enter-nudge.test.ts
+++ b/src/lib/overdeck/__tests__/conversation-forks-enter-nudge.test.ts
@@ -63,11 +63,11 @@ describe('injectForkSummary standalone Enter recovery', () => {
     );
   });
 
-  it('nudges when the verification prefix wraps before Enter recovery', async () => {
+  it('nudges when the verification prefix wraps across bordered rows before Enter recovery', async () => {
     vi.spyOn(forks, 'confirmForkPromptAccepted')
       .mockResolvedValueOnce('unknown')
       .mockResolvedValueOnce('accepted');
-    mocks.capturePaneText.mockResolvedValue('summary veri\nfy line');
+    mocks.capturePaneText.mockResolvedValue('summary veri\n│fy line');
 
     await expect(forks.injectForkSummary(conversation, 'summary verify line', 'summary-fork'))
       .resolves.toBe('submitted');

--- a/src/lib/overdeck/__tests__/conversation-forks-enter-nudge.test.ts
+++ b/src/lib/overdeck/__tests__/conversation-forks-enter-nudge.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  capturePaneText: vi.fn(),
+  deliverAgentMessage: vi.fn(),
+  sendKeysAsync: vi.fn(),
+}));
+
+vi.mock('../../tmux.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../../tmux.js')>(),
+  capturePaneText: mocks.capturePaneText,
+  sendKeysAsync: mocks.sendKeysAsync,
+}));
+
+vi.mock('../../agents.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../../agents.js')>(),
+  deliverAgentMessage: mocks.deliverAgentMessage,
+  waitForReadySignal: vi.fn().mockResolvedValue(true),
+}));
+
+import type { LegacyConversation as Conversation } from '../conversations.js';
+import * as forks from '../conversation-forks.js';
+
+const conversation = {
+  name: 'fork-conv',
+  tmuxSession: 'fork-session',
+  cwd: '/tmp/fork-conv',
+  harness: 'codex',
+} as Conversation;
+
+describe('injectForkSummary standalone Enter recovery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.capturePaneText.mockReset();
+    mocks.deliverAgentMessage.mockReset().mockResolvedValue(undefined);
+    mocks.sendKeysAsync.mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('submits with one standalone Enter when confirmation then reports accepted', async () => {
+    vi.spyOn(forks, 'confirmForkPromptAccepted')
+      .mockResolvedValueOnce('unknown')
+      .mockResolvedValueOnce('accepted');
+    mocks.capturePaneText.mockResolvedValue('summary verify line');
+
+    await expect(forks.injectForkSummary(conversation, 'summary verify line', 'summary-fork'))
+      .resolves.toBe('submitted');
+
+    expect(mocks.sendKeysAsync).toHaveBeenCalledOnce();
+    expect(mocks.sendKeysAsync).toHaveBeenCalledWith(
+      'fork-session',
+      'C-m',
+      'summary-fork:enter-nudge',
+    );
+  });
+
+  it('treats a cleared composer as submitted while the runtime mirror lags', async () => {
+    vi.spyOn(forks, 'confirmForkPromptAccepted').mockResolvedValue('unknown');
+    mocks.capturePaneText
+      .mockResolvedValueOnce('summary verify line')
+      .mockResolvedValueOnce('empty prompt');
+
+    await expect(forks.injectForkSummary(conversation, 'summary verify line', 'summary-fork'))
+      .resolves.toBe('submitted');
+
+    expect(mocks.sendKeysAsync).toHaveBeenCalledOnce();
+  });
+
+  it('returns stranded after two nudges without re-delivering onto a full composer', async () => {
+    vi.spyOn(forks, 'confirmForkPromptAccepted').mockResolvedValue('unknown');
+    mocks.capturePaneText.mockResolvedValue('summary verify line');
+
+    await expect(forks.injectForkSummary(conversation, 'summary verify line', 'summary-fork'))
+      .resolves.toBe('stranded');
+
+    expect(mocks.sendKeysAsync).toHaveBeenCalledTimes(2);
+    expect(mocks.deliverAgentMessage).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/overdeck/__tests__/conversation-forks-enter-nudge.test.ts
+++ b/src/lib/overdeck/__tests__/conversation-forks-enter-nudge.test.ts
@@ -63,6 +63,29 @@ describe('injectForkSummary standalone Enter recovery', () => {
     );
   });
 
+  it('nudges when the verification prefix wraps before Enter recovery', async () => {
+    vi.spyOn(forks, 'confirmForkPromptAccepted')
+      .mockResolvedValueOnce('unknown')
+      .mockResolvedValueOnce('accepted');
+    mocks.capturePaneText.mockResolvedValue('summary veri\nfy line');
+
+    await expect(forks.injectForkSummary(conversation, 'summary verify line', 'summary-fork'))
+      .resolves.toBe('submitted');
+
+    expect(mocks.sendKeysAsync).toHaveBeenCalledOnce();
+  });
+
+  it('keeps nudging when the verification prefix remains wrapped after Enter', async () => {
+    vi.spyOn(forks, 'confirmForkPromptAccepted').mockResolvedValue('unknown');
+    mocks.capturePaneText.mockResolvedValue('summary veri\nfy line');
+
+    await expect(forks.injectForkSummary(conversation, 'summary verify line', 'summary-fork'))
+      .resolves.toBe('stranded');
+
+    expect(mocks.sendKeysAsync).toHaveBeenCalledTimes(2);
+    expect(mocks.deliverAgentMessage).toHaveBeenCalledOnce();
+  });
+
   it('treats a cleared composer as submitted while the runtime mirror lags', async () => {
     vi.spyOn(forks, 'confirmForkPromptAccepted').mockResolvedValue('unknown');
     mocks.capturePaneText

--- a/src/lib/overdeck/__tests__/conversation-forks-enter-nudge.test.ts
+++ b/src/lib/overdeck/__tests__/conversation-forks-enter-nudge.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 const mocks = vi.hoisted(() => ({
   capturePaneText: vi.fn(),
@@ -19,6 +22,8 @@ vi.mock('../../agents.js', async (importOriginal) => ({
 }));
 
 import type { LegacyConversation as Conversation } from '../conversations.js';
+import { createConversation, getConversationByName } from '../conversations.js';
+import { sessionFilePath } from '../../paths.js';
 import * as forks from '../conversation-forks.js';
 
 const conversation = {
@@ -79,5 +84,79 @@ describe('injectForkSummary standalone Enter recovery', () => {
 
     expect(mocks.sendKeysAsync).toHaveBeenCalledTimes(2);
     expect(mocks.deliverAgentMessage).toHaveBeenCalledOnce();
+  });
+});
+
+describe('runForkPipeline stranded status', () => {
+  let testHome: string;
+  let originalHome: string | undefined;
+
+  beforeEach(async () => {
+    originalHome = process.env.HOME;
+    testHome = join(tmpdir(), `pan-2568-fork-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    process.env.HOME = testHome;
+    process.env.OVERDECK_HOME = testHome;
+    mkdirSync(testHome, { recursive: true });
+    const { closeOverdeckDatabaseSync } = await import('../infra.js');
+    closeOverdeckDatabaseSync();
+  });
+
+  afterEach(async () => {
+    const { closeOverdeckDatabaseSync } = await import('../infra.js');
+    closeOverdeckDatabaseSync();
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    delete process.env.OVERDECK_HOME;
+    rmSync(testHome, { recursive: true, force: true });
+  });
+
+  async function runWithInjectionResult(result: 'submitted' | 'stranded') {
+    const parentCwd = join(testHome, 'project');
+    const parentSessionId = 'parent-session';
+    const parentFile = sessionFilePath(parentCwd, parentSessionId);
+    const handoffDocPath = join(testHome, 'handoff.md');
+    mkdirSync(dirname(parentFile), { recursive: true });
+    writeFileSync(parentFile, '{"type":"prompt"}\n');
+    writeFileSync(handoffDocPath, 'summary verify line');
+    createConversation({
+      name: 'status-parent',
+      tmuxSession: 'status-parent-session',
+      cwd: parentCwd,
+      claudeSessionId: parentSessionId,
+      harness: 'claude-code',
+    });
+    createConversation({
+      name: 'status-fork',
+      tmuxSession: 'status-fork-session',
+      cwd: parentCwd,
+      harness: 'codex',
+      handoffDocPath,
+    });
+    vi.spyOn(forks, 'ensureForkSessionReady').mockResolvedValue(undefined);
+    vi.spyOn(forks, 'injectForkSummary').mockResolvedValue(result);
+
+    await forks.runForkPipeline(
+      'status-fork',
+      getConversationByName('status-parent')!,
+      'fork-session-id',
+      undefined,
+      'handoff',
+    );
+    return getConversationByName('status-fork')!;
+  }
+
+  it('surfaces a stranded injection as actionable failure without ending the live session', async () => {
+    const fork = await runWithInjectionResult('stranded');
+
+    expect(fork.forkStatus).toBe('failed');
+    expect(fork.forkError).toContain('Open the Terminal tab and press Enter');
+    expect(fork.endedAt).toBeNull();
+  });
+
+  it('clears fork status after a submitted injection', async () => {
+    const fork = await runWithInjectionResult('submitted');
+
+    expect(fork.forkStatus).toBeNull();
+    expect(fork.forkError).toBeNull();
   });
 });

--- a/src/lib/overdeck/__tests__/conversation-forks-enter-nudge.test.ts
+++ b/src/lib/overdeck/__tests__/conversation-forks-enter-nudge.test.ts
@@ -86,6 +86,17 @@ describe('injectForkSummary standalone Enter recovery', () => {
     expect(mocks.sendKeysAsync).not.toHaveBeenCalled();
   });
 
+  it('reports stranded when still-idle confirmation finds an empty prompt', async () => {
+    vi.spyOn(forks, 'confirmForkPromptAccepted').mockResolvedValue('still-idle');
+    mocks.capturePaneText.mockResolvedValue('empty prompt');
+
+    await expect(forks.injectForkSummary(conversation, 'summary verify line', 'summary-fork'))
+      .resolves.toBe('stranded');
+
+    expect(mocks.deliverAgentMessage).toHaveBeenCalledOnce();
+    expect(mocks.sendKeysAsync).not.toHaveBeenCalled();
+  });
+
   it('returns stranded after two nudges without re-delivering onto a full composer', async () => {
     vi.spyOn(forks, 'confirmForkPromptAccepted').mockResolvedValue('unknown');
     mocks.capturePaneText.mockResolvedValue('summary verify line');

--- a/src/lib/overdeck/conversation-forks.ts
+++ b/src/lib/overdeck/conversation-forks.ts
@@ -344,37 +344,28 @@ export async function injectForkSummary(conv: Conversation, summary: string, cal
   if (!ready) {
     console.warn(`[${caller}] ready signal not detected for ${conv.name} within 60s — delivering and confirming anyway`);
   }
-  const MAX_ATTEMPTS = 2;
-  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-    await deliverAgentMessage(conv.tmuxSession, summary, caller, method);
-    const outcome = await self.confirmForkPromptAccepted(conv.tmuxSession, 8000);
-    if (outcome === 'accepted') return 'submitted';
+  await deliverAgentMessage(conv.tmuxSession, summary, caller, method);
+  const outcome = await self.confirmForkPromptAccepted(conv.tmuxSession, 8000);
+  if (outcome === 'accepted') return 'submitted';
 
-    const verify = deliveryVerifyLine(summary).slice(0, 40);
-    let composerStillFull = false;
-    for (let nudge = 1; nudge <= 2; nudge++) {
-      const pane = await capturePaneText(conv.tmuxSession, 40);
-      composerStillFull = verify.length >= 3 && pane.includes(verify);
-      // A cleared composer is affirmative submission evidence even when the
-      // runtime mirror still lags. Re-delivering here can duplicate the full
-      // summary into a live successor; wrapped pane text can also make the
-      // raw verification substring absent while the first delivery succeeded.
-      if (!composerStillFull) return 'submitted';
-
-      console.warn(`[${caller}] ${conv.name} still has the delivered summary in its composer — sending standalone Enter (${nudge}/2)`);
-      await sendKeysAsync(conv.tmuxSession, 'C-m', `${caller}:enter-nudge`);
-      if (await self.confirmForkPromptAccepted(conv.tmuxSession, 8000) === 'accepted') return 'submitted';
-
-      const paneAfterNudge = await capturePaneText(conv.tmuxSession, 40);
-      if (!paneAfterNudge.includes(verify)) return 'submitted';
+  const verify = deliveryVerifyLine(summary).slice(0, 40);
+  for (let nudge = 1; nudge <= 2; nudge++) {
+    const pane = await capturePaneText(conv.tmuxSession, 40);
+    const composerStillFull = verify.length >= 3 && pane.includes(verify);
+    if (!composerStillFull) {
+      // `still-idle` is affirmative evidence that the first turn did not land;
+      // without independent acceptance evidence, surface the ambiguity rather
+      // than re-delivering or silently declaring success. `unknown` can mean a
+      // successful Enter cleared the composer before the runtime mirror caught up.
+      return outcome === 'unknown' ? 'submitted' : 'stranded';
     }
-    if (composerStillFull) return 'stranded';
 
-    if (attempt < MAX_ATTEMPTS) {
-      console.warn(`[${caller}] ${conv.name} still idle 8s after delivery (attempt ${attempt}/${MAX_ATTEMPTS}) — TUI likely dropped the paste during startup, re-delivering`);
-    } else {
-      console.warn(`[${caller}] could not confirm brief delivery for ${conv.name} after ${MAX_ATTEMPTS} attempts — successor may be sitting at an empty prompt`);
-    }
+    console.warn(`[${caller}] ${conv.name} still has the delivered summary in its composer — sending standalone Enter (${nudge}/2)`);
+    await sendKeysAsync(conv.tmuxSession, 'C-m', `${caller}:enter-nudge`);
+    if (await self.confirmForkPromptAccepted(conv.tmuxSession, 8000) === 'accepted') return 'submitted';
+
+    const paneAfterNudge = await capturePaneText(conv.tmuxSession, 40);
+    if (!paneAfterNudge.includes(verify)) return 'submitted';
   }
   return 'stranded';
 }

--- a/src/lib/overdeck/conversation-forks.ts
+++ b/src/lib/overdeck/conversation-forks.ts
@@ -348,7 +348,9 @@ export async function injectForkSummary(conv: Conversation, summary: string, cal
   const outcome = await self.confirmForkPromptAccepted(conv.tmuxSession, 8000);
   if (outcome === 'accepted') return 'submitted';
 
-  const normalizePaneVerification = (value: string): string => value.replace(/\s+/g, '');
+  const normalizePaneVerification = (value: string): string => value
+    .replace(/[─-╿]/g, '')
+    .replace(/\s+/g, '');
   const verify = normalizePaneVerification(deliveryVerifyLine(summary).slice(0, 40));
   for (let nudge = 1; nudge <= 2; nudge++) {
     const pane = await capturePaneText(conv.tmuxSession, 40);

--- a/src/lib/overdeck/conversation-forks.ts
+++ b/src/lib/overdeck/conversation-forks.ts
@@ -348,10 +348,11 @@ export async function injectForkSummary(conv: Conversation, summary: string, cal
   const outcome = await self.confirmForkPromptAccepted(conv.tmuxSession, 8000);
   if (outcome === 'accepted') return 'submitted';
 
-  const verify = deliveryVerifyLine(summary).slice(0, 40);
+  const normalizePaneVerification = (value: string): string => value.replace(/\s+/g, '');
+  const verify = normalizePaneVerification(deliveryVerifyLine(summary).slice(0, 40));
   for (let nudge = 1; nudge <= 2; nudge++) {
     const pane = await capturePaneText(conv.tmuxSession, 40);
-    const composerStillFull = verify.length >= 3 && pane.includes(verify);
+    const composerStillFull = verify.length >= 3 && normalizePaneVerification(pane).includes(verify);
     if (!composerStillFull) {
       // `still-idle` is affirmative evidence that the first turn did not land;
       // without independent acceptance evidence, surface the ambiguity rather
@@ -365,7 +366,7 @@ export async function injectForkSummary(conv: Conversation, summary: string, cal
     if (await self.confirmForkPromptAccepted(conv.tmuxSession, 8000) === 'accepted') return 'submitted';
 
     const paneAfterNudge = await capturePaneText(conv.tmuxSession, 40);
-    if (!paneAfterNudge.includes(verify)) return 'submitted';
+    if (!normalizePaneVerification(paneAfterNudge).includes(verify)) return 'submitted';
   }
   return 'stranded';
 }

--- a/src/lib/overdeck/conversation-forks.ts
+++ b/src/lib/overdeck/conversation-forks.ts
@@ -510,8 +510,16 @@ export async function runForkPipeline(
   }
   updateForkStatus(convName, 'spawning');
   await self.ensureForkSessionReady(conv, sessionId, false);
-  await self.injectForkSummary(conv, summary, effectiveForkMode === 'handoff' ? 'handoff' : 'summary-fork');
+  const injection = await self.injectForkSummary(conv, summary, effectiveForkMode === 'handoff' ? 'handoff' : 'summary-fork');
   markConversationActive(convName);
+  if (injection === 'stranded') {
+    updateForkStatus(
+      convName,
+      'failed',
+      'Summary was delivered to the terminal but never submitted. Open the Terminal tab and press Enter to submit it; the session is alive.',
+    );
+    return;
+  }
   updateForkStatus(convName, null);
 }
 

--- a/src/lib/overdeck/conversation-forks.ts
+++ b/src/lib/overdeck/conversation-forks.ts
@@ -325,6 +325,12 @@ export async function ensureForkSessionReady(
   await forkWaitForTmuxSession(conv.tmuxSession);
 }
 
+/**
+ * Deliver and submit the first fork turn. `submitted` means the runtime mirror
+ * accepted it or pane evidence shows the composer cleared; `stranded` means the
+ * composer stayed full after two standalone-Enter nudges and must be surfaced as
+ * a failed fork without re-delivering duplicate text.
+ */
 export async function injectForkSummary(conv: Conversation, summary: string, caller: string): Promise<'submitted' | 'stranded'> {
   updateForkStatus(conv.name, 'injecting');
   const method = resolveConversationDeliveryMethod(conv);

--- a/src/lib/overdeck/conversation-forks.ts
+++ b/src/lib/overdeck/conversation-forks.ts
@@ -355,7 +355,11 @@ export async function injectForkSummary(conv: Conversation, summary: string, cal
     for (let nudge = 1; nudge <= 2; nudge++) {
       const pane = await capturePaneText(conv.tmuxSession, 40);
       composerStillFull = verify.length >= 3 && pane.includes(verify);
-      if (!composerStillFull) break;
+      // A cleared composer is affirmative submission evidence even when the
+      // runtime mirror still lags. Re-delivering here can duplicate the full
+      // summary into a live successor; wrapped pane text can also make the
+      // raw verification substring absent while the first delivery succeeded.
+      if (!composerStillFull) return 'submitted';
 
       console.warn(`[${caller}] ${conv.name} still has the delivered summary in its composer — sending standalone Enter (${nudge}/2)`);
       await sendKeysAsync(conv.tmuxSession, 'C-m', `${caller}:enter-nudge`);

--- a/src/lib/overdeck/conversation-forks.ts
+++ b/src/lib/overdeck/conversation-forks.ts
@@ -60,7 +60,7 @@ import { sessionFilePath } from '../paths.js';
 import { getHarnessBehavior } from '../runtimes/behavior.js';
 import type { RuntimeName } from '../runtimes/types.js';
 import { getAgentRuntimeStateSync as getAgentRuntimeStateSyncFromAgents } from '../agents.js';
-import { isHarnessProcessAlive, sessionExists } from '../tmux.js';
+import { capturePaneText, deliveryVerifyLine, isHarnessProcessAlive, sendKeysAsync, sessionExists } from '../tmux.js';
 import {
   readLauncherPinnedSessionId,
   resolveCodexRolloutPath,
@@ -325,14 +325,14 @@ export async function ensureForkSessionReady(
   await forkWaitForTmuxSession(conv.tmuxSession);
 }
 
-export async function injectForkSummary(conv: Conversation, summary: string, caller: string): Promise<void> {
+export async function injectForkSummary(conv: Conversation, summary: string, caller: string): Promise<'submitted' | 'stranded'> {
   updateForkStatus(conv.name, 'injecting');
   const method = resolveConversationDeliveryMethod(conv);
   const behavior = getHarnessBehavior(conv.harness);
   if (behavior.transcriptKind === 'ohmypi-jsonl') {
     await waitForPiTuiReady(conv.tmuxSession, 60000);
     await deliverAgentMessage(conv.tmuxSession, summary, caller, method);
-    return;
+    return 'submitted';
   }
   const ready = await waitForReadySignal(conv.tmuxSession, 60);
   if (!ready) {
@@ -341,18 +341,32 @@ export async function injectForkSummary(conv: Conversation, summary: string, cal
   const MAX_ATTEMPTS = 2;
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     await deliverAgentMessage(conv.tmuxSession, summary, caller, method);
-    const outcome = await confirmForkPromptAccepted(conv.tmuxSession, 8000);
-    if (outcome === 'accepted') return;
-    if (outcome === 'unknown') {
-      console.warn(`[${caller}] delivery to ${conv.name} could not be confirmed (runtime mirror silent) — not retrying`);
-      return;
+    const outcome = await self.confirmForkPromptAccepted(conv.tmuxSession, 8000);
+    if (outcome === 'accepted') return 'submitted';
+
+    const verify = deliveryVerifyLine(summary).slice(0, 40);
+    let composerStillFull = false;
+    for (let nudge = 1; nudge <= 2; nudge++) {
+      const pane = await capturePaneText(conv.tmuxSession, 40);
+      composerStillFull = verify.length >= 3 && pane.includes(verify);
+      if (!composerStillFull) break;
+
+      console.warn(`[${caller}] ${conv.name} still has the delivered summary in its composer — sending standalone Enter (${nudge}/2)`);
+      await sendKeysAsync(conv.tmuxSession, 'C-m', `${caller}:enter-nudge`);
+      if (await self.confirmForkPromptAccepted(conv.tmuxSession, 8000) === 'accepted') return 'submitted';
+
+      const paneAfterNudge = await capturePaneText(conv.tmuxSession, 40);
+      if (!paneAfterNudge.includes(verify)) return 'submitted';
     }
+    if (composerStillFull) return 'stranded';
+
     if (attempt < MAX_ATTEMPTS) {
       console.warn(`[${caller}] ${conv.name} still idle 8s after delivery (attempt ${attempt}/${MAX_ATTEMPTS}) — TUI likely dropped the paste during startup, re-delivering`);
     } else {
       console.warn(`[${caller}] could not confirm brief delivery for ${conv.name} after ${MAX_ATTEMPTS} attempts — successor may be sitting at an empty prompt`);
     }
   }
+  return 'stranded';
 }
 
 export function handleForkPipelineFailure(name: string, err: unknown): void {

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -691,7 +691,7 @@ export function capturePaneSync(sessionName: string, lines: number = 50): string
   }
 }
 
-async function capturePaneText(
+export async function capturePaneText(
   sessionName: string,
   lines: number = 50,
   options?: { escapeSequences?: boolean }
@@ -1123,6 +1123,11 @@ export async function sendEscapeKeyAsync(sessionName: string, times = 1): Promis
   }
 }
 
+export function deliveryVerifyLine(content: string): string {
+  const lines = content.split('\n');
+  return ([...lines].reverse().find(line => line.trim().length >= 3) ?? lines[lines.length - 1])?.trim() ?? '';
+}
+
 export const sendKeys = (
   sessionName: string,
   keys: string,
@@ -1142,8 +1147,7 @@ export const sendKeys = (
         await tmuxExecAsync(['load-buffer', '-b', bufferName, tmpFile], { encoding: 'utf-8' });
         await tmuxExecAsync(['paste-buffer', '-b', bufferName, '-p', '-t', sessionName], { encoding: 'utf-8' });
 
-        const lines = keys.split('\n');
-        const verifyLine = ([...lines].reverse().find(l => l.trim().length >= 3) ?? lines[lines.length - 1])?.trim() ?? '';
+        const verifyLine = deliveryVerifyLine(keys);
         // 1.5s per attempt × 2 attempts = 3s worst case. The previous 8s × 2 = 16s
         // caused user-visible "Enter not sent" lag whenever the 10-line tail check
         // missed the verify line (e.g. tall Claude input box or wrapped paste).

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -1123,11 +1123,7 @@ export async function sendEscapeKeyAsync(sessionName: string, times = 1): Promis
   }
 }
 
-export function deliveryVerifyLine(content: string): string {
-  const lines = content.split('\n');
-  return ([...lines].reverse().find(line => line.trim().length >= 3) ?? lines[lines.length - 1])?.trim() ?? '';
-}
-
+export function deliveryVerifyLine(content: string): string { const lines = content.split('\n'); return ([...lines].reverse().find(line => line.trim().length >= 3) ?? lines[lines.length - 1])?.trim() ?? ''; }
 export const sendKeys = (
   sessionName: string,
   keys: string,


### PR DESCRIPTION
**Issue:** #2568

## Acceptance Criteria

- [ ] Shared payload-size-aware injection-budget module wired into supervisor and delivery client
- [ ] injectPtyMessage echo-confirm timeout and pre-Enter settle scale with payload size
- [ ] purgePtyInput erases the full written length; supervisor rejects payloads above the purge cap
- [ ] Export deliveryVerifyLine helper and capturePaneText from src/lib/tmux.ts
- [ ] Pane-verified standalone-Enter recovery in injectForkSummary
- [ ] Stranded forks set forkStatus='failed' with an actionable error instead of silently completing
- [ ] Regression tests: delivery-client timeout scales with payload and large payloads stay on the supervisor tier
- [ ] Document the injection budget, purge invariant, and stranded-fork surfacing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delivery reliability for large messages with payload-aware timing and retry handling.
  * Prevented duplicate composer text after failed delivery attempts.
  * Added a 262,144-character limit for supervisor messages; oversized requests are rejected safely.
  * Improved fork recovery by retrying submission confirmation and reporting actionable errors without ending the live conversation.

* **Documentation**
  * Expanded smoke-test guidance for large-message delivery, retries, and fork recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->