### PR TITLE
fix(cloister): route Codex kickoffs through app-server — stop taskless zombie spawns (PAN-2771)

### DIFF
--- a/src/lib/__tests__/agent-state-role.test.ts
+++ b/src/lib/__tests__/agent-state-role.test.ts
@@ -529,9 +529,11 @@ describe('AgentState role persistence', () => {
     rmSync(workspace, { recursive: true, force: true });
   });
 
-  it('PAN-2017: fails and stops a strike spawn when kickoff delivery fails', async () => {
+  it.each([
+    ['strike', 'strike-pan-2771'],
+    ['work', 'agent-pan-2771'],
+  ] as const)('PAN-2771: fails and stops a %s spawn when kickoff delivery fails', async (role, agentId) => {
     const workspace = mkdtempSync(join(tmpdir(), 'pan-strike-kickoff-fail-'));
-    const agentId = 'strike-pan-2017';
     const agentDir = join(tempHome, 'agents', agentId);
     const readyPath = join(agentDir, 'ready.json');
     const fifoPath = join(agentDir, 'rpc.in');
@@ -597,12 +599,12 @@ describe('AgentState role persistence', () => {
     try {
       const { getAgentStateSync, spawnAgent } = await import('../agents.js');
       const spawn = spawnAgent({
-        issueId: 'PAN-2017',
+        issueId: 'PAN-2771',
         workspace,
-        role: 'strike',
+        role,
         harness: 'ohmypi',
         model: 'claude-sonnet-4-6',
-        prompt: 'do the strike',
+        prompt: 'do the work',
       });
 
       await expect(spawn).rejects.toThrow(/kickoff delivery failed/);
@@ -617,7 +619,7 @@ describe('AgentState role persistence', () => {
         lastFailureReason: 'kickoff delivery failed',
       });
       expect(emitActivityEntry).not.toHaveBeenCalledWith(expect.objectContaining({
-        message: 'Work agent started for PAN-2017',
+        message: 'Work agent started for PAN-2771',
       }));
     } finally {
       process.env.HOME = originalHome;

--- a/src/lib/__tests__/deliver-agent-message.test.ts
+++ b/src/lib/__tests__/deliver-agent-message.test.ts
@@ -336,6 +336,70 @@ describe('initial kickoff transcript confirmation', () => {
     }
   });
 
+  it.each([
+    'spawnAgent:initial-prompt',
+    'deacon:redeliver-undelivered-kickoff',
+  ])('routes a Codex kickoff through auto delivery for %s when state selected the PTY supervisor', async (caller) => {
+    const workspace = mkdtempSync(join(tmpdir(), 'pan-codex-appserver-kickoff-'));
+    const deliver = vi.fn(async () => ({ ok: true, path: 'app-server' as const }));
+
+    try {
+      await expect(deliverInitialPromptWithRetry(
+        baseState.id,
+        'Full work instructions for PAN-2771',
+        caller,
+        'supervisor',
+        {
+          ...baseOptions,
+          getState: vi.fn(async () => ({ ...baseState, harness: 'codex', role: 'work', workspace })),
+          deliver,
+          snapshot: vi.fn(),
+        },
+      )).resolves.toMatchObject({ ok: true, path: 'app-server' });
+
+      expect(deliver).toHaveBeenCalledWith(
+        baseState.id,
+        expect.stringContaining('Read that file in full now'),
+        caller,
+        'auto',
+      );
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps strict PTY supervisor delivery for Claude Code kickoffs', async () => {
+    const deliver = vi.fn(async () => ({ ok: true, path: 'supervisor' as const }));
+    let userRecordCount = 0;
+    const snapshot = vi.fn(async () => ({
+      sessionFile: '/tmp/session.jsonl',
+      userRecordCount: userRecordCount++,
+      fileSize: 100,
+      rangeStartByte: 0,
+      readOffset: 100,
+    }));
+
+    await expect(deliverInitialPromptWithRetry(
+      baseState.id,
+      'Claude Code kickoff',
+      'spawnAgent:initial-prompt',
+      'supervisor',
+      {
+        ...baseOptions,
+        getState: vi.fn(async () => baseState),
+        deliver,
+        snapshot,
+      },
+    )).resolves.toMatchObject({ ok: true, path: 'supervisor' });
+
+    expect(deliver).toHaveBeenCalledWith(
+      baseState.id,
+      'Claude Code kickoff',
+      'spawnAgent:initial-prompt',
+      'supervisor',
+    );
+  });
+
   it('does not overwrite a work kickoff when delivering a codex role prompt in the same workspace', async () => {
     const workspace = mkdtempSync(join(tmpdir(), 'pan-codex-role-kickoff-'));
     const existingWorkPrompt = 'Full work instructions for PAN-2318';

--- a/src/lib/agents/delivery.ts
+++ b/src/lib/agents/delivery.ts
@@ -529,7 +529,15 @@ export async function deliverInitialPromptWithRetry(
     }
     try {
       const confirmationTarget = await resolveTranscriptConfirmationTarget(state);
-      const result = await deliver(agentId, deliveredPrompt, caller, deliveryMethod);
+      // Codex app-server agents do not have a PTY supervisor socket. Work-agent
+      // state can still project supervisorEnabled=true into the legacy strict
+      // `supervisor` method, so initial kickoff and Deacon redelivery must use
+      // auto routing for Codex: app-server first, then the PTY path used by
+      // Codex TUI. Claude Code keeps its strict supervisor contract.
+      const kickoffDeliveryMethod = state?.harness === 'codex'
+        ? resilientDeliveryMethod(deliveryMethod)
+        : deliveryMethod;
+      const result = await deliver(agentId, deliveredPrompt, caller, kickoffDeliveryMethod);
       if (result.ok) {
         if (!confirmationTarget) return result;
         const confirmed = await waitForTranscriptUserRecordLanding(

--- a/src/lib/agents/spawn.ts
+++ b/src/lib/agents/spawn.ts
@@ -753,11 +753,8 @@ export async function spawnAgent(options: SpawnOptions): Promise<AgentState> {
       console.error(`[${agentId}] ohmypi prompt delivery failed:`, err instanceof Error ? err.message : String(err));
       if (tracksKickoffDelivery) {
         await recordKickoffDeliveryFailure(state, options.issueId, role);
-        if (role === 'strike') {
-          await Effect.runPromise(stopAgent(agentId));
-          throw new Error(`Agent ${agentId} kickoff delivery failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-        return state;
+        await Effect.runPromise(stopAgent(agentId));
+        throw new Error(`Agent ${agentId} kickoff delivery failed: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
   } else if (prompt) {
@@ -775,11 +772,8 @@ export async function spawnAgent(options: SpawnOptions): Promise<AgentState> {
         await recordStartupSessionExit(state, options.issueId, role);
       }
       await recordKickoffDeliveryFailure(state, options.issueId, role);
-      if (role === 'strike') {
-        await Effect.runPromise(stopAgent(agentId));
-        throw new Error(`Agent ${agentId} kickoff delivery failed: ${delivery.failure ?? 'unknown error'}`);
-      }
-      return state;
+      await Effect.runPromise(stopAgent(agentId));
+      throw new Error(`Agent ${agentId} kickoff delivery failed: ${delivery.failure ?? 'unknown error'}`);
     }
   }
 


### PR DESCRIPTION
Every codex app-server work agent spawned tonight received no kickoff: delivery targeted the PTY supervisor socket (`socket-missing` on every attempt — spawn AND deacon redelivery), which is the Claude Code transport; codex app-server agents don't have one. The agents then idled forever as `status: running`. Seven issues were paralyzed at the starting line: PAN-1966, 2168, 2255, 2532, 2698, 2702, 2768. Proof by contrast: strike spawns use the app-server path and every strike delivered fine.

## Change

- Codex agents' kickoff (and deacon redelivery) use resilient/auto routing — app-server first, then the Codex-TUI PTY path. Claude Code keeps its strict supervisor contract.
- Kickoff delivery failure now stops the agent and fails the spawn loudly for ALL roles (was strike-only) — no more running-but-taskless zombies.
- 64-test delivery suite covering the routing.

## Verification (flywheel orchestrator, real exit codes)

- delivery + role suites: 64/64, exit 0
- typecheck: exit 0
- Post-merge live proof planned: deploy, then `pan start` a codex work agent and confirm `kickoffDelivered=true` with a `userMessage` in its `appserver-events.jsonl`.

Closes PAN-2771
