### PR TITLE
fix(review): recycle idle convoy reviewers — stop healthy-idle session before respawn (PAN-2743)

### DIFF
--- a/src/lib/cloister/review-convoy.ts
+++ b/src/lib/cloister/review-convoy.ts
@@ -141,7 +141,7 @@ async function spawnReviewSubRoleForIssuePromise(opts: {
   forkedSessionId?: string;
 }): Promise<{ success: boolean; message: string; error?: string; sessionId?: string }> {
   try {
-    const { saveAgentState, spawnRun, getAgentStateSync, getLatestSessionIdSync, resumeAgent } = await import('../agents.js');
+    const { saveAgentState, spawnRun, getAgentStateSync, getLatestSessionIdSync, resumeAgent, stopAgent } = await import('../agents.js');
     const cfg = loadYamlConfig().config;
     const outputPath = opts.outputPath ?? reviewerAgentOutputPath(opts.workspace, opts.runId, opts.subRole);
     const synthesisAgentId = opts.synthesisAgentId ?? `agent-${opts.issueId.toLowerCase()}-review`;
@@ -207,6 +207,14 @@ async function spawnReviewSubRoleForIssuePromise(opts: {
         return { success: true, message: `Review ${opts.subRole} resumed (session preserved): ${reviewerAgent}`, sessionId: reviewerAgent };
       }
       console.warn(`[review-agent] Convoy sub-reviewer ${opts.subRole} resume failed; falling back to a fresh session: ${resumeResult.error}`);
+      // PAN-2743: Codex reviewers intentionally remain alive at their prompt after
+      // finishing a cycle. resumeAgent correctly refuses to "resume" that healthy
+      // process, but spawnRun cannot replace it while its tmux session still exists.
+      // Stop only this explicit healthy-idle collision before the fresh spawn; other
+      // resume failures already imply no live session and need no teardown.
+      if (resumeResult.error?.includes('it appears healthy')) {
+        await Effect.runPromise(stopAgent(reviewerAgent));
+      }
     }
 
     const forkedPreface = opts.forkedSessionId
@@ -581,5 +589,4 @@ export function resolveReReviewScope(issueId?: string): ReReviewScope {
   const scope = loadYamlConfig().config.roles?.review?.reReviewScope;
   return scope === 'all' || scope === 'blockers' ? scope : 'changed';
 }
-
 

--- a/tests/lib/cloister/review-agent.test.ts
+++ b/tests/lib/cloister/review-agent.test.ts
@@ -49,6 +49,7 @@ const {
   mockResolveProjectForIssue,
   mockGetLatestSessionIdSync,
   mockResumeAgent,
+  mockStopAgent,
   mockWipeAgentStateDirs,
 } = vi.hoisted(() => ({
   mockKillSessionAsync: vi.fn().mockResolvedValue(undefined),
@@ -68,6 +69,7 @@ const {
   mockResolveProjectForIssue: vi.fn(() => ({ name: 'test', path: '/tmp/project' })),
   mockGetLatestSessionIdSync: vi.fn(() => null),
   mockResumeAgent: vi.fn().mockResolvedValue({ success: false, error: 'no session' }),
+  mockStopAgent: vi.fn().mockResolvedValue(undefined),
   mockWipeAgentStateDirs: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -96,6 +98,7 @@ vi.mock('../../../src/lib/agents.js', () => ({
   spawnRun: mockSpawnRun,
   getLatestSessionIdSync: mockGetLatestSessionIdSync,
   resumeAgent: mockResumeAgent,
+  stopAgent: (...args: Parameters<typeof mockStopAgent>) => Effect.promise(() => mockStopAgent(...args)),
   wipeAgentStateDirs: mockWipeAgentStateDirs,
   getProviderAuthMode: vi.fn(async () => 'apikey'),
 }));
@@ -833,6 +836,9 @@ describe('convoy orchestration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetAgentState.mockReturnValue(null);
+    mockGetLatestSessionIdSync.mockReturnValue(null);
+    mockResumeAgent.mockResolvedValue({ success: false, error: 'no session' });
+    mockStopAgent.mockResolvedValue(undefined);
     mockSpawnRun.mockResolvedValue({ id: 'agent-pan-1059-review-security' });
     mockGetAgentState.mockReturnValue(null);
     prepareWorkspace(REVIEW_AGENT_DEFAULT_WORKSPACE);
@@ -921,6 +927,35 @@ describe('convoy orchestration', () => {
       role: 'security',
       sessionName: 'agent-pan-1059-review-security',
     });
+  });
+
+  it('stops an idle-alive reviewer before fresh-spawning the new prompt', async () => {
+    const reviewerId = 'agent-pan-1059-review-security';
+    mockGetAgentState.mockReturnValue({
+      id: reviewerId,
+      model: 'configured-reviewer-model',
+      harness: 'codex',
+    });
+    mockGetLatestSessionIdSync.mockReturnValue('saved-session');
+    mockResumeAgent.mockResolvedValue({
+      success: false,
+      error: `Cannot resume ${reviewerId}: it appears healthy (tmux session up, harness process alive) — there is nothing to resume. Stop it first if you intend to restart it.`,
+    });
+
+    const result = await Effect.runPromise(spawnReviewSubRoleForIssue({
+      issueId: 'PAN-1059',
+      workspace: REVIEW_AGENT_SUBROLE_WORKSPACE,
+      subRole: 'security',
+      runId: REVIEW_AGENT_RUN_ID,
+      contextManifestPath: writeReviewManifest(REVIEW_AGENT_SUBROLE_WORKSPACE),
+    }));
+
+    expect(result.success).toBe(true);
+    expect(mockStopAgent).toHaveBeenCalledWith(reviewerId);
+    expect(mockStopAgent.mock.invocationCallOrder[0]).toBeLessThan(mockSpawnRun.mock.invocationCallOrder[0]);
+    expect(mockSpawnRun).toHaveBeenCalledWith('PAN-1059', 'review', expect.objectContaining({
+      prompt: expect.stringContaining('REVIEW TASK for PAN-1059 — SECURITY REVIEW'),
+    }));
   });
 });
 


### PR DESCRIPTION
Fixes the deadlock that has PAN-2710 — the last issue in the RUN-63 drain — stuck at **`review_retry_count = 18`**.

## Problem

A convoy cannot re-dispatch to a sub-reviewer that is **idle but alive**. Codex reviewers intentionally stay parked at their prompt after finishing a cycle, and that leaves both doors shut:

1. **Resume** refuses — *"Cannot resume `agent-pan-2710-review-correctness`: it appears healthy (tmux session up, harness process alive) — there is nothing to resume. **Stop it first if you intend to restart it.**"*
2. **Fresh-spawn** fallback then fails, because the tmux session still exists.

Nothing performed the stop the error message explicitly names, so the reviewer became permanently un-re-dispatchable. The resulting loop, straight from the log:

```
Convoy sub-reviewer correctness resume failed; falling back to a fresh session: … it appears healthy …
Convoy launched for PAN-2710, but 4 reviewer(s) failed to spawn
auto-dispatched review for PAN-2710 from durable journal intent (host-side)     ← and around we go
```
No prompt delivered → no reports → synthesis declares "infrastructure failure" → `reviewStatus=failed` → deacon resets to `pending` → dispatch again. Eighteen times, each burning a review cycle (PAN-2710 reached cycle 10).

## Fix

In `spawnReviewSubRoleForIssuePromise`, when resume fails specifically with the healthy-idle collision, stop that session before the fresh spawn — exactly what the error instructs:

```ts
if (resumeResult.error?.includes('it appears healthy')) {
  await Effect.runPromise(stopAgent(reviewerAgent));
}
```

Deliberately narrow: only this explicit collision triggers a teardown. Every other resume failure already implies there is no live session, so those paths keep their existing behaviour and pay no cost.

**Known limitation:** this matches on the error string. A typed error would be sturdier, but that's a wider refactor than a strike on the drain's last blocker should carry — noting it rather than hiding it.

## Gates (run locally on this branch)
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npx vitest run tests/unit/lib/cloister src/lib/cloister/__tests__ tests/lib/cloister` — **163 files / 1485 tests passed**
- `tests/lib/cloister/review-agent.test.ts` — 60 passed, extended with coverage for the healthy-idle recycle path

## Scope

This addresses the deadlock only. Two related defects found alongside it are filed separately and deliberately left out:
- **PAN-2742** — synthesis reports reviewers as "infrastructure failure" and emits a *blocking* CHANGES REQUESTED, consuming a cycle.
- The nested error (`Failed to signal <subrole> spawn failure to agent-…-review: Agent not running`) masks the original cause and should be cleaned up.

Part of a family with PAN-2735 / PAN-2731 / PAN-2725: codex idle-liveness is unmaintained and each consumer trusts it as ground truth. The durable answer is one liveness oracle, as PAN-2735 established for the review watchdog.

Closes #2743

🤖 Generated with [Claude Code](https://claude.com/claude-code)
