### PR TITLE
fix(dashboard): constrain nested conversation rows in the project tree

### DIFF
--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.test.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.test.tsx
@@ -121,8 +121,6 @@ vi.mock('../styles/command-deck.module.css', () => ({
     sessionList: 'sessionList',
     sessionNode: 'sessionNode',
     sessionNodeSelected: 'sessionNodeSelected',
-    sessionToggleSlot: 'sessionToggleSlot',
-    sessionDotSlot: 'sessionDotSlot',
     sessionIconSlot: 'sessionIconSlot',
     sessionLabel: 'sessionLabel',
     sessionModel: 'sessionModel',
@@ -1180,13 +1178,11 @@ describe('FeatureItem', () => {
     const activeLink = screen.getByTestId('conversation-42');
     expect(activeLink).toHaveAttribute('href', '/conv/42');
     expect(activeLink).toHaveTextContent('My conv');
-    expect(activeLink.children).toHaveLength(6);
-    expect(activeLink.children[0]).toHaveClass('sessionToggleSlot');
-    expect(activeLink.children[1]).toHaveClass('sessionDotSlot');
-    expect(activeLink.children[2]).toHaveClass('sessionIconSlot');
-    expect(activeLink.children[3]).toHaveClass('sessionLabel');
-    expect(activeLink.children[4]).toHaveClass('sessionStatus');
-    expect(activeLink.children[5]).toHaveClass('sessionModel');
+    expect(activeLink.children).toHaveLength(4);
+    expect(activeLink.children[0]).toHaveClass('sessionIconSlot');
+    expect(activeLink.children[1]).toHaveClass('sessionLabel');
+    expect(activeLink.children[2]).toHaveClass('sessionStatus');
+    expect(activeLink.children[3]).toHaveClass('sessionModel');
 
     const endedLink = screen.getByTestId('conversation-43');
     expect(endedLink).toHaveAttribute('href', '/conv/43');

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.test.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.test.tsx
@@ -121,6 +121,12 @@ vi.mock('../styles/command-deck.module.css', () => ({
     sessionList: 'sessionList',
     sessionNode: 'sessionNode',
     sessionNodeSelected: 'sessionNodeSelected',
+    sessionToggleSlot: 'sessionToggleSlot',
+    sessionDotSlot: 'sessionDotSlot',
+    sessionIconSlot: 'sessionIconSlot',
+    sessionLabel: 'sessionLabel',
+    sessionModel: 'sessionModel',
+    sessionStatus: 'sessionStatus',
   },
 }));
 
@@ -1174,6 +1180,13 @@ describe('FeatureItem', () => {
     const activeLink = screen.getByTestId('conversation-42');
     expect(activeLink).toHaveAttribute('href', '/conv/42');
     expect(activeLink).toHaveTextContent('My conv');
+    expect(activeLink.children).toHaveLength(6);
+    expect(activeLink.children[0]).toHaveClass('sessionToggleSlot');
+    expect(activeLink.children[1]).toHaveClass('sessionDotSlot');
+    expect(activeLink.children[2]).toHaveClass('sessionIconSlot');
+    expect(activeLink.children[3]).toHaveClass('sessionLabel');
+    expect(activeLink.children[4]).toHaveClass('sessionStatus');
+    expect(activeLink.children[5]).toHaveClass('sessionModel');
 
     const endedLink = screen.getByTestId('conversation-43');
     expect(endedLink).toHaveAttribute('href', '/conv/43');

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.tsx
@@ -1326,10 +1326,16 @@ export function FeatureItem({ feature, isSelected, onSelect, selectedSessionId, 
                     data-testid={`conversation-${conv.id}`}
                     title={conv.title ?? conv.name}
                   >
-                    <MessageSquare size={12} style={{ color: 'var(--muted-foreground)', flexShrink: 0 }} />
-                    <span style={{ fontSize: 12, fontWeight: 500 }}>{conv.title || 'Conversation'}</span>
-                    <span style={{ fontSize: 11, color: 'var(--muted-foreground)' }}>{conv.status}</span>
-                    <span style={{ fontSize: 10, color: 'var(--muted-foreground)', fontVariantNumeric: 'tabular-nums' }}>#{conv.id}</span>
+                    <span className={styles.sessionToggleSlot} />
+                    <span className={styles.sessionDotSlot} />
+                    <span className={styles.sessionIconSlot}>
+                      <MessageSquare size={12} />
+                    </span>
+                    <span className={styles.sessionLabel}>{conv.title || 'Conversation'}</span>
+                    <span className={`${styles.sessionStatus} ${styles[`sessionStatus_${conv.status}`] ?? ''}`}>
+                      {conv.status}
+                    </span>
+                    <span className={styles.sessionModel}>#{conv.id}</span>
                   </a>
                 ))}
               </>

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.tsx
@@ -1326,15 +1326,9 @@ export function FeatureItem({ feature, isSelected, onSelect, selectedSessionId, 
                     data-testid={`conversation-${conv.id}`}
                     title={conv.title ?? conv.name}
                   >
-                    <span className={styles.sessionToggleSlot} />
-                    <span className={styles.sessionDotSlot} />
-                    <span className={styles.sessionIconSlot}>
-                      <MessageSquare size={12} />
-                    </span>
+                    <span className={styles.sessionIconSlot}><MessageSquare size={12} /></span>
                     <span className={styles.sessionLabel}>{conv.title || 'Conversation'}</span>
-                    <span className={`${styles.sessionStatus} ${styles[`sessionStatus_${conv.status}`] ?? ''}`}>
-                      {conv.status}
-                    </span>
+                    <span className={`${styles.sessionStatus} ${styles[`sessionStatus_${conv.status}`] ?? ''}`}>{conv.status}</span>
                     <span className={styles.sessionModel}>#{conv.id}</span>
                   </a>
                 ))}


### PR DESCRIPTION
Fixes the garbled conversation row in the CommandDeck project tree, reported with a screenshot: the title wrapped **one word per line and broke mid-word** ("Implement / PAN- / 1228 / auto- / update") and the trailing status and id **overlapped** — `ended` painting over `#971`.

## Root cause

`FeatureItem.tsx:1326-1334` rendered the nested conversation row with **ad-hoc inline styles**, bypassing every layout guard the sibling `SessionNode` rows inherit from the shared classes. `.sessionNode` is a flex row; of the four children only the icon set `flexShrink: 0`. So the title span had no `flex`, `min-width: 0`, `overflow`, or `white-space` and collapsed below its content width (hence the mid-word breaks), while the status and id spans had no `flex-shrink: 0` and overlapped.

`.sessionLabel` (`command-deck.module.css:1129`) already carries exactly the four properties the inline-styled title lacked:

```css
flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
```

The row simply never adopted the design system.

## Change

Replace the inline styles with the existing shared classes — no new CSS, no new inline styles:

```diff
- <MessageSquare size={12} style={{ color: 'var(--muted-foreground)', flexShrink: 0 }} />
- <span style={{ fontSize: 12, fontWeight: 500 }}>{conv.title || 'Conversation'}</span>
- <span style={{ fontSize: 11, color: 'var(--muted-foreground)' }}>{conv.status}</span>
- <span style={{ fontSize: 10, ... }}>#{conv.id}</span>
+ <span className={styles.sessionIconSlot}><MessageSquare size={12} /></span>
+ <span className={styles.sessionLabel}>{conv.title || 'Conversation'}</span>
+ <span className={`${styles.sessionStatus} ${styles[`sessionStatus_${conv.status}`] ?? ''}`}>{conv.status}</span>
+ <span className={styles.sessionModel}>#{conv.id}</span>
```

The `title={conv.title ?? conv.name}` attribute is retained, so the full text stays available on hover once the label ellipsizes.

## Verification

- `src/dashboard/frontend` → `FeatureItem.test.tsx`: **51/51 pass, exit 0** (verified by the flywheel orchestrator on a real exit code, in the frontend vitest project — the root config excludes `src/dashboard/frontend/**`).
- Branch typechecks clean against current main. Its only standalone typecheck error was the inherited `dirname` bug from its merge-base `eb8f1da761`, fixed on main by `3369f78c81`; CI here runs against the merge result.

**Not yet verified: the visual result in a browser at a narrow tree width.** PAN-2753 asked for a before/after screenshot and the strike agent was killed by a provider capacity error before it could produce one. The fix is a direct adoption of the classes every sibling row already uses, so the risk is low — but a reviewer should eyeball the tree once.

Closes PAN-2753
