### PR TITLE
PAN-2698

### DIFF
--- a/configuration/harnesses.mdx
+++ b/configuration/harnesses.mdx
@@ -66,6 +66,9 @@ skills, MCP, and AGENTS.md — see the [Harness Landscape](/reference/harness-la
   (`src/lib/cost-parsers/codex-parser.ts`).
 - Native AGENTS.md and Claude-Code-compatible skills; `pan sync` distributes
   context layers and skills to it like any other harness.
+- Role-declared MCP servers, such as Playwright for the `test` role, are
+  provisioned as `[mcp_servers.<name>]` entries in the per-agent Codex config
+  so browser UAT can run on Codex.
 
 ## Installing oh-my-pi
 

--- a/docs/ROLES.md
+++ b/docs/ROLES.md
@@ -89,6 +89,26 @@ For a Role with no Claude-specific frontmatter (the review convoy sub-roles), th
 
 **Source of truth. Never deleted. Lives in the repo.**
 
+### Role MCP servers
+
+Top-level role files declare MCP servers in `mcpServers`, a YAML list of single-key maps. For example, `roles/test.md` declares Playwright as:
+
+```yaml
+mcpServers:
+  - playwright:
+      type: stdio
+      command: npx
+      args:
+        - "-y"
+        - "@playwright/mcp@latest"
+```
+
+Overdeck renders this declaration for each harness:
+
+- **Claude Code** gets a generated `--mcp-config` JSON file and an `mcp__<name>` entry in `--allowedTools` (PAN-2090).
+- **Codex** gets `[mcp_servers.<name>]` entries in the agent's `codex-home/config.toml`. Overdeck rewrites the entries on spawn, resume, and recovery so relaunching a role preserves its tools (PAN-2698).
+- **ohmypi** cannot provision role MCP servers. Overdeck logs a spawn-time warning that names every unavailable server.
+
 ### 2. Overdeck pipeline agent — `agents/pan-*-agent.md`
 
 Claude Code subagent definitions used by Overdeck's pipeline. These are committed under `agents/` in the overdeck repo and synced to every devroot's `<devroot>/.claude/agents/` by `pan install` / `pan sync`. From there, `mergeSkillsIntoWorkspace()` copies them into each workspace's `.claude/agents/` so Claude Code can load them when a pipeline run uses the `--agent` flag.

--- a/docs/ROLES.md
+++ b/docs/ROLES.md
@@ -100,8 +100,10 @@ mcpServers:
       command: npx
       args:
         - "-y"
-        - "@playwright/mcp@latest"
+        - "@playwright/mcp@0.0.78"
 ```
+
+Executable npm MCP declarations must use an exact version. npm checks the package's registry-published integrity digest, and Codex skips mutable tags, ranges, and unversioned `npx` selectors.
 
 Overdeck renders this declaration for each harness:
 

--- a/roles/test.md
+++ b/roles/test.md
@@ -17,7 +17,9 @@ mcpServers:
       command: npx
       args:
         - "-y"
-        - "@playwright/mcp@latest"
+        # Exact version; npm verifies the registry's published sha512 integrity:
+        # XLTUeA6mEN9sQ+hJ4dfG8EIkDbxS0K3Trc2RBkUJuf02TgE2FQRNTMtq/aJfhyRMINsRl/Ybc4sxcWLtFn4/TQ==
+        - "@playwright/mcp@0.0.78"
 hooks:
   PreToolUse:
     - matcher: ".*"

--- a/src/lib/agents/__tests__/role-mcp-parser.test.ts
+++ b/src/lib/agents/__tests__/role-mcp-parser.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { parseRoleMcpServersSync, roleSystemPromptInjectionSync } from '../runtime-command.js';
+import { getCodexLauncherFields, parseRoleMcpServersSync, roleSystemPromptInjectionSync } from '../runtime-command.js';
 
 const ROLE = `---
 name: test
@@ -23,16 +23,21 @@ Test role body.
 describe('parseRoleMcpServersSync', () => {
   let tempDir: string;
   let previousOverdeckHome: string | undefined;
+  let previousHome: string | undefined;
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'role-mcp-parser-'));
     previousOverdeckHome = process.env.OVERDECK_HOME;
+    previousHome = process.env.HOME;
     process.env.OVERDECK_HOME = tempDir;
+    process.env.HOME = tempDir;
   });
 
   afterEach(() => {
     if (previousOverdeckHome === undefined) delete process.env.OVERDECK_HOME;
     else process.env.OVERDECK_HOME = previousOverdeckHome;
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
     rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -72,5 +77,22 @@ describe('parseRoleMcpServersSync', () => {
     expect(JSON.parse(readFileSync(mcpPath, 'utf8'))).toEqual({
       mcpServers: parseRoleMcpServersSync(rolePath),
     });
+  });
+
+  it('preserves role MCP servers across Codex home rewrites', () => {
+    const fields = getCodexLauncherFields('agent-test-mcp', 'gpt-5.6', tempDir, 'test');
+    getCodexLauncherFields('agent-test-mcp', 'gpt-5.6', tempDir, 'test');
+
+    const config = readFileSync(join(fields.codexHome, 'config.toml'), 'utf8');
+    expect(config).toContain('[mcp_servers.playwright]');
+    expect(config).toContain('command = "npx"');
+    expect(config).toContain('args = ["-y", "@playwright/mcp@latest"]');
+  });
+
+  it('writes no MCP section for a role without declared servers', () => {
+    const fields = getCodexLauncherFields('agent-work-no-mcp', 'gpt-5.6', tempDir, 'work');
+    const config = readFileSync(join(fields.codexHome, 'config.toml'), 'utf8');
+
+    expect(config).not.toContain('[mcp_servers');
   });
 });

