### PR TITLE
fix(infra): repair devcontainer node_modules volume ownership (PAN-2777)

### DIFF
--- a/infra/.devcontainer-template/docker-compose.devcontainer.yml.template
+++ b/infra/.devcontainer-template/docker-compose.devcontainer.yml.template
@@ -19,6 +19,17 @@ services:
       - devnet
       - overdeck
 
+  # Docker creates named-volume roots as root. Repair ownership on every init so
+  # this also heals volumes created before PAN-2777.
+  init-perms:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    user: root
+    command: chown node:node /workspaces/overdeck/node_modules
+    volumes:
+      - container-node-modules:/workspaces/overdeck/node_modules
+
   # Init service: runs bun install + server build once for all workspaces
   # Frontend and server depend on this completing successfully
   init:
@@ -27,6 +38,9 @@ services:
       dockerfile: Dockerfile
     user: node
     working_dir: /workspaces/overdeck
+    depends_on:
+      init-perms:
+        condition: service_completed_successfully
     environment:
       - NODE_ENV=development
       - HUSKY=0
@@ -37,11 +51,9 @@ services:
         # PAN-1169: --filter leaves top-level node_modules un-hoisted on this named volume.
         # PAN-1764: retry once — install scripts fetch native prebuilds over the network
         # on a cold cache, and a transient DNS blip (EAI_AGAIN) must not hard-fail init.
-        # PAN-2777: cache and node_modules are separate mounts, so Bun's default
-        # hardlink backend cannot link packages between them. Copy files instead.
         # Package lifecycle scripts are unnecessary here: init explicitly builds the
         # required artifacts below, and running prepare can fail on an unlinked husky binary.
-        { bun install --backend=copyfile --ignore-scripts || { echo 'bun install failed — retrying once in 5s...'; sleep 5; bun install --backend=copyfile --ignore-scripts; }; } &&
+        { bun install --ignore-scripts || { echo 'bun install failed — retrying once in 5s...'; sleep 5; bun install --ignore-scripts; }; } &&
         echo 'Rebuilding native Node.js addons...' &&
         { npm rebuild better-sqlite3 2>&1 || { echo 'WARN: better-sqlite3 rebuild failed (dev-only transitive dep via evalite; runtime uses bundled node:sqlite/bun:sqlite) — continuing init (PAN-2312).'; }; } &&
         echo 'Building contracts...' &&
@@ -53,6 +65,10 @@ services:
       "
     volumes:
       - ../:/workspaces/overdeck:cached
+      # Worktree .git files point into the primary checkout's common metadata.
+      # The dashboard build reads the current commit, so expose that metadata
+      # read-only at the same absolute path used by the worktree pointer.
+      - {{PROJECT_PATH}}/.git:{{PROJECT_PATH}}/.git:ro
       # Shared host-side bun package cache (PAN-1764). Services run as `user: node`
       # (HOME=/home/node) — the old `bun-store:/root/...` named volume was never
       # read, and `docker compose down -v` (workspace rebuild) wiped it anyway.

--- a/infra/.devcontainer-template/docker-compose.devcontainer.yml.template
+++ b/infra/.devcontainer-template/docker-compose.devcontainer.yml.template
@@ -37,9 +37,11 @@ services:
         # PAN-1169: --filter leaves top-level node_modules un-hoisted on this named volume.
         # PAN-1764: retry once — install scripts fetch native prebuilds over the network
         # on a cold cache, and a transient DNS blip (EAI_AGAIN) must not hard-fail init.
+        # PAN-2777: cache and node_modules are separate mounts, so Bun's default
+        # hardlink backend cannot link packages between them. Copy files instead.
         # Package lifecycle scripts are unnecessary here: init explicitly builds the
         # required artifacts below, and running prepare can fail on an unlinked husky binary.
-        { bun install --ignore-scripts || { echo 'bun install failed — retrying once in 5s...'; sleep 5; bun install --ignore-scripts; }; } &&
+        { bun install --backend=copyfile --ignore-scripts || { echo 'bun install failed — retrying once in 5s...'; sleep 5; bun install --backend=copyfile --ignore-scripts; }; } &&
         echo 'Rebuilding native Node.js addons...' &&
         { npm rebuild better-sqlite3 2>&1 || { echo 'WARN: better-sqlite3 rebuild failed (dev-only transitive dep via evalite; runtime uses bundled node:sqlite/bun:sqlite) — continuing init (PAN-2312).'; }; } &&
         echo 'Building contracts...' &&

