### PR TITLE
fix(review): recover stale reviewing convoys (PAN-2735)

### DIFF
--- a/src/lib/cloister/__tests__/pan-2341-orphan-redispatch.test.ts
+++ b/src/lib/cloister/__tests__/pan-2341-orphan-redispatch.test.ts
@@ -1,5 +1,5 @@
 import { Effect } from 'effect';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ReviewStatus } from '../../review-status.js';
 
 const mocks = vi.hoisted(() => ({
@@ -120,6 +120,10 @@ function status(fields: Partial<ReviewStatus> = {}): ReviewStatus {
 }
 
 describe('PAN-2341 orphan journal reconcile before re-dispatch', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   beforeEach(async () => {
     vi.clearAllMocks();
     mocks.loadReviewStatuses.mockReturnValue({});
@@ -176,6 +180,58 @@ describe('PAN-2341 orphan journal reconcile before re-dispatch', () => {
       branch: 'feature/pan-3002',
       force: true,
     });
+  });
+
+  it('recovers reviewing when every review agent is stale', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-07T01:00:00.000Z'));
+    const raw = status({ issueId: 'PAN-3002', updatedAt: '2026-07-07T00:50:00.000Z' });
+    mocks.loadReviewStatuses.mockReturnValue({ 'PAN-3002': raw });
+    mocks.getReviewStatusSync.mockReturnValue(raw);
+    mocks.listRunningAgents.mockReturnValue(Effect.succeed([
+      { id: 'agent-pan-3002-review', issueId: 'PAN-3002', role: 'review', status: 'running', lastActivity: '2026-07-07T00:40:00.000Z' },
+      { id: 'agent-pan-3002-review-security', issueId: 'PAN-3002', role: 'review', status: 'running', lastActivity: '2026-07-07T00:40:00.000Z' },
+    ]));
+
+    const { checkOrphanedReviewStatuses } = await import('../deacon-review-status.js');
+    await checkOrphanedReviewStatuses();
+
+    expect(mocks.setReviewStatusSync).toHaveBeenCalledWith('PAN-3002', expect.objectContaining({ reviewStatus: 'pending' }));
+  });
+
+  it('recovers reviewing when the coordinator stopped but sub-reviewers remain running', async () => {
+    const raw = status({ issueId: 'PAN-3002', updatedAt: new Date().toISOString() });
+    mocks.loadReviewStatuses.mockReturnValue({ 'PAN-3002': raw });
+    mocks.getReviewStatusSync.mockReturnValue(raw);
+    mocks.listRunningAgents.mockReturnValue(Effect.succeed([
+      { id: 'agent-pan-3002-review', issueId: 'PAN-3002', role: 'review', status: 'stopped', lastActivity: new Date().toISOString() },
+      { id: 'agent-pan-3002-review-security', issueId: 'PAN-3002', role: 'review', status: 'running', lastActivity: new Date().toISOString() },
+    ]));
+
+    const { checkOrphanedReviewStatuses } = await import('../deacon-review-status.js');
+    await checkOrphanedReviewStatuses();
+
+    expect(mocks.setReviewStatusSync).toHaveBeenCalledWith('PAN-3002', expect.objectContaining({ reviewStatus: 'pending' }));
+  });
+
+  it('recovers reviewing after the hard watchdog deadline despite fresh agent activity', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-07T01:00:00.000Z'));
+    const raw = status({
+      issueId: 'PAN-3002',
+      reviewSpawnedAt: '2026-07-07T00:00:00.000Z',
+      updatedAt: '2026-07-07T00:55:00.000Z',
+    });
+    mocks.loadReviewStatuses.mockReturnValue({ 'PAN-3002': raw });
+    mocks.getReviewStatusSync.mockReturnValue(raw);
+    mocks.listRunningAgents.mockReturnValue(Effect.succeed([
+      { id: 'agent-pan-3002-review', issueId: 'PAN-3002', role: 'review', status: 'running', lastActivity: '2026-07-07T00:59:00.000Z' },
+    ]));
+
+    const { checkOrphanedReviewStatuses } = await import('../deacon-review-status.js');
+    await checkOrphanedReviewStatuses();
+
+    expect(mocks.setReviewStatusSync).toHaveBeenCalledWith('PAN-3002', expect.objectContaining({ reviewStatus: 'pending' }));
   });
 
   it('reconciles a journaled passed test verdict and does not spawn a fresh test', async () => {

--- a/src/lib/cloister/deacon-review-status.ts
+++ b/src/lib/cloister/deacon-review-status.ts
@@ -47,6 +47,8 @@ const execAsync = promisify(exec);
  * resets the counter (see review-agent.ts and checkPostReviewCommits below).
  */
 const REVIEW_INFRA_BREAKER_THRESHOLD = 3;
+const REVIEW_AGENT_IDLE_THRESHOLD_MS = 15 * 60 * 1000;
+const REVIEWING_WATCHDOG_THRESHOLD_MS = 45 * 60 * 1000;
 
 /**
  * Orphan-test self-heal state. A test role cannot spawn while the workspace
@@ -191,6 +193,8 @@ async function recoverUnhealthyTestStack(
 // ─────────────────────────────────────────────────────────────────────────────
 
 interface ReviewStatusLike {
+  updatedAt?: string;
+  reviewSpawnedAt?: string;
   reviewStatus?: string;
   verificationStatus?: string;
   testStatus?: string;
@@ -255,16 +259,31 @@ export function completedReviewSnapshotAfterCoordinatorExit(
   };
 }
 
-async function isReviewAgentActiveForIssue(issueId: string): Promise<boolean> {
+async function isReviewAgentActiveForIssue(issueId: string, status: ReviewStatusLike): Promise<boolean> {
   // PAN-1048 R5: role-primitive review/test runs (agent-<id>-review, agent-<id>-test).
   try {
     const agents = await Effect.runPromise(listRunningAgents());
-    for (const agent of agents) {
-      if (agent.status === 'stopped' || agent.status === 'error') continue;
+    const issueUpper = issueId.toUpperCase();
+    const reviewAgents = agents.filter((agent) => {
       const id = (agent.issueId ?? '').trim().toUpperCase();
-      if (!id || id !== issueId.toUpperCase()) continue;
       const role = agent.role ?? (agent.id.endsWith('-review') ? 'review' : agent.id.endsWith('-test') ? 'test' : null);
-      if (role === 'review') return true;
+      return id === issueUpper && role === 'review';
+    });
+
+    const coordinatorId = `agent-${issueId.toLowerCase()}-review`;
+    if (reviewAgents.some((agent) => agent.id === coordinatorId && (agent.status === 'stopped' || agent.status === 'error'))) {
+      return false;
+    }
+
+    const reviewStartedAt = Date.parse(status.reviewSpawnedAt ?? status.updatedAt ?? '');
+    if (Number.isFinite(reviewStartedAt) && Date.now() - reviewStartedAt >= REVIEWING_WATCHDOG_THRESHOLD_MS) {
+      return false;
+    }
+
+    for (const agent of reviewAgents) {
+      if (agent.status === 'stopped' || agent.status === 'error') continue;
+      const lastActivity = Date.parse(agent.lastActivity ?? '');
+      if (!Number.isFinite(lastActivity) || Date.now() - lastActivity < REVIEW_AGENT_IDLE_THRESHOLD_MS) return true;
     }
   } catch {
     // fall through
@@ -483,7 +502,7 @@ async function reconcileReviewStatusOrphan(
   const latestTerminalReview = latestHistoryEntry(status.history, 'review', ['passed', 'failed', 'blocked']);
   const latestTerminalTest = latestHistoryEntry(status.history, 'test', ['passed', 'failed', 'skipped']);
 
-  const reviewAgentActive = await isReviewAgentActiveForIssue(issueId);
+  const reviewAgentActive = await isReviewAgentActiveForIssue(issueId, status);
 
   // A supervised verification worker can finish after the dashboard process
   // that requested it has died. The worker records the pass, but the dead HTTP


### PR DESCRIPTION
Fixes the top blocker of the RUN-63 drain: `reviewStatus='reviewing'` was **unrecoverable**, pinning PAN-2597 (2h+) and PAN-2598 indefinitely.

## Problem

`deacon-review-status.ts:525` recovers an orphaned `reviewing` only `if (!reviewAgentActive)`. `isReviewAgentActiveForIssue` returned true for **any** review row not `stopped`/`error` — so idle codex sub-reviewers latched `status=running` kept the flag true forever and the recovery could never fire. There was no other watchdog on `reviewing`.

Live evidence: 2597/2598's four sub-reviewers sat `status=running` while idle 124m/100m, parked at the codex default prompt, with their synthesis coordinator already `stopped`. Four consecutive review runs on 2598 wrote only `context.json` and produced nothing.

The backstop was healthy — PAN-1864's deterministic deacon synthesis works and correctly returned CHANGES REQUESTED at 14:49. It was simply never invoked again, because the trigger's liveness signal was a lie.

## Fix

`isReviewAgentActiveForIssue` now treats three conditions as *not active*:
1. **Coordinator stopped** — if `agent-<id>-review` is `stopped`/`error`, the convoy is definitionally finished-or-dead.
2. **Stale reviewers** — `lastActivity` older than 15m (the field is populated; it was simply unused).
3. **Watchdog** — `reviewing` older than 45m via `reviewSpawnedAt` (a real field, `review-status.ts:98`), so no single signal can pin the state forever.

## Gates (run locally on this branch)
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npx vitest run tests/unit/lib/cloister src/lib/cloister/__tests__` — **139 files / 1062 tests passed**
- Focused regression `pan-2341-orphan-redispatch.test.ts` — 7/7, extended with coverage for all three conditions

Sibling: PAN-2731 (same root class — codex liveness fields are write-only, opposite direction).

Closes #2735

🤖 Generated with [Claude Code](https://claude.com/claude-code)