### PR TITLE
PAN-2633

### DIFF
--- a/docs/PENDING-INPUT.md
+++ b/docs/PENDING-INPUT.md
@@ -52,6 +52,18 @@ at read time) enumerates the active blocking surfaces. Labels live in one map:
   payload and the reconcile effect prunes optimistic/dismissed marks.
 - **Stale clicks can't inject keystrokes.** `POST /api/agents/:id/plan-action`
   409s unless the agent's JSONL still shows a pending `ExitPlanMode`.
+- **PAN-2633: liveness-gated wipe.** Pending-input payloads survive agent
+  status flaps while the agent's tmux session is alive. The
+  `agent.status_changed` reducer wipes them only when a stop-shaped event does
+  not assert `hasLiveTmuxSession: true` (origin PAN-1520). This prevents an
+  idle-alive agent (registry status `stopped` but pane still live and showing
+  an AskUserQuestion) from losing its needs-you entry and modal.
+- **PAN-2633: ≤10s convergence.** If a stop-shaped status event ever wipes the
+  read model's pending payload for a tmux-alive waiting agent, the enrichment
+  poller re-emits it on the next poll (~10s), so the read model converges
+  without a page refresh. The poller's `lastEnrichment` cache is intentionally
+  not cleared, preserving the PAN-1834 awaiting-input rising edge as a
+  single-shot activity entry + TTS notification.
 
 ## Data flow (plan approval)
 

--- a/packages/contracts/src/event-reducers.ts
+++ b/packages/contracts/src/event-reducers.ts
@@ -491,7 +491,11 @@ export function applyEvent(state: ReadModelState, event: DomainEvent): ReadModel
         // poller stops emitting events for non-running agents, so without this
         // a paused or stopped agent would keep showing INPUT/AskUserQuestion
         // forever from the operator's perspective.