--- a/src/lib/agents/__tests__/role-mcp-parser.test.ts
+++ b/src/lib/agents/__tests__/role-mcp-parser.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { parseRoleMcpServersSync, roleSystemPromptInjectionSync } from '../runtime-command.js';
+
+const ROLE = `---
+name: test
+tools:
+  - Read
+  - Bash
+mcpServers:
+  - playwright:
+      type: stdio
+      command: npx
+      args:
+        - "-y"
+        - "@playwright/mcp@latest"
+---
+Test role body.
+`;
+
+describe('parseRoleMcpServersSync', () => {
+  let tempDir: string;
+  let previousOverdeckHome: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'role-mcp-parser-'));
+    previousOverdeckHome = process.env.OVERDECK_HOME;
+    process.env.OVERDECK_HOME = tempDir;
+  });
+
+  afterEach(() => {
+    if (previousOverdeckHome === undefined) delete process.env.OVERDECK_HOME;
+    else process.env.OVERDECK_HOME = previousOverdeckHome;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('flattens the test role Playwright server definition', () => {
+    const rolePath = join(tempDir, 'test.md');
+    writeFileSync(rolePath, ROLE);
+
+    expect(parseRoleMcpServersSync(rolePath)).toEqual({
+      playwright: {
+        type: 'stdio',
+        command: 'npx',
+        args: ['-y', '@playwright/mcp@latest'],
+      },
+    });
+  });
+
+  it('returns an empty record for missing, absent, or malformed frontmatter', () => {
+    const absentPath = join(tempDir, 'absent.md');
+    const malformedPath = join(tempDir, 'malformed.md');
+    writeFileSync(absentPath, 'No frontmatter here.');
+    writeFileSync(malformedPath, '---\nmcpServers: [\n---\nBody');
+
+    expect(parseRoleMcpServersSync(join(tempDir, 'missing.md'))).toEqual({});
+    expect(parseRoleMcpServersSync(absentPath)).toEqual({});
+    expect(parseRoleMcpServersSync(malformedPath)).toEqual({});
+  });
+
+  it('preserves Claude role MCP config and allowed-tools flags', () => {
+    const rolePath = join(tempDir, 'test.md');
+    writeFileSync(rolePath, ROLE);
+
+    const flags = roleSystemPromptInjectionSync(rolePath);
+    const mcpPath = join(tempDir, 'role-prompts', 'test.mcp.json');
+
+    expect(flags).toContain(` --mcp-config '${mcpPath}'`);
+    expect(flags).toContain(" --allowedTools 'Read,Bash,mcp__playwright'");
+    expect(JSON.parse(readFileSync(mcpPath, 'utf8'))).toEqual({
+      mcpServers: parseRoleMcpServersSync(rolePath),
+    });
+  });
+});

