### PR TITLE
feat(cloister): auto re-trigger stale PR checks after red main clears (PAN-2710)

### DIFF
--- a/reference/troubleshooting.mdx
+++ b/reference/troubleshooting.mdx
@@ -9,6 +9,37 @@ import { ThemedImage } from "/snippets/themed-image.mdx";
 
 Solutions to common problems and issues with Overdeck.
 
+## PR stuck with stale failed checks after main recovers
+
+A pull request may remain `UNSTABLE` with a failed `test` check and
+`ready_for_merge=0` even though its review, test, and verification stages passed
+and `main` is green. `ready_for_merge=0` means the merge gate is deliberately
+holding the pull request out of the merge queue because GitHub still reports a
+required check failure.
+
+This happens when the pull request's check ran while `main` was failing and
+GitHub did not run it again after `main` recovered. The dashboard's stale-check
+re-trigger service detects these inherited failures and re-runs them once. A
+**red window** is the period from a completed failing run on `main` until the
+next completed successful run of the same workflow. The service only acts on a
+pull request run created inside a closed red window, never while that workflow
+is still failing on `main`.
+
+The service also requires the GitHub workflow run to have `attempt: 1`. This
+once-only attempt guard means a run that Overdeck already retriggered, including
+one that failed again, is not put into a retry loop. Decisions and actions are
+logged with the `[stale-check-retrigger]` prefix.
+
+If the dashboard is down, the run predates the available `main` history, or the
+run is already on attempt 2 or later, re-run the failed jobs manually:
+
+```bash
+gh run rerun <run-id> --failed
+```
+
+After GitHub reports the new result, the existing merge-blocker reconciliation
+poll clears the stale blocker within about 10 minutes.
+
 ## WSL2 Stability Issues (Windows Users)
 
 WSL2 can experience crashes and networking issues, especially under heavy AI agent workloads. Here are recommended `.wslconfig` settings to improve stability.

--- a/src/dashboard/server/main.ts
+++ b/src/dashboard/server/main.ts
@@ -14,7 +14,11 @@ import { runServer } from './server.js';
 import { startSharedIssueService, getSharedIssueService } from './services/issue-service-singleton.js';
 import { startAgentEnrichmentService, stopAgentEnrichmentService } from './services/agent-enrichment-service.js';
 import { startMergeBlockerReconcileService } from './services/merge-blocker-reconcile-service.js';
-import { startStaleCheckRetriggerService, stopStaleCheckRetriggerService } from './services/stale-check-retrigger-service.js';
+import {
+  shouldStartStaleCheckRetriggerService,
+  startStaleCheckRetriggerService,
+  stopStaleCheckRetriggerService,
+} from './services/stale-check-retrigger-service.js';
 import { startAgentOutputService, stopAgentOutputService } from './services/agent-output-service.js';
 import { startConversationLifecycleService, stopConversationLifecycleService } from './services/conversation-lifecycle.js';
 import { startRestartAnnouncer, stopRestartAnnouncer } from './services/restart-announcer.js';
@@ -170,8 +174,10 @@ console.log('[overdeck] AgentOutputService started');
 // Awaiting-Merge queue (and its live MERGE button) before any click.
 startMergeBlockerReconcileService();
 console.log('[overdeck] MergeBlockerReconcileService started');
-startStaleCheckRetriggerService();
-console.log('[overdeck] StaleCheckRetriggerService started');
+if (shouldStartStaleCheckRetriggerService()) {
+  startStaleCheckRetriggerService();
+  console.log('[overdeck] StaleCheckRetriggerService started');
+}
 
 // Desktop installs never run `pan install`, so provision the Claude Code hook
 // bundle (auto-approve, heartbeat, cost, lifecycle) at boot (PAN-2595).

--- a/src/dashboard/server/main.ts
+++ b/src/dashboard/server/main.ts
@@ -14,6 +14,7 @@ import { runServer } from './server.js';
 import { startSharedIssueService, getSharedIssueService } from './services/issue-service-singleton.js';
 import { startAgentEnrichmentService, stopAgentEnrichmentService } from './services/agent-enrichment-service.js';
 import { startMergeBlockerReconcileService } from './services/merge-blocker-reconcile-service.js';
+import { startStaleCheckRetriggerService, stopStaleCheckRetriggerService } from './services/stale-check-retrigger-service.js';
 import { startAgentOutputService, stopAgentOutputService } from './services/agent-output-service.js';
 import { startConversationLifecycleService, stopConversationLifecycleService } from './services/conversation-lifecycle.js';
 import { startRestartAnnouncer, stopRestartAnnouncer } from './services/restart-announcer.js';
@@ -169,6 +170,8 @@ console.log('[overdeck] AgentOutputService started');
 // Awaiting-Merge queue (and its live MERGE button) before any click.
 startMergeBlockerReconcileService();
 console.log('[overdeck] MergeBlockerReconcileService started');
+startStaleCheckRetriggerService();
+console.log('[overdeck] StaleCheckRetriggerService started');
 
 // Desktop installs never run `pan install`, so provision the Claude Code hook
 // bundle (auto-approve, heartbeat, cost, lifecycle) at boot (PAN-2595).
