### PR TITLE
fix(cloister): preserve auto routing for Codex kickoff (PAN-2781)

### DIFF
--- a/src/lib/__tests__/deliver-agent-message.test.ts
+++ b/src/lib/__tests__/deliver-agent-message.test.ts
@@ -348,10 +348,16 @@ describe('initial kickoff transcript confirmation', () => {
         baseState.id,
         'Full work instructions for PAN-2771',
         caller,
-        'supervisor',
+        undefined,
         {
           ...baseOptions,
-          getState: vi.fn(async () => ({ ...baseState, harness: 'codex', role: 'work', workspace })),
+          getState: vi.fn(async () => ({
+            ...baseState,
+            harness: 'codex',
+            role: 'work',
+            workspace,
+            deliveryMethod: 'supervisor',
+          })),
           deliver,
           snapshot: vi.fn(),
         },

--- a/src/lib/agents/delivery.ts
+++ b/src/lib/agents/delivery.ts
@@ -531,11 +531,13 @@ export async function deliverInitialPromptWithRetry(
       const confirmationTarget = await resolveTranscriptConfirmationTarget(state);
       // Codex app-server agents do not have a PTY supervisor socket. Work-agent
       // state can still project supervisorEnabled=true into the legacy strict
-      // `supervisor` method, so initial kickoff and Deacon redelivery must use
-      // auto routing for Codex: app-server first, then the PTY path used by
-      // Codex TUI. Claude Code keeps its strict supervisor contract.
+      // `supervisor` method. Resolve the persisted method here before forcing
+      // resilient routing; passing undefined would let deliverAgentMessage
+      // re-read that strict method and abort the cascade. Initial kickoff and
+      // Deacon redelivery use app-server first, then the PTY path used by Codex
+      // TUI. Claude Code keeps its strict supervisor contract.
       const kickoffDeliveryMethod = state?.harness === 'codex'
-        ? resilientDeliveryMethod(deliveryMethod)
+        ? resilientDeliveryMethod(deliveryMethod ?? state.deliveryMethod)
         : deliveryMethod;
       const result = await deliver(agentId, deliveredPrompt, caller, kickoffDeliveryMethod);
       if (result.ok) {


### PR DESCRIPTION
PAN-2771's routing fix never engaged at runtime: the kickoff call site passes deliveryMethod=undefined, so resilientDeliveryMethod(undefined) returned undefined and deliverAgentMessage re-read the agent's persisted strict 'supervisor' method — aborting the auto cascade with the supervisor tier's throw. Now the persisted method is resolved before forcing resilient routing.

Verified: delivery suite 36/36 exit 0, typecheck exit 0. Post-merge live proof: pan start a codex work agent → kickoffDelivered=true + userMessage in appserver-events.jsonl.

Strike agent was reaped mid-work by the PAN-2757 reaper 15s after its last event; work rescued from its workspace commit a6c3fee207.

Closes PAN-2781