### PR TITLE
PAN-1987

### DIFF
--- a/configuration/projects.mdx
+++ b/configuration/projects.mdx
@@ -45,6 +45,19 @@ pan project list
 pan project remove myproject
 ```
 
+### Rename a project
+
+```bash
+pan project rename <key> <newName>
+
+# Example: keep the stable `myn` key and change its display name
+pan project rename myn "Mind Your Now"
+```
+
+The registration key is the stable identifier stored as the project's YAML map key. It is derived when the project is registered and cannot be renamed. The display name is the human-facing label shown throughout Overdeck; it can be renamed, but it cannot match another project's registration key or display name, ignoring letter case.
+
+In the dashboard, use the pencil beside the name on the project page, or right-click the project tree row and choose **Rename project**. Both controls open an inline editor for the display name while preserving the registration key.
+
 ## Project Configuration
 
 Projects are defined in `~/.overdeck/projects.yaml`:

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -8,7 +8,7 @@
 1530 src/dashboard/frontend/src/components/chat/ConversationPanel.tsx
 1440 src/dashboard/server/routes/command-deck.ts
 1005 src/dashboard/server/routes/flywheel.ts
-1050 src/dashboard/server/routes/projects.ts
+1047 src/dashboard/server/routes/projects.ts
 1143 src/dashboard/server/routes/settings.ts
 1727 src/dashboard/server/routes/workspaces.ts
 1935 src/dashboard/server/routes/workspaces/merge-ops.ts

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -1,6 +1,6 @@
 1056 src/cli/commands/done.ts
 1306 src/cli/commands/start.ts
-1444 src/cli/index.ts
+1412 src/cli/index.ts
 1012 src/dashboard/frontend/src/components/AwaitingMergePage.tsx
 1350 src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.tsx
 1540 src/dashboard/frontend/src/components/CommandDeck/index.tsx

--- a/src/cli/commands/project.ts
+++ b/src/cli/commands/project.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import type { Command } from 'commander';
 import { existsSync, readFileSync } from 'fs';
 import { join, resolve } from 'path';
 import {
@@ -7,6 +8,7 @@ import {
   getProjectSync,
   initializeProjectsConfigSync,
   PROJECTS_CONFIG_FILE,
+  renameProjectSync,
   ProjectConfig,
   IssueRoutingRule,
   getIssuePrefix,
@@ -232,6 +234,21 @@ export async function projectListCommand(options: ListOptions = {}): Promise<voi
   console.log(chalk.dim(`Config: ${PROJECTS_CONFIG_FILE}`));
 }
 
+export async function projectRenameCommand(key: string, newName: string): Promise<void> {
+  try {
+    const project = getProjectSync(key);
+    if (!project) throw new Error(`Unknown project: ${key}`);
+
+    const oldName = project.name;
+    renameProjectSync(key, newName);
+    console.log(chalk.green(`✓ Renamed project: ${oldName} → ${newName.trim()}`));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(chalk.red(message));
+    process.exitCode = 1;
+  }
+}
+
 export async function projectRemoveCommand(nameOrPath: string): Promise<void> {
   // Try to find by key first, then by name, then by path
   const projects = listProjectsSync();
@@ -325,4 +342,41 @@ export async function projectShowCommand(keyOrName: string): Promise<void> {
   }
 
   console.log('');
+}
+
+export function registerProjectCommands(command: Command): void {
+  command
+    .command('add <path>')
+    .description('Register a project with Overdeck')
+    .option('--name <name>', 'Project name')
+    .option('--type <type>', 'Project type (standalone/monorepo)', 'standalone')
+    .option('--linear-team <team>', 'Linear team prefix (e.g., MIN, PAN)')
+    .option('--rally-project <oid>', 'Rally project OID (e.g., /project/822404704163)')
+    .action(projectAddCommand);
+
+  command
+    .command('list')
+    .description('List all registered projects')
+    .option('--json', 'Output as JSON')
+    .action(projectListCommand);
+
+  command
+    .command('show <key>')
+    .description('Show details for a specific project')
+    .action(projectShowCommand);
+
+  command
+    .command('rename <key> <newName>')
+    .description('Rename a project\'s display name (the registration key stays unchanged)')
+    .action(projectRenameCommand);
+
+  command
+    .command('remove <nameOrPath>')
+    .description('Remove a project from the registry')
+    .action(projectRemoveCommand);
+
+  command
+    .command('init')
+    .description('Initialize projects.yaml with example configuration')
+    .action(projectInitCommand);
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -96,7 +96,7 @@ import { registerInstallCommand } from './commands/install.js';
 import { registerAdminCommands } from './commands/admin/index.js';
 import { registerConversationsCommands } from './commands/conversations/index.js';
 import { registerOhmypiAuthCommands } from './commands/ohmypi-auth.js';
-import { projectAddCommand, projectListCommand, projectRemoveCommand, projectInitCommand, projectShowCommand } from './commands/project.js';
+import { registerProjectCommands } from './commands/project.js';
 import { doctorCommand } from './commands/doctor.js';
 import { systemHealthCommand } from './commands/system-health.js';
 import { updateCommand } from './commands/update.js';
@@ -1304,38 +1304,6 @@ program
   .option('--resume', 'Enable agent auto-resume on boot — auto-resume is OFF by default (PAN-1963)')
   .option('--no-resume', 'Disable agent auto-resume on restart (now the default; flag kept for explicitness)')
   .action(restartCommand);
-
-function registerProjectCommands(command: Command): void {
-  command
-    .command('add <path>')
-    .description('Register a project with Overdeck')
-    .option('--name <name>', 'Project name')
-    .option('--type <type>', 'Project type (standalone/monorepo)', 'standalone')
-    .option('--linear-team <team>', 'Linear team prefix (e.g., MIN, PAN)')
-    .option('--rally-project <oid>', 'Rally project OID (e.g., /project/822404704163)')
-    .action(projectAddCommand);
-
-  command
-    .command('list')
-    .description('List all registered projects')
-    .option('--json', 'Output as JSON')
-    .action(projectListCommand);
-
-  command
-    .command('show <key>')
-    .description('Show details for a specific project')
-    .action(projectShowCommand);
-
-  command
-    .command('remove <nameOrPath>')
-    .description('Remove a project from the registry')
-    .action(projectRemoveCommand);
-
-  command
-    .command('init')
-    .description('Initialize projects.yaml with example configuration')
-    .action(projectInitCommand);
-}
 
 // Project management commands
 const project = program.command('project').description('Project registry for multi-project workspace support');

--- a/src/dashboard/frontend/src/App.test.tsx
+++ b/src/dashboard/frontend/src/App.test.tsx
@@ -135,6 +135,7 @@ vi.mock('./lib/store', () => ({
     state.agentsWithPendingAskUserQuestion ?? [],
   selectAgentsWithPendingProposedPlan: (state: { agentsById?: Record<string, unknown> }) =>
     Object.values(state.agentsById ?? {}).filter((a) => (a as { pendingProposedPlan?: unknown }).pendingProposedPlan != null),
+  selectPendingInputSubjects: () => [],
 }));
 vi.mock('./lib/refresh-dashboard-state', () => ({
   refreshDashboardState: mockRefreshDashboardState,

--- a/src/dashboard/frontend/src/components/CommandDeck/CommandDeck.test.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/CommandDeck.test.tsx
@@ -79,7 +79,11 @@ vi.mock('./ProjectTree/ProjectNode', () => ({
   ProjectNode: (props: any) => {
     // Simulate tab switch to projects when rendered
     return (
-      <div data-testid="project-node" data-selected={props.selectedProject === props.name ? 'true' : 'false'}>
+      <div
+        data-testid="project-node"
+        data-project-key={props.projectKey}
+        data-selected={props.selectedProject === props.name ? 'true' : 'false'}
+      >
         <button data-testid={`project-${props.name}`} onClick={() => props.onSelectProject?.(props.name)}>
           {props.name}
         </button>
@@ -232,7 +236,7 @@ function renderCommandDeck(props?: Partial<React.ComponentProps<typeof CommandDe
           ok: true,
           json: async () => [
             { key: 'test-project', name: 'test-project', path: '/path/to/test-project' },
-            { key: 'other-project', name: 'other-project', path: '/path/to/other-project' },
+            { key: 'other-project', name: 'Other Project', path: '/path/to/other-project' },
           ],
         };
       }
@@ -393,6 +397,15 @@ describe('CommandDeck — project-scoped deck (PAN-1561)', () => {
     const stage = screen.getByTestId('stage');
     expect(stage).toHaveAttribute('data-deck', 'test-project');
     expect(screen.getByTestId('activity-feed')).toHaveAttribute('data-issues', 'PAN-821');
+  });
+
+  it('passes the immutable registration key to the project tree node', async () => {
+    renderCommandDeck({ selectedProject: 'Other Project' });
+
+    expect(await screen.findByTestId('project-node')).toHaveAttribute(
+      'data-project-key',
+      'other-project',
+    );
   });
 
   it('opens an issue tab in the deck when a tree issue is selected', async () => {

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectOverview.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectOverview.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useRef, type ReactNode } from 'react';
+import { useCallback, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { ReviewStatusSnapshot } from '@overdeck/contracts';
+import { Pencil } from 'lucide-react';
 import { useDashboardStore } from '../../lib/store';
 import { getPipelineIssuePhase, type PipelineIssuePhase } from '../../lib/pipeline-state';
 import type { ProjectFeature } from './ProjectTree/ProjectNode';
@@ -390,7 +391,7 @@ export function ProjectOverview({
         overflow: 'auto',
       }}
     >
-      <HeroBillboard projectName={projectName} metrics={metrics} />
+      <HeroBillboard projectName={projectName} projectKey={projectKey} metrics={metrics} />
 
       <ProjectCiHealthSection health={ciHealth} />
 
@@ -618,7 +619,70 @@ const HERO_TONE_COLOR: Record<HeroTone, string> = {
   muted: 'var(--foreground)',
 };
 
-function HeroBillboard({ projectName, metrics }: { projectName: string; metrics: HeroMetric[] }) {
+function HeroBillboard({
+  projectName,
+  projectKey,
+  metrics,
+}: {
+  projectName: string;
+  projectKey?: string;
+  metrics: HeroMetric[];
+}) {
+  const queryClient = useQueryClient();
+  const [editingName, setEditingName] = useState(false);
+  const [draftName, setDraftName] = useState('');
+  const [renameError, setRenameError] = useState<string | null>(null);
+  const editInputRef = useRef<HTMLInputElement>(null);
+  const draftNameRef = useRef('');
+  const committingRef = useRef(false);
+
+  const renameMutation = useMutation({
+    mutationFn: async (name: string) => {
+      const projectIdentifier = projectKey ?? projectName;
+      const res = await fetch(`/api/projects/${encodeURIComponent(projectIdentifier)}/rename`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      });
+      const data = await res.json().catch(() => null) as { error?: string } | null;
+      if (!res.ok) throw new Error(data?.error || 'Failed to rename project');
+    },
+    onSuccess: async () => {
+      setEditingName(false);
+      setRenameError(null);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['command-deck-projects'] }),
+        queryClient.invalidateQueries({ queryKey: ['registered-projects'] }),
+        queryClient.invalidateQueries({ queryKey: ['session-trees'] }),
+      ]);
+    },
+    onError: (error: Error) => {
+      committingRef.current = false;
+      setRenameError(error.message);
+    },
+  });
+
+  const beginRename = useCallback(() => {
+    committingRef.current = false;
+    draftNameRef.current = projectName;
+    setDraftName(projectName);
+    setRenameError(null);
+    setEditingName(true);
+    setTimeout(() => editInputRef.current?.select(), 0);
+  }, [projectName]);
+
+  const commitRename = useCallback(() => {
+    if (committingRef.current) return;
+    committingRef.current = true;
+    renameMutation.mutate(draftNameRef.current);
+  }, [renameMutation]);
+
+  const cancelRename = useCallback(() => {
+    setEditingName(false);
+    setDraftName('');
+    setRenameError(null);
+  }, []);
+
   // Tight, container-responsive glance row. No outer card and an auto-fill grid
   // (min 132px tiles) so it lays out by the PANE width — tiles never crush to
   // ~100px and truncate their labels the way the fixed 5-column MetricStrip did
@@ -626,7 +690,43 @@ function HeroBillboard({ projectName, metrics }: { projectName: string; metrics:
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
       <div className="flex items-baseline gap-2">
-        <h2 style={{ margin: 0, fontSize: 15, fontWeight: 700, color: 'var(--foreground)' }}>{projectName}</h2>
+        {editingName ? (
+          <>
+            <input
+              ref={editInputRef}
+              value={draftName}
+              onChange={(event) => {
+                setDraftName(event.target.value);
+                draftNameRef.current = event.target.value;
+                setRenameError(null);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') commitRename();
+                if (event.key === 'Escape') cancelRename();
+              }}
+              onBlur={commitRename}
+              aria-label={`Rename ${projectName}`}
+              disabled={renameMutation.isPending}
+              className="h-7 rounded-md border border-input bg-background px-2 text-[15px] font-bold text-foreground outline-none focus:ring-1 focus:ring-ring"
+            />
+            {renameError && (
+              <span role="alert" className="text-xs text-destructive">{renameError}</span>
+            )}
+          </>
+        ) : (
+          <>
+            <h2 style={{ margin: 0, fontSize: 15, fontWeight: 700, color: 'var(--foreground)' }}>{projectName}</h2>
+            <button
+              type="button"
+              onClick={beginRename}
+              title="Rename project"
+              aria-label={`Rename ${projectName}`}
+              className="inline-flex items-center text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <Pencil size={12} />
+            </button>
+          </>
+        )}
         <span style={{ fontSize: 11, color: 'var(--muted-foreground)' }}>pipeline overview</span>
       </div>
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(96px, 1fr))', gap: 6 }}>

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ProjectNode.test.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ProjectNode.test.tsx
@@ -100,6 +100,7 @@ describe('ProjectNode', () => {
   it('shows only alive features when alive filter is active', () => {
     render(
       <ProjectNode
+        projectKey="overdeck"
         name="overdeck"
         features={[
           makeFeature('PAN-854', [makeSession({ presence: 'active', status: 'running' })]),
@@ -119,6 +120,7 @@ describe('ProjectNode', () => {
   it('shows only failed features when failed filter is active', () => {
     render(
       <ProjectNode
+        projectKey="overdeck"
         name="overdeck"
         features={[
           makeFeature('PAN-854', [makeSession({ presence: 'active', status: 'running' })]),
@@ -140,6 +142,7 @@ describe('ProjectNode', () => {
 
     render(
       <ProjectNode
+        projectKey="overdeck"
         name="overdeck"
         features={[makeFeature('PAN-854')]}
         selectedFeature={null}
@@ -159,6 +162,7 @@ describe('ProjectNode', () => {
 
     render(
       <ProjectNode
+        projectKey="overdeck"
         name="overdeck"
         features={[]}
         selectedFeature={null}
@@ -180,6 +184,7 @@ describe('ProjectNode', () => {
 
     render(
       <ProjectNode
+        projectKey="overdeck"
         name="overdeck"
         features={[makeFeature('PAN-854')]}
         selectedFeature={null}
@@ -202,6 +207,7 @@ describe('ProjectNode', () => {
   it('offers project rename from the context menu', () => {
     render(
       <ProjectNode
+        projectKey="overdeck"
         name="overdeck"
         features={[]}
         selectedFeature={null}
@@ -218,6 +224,7 @@ describe('ProjectNode', () => {
     const onSelectProject = vi.fn();
     render(
       <ProjectNode
+        projectKey="overdeck"
         name="overdeck"
         features={[makeFeature('PAN-854')]}
         selectedFeature={null}
@@ -249,7 +256,8 @@ describe('ProjectNode', () => {
     vi.stubGlobal('fetch', fetchMock);
     const { queryClient } = render(
       <ProjectNode
-        name="overdeck"
+        projectKey="overdeck"
+        name="Overdeck CLI"
         features={[]}
         selectedFeature={null}
         onSelectFeature={() => {}}
@@ -257,9 +265,9 @@ describe('ProjectNode', () => {
     );
     const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
 
-    fireEvent.contextMenu(screen.getByRole('button', { name: /overdeck/i }));
+    fireEvent.contextMenu(screen.getByRole('button', { name: /overdeck cli/i }));
     fireEvent.click(screen.getByRole('button', { name: 'Rename project' }));
-    const input = screen.getByRole('textbox', { name: 'Rename overdeck' });
+    const input = screen.getByRole('textbox', { name: 'Rename Overdeck CLI' });
     fireEvent.change(input, { target: { value: 'Overdeck App' } });
     fireEvent.keyDown(input, { key: 'Enter' });
     fireEvent.blur(input);
@@ -284,6 +292,7 @@ describe('ProjectNode', () => {
     vi.stubGlobal('fetch', fetchMock);
     render(
       <ProjectNode
+        projectKey="overdeck"
         name="overdeck"
         features={[]}
         selectedFeature={null}
@@ -310,6 +319,7 @@ describe('ProjectNode', () => {
     ));
     render(
       <ProjectNode
+        projectKey="overdeck"
         name="overdeck"
         features={[]}
         selectedFeature={null}

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ProjectNode.test.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ProjectNode.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ProjectNode, type ProjectFeature } from './ProjectNode';
 import type { SessionNode as SessionNodeType } from '@overdeck/contracts';
 
@@ -47,6 +48,20 @@ vi.mock('../styles/command-deck.module.css', () => ({
   },
 }));
 
+function render(ui: Parameters<typeof rtlRender>[0]) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return {
+    ...rtlRender(ui, {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    }),
+    queryClient,
+  };
+}
+
 function makeSession(overrides?: Partial<SessionNodeType>): SessionNodeType {
   return {
     type: 'work',
@@ -78,6 +93,10 @@ function makeFeature(issueId: string, sessions?: SessionNodeType[]): ProjectFeat
 }
 
 describe('ProjectNode', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('shows only alive features when alive filter is active', () => {
     render(
       <ProjectNode
@@ -178,5 +197,139 @@ describe('ProjectNode', () => {
 
     expect(onNewConversation).toHaveBeenCalledWith('overdeck');
     expect(onSelectProject).not.toHaveBeenCalled();
+  });
+
+  it('offers project rename from the context menu', () => {
+    render(
+      <ProjectNode
+        name="overdeck"
+        features={[]}
+        selectedFeature={null}
+        onSelectFeature={() => {}}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: /overdeck/i }));
+
+    expect(screen.getByRole('button', { name: 'Rename project' })).toBeInTheDocument();
+  });
+
+  it('opens a selected inline editor without selecting or collapsing the project', async () => {
+    const onSelectProject = vi.fn();
+    render(
+      <ProjectNode
+        name="overdeck"
+        features={[makeFeature('PAN-854')]}
+        selectedFeature={null}
+        onSelectFeature={() => {}}
+        onSelectProject={onSelectProject}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: /overdeck/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Rename project' }));
+
+    const input = screen.getByRole('textbox', { name: 'Rename overdeck' }) as HTMLInputElement;
+    expect(input).toHaveValue('overdeck');
+    expect(screen.getByTestId('feature-PAN-854')).toBeInTheDocument();
+    expect(onSelectProject).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(input.selectionStart).toBe(0);
+      expect(input.selectionEnd).toBe('overdeck'.length);
+    });
+  });
+
+  it('posts an Enter rename once and invalidates project-name queries', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ key: 'overdeck', name: 'Overdeck App' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { queryClient } = render(
+      <ProjectNode
+        name="overdeck"
+        features={[]}
+        selectedFeature={null}
+        onSelectFeature={() => {}}
+      />,
+    );
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: /overdeck/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Rename project' }));
+    const input = screen.getByRole('textbox', { name: 'Rename overdeck' });
+    fireEvent.change(input, { target: { value: 'Overdeck App' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith('/api/projects/overdeck/rename', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Overdeck App' }),
+      });
+    });
+    await waitFor(() => {
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['command-deck-projects'] });
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['registered-projects'] });
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['session-trees'] });
+    });
+  });
+
+  it('cancels an inline rename on Escape without sending a request', () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    render(
+      <ProjectNode
+        name="overdeck"
+        features={[]}
+        selectedFeature={null}
+        onSelectFeature={() => {}}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: /overdeck/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Rename project' }));
+    fireEvent.keyDown(screen.getByRole('textbox', { name: 'Rename overdeck' }), {
+      key: 'Escape',
+    });
+
+    expect(screen.queryByRole('textbox', { name: 'Rename overdeck' })).not.toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps the inline editor and draft after a rename error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "Project name 'Krux' conflicts with existing project 'krux'" }), {
+        status: 409,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ));
+    render(
+      <ProjectNode
+        name="overdeck"
+        features={[]}
+        selectedFeature={null}
+        onSelectFeature={() => {}}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: /overdeck/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Rename project' }));
+    const input = screen.getByRole('textbox', { name: 'Rename overdeck' });
+    fireEvent.change(input, { target: { value: 'Krux' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      "Project name 'Krux' conflicts with existing project 'krux'",
+    );
+    expect(screen.getByRole('textbox', { name: 'Rename overdeck' })).toHaveValue('Krux');
+    expect(screen.getByRole('textbox', { name: 'Rename overdeck' }).closest('button')).toHaveAttribute(
+      'title',
+      "Project name 'Krux' conflicts with existing project 'krux'",
+    );
   });
 });

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ProjectNode.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ProjectNode.tsx
@@ -77,6 +77,7 @@ export interface ProjectFeature {
 }
 
 interface ProjectNodeProps {
+  projectKey: string;
   name: string;
   features: ProjectFeature[];
   selectedFeature: string | null;
@@ -210,7 +211,7 @@ function ProjectNodeMenu({
   );
 }
 
-export function ProjectNode({ name, features, selectedFeature, onSelectFeature, onSelectProject, selectedProject, selectedSessionId, onSelectSession, issueTitles, issueCosts, filter = 'all', onStopSession, onViewTerminal, onPauseSession, onResumeSession, onUnpauseSession, onRestartSession, onDeepWipe, onOpenStateDir, onViewJsonl, onCleanupOrphanedResources, onOpenPlanDialog, onNewConversation, containerStats }: ProjectNodeProps) {
+export function ProjectNode({ projectKey, name, features, selectedFeature, onSelectFeature, onSelectProject, selectedProject, selectedSessionId, onSelectSession, issueTitles, issueCosts, filter = 'all', onStopSession, onViewTerminal, onPauseSession, onResumeSession, onUnpauseSession, onRestartSession, onDeepWipe, onOpenStateDir, onViewJsonl, onCleanupOrphanedResources, onOpenPlanDialog, onNewConversation, containerStats }: ProjectNodeProps) {
   const visibleFeatures = useMemo(() => {
     if (filter === 'all') return features;
     return features.filter((feature) =>
@@ -229,7 +230,7 @@ export function ProjectNode({ name, features, selectedFeature, onSelectFeature, 
 
   const renameMutation = useMutation({
     mutationFn: async (newName: string) => {
-      const response = await fetch(`/api/projects/${encodeURIComponent(name)}/rename`, {
+      const response = await fetch(`/api/projects/${encodeURIComponent(projectKey)}/rename`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: newName }),

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ProjectNode.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ProjectNode.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ChevronRight, MessageSquarePlus } from 'lucide-react';
 import type { SessionNode } from '@overdeck/contracts';
 import { FeatureItem, sessionMatchesFilter, type TreeSessionFilter } from './FeatureItem';
@@ -112,11 +113,13 @@ function ProjectNodeMenu({
   x,
   y,
   onClose,
+  onRename,
   projectName,
 }: {
   x: number;
   y: number;
   onClose: () => void;
+  onRename: () => void;
   projectName: string;
 }) {
   const menuRef = useRef<HTMLDivElement>(null);
@@ -172,6 +175,31 @@ function ProjectNodeMenu({
           (e.currentTarget as HTMLElement).style.background = 'transparent';
         }}
         onClick={() => {
+          onRename();
+          onClose();
+        }}
+      >
+        Rename project
+      </button>
+      <button
+        style={{
+          display: 'block',
+          width: '100%',
+          padding: '6px 12px',
+          border: 'none',
+          background: 'none',
+          textAlign: 'left',
+          cursor: 'pointer',
+          color: 'var(--foreground)',
+          fontSize: 12,
+        }}
+        onMouseEnter={(e) => {
+          (e.currentTarget as HTMLElement).style.background = 'var(--accent)';
+        }}
+        onMouseLeave={(e) => {
+          (e.currentTarget as HTMLElement).style.background = 'transparent';
+        }}
+        onClick={() => {
           navigator.clipboard?.writeText(projectName).catch(() => { /* ignore */ });
           onClose();
         }}
@@ -189,8 +217,64 @@ export function ProjectNode({ name, features, selectedFeature, onSelectFeature, 
       (feature.sessions ?? []).some((session) => sessionMatchesFilter(session, filter)),
     );
   }, [features, filter]);
+  const queryClient = useQueryClient();
   const [expanded, setExpanded] = useState(visibleFeatures.length > 0);
   const [menu, setMenu] = useState<ContextMenuState>({ x: 0, y: 0, open: false });
+  const [editingName, setEditingName] = useState(false);
+  const [draftName, setDraftName] = useState('');
+  const [renameError, setRenameError] = useState<string | null>(null);
+  const editInputRef = useRef<HTMLInputElement>(null);
+  const draftNameRef = useRef('');
+  const committingRef = useRef(false);
+
+  const renameMutation = useMutation({
+    mutationFn: async (newName: string) => {
+      const response = await fetch(`/api/projects/${encodeURIComponent(name)}/rename`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newName }),
+      });
+      const data = await response.json().catch(() => null) as { error?: string } | null;
+      if (!response.ok) {
+        throw new Error(data?.error || 'Failed to rename project');
+      }
+    },
+    onSuccess: async () => {
+      setEditingName(false);
+      setRenameError(null);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['command-deck-projects'] }),
+        queryClient.invalidateQueries({ queryKey: ['registered-projects'] }),
+        queryClient.invalidateQueries({ queryKey: ['session-trees'] }),
+      ]);
+    },
+    onError: (error: Error) => {
+      committingRef.current = false;
+      setRenameError(error.message);
+    },
+  });
+
+  const beginRename = useCallback(() => {
+    committingRef.current = false;
+    draftNameRef.current = name;
+    setDraftName(name);
+    setRenameError(null);
+    setEditingName(true);
+    setTimeout(() => editInputRef.current?.select(), 0);
+  }, [name]);
+
+  const commitRename = useCallback(() => {
+    if (committingRef.current) return;
+    committingRef.current = true;
+    renameMutation.mutate(draftNameRef.current);
+  }, [renameMutation]);
+
+  const cancelRename = useCallback(() => {
+    committingRef.current = true;
+    setEditingName(false);
+    setDraftName('');
+    setRenameError(null);
+  }, []);
 
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -220,6 +304,7 @@ export function ProjectNode({ name, features, selectedFeature, onSelectFeature, 
         data-project-name={name}
         onClick={handleSelectProject}
         onContextMenu={handleContextMenu}
+        title={renameError ?? undefined}
         style={{ background: selectedProject === name ? 'var(--accent)' : undefined }}
       >
         <span
@@ -231,7 +316,35 @@ export function ProjectNode({ name, features, selectedFeature, onSelectFeature, 
             size={14}
           />
         </span>
-        <span data-testid="command-deck-tree-title" className={`${styles.projectName} font-display`}>{name}</span>
+        {editingName ? (
+          <span
+            className={styles.projectName}
+            onClick={(event) => event.stopPropagation()}
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <input
+              ref={editInputRef}
+              aria-label={`Rename ${name}`}
+              value={draftName}
+              onChange={(event) => {
+                draftNameRef.current = event.target.value;
+                setDraftName(event.target.value);
+                setRenameError(null);
+              }}
+              onClick={(event) => event.stopPropagation()}
+              onMouseDown={(event) => event.stopPropagation()}
+              onKeyDown={(event) => {
+                event.stopPropagation();
+                if (event.key === 'Enter') commitRename();
+                if (event.key === 'Escape') cancelRename();
+              }}
+              onBlur={commitRename}
+            />
+            {renameError && <span role="alert">{renameError}</span>}
+          </span>
+        ) : (
+          <span data-testid="command-deck-tree-title" className={`${styles.projectName} font-display`}>{name}</span>
+        )}
         <span className={styles.featureCount}>{visibleFeatures.length}</span>
         {onNewConversation && (
           <span
@@ -253,6 +366,7 @@ export function ProjectNode({ name, features, selectedFeature, onSelectFeature, 
           x={menu.x}
           y={menu.y}
           onClose={closeMenu}
+          onRename={beginRename}
           projectName={name}
         />
       )}

--- a/src/dashboard/frontend/src/components/CommandDeck/__tests__/ProjectOverview.test.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/__tests__/ProjectOverview.test.tsx
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render as rtlRender, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render as rtlRender, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReviewStatusSnapshot } from '@overdeck/contracts';
 import { bucketFeaturePhase, ProjectOverview } from '../ProjectOverview';
@@ -12,9 +12,12 @@ import type { ProjectFeature } from '../ProjectTree/ProjectNode';
 // existing call sites (and their rerender()) work unchanged.
 function render(ui: Parameters<typeof rtlRender>[0]) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return rtlRender(ui, {
-    wrapper: ({ children }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>,
-  });
+  return {
+    ...rtlRender(ui, {
+      wrapper: ({ children }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>,
+    }),
+    queryClient: client,
+  };
 }
 
 function makeFeature(overrides: Partial<ProjectFeature> = {}): ProjectFeature {
@@ -159,6 +162,119 @@ describe('bucketFeaturePhase', () => {
 describe('ProjectOverview', () => {
   beforeEach(() => {
     useDashboardStore.setState({ reviewStatusByIssueId: {} });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('opens a selected, pre-filled project name editor from the hero pencil', async () => {
+    render(
+      <ProjectOverview
+        projectName="Overdeck"
+        projectKey="overdeck"
+        features={[]}
+        issueCosts={{}}
+        onSelectFeature={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Overdeck' }));
+    const input = screen.getByRole('textbox', { name: 'Rename Overdeck' }) as HTMLInputElement;
+    expect(input).toHaveValue('Overdeck');
+    await waitFor(() => {
+      expect(input.selectionStart).toBe(0);
+      expect(input.selectionEnd).toBe('Overdeck'.length);
+    });
+  });
+
+  it('renames by project key and invalidates every project-name query', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ key: 'overdeck', name: 'Overdeck App' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { queryClient } = render(
+      <ProjectOverview
+        projectName="Overdeck"
+        projectKey="overdeck"
+        features={[]}
+        issueCosts={{}}
+        onSelectFeature={() => {}}
+      />,
+    );
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Overdeck' }));
+    const input = screen.getByRole('textbox', { name: 'Rename Overdeck' });
+    fireEvent.change(input, { target: { value: 'Overdeck App' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/projects/overdeck/rename', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Overdeck App' }),
+      });
+    });
+    await waitFor(() => {
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['command-deck-projects'] });
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['registered-projects'] });
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['session-trees'] });
+    });
+  });
+
+  it('cancels project rename on Escape without sending a request', () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    render(
+      <ProjectOverview
+        projectName="Overdeck"
+        projectKey="overdeck"
+        features={[]}
+        issueCosts={{}}
+        onSelectFeature={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Overdeck' }));
+    fireEvent.keyDown(screen.getByRole('textbox', { name: 'Rename Overdeck' }), { key: 'Escape' });
+
+    expect(screen.queryByRole('textbox', { name: 'Rename Overdeck' })).not.toBeInTheDocument();
+    expect(fetchMock.mock.calls).not.toContainEqual([
+      '/api/projects/overdeck/rename',
+      expect.any(Object),
+    ]);
+  });
+
+  it('keeps the draft editor open and shows a rename conflict', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "Project name 'Krux' conflicts with existing project 'krux'" }), {
+        status: 409,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ));
+    render(
+      <ProjectOverview
+        projectName="Overdeck"
+        features={[]}
+        issueCosts={{}}
+        onSelectFeature={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Overdeck' }));
+    const input = screen.getByRole('textbox', { name: 'Rename Overdeck' });
+    fireEvent.change(input, { target: { value: 'Krux' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      "Project name 'Krux' conflicts with existing project 'krux'",
+    );
+    expect(screen.getByRole('textbox', { name: 'Rename Overdeck' })).toHaveValue('Krux');
+    expect(fetch).toHaveBeenCalledWith('/api/projects/Overdeck/rename', expect.any(Object));
   });
 
   it('renders a project-scoped five-tile hero billboard that updates with feature state', () => {

--- a/src/dashboard/frontend/src/components/CommandDeck/index.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/index.tsx
@@ -1373,7 +1373,7 @@ export function CommandDeck({
                   </div>
                 ) : selectedProjectData ? (
                   <ProjectNode
-                    key={selectedProjectData.path}
+                    key={selectedProjectData.path} projectKey={selectedProjectData.key}
                     name={selectedProjectData.name}
                     features={selectedProjectData.features}
                     selectedFeature={selectedFeature}

--- a/src/dashboard/frontend/src/components/CommandDeck/projectsData.ts
+++ b/src/dashboard/frontend/src/components/CommandDeck/projectsData.ts
@@ -29,6 +29,7 @@ export function isUnscopedConversation(
 }
 
 export interface ProjectData {
+  key: string;
   name: string;
   path: string;
   features: ProjectFeature[];
@@ -45,6 +46,7 @@ export function groupProjects(issues: ProjectFeature[]): ProjectData[] {
     }
 
     grouped.set(issue.projectName, {
+      key: issue.projectName,
       name: issue.projectName,
       path: issue.projectName,
       features: [issue],
@@ -73,12 +75,13 @@ export async function fetchProjects(): Promise<ProjectData[]> {
   // Start with projects that have qualifying issues
   const projectMap = new Map(groupProjects(issues).map(p => [p.name, p]));
 
-  // Add registered projects that have no qualifying issues (empty features list)
+  // Preserve stable keys when registered projects already have grouped issues.
   for (const proj of registered) {
     const name = proj.name ?? proj.key;
-    if (!projectMap.has(name)) {
-      projectMap.set(name, { name, path: proj.path, features: [] });
-    }
+    const existing = projectMap.get(name);
+    projectMap.set(name, existing
+      ? { ...existing, key: proj.key, path: proj.path }
+      : { key: proj.key, name, path: proj.path, features: [] });
   }
 
   return [...projectMap.values()].sort((a, b) => a.name.localeCompare(b.name));

--- a/src/dashboard/server/routes/__tests__/projects-rename.test.ts
+++ b/src/dashboard/server/routes/__tests__/projects-rename.test.ts
@@ -1,0 +1,146 @@
+import { mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { Effect } from 'effect';
+import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { TEST_HOME } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { join } = require('node:path') as typeof import('node:path');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { tmpdir } = require('node:os') as typeof import('node:os');
+  return { TEST_HOME: join(tmpdir(), `projects-rename-route-test-${process.pid}`) };
+});
+
+vi.mock('../../../../lib/paths.js', async () => {
+  const real = await vi.importActual<typeof import('../../../../lib/paths.js')>('../../../../lib/paths.js');
+  return {
+    ...real,
+    OVERDECK_HOME: TEST_HOME,
+    CONFIG_DIR: TEST_HOME,
+  };
+});
+
+import {
+  getProjectSync,
+  PROJECTS_CONFIG_FILE,
+  registerProjectSync,
+} from '../../../../lib/projects.js';
+import {
+  _resetInternalTokenCacheForTests,
+  INTERNAL_TOKEN_HEADER,
+} from '../../../../lib/internal-token.js';
+
+interface RouteResult {
+  status: number;
+  body: unknown;
+}
+
+const INTERNAL_TOKEN = 'projects-rename-test-token';
+
+async function requestProjectRename(
+  projectKey: string,
+  body: unknown,
+  options: { authorized?: boolean } = {},
+): Promise<RouteResult> {
+  const { projectsRouteLayer } = await import('../projects.js');
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (options.authorized !== false) headers[INTERNAL_TOKEN_HEADER] = INTERNAL_TOKEN;
+
+  const request = HttpServerRequest.fromWeb(new Request(
+    `http://localhost/api/projects/${encodeURIComponent(projectKey)}/rename`,
+    {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    },
+  ));
+  const response = await Effect.runPromise(
+    Effect.scoped(
+      Effect.flatMap(HttpRouter.toHttpEffect(projectsRouteLayer), (app) =>
+        Effect.provideService(app, HttpServerRequest.HttpServerRequest, request),
+      ),
+    ),
+  );
+  const responseBody = response.body as { body?: Uint8Array } | null;
+  const text = responseBody?.body ? new TextDecoder().decode(responseBody.body) : '{}';
+  return { status: response.status, body: JSON.parse(text) };
+}
+
+beforeEach(() => {
+  process.env['OVERDECK_INTERNAL_TOKEN'] = INTERNAL_TOKEN;
+  _resetInternalTokenCacheForTests();
+  mkdirSync(TEST_HOME, { recursive: true });
+  rmSync(PROJECTS_CONFIG_FILE, { force: true });
+  registerProjectSync('alpha', { name: 'Alpha Project', path: '/projects/alpha' });
+  registerProjectSync('beta', { name: 'Beta Project', path: '/projects/beta' });
+});
+
+afterEach(() => {
+  delete process.env['OVERDECK_INTERNAL_TOKEN'];
+  _resetInternalTokenCacheForTests();
+  rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+describe('POST /api/projects/:projectKey/rename', () => {
+  it('renames a project resolved by registration key', async () => {
+    const result = await requestProjectRename('alpha', { name: '  Renamed Alpha  ' });
+
+    expect(result).toEqual({
+      status: 200,
+      body: { key: 'alpha', name: 'Renamed Alpha' },
+    });
+    expect(getProjectSync('alpha')?.name).toBe('Renamed Alpha');
+  });
+
+  it('renames a project resolved by its current display name', async () => {
+    const result = await requestProjectRename('Alpha Project', { name: 'New Alpha' });
+
+    expect(result).toEqual({
+      status: 200,
+      body: { key: 'alpha', name: 'New Alpha' },
+    });
+    expect(getProjectSync('alpha')?.name).toBe('New Alpha');
+  });
+
+  it('returns 404 for an unknown project', async () => {
+    await expect(requestProjectRename('missing', { name: 'New Name' })).resolves.toEqual({
+      status: 404,
+      body: { error: 'Project not found' },
+    });
+  });
+
+  it.each([
+    [{ name: '   ' }, 'Project name must not be empty'],
+    [{ name: 42 }, 'Project name must be a string'],
+  ])('returns 400 for an invalid name', async (body, error) => {
+    await expect(requestProjectRename('alpha', body)).resolves.toEqual({
+      status: 400,
+      body: { error },
+    });
+  });
+
+  it.each([
+    ['beta', "Project name 'beta' conflicts with existing project 'beta'"],
+    ['beta project', "Project name 'beta project' conflicts with existing project 'beta'"],
+  ])('returns 409 when the name conflicts with another project', async (name, error) => {
+    await expect(requestProjectRename('alpha', { name })).resolves.toEqual({
+      status: 409,
+      body: { error },
+    });
+    expect(getProjectSync('alpha')?.name).toBe('Alpha Project');
+  });
+
+  it('rejects unsafe requests before mutating the registry', async () => {
+    const before = readFileSync(PROJECTS_CONFIG_FILE, 'utf-8');
+
+    await expect(requestProjectRename(
+      'alpha',
+      { name: 'Unauthorized Rename' },
+      { authorized: false },
+    )).resolves.toEqual({
+      status: 401,
+      body: { error: 'unauthorized' },
+    });
+    expect(readFileSync(PROJECTS_CONFIG_FILE, 'utf-8')).toBe(before);
+  });
+});

--- a/src/dashboard/server/routes/__tests__/projects-rename.test.ts
+++ b/src/dashboard/server/routes/__tests__/projects-rename.test.ts
@@ -102,6 +102,20 @@ describe('POST /api/projects/:projectKey/rename', () => {
     expect(getProjectSync('alpha')?.name).toBe('New Alpha');
   });
 
+  it('prefers a registration key over another project\'s matching display name', async () => {
+    registerProjectSync('myn', { name: 'Mind Your Now', path: '/projects/myn' });
+    registerProjectSync('other', { name: 'myn', path: '/projects/other' });
+
+    const result = await requestProjectRename('myn', { name: 'Renamed Key Project' });
+
+    expect(result).toEqual({
+      status: 200,
+      body: { key: 'myn', name: 'Renamed Key Project' },
+    });
+    expect(getProjectSync('myn')?.name).toBe('Renamed Key Project');
+    expect(getProjectSync('other')?.name).toBe('myn');
+  });
+
   it('returns 404 for an unknown project', async () => {
     await expect(requestProjectRename('missing', { name: 'New Name' })).resolves.toEqual({
       status: 404,

--- a/src/dashboard/server/routes/project-rename.ts
+++ b/src/dashboard/server/routes/project-rename.ts
@@ -1,7 +1,8 @@
 import { Effect } from 'effect';
+import * as Result from 'effect/Result';
 import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
 
-import { listProjectsSync, renameProjectSync } from '../../../lib/projects.js';
+import { ProjectRenameError, renameProject } from '../../../lib/projects.js';
 import { jsonResponse } from '../http-helpers.js';
 import { rejectUnsafeDashboardMutationRequest } from './dashboard-auth.js';
 import { httpHandler } from './http-handler.js';
@@ -20,33 +21,26 @@ export const postProjectRenameRoute = HttpRouter.add(
     const authError = rejectUnsafeDashboardMutationRequest(request);
     if (authError) return authError;
 
-    const projectKey = (yield* HttpRouter.params)['projectKey'] ?? '';
-    const projects = listProjectsSync();
-    const project = projects.find(({ key }) => key === projectKey)
-      ?? projects.find(({ config }) => config.name === projectKey);
-    if (!project) return jsonResponse({ error: 'Project not found' }, { status: 404 });
-
+    const projectIdentifier = (yield* HttpRouter.params)['projectKey'] ?? '';
     const body = (yield* readJsonBody) as { name?: unknown };
     if (typeof body.name !== 'string') {
       return jsonResponse({ error: 'Project name must be a string' }, { status: 400 });
     }
 
-    try {
-      renameProjectSync(project.key, body.name);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (message.startsWith('Unknown project:')) {
-        return jsonResponse({ error: message }, { status: 404 });
+    const result = yield* Effect.result(renameProject(projectIdentifier, body.name));
+    if (Result.isFailure(result)) {
+      if (!(result.failure instanceof ProjectRenameError)) {
+        return yield* Effect.fail(result.failure);
       }
-      if (message === 'Project name must not be empty') {
-        return jsonResponse({ error: message }, { status: 400 });
+      if (result.failure.reason === 'not-found') {
+        return jsonResponse({ error: 'Project not found' }, { status: 404 });
       }
-      if (message.includes('conflicts with existing project')) {
-        return jsonResponse({ error: message }, { status: 409 });
+      if (result.failure.reason === 'empty') {
+        return jsonResponse({ error: result.failure.message }, { status: 400 });
       }
-      throw err;
+      return jsonResponse({ error: result.failure.message }, { status: 409 });
     }
 
-    return jsonResponse({ key: project.key, name: body.name.trim() });
+    return jsonResponse(result.success);
   })),
 );

--- a/src/dashboard/server/routes/project-rename.ts
+++ b/src/dashboard/server/routes/project-rename.ts
@@ -1,0 +1,52 @@
+import { Effect } from 'effect';
+import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
+
+import { listProjectsSync, renameProjectSync } from '../../../lib/projects.js';
+import { jsonResponse } from '../http-helpers.js';
+import { rejectUnsafeDashboardMutationRequest } from './dashboard-auth.js';
+import { httpHandler } from './http-handler.js';
+
+const readJsonBody = Effect.gen(function* () {
+  const request = yield* HttpServerRequest.HttpServerRequest;
+  const text = yield* request.text;
+  try { return text ? JSON.parse(text) : {}; } catch { return {}; }
+});
+
+export const postProjectRenameRoute = HttpRouter.add(
+  'POST',
+  '/api/projects/:projectKey/rename',
+  httpHandler(Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const authError = rejectUnsafeDashboardMutationRequest(request);
+    if (authError) return authError;
+
+    const projectKey = (yield* HttpRouter.params)['projectKey'] ?? '';
+    const projects = listProjectsSync();
+    const project = projects.find(({ key }) => key === projectKey)
+      ?? projects.find(({ config }) => config.name === projectKey);
+    if (!project) return jsonResponse({ error: 'Project not found' }, { status: 404 });
+
+    const body = (yield* readJsonBody) as { name?: unknown };
+    if (typeof body.name !== 'string') {
+      return jsonResponse({ error: 'Project name must be a string' }, { status: 400 });
+    }
+
+    try {
+      renameProjectSync(project.key, body.name);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.startsWith('Unknown project:')) {
+        return jsonResponse({ error: message }, { status: 404 });
+      }
+      if (message === 'Project name must not be empty') {
+        return jsonResponse({ error: message }, { status: 400 });
+      }
+      if (message.includes('conflicts with existing project')) {
+        return jsonResponse({ error: message }, { status: 409 });
+      }
+      throw err;
+    }
+
+    return jsonResponse({ key: project.key, name: body.name.trim() });
+  })),
+);

--- a/src/dashboard/server/routes/projects.ts
+++ b/src/dashboard/server/routes/projects.ts
@@ -14,7 +14,7 @@ import { Effect, Layer } from 'effect';
 import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
 
 import { httpHandler } from './http-handler.js';
-import { resolveProjectFromIssueSync, listProjectsSync, getProjectSync, setProjectAutoMergeDefaultSync, setProjectSwarmPolicySync } from '../../../lib/projects.js';
+import { resolveProjectFromIssueSync, listProjectsSync, getProjectSync, renameProjectSync, setProjectAutoMergeDefaultSync, setProjectSwarmPolicySync } from '../../../lib/projects.js';
 import { resolveSwarmPolicy } from '../../../lib/swarm-policy.js';
 import type { SwarmPolicyLayer } from '../../../lib/swarm-policy.js';
 import { readIssueRecordSync } from '../../../lib/pan-dir/record.js';
@@ -769,6 +769,46 @@ const postProjectAutoMergeDefaultRoute = HttpRouter.add(
   })),
 );
 
+// ─── Route: POST /api/projects/:projectKey/rename ─────────────────────────────
+const postProjectRenameRoute = HttpRouter.add(
+  'POST',
+  '/api/projects/:projectKey/rename',
+  httpHandler(Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const authError = rejectUnsafeDashboardMutationRequest(request);
+    if (authError) return authError;
+
+    const projectKey = (yield* HttpRouter.params)['projectKey'] ?? '';
+    const projects = listProjectsSync();
+    const project = projects.find(({ key }) => key === projectKey)
+      ?? projects.find(({ config }) => config.name === projectKey);
+    if (!project) return jsonResponse({ error: 'Project not found' }, { status: 404 });
+
+    const body = (yield* readProjectJsonBody) as { name?: unknown };
+    if (typeof body.name !== 'string') {
+      return jsonResponse({ error: 'Project name must be a string' }, { status: 400 });
+    }
+
+    try {
+      renameProjectSync(project.key, body.name);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.startsWith('Unknown project:')) {
+        return jsonResponse({ error: message }, { status: 404 });
+      }
+      if (message === 'Project name must not be empty') {
+        return jsonResponse({ error: message }, { status: 400 });
+      }
+      if (message.includes('conflicts with existing project')) {
+        return jsonResponse({ error: message }, { status: 409 });
+      }
+      throw err;
+    }
+
+    return jsonResponse({ key: project.key, name: body.name.trim() });
+  })),
+);
+
 const getProjectSwarmPolicyRoute = HttpRouter.add('GET', '/api/projects/:projectKey/swarm-policy', httpHandler(Effect.gen(function* () {
   const key = (yield* HttpRouter.params)['projectKey'] ?? '';
   const config = getProjectSync(key);
@@ -1038,6 +1078,7 @@ export const projectsRouteLayer = Layer.mergeAll(
   getProjectReleaseStatusRoute,
   getProjectAutoMergeDefaultRoute,
   postProjectAutoMergeDefaultRoute,
+  postProjectRenameRoute,
   getProjectSwarmPolicyRoute,
   postProjectSwarmPolicyRoute,
   getIssueSwarmPolicyRoute,

--- a/src/dashboard/server/routes/projects.ts
+++ b/src/dashboard/server/routes/projects.ts
@@ -1,10 +1,5 @@
 import { jsonResponse } from "../http-helpers.js";
-/**
- * Projects route module — Effect HttpRouter.Layer (PAN-821)
- *
- * Implements:
- *   GET /api/projects/:projectKey/session-tree
- */
+/** Projects route module — Effect HttpRouter.Layer (PAN-821). */
 
 import { access, readFile, readdir, mkdir, stat, realpath } from 'node:fs/promises';
 import { join, isAbsolute, sep, resolve, normalize, dirname, relative } from 'node:path';
@@ -14,7 +9,8 @@ import { Effect, Layer } from 'effect';
 import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
 
 import { httpHandler } from './http-handler.js';
-import { resolveProjectFromIssueSync, listProjectsSync, getProjectSync, renameProjectSync, setProjectAutoMergeDefaultSync, setProjectSwarmPolicySync } from '../../../lib/projects.js';
+import { postProjectRenameRoute } from './project-rename.js';
+import { resolveProjectFromIssueSync, listProjectsSync, getProjectSync, setProjectAutoMergeDefaultSync, setProjectSwarmPolicySync } from '../../../lib/projects.js';
 import { resolveSwarmPolicy } from '../../../lib/swarm-policy.js';
 import type { SwarmPolicyLayer } from '../../../lib/swarm-policy.js';
 import { readIssueRecordSync } from '../../../lib/pan-dir/record.js';
@@ -766,46 +762,6 @@ const postProjectAutoMergeDefaultRoute = HttpRouter.add(
     }
     setProjectAutoMergeDefaultSync(key, v);
     return jsonResponse({ value: v });
-  })),
-);
-
-// ─── Route: POST /api/projects/:projectKey/rename ─────────────────────────────
-const postProjectRenameRoute = HttpRouter.add(
-  'POST',
-  '/api/projects/:projectKey/rename',
-  httpHandler(Effect.gen(function* () {
-    const request = yield* HttpServerRequest.HttpServerRequest;
-    const authError = rejectUnsafeDashboardMutationRequest(request);
-    if (authError) return authError;
-
-    const projectKey = (yield* HttpRouter.params)['projectKey'] ?? '';
-    const projects = listProjectsSync();
-    const project = projects.find(({ key }) => key === projectKey)
-      ?? projects.find(({ config }) => config.name === projectKey);
-    if (!project) return jsonResponse({ error: 'Project not found' }, { status: 404 });
-
-    const body = (yield* readProjectJsonBody) as { name?: unknown };
-    if (typeof body.name !== 'string') {
-      return jsonResponse({ error: 'Project name must be a string' }, { status: 400 });
-    }
-
-    try {
-      renameProjectSync(project.key, body.name);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (message.startsWith('Unknown project:')) {
-        return jsonResponse({ error: message }, { status: 404 });
-      }
-      if (message === 'Project name must not be empty') {
-        return jsonResponse({ error: message }, { status: 400 });
-      }
-      if (message.includes('conflicts with existing project')) {
-        return jsonResponse({ error: message }, { status: 409 });
-      }
-      throw err;
-    }
-
-    return jsonResponse({ key: project.key, name: body.name.trim() });
   })),
 );
 

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -308,6 +308,26 @@ export function setProjectAutoMergeDefaultSync(key: string, value: 'auto' | 'hol
   registerProjectSync(key, updated);
 }
 
+export function renameProjectSync(key: string, newName: string): void {
+  const config = loadProjectsConfigSync();
+  const project = config.projects[key];
+  if (!project) throw new Error(`Unknown project: ${key}`);
+
+  const name = newName.trim();
+  if (!name) throw new Error('Project name must not be empty');
+  if (name === project.name) return;
+
+  const normalizedName = name.toLowerCase();
+  for (const [otherKey, otherProject] of Object.entries(config.projects)) {
+    if (otherKey === key) continue;
+    if (otherKey.toLowerCase() === normalizedName || otherProject.name.toLowerCase() === normalizedName) {
+      throw new Error(`Project name '${name}' conflicts with existing project '${otherKey}'`);
+    }
+  }
+
+  registerProjectSync(key, { ...project, name });
+}
+
 export function setProjectSwarmPolicySync(key: string, value: Omit<SwarmConfig, 'hotspots'> | null): void {
   const config = getProjectSync(key);
   if (!config) throw new Error(`Unknown project: ${key}`);

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -233,6 +233,25 @@ export interface ResolvedProject {
   linearTeam?: string;
 }
 
+export type ProjectRenameErrorReason = 'not-found' | 'empty' | 'conflict';
+
+export class ProjectRenameError extends Error {
+  constructor(
+    readonly reason: ProjectRenameErrorReason,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ProjectRenameError';
+  }
+}
+
+interface ProjectRenamePlan {
+  key: string;
+  name: string;
+  config: ProjectsConfig;
+  changed: boolean;
+}
+
 // Mtime-based cache: re-parse projects.yaml only when the file changes on disk.
 // Without this cache, every call to resolveProjectFromIssue (enrichment service,
 // deacon patrol, status updates — dozens of times per minute) re-read and re-parsed
@@ -308,24 +327,56 @@ export function setProjectAutoMergeDefaultSync(key: string, value: 'auto' | 'hol
   registerProjectSync(key, updated);
 }
 
-export function renameProjectSync(key: string, newName: string): void {
-  const config = loadProjectsConfigSync();
-  const project = config.projects[key];
-  if (!project) throw new Error(`Unknown project: ${key}`);
+function prepareProjectRename(
+  config: ProjectsConfig,
+  projectIdentifier: string,
+  newName: string,
+): ProjectRenamePlan | ProjectRenameError {
+  const key = config.projects[projectIdentifier]
+    ? projectIdentifier
+    : Object.entries(config.projects).find(([, project]) => project.name === projectIdentifier)?.[0];
+  if (!key) {
+    return new ProjectRenameError('not-found', `Unknown project: ${projectIdentifier}`);
+  }
 
+  const project = config.projects[key]!;
   const name = newName.trim();
-  if (!name) throw new Error('Project name must not be empty');
-  if (name === project.name) return;
+  if (!name) {
+    return new ProjectRenameError('empty', 'Project name must not be empty');
+  }
+  if (name === project.name) {
+    return { key, name, config, changed: false };
+  }
 
   const normalizedName = name.toLowerCase();
   for (const [otherKey, otherProject] of Object.entries(config.projects)) {
     if (otherKey === key) continue;
     if (otherKey.toLowerCase() === normalizedName || otherProject.name.toLowerCase() === normalizedName) {
-      throw new Error(`Project name '${name}' conflicts with existing project '${otherKey}'`);
+      return new ProjectRenameError(
+        'conflict',
+        `Project name '${name}' conflicts with existing project '${otherKey}'`,
+      );
     }
   }
 
-  registerProjectSync(key, { ...project, name });
+  return {
+    key,
+    name,
+    config: {
+      ...config,
+      projects: {
+        ...config.projects,
+        [key]: { ...project, name },
+      },
+    },
+    changed: true,
+  };
+}
+
+export function renameProjectSync(key: string, newName: string): void {
+  const plan = prepareProjectRename(loadProjectsConfigSync(), key, newName);
+  if (plan instanceof ProjectRenameError) throw plan;
+  if (plan.changed) saveProjectsConfigSync(plan.config);
 }
 
 export function setProjectSwarmPolicySync(key: string, value: Omit<SwarmConfig, 'hotspots'> | null): void {
@@ -753,6 +804,28 @@ export const listProjects = (): Effect.Effect<Array<{ key: string; config: Proje
       Object.entries(config.projects).map(([key, projectConfig]) => ({ key, config: projectConfig })),
     ),
   );
+
+/**
+ * Rename a project's display name by registration key or exact display name.
+ * Loads and persists the registry once so long-lived callers avoid sync I/O.
+ */
+export const renameProject = (
+  projectIdentifier: string,
+  newName: string,
+): Effect.Effect<
+  { key: string; name: string },
+  ProjectRenameError | ConfigParseError | FsError
+> =>
+  Effect.gen(function* () {
+    const plan = prepareProjectRename(
+      yield* loadProjectsConfig(),
+      projectIdentifier,
+      newName,
+    );
+    if (plan instanceof ProjectRenameError) return yield* Effect.fail(plan);
+    if (plan.changed) yield* saveProjectsConfig(plan.config);
+    return { key: plan.key, name: plan.name };
+  });
 
 /** Effect variant of {@link registerProjectSync}. */
 export const registerProject = (key: string, projectConfig: ProjectConfig): Effect.Effect<void, ConfigParseError | FsError> =>

--- a/sync-sources/skills/pan-projects/SKILL.md
+++ b/sync-sources/skills/pan-projects/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: pan-projects
-description: "pan project <subcommand> — add, remove, and manage Overdeck-monitored projects"
+description: "pan project <subcommand> — add, rename, remove, and manage Overdeck-monitored projects"
 triggers:
   - pan projects
   - add project
   - remove project
+  - rename project
   - list projects
   - manage projects
   - register project
@@ -23,6 +24,7 @@ This skill guides you through managing projects with Overdeck. Projects must be 
 
 - Adding a new project to Overdeck
 - Listing managed projects
+- Renaming a project's display name
 - Removing a project from Overdeck
 - Setting up project-to-tracker mappings
 
@@ -63,6 +65,14 @@ Registered Projects:
   backend     /home/user/projects/backend
   frontend    /home/user/projects/frontend
 ```
+
+### Rename a Project
+
+```bash
+pan project rename myproject "My Project"
+```
+
+The registration key (`myproject`) is immutable. The display name (`My Project`) is the human-facing label shown in Overdeck.
 
 ### Remove a Project
 

--- a/tests/unit/lib/overdeck/no-loss-matrix.ts
+++ b/tests/unit/lib/overdeck/no-loss-matrix.ts
@@ -380,6 +380,7 @@ export const NO_LOSS_MATRIX: MatrixEntry[] = [
   { surface: 'GET /api/session-trees',                              kind: 'http', disposition: 'RELOCATE',    door: 'Conversations' },
   { surface: 'GET /api/projects/:projectKey/auto-merge-default',    kind: 'http', disposition: 'READ',        door: 'ConfigResolver.getProject (autoMergeDefault field)' },
   { surface: 'POST /api/projects/:projectKey/auto-merge-default',   kind: 'http', disposition: 'RELOCATE',    door: 'Config (ConfigWriter.setAutoMergeDefault, to be designed)' },
+  { surface: 'POST /api/projects/:projectKey/rename',               kind: 'http', disposition: 'WRITE',       door: 'Project registry write door (renameProjectSync → registerProjectSync)' },
 
   // ── remote.ts ─────────────────────────────────────────────────────────────
   { surface: 'GET /api/remote/status',                                      kind: 'http', disposition: 'RELOCATE',    door: 'Infra/Settings (remote substrate health)' },

--- a/tests/unit/lib/overdeck/no-loss-matrix.ts
+++ b/tests/unit/lib/overdeck/no-loss-matrix.ts
@@ -380,7 +380,7 @@ export const NO_LOSS_MATRIX: MatrixEntry[] = [
   { surface: 'GET /api/session-trees',                              kind: 'http', disposition: 'RELOCATE',    door: 'Conversations' },
   { surface: 'GET /api/projects/:projectKey/auto-merge-default',    kind: 'http', disposition: 'READ',        door: 'ConfigResolver.getProject (autoMergeDefault field)' },
   { surface: 'POST /api/projects/:projectKey/auto-merge-default',   kind: 'http', disposition: 'RELOCATE',    door: 'Config (ConfigWriter.setAutoMergeDefault, to be designed)' },
-  { surface: 'POST /api/projects/:projectKey/rename',               kind: 'http', disposition: 'WRITE',       door: 'Project registry write door (renameProjectSync → registerProjectSync)' },
+  { surface: 'POST /api/projects/:projectKey/rename',               kind: 'http', disposition: 'WRITE',       door: 'Project registry rename write door (renameProject)' },
 
   // ── remote.ts ─────────────────────────────────────────────────────────────
   { surface: 'GET /api/remote/status',                                      kind: 'http', disposition: 'RELOCATE',    door: 'Infra/Settings (remote substrate health)' },

--- a/tests/unit/lib/projects-rename.test.ts
+++ b/tests/unit/lib/projects-rename.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, readFileSync, rmSync } from 'node:fs';
+
+const { TEST_HOME } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { join } = require('node:path') as typeof import('node:path');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { tmpdir } = require('node:os') as typeof import('node:os');
+  return { TEST_HOME: join(tmpdir(), `project-rename-test-${process.pid}`) };
+});
+
+vi.mock('../../../src/lib/paths.js', async () => {
+  const real = await vi.importActual<typeof import('../../../src/lib/paths.js')>('../../../src/lib/paths.js');
+  return {
+    ...real,
+    OVERDECK_HOME: TEST_HOME,
+    CONFIG_DIR: TEST_HOME,
+  };
+});
+
+import {
+  getProjectSync,
+  PROJECTS_CONFIG_FILE,
+  registerProjectSync,
+  renameProjectSync,
+  type ProjectConfig,
+} from '../../../src/lib/projects.js';
+
+const PROJECT: ProjectConfig = {
+  name: 'Original Name',
+  path: '/projects/original',
+  issue_prefix: 'ORIG',
+  workspace: {
+    type: 'monorepo',
+    workspaces_dir: 'workspaces',
+    default_branch: 'main',
+  },
+};
+
+beforeEach(() => {
+  mkdirSync(TEST_HOME, { recursive: true });
+  rmSync(PROJECTS_CONFIG_FILE, { force: true });
+  registerProjectSync('original-key', PROJECT);
+});
+
+afterEach(() => {
+  rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+describe('renameProjectSync', () => {
+  it('persists the trimmed name and preserves all other project fields', () => {
+    renameProjectSync('original-key', '  Renamed Project  ');
+
+    expect(getProjectSync('original-key')).toEqual({
+      ...PROJECT,
+      name: 'Renamed Project',
+    });
+  });
+
+  it('throws for an unknown project without modifying projects.yaml', () => {
+    const before = readFileSync(PROJECTS_CONFIG_FILE, 'utf-8');
+
+    expect(() => renameProjectSync('missing', 'New Name')).toThrow('Unknown project: missing');
+    expect(readFileSync(PROJECTS_CONFIG_FILE, 'utf-8')).toBe(before);
+  });
+
+  it('throws for an empty or whitespace-only name without modifying projects.yaml', () => {
+    const before = readFileSync(PROJECTS_CONFIG_FILE, 'utf-8');
+
+    expect(() => renameProjectSync('original-key', '   ')).toThrow('Project name must not be empty');
+    expect(readFileSync(PROJECTS_CONFIG_FILE, 'utf-8')).toBe(before);
+  });
+
+  it("rejects a case-insensitive collision with another project's name", () => {
+    registerProjectSync('other-key', {
+      name: 'Existing Project',
+      path: '/projects/other',
+    });
+
+    expect(() => renameProjectSync('original-key', 'existing project')).toThrow(
+      "Project name 'existing project' conflicts with existing project 'other-key'",
+    );
+  });
+
+  it("rejects a case-insensitive collision with another project's key", () => {
+    registerProjectSync('existing-key', {
+      name: 'Unrelated Name',
+      path: '/projects/other',
+    });
+
+    expect(() => renameProjectSync('original-key', 'EXISTING-KEY')).toThrow(
+      "Project name 'EXISTING-KEY' conflicts with existing project 'existing-key'",
+    );
+  });
+
+  it('returns without modifying projects.yaml when the name is unchanged', () => {
+    const before = readFileSync(PROJECTS_CONFIG_FILE, 'utf-8');
+
+    expect(() => renameProjectSync('original-key', 'Original Name')).not.toThrow();
+    expect(readFileSync(PROJECTS_CONFIG_FILE, 'utf-8')).toBe(before);
+  });
+});


### PR DESCRIPTION
**Issue:** #1987

## Acceptance Criteria

- [ ] Add renameProjectSync write-door helper with validation to src/lib/projects.ts
- [ ] Add POST /api/projects/:projectKey/rename route to the dashboard server
- [ ] Add `pan project rename <key> <newName>` CLI command and update the pan-projects skill
- [ ] Inline pencil rename on the project page hero (ProjectOverview HeroBillboard)
- [ ] Rename project from the Command Deck tree row (ProjectNode context menu + inline edit)
- [ ] Document project rename and the display-name vs registration-key distinction