### PR TITLE
fix(cli): refuse workspace dashboard restarts (PAN-2727)

### DIFF
--- a/src/cli/commands/__tests__/restart-workspace-guard.test.ts
+++ b/src/cli/commands/__tests__/restart-workspace-guard.test.ts
@@ -1,0 +1,51 @@
+import { Effect } from 'effect';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  readPlatformConfigSync: vi.fn(),
+  restartDashboard: vi.fn(),
+  stopDashboard: vi.fn(),
+}));
+
+vi.mock('fs', async (importActual) => ({
+  ...(await importActual<typeof import('fs')>()),
+  existsSync: mocks.existsSync,
+}));
+
+vi.mock('../../../lib/platform-lifecycle.js', async (importActual) => ({
+  ...(await importActual<typeof import('../../../lib/platform-lifecycle.js')>()),
+  readPlatformConfigSync: mocks.readPlatformConfigSync,
+  restartDashboard: mocks.restartDashboard,
+  stopDashboard: mocks.stopDashboard,
+}));
+
+import { restartCommand } from '../restart.js';
+
+describe('restartCommand workspace guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = undefined;
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(process, 'cwd').mockReturnValue('/repo/workspaces/feature-pan-2727/src/cli');
+    mocks.existsSync.mockImplementation((path: string) => path === '/repo/workspaces/feature-pan-2727/.git');
+    mocks.restartDashboard.mockReturnValue(Effect.succeed(undefined));
+    mocks.stopDashboard.mockReturnValue(Effect.succeed(undefined));
+  });
+
+  it.each([
+    [{}, 'dashboard'],
+    [{ full: true }, 'full'],
+  ])('refuses a %s restart before any dashboard stop', async (options) => {
+    await restartCommand(options);
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining(
+      'Run this command from the primary checkout at /repo',
+    ));
+    expect(process.exitCode).toBe(2);
+    expect(mocks.readPlatformConfigSync).not.toHaveBeenCalled();
+    expect(mocks.restartDashboard).not.toHaveBeenCalled();
+    expect(mocks.stopDashboard).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands/restart.ts
+++ b/src/cli/commands/restart.ts
@@ -19,9 +19,10 @@ import { Effect } from 'effect';
 
 import chalk from 'chalk';
 import { spawn } from 'child_process';
-import { dirname, join } from 'path';
+import { dirname, join, parse, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { existsSync } from 'fs';
+import { isWorkspaceRepoRoot } from '../../dashboard/server/identity.js';
 
 import { acquireRestartLock, readRestartLockHolder, type RestartLockHandle } from '../../lib/restart-lock.js';
 import { writeRestartStatus } from '../../lib/restart-status.js';
@@ -65,6 +66,29 @@ function resolveScope(options: RestartOptions): 'dashboard' | 'cliproxy' | 'trae
     process.exit(2);
   }
   return (flags[0] as any) || 'dashboard';
+}
+
+export function resolveGitRepoRoot(cwd: string): string | null {
+  let candidate = resolve(cwd);
+  const filesystemRoot = parse(candidate).root;
+  while (true) {
+    if (existsSync(join(candidate, '.git'))) return candidate;
+    if (candidate === filesystemRoot) return null;
+    candidate = dirname(candidate);
+  }
+}
+
+function refuseWorkspaceDashboardRestart(cwd: string): boolean {
+  const repoRoot = resolveGitRepoRoot(cwd);
+  if (!repoRoot || !isWorkspaceRepoRoot(repoRoot)) return false;
+
+  const primaryRepoRoot = dirname(dirname(repoRoot));
+  console.error(chalk.red(
+    `Refusing to restart the host dashboard from workspace checkout ${repoRoot}. ` +
+      `Run this command from the primary checkout at ${primaryRepoRoot}.`,
+  ));
+  process.exitCode = 2;
+  return true;
 }
 
 function resolveNode22(): string {
@@ -185,6 +209,9 @@ export async function shouldRunManualSupervisorCycle(env: NodeJS.ProcessEnv = pr
 export async function restartCommand(options: RestartOptions): Promise<void> {
   const startedAt = Date.now();
   const scope = resolveScope(options);
+  if ((scope === 'dashboard' || scope === 'full') && refuseWorkspaceDashboardRestart(process.cwd())) {
+    return;
+  }
   const config = readPlatformConfigSync();
   const healthTimeoutMs = options.healthTimeout
     ? parseInt(options.healthTimeout, 10)


### PR DESCRIPTION
`pan restart` from a workspace checkout killed the **host** dashboard before any
guard could refuse the rebind — an outage until the watchdog recovered (~2min).

`runFullRestart` called `stopDashboard(config)` at the top of its Stop phase with
no cwd validation. The `expectedIdentity: { repoRoot: process.cwd(), mode:
'primary' }` guard existed only at the **boot** sites (lines 235/352) — i.e. it
refused to rebind a server that was already dead. Wrong order: the destructive
step ran first, the validation second.

`restartCommand` now refuses up front, before `readPlatformConfigSync` and before
anything is stopped:

```ts
const scope = resolveScope(options);
if ((scope === 'dashboard' || scope === 'full') && refuseWorkspaceDashboardRestart(process.cwd())) {
  return;
}
```

`refuseWorkspaceDashboardRestart` resolves the enclosing git repo root and refuses
when it is a workspace checkout (`isWorkspaceRepoRoot` → matches
`…/workspaces/feature-*`), naming the primary checkout to use instead and exiting
2. Scoped to `dashboard`/`full` only — `--cliproxy` / `--traefik` do not touch the
dashboard and are unaffected.

Verified this does not break the sanctioned deploy path: the flywheel restarts
from the primary checkout (`/home/eltmon/Projects/overdeck`), which does not match
`isWorkspaceRepoRoot` and is not refused. Workspace *and* strike checkouts both
match and are refused, which is correct — neither should restart the host.

## Gates (verified by the flywheel)
- `src/cli/commands/__tests__/restart-workspace-guard.test.ts` → 2 passed
- `npm run typecheck` → green
- `npm run lint` → green

## Live incident this fixes
`agent-pan-2598` ran `pan restart` from its workspace cwd today and took down
`:3011`. That outage is what stranded `planning-pan-2702`'s promotion: planning
finished at 08:58, could not reach the dashboard, exhausted 5 retries, and left a
complete plan stranded workspace-local until it was promoted by hand.

Authored by strike-pan-2727.

Closes PAN-2727

🤖 Generated with [Claude Code](https://claude.com/claude-code)