### PR TITLE
fix(infra): skip package lifecycle scripts in devcontainer init (PAN-2770)

### DIFF
--- a/infra/.devcontainer-template/docker-compose.devcontainer.yml.template
+++ b/infra/.devcontainer-template/docker-compose.devcontainer.yml.template
@@ -37,7 +37,9 @@ services:
         # PAN-1169: --filter leaves top-level node_modules un-hoisted on this named volume.
         # PAN-1764: retry once — install scripts fetch native prebuilds over the network
         # on a cold cache, and a transient DNS blip (EAI_AGAIN) must not hard-fail init.
-        { bun install || { echo 'bun install failed — retrying once in 5s...'; sleep 5; bun install; }; } &&
+        # Package lifecycle scripts are unnecessary here: init explicitly builds the
+        # required artifacts below, and running prepare can fail on an unlinked husky binary.
+        { bun install --ignore-scripts || { echo 'bun install failed — retrying once in 5s...'; sleep 5; bun install --ignore-scripts; }; } &&
         echo 'Rebuilding native Node.js addons...' &&
         { npm rebuild better-sqlite3 2>&1 || { echo 'WARN: better-sqlite3 rebuild failed (dev-only transitive dep via evalite; runtime uses bundled node:sqlite/bun:sqlite) — continuing init (PAN-2312).'; }; } &&
         echo 'Building contracts...' &&

--- a/tests/unit/lib/workspace/devcontainer-init-command.test.ts
+++ b/tests/unit/lib/workspace/devcontainer-init-command.test.ts
@@ -25,6 +25,14 @@ function readDevcontainerTemplate(): DevcontainerCompose {
 }
 
 describe('devcontainer init command', () => {
+  it('skips package lifecycle scripts on both dependency install attempts', () => {
+    const compose = readDevcontainerTemplate();
+    const command = compose.services?.init?.command;
+
+    expect(command).toEqual(expect.any(String));
+    expect(command?.match(/bun install --ignore-scripts/g)).toHaveLength(2);
+  });
+
   it('keeps the better-sqlite3 rebuild non-fatal', () => {
     const compose = readDevcontainerTemplate();
     const command = compose.services?.init?.command;


### PR DESCRIPTION
Workspace devcontainer `init` exits 127 because `bun install` runs the root `prepare` script (`husky`), whose binary never gets linked inside the container (`ENOENT ... failed to link package`). Init failing makes the stack unhealthy, and `pan start` then hard-refuses to spawn the work agent — a container install hiccup silently converts a planned, ready issue into one that cannot be worked.

**Currently blocking five issues:** PAN-2168, PAN-2255, PAN-2532, PAN-1966, PAN-2768.

## Change

`bun install --ignore-scripts` on both install attempts in the init command. Git hooks have no purpose inside the init container — it explicitly builds the artifacts it needs in the following steps — so lifecycle scripts are dead weight there and `prepare` was only a way to fail. Regression test asserts both attempts carry the flag.

## Verification (flywheel orchestrator, real exit codes)

- `devcontainer-init-command.test.ts` — 2/2 pass, exit 0
- `npm run typecheck` — exit 0

Note: existing workspaces keep their already-rendered compose files; they need a `pan workspace rebuild <id>` (or recreate) to pick up the template change. I'll rebuild the five blocked workspaces after merge.

Closes PAN-2770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development container setup reliability by preventing package lifecycle scripts from running during dependency installation.
  * Preserved automatic retry behavior when installation fails.

* **Tests**
  * Added coverage to verify lifecycle scripts are skipped on both installation attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->