-        if (event.payload.status !== 'running' && event.payload.status !== 'starting') {
+        // PAN-2633 — an idle-alive agent (stopped-shaped status, live tmux pane)
+        // is the archetypal awaiting-operator state and must keep its pending-input
+        // payload; gate the wipe on the liveness flag carried in the event.
+        const sessionAlive = event.payload.hasLiveTmuxSession === true
+        if (event.payload.status !== 'running' && event.payload.status !== 'starting' && !sessionAlive) {
           delete base['hasPendingQuestion']
           delete base['pendingQuestionCount']
           delete base['pendingQuestionPrompt']

--- a/src/dashboard/server/deacon-main.ts
+++ b/src/dashboard/server/deacon-main.ts
@@ -78,7 +78,9 @@ setAgentStoppedNotifier((agentId) => {
       const state = await Effect.runPromise(getAgentState(agentId));
       if (state) {
         append(domainEvent('agent.heartbeat_dead', { agentId, issueId: state.issueId, sessionId: state.sessionId }));
-        append(domainEvent('agent.status_changed', buildAgentStatusChangedPayload(state)));
+        // PAN-2633: heartbeat_dead means the deacon has determined the tmux
+        // session is gone, so assert hasLiveTmuxSession: false explicitly.
+        append(domainEvent('agent.status_changed', buildAgentStatusChangedPayload(state, undefined, false)));
         return;
       }
       append(domainEvent('agent.heartbeat_dead', { agentId }));

--- a/src/dashboard/server/main.ts
+++ b/src/dashboard/server/main.ts
@@ -400,10 +400,12 @@ setAgentStoppedNotifier((agentId) => {
         } as any);
         // PAN-1908: write-through projection — agents-row upsert + lifecycle
         // event append in one SQLite transaction.
+        // PAN-2633: heartbeat_dead means the deacon has determined the tmux
+        // session is gone, so assert hasLiveTmuxSession: false explicitly.
         saveAgentStateAndEmitEvent(state, {
           type: 'agent.status_changed',
           timestamp: new Date().toISOString(),
-          payload: buildAgentStatusChangedPayload(state),
+          payload: buildAgentStatusChangedPayload(state, undefined, false),
         });
         return;
       }

--- a/src/dashboard/server/routes/agents/lifecycle-stop.ts
+++ b/src/dashboard/server/routes/agents/lifecycle-stop.ts
@@ -229,10 +229,13 @@ export const postAgentPauseRoute = HttpRouter.add(
     }));
     // PAN-1908: write-through projection — agents-row upsert + lifecycle event
     // append in one SQLite transaction.
+    // PAN-2633: assert tmux liveness at emission time so the reducer knows whether
+    // this stop-shaped transition is idle-alive (preserve pending-input payload).
+    const hasLiveTmuxSession = yield* sessionExists(id);
     yield* saveAgentStateAndEmitEventProgram(updatedState, {
       type: 'agent.status_changed',
       timestamp: new Date().toISOString(),
-      payload: buildAgentControlEventPayload(updatedState, previousStatus),
+      payload: buildAgentControlEventPayload(updatedState, previousStatus, hasLiveTmuxSession),
     });
 
     invalidateAgentsCache();
@@ -276,10 +279,13 @@ export const postAgentUnpauseRoute = HttpRouter.add(
     }
     // PAN-1908: write-through projection — agents-row upsert + lifecycle event
     // append in one SQLite transaction.
+    // PAN-2633: assert tmux liveness at emission time so the reducer knows whether
+    // this stop-shaped transition is idle-alive (preserve pending-input payload).
+    const hasLiveTmuxSession = yield* sessionExists(id);
     yield* saveAgentStateAndEmitEventProgram(updatedState, {
       type: 'agent.status_changed',
       timestamp: new Date().toISOString(),
-      payload: buildAgentControlEventPayload(updatedState, toAgentStatusPayload(stateBeforeUnpause.status)),
+      payload: buildAgentControlEventPayload(updatedState, toAgentStatusPayload(stateBeforeUnpause.status), hasLiveTmuxSession),
     });
 
     invalidateAgentsCache();
@@ -323,10 +329,13 @@ export const postAgentUntroubledRoute = HttpRouter.add(
     }
     // PAN-1908: write-through projection — agents-row upsert + lifecycle event
     // append in one SQLite transaction.
+    // PAN-2633: assert tmux liveness at emission time so the reducer knows whether
+    // this stop-shaped transition is idle-alive (preserve pending-input payload).
+    const hasLiveTmuxSession = yield* sessionExists(id);
     yield* saveAgentStateAndEmitEventProgram(updatedState, {
       type: 'agent.status_changed',
       timestamp: new Date().toISOString(),
-      payload: buildAgentControlEventPayload(updatedState, toAgentStatusPayload(stateBeforeClear.status)),
+      payload: buildAgentControlEventPayload(updatedState, toAgentStatusPayload(stateBeforeClear.status), hasLiveTmuxSession),
     });
 
     invalidateAgentsCache();

--- a/src/dashboard/server/routes/agents/shared.ts
+++ b/src/dashboard/server/routes/agents/shared.ts
@@ -273,12 +273,13 @@ function toAgentStatusPayload(status: AgentState['status'] | undefined): AgentSt
     : 'unknown';
 }
 