--- a/tests/unit/lib/workspace/devcontainer-init-command.test.ts
+++ b/tests/unit/lib/workspace/devcontainer-init-command.test.ts
@@ -25,12 +25,12 @@ function readDevcontainerTemplate(): DevcontainerCompose {
 }
 
 describe('devcontainer init command', () => {
-  it('skips package lifecycle scripts on both dependency install attempts', () => {
+  it('copies cached packages across mounts and skips lifecycle scripts on both install attempts', () => {
     const compose = readDevcontainerTemplate();
     const command = compose.services?.init?.command;
 
     expect(command).toEqual(expect.any(String));
-    expect(command?.match(/bun install --ignore-scripts/g)).toHaveLength(2);
+    expect(command?.match(/bun install --backend=copyfile --ignore-scripts/g)).toHaveLength(2);
   });
 
   it('keeps the better-sqlite3 rebuild non-fatal', () => {

--- a/tests/unit/lib/workspace/devcontainer-init-command.test.ts
+++ b/tests/unit/lib/workspace/devcontainer-init-command.test.ts
@@ -5,8 +5,15 @@ import { parse as parseYaml } from 'yaml';
 
 interface DevcontainerCompose {
   services?: {
+    'init-perms'?: {
+      user?: string;
+      command?: string;
+      volumes?: string[];
+    };
     init?: {
       command?: string;
+      depends_on?: Record<string, { condition?: string }>;
+      volumes?: string[];
     };
   };
 }
@@ -25,12 +32,29 @@ function readDevcontainerTemplate(): DevcontainerCompose {
 }
 
 describe('devcontainer init command', () => {
-  it('copies cached packages across mounts and skips lifecycle scripts on both install attempts', () => {
+  it('repairs the node_modules volume ownership before installing dependencies', () => {
+    const compose = readDevcontainerTemplate();
+    const perms = compose.services?.['init-perms'];
+    const init = compose.services?.init;
+
+    expect(perms).toMatchObject({
+      user: 'root',
+      command: 'chown node:node /workspaces/overdeck/node_modules',
+      volumes: ['container-node-modules:/workspaces/overdeck/node_modules'],
+    });
+    expect(init?.depends_on?.['init-perms']).toEqual({
+      condition: 'service_completed_successfully',
+    });
+    expect(init?.volumes).toContain('test-project_path/.git:test-project_path/.git:ro');
+  });
+
+  it('skips package lifecycle scripts on both dependency install attempts', () => {
     const compose = readDevcontainerTemplate();
     const command = compose.services?.init?.command;
 
     expect(command).toEqual(expect.any(String));
-    expect(command?.match(/bun install --backend=copyfile --ignore-scripts/g)).toHaveLength(2);
+    expect(command?.match(/bun install --ignore-scripts/g)).toHaveLength(2);
+    expect(command).not.toContain('--backend=copyfile');
   });
 
   it('keeps the better-sqlite3 rebuild non-fatal', () => {


### PR DESCRIPTION
Workspace init failed with ~1,618 `failed to link package` errors because the `container-node-modules` named volume mounts **root-owned** while init runs as `node` (uid 1000) — proven in-container: `touch node_modules/.writetest` → Permission denied. Everything downstream (bun link ENOENT/EPERM, unlinked husky, exit 127) was ownership. PAN-2770's `--ignore-scripts` was necessary but insufficient.

## Change

- New `init-perms` service: runs as root, `chown node:node /workspaces/overdeck/node_modules`, ordered before init via `depends_on: service_completed_successfully`. Runs on **every** init, so it also heals volumes created root-owned before this fix.
- First (disproven) attempt `--backend=copyfile` reverted — the final template keeps only `--ignore-scripts`.
- Read-only mount of the primary checkout's `.git` at the worktree pointer path, so in-container builds can read the current commit.
- Template test asserts the perms step exists, runs as root, and orders before install.

## Verification (flywheel orchestrator, live)

- Root cause proven in-container (root-owned mountpoint, write denied as node).
- Heal verified live on `feature-pan-2168`: volume now `node:node`, writable.
- **Full init run: exit 0** (was exit 1 with 1,618 failures).
- Template test 3/3, typecheck exit 0.

Unblocks PAN-2168, PAN-2255, PAN-2532 (with a `pan workspace render-devcontainer` re-render each). Related: #1198.

Closes PAN-2777
