### PR TITLE
fix(dashboard): align workspace spawn test with CLI invocation (red main)

### DIFF
--- a/src/dashboard/server/routes/__tests__/workspaces-rebuild-and-start.test.ts
+++ b/src/dashboard/server/routes/__tests__/workspaces-rebuild-and-start.test.ts
@@ -33,8 +33,13 @@ vi.mock('../../../../lib/activity-logger.js', () => ({
 }));
 
 import { spawnPanCommand } from '../workspaces.js';
+import { panCliInvocation } from '../../../../lib/pan-cli-invocation.js';
 
 const CHAIN = { args: ['start', 'MIN-831'], phaseLabel: 'Stack rebuilt — starting agent for MIN-831' };
+const expectedSpawn = (args: string[]) => {
+  const invocation = panCliInvocation(args);
+  return { cmd: invocation.command, args: invocation.args };
+};
 
 describe('spawnPanCommand chainOnSuccess (rebuild-and-start)', () => {
   beforeEach(() => {
@@ -51,12 +56,12 @@ describe('spawnPanCommand chainOnSuccess (rebuild-and-start)', () => {
 
     // Phase 1 fired immediately; phase 2 has not.
     expect(harness.spawnCalls).toHaveLength(1);
-    expect(harness.spawnCalls[0]).toEqual({ cmd: 'pan', args: ['workspace', 'rebuild', 'MIN-831'] });
+    expect(harness.spawnCalls[0]).toEqual(expectedSpawn(['workspace', 'rebuild', 'MIN-831']));
 
     // Rebuild succeeds → start spawns.
     harness.children[0].emit('close', 0);
     expect(harness.spawnCalls).toHaveLength(2);
-    expect(harness.spawnCalls[1]).toEqual({ cmd: 'pan', args: ['start', 'MIN-831'] });
+    expect(harness.spawnCalls[1]).toEqual(expectedSpawn(['start', 'MIN-831']));
 
     // Start succeeds → no further spawns.
     harness.children[1].emit('close', 0);


### PR DESCRIPTION
Fixes red main. **Test-only change — no production code.**

`main` has been RED since `8e458171b5` (2026-07-16T00:25Z); six commits have now landed on top of it, and the failure has begun blocking unrelated strikes (PAN-2752 correctly refused to push against a red full-suite run).

## Root cause

`panCliInvocation()` (`src/lib/pan-cli-invocation.ts`) always returns `process.execPath` + `dist/cli/index.js`:

```ts
command: runtime.nodePath ?? process.execPath,
args: [join(runtime.root ?? packageRoot, 'dist', 'cli', 'index.js'), ...args],
```

The test asserted `cmd: 'pan'` — a value no code path can ever produce. The assertion was unsatisfiable by construction and **had never passed in any environment**, CI or local. The implementation is correct (resolving through node removes the dependency on `pan` being on PATH); the test was stale, asserting a binary-resolution detail it never meant to test. Its other two cases — the real chaining intent — always passed.

`8e458171b5` (*refactor(dashboard): keep pan launcher within size guard*) routed the spawn through `spawnPanCli` to satisfy `scripts/file-size-baseline.txt` and never re-ran the affected test. It was a direct push to main with no PR and no CI before landing.

## Fix

Assert against the real invocation instead of a hardcoded literal, keeping the test's intent and making it environment-independent.

## Verification (run by the flywheel orchestrator, not taken on claim)

- `workspaces-rebuild-and-start.test.ts` — **3/3 pass** (was 1 failing)
- `npm run typecheck` — clean
- `npm run lint` — clean (ratchet + quarantine audits green)
- Test also verified passing on the merged tree

Closes PAN-2748


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated rebuild-and-start chain coverage to validate command execution using the application’s current invocation format.
  * Improved test resilience against internal command-argument transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->