-function buildAgentControlEventPayload(state: AgentState, previousStatus?: AgentStatus) {
+function buildAgentControlEventPayload(state: AgentState, previousStatus: AgentStatus | undefined, hasLiveTmuxSession: boolean) {
   return {
     agentId: state.id,
     issueId: state.issueId,
     status: toAgentStatusPayload(state.status),
     previousStatus,
+    hasLiveTmuxSession,
     stoppedByUser: state.stoppedByUser === true,
     paused: state.paused === true,
     pausedReason: state.pausedReason ?? null,

--- a/src/dashboard/server/services/__tests__/agent-enrichment-service.test.ts
+++ b/src/dashboard/server/services/__tests__/agent-enrichment-service.test.ts
@@ -2,10 +2,15 @@ import { describe, expect, it } from 'vitest'
 import {
   buildAwaitingInputActivityMessage,
   isAwaitingInputRisingEdge,
+  shouldForceReemitPendingInput,
 } from '../agent-enrichment-service.js'
 import type { AgentEnrichment } from '../../../../lib/agent-enrichment.js'
 
-function makeEnrichment(pendingInputCount: number, pendingInputKinds: string[] = []): AgentEnrichment {
+function makeEnrichment(
+  pendingInputCount: number,
+  pendingInputKinds: string[] = [],
+  overrides: Partial<AgentEnrichment> = {},
+): AgentEnrichment {
   return {
     role: 'work',
     hasPendingQuestion: pendingInputCount > 0,
@@ -14,6 +19,7 @@ function makeEnrichment(pendingInputCount: number, pendingInputKinds: string[] =
     pendingInputKinds: pendingInputKinds as AgentEnrichment['pendingInputKinds'],
     resolution: 'working',
     resolutionCount: 0,
+    ...overrides,
   }
 }
 
@@ -62,5 +68,43 @@ describe('buildAwaitingInputActivityMessage', () => {
     expect(buildAwaitingInputActivityMessage('agent-pan-123', 'PAN-123', [])).toBe(
       'agent-pan-123 on PAN-123 is waiting for input',
     )
+  })
+})
+
+describe('shouldForceReemitPendingInput', () => {
+  it('returns true for stopped status with pendingAskUserQuestion', () => {
+    const enrichment = makeEnrichment(0, [], { pendingAskUserQuestion: { toolUseId: 't1' } as any })
+    expect(shouldForceReemitPendingInput('stopped', enrichment)).toBe(true)
+  })
+
+  it('returns true for stopped status with pendingProposedPlan', () => {
+    const enrichment = makeEnrichment(0, [], { pendingProposedPlan: { toolUseId: 't2' } as any })
+    expect(shouldForceReemitPendingInput('stopped', enrichment)).toBe(true)
+  })
+
+  it('returns true for stopped status with pendingInputCount > 0', () => {
+    const enrichment = makeEnrichment(1, ['askUserQuestion'])
+    expect(shouldForceReemitPendingInput('stopped', enrichment)).toBe(true)
+  })
+
+  it('returns false for running and starting status regardless of pending payload', () => {
+    const enrichment = makeEnrichment(2, ['askUserQuestion', 'plan'], {
+      pendingAskUserQuestion: { toolUseId: 't1' } as any,
+      pendingProposedPlan: { toolUseId: 't2' } as any,
+    })
+    expect(shouldForceReemitPendingInput('running', enrichment)).toBe(false)
+    expect(shouldForceReemitPendingInput('starting', enrichment)).toBe(false)
+  })
+
+  it('returns false for stopped status with empty enrichment', () => {
+    const enrichment = makeEnrichment(0)
+    expect(shouldForceReemitPendingInput('stopped', enrichment)).toBe(false)
+  })
+})
+
+describe('forced re-emission does not re-trigger awaiting-input rising edge', () => {
+  it('returns false when previous equals current with pendingInputCount > 0', () => {
+    const enrichment = makeEnrichment(2, ['askUserQuestion'])
+    expect(isAwaitingInputRisingEdge(enrichment, enrichment)).toBe(false)
   })
 })

--- a/src/dashboard/server/services/agent-enrichment-service.ts
+++ b/src/dashboard/server/services/agent-enrichment-service.ts
@@ -73,6 +73,24 @@ export function isAwaitingInputRisingEdge(
   return previousCount === 0 && current.pendingInputCount > 0
 }
 
+// PAN-2633 — force re-emission for idle-alive waiting agents. A stop-shaped
+// status_changed event can wipe the read model's pending payload, and the
+// private lastEnrichment cache cannot see that wipe. While the agent's tmux
+// session is still alive and a pending payload exists, bypass the dedup so the
+// read model converges within one ~10s poll. previousEnrichment stays intact,
+// so the PAN-1834 awaiting-input rising edge (activity + TTS) does not re-fire.
+export function shouldForceReemitPendingInput(
+  agentStatus: string,
+  enrichment: AgentEnrichment,
+): boolean {
+  if (agentStatus === 'running' || agentStatus === 'starting') return false
+  return (
+    enrichment.pendingInputCount > 0 ||
+    enrichment.pendingAskUserQuestion != null ||
+    enrichment.pendingProposedPlan != null
+  )
+}
+
 export function buildAwaitingInputActivityMessage(
   agentId: string,
   issueId: string | undefined,
@@ -215,7 +233,12 @@ async function pollOnce(state: EnrichmentServiceState): Promise<void> {
         emitActivityTtsSync({ utterance: message, priority: 1, issueId, source, eventType: 'awaiting_input' })
       }
 
-      if (!enrichmentChanged(previousEnrichment, enrichment)) {
+      // PAN-2633 — a stop-shaped status_changed event may have wiped the read
+      // model's pending payload while the tmux session is still alive. Bypass
+      // the dedup for idle-alive waiting agents so the read model converges
+      // within one poll; keep lastEnrichment intact so the rising-edge above
+      // does not re-fire every poll.
+      if (!enrichmentChanged(previousEnrichment, enrichment) && !shouldForceReemitPendingInput(agent.status, enrichment)) {
         return
       }
 

--- a/tests/dashboard/event-reducers.test.ts
+++ b/tests/dashboard/event-reducers.test.ts
@@ -308,6 +308,95 @@ describe('applyEvent — agent.status_changed', () => {
     })
     expect(next.turnDiffSummariesByAgentId['agent-1']).toBeUndefined()
   })
+
+  // PAN-2633 — pending-input wipe must be gated on tmux liveness for idle-alive agents.
+  const agentWithPendingInput: AgentSnapshot = {
+    ...baseAgent,
+    hasPendingQuestion: true,
+    pendingQuestionCount: 1,
+    pendingQuestionPrompt: 'Approve this plan?',
+    pendingQuestionReason: 'plan-approval',
+    pendingInputCount: 2,
+    pendingInputKinds: ['auq', 'plan'],
+    pendingAskUserQuestion: { question: 'Approve this plan?', options: [{ label: 'Yes', value: 'yes' }] } as any,
+    pendingProposedPlan: { planId: 'plan-1', title: 'Plan' } as any,
+  }
+
+  it('preserves pending-input fields on stopped status when tmux session is live', () => {
+    const state = makeState({ agentsById: { 'agent-1': agentWithPendingInput } })
+    const next = applyEvent(state, {
+      type: 'agent.status_changed',
+      sequence: 5,
+      timestamp: ts(),
+      payload: { agentId: 'agent-1', status: 'stopped', hasLiveTmuxSession: true },
+    })
+    const agent = next.agentsById['agent-1']!
+    expect(agent.hasPendingQuestion).toBe(true)
+    expect(agent.pendingQuestionCount).toBe(1)
+    expect(agent.pendingQuestionPrompt).toBe('Approve this plan?')
+    expect(agent.pendingQuestionReason).toBe('plan-approval')
+    expect(agent.pendingInputCount).toBe(2)
+    expect(agent.pendingInputKinds).toEqual(['auq', 'plan'])
+    expect(agent.pendingAskUserQuestion).toEqual(agentWithPendingInput.pendingAskUserQuestion)
+    expect(agent.pendingProposedPlan).toEqual(agentWithPendingInput.pendingProposedPlan)
+  })
+
+  it('deletes pending-input fields on stopped status when tmux session is not live', () => {
+    const state = makeState({ agentsById: { 'agent-1': agentWithPendingInput } })
+    const next = applyEvent(state, {
+      type: 'agent.status_changed',
+      sequence: 5,
+      timestamp: ts(),
+      payload: { agentId: 'agent-1', status: 'stopped', hasLiveTmuxSession: false },
+    })
+    const agent = next.agentsById['agent-1']!
+    expect(agent.hasPendingQuestion).toBeUndefined()
+    expect(agent.pendingQuestionCount).toBeUndefined()
+    expect(agent.pendingQuestionPrompt).toBeUndefined()
+    expect(agent.pendingQuestionReason).toBeUndefined()
+    expect(agent.pendingInputCount).toBeUndefined()
+    expect(agent.pendingInputKinds).toBeUndefined()
+    expect(agent.pendingAskUserQuestion).toBeUndefined()
+    expect(agent.pendingProposedPlan).toBeUndefined()
+  })
+
+  it('deletes pending-input fields on stopped status when hasLiveTmuxSession is absent', () => {
+    const state = makeState({ agentsById: { 'agent-1': agentWithPendingInput } })
+    const next = applyEvent(state, {
+      type: 'agent.status_changed',
+      sequence: 5,
+      timestamp: ts(),
+      payload: { agentId: 'agent-1', status: 'stopped' },
+    })
+    const agent = next.agentsById['agent-1']!
+    expect(agent.hasPendingQuestion).toBeUndefined()
+    expect(agent.pendingQuestionCount).toBeUndefined()
+    expect(agent.pendingQuestionPrompt).toBeUndefined()
+    expect(agent.pendingQuestionReason).toBeUndefined()
+    expect(agent.pendingInputCount).toBeUndefined()
+    expect(agent.pendingInputKinds).toBeUndefined()
+    expect(agent.pendingAskUserQuestion).toBeUndefined()
+    expect(agent.pendingProposedPlan).toBeUndefined()
+  })
+
+  it('preserves pending-input fields while running regardless of hasLiveTmuxSession', () => {
+    const state = makeState({ agentsById: { 'agent-1': agentWithPendingInput } })
+    const next = applyEvent(state, {
+      type: 'agent.status_changed',
+      sequence: 5,
+      timestamp: ts(),
+      payload: { agentId: 'agent-1', status: 'running', hasLiveTmuxSession: false },
+    })
+    const agent = next.agentsById['agent-1']!
+    expect(agent.hasPendingQuestion).toBe(true)
+    expect(agent.pendingQuestionCount).toBe(1)
+    expect(agent.pendingQuestionPrompt).toBe('Approve this plan?')
+    expect(agent.pendingQuestionReason).toBe('plan-approval')
+    expect(agent.pendingInputCount).toBe(2)
+    expect(agent.pendingInputKinds).toEqual(['auq', 'plan'])
+    expect(agent.pendingAskUserQuestion).toEqual(agentWithPendingInput.pendingAskUserQuestion)
+    expect(agent.pendingProposedPlan).toEqual(agentWithPendingInput.pendingProposedPlan)
+  })
 })
 
 describe('applyEvent — agent.turn_diff_completed', () => {


### PR DESCRIPTION
**Issue:** #2633

## Acceptance Criteria

- [ ] Gate the status_changed pending-input wipe on hasLiveTmuxSession
- [ ] Thread accurate hasLiveTmuxSession through every stop-shaped status_changed emitter
- [ ] Enrichment poller re-emits pending payload for idle-alive waiting agents (dedup bypass)
- [ ] Document the liveness-gated wipe + convergence invariant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved pending-input prompts and needs-you indicators when an agent is stopped but its live session remains available.
  * Cleared stale pending-input information when an agent is confirmed offline.
  * Restored pending-input displays automatically during background updates if they are unexpectedly cleared.
  * Prevented duplicate awaiting-input notifications while restoring pending-input information.

* **Tests**
  * Added coverage for live-session detection, pending-input preservation, cleanup, and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->