### PR TITLE
PAN-2768

### DIFF
--- a/apps/desktop/.gitignore
+++ b/apps/desktop/.gitignore
@@ -1,2 +1,3 @@
 drizzle
 sync-sources
+cli

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,7 +35,7 @@
     "start": "bun run scripts/start-electron.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --configLoader runner --passWithNoTests",
-    "dist:linux": "node scripts/prepare-server-resources.mjs && electron-builder --linux AppImage --publish never && node scripts/stamp-update-manifests.mjs",
+    "dist:linux": "node scripts/prepare-server-resources.mjs && electron-builder --linux AppImage --publish never && node scripts/smoke-appimage-cli.mjs && node scripts/stamp-update-manifests.mjs",
     "dist:mac": "node scripts/prepare-server-resources.mjs && electron-builder --mac dmg zip --arm64 --publish never && node scripts/stamp-update-manifests.mjs",
     "dist:win": "node scripts/prepare-server-resources.mjs && electron-builder --win nsis --publish never && node scripts/stamp-update-manifests.mjs",
     "postinstall": "electron-rebuild -f -w node-pty 2>/dev/null; exit 0"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -78,6 +78,14 @@
         "to": "sync-sources"
       },
       {
+        "from": "cli",
+        "to": "dist",
+        "filter": [
+          "**/*",
+          "!**/*.map"
+        ]
+      },
+      {
         "from": "server",
         "to": "server",
         "filter": [

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -86,6 +86,10 @@
         ]
       },
       {
+        "from": "cli/package.json",
+        "to": "package.json"
+      },
+      {
         "from": "server",
         "to": "server",
         "filter": [

--- a/apps/desktop/scripts/prepare-server-resources.mjs
+++ b/apps/desktop/scripts/prepare-server-resources.mjs
@@ -29,10 +29,11 @@
  * Prerequisite: `npm run build` at the repo root.
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import {
   cpSync,
   existsSync,
+  mkdtempSync,
   mkdirSync,
   readdirSync,
   readFileSync,
@@ -43,7 +44,7 @@ import {
 } from "node:fs";
 import Module, { createRequire } from "node:module";
 import * as OS from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -51,6 +52,8 @@ const desktopDir = join(__dirname, "..");
 const repoRoot = resolve(desktopDir, "../..");
 const distDashboard = join(repoRoot, "dist/dashboard");
 const serverDir = join(desktopDir, "server");
+const distRoot = join(repoRoot, "dist");
+const cliDir = join(desktopDir, "cli");
 
 // ─── Preflight ────────────────────────────────────────────────────────────────
 
@@ -114,6 +117,67 @@ const packageNameOf = (specifier) => {
 };
 const VALID_PACKAGE = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
 
+const scanImportClosure = (rootDir, entryPoints, skipPackages = new Set()) => {
+  const seen = new Set();
+  const queue = entryPoints.filter((entry) => existsSync(join(rootDir, entry)));
+  const packages = new Set();
+
+  while (queue.length > 0) {
+    const file = queue.pop();
+    if (seen.has(file) || !existsSync(join(rootDir, file))) continue;
+    seen.add(file);
+    const source = readFileSync(join(rootDir, file), "utf8");
+    const specifiers = [
+      ...source.matchAll(/from\s*["']([^"'\n]+)["']/g),
+      ...source.matchAll(/import\(\s*["']([^"'\n]+)["']\s*\)/g),
+      ...source.matchAll(/require\(\s*["']([^"'\n]+)["']\s*\)/g),
+    ].map((match) => match[1]);
+    for (const specifier of specifiers) {
+      if (specifier.startsWith("./") || specifier.startsWith("../")) {
+        const target = resolve(dirname(join(rootDir, file)), specifier);
+        const targetRelative = relative(rootDir, target);
+        if (targetRelative.endsWith(".js") && !targetRelative.startsWith("..")) queue.push(targetRelative);
+        continue;
+      }
+      if (specifier.startsWith("node:") || specifier.startsWith("bun:")) continue;
+      const packageName = packageNameOf(specifier);
+      if (!VALID_PACKAGE.test(packageName)) continue;
+      if (builtins.has(packageName) || skipPackages.has(packageName)) continue;
+      packages.add(packageName);
+    }
+  }
+
+  return { seen, packages };
+};
+
+const pinnedDependencies = (packages, label) => {
+  const dependencies = {};
+  for (const packageName of [...packages].sort()) {
+    const manifestPath = join(repoRoot, "node_modules", packageName, "package.json");
+    if (!existsSync(manifestPath)) {
+      console.warn(`[prepare-server] Skipping '${packageName}' — imported by the ${label} but not installed at the repo root (matching pan up)`);
+      continue;
+    }
+    dependencies[packageName] = JSON.parse(readFileSync(manifestPath, "utf8")).version;
+  }
+  return dependencies;
+};
+
+const installDependencies = (runtimeDir) => {
+  execSync("npm install --omit=dev --no-audit --no-fund", {
+    cwd: runtimeDir,
+    stdio: "inherit",
+  });
+};
+
+const removeSourceMaps = (dir) => {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = join(dir, entry.name);
+    if (entry.isDirectory()) removeSourceMaps(entryPath);
+    else if (entry.isFile() && entry.name.endsWith(".map")) rmSync(entryPath);
+  }
+};
+
 // ─── Stage the PTY supervisor (PAN-2592) ──────────────────────────────────────
 // Conversations and work agents wrap Claude in dist/pty-supervisor.js — a
 // root-build artifact the server locates via resolvePtySupervisorScriptPath()
@@ -133,32 +197,7 @@ mkdirSync(supervisorDir, { recursive: true });
 
 // Walk the supervisor's relative-import closure over repo dist/ (the root
 // build is code-split; shipping the entry alone cannot boot).
-const supervisorSeen = new Set();
-const supervisorQueue = ["pty-supervisor.js"];
-const supervisorExternals = new Set();
-while (supervisorQueue.length > 0) {
-  const file = supervisorQueue.pop();
-  if (supervisorSeen.has(file) || !existsSync(join(repoRoot, "dist", file))) continue;
-  supervisorSeen.add(file);
-  const source = readFileSync(join(repoRoot, "dist", file), "utf8");
-  const specifiers = [
-    ...source.matchAll(/from\s*["']([^"'\n]+)["']/g),
-    ...source.matchAll(/import\(\s*["']([^"'\n]+)["']\s*\)/g),
-    ...source.matchAll(/require\(\s*["']([^"'\n]+)["']\s*\)/g),
-  ].map((match) => match[1]);
-  for (const specifier of specifiers) {
-    if (specifier.startsWith("./") || specifier.startsWith("../")) {
-      const target = specifier.replace(/^\.\//, "");
-      if (target.endsWith(".js") && !target.includes("/")) supervisorQueue.push(target);
-      continue;
-    }
-    if (specifier.startsWith("node:")) continue;
-    const packageName = packageNameOf(specifier);
-    if (!VALID_PACKAGE.test(packageName)) continue;
-    if (builtins.has(packageName)) continue;
-    supervisorExternals.add(packageName);
-  }
-}
+const { seen: supervisorSeen, packages: supervisorExternals } = scanImportClosure(distRoot, ["pty-supervisor.js"]);
 for (const file of supervisorSeen) {
   cpSync(join(repoRoot, "dist", file), join(supervisorDir, file));
 }
@@ -255,47 +294,13 @@ const SKIP_PACKAGES = new Set([
   "playwright-core",
 ]);
 
-const seen = new Set();
-const queue = ENTRY_POINTS.filter((entry) => existsSync(join(serverDir, entry)));
-const packages = new Set();
-
-while (queue.length > 0) {
-  const file = queue.pop();
-  if (seen.has(file) || !existsSync(join(serverDir, file))) continue;
-  seen.add(file);
-  const source = readFileSync(join(serverDir, file), "utf8");
-  const specifiers = [
-    ...source.matchAll(/from\s*["']([^"'\n]+)["']/g),
-    ...source.matchAll(/import\(\s*["']([^"'\n]+)["']\s*\)/g),
-    ...source.matchAll(/require\(\s*["']([^"'\n]+)["']\s*\)/g),
-  ].map((match) => match[1]);
-  for (const specifier of specifiers) {
-    if (specifier.startsWith("./") || specifier.startsWith("../")) {
-      const target = specifier.replace(/^\.\//, "");
-      if (target.endsWith(".js") && !target.includes("/")) queue.push(target);
-      continue;
-    }
-    if (specifier.startsWith("node:") || specifier.startsWith("bun:")) continue;
-    const packageName = packageNameOf(specifier);
-    if (!VALID_PACKAGE.test(packageName)) continue; // string literal noise in minified code
-    if (builtins.has(packageName) || SKIP_PACKAGES.has(packageName)) continue;
-    packages.add(packageName);
-  }
-}
+const { seen, packages } = scanImportClosure(serverDir, ENTRY_POINTS, SKIP_PACKAGES);
 
 // Pin each external to the version actually installed at the repo root, so
 // the packaged server runs exactly what `pan up` runs. An external the root
 // doesn't have installed is one the live server also runs without (e.g. ws's
 // optional try/catch-guarded bufferutil) — skip it for parity.
-const dependencies = {};
-for (const packageName of [...packages].sort()) {
-  const manifestPath = join(repoRoot, "node_modules", packageName, "package.json");
-  if (!existsSync(manifestPath)) {
-    console.warn(`[prepare-server] Skipping '${packageName}' — imported by the bundle but not installed at the repo root (matching pan up)`);
-    continue;
-  }
-  dependencies[packageName] = JSON.parse(readFileSync(manifestPath, "utf8")).version;
-}
+const dependencies = pinnedDependencies(packages, "bundle");
 console.log(
   `[prepare-server] Externalized deps (${seen.size} reachable chunks): ${Object.entries(dependencies)
     .map(([name, version]) => `${name}@${version}`)
@@ -335,10 +340,7 @@ writeFileSync(
 );
 
 console.log("[prepare-server] Installing externalized deps...");
-execSync("npm install --omit=dev --no-audit --no-fund", {
-  cwd: serverDir,
-  stdio: "inherit",
-});
+installDependencies(serverDir);
 
 const desktopRequire = Module.createRequire(join(desktopDir, "package.json"));
 
@@ -379,4 +381,79 @@ try {
   console.warn("[prepare-server] electron binary not resolvable here — skipping the ABI load check");
 }
 
-console.log("[prepare-server] Done. server/ is ready for packaging.");
+// ─── Stage the pan CLI runtime (PAN-2768) ────────────────────────────────────
+
+const distCli = join(distRoot, "cli");
+if (!existsSync(join(distCli, "index.js"))) {
+  console.error("[prepare-server] dist/cli/index.js not found — run 'npm run build' at the repo root first.");
+  process.exit(1);
+}
+
+rmSync(cliDir, { recursive: true, force: true });
+mkdirSync(cliDir, { recursive: true });
+cpSync(distCli, join(cliDir, "cli"), {
+  recursive: true,
+  filter: (source) => !source.endsWith(".map"),
+});
+
+const { seen: cliSeen, packages: cliPackages } = scanImportClosure(distRoot, ["cli/index.js"]);
+for (const file of cliSeen) {
+  if (file.startsWith(`cli${OS.platform() === "win32" ? "\\" : "/"}`)) continue;
+  const destination = join(cliDir, file);
+  mkdirSync(dirname(destination), { recursive: true });
+  cpSync(join(distRoot, file), destination);
+}
+
+const cliDependencies = pinnedDependencies(cliPackages, "CLI bundle");
+writeFileSync(
+  join(cliDir, "package.json"),
+  `${JSON.stringify(
+    {
+      name: "@overdeck/desktop-cli",
+      version: rootPkg.version,
+      private: true,
+      type: "module",
+      dependencies: cliDependencies,
+    },
+    null,
+    2,
+  )}\n`,
+);
+console.log(
+  `[prepare-server] Staged pan CLI (${cliSeen.size} reachable chunks): ${Object.entries(cliDependencies)
+    .map(([name, version]) => `${name}@${version}`)
+    .join(", ")}`,
+);
+console.log("[prepare-server] Installing CLI externalized deps...");
+installDependencies(cliDir);
+removeSourceMaps(cliDir);
+
+{
+  const smokeRoot = mkdtempSync(join(OS.tmpdir(), "overdeck-cli-smoke-"));
+  const smokeRuntime = join(smokeRoot, "runtime");
+  const smokeHome = join(smokeRoot, "home");
+  cpSync(cliDir, smokeRuntime, { recursive: true });
+  // Electron exposes the app manifest at resources/package.json while
+  // extraResources maps this staged tree to resources/dist/. The CLI reads
+  // its version from that package root, but resolves externals from
+  // resources/dist/node_modules.
+  cpSync(join(cliDir, "package.json"), join(smokeRoot, "package.json"));
+  mkdirSync(smokeHome, { recursive: true });
+  try {
+    execFileSync(process.execPath, [join(smokeRuntime, "cli/index.js"), "--version"], {
+      cwd: smokeRuntime,
+      stdio: "pipe",
+      env: { ...process.env, OVERDECK_HOME: smokeHome },
+    });
+  } catch (error) {
+    console.error(`[prepare-server] Staged CLI smoke run failed with exit ${String(error?.status ?? -1)}.`);
+    if (error?.stderr) console.error(String(error.stderr));
+    process.exitCode = 1;
+  } finally {
+    rmSync(smokeRoot, { recursive: true, force: true });
+  }
+  if (process.exitCode) process.exit(process.exitCode);
+  console.log("[prepare-server] Verified: staged pan CLI boots from an isolated temp directory");
+}
+
+console.log("[prepare-server] Done. server/ and cli/ are ready for packaging.");

--- a/apps/desktop/scripts/prepare-server-resources.mjs
+++ b/apps/desktop/scripts/prepare-server-resources.mjs
@@ -97,16 +97,16 @@ rmSync(drizzleDest, { recursive: true, force: true });
 cpSync(join(repoRoot, "drizzle"), drizzleDest, { recursive: true });
 console.log("[prepare-server] Copied migration SQL → drizzle/");
 
-// ─── Stage the Claude Code hook bundle (PAN-2595) ─────────────────────────────
-// Desktop installs never run `pan install`, so the dashboard server provisions
-// the hooks at boot (src/lib/claude-hooks-provision.ts). It resolves them from
-// SYNC_SOURCES.hooks = <packageRoot>/sync-sources/hooks — resources/ in the
-// packaged app (extraResources maps sync-sources → sync-sources), the package
-// root in the npx flavor (`files` includes sync-sources).
+// ─── Stage sync sources (PAN-2595, PAN-2768) ──────────────────────────────────
+// Desktop installs never run `pan install`, so the dashboard provisions hooks
+// at boot and `pan sync` reads skills, rules, agents, dev skills, and hooks from
+// <packageRoot>/sync-sources. packageRoot is resources/ in the packaged app
+// (extraResources maps sync-sources → sync-sources), so Sync Now needs the full
+// tree rather than only the hook bundle.
 const hooksStageDir = join(desktopDir, "sync-sources");
 rmSync(hooksStageDir, { recursive: true, force: true });
-cpSync(join(repoRoot, "sync-sources", "hooks"), join(hooksStageDir, "hooks"), { recursive: true });
-console.log("[prepare-server] Staged Claude hook bundle → sync-sources/hooks/");
+cpSync(join(repoRoot, "sync-sources"), hooksStageDir, { recursive: true });
+console.log("[prepare-server] Staged sync payload → sync-sources/");
 
 // ─── Bare-specifier scan helpers (shared by supervisor + server staging) ──────
 

--- a/apps/desktop/scripts/prepare-server-resources.mjs
+++ b/apps/desktop/scripts/prepare-server-resources.mjs
@@ -6,8 +6,8 @@
  * sibling rolldown chunks, and spawns the deacon/worker entries by path.
  * Shipping server.js alone (the pre-PAN-2561 packaging) can never boot.
  *
- * This script assembles apps/desktop/server/ (gitignored) from the repo-root
- * build output:
+ * This script assembles the gitignored desktop packaging payload from the
+ * repo-root build output:
  *   - dist/dashboard/*.js       → server/          (entry + full chunk graph)
  *   - dist/dashboard/public/    → server/public/
  *   - server/package.json       ({type: "module"} so the chunks load as ESM)
@@ -17,6 +17,8 @@
  *     broken package), then installed at the repo's installed versions.
  *     @lydell/node-pty ships Node-API prebuilds, so the packaged server child
  *     can use the same platform package under stock Node and Electron.
+ *   - dist/cli/ + chunk closure → cli/              (self-contained CLI runtime)
+ *   - sync-sources/             → sync-sources/     (full sync payload, not hooks only)
  *
  * Deliberately skipped externals: bun-only modules (never imported under
  * Node), and playwright (lazy import for artifact thumbnails, PAN-1645 —

--- a/apps/desktop/scripts/smoke-appimage-cli.mjs
+++ b/apps/desktop/scripts/smoke-appimage-cli.mjs
@@ -1,0 +1,71 @@
+/**
+ * Verify the CLI from the built Linux AppImage, using its bundled Electron as
+ * Node. This runs after electron-builder so staging-only success cannot mask a
+ * broken extraResources layout.
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import * as OS from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const desktopDir = resolve(__dirname, "..");
+const desktopPkg = JSON.parse(readFileSync(join(desktopDir, "package.json"), "utf8"));
+const appImage = join(desktopDir, "dist", `${desktopPkg.build.productName}-${desktopPkg.version}.AppImage`);
+
+if (!existsSync(appImage)) {
+  throw new Error(`[smoke-appimage-cli] AppImage not found: ${appImage}`);
+}
+
+const smokeRoot = mkdtempSync(join(OS.tmpdir(), "overdeck-appimage-smoke-"));
+try {
+  execFileSync(appImage, ["--appimage-extract"], {
+    cwd: smokeRoot,
+    // AppImage extraction prints every file path; discard that multi-megabyte
+    // listing so execFileSync's output buffer cannot terminate a valid build.
+    stdio: "ignore",
+  });
+
+  const appDir = join(smokeRoot, "squashfs-root");
+  const packageManifest = join(appDir, "resources", "package.json");
+  const cliEntry = join(appDir, "resources", "dist", "cli", "index.js");
+  const cliModules = join(appDir, "resources", "dist", "node_modules");
+  for (const requiredPath of [packageManifest, cliEntry, cliModules]) {
+    if (!existsSync(requiredPath)) {
+      throw new Error(`[smoke-appimage-cli] Packaged CLI path missing: ${requiredPath}`);
+    }
+  }
+
+  const appRun = readFileSync(join(appDir, "AppRun"), "utf8");
+  const binaryName = appRun.match(/^BIN="\$APPDIR\/([^"/]+)"$/m)?.[1];
+  if (!binaryName) {
+    throw new Error("[smoke-appimage-cli] Could not resolve the bundled Electron binary from AppRun");
+  }
+
+  const smokeHome = join(smokeRoot, "home");
+  mkdirSync(smokeHome);
+  const version = execFileSync(join(appDir, binaryName), [cliEntry, "--version"], {
+    cwd: appDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ELECTRON_RUN_AS_NODE: "1",
+      OVERDECK_HOME: smokeHome,
+    },
+  }).trim();
+
+  if (version !== desktopPkg.version) {
+    throw new Error(`[smoke-appimage-cli] Packaged CLI returned version '${version}', expected '${desktopPkg.version}'`);
+  }
+  console.log(`[smoke-appimage-cli] Verified packaged CLI under bundled Electron: ${version}`);
+} finally {
+  rmSync(smokeRoot, { recursive: true, force: true });
+}

--- a/apps/desktop/tests/package-structure.test.ts
+++ b/apps/desktop/tests/package-structure.test.ts
@@ -67,6 +67,17 @@ describe("package.json", () => {
     expect(scripts?.["build:publish"]).toBeDefined();
   });
 
+  it("smoke-tests the built AppImage CLI before stamping Linux manifests", () => {
+    const pkg = readPkg();
+    const scripts = pkg.scripts as Record<string, string> | undefined;
+
+    expect(scripts?.["dist:linux"]).toContain("electron-builder --linux AppImage");
+    expect(scripts?.["dist:linux"]).toContain("node scripts/smoke-appimage-cli.mjs");
+    expect(scripts?.["dist:linux"]?.indexOf("smoke-appimage-cli.mjs")).toBeLessThan(
+      scripts?.["dist:linux"]?.indexOf("stamp-update-manifests.mjs") ?? -1,
+    );
+  });
+
   it("ships the staged CLI and preserves every existing extra resource", () => {
     const pkg = readPkg();
     const build = pkg.build as Record<string, unknown> | undefined;
@@ -150,5 +161,19 @@ describe("scripts/prepare-server-resources.mjs", () => {
 
     expect(script).toContain('cpSync(join(repoRoot, "sync-sources"), hooksStageDir, { recursive: true })');
     expect(script).not.toContain('cpSync(join(repoRoot, "sync-sources", "hooks")');
+  });
+});
+
+describe("scripts/smoke-appimage-cli.mjs", () => {
+  it("extracts the AppImage and runs its CLI under bundled Electron-as-Node", () => {
+    const script = FS.readFileSync(
+      Path.join(desktopDir, "scripts/smoke-appimage-cli.mjs"),
+      "utf8",
+    );
+
+    expect(script).toContain('execFileSync(appImage, ["--appimage-extract"]');
+    expect(script).toContain('"resources", "dist", "cli", "index.js"');
+    expect(script).toContain('ELECTRON_RUN_AS_NODE: "1"');
+    expect(script).toContain('[cliEntry, "--version"]');
   });
 });

--- a/apps/desktop/tests/package-structure.test.ts
+++ b/apps/desktop/tests/package-structure.test.ts
@@ -66,6 +66,28 @@ describe("package.json", () => {
     const scripts = pkg.scripts as Record<string, string> | undefined;
     expect(scripts?.["build:publish"]).toBeDefined();
   });
+
+  it("ships the staged CLI and preserves every existing extra resource", () => {
+    const pkg = readPkg();
+    const build = pkg.build as Record<string, unknown> | undefined;
+    const extraResources = build?.extraResources as
+      | Array<{ from?: string; to?: string; filter?: string[] }>
+      | undefined;
+
+    expect(extraResources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ from: "drizzle", to: "drizzle" }),
+        expect.objectContaining({ from: "sync-sources", to: "sync-sources" }),
+        expect.objectContaining({
+          from: "cli",
+          to: "dist",
+          filter: expect.arrayContaining(["**/*", "!**/*.map"]),
+        }),
+        expect.objectContaining({ from: "server", to: "server" }),
+        expect.objectContaining({ from: "resources", to: "resources" }),
+      ]),
+    );
+  });
 });
 
 describe("bin/overdeck.mjs", () => {
@@ -107,5 +129,25 @@ describe("scripts/stamp-update-manifests.mjs", () => {
 
     expect(script).toContain("fileURLToPath(new URL('../dist/', import.meta.url))");
     expect(script).not.toContain("distDir.pathname");
+  });
+});
+
+describe("scripts/prepare-server-resources.mjs", () => {
+  const scriptPath = Path.join(desktopDir, "scripts/prepare-server-resources.mjs");
+
+  it("stages and smoke-runs the packaged CLI runtime", () => {
+    const script = FS.readFileSync(scriptPath, "utf8");
+
+    expect(script).toContain('const cliDir = join(desktopDir, "cli")');
+    expect(script).toContain('cpSync(distCli, join(cliDir, "cli")');
+    expect(script).toContain('join(smokeRuntime, "cli/index.js")');
+    expect(script).toContain("Staged CLI smoke run failed");
+  });
+
+  it("stages the full sync-sources tree instead of only hooks", () => {
+    const script = FS.readFileSync(scriptPath, "utf8");
+
+    expect(script).toContain('cpSync(join(repoRoot, "sync-sources"), hooksStageDir, { recursive: true })');
+    expect(script).not.toContain('cpSync(join(repoRoot, "sync-sources", "hooks")');
   });
 });

--- a/apps/desktop/tests/package-structure.test.ts
+++ b/apps/desktop/tests/package-structure.test.ts
@@ -83,6 +83,7 @@ describe("package.json", () => {
           to: "dist",
           filter: expect.arrayContaining(["**/*", "!**/*.map"]),
         }),
+        expect.objectContaining({ from: "cli/package.json", to: "package.json" }),
         expect.objectContaining({ from: "server", to: "server" }),
         expect.objectContaining({ from: "resources", to: "resources" }),
       ]),

--- a/docs/DESKTOP-APP.md
+++ b/docs/DESKTOP-APP.md
@@ -235,13 +235,18 @@ external dependencies. `apps/desktop/package.json` installs the staged runtime
 with this electron-builder resource mapping:
 
 ```json
-{ "from": "cli", "to": "dist", "filter": ["**/*", "!**/*.map"] }
+[
+  { "from": "cli", "to": "dist", "filter": ["**/*", "!**/*.map"] },
+  { "from": "cli/package.json", "to": "package.json" }
+]
 ```
 
 The dashboard's `panCliInvocation` helper resolves the entry from
 `packageRoot/dist/cli/index.js`. In a packaged app, `packageRoot` is Electron's
 `resources/` directory, so the normal resolver reaches the packaged runtime
-without a desktop-specific code path. The preparation script also copies the
+without a desktop-specific code path. The second resource mapping places the
+generated CLI manifest at `resources/package.json`, where the shared version
+resolver expects the package-root manifest. The preparation script also copies the
 complete `sync-sources/` tree because commands such as `pan sync` need the
 skills, rules, agents, development skills, and hooks payload.
 

--- a/docs/DESKTOP-APP.md
+++ b/docs/DESKTOP-APP.md
@@ -227,6 +227,36 @@ The `beta` channel maps to GitHub prereleases; `latest` maps to full releases. O
 
 See [BUILD.md § Electron Desktop App](./BUILD.md#electron-desktop-app-appsdesktop) for the full build pipeline.
 
+### Packaged CLI runtime
+
+The packaged app includes a self-contained `pan` CLI runtime at
+`resources/dist/cli/index.js`, together with its reachable build chunks and
+external dependencies. `apps/desktop/package.json` installs the staged runtime
+with this electron-builder resource mapping:
+
+```json
+{ "from": "cli", "to": "dist", "filter": ["**/*", "!**/*.map"] }
+```
+
+The dashboard's `panCliInvocation` helper resolves the entry from
+`packageRoot/dist/cli/index.js`. In a packaged app, `packageRoot` is Electron's
+`resources/` directory, so the normal resolver reaches the packaged runtime
+without a desktop-specific code path. The preparation script also copies the
+complete `sync-sources/` tree because commands such as `pan sync` need the
+skills, rules, agents, development skills, and hooks payload.
+
+The embedded dashboard server starts under Electron with
+`ELECTRON_RUN_AS_NODE=1`, and every `pan` child inherits that environment. This
+inheritance is what makes `process.execPath` behave as Node when the executable
+is Electron. A packaged `pan` spawn site must preserve the inherited environment
+or explicitly retain `ELECTRON_RUN_AS_NODE=1`; passing a replacement `env`
+without it launches Electron as an application instead of running the CLI.
+
+This staged CLI runtime belongs to the electron-builder packages (AppImage,
+DMG, and NSIS). The npm/npx flavor does not copy it: npm packaging strips
+nested `node_modules`, and its runtime-vendoring work remains part of the
+[PAN-2561](https://github.com/eltmon/overdeck/issues/2561) packaging story.
+
 ---
 
 ## Architecture


### PR DESCRIPTION
**Issue:** #2768

## Acceptance Criteria

- [ ] Stage a self-contained pan CLI runtime in prepare-server-resources.mjs
- [ ] Map the staged CLI into the package via extraResources cli → dist
- [ ] Stage the full sync-sources tree so packaged pan sync has its payload
- [ ] Extend package-structure tests to lock the CLI and sync-sources packaging contract
- [ ] Build the Linux AppImage and verify the packaged CLI launches under bundled Electron-as-Node
- [ ] Document the packaged CLI runtime and the ELECTRON_RUN_AS_NODE inheritance invariant