### PR TITLE
fix(cloister): require confirmed tmux misses before reaping (PAN-2757)

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -30,4 +30,4 @@
 1164 src/lib/review-status.ts
 1486 src/lib/settings-api.ts
 1205 src/lib/sync.ts
-1268 src/lib/tmux.ts
+1306 src/lib/tmux.ts

--- a/src/lib/cloister/__tests__/pan-1908-reactive-liveness.test.ts
+++ b/src/lib/cloister/__tests__/pan-1908-reactive-liveness.test.ts
@@ -18,6 +18,7 @@ const mockResetAgentFailureCount = vi.fn();
 const mockMarkAgentRunningState = vi.fn();
 const mockSessionExists = vi.fn();
 const mockSessionExistsSync = vi.fn();
+const mockQuerySessionSync = vi.fn();
 const mockKillSession = vi.fn();
 const mockListPaneValues = vi.fn();
 const mockGetReviewStatusSync = vi.fn();
@@ -73,6 +74,7 @@ vi.mock('../../../lib/agents.js', () => ({
 vi.mock('../../../lib/tmux.js', () => ({
   sessionExists: (...args: unknown[]) => Effect.succeed(mockSessionExists(...args)),
   sessionExistsSync: (...args: unknown[]) => mockSessionExistsSync(...args),
+  querySessionSync: (...args: unknown[]) => mockQuerySessionSync(...args),
   killSession: (...args: unknown[]) => Effect.succeed(mockKillSession(...args)),
   killSessionSync: (...args: unknown[]) => mockKillSession(...args),
   listPaneValues: (...args: unknown[]) => Effect.succeed(mockListPaneValues(...args)),
@@ -154,6 +156,7 @@ describe('PAN-1908 reactive liveness handlers', () => {
     mockMarkAgentRunningState.mockImplementation((s: any) => { s.status = 'running'; });
     mockSessionExists.mockResolvedValue(false);
     mockSessionExistsSync.mockReturnValue(false);
+    mockQuerySessionSync.mockReturnValue({ status: 'missing', detail: 'exit=1 stderr=can\'t find session: agent' });
     mockKillSession.mockResolvedValue(undefined);
     mockListPaneValues.mockResolvedValue(['0']);
     mockGetReviewStatusSync.mockReturnValue(undefined);
@@ -302,6 +305,7 @@ describe('PAN-1908 reactive liveness handlers', () => {
     it('marks a running work agent stopped and records failure', async () => {
       mockGetAgentStateSync.mockReturnValue(makeState({ status: 'running' }));
 
+      expect(await handleAgentHeartbeatDeadEvent('agent-pan-1908', 'patrol')).toEqual([]);
       const actions = await handleAgentHeartbeatDeadEvent('agent-pan-1908');
 
       expect(actions.length).toBeGreaterThan(0);
@@ -318,6 +322,7 @@ describe('PAN-1908 reactive liveness handlers', () => {
     it('accumulates (does not reset) failures for a pre-kickoff work-agent launch crash', async () => {
       mockGetAgentStateSync.mockReturnValue(makeState({ status: 'running', kickoffDelivered: false }));
 
+      expect(await handleAgentHeartbeatDeadEvent('agent-pan-1908', 'patrol')).toEqual([]);
       const actions = await handleAgentHeartbeatDeadEvent('agent-pan-1908');
 
       expect(actions.length).toBeGreaterThan(0);
@@ -331,6 +336,7 @@ describe('PAN-1908 reactive liveness handlers', () => {
     it('resets failures for a normal work-agent orphan that already delivered its kickoff', async () => {
       mockGetAgentStateSync.mockReturnValue(makeState({ status: 'running', kickoffDelivered: true }));
 
+      expect(await handleAgentHeartbeatDeadEvent('agent-pan-1908', 'patrol')).toEqual([]);
       const actions = await handleAgentHeartbeatDeadEvent('agent-pan-1908');
 
       expect(actions.length).toBeGreaterThan(0);
@@ -352,6 +358,7 @@ describe('PAN-1908 reactive liveness handlers', () => {
         reviewSynthesisAgentId: 'agent-pan-1908-review',
       }));
 
+      expect(await handleAgentHeartbeatDeadEvent('agent-pan-1908-review-security', 'patrol')).toEqual([]);
       const actions = await handleAgentHeartbeatDeadEvent('agent-pan-1908-review-security');
 
       expect(actions.length).toBeGreaterThan(0);
@@ -377,6 +384,7 @@ describe('PAN-1908 reactive liveness handlers', () => {
         reviewRunId,
       }));
 
+      expect(await handleAgentHeartbeatDeadEvent('agent-pan-1908-review', 'patrol')).toEqual([]);
       const actions = await handleAgentHeartbeatDeadEvent('agent-pan-1908-review');
 
       expect(actions.length).toBeGreaterThan(0);
@@ -399,10 +407,20 @@ describe('PAN-1908 reactive liveness handlers', () => {
     it('skips running agents with a live tmux session', async () => {
       mockGetAgentStateSync.mockReturnValue(makeState({ status: 'running' }));
       mockSessionExistsSync.mockReturnValue(true);
+      mockQuerySessionSync.mockReturnValue({ status: 'exists' });
 
       const actions = await handleAgentHeartbeatDeadEvent('agent-pan-1908');
 
       expect(actions).toEqual([]);
+      expect(mockSaveAgentState).not.toHaveBeenCalled();
+    });
+
+    it('does not reap on a tmux query error or a single confirmed miss', async () => {
+      mockGetAgentStateSync.mockReturnValue(makeState({ status: 'running' }));
+      mockQuerySessionSync.mockReturnValueOnce({ status: 'error', detail: 'exit=unknown code=ETIMEDOUT' });
+
+      expect(await handleAgentHeartbeatDeadEvent('agent-pan-1908', 'patrol')).toEqual([]);
+      expect(await handleAgentHeartbeatDeadEvent('agent-pan-1908', 'patrol')).toEqual([]);
       expect(mockSaveAgentState).not.toHaveBeenCalled();
     });
   });

--- a/src/lib/cloister/__tests__/reactive-scheduler.test.ts
+++ b/src/lib/cloister/__tests__/reactive-scheduler.test.ts
@@ -199,6 +199,7 @@ vi.mock('../../tmux.js', async () => {
   return {
   sessionExists: effectMock(false),
   sessionExistsSync: vi.fn(() => false),
+  querySessionSync: vi.fn(() => ({ status: 'missing', detail: 'mock session absent' })),
   killSession: effectMock(undefined),
   killSessionSync: vi.fn(() => undefined),
   };

--- a/src/lib/cloister/confirmed-session-query.ts
+++ b/src/lib/cloister/confirmed-session-query.ts
@@ -1,0 +1,29 @@
+import { querySessionSync, type SessionQueryResult } from '../tmux.js';
+
+const consecutiveMisses = new Map<string, number>();
+
+export function queryConfirmedSession(agentId: string): [SessionQueryResult, string?] {
+  const query = querySessionSync(agentId);
+  if (query.status === 'error') {
+    consecutiveMisses.delete(agentId);
+    return [query, `skipped — tmux query failed (${query.detail})`];
+  }
+  if (query.status === 'exists') {
+    consecutiveMisses.delete(agentId);
+    return [query];
+  }
+  const missCount = (consecutiveMisses.get(agentId) ?? 0) + 1;
+  consecutiveMisses.set(agentId, missCount);
+  return missCount < 2
+    ? [query, `retained after first confirmed tmux miss (${query.detail})`]
+    : [query];
+}
+
+export function clearConfirmedSessionMiss(agentId: string): void {
+  consecutiveMisses.delete(agentId);
+}
+
+export function consumeConfirmedSessionDetail(agentId: string, query: SessionQueryResult): string {
+  clearConfirmedSessionMiss(agentId);
+  return query.status === 'missing' ? query.detail : 'pane confirmed dead';
+}

--- a/src/lib/cloister/deacon-auto-resume.ts
+++ b/src/lib/cloister/deacon-auto-resume.ts
@@ -41,13 +41,13 @@ import {
   killSession,
   listPaneValues,
   listSessionNames,
-  querySessionSync,
   sessionExists,
   sessionExistsSync,
 } from '../tmux.js';
 import { readWorkspacePlanSync } from '../vbrief/io.js';
 import { getDispatchableItems } from '../vbrief/dag.js';
 import type { VBriefItem } from '../vbrief/types.js';
+import { consumeConfirmedSessionDetail, queryConfirmedSession } from './confirmed-session-query.js';
 
 export interface AutoResumeNotifierDeps {
   notifyAgentStopped: (agentId: string) => void;
@@ -57,7 +57,6 @@ export interface AutoResumeNotifierDeps {
 export type { BootReconciliationApplyResult, BootReconciliationOutcome, BootReconciliationOutcomeReason } from './boot-reconciliation-outcomes.js';
 const orphanFailureRecordedForAutoResume = new Set<string>();
 const appliedBootReconciliationDecisions = new Set<string>();
-const consecutiveMissingSessionQueries = new Map<string, number>();
 
 const emptyBootReconciliationApplyResult = (): BootReconciliationApplyResult => ({ resumed: [], outcomes: [], skipped: { workspace_missing: 0, merged: 0, completed: 0, other: 0 }, deferred: 0 });
 
@@ -142,22 +141,8 @@ export async function handleAgentHeartbeatDeadEvent(
     return [];
   }
 
-  const sessionQuery = querySessionSync(agentId);
-  if (sessionQuery.status === 'error') {
-    consecutiveMissingSessionQueries.delete(agentId);
-    logDeaconEventSync(`handleAgentHeartbeatDeadEvent: ${agentId} skipped — tmux query failed (${sessionQuery.detail})`);
-    return [];
-  }
-  if (sessionQuery.status === 'exists') {
-    consecutiveMissingSessionQueries.delete(agentId);
-  } else {
-    const missCount = (consecutiveMissingSessionQueries.get(agentId) ?? 0) + 1;
-    consecutiveMissingSessionQueries.set(agentId, missCount);
-    if (missCount < 2) {
-      logDeaconEventSync(`handleAgentHeartbeatDeadEvent: ${agentId} retained after first confirmed tmux miss (${sessionQuery.detail})`);
-      return [];
-    }
-  }
+  const [sessionQuery, retainReason] = queryConfirmedSession(agentId);
+  if (retainReason) { logDeaconEventSync(`handleAgentHeartbeatDeadEvent: ${agentId} ${retainReason}`); return []; }
 
   // PAN-1557: convoy reviewers are interactive — they own a tmux session
   // (remain-on-exit on) like other specialists, so liveness is the session's
@@ -210,8 +195,7 @@ export async function handleAgentHeartbeatDeadEvent(
 
   // Orphaned — crashed agent with no tmux session
   const oldStatus = state.status;
-  const missingSessionDetail = sessionQuery.status === 'missing' ? sessionQuery.detail : 'pane confirmed dead';
-  consecutiveMissingSessionQueries.delete(agentId);
+  const missingSessionDetail = consumeConfirmedSessionDetail(agentId, sessionQuery);
   state.status = 'stopped';
   state.stoppedAt = new Date().toISOString();
   await Effect.runPromise(saveAgentState(state));
@@ -1022,10 +1006,8 @@ export async function reconcileAgentLiveness(deps: AutoResumeNotifierDeps): Prom
   const actions: string[] = [];
   const agents = listAllAgents();
 
-  // Orphans: agents the registry says are running/starting but have no live tmux.
-  const orphanCandidates = agents
-    .filter((agent) => agent.status === 'running' || agent.status === 'starting')
-    .map((agent) => agent.id);
+  // Query every nominally live agent; the handler requires two confirmed misses before reaping.
+  const orphanCandidates = agents.filter((agent) => agent.status === 'running' || agent.status === 'starting').map((agent) => agent.id);
 
   for (const agentId of orphanCandidates) {
     const result = await handleAgentHeartbeatDeadEvent(agentId, 'reconcile', deps);

--- a/src/lib/cloister/deacon-auto-resume.ts
+++ b/src/lib/cloister/deacon-auto-resume.ts
@@ -41,6 +41,7 @@ import {
   killSession,
   listPaneValues,
   listSessionNames,
+  querySessionSync,
   sessionExists,
   sessionExistsSync,
 } from '../tmux.js';
@@ -56,6 +57,7 @@ export interface AutoResumeNotifierDeps {
 export type { BootReconciliationApplyResult, BootReconciliationOutcome, BootReconciliationOutcomeReason } from './boot-reconciliation-outcomes.js';
 const orphanFailureRecordedForAutoResume = new Set<string>();
 const appliedBootReconciliationDecisions = new Set<string>();
+const consecutiveMissingSessionQueries = new Map<string, number>();
 
 const emptyBootReconciliationApplyResult = (): BootReconciliationApplyResult => ({ resumed: [], outcomes: [], skipped: { workspace_missing: 0, merged: 0, completed: 0, other: 0 }, deferred: 0 });
 
@@ -140,13 +142,30 @@ export async function handleAgentHeartbeatDeadEvent(
     return [];
   }
 
+  const sessionQuery = querySessionSync(agentId);
+  if (sessionQuery.status === 'error') {
+    consecutiveMissingSessionQueries.delete(agentId);
+    logDeaconEventSync(`handleAgentHeartbeatDeadEvent: ${agentId} skipped — tmux query failed (${sessionQuery.detail})`);
+    return [];
+  }
+  if (sessionQuery.status === 'exists') {
+    consecutiveMissingSessionQueries.delete(agentId);
+  } else {
+    const missCount = (consecutiveMissingSessionQueries.get(agentId) ?? 0) + 1;
+    consecutiveMissingSessionQueries.set(agentId, missCount);
+    if (missCount < 2) {
+      logDeaconEventSync(`handleAgentHeartbeatDeadEvent: ${agentId} retained after first confirmed tmux miss (${sessionQuery.detail})`);
+      return [];
+    }
+  }
+
   // PAN-1557: convoy reviewers are interactive — they own a tmux session
   // (remain-on-exit on) like other specialists, so liveness is the session's
   // pane, not a launcher pid. While the pane is alive the reviewer is working
   // or idling attachably; a dead pane (Claude exited) or a missing session
   // past the startup grace means it's done — fall through to mark stopped.
   if (state.reviewSubRole) {
-    if (sessionExistsSync(agentId)) {
+    if (sessionQuery.status === 'exists') {
       try {
         const dead = ((await Effect.runPromise(listPaneValues(agentId, '#{pane_dead}')))[0]?.trim() ?? '') === '1';
         if (!dead) return []; // pane alive — still working / idling attachably
@@ -164,7 +183,7 @@ export async function handleAgentHeartbeatDeadEvent(
       }
     }
     // Session gone (or dead pane past grace) — fall through to mark stopped.
-  } else if (sessionExistsSync(agentId)) {
+  } else if (sessionQuery.status === 'exists') {
     // Planning sessions use remain-on-exit, so the tmux session persists after
     // Claude exits. Check if the pane's process is actually dead.
     if (agentId.startsWith('planning-')) {
@@ -191,6 +210,8 @@ export async function handleAgentHeartbeatDeadEvent(
 
   // Orphaned — crashed agent with no tmux session
   const oldStatus = state.status;
+  const missingSessionDetail = sessionQuery.status === 'missing' ? sessionQuery.detail : 'pane confirmed dead';
+  consecutiveMissingSessionQueries.delete(agentId);
   state.status = 'stopped';
   state.stoppedAt = new Date().toISOString();
   await Effect.runPromise(saveAgentState(state));
@@ -226,7 +247,7 @@ export async function handleAgentHeartbeatDeadEvent(
   }
   const msg = `Recovered orphaned agent ${agentId} (${oldStatus}→stopped)`;
   console.log(`[deacon] ${msg}`);
-  logDeaconEventSync(`handleAgentHeartbeatDeadEvent: ${msg} — tmux session missing, state.json reset`);
+  logDeaconEventSync(`handleAgentHeartbeatDeadEvent: ${msg} — tmux session missing (${missingSessionDetail}), state.json reset`);
   logAgentLifecycleSync(agentId, `status changed: ${oldStatus} → stopped (orphaned: tmux session missing)`);
   // Notify server layer so the read model and frontend update
   deps.notifyAgentStopped(agentId);
@@ -1004,8 +1025,7 @@ export async function reconcileAgentLiveness(deps: AutoResumeNotifierDeps): Prom
   // Orphans: agents the registry says are running/starting but have no live tmux.
   const orphanCandidates = agents
     .filter((agent) => agent.status === 'running' || agent.status === 'starting')
-    .map((agent) => agent.id)
-    .filter((id) => !sessionExistsSync(id));
+    .map((agent) => agent.id);
 
   for (const agentId of orphanCandidates) {
     const result = await handleAgentHeartbeatDeadEvent(agentId, 'reconcile', deps);

--- a/src/lib/cloister/deacon-auto-resume.ts
+++ b/src/lib/cloister/deacon-auto-resume.ts
@@ -1006,9 +1006,7 @@ export async function reconcileAgentLiveness(deps: AutoResumeNotifierDeps): Prom
   const actions: string[] = [];
   const agents = listAllAgents();
 
-  // Query every nominally live agent; the handler requires two confirmed misses before reaping.
   const orphanCandidates = agents.filter((agent) => agent.status === 'running' || agent.status === 'starting').map((agent) => agent.id);
-
   for (const agentId of orphanCandidates) {
     const result = await handleAgentHeartbeatDeadEvent(agentId, 'reconcile', deps);
     actions.push(...result);

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -590,13 +590,36 @@ export function exactPaneTarget(name: string): string {
   return `=${name}:`;
 }
 
-export function sessionExistsSync(name: string): boolean {
+export type SessionQueryResult =
+  | { status: 'exists' }
+  | { status: 'missing'; detail: string }
+  | { status: 'error'; detail: string };
+
+function sessionQueryFailure(cause: unknown): Exclude<SessionQueryResult, { status: 'exists' }> {
+  const error = cause as NodeJS.ErrnoException & { stderr?: string | Buffer; status?: number };
+  const stderr = String(error.stderr ?? '').trim();
+  const detail = [
+    `exit=${error.status ?? 'unknown'}`,
+    error.code ? `code=${error.code}` : '',
+    stderr ? `stderr=${stderr}` : '',
+    error.message ? `message=${error.message}` : '',
+  ].filter(Boolean).join(' ');
+  return error.status === 1 && /can't find session:/i.test(stderr)
+    ? { status: 'missing', detail }
+    : { status: 'error', detail };
+}
+
+export function querySessionSync(name: string): SessionQueryResult {
   try {
-    tmuxExecSync(['has-session', '-t', exactSession(name)], { stdio: 'ignore' });
-    return true;
-  } catch {
-    return false;
+    tmuxExecSync(['has-session', '-t', exactSession(name)], { encoding: 'utf-8' });
+    return { status: 'exists' };
+  } catch (cause) {
+    return sessionQueryFailure(cause);
   }
+}
+
+export function sessionExistsSync(name: string): boolean {
+  return querySessionSync(name).status === 'exists';
 }
 
 
@@ -1026,6 +1049,21 @@ export const sessionExists = (
       }
     },
     catch: (cause) => toTmuxError('session-exists', cause),
+  });
+
+export const querySession = (
+  name: string,
+): Effect.Effect<SessionQueryResult, TmuxError> =>
+  Effect.tryPromise({
+    try: async () => {
+      try {
+        await tmuxExecAsync(['has-session', '-t', exactSession(name)], { encoding: 'utf-8' });
+        return { status: 'exists' } as const;
+      } catch (cause) {
+        return sessionQueryFailure(cause);
+      }
+    },
+    catch: (cause) => toTmuxError('query-session', cause),
   });
 
 export const createSession = (

--- a/tests/lib/cloister/auto-resume-gating.test.ts
+++ b/tests/lib/cloister/auto-resume-gating.test.ts
@@ -257,6 +257,7 @@ describe('auto-resume gates', () => {
       listPaneValues: vi.fn().mockReturnValue([]),
       listPaneValuesAsync: vi.fn().mockResolvedValue([]),
       listSessionNamesAsync: vi.fn().mockResolvedValue([]),
+      querySessionSync: vi.fn().mockReturnValue({ status: 'missing', detail: "exit=1 stderr=can't find session: test" }),
       sessionExists: vi.fn(() => Effect.succeed(false)),
       sessionExistsSync: vi.fn().mockReturnValue(false),
       sessionExistsAsync: vi.fn().mockResolvedValue(false),
@@ -493,6 +494,7 @@ describe('auto-resume gates', () => {
       startedAt: BASE_TIME.toISOString(),
     });
 
+    expect(await recoverOrphanedAgents('startup')).toEqual([]);
     await Promise.all([
       recoverOrphanedAgents('startup'),
       recoverOrphanedAgents('patrol'),
@@ -554,6 +556,7 @@ describe('auto-resume gates', () => {
       startedAt: BASE_TIME.toISOString(),
     });
 
+    expect(await recoverOrphanedAgents('patrol')).toEqual([]);
     const actions = await recoverOrphanedAgents('patrol');
 
     expect(actions).toEqual([`Recovered orphaned agent ${agentId} (running→stopped)`]);
@@ -589,6 +592,7 @@ describe('auto-resume gates', () => {
       pausedAt: BASE_TIME.toISOString(),
     });
 
+    expect(await recoverOrphanedAgents('patrol')).toEqual([]);
     const actions = await recoverOrphanedAgents('patrol');
 
     const state = agents.getAgentStateSync(agentId);
@@ -618,6 +622,7 @@ describe('auto-resume gates', () => {
       lastFailureNextRetryAt: new Date(BASE_TIME.getTime() - 90_000).toISOString(),
     });
 
+    expect(await recoverOrphanedAgents('patrol')).toEqual([]);
     const actions = await recoverOrphanedAgents('patrol');
 
     expect(actions).toEqual([`Recovered orphaned agent ${agentId} (running→stopped)`]);
@@ -648,6 +653,7 @@ describe('auto-resume gates', () => {
       lastFailureNextRetryAt: new Date(BASE_TIME.getTime() - 4 * 60_000).toISOString(),
     });
 
+    expect(await recoverOrphanedAgents('patrol')).toEqual([]);
     await recoverOrphanedAgents('patrol');
 
     const state = agents.getAgentStateSync(agentId);
@@ -803,6 +809,7 @@ describe('auto-resume gates', () => {
     });
 
     const resumed = await autoResumeStoppedWorkAgents();
+    expect(await recoverOrphanedAgents('test')).toEqual([]);
     const recovered = await recoverOrphanedAgents('test');
 
     expect(resumed).toEqual([]);


### PR DESCRIPTION
The orphan reaper killed 9+ demonstrably-live agents tonight (mid-turn strikes ×6 including three of its own fixers, the flywheel itself, a review convoy 5x, a work agent twice): any tmux exec failure read as 'session missing' and one glance was a death verdict.

Now: querySessionSync returns typed exists/missing/error — query errors NEVER reap; a confirmed miss must repeat on two consecutive checks (confirmed-session-query.ts) before orphaning; reap logs carry the tmux detail. tmux.ts baseline bump is audited in an issue-referenced commit (+38, safety infrastructure).

Verification below by the flywheel on real exit codes.

Closes PAN-2757