### PR TITLE
fix(db): accept explicit conversation title sources

### DIFF
--- a/src/lib/database/conversations-db.ts
+++ b/src/lib/database/conversations-db.ts
@@ -18,7 +18,7 @@ export { DatabaseError };
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
-export type TitleSource = 'auto' | 'ai' | 'ai-refined' | 'manual' | 'default';
+export type TitleSource = 'auto' | 'ai' | 'ai-refined' | 'ai-explicit' | 'manual' | 'default';
 
 export interface ForkRequest {
   parentConversationName: string;
@@ -846,4 +846,3 @@ export function removeFavorite(type: FavoriteType, itemId: string): void {
   const db = getDatabase();
   db.prepare(`DELETE FROM favorites WHERE type = ? AND item_id = ?`).run(type, itemId);
 }
-

--- a/src/lib/overdeck/conversations.ts
+++ b/src/lib/overdeck/conversations.ts
@@ -102,7 +102,7 @@ export type  ConversationName = typeof ConversationName.Type;
 export const Harness     = Schema.Literals(['claude-code', 'pi', 'codex', 'kimi']);
 export type  Harness     = typeof Harness.Type;
 
-export const TitleSource = Schema.Literals(['manual', 'auto', 'ai', 'default']);
+export const TitleSource = Schema.Literals(['manual', 'auto', 'ai', 'ai-refined', 'ai-explicit', 'default']);
 export type  TitleSource = typeof TitleSource.Type;
 
 export const FavoriteType = Schema.Literals(['conversation', 'project']);

--- a/tests/unit/lib/overdeck/title-sources.test.ts
+++ b/tests/unit/lib/overdeck/title-sources.test.ts
@@ -2,13 +2,16 @@ import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { Schema } from 'effect';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  Conversation,
   canRefineTitle,
   canReplaceTitle,
   createConversation,
   getConversationByName,
+  updateConversationTitle,
   type LegacyConversation,
 } from '../../../../src/lib/overdeck/conversations.js';
 
@@ -80,13 +83,38 @@ describe('canRefineTitle', () => {
   });
 });
 
+describe('TitleSource schema', () => {
+  it.each(['ai-refined', 'ai-explicit'] as const)('decodes a conversation with title_source=%s', (titleSource) => {
+    const decodeConversation = Schema.decodeUnknownSync(Conversation);
+
+    expect(decodeConversation({
+      id: 'conversation-id',
+      name: 'schema-test',
+      cwd: '/tmp',
+      issueId: null,
+      harness: null,
+      model: null,
+      effort: null,
+      title: 'Generated title',
+      titleSource,
+      createdAt: new Date(),
+      archivedAt: null,
+      handoffDocPath: null,
+      handoffTargetConvId: null,
+      clearedToConvId: null,
+      files: [],
+    }).titleSource).toBe(titleSource);
+  });
+});
+
 describe('retitleConversation source', () => {
-  it('persists title_source as ai-explicit on successful AI summary', async () => {
+  it('overrides a manual title and protects the explicit result from auto/refine passes', async () => {
     const { retitleConversation } = await import('../../../../src/lib/overdeck/conversation-reads.js');
     const transcriptSummary = await import('../../../../src/lib/conversations/transcript-summary.js');
     vi.spyOn(transcriptSummary, 'summarizeTranscriptTitle').mockResolvedValue('OAuth login bug fix');
 
     createConversation({ name: 'retitle-ai', tmuxSession: 'conv-retitle-ai', cwd: '/tmp' });
+    updateConversationTitle('retitle-ai', 'My manual title', 'manual');
     const sessionFile = join(testHome, 'retitle-ai.jsonl');
     writeFileSync(sessionFile, JSON.stringify({ type: 'user', message: { content: 'Please help me fix the OAuth login bug' } }) + '\n');
 
@@ -94,10 +122,14 @@ describe('retitleConversation source', () => {
       resolveSessionFile: () => Promise.resolve(sessionFile),
     });
 
+    // An omitted status is serialized by the route as HTTP 200.
+    expect(result.status).toBeUndefined();
     expect(result.body).toEqual(expect.objectContaining({ title: 'OAuth login bug fix' }));
     const updated = getConversationByName('retitle-ai');
     expect(updated?.title).toBe('OAuth login bug fix');
     expect(updated?.titleSource).toBe('ai-explicit');
+    expect(canReplaceTitle(updated!)).toBe(false);
+    expect(canRefineTitle(updated!)).toBe(false);
   });
 
   it('persists title_source as ai-explicit when AI times out and deterministic fallback is used', async () => {


### PR DESCRIPTION
`retitleConversation` writes `title_source = 'ai-explicit'`, but that value was absent from both canonical `TitleSource` unions — it existed only in `LegacyTitleSource`. Every explicit "Regenerate title" click persisted an **out-of-enum value** into a column whose Effect Schema could not decode it.

That is the same class as the out-of-enum `agents`-table row that bricked dashboard boot: a strict decode over a list of rows fails on the one bad row and takes the whole list with it.

## Change

Widen both unions to match what is actually persisted. `'ai-refined'` was missing from the Schema union too, and is added for the same reason.

```diff
- export type TitleSource = 'auto' | 'ai' | 'ai-refined' | 'manual' | 'default';
+ export type TitleSource = 'auto' | 'ai' | 'ai-refined' | 'ai-explicit' | 'manual' | 'default';

- export const TitleSource = Schema.Literals(['manual', 'auto', 'ai', 'default']);
+ export const TitleSource = Schema.Literals(['manual', 'auto', 'ai', 'ai-refined', 'ai-explicit', 'default']);
```

Plus `tests/unit/lib/overdeck/title-sources.test.ts` covering the decode.

## Why widen rather than write `'ai'` instead

Writing `'ai'` would have been the smaller diff but is **wrong**: `canRefineTitle` (`conversations.ts:1432`) lists `'ai'` and `'ai-refined'` but not `'ai-explicit'`. Mapping the explicit path onto `'ai'` would make `canRefineTitle` return **true**, letting auto-refinement clobber a title the user explicitly asked for. `'ai-explicit'` is deliberately outside both `canReplaceTitle` and `canRefineTitle` so an explicitly regenerated title is protected. This change preserves that; no production behavior changes.

## On the original report

The issue began as "regenerate title should override a manually-edited title." Investigation found **that already works** — `retitleConversation` never consults `canReplaceTitle`; the `'manual'` guard is only on the auto path (`conversation-reads.ts:679,690`), and the frontend has no guard. The out-of-enum write is the real defect found underneath, and is what this PR fixes.

## Verification (run by the flywheel orchestrator, on real exit codes)

- `tests/unit/lib/overdeck/title-sources.test.ts` — **7/7 pass**
- `npm run typecheck` — **exit 0, 0 errors**

Closes PAN-2752


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking explicitly AI-generated and AI-refined conversation titles.
  * Updated conversation handling to recognize the new title-source values.

* **Bug Fixes**
  * Improved title-source validation and decoding for conversations.
  * Ensured explicitly AI-generated titles cannot be unintentionally replaced or refined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->