--- a/src/lib/agents/__tests__/role-mcp-parser.test.ts
+++ b/src/lib/agents/__tests__/role-mcp-parser.test.ts
@@ -15,7 +15,7 @@ mcpServers:
       command: npx
       args:
         - "-y"
-        - "@playwright/mcp@latest"
+        - "@playwright/mcp@0.0.78"
 ---
 Test role body.
 `;
@@ -49,7 +49,7 @@ describe('parseRoleMcpServersSync', () => {
       playwright: {
         type: 'stdio',
         command: 'npx',
-        args: ['-y', '@playwright/mcp@latest'],
+        args: ['-y', '@playwright/mcp@0.0.78'],
       },
     });
   });
@@ -86,7 +86,7 @@ describe('parseRoleMcpServersSync', () => {
     const config = readFileSync(join(fields.codexHome, 'config.toml'), 'utf8');
     expect(config).toContain('[mcp_servers.playwright]');
     expect(config).toContain('command = "npx"');
-    expect(config).toContain('args = ["-y", "@playwright/mcp@latest"]');
+    expect(config).toContain('args = ["-y", "@playwright/mcp@0.0.78"]');
   });
 
   it('writes no MCP section for a role without declared servers', () => {

--- a/src/lib/agents/__tests__/role-mcp-parser.test.ts
+++ b/src/lib/agents/__tests__/role-mcp-parser.test.ts
@@ -1,8 +1,8 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { getCodexLauncherFields, parseRoleMcpServersSync, roleSystemPromptInjectionSync } from '../runtime-command.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getCodexLauncherFields, getRoleRuntimeBaseCommand, parseRoleMcpServersSync, roleSystemPromptInjectionSync } from '../runtime-command.js';
 
 const ROLE = `---
 name: test
