### PR TITLE
fix(cloister): preserve quality-gate failure output — stop feeding agents stderr's tail (PAN-2741)

### DIFF
--- a/src/lib/cloister/validation.ts
+++ b/src/lib/cloister/validation.ts
@@ -20,6 +20,23 @@ import { GitError } from '../errors.js';
 const execAsync = promisify(exec);
 const DASHBOARD_RUNTIME_ENV_KEYS = ['API_PORT', 'PORT', 'DASHBOARD_URL'] as const;
 
+function clipGateStream(stream: string, limit: number): string {
+  const signal = stream
+    .split('\n')
+    .filter(line => !/^\s*(?:hint|warning):\s/i.test(line))
+    .join('\n');
+  if (signal.length <= limit) return signal;
+
+  const headLength = Math.floor(limit / 2);
+  const tailLength = limit - headLength;
+  return `${signal.slice(0, headLength)}\n…(${signal.length - limit} chars elided)…\n${signal.slice(-tailLength)}`;
+}
+
+function formatGateOutput(stdout: string, stderr: string): string {
+  const streams = [clipGateStream(stdout, 4000), clipGateStream(stderr, 2000)].filter(Boolean);
+  return streams.join('\n--- stderr ---\n');
+}
+
 function buildQualityGateEnv(gateEnv: Record<string, string> | undefined): NodeJS.ProcessEnv {
   const env = { ...process.env };
   for (const key of DASHBOARD_RUNTIME_ENV_KEYS) {
@@ -557,7 +574,7 @@ export const DEFAULT_GATES: Record<string, QualityGateConfig> = {
         const { stdout, stderr } = await execPromise;
         killGateProcessGroup(gatePgid);
         passedGate = true;
-        passOutput = (stdout + stderr).slice(-2000); // keep last 2KB
+        passOutput = formatGateOutput(stdout, stderr);
         break;
       } catch (error: any) {
         killGateProcessGroup(gatePgid);
@@ -584,7 +601,7 @@ export const DEFAULT_GATES: Record<string, QualityGateConfig> = {
     } else {
       const error: any = lastError;
       const durationMs = Date.now() - startTime;
-      const output = ((error.stdout || '') + (error.stderr || '')).slice(-2000);
+      const output = formatGateOutput(error.stdout || '', error.stderr || '');
       console.log(`[quality-gate] ✗ "${name}" failed (${durationMs}ms): ${error.message?.slice(0, 200)}`);
       opts.onLog?.(`✗ ${name} FAILED (${Math.round(durationMs/1000)}s): ${error.message?.slice(0, 160)}`);
       results.push({

--- a/tests/unit/lib/cloister/validation.test.ts
+++ b/tests/unit/lib/cloister/validation.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdirSync, rmSync, writeFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { runMergeValidation, autoRevertMerge } from '../../../../src/lib/cloister/validation.js';
+import { runMergeValidation, autoRevertMerge, runQualityGates } from '../../../../src/lib/cloister/validation.js';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
@@ -236,6 +236,58 @@ exit 0
       expect(result.valid).toBe(true);
       expect(result.buildPassed).toBe(null); // Skipped, not passed or failed
       expect(result.testsPassed).toBe(null); // Skipped
+    });
+  });
+
+  describe('runQualityGates', () => {
+    it('preserves stdout failure details when trailing stderr noise exceeds its budget', async () => {
+      const scriptPath = join(testDir, 'failing-gate.sh');
+      writeFileSync(
+        scriptPath,
+        `#!/bin/bash
+echo "FAIL src/example.test.ts > reports the actual assertion"
+echo "AssertionError: expected true to be false"
+for i in {1..500}; do echo "stdout filler $i"; done
+for i in {1..500}; do echo "hint: noisy git advice $i" >&2; done
+echo "stderr diagnostic survives too" >&2
+exit 1
+`,
+        { mode: 0o755 },
+      );
+
+      const [result] = await Effect.runPromise(runQualityGates({
+        test: { command: scriptPath },
+      }, testDir));
+
+      expect(result.passed).toBe(false);
+      expect(result.output).toContain('FAIL src/example.test.ts');
+      expect(result.output).toContain('AssertionError: expected true to be false');
+      expect(result.output).toContain('stderr diagnostic survives too');
+      expect(result.output).not.toContain('hint: noisy git advice');
+      expect(result.output).toContain('chars elided');
+    });
+
+    it('uses the same separate stream budgets for passing gates', async () => {
+      const scriptPath = join(testDir, 'passing-gate.sh');
+      writeFileSync(
+        scriptPath,
+        `#!/bin/bash
+echo "pass output starts here"
+for i in {1..500}; do echo "stdout filler $i"; done
+for i in {1..500}; do echo "warning: noisy tooling chatter $i" >&2; done
+echo "pass stderr diagnostic" >&2
+`,
+        { mode: 0o755 },
+      );
+
+      const [result] = await Effect.runPromise(runQualityGates({
+        test: { command: scriptPath },
+      }, testDir));
+
+      expect(result.passed).toBe(true);
+      expect(result.output).toContain('pass output starts here');
+      expect(result.output).toContain('pass stderr diagnostic');
+      expect(result.output).not.toContain('warning: noisy tooling chatter');
     });
   });
 


### PR DESCRIPTION
When a quality gate failed, the feedback stored for the work agent was `((stdout + stderr)).slice(-2000)` — the tail of whatever wrote last. For any suite that shells out to git, that tail is git's `init.defaultBranch` hint block, and vitest's actual failure report (in stdout) was silently discarded. Agents were asked to fix failures they were never shown, burned their 3 verification cycles, and latched `stuck` (PAN-2598 measured: 2,041 chars of pure git hints, zero failing test names; PAN-1491 stuck the same way).

## Change

- `formatGateOutput`: stdout and stderr clipped **separately** (4,000 / 2,000 char budgets) and labeled, so the stream that carries the failure can't be evicted by the noisier one.
- `clipGateStream`: head+tail clip with an explicit `…(N chars elided)…` marker — a test runner's failure report is near the top, its summary near the bottom; both survive. `hint:`/`warning:` noise lines filtered.
- Same treatment on the pass path (`passOutput`).
- Regression test reproduces the exact field failure: a gate whose stdout carries `FAIL`/`AssertionError` followed by 500 lines of git-hint stderr — asserts the assertion survives, the noise doesn't, and elision is marked.

## Verification (flywheel orchestrator, real exit codes)

- `validation.test.ts` — 11/11 pass, exit 0
- `npm run typecheck` — exit 0

Unblocks PAN-1491 (stuck on 3/3 verification cycles with invisible failures).

Closes PAN-2741


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quality-gate output handling by removing noisy hints and warnings.
  * Preserved important success and failure details while limiting excessive output.
  * Kept standard output and error output clearly separated for easier troubleshooting.
  * Prevented noisy error messages from obscuring key failure information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->