@@ -566,6 +569,7 @@ const handleShutdownSignal = async (signal: NodeJS.Signals) => {
   stopEventLoopMonitor();
   stopTranscriptPoller();
   stopCostReconcileService();
+  stopStaleCheckRetriggerService();
   stopRestartAnnouncer();
   await stopDeaconChild().catch((err) => console.warn('[deacon-supervisor] child shutdown failed:', err?.message ?? err));
   try {

--- a/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
+++ b/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
@@ -11,7 +11,13 @@ vi.mock('../../../../lib/overdeck/review-status-sync.js', () => ({
 vi.mock('../../../../lib/cloister/stale-check-github.js', () => ({
   listRecentMainRuns: mocks.mainRuns,
   getPrHead: mocks.prHead,
-  listPrHeadFailingRuns: mocks.prRuns,
+  probePrHeadFailingRuns: async (...args: unknown[]) => {
+    try {
+      return { ok: true, runs: await mocks.prRuns(...args) };
+    } catch {
+      return { ok: false };
+    }
+  },
   rerunFailedRun: mocks.rerun,
 }));
 

--- a/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
+++ b/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
@@ -17,6 +17,7 @@ vi.mock('../../../../lib/cloister/stale-check-github.js', () => ({
 
 import {
   __tickOnceForTests,
+  shouldStartStaleCheckRetriggerService,
   startStaleCheckRetriggerService,
   stopStaleCheckRetriggerService,
 } from '../stale-check-retrigger-service.js';
@@ -179,6 +180,27 @@ it('evicts departed failed-run state when GitHub proves the PR head changed', as
   await __tickOnceForTests();
 
   expect(mocks.rerun).toHaveBeenCalledTimes(2);
+});
+
+it('evicts departed failed-run state when GitHub reports no failing runs', async () => {
+  mocks.rerun.mockResolvedValue(false);
+  await __tickOnceForTests();
+
+  mocks.candidates.mockReturnValue([]);
+  mocks.prRuns.mockResolvedValue([]);
+  vi.advanceTimersByTime(10 * 60_000);
+  await __tickOnceForTests();
+
+  mocks.candidates.mockReturnValue([candidate()]);
+  mocks.prRuns.mockResolvedValue([run()]);
+  await __tickOnceForTests();
+
+  expect(mocks.rerun).toHaveBeenCalledTimes(2);
+});
+
+it('does not start the mutating service in a read-only peer dashboard', () => {
+  expect(shouldStartStaleCheckRetriggerService({ OVERDECK_DISABLE_DEACON: '1' })).toBe(false);
+  expect(shouldStartStaleCheckRetriggerService({})).toBe(true);
 });
 
 it('tracks failed attempts by exact run ID regardless of response order', async () => {

--- a/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
+++ b/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
@@ -137,7 +137,7 @@ it('prunes issue throttles when candidates disappear', async () => {
 
   await __tickOnceForTests();
   expect(mocks.prHead).toHaveBeenCalledTimes(2);
-  expect(mocks.rerun).toHaveBeenCalledTimes(2);
+  expect(mocks.rerun).toHaveBeenCalledTimes(1);
 });
 
 it('does not retry a failed rerun command after the retention window', async () => {
@@ -150,6 +150,34 @@ it('does not retry a failed rerun command after the retention window', async () 
 
   expect(mocks.rerun).toHaveBeenCalledTimes(1);
   expect(log).not.toHaveBeenCalledWith(expect.stringContaining('skipping run 10'));
+});
+
+it('does not retry a failed rerun when its candidate disappears and returns', async () => {
+  mocks.rerun.mockResolvedValue(false);
+  await __tickOnceForTests();
+
+  mocks.candidates.mockReturnValue([]);
+  await __tickOnceForTests();
+  mocks.candidates.mockReturnValue([candidate()]);
+  vi.advanceTimersByTime(10 * 60_000);
+  await __tickOnceForTests();
+
+  expect(mocks.rerun).toHaveBeenCalledTimes(1);
+});
+
+it('bounds failed-attempt suppression to one high watermark per issue', async () => {
+  mocks.rerun.mockResolvedValue(false);
+  mocks.prRuns.mockResolvedValue([
+    run({ databaseId: 10 }),
+    run({ databaseId: 11 }),
+    run({ databaseId: 12 }),
+  ]);
+  await __tickOnceForTests();
+
+  vi.advanceTimersByTime(24 * 60 * 60_000 + 1);
+  await __tickOnceForTests();
+
+  expect(mocks.rerun).toHaveBeenCalledTimes(3);
 });
 
 it('expires skip-log deduplication after its retention window', async () => {

--- a/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
+++ b/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
@@ -152,14 +152,14 @@ it('does not retry a failed rerun command after the retention window', async () 
   expect(log).not.toHaveBeenCalledWith(expect.stringContaining('skipping run 10'));
 });
 
-it('does not retry a failed rerun when its candidate disappears and returns', async () => {
+it('does not retry a failed rerun when its candidate disappears for over 24 hours and returns', async () => {
   mocks.rerun.mockResolvedValue(false);
   await __tickOnceForTests();
 
   mocks.candidates.mockReturnValue([]);
+  vi.advanceTimersByTime(24 * 60 * 60_000 + 1);
   await __tickOnceForTests();
   mocks.candidates.mockReturnValue([candidate()]);
-  vi.advanceTimersByTime(10 * 60_000);
   await __tickOnceForTests();
 
   expect(mocks.rerun).toHaveBeenCalledTimes(1);

--- a/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
+++ b/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
@@ -165,12 +165,12 @@ it('does not retry a failed rerun when its candidate disappears and returns', as
   expect(mocks.rerun).toHaveBeenCalledTimes(1);
 });
 
-it('bounds failed-attempt suppression to one high watermark per issue', async () => {
+it('tracks failed attempts by exact run ID regardless of response order', async () => {
   mocks.rerun.mockResolvedValue(false);
   mocks.prRuns.mockResolvedValue([
-    run({ databaseId: 10 }),
-    run({ databaseId: 11 }),
     run({ databaseId: 12 }),
+    run({ databaseId: 11 }),
+    run({ databaseId: 10 }),
   ]);
   await __tickOnceForTests();
 
@@ -178,6 +178,20 @@ it('bounds failed-attempt suppression to one high watermark per issue', async ()
   await __tickOnceForTests();
 
   expect(mocks.rerun).toHaveBeenCalledTimes(3);
+});
+
+it('prunes exact failed IDs to the current bounded run set', async () => {
+  mocks.rerun.mockResolvedValue(false);
+  mocks.prRuns.mockResolvedValue(Array.from(
+    { length: 100 },
+    (_, index) => run({ databaseId: index + 1 }),
+  ));
+  for (let tick = 0; tick < 20; tick++) await __tickOnceForTests();
+
+  vi.advanceTimersByTime(10 * 60_000);
+  mocks.prRuns.mockResolvedValue([run({ databaseId: 101 })]);
+  await __tickOnceForTests();
+  expect(mocks.rerun).toHaveBeenCalledTimes(101);
 });
 
 it('expires skip-log deduplication after its retention window', async () => {

--- a/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
+++ b/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
@@ -165,6 +165,22 @@ it('does not retry a failed rerun when its candidate disappears for over 24 hour
   expect(mocks.rerun).toHaveBeenCalledTimes(1);
 });
 
+it('evicts departed failed-run state when GitHub proves the PR head changed', async () => {
+  mocks.rerun.mockResolvedValue(false);
+  await __tickOnceForTests();
+
+  mocks.candidates.mockReturnValue([]);
+  mocks.prHead.mockResolvedValue({ headRefName: 'feature/pan-2710', headRefOid: 'new-sha' });
+  vi.advanceTimersByTime(10 * 60_000);
+  await __tickOnceForTests();
+
+  mocks.candidates.mockReturnValue([candidate()]);
+  mocks.prHead.mockResolvedValue({ headRefName: 'feature/pan-2710', headRefOid: 'sha' });
+  await __tickOnceForTests();
+
+  expect(mocks.rerun).toHaveBeenCalledTimes(2);
+});
+
 it('tracks failed attempts by exact run ID regardless of response order', async () => {
   mocks.rerun.mockResolvedValue(false);
   mocks.prRuns.mockResolvedValue([

--- a/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
+++ b/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
@@ -115,3 +115,49 @@ it('swallows adapter errors and keeps the interval firing', async () => {
   expect(warn).toHaveBeenCalledWith('[stale-check-retrigger] tick failed:', 'offline');
   expect(mocks.mainRuns).toHaveBeenCalledTimes(2);
 });
+
+it('does not overlap interval ticks while an evaluation is pending', async () => {
+  let resolveHead!: (head: { headRefName: string; headRefOid: string }) => void;
+  mocks.prHead.mockReturnValue(new Promise((resolve) => { resolveHead = resolve; }));
+  startStaleCheckRetriggerService();
+
+  await vi.advanceTimersByTimeAsync(60_000);
+  await vi.advanceTimersByTimeAsync(60_000);
+  expect(mocks.prHead).toHaveBeenCalledTimes(1);
+
+  resolveHead({ headRefName: 'feature/pan-2710', headRefOid: 'sha' });
+  await vi.advanceTimersByTimeAsync(0);
+});
+
+it('prunes issue throttles when candidates disappear', async () => {
+  await __tickOnceForTests();
+  mocks.candidates.mockReturnValue([]);
+  await __tickOnceForTests();
+  mocks.candidates.mockReturnValue([candidate()]);
+
+  await __tickOnceForTests();
+  expect(mocks.prHead).toHaveBeenCalledTimes(2);
+});
+
+it('expires run-id deduplication state after its retention window', async () => {
+  const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+  mocks.rerun.mockResolvedValue(false);
+  await __tickOnceForTests();
+
+  vi.advanceTimersByTime(24 * 60 * 60_000 + 1);
+  await __tickOnceForTests();
+
+  expect(mocks.rerun).toHaveBeenCalledTimes(2);
+  expect(log).not.toHaveBeenCalledWith(expect.stringContaining('skipping run 10'));
+});
+
+it('expires skip-log deduplication after its retention window', async () => {
+  const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+  mocks.prRuns.mockResolvedValue([run({ attempt: 2 })]);
+  await __tickOnceForTests();
+
+  vi.advanceTimersByTime(24 * 60 * 60_000 + 1);
+  await __tickOnceForTests();
+
+  expect(log.mock.calls.filter(([message]) => String(message).includes('skipping run 10'))).toHaveLength(2);
+});

--- a/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
+++ b/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
@@ -9,7 +9,13 @@ vi.mock('../../../../lib/overdeck/review-status-sync.js', () => ({
   getMergeBlockerReconcileCandidates: () => Effect.succeed(mocks.candidates()),
 }));
 vi.mock('../../../../lib/cloister/stale-check-github.js', () => ({
-  listRecentMainRuns: mocks.mainRuns,
+  probeRecentMainRuns: async (...args: unknown[]) => {
+    try {
+      return { ok: true, runs: await mocks.mainRuns(...args) };
+    } catch {
+      return { ok: false };
+    }
+  },
   getPrHead: mocks.prHead,
   probePrHeadFailingRuns: async (...args: unknown[]) => {
     try {
@@ -114,12 +120,10 @@ it('throttles main probes for three minutes and issue evaluation for ten', async
 });
 
 it('swallows adapter errors and keeps the interval firing', async () => {
-  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
   mocks.mainRuns.mockRejectedValueOnce(new Error('offline')).mockResolvedValue([]);
   startStaleCheckRetriggerService();
   await vi.advanceTimersByTimeAsync(60_000);
   await vi.advanceTimersByTimeAsync(60_000);
-  expect(warn).toHaveBeenCalledWith('[stale-check-retrigger] tick failed:', 'offline');
   expect(mocks.mainRuns).toHaveBeenCalledTimes(2);
 });
 

--- a/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
+++ b/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
@@ -1,0 +1,117 @@
+import { Effect } from 'effect';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  candidates: vi.fn(), mainRuns: vi.fn(), prHead: vi.fn(), prRuns: vi.fn(), rerun: vi.fn(),
+}));
+
+vi.mock('../../../../lib/overdeck/review-status-sync.js', () => ({
+  getMergeBlockerReconcileCandidates: () => Effect.succeed(mocks.candidates()),
+}));
+vi.mock('../../../../lib/cloister/stale-check-github.js', () => ({
+  listRecentMainRuns: mocks.mainRuns,
+  getPrHead: mocks.prHead,
+  listPrHeadFailingRuns: mocks.prRuns,
+  rerunFailedRun: mocks.rerun,
+}));
+
+import {
+  __tickOnceForTests,
+  startStaleCheckRetriggerService,
+  stopStaleCheckRetriggerService,
+} from '../stale-check-retrigger-service.js';
+
+const candidate = (issueId = 'PAN-2710', number = 42) => ({
+  issueId, prUrl: `https://github.com/eltmon/overdeck/pull/${number}`,
+  blockerReasons: [{ type: 'failing_checks' }], readyForMerge: false,
+});
+const run = (overrides = {}) => ({
+  databaseId: 10, workflowName: 'CI', createdAt: '2026-07-15T10:30:00Z',
+  conclusion: 'FAILURE', status: 'completed', attempt: 1, headSha: 'sha', ...overrides,
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-07-15T12:00:00Z'));
+  vi.clearAllMocks();
+  mocks.candidates.mockReturnValue([candidate()]);
+  mocks.mainRuns.mockResolvedValue([
+    run({ createdAt: '2026-07-15T10:00:00Z' }),
+    run({ createdAt: '2026-07-15T11:00:00Z', conclusion: 'SUCCESS' }),
+  ]);
+  mocks.prHead.mockResolvedValue({ headRefName: 'feature/pan-2710', headRefOid: 'sha' });
+  mocks.prRuns.mockResolvedValue([run()]);
+  mocks.rerun.mockResolvedValue(true);
+});
+
+afterEach(() => {
+  stopStaleCheckRetriggerService();
+  vi.useRealTimers();
+});
+
+it('reruns an inherited failure and logs its red window', async () => {
+  const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+  await __tickOnceForTests();
+  expect(mocks.rerun).toHaveBeenCalledWith('eltmon/overdeck', 10);
+  expect(log).toHaveBeenCalledWith(expect.stringContaining('re-ran run 10 (CI) for PAN-2710 PR #42'));
+  expect(log).toHaveBeenCalledWith(expect.stringContaining('2026-07-15T10:00:00Z → 2026-07-15T11:00:00Z'));
+});
+
+it('makes zero GitHub calls without failing-check candidates', async () => {
+  mocks.candidates.mockReturnValue([{ ...candidate(), blockerReasons: [] }]);
+  await __tickOnceForTests();
+  expect(mocks.mainRuns).not.toHaveBeenCalled();
+  expect(mocks.prHead).not.toHaveBeenCalled();
+});
+
+it.each([
+  ['main-still-red', [run({ createdAt: '2026-07-15T10:00:00Z' })], run(), 'main-still-red'],
+  ['attempt-exceeded', [run({ createdAt: '2026-07-15T10:00:00Z' }), run({ createdAt: '2026-07-15T11:00:00Z', conclusion: 'SUCCESS' })], run({ attempt: 2 }), 'attempt-exceeded'],
+  ['no-red-window-match', [run({ createdAt: '2026-07-15T10:00:00Z' }), run({ createdAt: '2026-07-15T11:00:00Z', conclusion: 'SUCCESS' })], run({ createdAt: '2026-07-15T11:30:00Z' }), 'no-red-window-match'],
+])('skips %s once across ticks', async (_label, mainRuns, prRun, reason) => {
+  const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+  mocks.mainRuns.mockResolvedValue(mainRuns);
+  mocks.prRuns.mockResolvedValue([prRun]);
+  await __tickOnceForTests();
+  vi.advanceTimersByTime(10 * 60_000);
+  await __tickOnceForTests();
+  expect(mocks.rerun).not.toHaveBeenCalled();
+  expect(log.mock.calls.filter(([message]) => String(message).includes(`: ${reason}`))).toHaveLength(1);
+});
+
+it('never retries an attempted run, including a failed rerun', async () => {
+  mocks.rerun.mockResolvedValue(false);
+  await __tickOnceForTests();
+  vi.advanceTimersByTime(10 * 60_000);
+  await __tickOnceForTests();
+  expect(mocks.rerun).toHaveBeenCalledTimes(1);
+});
+
+it('caps reruns at five and defers the remainder', async () => {
+  mocks.prRuns.mockResolvedValue(Array.from({ length: 7 }, (_, index) => run({ databaseId: index + 1 })));
+  await __tickOnceForTests();
+  expect(mocks.rerun).toHaveBeenCalledTimes(5);
+  await __tickOnceForTests();
+  expect(mocks.rerun).toHaveBeenCalledTimes(7);
+});
+
+it('throttles main probes for three minutes and issue evaluation for ten', async () => {
+  await __tickOnceForTests();
+  await __tickOnceForTests();
+  expect(mocks.mainRuns).toHaveBeenCalledTimes(1);
+  expect(mocks.prHead).toHaveBeenCalledTimes(1);
+  vi.advanceTimersByTime(10 * 60_000);
+  await __tickOnceForTests();
+  expect(mocks.mainRuns).toHaveBeenCalledTimes(2);
+  expect(mocks.prHead).toHaveBeenCalledTimes(2);
+});
+
+it('swallows adapter errors and keeps the interval firing', async () => {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  mocks.mainRuns.mockRejectedValueOnce(new Error('offline')).mockResolvedValue([]);
+  startStaleCheckRetriggerService();
+  await vi.advanceTimersByTimeAsync(60_000);
+  await vi.advanceTimersByTimeAsync(60_000);
+  expect(warn).toHaveBeenCalledWith('[stale-check-retrigger] tick failed:', 'offline');
+  expect(mocks.mainRuns).toHaveBeenCalledTimes(2);
+});

--- a/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
+++ b/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
@@ -137,9 +137,10 @@ it('prunes issue throttles when candidates disappear', async () => {
 
   await __tickOnceForTests();
   expect(mocks.prHead).toHaveBeenCalledTimes(2);
+  expect(mocks.rerun).toHaveBeenCalledTimes(2);
 });
 
-it('expires run-id deduplication state after its retention window', async () => {
+it('does not retry a failed rerun command after the retention window', async () => {
   const log = vi.spyOn(console, 'log').mockImplementation(() => {});
   mocks.rerun.mockResolvedValue(false);
   await __tickOnceForTests();
@@ -147,7 +148,7 @@ it('expires run-id deduplication state after its retention window', async () => 
   vi.advanceTimersByTime(24 * 60 * 60_000 + 1);
   await __tickOnceForTests();
 
-  expect(mocks.rerun).toHaveBeenCalledTimes(2);
+  expect(mocks.rerun).toHaveBeenCalledTimes(1);
   expect(log).not.toHaveBeenCalledWith(expect.stringContaining('skipping run 10'));
 });
 

--- a/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
+++ b/src/dashboard/server/services/__tests__/stale-check-retrigger-service.test.ts
@@ -140,6 +140,15 @@ it('does not overlap interval ticks while an evaluation is pending', async () =>
   await vi.advanceTimersByTimeAsync(0);
 });
 
+it('stops future interval ticks', async () => {
+  startStaleCheckRetriggerService();
+  stopStaleCheckRetriggerService();
+
+  await vi.advanceTimersByTimeAsync(2 * 60_000);
+
+  expect(mocks.candidates).not.toHaveBeenCalled();
+});
+
 it('prunes issue throttles when candidates disappear', async () => {
   await __tickOnceForTests();
   mocks.candidates.mockReturnValue([]);

--- a/src/dashboard/server/services/stale-check-retrigger-service.ts
+++ b/src/dashboard/server/services/stale-check-retrigger-service.ts
@@ -14,22 +14,40 @@ interface ServiceState {
   timer: ReturnType<typeof setInterval> | null;
   repoWindows: Map<string, CachedWindows>;
   lastEvaluated: Map<string, number>;
-  attemptedRunIds: Set<number>;
-  loggedSkips: Set<number>;
+  attemptedRunIds: Map<number, number>;
+  loggedSkips: Map<number, number>;
+  inFlight: boolean;
 }
 
 const POLL_INTERVAL_MS = 60_000;
 const MAIN_PROBE_INTERVAL_MS = 3 * 60_000;
 const EVAL_INTERVAL_MS = 10 * 60_000;
 const MAX_RERUNS_PER_TICK = 5;
+const RUN_STATE_RETENTION_MS = 24 * 60 * 60_000;
 
 const serviceState: ServiceState = {
   timer: null,
   repoWindows: new Map(),
   lastEvaluated: new Map(),
-  attemptedRunIds: new Set(),
-  loggedSkips: new Set(),
+  attemptedRunIds: new Map(),
+  loggedSkips: new Map(),
+  inFlight: false,
 };
+
+function pruneState(state: ServiceState, issueIds: Set<string>, repos: Set<string>, now: number): void {
+  for (const issueId of state.lastEvaluated.keys()) {
+    if (!issueIds.has(issueId)) state.lastEvaluated.delete(issueId);
+  }
+  for (const repo of state.repoWindows.keys()) {
+    if (!repos.has(repo)) state.repoWindows.delete(repo);
+  }
+  for (const [runId, recordedAt] of state.attemptedRunIds) {
+    if (now - recordedAt >= RUN_STATE_RETENTION_MS) state.attemptedRunIds.delete(runId);
+  }
+  for (const [runId, recordedAt] of state.loggedSkips) {
+    if (now - recordedAt >= RUN_STATE_RETENTION_MS) state.loggedSkips.delete(runId);
+  }
+}
 
 function parsePrUrl(url: string | undefined | null): PrRef | null {
   if (!url) return null;
@@ -53,9 +71,15 @@ async function tickOnce(state: ServiceState): Promise<void> {
       const failing = candidate.blockerReasons?.some((blocker) => blocker.type === 'failing_checks');
       return ref && failing ? [{ candidate, ref }] : [];
     });
+    const now = Date.now();
+    pruneState(
+      state,
+      new Set(candidates.map(({ candidate }) => candidate.issueId)),
+      new Set(candidates.map(({ ref }) => ref.repo)),
+      now,
+    );
     if (candidates.length === 0) return;
 
-    const now = Date.now();
     let retriggered = 0;
     let skipped = 0;
 
@@ -76,7 +100,7 @@ async function tickOnce(state: ServiceState): Promise<void> {
       for (const entry of selection.skipped) {
         skipped++;
         if (!state.loggedSkips.has(entry.run.databaseId)) {
-          state.loggedSkips.add(entry.run.databaseId);
+          state.loggedSkips.set(entry.run.databaseId, now);
           console.log(`[stale-check-retrigger] skipping run ${entry.run.databaseId} for ${candidate.issueId}: ${entry.reason}`);
         }
       }
@@ -90,7 +114,7 @@ async function tickOnce(state: ServiceState): Promise<void> {
         }
         const window = windows.get(run.workflowName)?.find(({ start, end }) =>
           end !== null && start <= run.createdAt && run.createdAt < end);
-        state.attemptedRunIds.add(run.databaseId);
+        state.attemptedRunIds.set(run.databaseId, now);
         const succeeded = await rerunFailedRun(ref.repo, run.databaseId);
         if (succeeded && window?.end) {
           retriggered++;
@@ -108,9 +132,19 @@ async function tickOnce(state: ServiceState): Promise<void> {
   }
 }
 
+async function runTickIfIdle(state: ServiceState): Promise<void> {
+  if (state.inFlight) return;
+  state.inFlight = true;
+  try {
+    await tickOnce(state);
+  } finally {
+    state.inFlight = false;
+  }
+}
+
 export function startStaleCheckRetriggerService(): void {
   if (serviceState.timer !== null) return;
-  serviceState.timer = setInterval(() => void tickOnce(serviceState), POLL_INTERVAL_MS);
+  serviceState.timer = setInterval(() => void runTickIfIdle(serviceState), POLL_INTERVAL_MS);
   serviceState.timer.unref?.();
 }
 
@@ -124,5 +158,5 @@ export function stopStaleCheckRetriggerService(): void {
 }
 
 export async function __tickOnceForTests(): Promise<void> {
-  await tickOnce(serviceState);
+  await runTickIfIdle(serviceState);
 }

--- a/src/dashboard/server/services/stale-check-retrigger-service.ts
+++ b/src/dashboard/server/services/stale-check-retrigger-service.ts
@@ -3,8 +3,8 @@ import { getMergeBlockerReconcileCandidates } from '../../../lib/overdeck/review
 import { computeRedWindows, selectRerunCandidates, type RedWindow } from '../../../lib/cloister/stale-check-classifier.js';
 import {
   getPrHead,
-  listRecentMainRuns,
   probePrHeadFailingRuns,
+  probeRecentMainRuns,
   rerunFailedRun,
 } from '../../../lib/cloister/stale-check-github.js';
 
@@ -89,10 +89,12 @@ function parsePrUrl(url: string | undefined | null): PrRef | null {
   return match ? { repo: `${match[1]}/${match[2]}`, number: Number(match[3]) } : null;
 }
 
-async function windowsForRepo(state: ServiceState, repo: string, now: number): Promise<Map<string, RedWindow[]>> {
+async function windowsForRepo(state: ServiceState, repo: string, now: number): Promise<Map<string, RedWindow[]> | null> {
   const cached = state.repoWindows.get(repo);
   if (cached && now - cached.probedAt < MAIN_PROBE_INTERVAL_MS) return cached.windows;
-  const windows = computeRedWindows(await listRecentMainRuns(repo));
+  const result = await probeRecentMainRuns(repo);
+  if (!result.ok) return null;
+  const windows = computeRedWindows(result.runs);
   state.repoWindows.set(repo, { probedAt: now, windows });
   return windows;
 }
@@ -126,6 +128,7 @@ async function tickOnce(state: ServiceState): Promise<void> {
       if (now - last < EVAL_INTERVAL_MS) continue;
 
       const windows = await windowsForRepo(state, ref.repo, now);
+      if (!windows) continue;
       const head = await getPrHead(ref.repo, ref.number);
       if (!head) {
         state.lastEvaluated.set(candidate.issueId, now);

--- a/src/dashboard/server/services/stale-check-retrigger-service.ts
+++ b/src/dashboard/server/services/stale-check-retrigger-service.ts
@@ -10,7 +10,7 @@ import {
 
 interface PrRef { repo: string; number: number }
 interface CachedWindows { probedAt: number; windows: Map<string, RedWindow[]> }
-interface FailedRuns { runIds: Set<number>; lastSeenAt: number }
+interface FailedRuns { runIds: Set<number> }
 interface ServiceState {
   timer: ReturnType<typeof setInterval> | null;
   repoWindows: Map<string, CachedWindows>;
@@ -49,10 +49,6 @@ function pruneState(state: ServiceState, issueIds: Set<string>, repos: Set<strin
   }
   for (const [runId, recordedAt] of state.loggedSkips) {
     if (now - recordedAt >= RUN_STATE_RETENTION_MS) state.loggedSkips.delete(runId);
-  }
-  for (const [issueId, failedRuns] of state.failedRunsByIssue) {
-    if (issueIds.has(issueId)) failedRuns.lastSeenAt = now;
-    else if (now - failedRuns.lastSeenAt >= RUN_STATE_RETENTION_MS) state.failedRunsByIssue.delete(issueId);
   }
 }
 
@@ -138,9 +134,8 @@ async function tickOnce(state: ServiceState): Promise<void> {
           console.log(`[stale-check-retrigger] re-ran run ${run.databaseId} (${run.workflowName}) for ${candidate.issueId} PR #${ref.number}: failed at ${run.createdAt} inside main red window ${window.start} → ${window.end}`);
         } else {
           const issueFailedRuns = state.failedRunsByIssue.get(candidate.issueId)
-            ?? { runIds: new Set<number>(), lastSeenAt: now };
+            ?? { runIds: new Set<number>() };
           issueFailedRuns.runIds.add(run.databaseId);
-          issueFailedRuns.lastSeenAt = now;
           state.failedRunsByIssue.set(candidate.issueId, issueFailedRuns);
           skipped++;
         }

--- a/src/dashboard/server/services/stale-check-retrigger-service.ts
+++ b/src/dashboard/server/services/stale-check-retrigger-service.ts
@@ -3,8 +3,8 @@ import { getMergeBlockerReconcileCandidates } from '../../../lib/overdeck/review
 import { computeRedWindows, selectRerunCandidates, type RedWindow } from '../../../lib/cloister/stale-check-classifier.js';
 import {
   getPrHead,
-  listPrHeadFailingRuns,
   listRecentMainRuns,
+  probePrHeadFailingRuns,
   rerunFailedRun,
 } from '../../../lib/cloister/stale-check-github.js';
 
@@ -68,7 +68,9 @@ async function pruneDepartedFailedRuns(state: ServiceState, issueIds: Set<string
       state.failedRunsByIssue.delete(issueId);
       continue;
     }
-    const runs = await listPrHeadFailingRuns(failedRuns.ref.repo, head.headRefName, head.headRefOid);
+    const result = await probePrHeadFailingRuns(failedRuns.ref.repo, head.headRefName, head.headRefOid);
+    if (!result.ok) continue;
+    const runs = result.runs;
     if (runs.length === 0) {
       state.failedRunsByIssue.delete(issueId);
       continue;
@@ -129,7 +131,9 @@ async function tickOnce(state: ServiceState): Promise<void> {
         state.lastEvaluated.set(candidate.issueId, now);
         continue;
       }
-      const runs = await listPrHeadFailingRuns(ref.repo, head.headRefName, head.headRefOid);
+      const result = await probePrHeadFailingRuns(ref.repo, head.headRefName, head.headRefOid);
+      if (!result.ok) continue;
+      const runs = result.runs;
       const currentRunIds = new Set(runs.map((run) => run.databaseId));
       const failedRuns = state.failedRunsByIssue.get(candidate.issueId);
       if (failedRuns && currentRunIds.size === 0) {

--- a/src/dashboard/server/services/stale-check-retrigger-service.ts
+++ b/src/dashboard/server/services/stale-check-retrigger-service.ts
@@ -10,12 +10,13 @@ import {
 
 interface PrRef { repo: string; number: number }
 interface CachedWindows { probedAt: number; windows: Map<string, RedWindow[]> }
+interface FailedRuns { runIds: Set<number>; lastSeenAt: number }
 interface ServiceState {
   timer: ReturnType<typeof setInterval> | null;
   repoWindows: Map<string, CachedWindows>;
   lastEvaluated: Map<string, number>;
   successfulRunIds: Map<number, number>;
-  failedRunHighWatermarks: Map<string, number>;
+  failedRunsByIssue: Map<string, FailedRuns>;
   loggedSkips: Map<number, number>;
   inFlight: boolean;
 }
@@ -31,7 +32,7 @@ const serviceState: ServiceState = {
   repoWindows: new Map(),
   lastEvaluated: new Map(),
   successfulRunIds: new Map(),
-  failedRunHighWatermarks: new Map(),
+  failedRunsByIssue: new Map(),
   loggedSkips: new Map(),
   inFlight: false,
 };
@@ -48,6 +49,10 @@ function pruneState(state: ServiceState, issueIds: Set<string>, repos: Set<strin
   }
   for (const [runId, recordedAt] of state.loggedSkips) {
     if (now - recordedAt >= RUN_STATE_RETENTION_MS) state.loggedSkips.delete(runId);
+  }
+  for (const [issueId, failedRuns] of state.failedRunsByIssue) {
+    if (issueIds.has(issueId)) failedRuns.lastSeenAt = now;
+    else if (now - failedRuns.lastSeenAt >= RUN_STATE_RETENTION_MS) state.failedRunsByIssue.delete(issueId);
   }
 }
 
@@ -83,10 +88,11 @@ async function tickOnce(state: ServiceState): Promise<void> {
     if (candidates.length === 0) return;
 
     let retriggered = 0;
+    let attempted = 0;
     let skipped = 0;
 
     for (const { candidate, ref } of candidates) {
-      if (retriggered >= MAX_RERUNS_PER_TICK) break;
+      if (attempted >= MAX_RERUNS_PER_TICK) break;
       const last = state.lastEvaluated.get(candidate.issueId) ?? 0;
       if (now - last < EVAL_INTERVAL_MS) continue;
 
@@ -97,6 +103,13 @@ async function tickOnce(state: ServiceState): Promise<void> {
         continue;
       }
       const runs = await listPrHeadFailingRuns(ref.repo, head.headRefName, head.headRefOid);
+      const currentRunIds = new Set(runs.map((run) => run.databaseId));
+      const failedRuns = state.failedRunsByIssue.get(candidate.issueId);
+      if (failedRuns && currentRunIds.size > 0) {
+        for (const runId of failedRuns.runIds) {
+          if (!currentRunIds.has(runId)) failedRuns.runIds.delete(runId);
+        }
+      }
       const selection = selectRerunCandidates(runs, windows);
 
       for (const entry of selection.skipped) {
@@ -109,24 +122,26 @@ async function tickOnce(state: ServiceState): Promise<void> {
 
       let deferred = false;
       for (const run of selection.rerun) {
-        const failedRunHighWatermark = state.failedRunHighWatermarks.get(candidate.issueId) ?? 0;
-        if (state.successfulRunIds.has(run.databaseId) || run.databaseId <= failedRunHighWatermark) continue;
-        if (retriggered >= MAX_RERUNS_PER_TICK) {
+        if (state.successfulRunIds.has(run.databaseId)
+          || state.failedRunsByIssue.get(candidate.issueId)?.runIds.has(run.databaseId)) continue;
+        if (attempted >= MAX_RERUNS_PER_TICK) {
           deferred = true;
           break;
         }
         const window = windows.get(run.workflowName)?.find(({ start, end }) =>
           end !== null && start <= run.createdAt && run.createdAt < end);
+        attempted++;
         const succeeded = await rerunFailedRun(ref.repo, run.databaseId);
         if (succeeded && window?.end) {
           state.successfulRunIds.set(run.databaseId, now);
           retriggered++;
           console.log(`[stale-check-retrigger] re-ran run ${run.databaseId} (${run.workflowName}) for ${candidate.issueId} PR #${ref.number}: failed at ${run.createdAt} inside main red window ${window.start} → ${window.end}`);
         } else {
-          state.failedRunHighWatermarks.set(
-            candidate.issueId,
-            Math.max(failedRunHighWatermark, run.databaseId),
-          );
+          const issueFailedRuns = state.failedRunsByIssue.get(candidate.issueId)
+            ?? { runIds: new Set<number>(), lastSeenAt: now };
+          issueFailedRuns.runIds.add(run.databaseId);
+          issueFailedRuns.lastSeenAt = now;
+          state.failedRunsByIssue.set(candidate.issueId, issueFailedRuns);
           skipped++;
         }
       }
@@ -161,7 +176,7 @@ export function stopStaleCheckRetriggerService(): void {
   serviceState.repoWindows.clear();
   serviceState.lastEvaluated.clear();
   serviceState.successfulRunIds.clear();
-  serviceState.failedRunHighWatermarks.clear();
+  serviceState.failedRunsByIssue.clear();
   serviceState.loggedSkips.clear();
 }
 

--- a/src/dashboard/server/services/stale-check-retrigger-service.ts
+++ b/src/dashboard/server/services/stale-check-retrigger-service.ts
@@ -10,11 +10,12 @@ import {
 
 interface PrRef { repo: string; number: number }
 interface CachedWindows { probedAt: number; windows: Map<string, RedWindow[]> }
+interface AttemptedRun { recordedAt: number; issueId: string; commandFailed: boolean }
 interface ServiceState {
   timer: ReturnType<typeof setInterval> | null;
   repoWindows: Map<string, CachedWindows>;
   lastEvaluated: Map<string, number>;
-  attemptedRunIds: Map<number, number>;
+  attemptedRunIds: Map<number, AttemptedRun>;
   loggedSkips: Map<number, number>;
   inFlight: boolean;
 }
@@ -41,8 +42,11 @@ function pruneState(state: ServiceState, issueIds: Set<string>, repos: Set<strin
   for (const repo of state.repoWindows.keys()) {
     if (!repos.has(repo)) state.repoWindows.delete(repo);
   }
-  for (const [runId, recordedAt] of state.attemptedRunIds) {
-    if (now - recordedAt >= RUN_STATE_RETENTION_MS) state.attemptedRunIds.delete(runId);
+  for (const [runId, attempt] of state.attemptedRunIds) {
+    if (!issueIds.has(attempt.issueId)
+      || (!attempt.commandFailed && now - attempt.recordedAt >= RUN_STATE_RETENTION_MS)) {
+      state.attemptedRunIds.delete(runId);
+    }
   }
   for (const [runId, recordedAt] of state.loggedSkips) {
     if (now - recordedAt >= RUN_STATE_RETENTION_MS) state.loggedSkips.delete(runId);
@@ -114,9 +118,18 @@ async function tickOnce(state: ServiceState): Promise<void> {
         }
         const window = windows.get(run.workflowName)?.find(({ start, end }) =>
           end !== null && start <= run.createdAt && run.createdAt < end);
-        state.attemptedRunIds.set(run.databaseId, now);
+        state.attemptedRunIds.set(run.databaseId, {
+          recordedAt: now,
+          issueId: candidate.issueId,
+          commandFailed: true,
+        });
         const succeeded = await rerunFailedRun(ref.repo, run.databaseId);
         if (succeeded && window?.end) {
+          state.attemptedRunIds.set(run.databaseId, {
+            recordedAt: now,
+            issueId: candidate.issueId,
+            commandFailed: false,
+          });
           retriggered++;
           console.log(`[stale-check-retrigger] re-ran run ${run.databaseId} (${run.workflowName}) for ${candidate.issueId} PR #${ref.number}: failed at ${run.createdAt} inside main red window ${window.start} → ${window.end}`);
         } else {

--- a/src/dashboard/server/services/stale-check-retrigger-service.ts
+++ b/src/dashboard/server/services/stale-check-retrigger-service.ts
@@ -69,7 +69,10 @@ async function pruneDepartedFailedRuns(state: ServiceState, issueIds: Set<string
       continue;
     }
     const runs = await listPrHeadFailingRuns(failedRuns.ref.repo, head.headRefName, head.headRefOid);
-    if (runs.length === 0) continue;
+    if (runs.length === 0) {
+      state.failedRunsByIssue.delete(issueId);
+      continue;
+    }
     const currentRunIds = new Set(runs.map((run) => run.databaseId));
     for (const runId of failedRuns.runIds) {
       if (!currentRunIds.has(runId)) failedRuns.runIds.delete(runId);
@@ -129,7 +132,9 @@ async function tickOnce(state: ServiceState): Promise<void> {
       const runs = await listPrHeadFailingRuns(ref.repo, head.headRefName, head.headRefOid);
       const currentRunIds = new Set(runs.map((run) => run.databaseId));
       const failedRuns = state.failedRunsByIssue.get(candidate.issueId);
-      if (failedRuns && currentRunIds.size > 0) {
+      if (failedRuns && currentRunIds.size === 0) {
+        state.failedRunsByIssue.delete(candidate.issueId);
+      } else if (failedRuns) {
         for (const runId of failedRuns.runIds) {
           if (!currentRunIds.has(runId)) failedRuns.runIds.delete(runId);
         }
@@ -196,6 +201,12 @@ export function startStaleCheckRetriggerService(): void {
   if (serviceState.timer !== null) return;
   serviceState.timer = setInterval(() => void runTickIfIdle(serviceState), POLL_INTERVAL_MS);
   serviceState.timer.unref?.();
+}
+
+export function shouldStartStaleCheckRetriggerService(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return env.OVERDECK_DISABLE_DEACON !== '1';
 }
 
 export function stopStaleCheckRetriggerService(): void {

--- a/src/dashboard/server/services/stale-check-retrigger-service.ts
+++ b/src/dashboard/server/services/stale-check-retrigger-service.ts
@@ -1,0 +1,128 @@
+import { Effect } from 'effect';
+import { getMergeBlockerReconcileCandidates } from '../../../lib/overdeck/review-status-sync.js';
+import { computeRedWindows, selectRerunCandidates, type RedWindow } from '../../../lib/cloister/stale-check-classifier.js';
+import {
+  getPrHead,
+  listPrHeadFailingRuns,
+  listRecentMainRuns,
+  rerunFailedRun,
+} from '../../../lib/cloister/stale-check-github.js';
+
+interface PrRef { repo: string; number: number }
+interface CachedWindows { probedAt: number; windows: Map<string, RedWindow[]> }
+interface ServiceState {
+  timer: ReturnType<typeof setInterval> | null;
+  repoWindows: Map<string, CachedWindows>;
+  lastEvaluated: Map<string, number>;
+  attemptedRunIds: Set<number>;
+  loggedSkips: Set<number>;
+}
+
+const POLL_INTERVAL_MS = 60_000;
+const MAIN_PROBE_INTERVAL_MS = 3 * 60_000;
+const EVAL_INTERVAL_MS = 10 * 60_000;
+const MAX_RERUNS_PER_TICK = 5;
+
+const serviceState: ServiceState = {
+  timer: null,
+  repoWindows: new Map(),
+  lastEvaluated: new Map(),
+  attemptedRunIds: new Set(),
+  loggedSkips: new Set(),
+};
+
+function parsePrUrl(url: string | undefined | null): PrRef | null {
+  if (!url) return null;
+  const match = url.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+  return match ? { repo: `${match[1]}/${match[2]}`, number: Number(match[3]) } : null;
+}
+
+async function windowsForRepo(state: ServiceState, repo: string, now: number): Promise<Map<string, RedWindow[]>> {
+  const cached = state.repoWindows.get(repo);
+  if (cached && now - cached.probedAt < MAIN_PROBE_INTERVAL_MS) return cached.windows;
+  const windows = computeRedWindows(await listRecentMainRuns(repo));
+  state.repoWindows.set(repo, { probedAt: now, windows });
+  return windows;
+}
+
+async function tickOnce(state: ServiceState): Promise<void> {
+  try {
+    const allCandidates = await Effect.runPromise(getMergeBlockerReconcileCandidates());
+    const candidates = allCandidates.flatMap((candidate) => {
+      const ref = parsePrUrl(candidate.prUrl);
+      const failing = candidate.blockerReasons?.some((blocker) => blocker.type === 'failing_checks');
+      return ref && failing ? [{ candidate, ref }] : [];
+    });
+    if (candidates.length === 0) return;
+
+    const now = Date.now();
+    let retriggered = 0;
+    let skipped = 0;
+
+    for (const { candidate, ref } of candidates) {
+      if (retriggered >= MAX_RERUNS_PER_TICK) break;
+      const last = state.lastEvaluated.get(candidate.issueId) ?? 0;
+      if (now - last < EVAL_INTERVAL_MS) continue;
+
+      const windows = await windowsForRepo(state, ref.repo, now);
+      const head = await getPrHead(ref.repo, ref.number);
+      if (!head) {
+        state.lastEvaluated.set(candidate.issueId, now);
+        continue;
+      }
+      const runs = await listPrHeadFailingRuns(ref.repo, head.headRefName, head.headRefOid);
+      const selection = selectRerunCandidates(runs, windows);
+
+      for (const entry of selection.skipped) {
+        skipped++;
+        if (!state.loggedSkips.has(entry.run.databaseId)) {
+          state.loggedSkips.add(entry.run.databaseId);
+          console.log(`[stale-check-retrigger] skipping run ${entry.run.databaseId} for ${candidate.issueId}: ${entry.reason}`);
+        }
+      }
+
+      let deferred = false;
+      for (const run of selection.rerun) {
+        if (state.attemptedRunIds.has(run.databaseId)) continue;
+        if (retriggered >= MAX_RERUNS_PER_TICK) {
+          deferred = true;
+          break;
+        }
+        const window = windows.get(run.workflowName)?.find(({ start, end }) =>
+          end !== null && start <= run.createdAt && run.createdAt < end);
+        state.attemptedRunIds.add(run.databaseId);
+        const succeeded = await rerunFailedRun(ref.repo, run.databaseId);
+        if (succeeded && window?.end) {
+          retriggered++;
+          console.log(`[stale-check-retrigger] re-ran run ${run.databaseId} (${run.workflowName}) for ${candidate.issueId} PR #${ref.number}: failed at ${run.createdAt} inside main red window ${window.start} → ${window.end}`);
+        } else {
+          skipped++;
+        }
+      }
+      if (!deferred) state.lastEvaluated.set(candidate.issueId, now);
+    }
+
+    console.log(`[stale-check-retrigger] ${candidates.length} candidate PR(s) with failing_checks; ${retriggered} re-triggered, ${skipped} skipped`);
+  } catch (error) {
+    console.warn('[stale-check-retrigger] tick failed:', error instanceof Error ? error.message : String(error));
+  }
+}
+
+export function startStaleCheckRetriggerService(): void {
+  if (serviceState.timer !== null) return;
+  serviceState.timer = setInterval(() => void tickOnce(serviceState), POLL_INTERVAL_MS);
+  serviceState.timer.unref?.();
+}
+
+export function stopStaleCheckRetriggerService(): void {
+  if (serviceState.timer !== null) clearInterval(serviceState.timer);
+  serviceState.timer = null;
+  serviceState.repoWindows.clear();
+  serviceState.lastEvaluated.clear();
+  serviceState.attemptedRunIds.clear();
+  serviceState.loggedSkips.clear();
+}
+
+export async function __tickOnceForTests(): Promise<void> {
+  await tickOnce(serviceState);
+}

--- a/src/dashboard/server/services/stale-check-retrigger-service.ts
+++ b/src/dashboard/server/services/stale-check-retrigger-service.ts
@@ -10,7 +10,12 @@ import {
 
 interface PrRef { repo: string; number: number }
 interface CachedWindows { probedAt: number; windows: Map<string, RedWindow[]> }
-interface FailedRuns { runIds: Set<number> }
+interface FailedRuns {
+  runIds: Set<number>;
+  ref: PrRef;
+  headRefOid: string;
+  lastProbedAt: number;
+}
 interface ServiceState {
   timer: ReturnType<typeof setInterval> | null;
   repoWindows: Map<string, CachedWindows>;
@@ -52,6 +57,27 @@ function pruneState(state: ServiceState, issueIds: Set<string>, repos: Set<strin
   }
 }
 
+async function pruneDepartedFailedRuns(state: ServiceState, issueIds: Set<string>, now: number): Promise<void> {
+  for (const [issueId, failedRuns] of state.failedRunsByIssue) {
+    if (issueIds.has(issueId)) continue;
+    if (now - failedRuns.lastProbedAt < EVAL_INTERVAL_MS) continue;
+    failedRuns.lastProbedAt = now;
+    const head = await getPrHead(failedRuns.ref.repo, failedRuns.ref.number);
+    if (!head) continue;
+    if (head.headRefOid !== failedRuns.headRefOid) {
+      state.failedRunsByIssue.delete(issueId);
+      continue;
+    }
+    const runs = await listPrHeadFailingRuns(failedRuns.ref.repo, head.headRefName, head.headRefOid);
+    if (runs.length === 0) continue;
+    const currentRunIds = new Set(runs.map((run) => run.databaseId));
+    for (const runId of failedRuns.runIds) {
+      if (!currentRunIds.has(runId)) failedRuns.runIds.delete(runId);
+    }
+    if (failedRuns.runIds.size === 0) state.failedRunsByIssue.delete(issueId);
+  }
+}
+
 function parsePrUrl(url: string | undefined | null): PrRef | null {
   if (!url) return null;
   const match = url.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
@@ -75,12 +101,14 @@ async function tickOnce(state: ServiceState): Promise<void> {
       return ref && failing ? [{ candidate, ref }] : [];
     });
     const now = Date.now();
+    const issueIds = new Set(candidates.map(({ candidate }) => candidate.issueId));
     pruneState(
       state,
-      new Set(candidates.map(({ candidate }) => candidate.issueId)),
+      issueIds,
       new Set(candidates.map(({ ref }) => ref.repo)),
       now,
     );
+    await pruneDepartedFailedRuns(state, issueIds, now);
     if (candidates.length === 0) return;
 
     let retriggered = 0;
@@ -105,6 +133,7 @@ async function tickOnce(state: ServiceState): Promise<void> {
         for (const runId of failedRuns.runIds) {
           if (!currentRunIds.has(runId)) failedRuns.runIds.delete(runId);
         }
+        if (failedRuns.runIds.size === 0) state.failedRunsByIssue.delete(candidate.issueId);
       }
       const selection = selectRerunCandidates(runs, windows);
 
@@ -134,7 +163,11 @@ async function tickOnce(state: ServiceState): Promise<void> {
           console.log(`[stale-check-retrigger] re-ran run ${run.databaseId} (${run.workflowName}) for ${candidate.issueId} PR #${ref.number}: failed at ${run.createdAt} inside main red window ${window.start} → ${window.end}`);
         } else {
           const issueFailedRuns = state.failedRunsByIssue.get(candidate.issueId)
-            ?? { runIds: new Set<number>() };
+            ?? {
+              runIds: new Set<number>(), ref,
+              headRefOid: head.headRefOid,
+              lastProbedAt: now,
+            };
           issueFailedRuns.runIds.add(run.databaseId);
           state.failedRunsByIssue.set(candidate.issueId, issueFailedRuns);
           skipped++;

--- a/src/dashboard/server/services/stale-check-retrigger-service.ts
+++ b/src/dashboard/server/services/stale-check-retrigger-service.ts
@@ -10,12 +10,12 @@ import {
 
 interface PrRef { repo: string; number: number }
 interface CachedWindows { probedAt: number; windows: Map<string, RedWindow[]> }
-interface AttemptedRun { recordedAt: number; issueId: string; commandFailed: boolean }
 interface ServiceState {
   timer: ReturnType<typeof setInterval> | null;
   repoWindows: Map<string, CachedWindows>;
   lastEvaluated: Map<string, number>;
-  attemptedRunIds: Map<number, AttemptedRun>;
+  successfulRunIds: Map<number, number>;
+  failedRunHighWatermarks: Map<string, number>;
   loggedSkips: Map<number, number>;
   inFlight: boolean;
 }
@@ -30,7 +30,8 @@ const serviceState: ServiceState = {
   timer: null,
   repoWindows: new Map(),
   lastEvaluated: new Map(),
-  attemptedRunIds: new Map(),
+  successfulRunIds: new Map(),
+  failedRunHighWatermarks: new Map(),
   loggedSkips: new Map(),
   inFlight: false,
 };
@@ -42,11 +43,8 @@ function pruneState(state: ServiceState, issueIds: Set<string>, repos: Set<strin
   for (const repo of state.repoWindows.keys()) {
     if (!repos.has(repo)) state.repoWindows.delete(repo);
   }
-  for (const [runId, attempt] of state.attemptedRunIds) {
-    if (!issueIds.has(attempt.issueId)
-      || (!attempt.commandFailed && now - attempt.recordedAt >= RUN_STATE_RETENTION_MS)) {
-      state.attemptedRunIds.delete(runId);
-    }
+  for (const [runId, recordedAt] of state.successfulRunIds) {
+    if (now - recordedAt >= RUN_STATE_RETENTION_MS) state.successfulRunIds.delete(runId);
   }
   for (const [runId, recordedAt] of state.loggedSkips) {
     if (now - recordedAt >= RUN_STATE_RETENTION_MS) state.loggedSkips.delete(runId);
@@ -111,28 +109,24 @@ async function tickOnce(state: ServiceState): Promise<void> {
 
       let deferred = false;
       for (const run of selection.rerun) {
-        if (state.attemptedRunIds.has(run.databaseId)) continue;
+        const failedRunHighWatermark = state.failedRunHighWatermarks.get(candidate.issueId) ?? 0;
+        if (state.successfulRunIds.has(run.databaseId) || run.databaseId <= failedRunHighWatermark) continue;
         if (retriggered >= MAX_RERUNS_PER_TICK) {
           deferred = true;
           break;
         }
         const window = windows.get(run.workflowName)?.find(({ start, end }) =>
           end !== null && start <= run.createdAt && run.createdAt < end);
-        state.attemptedRunIds.set(run.databaseId, {
-          recordedAt: now,
-          issueId: candidate.issueId,
-          commandFailed: true,
-        });
         const succeeded = await rerunFailedRun(ref.repo, run.databaseId);
         if (succeeded && window?.end) {
-          state.attemptedRunIds.set(run.databaseId, {
-            recordedAt: now,
-            issueId: candidate.issueId,
-            commandFailed: false,
-          });
+          state.successfulRunIds.set(run.databaseId, now);
           retriggered++;
           console.log(`[stale-check-retrigger] re-ran run ${run.databaseId} (${run.workflowName}) for ${candidate.issueId} PR #${ref.number}: failed at ${run.createdAt} inside main red window ${window.start} → ${window.end}`);
         } else {
+          state.failedRunHighWatermarks.set(
+            candidate.issueId,
+            Math.max(failedRunHighWatermark, run.databaseId),
+          );
           skipped++;
         }
       }
@@ -166,7 +160,8 @@ export function stopStaleCheckRetriggerService(): void {
   serviceState.timer = null;
   serviceState.repoWindows.clear();
   serviceState.lastEvaluated.clear();
-  serviceState.attemptedRunIds.clear();
+  serviceState.successfulRunIds.clear();
+  serviceState.failedRunHighWatermarks.clear();
   serviceState.loggedSkips.clear();
 }
 

--- a/src/lib/cloister/stale-check-classifier.ts
+++ b/src/lib/cloister/stale-check-classifier.ts
@@ -1,0 +1,111 @@
+/**
+ * Pure classification for stale PR checks inherited from a red main branch.
+ *
+ * GitHub CLI timestamps use one normalized ISO-8601 format, so chronological
+ * comparisons here intentionally use their string representation.
+ */
+
+import { FAILING_CHECK_CONCLUSIONS } from '../webhook-handlers.js';
+
+export interface WorkflowRun {
+  databaseId: number;
+  workflowName: string;
+  createdAt: string;
+  conclusion: string;
+  status: string;
+  attempt: number;
+  headSha?: string;
+}
+
+export interface RedWindow {
+  start: string;
+  end: string | null;
+}
+
+export type RerunSkipReason =
+  | 'attempt-exceeded'
+  | 'main-still-red'
+  | 'no-red-window-match'
+  | 'not-completed'
+  | 'missing-attempt';
+
+const isCompleted = (run: WorkflowRun): boolean => run.status.toLowerCase() === 'completed';
+
+const isFailing = (run: WorkflowRun): boolean =>
+  FAILING_CHECK_CONCLUSIONS.has(run.conclusion.toUpperCase());
+
+export function computeRedWindows(mainRuns: WorkflowRun[]): Map<string, RedWindow[]> {
+  const runsByWorkflow = new Map<string, WorkflowRun[]>();
+
+  for (const run of mainRuns) {
+    if (!isCompleted(run)) continue;
+    const runs = runsByWorkflow.get(run.workflowName) ?? [];
+    runs.push(run);
+    runsByWorkflow.set(run.workflowName, runs);
+  }
+
+  const result = new Map<string, RedWindow[]>();
+  for (const [workflowName, runs] of runsByWorkflow) {
+    const windows: RedWindow[] = [];
+    let openWindow: RedWindow | null = null;
+
+    for (const run of runs.sort((left, right) => left.createdAt.localeCompare(right.createdAt))) {
+      if (isFailing(run)) {
+        if (!openWindow) {
+          openWindow = { start: run.createdAt, end: null };
+          windows.push(openWindow);
+        }
+      } else if (run.conclusion.toUpperCase() === 'SUCCESS' && openWindow) {
+        openWindow.end = run.createdAt;
+        openWindow = null;
+      }
+    }
+
+    if (windows.length > 0) result.set(workflowName, windows);
+  }
+
+  return result;
+}
+
+export function selectRerunCandidates(
+  prFailingRuns: WorkflowRun[],
+  redWindows: ReturnType<typeof computeRedWindows>,
+): {
+  rerun: WorkflowRun[];
+  skipped: Array<{ run: WorkflowRun; reason: RerunSkipReason }>;
+} {
+  const rerun: WorkflowRun[] = [];
+  const skipped: Array<{ run: WorkflowRun; reason: RerunSkipReason }> = [];
+
+  for (const run of prFailingRuns) {
+    if (!isCompleted(run)) {
+      skipped.push({ run, reason: 'not-completed' });
+      continue;
+    }
+    if (typeof run.attempt !== 'number') {
+      skipped.push({ run, reason: 'missing-attempt' });
+      continue;
+    }
+    if (run.attempt !== 1) {
+      skipped.push({ run, reason: 'attempt-exceeded' });
+      continue;
+    }
+    if (!isFailing(run)) {
+      skipped.push({ run, reason: 'no-red-window-match' });
+      continue;
+    }
+
+    const containingWindow = (redWindows.get(run.workflowName) ?? []).find(({ start, end }) =>
+      start <= run.createdAt && (end === null || run.createdAt < end));
+
+    if (!containingWindow) {
+      skipped.push({ run, reason: 'no-red-window-match' });
+    } else if (containingWindow.end === null) {
+      skipped.push({ run, reason: 'main-still-red' });
+    } else {
+      rerun.push(run);
+    }
+  }
+
+  return { rerun, skipped };
+}

--- a/src/lib/cloister/stale-check-github.ts
+++ b/src/lib/cloister/stale-check-github.ts
@@ -44,7 +44,7 @@ export async function listPrHeadFailingRuns(
       && FAILING_CHECK_CONCLUSIONS.has(run.conclusion.toUpperCase()));
   } catch (error) {
     warn(`list failing runs for ${headRef}`, error);
-    return [];
+    throw error;
   }
 }
 

--- a/src/lib/cloister/stale-check-github.ts
+++ b/src/lib/cloister/stale-check-github.ts
@@ -1,5 +1,6 @@
 import { execFile } from 'node:child_process';
 import type { WorkflowRun } from './stale-check-classifier.js';
+import { FAILING_CHECK_CONCLUSIONS } from '../webhook-handlers.js';
 
 const RUN_FIELDS = 'databaseId,workflowName,createdAt,conclusion,status,attempt,headSha';
 
@@ -34,9 +35,12 @@ export async function listPrHeadFailingRuns(
 ): Promise<WorkflowRun[]> {
   try {
     const runs = JSON.parse(await execGh([
-      'run', 'list', '--repo', repo, '--branch', headRef, '--status', 'failure', '--json', RUN_FIELDS,
+      'run', 'list', '--repo', repo, '--branch', headRef, '--status', 'completed', '--json', RUN_FIELDS,
     ])) as WorkflowRun[];
-    return runs.filter((run) => run.headSha === headSha);
+    return runs.filter((run) =>
+      run.headSha === headSha
+      && run.status.toLowerCase() === 'completed'
+      && FAILING_CHECK_CONCLUSIONS.has(run.conclusion.toUpperCase()));
   } catch (error) {
     warn(`list failing runs for ${headRef}`, error);
     return [];

--- a/src/lib/cloister/stale-check-github.ts
+++ b/src/lib/cloister/stale-check-github.ts
@@ -18,13 +18,20 @@ function warn(action: string, error: unknown): void {
 }
 
 export async function listRecentMainRuns(repo: string): Promise<WorkflowRun[]> {
+  const result = await probeRecentMainRuns(repo);
+  return result.ok ? result.runs : [];
+}
+
+export async function probeRecentMainRuns(
+  repo: string,
+): Promise<{ ok: true; runs: WorkflowRun[] } | { ok: false }> {
   try {
-    return JSON.parse(await execGh([
+    return { ok: true, runs: JSON.parse(await execGh([
       'run', 'list', '--repo', repo, '--branch', 'main', '--limit', '50', '--json', RUN_FIELDS,
-    ])) as WorkflowRun[];
+    ])) as WorkflowRun[] };
   } catch (error) {
     warn(`list recent main runs for ${repo}`, error);
-    return [];
+    return { ok: false };
   }
 }
 

--- a/src/lib/cloister/stale-check-github.ts
+++ b/src/lib/cloister/stale-check-github.ts
@@ -33,18 +33,27 @@ export async function listPrHeadFailingRuns(
   headRef: string,
   headSha: string,
 ): Promise<WorkflowRun[]> {
+  const result = await probePrHeadFailingRuns(repo, headRef, headSha);
+  return result.ok ? result.runs : [];
+}
+
+export async function probePrHeadFailingRuns(
+  repo: string,
+  headRef: string,
+  headSha: string,
+): Promise<{ ok: true; runs: WorkflowRun[] } | { ok: false }> {
   try {
     const runs = JSON.parse(await execGh([
       'run', 'list', '--repo', repo, '--branch', headRef, '--commit', headSha,
       '--status', 'completed', '--limit', '100', '--json', RUN_FIELDS,
     ])) as WorkflowRun[];
-    return runs.filter((run) =>
+    return { ok: true, runs: runs.filter((run) =>
       run.headSha === headSha
       && run.status.toLowerCase() === 'completed'
-      && FAILING_CHECK_CONCLUSIONS.has(run.conclusion.toUpperCase()));
+      && FAILING_CHECK_CONCLUSIONS.has(run.conclusion.toUpperCase())) };
   } catch (error) {
     warn(`list failing runs for ${headRef}`, error);
-    throw error;
+    return { ok: false };
   }
 }
 

--- a/src/lib/cloister/stale-check-github.ts
+++ b/src/lib/cloister/stale-check-github.ts
@@ -1,0 +1,68 @@
+import { execFile } from 'node:child_process';
+import type { WorkflowRun } from './stale-check-classifier.js';
+
+const RUN_FIELDS = 'databaseId,workflowName,createdAt,conclusion,status,attempt,headSha';
+
+function execGh(args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile('gh', args, { encoding: 'utf-8', timeout: 30000 }, (error, stdout) => {
+      if (error) reject(error);
+      else resolve(stdout as string);
+    });
+  });
+}
+
+function warn(action: string, error: unknown): void {
+  console.warn(`[stale-check-github] Failed to ${action}:`, error instanceof Error ? error.message : String(error));
+}
+
+export async function listRecentMainRuns(repo: string): Promise<WorkflowRun[]> {
+  try {
+    return JSON.parse(await execGh([
+      'run', 'list', '--repo', repo, '--branch', 'main', '--limit', '50', '--json', RUN_FIELDS,
+    ])) as WorkflowRun[];
+  } catch (error) {
+    warn(`list recent main runs for ${repo}`, error);
+    return [];
+  }
+}
+
+export async function listPrHeadFailingRuns(
+  repo: string,
+  headRef: string,
+  headSha: string,
+): Promise<WorkflowRun[]> {
+  try {
+    const runs = JSON.parse(await execGh([
+      'run', 'list', '--repo', repo, '--branch', headRef, '--status', 'failure', '--json', RUN_FIELDS,
+    ])) as WorkflowRun[];
+    return runs.filter((run) => run.headSha === headSha);
+  } catch (error) {
+    warn(`list failing runs for ${headRef}`, error);
+    return [];
+  }
+}
+
+export async function getPrHead(
+  repo: string,
+  prNumber: number,
+): Promise<{ headRefName: string; headRefOid: string } | null> {
+  try {
+    return JSON.parse(await execGh([
+      'pr', 'view', String(prNumber), '--repo', repo, '--json', 'headRefName,headRefOid',
+    ])) as { headRefName: string; headRefOid: string };
+  } catch (error) {
+    warn(`resolve PR #${prNumber} head`, error);
+    return null;
+  }
+}
+
+export async function rerunFailedRun(repo: string, runId: number): Promise<boolean> {
+  try {
+    await execGh(['run', 'rerun', String(runId), '--failed', '--repo', repo]);
+    return true;
+  } catch (error) {
+    warn(`rerun failed jobs for run ${runId}`, error);
+    return false;
+  }
+}

--- a/src/lib/cloister/stale-check-github.ts
+++ b/src/lib/cloister/stale-check-github.ts
@@ -35,7 +35,8 @@ export async function listPrHeadFailingRuns(
 ): Promise<WorkflowRun[]> {
   try {
     const runs = JSON.parse(await execGh([
-      'run', 'list', '--repo', repo, '--branch', headRef, '--status', 'completed', '--json', RUN_FIELDS,
+      'run', 'list', '--repo', repo, '--branch', headRef, '--commit', headSha,
+      '--status', 'completed', '--limit', '100', '--json', RUN_FIELDS,
     ])) as WorkflowRun[];
     return runs.filter((run) =>
       run.headSha === headSha

--- a/tests/unit/lib/cloister/stale-check-classifier.test.ts
+++ b/tests/unit/lib/cloister/stale-check-classifier.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeRedWindows,
+  selectRerunCandidates,
+  type WorkflowRun,
+} from '../../../../src/lib/cloister/stale-check-classifier.js';
+
+const run = (overrides: Partial<WorkflowRun> = {}): WorkflowRun => ({
+  databaseId: 1,
+  workflowName: 'CI',
+  createdAt: '2026-07-15T10:00:00Z',
+  conclusion: 'FAILURE',
+  status: 'completed',
+  attempt: 1,
+  ...overrides,
+});
+
+describe('computeRedWindows', () => {
+  it('opens a window on failure and closes it at the next success', () => {
+    const windows = computeRedWindows([
+      run({ createdAt: '2026-07-15T10:00:00Z' }),
+      run({ createdAt: '2026-07-15T11:00:00Z', conclusion: 'SUCCESS' }),
+    ]);
+
+    expect(windows.get('CI')).toEqual([{
+      start: '2026-07-15T10:00:00Z',
+      end: '2026-07-15T11:00:00Z',
+    }]);
+  });
+
+  it('leaves a trailing failure window open', () => {
+    expect(computeRedWindows([run()]).get('CI')).toEqual([{
+      start: '2026-07-15T10:00:00Z',
+      end: null,
+    }]);
+  });
+
+  it('sorts runs, keeps workflows independent, and returns multiple windows', () => {
+    const windows = computeRedWindows([
+      run({ workflowName: 'Lint', createdAt: '2026-07-15T12:00:00Z' }),
+      run({ createdAt: '2026-07-15T14:00:00Z', conclusion: 'SUCCESS' }),
+      run({ createdAt: '2026-07-15T13:00:00Z' }),
+      run({ createdAt: '2026-07-15T11:00:00Z', conclusion: 'SUCCESS' }),
+      run({ createdAt: '2026-07-15T10:00:00Z' }),
+    ]);
+
+    expect(windows.get('CI')).toEqual([
+      { start: '2026-07-15T10:00:00Z', end: '2026-07-15T11:00:00Z' },
+      { start: '2026-07-15T13:00:00Z', end: '2026-07-15T14:00:00Z' },
+    ]);
+    expect(windows.get('Lint')).toEqual([
+      { start: '2026-07-15T12:00:00Z', end: null },
+    ]);
+  });
+
+  it('ignores queued and in-progress runs', () => {
+    expect(computeRedWindows([
+      run({ status: 'queued' }),
+      run({ status: 'in_progress', conclusion: 'SUCCESS' }),
+    ])).toEqual(new Map());
+  });
+
+  it('recognizes every conclusion from the canonical failing set', () => {
+    const conclusions = ['FAILURE', 'ERROR', 'TIMED_OUT', 'CANCELLED', 'ACTION_REQUIRED', 'STARTUP_FAILURE', 'STALE'];
+    const runs = conclusions.flatMap((conclusion, index) => [
+      run({ workflowName: conclusion, conclusion, createdAt: `2026-07-15T10:0${index}:00Z` }),
+      run({ workflowName: conclusion, conclusion: 'SUCCESS', createdAt: `2026-07-15T11:0${index}:00Z` }),
+    ]);
+
+    expect([...computeRedWindows(runs).keys()]).toEqual(conclusions);
+  });
+});
+
+describe('selectRerunCandidates', () => {
+  const closedAndOpenWindows = new Map([
+    ['CI', [
+      { start: '2026-07-15T10:00:00Z', end: '2026-07-15T11:00:00Z' },
+      { start: '2026-07-15T13:00:00Z', end: null },
+    ]],
+  ]);
+
+  it('selects a completed first-attempt failure inside a matching closed window', () => {
+    const candidate = run({ createdAt: '2026-07-15T10:30:00Z' });
+
+    expect(selectRerunCandidates([candidate], closedAndOpenWindows)).toEqual({
+      rerun: [candidate],
+      skipped: [],
+    });
+  });
+
+  it('uses closed-window boundaries [start, end)', () => {
+    const atStart = run({ databaseId: 1, createdAt: '2026-07-15T10:00:00Z' });
+    const atEnd = run({ databaseId: 2, createdAt: '2026-07-15T11:00:00Z' });
+    const result = selectRerunCandidates([atStart, atEnd], closedAndOpenWindows);
+
+    expect(result.rerun).toEqual([atStart]);
+    expect(result.skipped).toEqual([{ run: atEnd, reason: 'no-red-window-match' }]);
+  });
+
+  it.each([
+    ['open main red window', run({ createdAt: '2026-07-15T13:30:00Z' }), 'main-still-red'],
+    ['main-green interval', run({ createdAt: '2026-07-15T12:00:00Z' }), 'no-red-window-match'],
+    ['run predating history', run({ createdAt: '2026-07-15T09:00:00Z' }), 'no-red-window-match'],
+    ['workflow mismatch', run({ workflowName: 'Lint', createdAt: '2026-07-15T10:30:00Z' }), 'no-red-window-match'],
+    ['second attempt', run({ createdAt: '2026-07-15T10:30:00Z', attempt: 2 }), 'attempt-exceeded'],
+    ['in-progress run', run({ createdAt: '2026-07-15T10:30:00Z', status: 'in_progress' }), 'not-completed'],
+  ] as const)('skips a %s with the specific reason', (_label, candidate, reason) => {
+    expect(selectRerunCandidates([candidate], closedAndOpenWindows)).toEqual({
+      rerun: [],
+      skipped: [{ run: candidate, reason }],
+    });
+  });
+
+  it('reports a missing attempt before evaluating red-window membership', () => {
+    const candidate = run({ createdAt: '2026-07-15T10:30:00Z' });
+    delete (candidate as Partial<WorkflowRun>).attempt;
+
+    expect(selectRerunCandidates([candidate], closedAndOpenWindows)).toEqual({
+      rerun: [],
+      skipped: [{ run: candidate, reason: 'missing-attempt' }],
+    });
+  });
+
+  it('does not select a non-failing completed run', () => {
+    const candidate = run({ createdAt: '2026-07-15T10:30:00Z', conclusion: 'SUCCESS' });
+
+    expect(selectRerunCandidates([candidate], closedAndOpenWindows)).toEqual({
+      rerun: [],
+      skipped: [{ run: candidate, reason: 'no-red-window-match' }],
+    });
+  });
+});

--- a/tests/unit/lib/cloister/stale-check-github.test.ts
+++ b/tests/unit/lib/cloister/stale-check-github.test.ts
@@ -7,7 +7,10 @@ import {
   rerunFailedRun,
 } from '../../../../src/lib/cloister/stale-check-github.js';
 
-vi.mock('node:child_process', () => ({ execFile: vi.fn() }));
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...await importOriginal<typeof import('node:child_process')>(),
+  execFile: vi.fn(),
+}));
 
 const execFileMock = execFile as unknown as ReturnType<typeof vi.fn>;
 
@@ -50,9 +53,29 @@ describe('listPrHeadFailingRuns', () => {
 
     await expect(listPrHeadFailingRuns('eltmon/overdeck', 'feature/pan-2710', 'current')).resolves.toEqual([current]);
     expect(execFileMock.mock.calls[0][1]).toEqual([
-      'run', 'list', '--repo', 'eltmon/overdeck', '--branch', 'feature/pan-2710', '--status', 'failure',
+      'run', 'list', '--repo', 'eltmon/overdeck', '--branch', 'feature/pan-2710', '--status', 'completed',
       '--json', 'databaseId,workflowName,createdAt,conclusion,status,attempt,headSha',
     ]);
+  });
+
+  it.each(['ERROR', 'TIMED_OUT', 'CANCELLED', 'ACTION_REQUIRED', 'STARTUP_FAILURE', 'STALE'])(
+    'keeps the canonical %s failing conclusion',
+    async (conclusion) => {
+      const failing = { databaseId: 20, workflowName: 'CI', createdAt: '2026-07-15T10:00:00Z', conclusion, status: 'completed', attempt: 1, headSha: 'current' };
+      respond(JSON.stringify([failing]));
+
+      await expect(listPrHeadFailingRuns('repo', 'branch', 'current')).resolves.toEqual([failing]);
+    },
+  );
+
+  it('discards successful and incomplete runs before classification', async () => {
+    const base = { databaseId: 20, workflowName: 'CI', createdAt: '2026-07-15T10:00:00Z', status: 'completed', attempt: 1, headSha: 'current' };
+    respond(JSON.stringify([
+      { ...base, conclusion: 'SUCCESS' },
+      { ...base, databaseId: 21, conclusion: 'FAILURE', status: 'in_progress' },
+    ]));
+
+    await expect(listPrHeadFailingRuns('repo', 'branch', 'current')).resolves.toEqual([]);
   });
 
   it('returns an empty list and warns on malformed output', async () => {

--- a/tests/unit/lib/cloister/stale-check-github.test.ts
+++ b/tests/unit/lib/cloister/stale-check-github.test.ts
@@ -53,7 +53,8 @@ describe('listPrHeadFailingRuns', () => {
 
     await expect(listPrHeadFailingRuns('eltmon/overdeck', 'feature/pan-2710', 'current')).resolves.toEqual([current]);
     expect(execFileMock.mock.calls[0][1]).toEqual([
-      'run', 'list', '--repo', 'eltmon/overdeck', '--branch', 'feature/pan-2710', '--status', 'completed',
+      'run', 'list', '--repo', 'eltmon/overdeck', '--branch', 'feature/pan-2710', '--commit', 'current',
+      '--status', 'completed', '--limit', '100',
       '--json', 'databaseId,workflowName,createdAt,conclusion,status,attempt,headSha',
     ]);
   });

--- a/tests/unit/lib/cloister/stale-check-github.test.ts
+++ b/tests/unit/lib/cloister/stale-check-github.test.ts
@@ -79,11 +79,11 @@ describe('listPrHeadFailingRuns', () => {
     await expect(listPrHeadFailingRuns('repo', 'branch', 'current')).resolves.toEqual([]);
   });
 
-  it('returns an empty list and warns on malformed output', async () => {
+  it('rejects and warns on malformed output so failure is distinct from no runs', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     respond('not json');
 
-    await expect(listPrHeadFailingRuns('repo', 'branch', 'sha')).resolves.toEqual([]);
+    await expect(listPrHeadFailingRuns('repo', 'branch', 'sha')).rejects.toThrow();
     expect(warn).toHaveBeenCalledOnce();
   });
 });

--- a/tests/unit/lib/cloister/stale-check-github.test.ts
+++ b/tests/unit/lib/cloister/stale-check-github.test.ts
@@ -4,6 +4,7 @@ import {
   getPrHead,
   listPrHeadFailingRuns,
   listRecentMainRuns,
+  probeRecentMainRuns,
   rerunFailedRun,
 } from '../../../../src/lib/cloister/stale-check-github.js';
 
@@ -43,6 +44,15 @@ describe('listRecentMainRuns', () => {
 
     await expect(listRecentMainRuns('eltmon/overdeck')).resolves.toEqual([]);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('Failed to list recent main runs'), 'offline');
+  });
+
+  it('distinguishes a failed main-history probe from a successful empty result', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    respond('', new Error('offline'));
+    respond('[]');
+
+    await expect(probeRecentMainRuns('eltmon/overdeck')).resolves.toEqual({ ok: false });
+    await expect(probeRecentMainRuns('eltmon/overdeck')).resolves.toEqual({ ok: true, runs: [] });
   });
 });
 

--- a/tests/unit/lib/cloister/stale-check-github.test.ts
+++ b/tests/unit/lib/cloister/stale-check-github.test.ts
@@ -79,11 +79,11 @@ describe('listPrHeadFailingRuns', () => {
     await expect(listPrHeadFailingRuns('repo', 'branch', 'current')).resolves.toEqual([]);
   });
 
-  it('rejects and warns on malformed output so failure is distinct from no runs', async () => {
+  it('returns an empty list and warns on malformed output', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     respond('not json');
 
-    await expect(listPrHeadFailingRuns('repo', 'branch', 'sha')).rejects.toThrow();
+    await expect(listPrHeadFailingRuns('repo', 'branch', 'sha')).resolves.toEqual([]);
     expect(warn).toHaveBeenCalledOnce();
   });
 });

--- a/tests/unit/lib/cloister/stale-check-github.test.ts
+++ b/tests/unit/lib/cloister/stale-check-github.test.ts
@@ -1,0 +1,106 @@
+import { execFile } from 'node:child_process';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getPrHead,
+  listPrHeadFailingRuns,
+  listRecentMainRuns,
+  rerunFailedRun,
+} from '../../../../src/lib/cloister/stale-check-github.js';
+
+vi.mock('node:child_process', () => ({ execFile: vi.fn() }));
+
+const execFileMock = execFile as unknown as ReturnType<typeof vi.fn>;
+
+function respond(stdout: string, error: Error | null = null): void {
+  execFileMock.mockImplementationOnce(
+    (_file, _args, _options, callback: (err: Error | null, stdout: string, stderr: string) => void) =>
+      callback(error, stdout, ''),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('listRecentMainRuns', () => {
+  it('lists recent main runs with the attempt field', async () => {
+    const runs = [{ databaseId: 10, workflowName: 'CI', createdAt: '2026-07-15T10:00:00Z', conclusion: 'FAILURE', status: 'completed', attempt: 1, headSha: 'abc' }];
+    respond(JSON.stringify(runs));
+
+    await expect(listRecentMainRuns('eltmon/overdeck')).resolves.toEqual(runs);
+    expect(execFileMock).toHaveBeenCalledWith('gh', [
+      'run', 'list', '--repo', 'eltmon/overdeck', '--branch', 'main', '--limit', '50',
+      '--json', 'databaseId,workflowName,createdAt,conclusion,status,attempt,headSha',
+    ], { encoding: 'utf-8', timeout: 30000 }, expect.any(Function));
+  });
+
+  it('returns an empty list and warns when gh fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    respond('', new Error('offline'));
+
+    await expect(listRecentMainRuns('eltmon/overdeck')).resolves.toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Failed to list recent main runs'), 'offline');
+  });
+});
+
+describe('listPrHeadFailingRuns', () => {
+  it('keeps only runs for the current PR head SHA', async () => {
+    const current = { databaseId: 20, workflowName: 'CI', createdAt: '2026-07-15T10:00:00Z', conclusion: 'FAILURE', status: 'completed', attempt: 1, headSha: 'current' };
+    respond(JSON.stringify([current, { ...current, databaseId: 19, headSha: 'old' }]));
+
+    await expect(listPrHeadFailingRuns('eltmon/overdeck', 'feature/pan-2710', 'current')).resolves.toEqual([current]);
+    expect(execFileMock.mock.calls[0][1]).toEqual([
+      'run', 'list', '--repo', 'eltmon/overdeck', '--branch', 'feature/pan-2710', '--status', 'failure',
+      '--json', 'databaseId,workflowName,createdAt,conclusion,status,attempt,headSha',
+    ]);
+  });
+
+  it('returns an empty list and warns on malformed output', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    respond('not json');
+
+    await expect(listPrHeadFailingRuns('repo', 'branch', 'sha')).resolves.toEqual([]);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});
+
+describe('getPrHead', () => {
+  it('returns the PR head ref and oid', async () => {
+    respond('{"headRefName":"feature/pan-2710","headRefOid":"abc123"}');
+
+    await expect(getPrHead('eltmon/overdeck', 42)).resolves.toEqual({
+      headRefName: 'feature/pan-2710',
+      headRefOid: 'abc123',
+    });
+    expect(execFileMock.mock.calls[0][1]).toEqual([
+      'pr', 'view', '42', '--repo', 'eltmon/overdeck', '--json', 'headRefName,headRefOid',
+    ]);
+  });
+
+  it('returns null and warns on failure', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    respond('', new Error('missing'));
+
+    await expect(getPrHead('repo', 42)).resolves.toBeNull();
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});
+
+describe('rerunFailedRun', () => {
+  it('runs only failed jobs and returns true on success', async () => {
+    respond('');
+
+    await expect(rerunFailedRun('eltmon/overdeck', 123)).resolves.toBe(true);
+    expect(execFileMock.mock.calls[0][1]).toEqual([
+      'run', 'rerun', '123', '--failed', '--repo', 'eltmon/overdeck',
+    ]);
+  });
+
+  it('returns false and warns on failure', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    respond('', new Error('expired'));
+
+    await expect(rerunFailedRun('repo', 123)).resolves.toBe(false);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
The full PAN-2710 feature plus all three convoy-review findings: runTickIfIdle overlap guard (no concurrent ticks/subprocess growth), bounded dedup state with eviction, and rerun candidacy driven from FAILING_CHECK_CONCLUSIONS (TIMED_OUT/CANCELLED/etc no longer silently ignored). Convoy review artifacts on the issue; findings fixed per synthesis.

Gates (flywheel, real exit codes): 550 tests pass, typecheck 0. Supersedes #2736.

Closes PAN-2710

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically detects stale failed checks after the main branch recovers and selectively reruns eligible failed workflows.
  * Adds safeguards for retry limits, recent failure tracking, and read-only dashboard environments.
  * Logs skipped or retriggered checks to improve visibility.

* **Documentation**
  * Added troubleshooting guidance, including manual rerun steps and expected merge-status reconciliation delays.

* **Tests**
  * Added comprehensive coverage for stale-check detection, reruns, throttling, error handling, and state cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->