@@ -94,5 +94,27 @@ describe('parseRoleMcpServersSync', () => {
     const config = readFileSync(join(fields.codexHome, 'config.toml'), 'utf8');
 
     expect(config).not.toContain('[mcp_servers');
+  });
+
+  it('warns when ohmypi cannot provision a role MCP server', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const command = await getRoleRuntimeBaseCommand('gpt-5.6', 'agent-test', 'test', 'ohmypi');
+
+    expect(command).toBe("omp --mode rpc --model 'gpt-5.6'");
+    expect(warn).toHaveBeenCalledWith(
+      "[spawn] role 'test' declares MCP servers (playwright) but harness 'ohmypi' does not provision MCP — those tools will be unavailable",
+    );
+    warn.mockRestore();
+  });
+
+  it('does not warn for roles without MCP or harnesses that provision it', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await getRoleRuntimeBaseCommand('gpt-5.6', 'agent-work', 'work', 'ohmypi');
+    await getRoleRuntimeBaseCommand('gpt-5.6', 'agent-test', 'test', 'codex');
+
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/src/lib/agents/messaging.ts
+++ b/src/lib/agents/messaging.ts
@@ -251,7 +251,7 @@ export async function messageAgent(
       ? await getOhmypiLauncherFields(normalizedId, resumeModel)
       : {};
     const fallbackCodexFields = fallbackHarness === 'codex'
-      ? getCodexLauncherFields(normalizedId, resumeModel, agentState.workspace)
+      ? getCodexLauncherFields(normalizedId, resumeModel, agentState.workspace, resumeRole)
       : {};
     const fallbackSupervisorLaunch = await prepareSupervisorForRelaunch(normalizedId, agentState, resumeModel, fallbackHarness);
     const fallbackContent = generateLauncherScriptSync({

--- a/src/lib/agents/recovery.ts
+++ b/src/lib/agents/recovery.ts
@@ -353,7 +353,7 @@ export async function recoverAgent(
   }
 
   const recoveryCodexFields = recoveryHarness === 'codex'
-    ? getCodexLauncherFields(normalizedId, state.model, state.workspace)
+    ? getCodexLauncherFields(normalizedId, state.model, state.workspace, recoveryRole)
     : {};
   const recoveryLauncherContent = generateLauncherScriptSync({
     role: recoveryRole,

--- a/src/lib/agents/runtime-command.ts
+++ b/src/lib/agents/runtime-command.ts
@@ -812,6 +812,10 @@ export async function getRoleRuntimeBaseCommand(
   const quotedModel = shellQuoteModelIdSync(validatedModel);
   const behavior = getHarnessBehavior(harness);
   if (behavior.launchCommandKind === 'ohmypi-rpc') {
+    const mcpNames = Object.keys(parseRoleMcpServersSync(roleAgentDefinitionPath(role)));
+    if (mcpNames.length > 0) {
+      console.warn(`[spawn] role '${role}' declares MCP servers (${mcpNames.join(', ')}) but harness 'ohmypi' does not provision MCP — those tools will be unavailable`);
+    }
     return `omp --mode rpc --model ${quotedModel}`;
   }
   if (behavior.launchCommandKind === 'codex-work-tui') {

--- a/src/lib/agents/runtime-command.ts
+++ b/src/lib/agents/runtime-command.ts
@@ -212,7 +212,7 @@ export async function getOhmypiLauncherFields(agentId: string, model: string): P
   };
 }
 
-export function getCodexLauncherFields(agentId: string, model: string, workspacePath?: string): {
+export function getCodexLauncherFields(agentId: string, model: string, workspacePath?: string, role?: Role): {
   harness: 'codex';
   codexMode: 'app-server' | 'work-tui';
   codexHome: string;
@@ -240,6 +240,7 @@ export function getCodexLauncherFields(agentId: string, model: string, workspace
     approvalPolicy,
     sandboxMode,
     approvalsReviewer,
+    mcpServers: role ? parseRoleMcpServersSync(roleAgentDefinitionPath(role)) : undefined,
   });
   return {
     harness: 'codex',

--- a/src/lib/agents/runtime-command.ts
+++ b/src/lib/agents/runtime-command.ts
@@ -33,6 +33,43 @@ import { CLI_PROXY_MODEL_ALIASES } from './provider-env.js';
 const execAsync = promisify(exec);
 const missingRoleDefinitionWarnings = new Set<string>();
 
+export interface RoleMcpServerDef {
+  type?: string;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+/** Parse and flatten a role definition's mcpServers frontmatter. */
+export function parseRoleMcpServersSync(definitionPath: string): Record<string, RoleMcpServerDef> {
+  const abs = resolve(definitionPath);
+  if (!existsSync(abs)) return {};
+
+  const raw = readFileSync(abs, 'utf8');
+  const fm = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!fm) return {};
+
+  try {
+    const frontmatter = parseYaml(fm[1]);
+    if (!frontmatter || typeof frontmatter !== 'object') return {};
+    const entries = (frontmatter as Record<string, unknown>).mcpServers;
+    if (!Array.isArray(entries)) return {};
+
+    const servers: Record<string, RoleMcpServerDef> = {};
+    for (const entry of entries) {
+      if (!entry || typeof entry !== 'object') continue;
+      for (const [name, definition] of Object.entries(entry as Record<string, unknown>)) {
+        if (definition && typeof definition === 'object') {
+          servers[name] = definition as RoleMcpServerDef;
+        }
+      }
+    }
+    return servers;
+  } catch {
+    return {};
+  }
+}
+
 /**
  * Write an agent launcher script atomically. Every agent shares a fixed
  * `launcher.sh` path inside its agent dir, and spawn/resume/restart paths can
@@ -739,22 +776,12 @@ export function roleSystemPromptInjectionSync(definitionPath: string, explicitEf
   // into one { mcpServers: { name: def } } config loaded via --mcp-config. It is
   // additive (the launcher's channels --mcp-config still applies; no
   // --strict-mcp-config), so the role keeps any project/global MCP servers too.
-  const mcpNames: string[] = [];
-  if (Array.isArray(frontmatter.mcpServers) && frontmatter.mcpServers.length > 0) {
-    const servers: Record<string, unknown> = {};
-    for (const entry of frontmatter.mcpServers) {
-      if (entry && typeof entry === 'object') {
-        for (const [name, def] of Object.entries(entry as Record<string, unknown>)) {
-          servers[name] = def;
-          mcpNames.push(name);
-        }
-      }
-    }
-    if (Object.keys(servers).length > 0) {
-      const mcpPath = join(dir, `${stem}.mcp.json`);
-      writeFileSync(mcpPath, JSON.stringify({ mcpServers: servers }, null, 2));
-      flags.push(` --mcp-config '${mcpPath}'`);
-    }
+  const servers = parseRoleMcpServersSync(definitionPath);
+  const mcpNames = Object.keys(servers);
+  if (mcpNames.length > 0) {
+    const mcpPath = join(dir, `${stem}.mcp.json`);
+    writeFileSync(mcpPath, JSON.stringify({ mcpServers: servers }, null, 2));
+    flags.push(` --mcp-config '${mcpPath}'`);
   }
 
   // tools: allow-list → --allowedTools (comma-joined single arg so the variadic

--- a/src/lib/agents/spawn-prep.ts
+++ b/src/lib/agents/spawn-prep.ts
@@ -478,7 +478,7 @@ export async function buildAgentLaunchConfig(opts: {
     ? await getOhmypiLauncherFields(opts.agentId, model)
     : {};
   const codexLauncherFields = behavior.usesCodexHome
-    ? getCodexLauncherFields(opts.agentId, model, opts.workspace)
+    ? getCodexLauncherFields(opts.agentId, model, opts.workspace, launchRole)
     : {};
 
   if (opts.spawnMode === 'resume' && opts.resumeSessionId) {

--- a/src/lib/agents/spawn.ts
+++ b/src/lib/agents/spawn.ts
@@ -253,7 +253,7 @@ export async function spawnRun(issueId: string, role: Role, options: SpawnRunOpt
     ? await getOhmypiLauncherFields(agentId, selectedModel)
     : {};
   const codexLauncherFields = resolvedHarness === 'codex'
-    ? getCodexLauncherFields(agentId, selectedModel, workspace)
+    ? getCodexLauncherFields(agentId, selectedModel, workspace, role)
     : {};
 
   // Create a conversation record for every specialist role — sub-role reviewers,

--- a/src/lib/planning/spawn-planning-session.ts
+++ b/src/lib/planning/spawn-planning-session.ts
@@ -661,7 +661,7 @@ export async function spawnPlanningSession(opts: SpawnPlanningOptions): Promise<
       ? await getOhmypiLauncherFields(sessionName, planningModel)
       : {};
     const codexLauncherFields = behavior.usesCodexHome
-      ? getCodexLauncherFields(sessionName, planningModel, workspacePath)
+      ? getCodexLauncherFields(sessionName, planningModel, workspacePath, 'plan')
       : {};
 
     const providerExports = await getProviderExportsForModel(planningModel);

--- a/src/lib/runtimes/__tests__/codex.test.ts
+++ b/src/lib/runtimes/__tests__/codex.test.ts
@@ -148,7 +148,7 @@ describe('initCodexHome', () => {
     const codexDir = join(ctx.codexHome, 'agent-init-mcp')
     initCodexHome(codexDir, {
       mcpServers: {
-        playwright: { type: 'stdio', command: 'npx', args: ['-y', '@playwright/mcp@latest'] },
+        playwright: { type: 'stdio', command: 'npx', args: ['-y', '@playwright/mcp@0.0.78'] },
         'quoted.server': {
           command: 'path\\to"command',
           args: ['arg\\with"quotes'],
@@ -159,7 +159,7 @@ describe('initCodexHome', () => {
 
     const { readFileSync: readNode } = require('node:fs')
     const config = readNode(join(codexDir, 'config.toml'), 'utf8')
-    expect(config).toContain('[mcp_servers.playwright]\ncommand = "npx"\nargs = ["-y", "@playwright/mcp@latest"]')
+    expect(config).toContain('[mcp_servers.playwright]\ncommand = "npx"\nargs = ["-y", "@playwright/mcp@0.0.78"]')
     expect(config).toContain('[mcp_servers."quoted.server"]')
     expect(config).toContain('command = "path\\\\to\\"command"')
     expect(config).toContain('args = ["arg\\\\with\\"quotes"]')
@@ -176,6 +176,21 @@ describe('initCodexHome', () => {
     const config = readNode(join(codexDir, 'config.toml'), 'utf8')
     expect(config).not.toContain('[mcp_servers')
     expect(warn).toHaveBeenCalledWith('[codex] skipping MCP server "remote" — only stdio command servers are provisioned into codex config')
+    warn.mockRestore()
+  })
+
+  it('rejects mutable npx MCP package selectors', () => {
+    const codexDir = join(ctx.codexHome, 'agent-init-mcp-mutable')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    initCodexHome(codexDir, {
+      mcpServers: { playwright: { command: 'npx', args: ['-y', '@playwright/mcp@latest'] } },
+    })
+
+    const { readFileSync: readNode } = require('node:fs')
+    const config = readNode(join(codexDir, 'config.toml'), 'utf8')
+    expect(config).not.toContain('[mcp_servers.playwright]')
+    expect(warn).toHaveBeenCalledWith('[codex] skipping MCP server "playwright" — npx MCP packages must use an exact immutable version')
     warn.mockRestore()
   })
 

--- a/src/lib/runtimes/__tests__/codex.test.ts
+++ b/src/lib/runtimes/__tests__/codex.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -124,6 +124,7 @@ describe('initCodexHome', () => {
     // nudge that freezes an unattended pipeline agent's pane.
     expect(config).toContain('[notice]')
     expect(config).toContain('hide_rate_limit_model_nudge = true')
+    expect(config).not.toContain('[mcp_servers')
   })
 
   it('pre-seeds folder trust and autonomy so the TUI skips its first-run wizard', () => {
@@ -141,6 +142,41 @@ describe('initCodexHome', () => {
     // it suppresses the wizard on a fresh per-agent CODEX_HOME.
     expect(config).toContain('[projects."/home/eltmon/Projects/overdeck"]')
     expect(config).toContain('trust_level = "trusted"')
+  })
+
+  it('writes stdio MCP servers with escaped args, environment, and quoted names', () => {
+    const codexDir = join(ctx.codexHome, 'agent-init-mcp')
+    initCodexHome(codexDir, {
+      mcpServers: {
+        playwright: { type: 'stdio', command: 'npx', args: ['-y', '@playwright/mcp@latest'] },
+        'quoted.server': {
+          command: 'path\\to"command',
+          args: ['arg\\with"quotes'],
+          env: { 'API"KEY': 'value\\path' },
+        },
+      },
+    })
+
+    const { readFileSync: readNode } = require('node:fs')
+    const config = readNode(join(codexDir, 'config.toml'), 'utf8')
+    expect(config).toContain('[mcp_servers.playwright]\ncommand = "npx"\nargs = ["-y", "@playwright/mcp@latest"]')
+    expect(config).toContain('[mcp_servers."quoted.server"]')
+    expect(config).toContain('command = "path\\\\to\\"command"')
+    expect(config).toContain('args = ["arg\\\\with\\"quotes"]')
+    expect(config).toContain('env = { "API\\"KEY" = "value\\\\path" }')
+  })
+
+  it('omits unsupported MCP servers and warns with their name', () => {
+    const codexDir = join(ctx.codexHome, 'agent-init-mcp-unsupported')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    initCodexHome(codexDir, { mcpServers: { remote: { type: 'http' } } })
+
+    const { readFileSync: readNode } = require('node:fs')
+    const config = readNode(join(codexDir, 'config.toml'), 'utf8')
+    expect(config).not.toContain('[mcp_servers')
+    expect(warn).toHaveBeenCalledWith('[codex] skipping MCP server "remote" — only stdio command servers are provisioned into codex config')
+    warn.mockRestore()
   })
 
   it('symlinks auth.json to the global ~/.codex so all agents share one token family (PAN-2285)', () => {

--- a/src/lib/runtimes/__tests__/codex.test.ts
+++ b/src/lib/runtimes/__tests__/codex.test.ts
@@ -150,6 +150,7 @@ describe('initCodexHome', () => {
       mcpServers: {
         playwright: { type: 'stdio', command: 'npx', args: ['-y', '@playwright/mcp@0.0.78'] },
         'quoted.server': {
+          type: 'stdio',
           command: 'path\\to"command',
           args: ['arg\\with"quotes'],
           env: { 'API"KEY': 'value\\path' },
@@ -170,7 +171,7 @@ describe('initCodexHome', () => {
     const codexDir = join(ctx.codexHome, 'agent-init-mcp-unsupported')
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
 
-    initCodexHome(codexDir, { mcpServers: { remote: { type: 'http' } } })
+    initCodexHome(codexDir, { mcpServers: { remote: { type: 'http', command: 'proxy' } } })
 
     const { readFileSync: readNode } = require('node:fs')
     const config = readNode(join(codexDir, 'config.toml'), 'utf8')
@@ -184,7 +185,7 @@ describe('initCodexHome', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
 
     initCodexHome(codexDir, {
-      mcpServers: { playwright: { command: 'npx', args: ['-y', '@playwright/mcp@latest'] } },
+      mcpServers: { playwright: { type: 'stdio', command: 'npx', args: ['-y', '@playwright/mcp@latest'] } },
     })
 
     const { readFileSync: readNode } = require('node:fs')

--- a/src/lib/runtimes/codex.ts
+++ b/src/lib/runtimes/codex.ts
@@ -48,6 +48,12 @@ function escapeTomlBasicString(value: string): string {
   return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
 }
 
+function hasImmutableNpxPackageSelector(args: string[] | undefined): boolean {
+  const selector = args?.find(arg => !arg.startsWith('-'))
+  if (!selector) return false
+  return /^(?:@[^/]+\/[^@]+|[^@/][^@]*)@\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(selector)
+}
+
 export interface CodexMcpServerDef {
   type?: string
   command?: string
@@ -343,6 +349,10 @@ export function initCodexHome(codexHomeDir: string, opts: InitCodexHomeOpts = {}
     for (const [name, definition] of Object.entries(opts.mcpServers ?? {})) {
       if (typeof definition.command !== 'string' || definition.command.length === 0) {
         console.warn(`[codex] skipping MCP server "${name}" — only stdio command servers are provisioned into codex config`)
+        continue
+      }
+      if (definition.command === 'npx' && !hasImmutableNpxPackageSelector(definition.args)) {
+        console.warn(`[codex] skipping MCP server "${name}" — npx MCP packages must use an exact immutable version`)
         continue
       }
 

--- a/src/lib/runtimes/codex.ts
+++ b/src/lib/runtimes/codex.ts
@@ -347,7 +347,7 @@ export function initCodexHome(codexHomeDir: string, opts: InitCodexHomeOpts = {}
       lines.push('', `[projects."${escaped}"]`, 'trust_level = "trusted"')
     }
     for (const [name, definition] of Object.entries(opts.mcpServers ?? {})) {
-      if (typeof definition.command !== 'string' || definition.command.length === 0) {
+      if (definition.type !== 'stdio' || typeof definition.command !== 'string' || definition.command.length === 0) {
         console.warn(`[codex] skipping MCP server "${name}" — only stdio command servers are provisioned into codex config`)
         continue
       }

--- a/src/lib/runtimes/codex.ts
+++ b/src/lib/runtimes/codex.ts
@@ -44,6 +44,17 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
 
+function escapeTomlBasicString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
+
+export interface CodexMcpServerDef {
+  type?: string
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+}
+
 function overdeckDir(): string {
   return join(homedir(), '.overdeck')
 }
@@ -275,6 +286,7 @@ export interface InitCodexHomeOpts {
   approvalPolicy?: string
   sandboxMode?: string
   approvalsReviewer?: string
+  mcpServers?: Record<string, CodexMcpServerDef>
 }
 
 /**
@@ -325,8 +337,28 @@ export function initCodexHome(codexHomeDir: string, opts: InitCodexHomeOpts = {}
     if (opts.trustedDir) {
       // Pre-seed folder trust so the TUI skips its first-run autonomy wizard.
       // TOML basic-string key: escape backslashes and double-quotes in the path.
-      const escaped = opts.trustedDir.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+      const escaped = escapeTomlBasicString(opts.trustedDir)
       lines.push('', `[projects."${escaped}"]`, 'trust_level = "trusted"')
+    }
+    for (const [name, definition] of Object.entries(opts.mcpServers ?? {})) {
+      if (typeof definition.command !== 'string' || definition.command.length === 0) {
+        console.warn(`[codex] skipping MCP server "${name}" — only stdio command servers are provisioned into codex config`)
+        continue
+      }
+
+      const escapedName = escapeTomlBasicString(name)
+      const sectionKey = /^[A-Za-z0-9_-]+$/.test(name) ? name : `"${escapedName}"`
+      lines.push('', `[mcp_servers.${sectionKey}]`)
+      lines.push(`command = "${escapeTomlBasicString(definition.command)}"`)
+      const args = definition.args?.filter((arg): arg is string => typeof arg === 'string') ?? []
+      if (args.length > 0) {
+        lines.push(`args = [${args.map(arg => `"${escapeTomlBasicString(arg)}"`).join(', ')}]`)
+      }
+      const env = Object.entries(definition.env ?? {}).filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+      if (env.length > 0) {
+        const values = env.map(([key, value]) => `"${escapeTomlBasicString(key)}" = "${escapeTomlBasicString(value)}"`)
+        lines.push(`env = { ${values.join(', ')} }`)
+      }
     }
     lines.push('')
     writeFileSync(configPath, lines.join('\n'), { mode: 0o600 })


### PR DESCRIPTION
**Issue:** #2698

## Acceptance Criteria

- [ ] Extract shared parseRoleMcpServersSync helper from roleSystemPromptInjectionSync
- [ ] initCodexHome emits [mcp_servers.<name>] sections from a new InitCodexHomeOpts.mcpServers option
- [ ] Thread role through getCodexLauncherFields into initCodexHome at all five role-spawn call sites
- [ ] Warn at spawn when a role declaring MCP servers routes to a harness that cannot provision them
- [ ] Document per-harness role MCP provisioning