### PR TITLE
PAN-2772

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,7 +330,14 @@ The dashboard server uses **Effect.js** for HTTP routes and structured RPC, plus
 **Terminal architecture** (`ws-terminal.ts` + `XTerminal.tsx`):
 - Server: raw `WebSocketServer` with `noServer: true`, deferred PTY spawn (waits for
   client resize dimensions), `node-pty` spawns `tmux attach-session`
-- Client: raw `WebSocket` API with exponential backoff reconnection
+- Client: raw `WebSocket` API with a five-minute patient reconnect window from
+  `terminalReconnectPolicy.ts`: delays are 1s, 2s, 4s, then a flat 5s.
+- Reconnect state stays outside xterm scrollback in a status overlay; exhaustion keeps
+  the terminal mounted and offers a manual Reconnect action.
+- Close code `4404` means the tmux session is still gone after the server-side wait and
+  is fatal. Close code `4503` means the dashboard is gracefully restarting, so the UI
+  shows calm "Dashboard restarting" copy and uses the same patient reconnect policy;
+  `handleShutdownSignal` broadcasts `4503` before server teardown.
 - PTY waits for tmux session to exist (`waitForTmuxSession`) before spawning
 - Data flows immediately on attach — no stale data suppression
 - Dimension toggle at 200ms forces correct-size repaint

--- a/src/cli/commands/__tests__/reload.test.ts
+++ b/src/cli/commands/__tests__/reload.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events';
 import { promisify } from 'node:util';
 import { Effect } from 'effect';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   acquireRestartLock: vi.fn(),
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   fsRename: vi.fn(),
   readDevSupervisorMarker: vi.fn(),
   devSupervisorRefusalLines: vi.fn(),
+  agentRestartBlockReason: vi.fn(),
 }));
 
 // reloadCommand refuses to run when a `pan dev` supervisor marker is present.
@@ -34,6 +35,10 @@ vi.mock('../../../lib/dev-supervisor.js', () => ({
 vi.mock('../../../lib/restart-lock.js', () => ({
   acquireRestartLock: mocks.acquireRestartLock,
   readRestartLockHolder: mocks.readRestartLockHolder,
+}));
+
+vi.mock('../../../lib/deploy/agent-restart-gate.js', () => ({
+  agentRestartBlockReason: mocks.agentRestartBlockReason,
 }));
 
 vi.mock('../../../lib/platform-lifecycle.js', () => ({
@@ -111,10 +116,18 @@ function mockExecByCommand(handlers: Record<string, Array<{ stdout?: string; cod
   });
 }
 
+const originalAgentId = process.env.OVERDECK_AGENT_ID;
+
+function restoreAgentId(): void {
+  if (originalAgentId === undefined) delete process.env.OVERDECK_AGENT_ID;
+  else process.env.OVERDECK_AGENT_ID = originalAgentId;
+}
+
 describe('reloadCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.exitCode = undefined;
+    delete process.env.OVERDECK_AGENT_ID;
     vi.spyOn(process, 'cwd').mockReturnValue('/repo');
     vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -133,6 +146,7 @@ describe('reloadCommand', () => {
     mocks.resolveBundledServerPath.mockReturnValue('/tmp/server.js');
     mocks.readDevSupervisorMarker.mockReturnValue(null);
     mocks.devSupervisorRefusalLines.mockReturnValue([]);
+    mocks.agentRestartBlockReason.mockResolvedValue(null);
     mocks.fsRm.mockResolvedValue(undefined);
     mocks.fsCp.mockResolvedValue(undefined);
     mocks.fsRename.mockResolvedValue(undefined);
@@ -141,6 +155,11 @@ describe('reloadCommand', () => {
       "git 'fetch' 'origin' 'main'": [{ stdout: '' }],
       "git 'merge-base' '--is-ancestor' 'origin/main' 'HEAD'": [{ stdout: '' }],
     });
+  });
+
+  afterEach(() => {
+    restoreAgentId();
+    process.exitCode = undefined;
   });
 
   it('signals a running pan dev supervisor (SIGUSR2) instead of refusing or restarting (PAN-1662)', async () => {
@@ -205,6 +224,54 @@ describe('reloadCommand', () => {
       expect.objectContaining({ success: false, error: expect.stringContaining('restart in progress') }),
     );
     expect(process.exitCode).toBe(2);
+  });
+
+  it('refuses a blocked agent reload before acquiring the restart lock or building', async () => {
+    process.env.OVERDECK_AGENT_ID = 'agent-pan-2772';
+    mocks.agentRestartBlockReason.mockResolvedValue('Restart refused by active deployment gate.');
+
+    await reloadCommand({});
+
+    expect(mocks.agentRestartBlockReason).toHaveBeenCalledWith({
+      initiator: 'agent-pan-2772',
+      force: false,
+    });
+    expect(console.error).toHaveBeenCalledWith('Restart refused by active deployment gate.');
+    expect(process.exitCode).toBe(1);
+    expect(mocks.acquireRestartLock).not.toHaveBeenCalled();
+    expect(mocks.spawn).not.toHaveBeenCalled();
+    expect(mocks.restartDashboard).not.toHaveBeenCalled();
+  });
+
+  it('allows --force to proceed through the agent reload gate', async () => {
+    process.env.OVERDECK_AGENT_ID = 'agent-pan-2772';
+
+    await reloadCommand({ force: true, skipBuild: true });
+
+    expect(mocks.agentRestartBlockReason).toHaveBeenCalledWith({
+      initiator: 'agent-pan-2772',
+      force: true,
+    });
+    expect(mocks.acquireRestartLock).toHaveBeenCalledWith('pan reload');
+    expect(mocks.restartDashboard).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the agent reload gate when no initiator is present', async () => {
+    await reloadCommand({ skipBuild: true });
+
+    expect(mocks.agentRestartBlockReason).not.toHaveBeenCalled();
+    expect(mocks.acquireRestartLock).toHaveBeenCalledWith('pan reload');
+    expect(mocks.restartDashboard).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns that a proceeding agent reload disconnects live sessions', async () => {
+    process.env.OVERDECK_AGENT_ID = 'agent-pan-2772';
+
+    await reloadCommand({ skipBuild: true });
+
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining(
+      'disconnect every live conversation and terminal until clients reconnect',
+    ));
   });
 
   it('runs bun install before the build, then restartDashboard, on success', async () => {

--- a/src/cli/commands/__tests__/restart-agent-gate.test.ts
+++ b/src/cli/commands/__tests__/restart-agent-gate.test.ts
@@ -1,0 +1,160 @@
+import { Effect } from 'effect';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  acquireRestartLock: vi.fn(),
+  readRestartLockHolder: vi.fn(),
+  readPlatformConfigSync: vi.fn(),
+  restartDashboard: vi.fn(),
+  writeRestartStatus: vi.fn(),
+  readDevSupervisorMarker: vi.fn(),
+  devSupervisorRefusalLines: vi.fn(),
+  agentRestartBlockReason: vi.fn(),
+  releaseRestartLock: vi.fn(),
+}));
+
+vi.mock('../../../lib/restart-lock.js', () => ({
+  acquireRestartLock: mocks.acquireRestartLock,
+  readRestartLockHolder: mocks.readRestartLockHolder,
+}));
+
+vi.mock('../../../lib/platform-lifecycle.js', () => ({
+  openDashboardLogStdio: vi.fn(),
+  readPlatformConfigSync: mocks.readPlatformConfigSync,
+  restartDashboard: mocks.restartDashboard,
+  restartCliproxy: vi.fn(),
+  restartTraefik: vi.fn(),
+  startTraefik: vi.fn(),
+  stopTraefik: vi.fn(),
+  waitForDashboardHealth: vi.fn(),
+  stopDashboard: vi.fn(),
+  StageError: class StageError extends Error {
+    failure: { stage: string; reason: string };
+    constructor(failure: { stage: string; reason: string }) {
+      super(`[${failure.stage}] ${failure.reason}`);
+      this.failure = failure;
+    }
+  },
+}));
+
+vi.mock('../../../lib/restart-status.js', () => ({
+  writeRestartStatus: mocks.writeRestartStatus,
+}));
+
+vi.mock('../../../lib/dev-supervisor.js', () => ({
+  readDevSupervisorMarker: mocks.readDevSupervisorMarker,
+  devSupervisorRefusalLines: mocks.devSupervisorRefusalLines,
+}));
+
+vi.mock('../../../lib/deploy/agent-restart-gate.js', () => ({
+  agentRestartBlockReason: mocks.agentRestartBlockReason,
+}));
+
+import { restartCommand } from '../restart.js';
+
+const originalAgentId = process.env.OVERDECK_AGENT_ID;
+const originalLockHeld = process.env.OVERDECK_RESTART_LOCK_HELD;
+const originalSkipSupervisorCycle = process.env.OVERDECK_SKIP_SUPERVISOR_CYCLE;
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+describe('restartCommand agent deploy-window gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = undefined;
+    delete process.env.OVERDECK_AGENT_ID;
+    delete process.env.OVERDECK_RESTART_LOCK_HELD;
+    process.env.OVERDECK_SKIP_SUPERVISOR_CYCLE = '1';
+
+    vi.spyOn(process, 'cwd').mockReturnValue('/repo');
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    mocks.readPlatformConfigSync.mockReturnValue({
+      dashboardPort: 3010,
+      dashboardApiPort: 3011,
+      traefikEnabled: false,
+      traefikDomain: 'overdeck.localhost',
+      traefikDir: '/tmp/traefik',
+    });
+    mocks.readDevSupervisorMarker.mockReturnValue(null);
+    mocks.devSupervisorRefusalLines.mockReturnValue([]);
+    mocks.agentRestartBlockReason.mockResolvedValue(null);
+    mocks.acquireRestartLock.mockReturnValue(Effect.succeed({
+      release: mocks.releaseRestartLock,
+    }));
+    mocks.restartDashboard.mockReturnValue(Effect.succeed(undefined));
+    mocks.writeRestartStatus.mockReturnValue(Effect.succeed(undefined));
+    mocks.releaseRestartLock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    restoreEnv('OVERDECK_AGENT_ID', originalAgentId);
+    restoreEnv('OVERDECK_RESTART_LOCK_HELD', originalLockHeld);
+    restoreEnv('OVERDECK_SKIP_SUPERVISOR_CYCLE', originalSkipSupervisorCycle);
+    process.exitCode = undefined;
+  });
+
+  it('refuses a blocked agent restart before acquiring the restart lock', async () => {
+    process.env.OVERDECK_AGENT_ID = 'agent-pan-2772';
+    mocks.agentRestartBlockReason.mockResolvedValue('Restart refused by active deployment gate.');
+
+    await restartCommand({ dashboard: true });
+
+    expect(mocks.agentRestartBlockReason).toHaveBeenCalledWith({
+      initiator: 'agent-pan-2772',
+      force: false,
+    });
+    expect(console.error).toHaveBeenCalledWith('Restart refused by active deployment gate.');
+    expect(process.exitCode).toBe(1);
+    expect(mocks.acquireRestartLock).not.toHaveBeenCalled();
+    expect(mocks.restartDashboard).not.toHaveBeenCalled();
+  });
+
+  it('allows --force to proceed through the gate and acquire the restart lock', async () => {
+    process.env.OVERDECK_AGENT_ID = 'agent-pan-2772';
+
+    await restartCommand({ dashboard: true, force: true });
+
+    expect(mocks.agentRestartBlockReason).toHaveBeenCalledWith({
+      initiator: 'agent-pan-2772',
+      force: true,
+    });
+    expect(mocks.acquireRestartLock).toHaveBeenCalledWith('pan restart');
+    expect(mocks.restartDashboard).toHaveBeenCalledTimes(1);
+    expect(mocks.releaseRestartLock).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the gate and lock acquisition for an inner restart invocation', async () => {
+    process.env.OVERDECK_AGENT_ID = 'agent-pan-2772';
+    process.env.OVERDECK_RESTART_LOCK_HELD = '1';
+
+    await restartCommand({ dashboard: true });
+
+    expect(mocks.agentRestartBlockReason).not.toHaveBeenCalled();
+    expect(mocks.acquireRestartLock).not.toHaveBeenCalled();
+    expect(mocks.restartDashboard).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the gate for a restart without an agent initiator', async () => {
+    await restartCommand({ dashboard: true });
+
+    expect(mocks.agentRestartBlockReason).not.toHaveBeenCalled();
+    expect(mocks.acquireRestartLock).toHaveBeenCalledWith('pan restart');
+    expect(mocks.restartDashboard).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns that a proceeding agent restart disconnects live sessions', async () => {
+    process.env.OVERDECK_AGENT_ID = 'agent-pan-2772';
+
+    await restartCommand({ dashboard: true });
+
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining(
+      'disconnect every live conversation and terminal until clients reconnect',
+    ));
+  });
+});

--- a/src/cli/commands/reload.ts
+++ b/src/cli/commands/reload.ts
@@ -7,12 +7,14 @@ import { promises as fs, statSync } from 'fs';
 import { acquireRestartLock, readRestartLockHolder } from '../../lib/restart-lock.js';
 import { readPlatformConfigSync, restartDashboard, StageError } from '../../lib/platform-lifecycle.js';
 import { writeRestartStatus } from '../../lib/restart-status.js';
+import { agentRestartBlockReason } from '../../lib/deploy/agent-restart-gate.js';
 import { resolveBundledServerPath, spawnDashboardDetached } from './restart.js';
 
 export interface ReloadOptions {
   skipBuild?: boolean;
   healthTimeout?: string;
   deacon?: boolean;
+  force?: boolean;
 }
 
 class UsageError extends Error {}
@@ -188,6 +190,22 @@ export async function reloadCommand(options: ReloadOptions): Promise<void> {
     console.error(chalk.red(`Error: ${(error as Error).message}`));
     process.exitCode = 2;
     return;
+  }
+
+  const restartInitiator = process.env.OVERDECK_AGENT_ID;
+  if (restartInitiator) {
+    const restartBlock = await agentRestartBlockReason({
+      initiator: restartInitiator,
+      force: options.force === true,
+    });
+    if (restartBlock) {
+      console.error(restartBlock);
+      process.exitCode = 1;
+      return;
+    }
+    console.log(chalk.yellow(
+      '  This agent-issued restart will disconnect every live conversation and terminal until clients reconnect.',
+    ));
   }
 
   const lock = await Effect.runPromise(acquireRestartLock('pan reload'));

--- a/src/cli/commands/restart.ts
+++ b/src/cli/commands/restart.ts
@@ -27,6 +27,7 @@ import { isWorkspaceRepoRoot } from '../../dashboard/server/identity.js';
 import { acquireRestartLock, readRestartLockHolder, type RestartLockHandle } from '../../lib/restart-lock.js';
 import { writeRestartStatus } from '../../lib/restart-status.js';
 import { applyBootGateEnv, formatBootGateState, resolveBootGates, type BootGateOptions } from '../../lib/boot-gates.js';
+import { agentRestartBlockReason } from '../../lib/deploy/agent-restart-gate.js';
 
 import {
   openDashboardLogStdio,
@@ -237,6 +238,22 @@ export async function restartCommand(options: RestartOptions): Promise<void> {
 
   const lockInherited = process.env.OVERDECK_RESTART_LOCK_HELD === '1';
   const needsRestartLock = (scope === 'dashboard' || scope === 'full') && !lockInherited;
+  const restartInitiator = process.env.OVERDECK_AGENT_ID;
+  if (needsRestartLock && restartInitiator) {
+    const restartBlock = await agentRestartBlockReason({
+      initiator: restartInitiator,
+      force: options.force === true,
+    });
+    if (restartBlock) {
+      console.error(restartBlock);
+      process.exitCode = 1;
+      return;
+    }
+    console.log(chalk.yellow(
+      '  This agent-issued restart will disconnect every live conversation and terminal until clients reconnect.',
+    ));
+  }
+
   let restartLock: RestartLockHandle | null = null;
   if (needsRestartLock) {
     restartLock = await Effect.runPromise(acquireRestartLock('pan restart'));

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1297,7 +1297,7 @@ program
   .option('--cliproxy', 'Restart only the CLIProxy sidecar')
   .option('--traefik', 'Restart only Traefik')
   .option('--full', 'Restart the entire stack (equivalent to pan down && pan up)')
-  .option('--force', 'For --cliproxy: redownload binary at the pinned version before restarting (use after bumping CLIPROXY_RELEASE_VERSION)')
+  .option('--force', 'For --cliproxy: redownload binary at the pinned version before restarting (use after bumping CLIPROXY_RELEASE_VERSION). For dashboard scope: bypass the agent deploy-window gate (agent-initiated restarts are otherwise refused while deploy-window block reasons are active)')
   .option('--health-timeout <ms>', 'Dashboard /api/health wait budget in ms (default 15000)')
   .option('--deacon', 'Force Cloister/Deacon auto-start even if the shell inherited OVERDECK_DISABLE_DEACON')
   .option('--no-deacon', 'Skip Cloister/Deacon auto-start on restart (escape hatch when deacon\'s startup scan is starving the event loop)')

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1278,11 +1278,11 @@ program
 
     console.log('');
   });
-
 program
   .command('reload')
   .description('Build Overdeck, then restart the dashboard only after the build succeeds')
   .option('--skip-build', 'Skip npm run build and restart the existing bundle')
+  .option('--force', 'Bypass the agent deploy-window gate (agent-initiated reloads are otherwise refused while deploy-window block reasons are active)')
   .option('--health-timeout <ms>', 'Dashboard /api/health wait budget in ms (default 30000)')
   .option('--no-deacon', 'Skip Cloister/Deacon auto-start after reload')
   .action(reloadCommand);

--- a/src/dashboard/frontend/src/components/XTerminal.test.tsx
+++ b/src/dashboard/frontend/src/components/XTerminal.test.tsx
@@ -627,21 +627,26 @@ describe('XTerminal - patient reconnect', () => {
     vi.useRealTimers();
   });
 
-  it('keeps reconnecting past five attempts and 31 seconds', async () => {
+  it('keeps reconnecting past five attempts without writing retry messages to scrollback', async () => {
     render(<XTerminal sessionName="test-session" />);
     await act(async () => vi.advanceTimersByTimeAsync(0));
 
+    const term = (Terminal as unknown as {
+      instances: Array<{ writeln: ReturnType<typeof vi.fn> }>;
+    }).instances[0];
     const delays = [1_000, 2_000, 4_000, 5_000, 5_000, 5_000, 5_000, 5_000];
     for (const delay of delays) {
       const socket = MockWebSocket.instances.at(-1)!;
       act(() => socket.onclose?.({ code: 1006, reason: 'restart' }));
+      expect(screen.getByRole('status')).toHaveTextContent('Connection lost — reconnecting…');
       await act(async () => vi.advanceTimersByTimeAsync(delay));
     }
 
     expect(MockWebSocket.instances).toHaveLength(9);
+    expect(term.writeln).not.toHaveBeenCalled();
   });
 
-  it('stops reconnecting when the five-minute window expires without healthy data', async () => {
+  it('shows a manual Reconnect button when the five-minute window expires', async () => {
     const onDisconnect = vi.fn();
     render(<XTerminal sessionName="test-session" onDisconnect={onDisconnect} />);
     await act(async () => vi.advanceTimersByTimeAsync(0));
@@ -652,10 +657,38 @@ describe('XTerminal - patient reconnect', () => {
 
     await act(async () => vi.advanceTimersByTimeAsync(PATIENT_WINDOW_MS - 1_000));
     act(() => MockWebSocket.instances[1].onclose?.({ code: 1006, reason: 'still down' }));
-    await act(async () => vi.runOnlyPendingTimersAsync());
 
     expect(MockWebSocket.instances).toHaveLength(2);
-    expect(onDisconnect).toHaveBeenCalledOnce();
+    expect(screen.getByRole('status')).toHaveTextContent('Connection unavailable.');
+    expect(screen.getByRole('button', { name: 'Reconnect' })).toBeInTheDocument();
+    expect(onDisconnect).not.toHaveBeenCalled();
+  });
+
+  it('reconnects immediately when requested and clears the overlay on snapshot data', async () => {
+    render(<XTerminal sessionName="test-session" />);
+    await act(async () => vi.advanceTimersByTimeAsync(0));
+
+    act(() => MockWebSocket.instances[0].onclose?.({ code: 1006, reason: 'restart' }));
+    await act(async () => vi.advanceTimersByTimeAsync(PATIENT_WINDOW_MS));
+    act(() => MockWebSocket.instances[1].onclose?.({ code: 1006, reason: 'still down' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reconnect' }));
+
+    expect(MockWebSocket.instances).toHaveLength(3);
+    expect(screen.getByRole('status')).toHaveTextContent('Connection lost — reconnecting…');
+
+    const snapshot = '\u001b[31mreconnected snapshot\u001b[0m';
+    act(() => {
+      MockWebSocket.instances[2].onmessage?.({
+        data: `\u0000${JSON.stringify({ type: 'snapshot', data: snapshot, cols: 80, rows: 24 })}`,
+      });
+    });
+
+    const term = (Terminal as unknown as {
+      instances: Array<{ write: ReturnType<typeof vi.fn> }>;
+    }).instances[0];
+    expect(term.write).toHaveBeenCalledWith(snapshot, expect.any(Function));
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
 
   it('starts a fresh reconnect window after a snapshot proves the connection healthy', async () => {
@@ -689,6 +722,7 @@ describe('XTerminal - patient reconnect', () => {
     }).instances[0];
     expect(term.writeln).toHaveBeenCalledWith(expect.stringContaining('has ended'));
     expect(onDisconnect).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
     expect(MockWebSocket.instances).toHaveLength(1);
   });
 });

--- a/src/dashboard/frontend/src/components/XTerminal.test.tsx
+++ b/src/dashboard/frontend/src/components/XTerminal.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { act, render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
+import { PATIENT_WINDOW_MS } from '../lib/terminalReconnectPolicy';
 import { XTerminal } from './XTerminal';
 
 // Mock xterm.js — it performs real DOM/media-query operations that break in jsdom.
@@ -76,7 +77,7 @@ class MockWebSocket {
   readyState = 1;
   binaryType = 'blob';
   onopen: (() => void) | null = null;
-  onclose: (() => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
   onmessage: ((event: unknown) => void) | null = null;
   onerror: (() => void) | null = null;
   send = vi.fn();
@@ -602,6 +603,93 @@ describe('XTerminal - WebSocket', () => {
     await waitFor(() => {
       expect(screen.getByTitle('Terminal settings')).toBeInTheDocument();
     });
+  });
+});
+
+describe('XTerminal - patient reconnect', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    MockWebSocket.instances = [];
+    (Terminal as unknown as { instances: unknown[] }).instances = [];
+    (FitAddon as unknown as { instances: unknown[] }).instances = [];
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      value: 800,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('keeps reconnecting past five attempts and 31 seconds', async () => {
+    render(<XTerminal sessionName="test-session" />);
+    await act(async () => vi.advanceTimersByTimeAsync(0));
+
+    const delays = [1_000, 2_000, 4_000, 5_000, 5_000, 5_000, 5_000, 5_000];
+    for (const delay of delays) {
+      const socket = MockWebSocket.instances.at(-1)!;
+      act(() => socket.onclose?.({ code: 1006, reason: 'restart' }));
+      await act(async () => vi.advanceTimersByTimeAsync(delay));
+    }
+
+    expect(MockWebSocket.instances).toHaveLength(9);
+  });
+
+  it('stops reconnecting when the five-minute window expires without healthy data', async () => {
+    const onDisconnect = vi.fn();
+    render(<XTerminal sessionName="test-session" onDisconnect={onDisconnect} />);
+    await act(async () => vi.advanceTimersByTimeAsync(0));
+
+    act(() => MockWebSocket.instances[0].onclose?.({ code: 1006, reason: 'restart' }));
+    await act(async () => vi.advanceTimersByTimeAsync(1_000));
+    expect(MockWebSocket.instances).toHaveLength(2);
+
+    await act(async () => vi.advanceTimersByTimeAsync(PATIENT_WINDOW_MS - 1_000));
+    act(() => MockWebSocket.instances[1].onclose?.({ code: 1006, reason: 'still down' }));
+    await act(async () => vi.runOnlyPendingTimersAsync());
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+    expect(onDisconnect).toHaveBeenCalledOnce();
+  });
+
+  it('starts a fresh reconnect window after a snapshot proves the connection healthy', async () => {
+    render(<XTerminal sessionName="test-session" />);
+    await act(async () => vi.advanceTimersByTimeAsync(0));
+
+    act(() => MockWebSocket.instances[0].onclose?.({ code: 1006, reason: 'restart' }));
+    await act(async () => vi.advanceTimersByTimeAsync(1_000));
+    await act(async () => vi.advanceTimersByTimeAsync(PATIENT_WINDOW_MS));
+
+    const reconnected = MockWebSocket.instances[1];
+    act(() => reconnected.onmessage?.({
+      data: `\u0000${JSON.stringify({ type: 'snapshot', cols: 100, rows: 30, data: 'healthy' })}`,
+    }));
+    act(() => reconnected.onclose?.({ code: 1006, reason: 'another restart' }));
+    await act(async () => vi.advanceTimersByTimeAsync(1_000));
+
+    expect(MockWebSocket.instances).toHaveLength(3);
+  });
+
+  it('treats close code 4404 as fatal without scheduling a retry', async () => {
+    const onDisconnect = vi.fn();
+    render(<XTerminal sessionName="test-session" onDisconnect={onDisconnect} />);
+    await act(async () => vi.advanceTimersByTimeAsync(0));
+
+    act(() => MockWebSocket.instances[0].onclose?.({ code: 4404, reason: 'missing' }));
+    await act(async () => vi.runOnlyPendingTimersAsync());
+
+    const term = (Terminal as unknown as {
+      instances: Array<{ writeln: ReturnType<typeof vi.fn> }>;
+    }).instances[0];
+    expect(term.writeln).toHaveBeenCalledWith(expect.stringContaining('has ended'));
+    expect(onDisconnect).toHaveBeenCalledOnce();
+    expect(MockWebSocket.instances).toHaveLength(1);
   });
 });
 

--- a/src/dashboard/frontend/src/components/XTerminal.test.tsx
+++ b/src/dashboard/frontend/src/components/XTerminal.test.tsx
@@ -646,6 +646,29 @@ describe('XTerminal - patient reconnect', () => {
     expect(term.writeln).not.toHaveBeenCalled();
   });
 
+  it('treats close code 4503 as a planned restart and clears the banner after recovery', async () => {
+    render(<XTerminal sessionName="test-session" />);
+    await act(async () => vi.advanceTimersByTimeAsync(0));
+
+    act(() => MockWebSocket.instances[0].onclose?.({ code: 4503, reason: 'server-restarting' }));
+
+    const status = screen.getByRole('status');
+    expect(status).toHaveTextContent('Dashboard restarting — reconnecting automatically…');
+    expect(status).toHaveClass('text-muted-foreground');
+    expect(status).not.toHaveTextContent('Connection lost');
+
+    await act(async () => vi.advanceTimersByTimeAsync(1_000));
+    expect(MockWebSocket.instances).toHaveLength(2);
+
+    act(() => {
+      MockWebSocket.instances[1].onmessage?.({
+        data: `\u0000${JSON.stringify({ type: 'snapshot', data: 'healthy', cols: 80, rows: 24 })}`,
+      });
+    });
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
   it('shows a manual Reconnect button when the five-minute window expires', async () => {
     const onDisconnect = vi.fn();
     render(<XTerminal sessionName="test-session" onDisconnect={onDisconnect} />);

--- a/src/dashboard/frontend/src/components/XTerminal.test.tsx
+++ b/src/dashboard/frontend/src/components/XTerminal.test.tsx
@@ -610,6 +610,7 @@ describe('XTerminal - patient reconnect', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
     MockWebSocket.instances = [];
     (Terminal as unknown as { instances: unknown[] }).instances = [];
     (FitAddon as unknown as { instances: unknown[] }).instances = [];
@@ -625,6 +626,20 @@ describe('XTerminal - patient reconnect', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('adds stable per-terminal jitter to reconnect attempts', async () => {
+    vi.mocked(Math.random).mockReturnValue(0.5);
+    render(<XTerminal sessionName="test-session" />);
+    await act(async () => vi.advanceTimersByTimeAsync(0));
+
+    act(() => MockWebSocket.instances[0].onclose?.({ code: 1006, reason: 'restart' }));
+    await act(async () => vi.advanceTimersByTimeAsync(1_249));
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    await act(async () => vi.advanceTimersByTimeAsync(1));
+    expect(MockWebSocket.instances).toHaveLength(2);
   });
 
   it('keeps reconnecting past five attempts without writing retry messages to scrollback', async () => {
@@ -730,6 +745,26 @@ describe('XTerminal - patient reconnect', () => {
     await act(async () => vi.advanceTimersByTimeAsync(1_000));
 
     expect(MockWebSocket.instances).toHaveLength(3);
+  });
+
+  it('closes the replacement socket on unmount without scheduling another retry', async () => {
+    const { unmount } = render(<XTerminal sessionName="test-session" />);
+    await act(async () => vi.advanceTimersByTimeAsync(0));
+
+    act(() => MockWebSocket.instances[0].onclose?.({ code: 1006, reason: 'restart' }));
+    await act(async () => vi.advanceTimersByTimeAsync(1_000));
+
+    const replacement = MockWebSocket.instances[1];
+    const queuedCloseHandler = replacement.onclose;
+    unmount();
+
+    expect(replacement.close).toHaveBeenCalledOnce();
+    expect(replacement.onclose).toBeNull();
+
+    act(() => queuedCloseHandler?.({ code: 1006, reason: 'queued-after-unmount' }));
+    await act(async () => vi.runOnlyPendingTimersAsync());
+
+    expect(MockWebSocket.instances).toHaveLength(2);
   });
 
   it('treats close code 4404 as fatal without scheduling a retry', async () => {

--- a/src/dashboard/frontend/src/components/XTerminal.tsx
+++ b/src/dashboard/frontend/src/components/XTerminal.tsx
@@ -78,6 +78,8 @@ interface XTerminalProps {
   embedded?: boolean;
 }
 
+type ConnectionStatus = 'connected' | 'reconnecting' | 'restarting' | 'failed';
+
 interface TerminalSnapshotMessage {
   type: 'snapshot';
   cols: number;
@@ -139,10 +141,12 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectPolicy = useRef<ReconnectPolicyState | null>(null);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const connectRef = useRef<(() => void) | null>(null);
   const remoteSize = useRef<{ cols: number; rows: number } | null>(null);
   const requestedSize = useRef<{ cols: number; rows: number } | null>(null);
   const readyForLiveData = useRef(false);
   const [shouldReconnect, setShouldReconnect] = useState(true);
+  const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('connected');
 
   // Auto-copy state from localStorage or prop
   const [autoCopyOnSelect, setAutoCopyOnSelect] = useState(() => {
@@ -599,6 +603,7 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
     // that blocked the main thread and caused multi-second typing lag.
     const queueLiveData = (data: string) => {
       reconnectPolicy.current = null;
+      setConnectionStatus('connected');
       if (!term) return;
       if (DEBUG_TERMINAL) {
         console.log(`XTerminal-debug: WRITE len=${data.length}`);
@@ -660,6 +665,7 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
             sendResizeIfNeeded();
           });
           reconnectPolicy.current = null;
+          setConnectionStatus('connected');
           ws.send(JSON.stringify({ type: 'ready' }));
           profMark(sessionName, tProf, 'ready sent');
           return;
@@ -708,15 +714,13 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
 
       if (delay !== null) {
         policy.attempt += 1;
-
-        term!.writeln(`\r\n\x1b[33m● Connection lost — reconnecting to \x1b[1m${sessionName}\x1b[0m\x1b[33m in ${delay / 1000}s (attempt ${policy.attempt})...\x1b[0m`);
+        setConnectionStatus('reconnecting');
 
         reconnectTimer.current = setTimeout(() => {
           connect();
         }, delay);
       } else {
-        term!.writeln(`\r\n\x1b[31m● Could not reconnect to \x1b[1m${sessionName}\x1b[0m\x1b[31m after 5 minutes.\x1b[0m`);
-        onDisconnectRef.current?.();
+        setConnectionStatus('failed');
       }
     };
 
@@ -764,6 +768,7 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
       fitAddon.current = null;
     };
   }, [sessionName, shouldReconnect, autoCopyOnSelect, handleKeyEvent, handleContextMenu, handleTerminalWheel, getMeasuredSize, sendResizeIfNeeded]);
+  connectRef.current = connect;
 
   useEffect(() => {
     const tMount = performance.now();
@@ -817,6 +822,12 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
 
   const handleClick = () => {
     terminalInstance.current?.focus();
+  };
+
+  const handleReconnect = () => {
+    reconnectPolicy.current = null;
+    setConnectionStatus('reconnecting');
+    connectRef.current?.();
   };
 
   return (
@@ -900,6 +911,33 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
           outline: 'none',
         }}
       />
+
+      {connectionStatus !== 'connected' && (
+        <div className="pointer-events-none absolute inset-x-0 bottom-4 z-20 flex justify-center px-4">
+          <div
+            role="status"
+            aria-live="polite"
+            className="pointer-events-auto flex items-center gap-3 rounded-lg border border-border bg-card/90 px-4 py-2 text-sm text-muted-foreground shadow-lg backdrop-blur-sm"
+          >
+            <span>
+              {connectionStatus === 'failed'
+                ? 'Connection unavailable.'
+                : connectionStatus === 'restarting'
+                  ? 'Server restarting — reconnecting…'
+                  : 'Connection lost — reconnecting…'}
+            </span>
+            {connectionStatus === 'failed' && (
+              <button
+                type="button"
+                onClick={handleReconnect}
+                className="rounded-md border border-border bg-muted px-3 py-1 text-sm text-foreground transition-colors hover:bg-accent"
+              >
+                Reconnect
+              </button>
+            )}
+          </div>
+        </div>
+      )}
 
       {/* Context menu */}
       {contextMenu.visible && (

--- a/src/dashboard/frontend/src/components/XTerminal.tsx
+++ b/src/dashboard/frontend/src/components/XTerminal.tsx
@@ -6,6 +6,10 @@ import '@xterm/xterm/css/xterm.css';
 import { Sun, Moon, SunMoon } from 'lucide-react';
 import { toast } from 'sonner';
 import { useTheme } from '../hooks/useTheme';
+import {
+  nextReconnectDelay,
+  type ReconnectPolicyState,
+} from '../lib/terminalReconnectPolicy';
 
 // Terminal background, exported so embedders can match the surrounding chrome.
 // Must match TERMINAL_BG in src/lib/ui-theme.ts — new tmux sessions stamp
@@ -133,12 +137,11 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
   const terminalInstance = useRef<Terminal | null>(null);
   const fitAddon = useRef<FitAddon | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
-  const reconnectAttempts = useRef(0);
+  const reconnectPolicy = useRef<ReconnectPolicyState | null>(null);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const remoteSize = useRef<{ cols: number; rows: number } | null>(null);
   const requestedSize = useRef<{ cols: number; rows: number } | null>(null);
   const readyForLiveData = useRef(false);
-  const maxReconnectAttempts = 5;
   const [shouldReconnect, setShouldReconnect] = useState(true);
 
   // Auto-copy state from localStorage or prop
@@ -193,11 +196,6 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
       console.error('Failed to save Ctrl+V paste setting:', err);
     }
   }, [ctrlVPaste]);
-
-  // Calculate exponential backoff delay: 1s, 2s, 4s, 8s, max 30s
-  const getReconnectDelay = (attempt: number): number => {
-    return Math.min(1000 * Math.pow(2, attempt), 30000);
-  };
 
   const getMeasuredSize = useCallback((): { cols: number; rows: number } | null => {
     const term = terminalInstance.current;
@@ -600,7 +598,7 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
     // xterm.js parsed the current batch, producing an ever-larger next batch
     // that blocked the main thread and caused multi-second typing lag.
     const queueLiveData = (data: string) => {
-      reconnectAttempts.current = 0;
+      reconnectPolicy.current = null;
       if (!term) return;
       if (DEBUG_TERMINAL) {
         console.log(`XTerminal-debug: WRITE len=${data.length}`);
@@ -661,7 +659,7 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
             readyForLiveData.current = true;
             sendResizeIfNeeded();
           });
-          reconnectAttempts.current = 0;
+          reconnectPolicy.current = null;
           ws.send(JSON.stringify({ type: 'ready' }));
           profMark(sessionName, tProf, 'ready sent');
           return;
@@ -703,17 +701,21 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
       // For normal close (1000) or unexpected close, attempt reconnection.
       // The server sends 1000 when the PTY exits, which can happen if the
       // tmux session is killed and recreated during workspace setup retries.
-      if (reconnectAttempts.current < maxReconnectAttempts) {
-        const delay = getReconnectDelay(reconnectAttempts.current);
-        reconnectAttempts.current += 1;
+      const now = Date.now();
+      const policy = reconnectPolicy.current ?? { attempt: 0, windowStartedAt: now };
+      reconnectPolicy.current = policy;
+      const delay = nextReconnectDelay(policy, now);
 
-        term!.writeln(`\r\n\x1b[33m● Connection lost — reconnecting to \x1b[1m${sessionName}\x1b[0m\x1b[33m in ${delay / 1000}s (attempt ${reconnectAttempts.current}/${maxReconnectAttempts})...\x1b[0m`);
+      if (delay !== null) {
+        policy.attempt += 1;
+
+        term!.writeln(`\r\n\x1b[33m● Connection lost — reconnecting to \x1b[1m${sessionName}\x1b[0m\x1b[33m in ${delay / 1000}s (attempt ${policy.attempt})...\x1b[0m`);
 
         reconnectTimer.current = setTimeout(() => {
           connect();
         }, delay);
       } else {
-        term!.writeln(`\r\n\x1b[31m● Could not reconnect to \x1b[1m${sessionName}\x1b[0m\x1b[31m after ${maxReconnectAttempts} attempts.\x1b[0m`);
+        term!.writeln(`\r\n\x1b[31m● Could not reconnect to \x1b[1m${sessionName}\x1b[0m\x1b[31m after 5 minutes.\x1b[0m`);
         onDisconnectRef.current?.();
       }
     };

--- a/src/dashboard/frontend/src/components/XTerminal.tsx
+++ b/src/dashboard/frontend/src/components/XTerminal.tsx
@@ -80,6 +80,8 @@ interface XTerminalProps {
 
 type ConnectionStatus = 'connected' | 'reconnecting' | 'restarting' | 'failed';
 
+const SERVER_RESTARTING_CLOSE_CODE = 4503;
+
 interface TerminalSnapshotMessage {
   type: 'snapshot';
   cols: number;
@@ -704,6 +706,12 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
         return;
       }
 
+      // 4503 = the dashboard is intentionally restarting. Retry with the same
+      // patient policy as an unexpected close, but tell the operator it is planned.
+      const retryStatus: ConnectionStatus = event.code === SERVER_RESTARTING_CLOSE_CODE
+        ? 'restarting'
+        : 'reconnecting';
+
       // For normal close (1000) or unexpected close, attempt reconnection.
       // The server sends 1000 when the PTY exits, which can happen if the
       // tmux session is killed and recreated during workspace setup retries.
@@ -714,7 +722,7 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
 
       if (delay !== null) {
         policy.attempt += 1;
-        setConnectionStatus('reconnecting');
+        setConnectionStatus(retryStatus);
 
         reconnectTimer.current = setTimeout(() => {
           connect();
@@ -923,7 +931,7 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
               {connectionStatus === 'failed'
                 ? 'Connection unavailable.'
                 : connectionStatus === 'restarting'
-                  ? 'Server restarting — reconnecting…'
+                  ? 'Dashboard restarting — reconnecting automatically…'
                   : 'Connection lost — reconnecting…'}
             </span>
             {connectionStatus === 'failed' && (

--- a/src/dashboard/frontend/src/components/XTerminal.tsx
+++ b/src/dashboard/frontend/src/components/XTerminal.tsx
@@ -7,6 +7,7 @@ import { Sun, Moon, SunMoon } from 'lucide-react';
 import { toast } from 'sonner';
 import { useTheme } from '../hooks/useTheme';
 import {
+  createReconnectJitter,
   nextReconnectDelay,
   type ReconnectPolicyState,
 } from '../lib/terminalReconnectPolicy';
@@ -141,13 +142,15 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
   const terminalInstance = useRef<Terminal | null>(null);
   const fitAddon = useRef<FitAddon | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
+  const connectionCleanupRef = useRef<(() => void) | null>(null);
   const reconnectPolicy = useRef<ReconnectPolicyState | null>(null);
+  const [reconnectJitterMs] = useState(() => createReconnectJitter());
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const connectRef = useRef<(() => void) | null>(null);
+  const mountedRef = useRef(false);
   const remoteSize = useRef<{ cols: number; rows: number } | null>(null);
   const requestedSize = useRef<{ cols: number; rows: number } | null>(null);
   const readyForLiveData = useRef(false);
-  const [shouldReconnect, setShouldReconnect] = useState(true);
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('connected');
 
   // Auto-copy state from localStorage or prop
@@ -352,6 +355,30 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
     return true;
   }, []);
 
+  const handleForcedSelectionMouseDown = useCallback((event: MouseEvent) => {
+    if (!event.isTrusted || event.button !== 0) return;
+    if (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey) return;
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    event.stopPropagation();
+    const synthetic = new MouseEvent('mousedown', {
+      bubbles: true, cancelable: true, composed: true, view: window,
+      button: event.button, buttons: event.buttons,
+      clientX: event.clientX, clientY: event.clientY,
+      screenX: event.screenX, screenY: event.screenY,
+      detail: event.detail,
+      shiftKey: true,
+    });
+    target.dispatchEvent(synthetic);
+  }, []);
+
+  const handleSelectionContextMouseDown = useCallback((event: MouseEvent) => {
+    if (event.button !== 2 || !terminalInstance.current?.hasSelection()) return;
+    // xterm clears its selection while processing a right-button mousedown.
+    // Keep that event away from xterm so the context menu can still offer Copy.
+    event.stopPropagation();
+  }, []);
+
   // Close context menu
   const closeContextMenu = useCallback(() => {
     setContextMenu(prev => ({ ...prev, visible: false }));
@@ -386,18 +413,24 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
     const tProf = performance.now();
     profMark(sessionName, tProf, 'connect() entered');
 
-    // Clear any pending reconnect timer
+    // Clear any pending reconnect timer and dispose the previous connection.
+    // Each retry installs connection-scoped window/document listeners, so the
+    // replacement must tear those down instead of relying on the initial
+    // mount's cleanup closure.
     if (reconnectTimer.current) {
       clearTimeout(reconnectTimer.current);
       reconnectTimer.current = null;
     }
+    const previousConnectionCleanup = connectionCleanupRef.current;
+    connectionCleanupRef.current = null;
+    previousConnectionCleanup?.();
 
     // Ensure container has dimensions before creating terminal
     const container = terminalRef.current;
     if (container.clientWidth === 0 || container.clientHeight === 0) {
       console.warn('XTerminal: Container has no size, retrying in 100ms');
       profMark(sessionName, tProf, 'container 0x0, retry in 100ms');
-      setTimeout(() => connect(), 100);
+      reconnectTimer.current = setTimeout(() => connect(), 100);
       return;
     }
     profMark(sessionName, tProf, 'container sized', `${container.clientWidth}x${container.clientHeight}`);
@@ -407,37 +440,6 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
     // Create terminal instance if it doesn't exist, otherwise reuse
     let term = terminalInstance.current;
     let fit = fitAddon.current;
-    const handleForcedSelectionMouseDown = (event: MouseEvent) => {
-      if (!event.isTrusted) return;
-      if (event.button !== 0) return;
-      if (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey) return;
-      const target = event.target;
-      if (!(target instanceof Element)) return;
-      event.stopPropagation();
-      const synthetic = new MouseEvent('mousedown', {
-        bubbles: true,
-        cancelable: true,
-        composed: true,
-        view: window,
-        button: event.button,
-        buttons: event.buttons,
-        clientX: event.clientX,
-        clientY: event.clientY,
-        screenX: event.screenX,
-        screenY: event.screenY,
-        detail: event.detail,
-        shiftKey: true,
-      });
-      target.dispatchEvent(synthetic);
-    };
-    const handleSelectionContextMouseDown = (event: MouseEvent) => {
-      if (event.button === 2 && term?.hasSelection()) {
-        // xterm clears its selection while processing a right-button mousedown.
-        // Keep that event away from xterm so the following contextmenu event can
-        // still offer Copy for the selected text.
-        event.stopPropagation();
-      }
-    };
 
     if (!term) {
       term = new Terminal({
@@ -692,11 +694,10 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
     ws.onclose = (event) => {
       console.log('XTerminal: WebSocket closed', event.code, event.reason);
 
-      if (!shouldReconnect) {
-        term!.writeln('\r\n\x1b[33m● Session disconnected\x1b[0m');
-        onDisconnectRef.current?.();
-        return;
-      }
+      // A close callback may already be queued when React unmounts the
+      // component. Ignore it so the stale connection cannot schedule another
+      // socket or update disposed terminal state.
+      if (!mountedRef.current) return;
 
       // 4404 = session not found on the server (tmux session doesn't exist).
       // Do NOT retry — the session is gone. Retrying just hammers the server.
@@ -718,7 +719,7 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
       const now = Date.now();
       const policy = reconnectPolicy.current ?? { attempt: 0, windowStartedAt: now };
       reconnectPolicy.current = policy;
-      const delay = nextReconnectDelay(policy, now);
+      const delay = nextReconnectDelay(policy, now, reconnectJitterMs);
 
       if (delay !== null) {
         policy.attempt += 1;
@@ -754,28 +755,21 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
     };
     document.addEventListener('visibilitychange', handleVisibilityChange);
 
-    return () => {
+    const cleanupConnection = () => {
       window.removeEventListener('resize', handleResize);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
-      terminalRef.current?.removeEventListener('mousedown', handleForcedSelectionMouseDown, true);
-      terminalRef.current?.removeEventListener('mousedown', handleSelectionContextMouseDown, true);
-      terminalRef.current?.removeEventListener('contextmenu', handleContextMenu);
-      setShouldReconnect(false);
-      readyForLiveData.current = false;
-      if (reconnectTimer.current) {
-        clearTimeout(reconnectTimer.current);
-      }
-      // Prevent the old ws.onclose handler (which closes over the stale
-      // shouldReconnect value) from scheduling an orphaned reconnect timer
-      // after the component has already remounted.
+      ws.onopen = null;
       ws.onclose = null;
+      ws.onmessage = null;
+      ws.onerror = null;
       ws.close();
-      wsRef.current = null;
-      term?.dispose();
-      terminalInstance.current = null;
-      fitAddon.current = null;
+      if (wsRef.current === ws) {
+        wsRef.current = null;
+        readyForLiveData.current = false;
+      }
     };
-  }, [sessionName, shouldReconnect, autoCopyOnSelect, handleKeyEvent, handleContextMenu, handleTerminalWheel, getMeasuredSize, sendResizeIfNeeded]);
+    connectionCleanupRef.current = cleanupConnection;
+  }, [sessionName, token, autoCopyOnSelect, reconnectJitterMs, handleKeyEvent, handleContextMenu, handleTerminalWheel, handleForcedSelectionMouseDown, handleSelectionContextMouseDown, getMeasuredSize, sendResizeIfNeeded]);
   connectRef.current = connect;
 
   useEffect(() => {
@@ -793,16 +787,30 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
     // cold-path latency win; connect()'s own clientWidth/Height check still
     // covers the rare container-not-yet-sized case via its 100ms retry.
     let cancelled = false;
-    let cleanupFn: (() => void) | undefined;
+    mountedRef.current = true;
     const timer = setTimeout(() => {
-      if (!cancelled) cleanupFn = connect();
+      if (!cancelled) connect();
     }, 0);
     return () => {
       cancelled = true;
+      mountedRef.current = false;
       clearTimeout(timer);
-      cleanupFn?.();
+      if (reconnectTimer.current) {
+        clearTimeout(reconnectTimer.current);
+        reconnectTimer.current = null;
+      }
+      const cleanupConnection = connectionCleanupRef.current;
+      connectionCleanupRef.current = null;
+      cleanupConnection?.();
+      terminalRef.current?.removeEventListener('mousedown', handleForcedSelectionMouseDown, true);
+      terminalRef.current?.removeEventListener('mousedown', handleSelectionContextMouseDown, true);
+      terminalRef.current?.removeEventListener('contextmenu', handleContextMenu);
+      readyForLiveData.current = false;
+      terminalInstance.current?.dispose();
+      terminalInstance.current = null;
+      fitAddon.current = null;
     };
-  }, [connect, sessionName]);
+  }, [connect, sessionName, handleContextMenu, handleForcedSelectionMouseDown, handleSelectionContextMouseDown]);
 
   useEffect(() => {
     const debouncedFit = debounce(() => {

--- a/src/dashboard/frontend/src/lib/__tests__/terminalReconnectPolicy.test.ts
+++ b/src/dashboard/frontend/src/lib/__tests__/terminalReconnectPolicy.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+  createReconnectJitter,
   FLAT_DELAY_MS,
+  MAX_RECONNECT_JITTER_MS,
   nextReconnectDelay,
   PATIENT_WINDOW_MS,
 } from '../terminalReconnectPolicy';
@@ -16,16 +18,46 @@ describe('terminalReconnectPolicy', () => {
     expect(nextReconnectDelay({ attempt: 10, windowStartedAt }, windowStartedAt)).toBe(FLAT_DELAY_MS);
   });
 
+  it('adds bounded jitter to exponential and flat delays', () => {
+    const windowStartedAt = 1_000;
+
+    expect(nextReconnectDelay(
+      { attempt: 0, windowStartedAt },
+      windowStartedAt,
+      250,
+    )).toBe(1_250);
+    expect(nextReconnectDelay(
+      { attempt: 3, windowStartedAt },
+      windowStartedAt,
+      250,
+    )).toBe(FLAT_DELAY_MS + 250);
+    expect(nextReconnectDelay(
+      { attempt: 3, windowStartedAt },
+      windowStartedAt,
+      MAX_RECONNECT_JITTER_MS + 1,
+    )).toBe(FLAT_DELAY_MS + MAX_RECONNECT_JITTER_MS);
+  });
+
+  it('creates deterministic bounded jitter from an injected random source', () => {
+    expect(createReconnectJitter(() => 0)).toBe(0);
+    expect(createReconnectJitter(() => 0.5)).toBe(250);
+    expect(createReconnectJitter(() => 1)).toBe(MAX_RECONNECT_JITTER_MS);
+    expect(createReconnectJitter(() => -1)).toBe(0);
+    expect(createReconnectJitter(() => Number.NaN)).toBe(0);
+  });
+
   it('returns null at and after the patient reconnect window boundary', () => {
     const windowStartedAt = 1_000;
 
     expect(nextReconnectDelay(
       { attempt: 3, windowStartedAt },
       windowStartedAt + PATIENT_WINDOW_MS - 1,
-    )).toBe(FLAT_DELAY_MS);
+      MAX_RECONNECT_JITTER_MS,
+    )).toBe(FLAT_DELAY_MS + MAX_RECONNECT_JITTER_MS);
     expect(nextReconnectDelay(
       { attempt: 3, windowStartedAt },
       windowStartedAt + PATIENT_WINDOW_MS,
+      MAX_RECONNECT_JITTER_MS,
     )).toBeNull();
     expect(nextReconnectDelay(
       { attempt: 3, windowStartedAt },

--- a/src/dashboard/frontend/src/lib/__tests__/terminalReconnectPolicy.test.ts
+++ b/src/dashboard/frontend/src/lib/__tests__/terminalReconnectPolicy.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FLAT_DELAY_MS,
+  nextReconnectDelay,
+  PATIENT_WINDOW_MS,
+} from '../terminalReconnectPolicy';
+
+describe('terminalReconnectPolicy', () => {
+  it('uses exponential delays before settling at the flat delay', () => {
+    const windowStartedAt = 1_000;
+
+    expect(nextReconnectDelay({ attempt: 0, windowStartedAt }, windowStartedAt)).toBe(1_000);
+    expect(nextReconnectDelay({ attempt: 1, windowStartedAt }, windowStartedAt)).toBe(2_000);
+    expect(nextReconnectDelay({ attempt: 2, windowStartedAt }, windowStartedAt)).toBe(4_000);
+    expect(nextReconnectDelay({ attempt: 3, windowStartedAt }, windowStartedAt)).toBe(FLAT_DELAY_MS);
+    expect(nextReconnectDelay({ attempt: 10, windowStartedAt }, windowStartedAt)).toBe(FLAT_DELAY_MS);
+  });
+
+  it('returns null at and after the patient reconnect window boundary', () => {
+    const windowStartedAt = 1_000;
+
+    expect(nextReconnectDelay(
+      { attempt: 3, windowStartedAt },
+      windowStartedAt + PATIENT_WINDOW_MS - 1,
+    )).toBe(FLAT_DELAY_MS);
+    expect(nextReconnectDelay(
+      { attempt: 3, windowStartedAt },
+      windowStartedAt + PATIENT_WINDOW_MS,
+    )).toBeNull();
+    expect(nextReconnectDelay(
+      { attempt: 3, windowStartedAt },
+      windowStartedAt + PATIENT_WINDOW_MS + 1,
+    )).toBeNull();
+  });
+
+  it('keeps large attempt counts at the flat delay without exponent overflow', () => {
+    expect(nextReconnectDelay({ attempt: 40, windowStartedAt: 0 }, 0)).toBe(FLAT_DELAY_MS);
+  });
+});

--- a/src/dashboard/frontend/src/lib/terminalReconnectPolicy.ts
+++ b/src/dashboard/frontend/src/lib/terminalReconnectPolicy.ts
@@ -1,0 +1,16 @@
+export interface ReconnectPolicyState {
+  attempt: number;
+  windowStartedAt: number;
+}
+
+export const PATIENT_WINDOW_MS = 5 * 60_000;
+export const FLAT_DELAY_MS = 5_000;
+
+export function nextReconnectDelay(
+  state: ReconnectPolicyState,
+  now: number,
+): number | null {
+  if (now - state.windowStartedAt >= PATIENT_WINDOW_MS) return null;
+  if (state.attempt >= 3) return FLAT_DELAY_MS;
+  return 1_000 * 2 ** state.attempt;
+}

--- a/src/dashboard/frontend/src/lib/terminalReconnectPolicy.ts
+++ b/src/dashboard/frontend/src/lib/terminalReconnectPolicy.ts
@@ -5,12 +5,25 @@ export interface ReconnectPolicyState {
 
 export const PATIENT_WINDOW_MS = 5 * 60_000;
 export const FLAT_DELAY_MS = 5_000;
+export const MAX_RECONNECT_JITTER_MS = 500;
+
+function clampReconnectJitter(jitterMs: number): number {
+  if (!Number.isFinite(jitterMs)) return 0;
+  return Math.min(MAX_RECONNECT_JITTER_MS, Math.max(0, Math.round(jitterMs)));
+}
+
+export function createReconnectJitter(random: () => number = Math.random): number {
+  return clampReconnectJitter(random() * MAX_RECONNECT_JITTER_MS);
+}
 
 export function nextReconnectDelay(
   state: ReconnectPolicyState,
   now: number,
+  jitterMs = 0,
 ): number | null {
   if (now - state.windowStartedAt >= PATIENT_WINDOW_MS) return null;
-  if (state.attempt >= 3) return FLAT_DELAY_MS;
-  return 1_000 * 2 ** state.attempt;
+  const baseDelay = state.attempt >= 3
+    ? FLAT_DELAY_MS
+    : 1_000 * 2 ** state.attempt;
+  return baseDelay + clampReconnectJitter(jitterMs);
 }

--- a/src/dashboard/server/main.ts
+++ b/src/dashboard/server/main.ts
@@ -75,6 +75,7 @@ import { isSmeeConfiguredSync, startSmeeProcessSync } from '../../lib/smee.js';
 import { flushAllPendingAutoCommits } from '../../lib/pan-dir/auto-commit.js';
 import { listProjectsSync } from '../../lib/projects.js';
 import { ensureAutomaticStateMigration, decideDeaconBootGate } from '../../lib/state-auto-migrate.js';
+import { broadcastServerRestarting } from './ws-terminal.js';
 
 declare const Bun: unknown;
 
@@ -556,6 +557,12 @@ const handleShutdownSignal = async (signal: NodeJS.Signals) => {
   if (shuttingDown) return;
   shuttingDown = true;
   console.log(`[overdeck] received ${signal} (pid=${process.pid} ppid=${process.ppid}) — shutting down`);
+  try {
+    const notifiedClients = broadcastServerRestarting();
+    console.log(`[overdeck] notified ${notifiedClients} terminal client(s) of restart`);
+  } catch (err) {
+    console.warn('[overdeck] failed to notify terminal clients of restart:', err);
+  }
   emitShutdownActivity();
   const forkGrace = await waitForInFlightForkPipelines(10_000);
   if (forkGrace.count > 0) {

--- a/src/dashboard/server/ws-terminal.ts
+++ b/src/dashboard/server/ws-terminal.ts
@@ -5,9 +5,10 @@
  * browser. This module restores the working raw WebSocket `/ws/terminal` endpoint
  * from pre-PAN-435 code.
  *
- * Exports a single function `setupTerminalWebSocket(server)` that installs a
- * `noServer` WebSocketServer on the given HTTP server's `upgrade` event for the
- * `/ws/terminal` path. Other upgrade paths (e.g., `/ws/rpc`) are left untouched.
+ * `setupTerminalWebSocket(server)` installs a `noServer` WebSocketServer on the
+ * given HTTP server's `upgrade` event for the `/ws/terminal` path. The shutdown
+ * path uses `broadcastServerRestarting()` to give every client a retryable close.
+ * Other upgrade paths (e.g., `/ws/rpc`) are left untouched.
  *
  * PAN-484: Multiple WebSocket clients (browser tabs) for the same tmux session
  * are handled via a shared PTY hub — one PTY process, many WebSocket clients.
@@ -41,6 +42,36 @@ const ATTACH_TIMEOUT_MS = 5000;
 const READY_TIMEOUT_MS = 10_000;
 const PRE_ATTACH_MAX_MESSAGES = 32;
 const PRE_ATTACH_MAX_BYTES = 64 * 1024;
+const SESSION_NOT_FOUND_CLOSE_CODE = 4404;
+export const SERVER_RESTARTING_CLOSE_CODE = 4503;
+const SERVER_RESTARTING_REASON = 'server-restarting';
+
+interface RestartableTerminalClient {
+  readyState: number;
+  close(code: number, reason?: string): void;
+}
+
+const preAttachTerminalClients = new Set<WebSocket>();
+
+function collectRestartableTerminalClients(): Set<RestartableTerminalClient> {
+  const clients = new Set<RestartableTerminalClient>(preAttachTerminalClients);
+  for (const hub of activePtyHubs.values()) {
+    for (const client of hub.clients) clients.add(client);
+  }
+  return clients;
+}
+
+export function broadcastServerRestarting(
+  clients: Iterable<RestartableTerminalClient> = collectRestartableTerminalClients(),
+): number {
+  let closedCount = 0;
+  for (const client of clients) {
+    if (client.readyState !== WebSocket.OPEN) continue;
+    client.close(SERVER_RESTARTING_CLOSE_CODE, SERVER_RESTARTING_REASON);
+    closedCount += 1;
+  }
+  return closedCount;
+}
 
 function parseControlMessage(message: string): ClientControlMessage | null {
   if (!message.startsWith('{')) return null;
@@ -190,6 +221,9 @@ export function setupTerminalWebSocket(server: http.Server): void {
   });
 
   wss.on('connection', (ws: WebSocket, req: http.IncomingMessage) => {
+    preAttachTerminalClients.add(ws);
+    ws.once('close', () => preAttachTerminalClients.delete(ws));
+
     const url = new URL(req.url || '', `http://${req.headers.host}`);
     const sessionName = url.searchParams.get('session');
 
@@ -269,11 +303,11 @@ export function setupTerminalWebSocket(server: http.Server): void {
           if (isRespawnPending(sessionName)) {
             const cameBack = await waitForSessionRespawn(sessionName, RESPAWN_WAIT_MS);
             if (!cameBack) {
-              ws.close(4404, 'session-not-found');
+              ws.close(SESSION_NOT_FOUND_CLOSE_CODE, 'session-not-found');
               return;
             }
           } else {
-            ws.close(4404, 'session-not-found');
+            ws.close(SESSION_NOT_FOUND_CLOSE_CODE, 'session-not-found');
             return;
           }
         }
@@ -342,6 +376,7 @@ export function setupTerminalWebSocket(server: http.Server): void {
       if (existingHub) {
         console.log(`[ws-terminal] Joining existing PTY hub for ${sessionName} (${existingHub.clients.size} existing clients)`);
         addClientToHub(existingHub, ws, false);
+        preAttachTerminalClients.delete(ws);
         existingHub.inputClient = ws;
 
         const dimsMatchHub = existingHub.cols === requestedCols && existingHub.rows === requestedRows;
@@ -461,6 +496,7 @@ export function setupTerminalWebSocket(server: http.Server): void {
 
       activePtyHubs.set(sessionName, hub);
       addClientToHub(hub, ws, false);
+      preAttachTerminalClients.delete(ws);
 
       const startLocalPty = async () => {
         if (ptyStarted) return;
@@ -478,13 +514,13 @@ export function setupTerminalWebSocket(server: http.Server): void {
             // "session doesn't exist" from "normal disconnect". The client
             // should NOT retry on 4404 — the session is gone.
             activePtyHubs.delete(sessionName);
-            ws.close(4404, 'session-not-found');
+            ws.close(SESSION_NOT_FOUND_CLOSE_CODE, 'session-not-found');
             return;
           }
         } catch {
           console.log(`[ws-terminal] Session ${sessionName} does not exist — closing without PTY spawn`);
           activePtyHubs.delete(sessionName);
-          ws.close(4404, 'session-not-found');
+          ws.close(SESSION_NOT_FOUND_CLOSE_CODE, 'session-not-found');
           return;
         }
 

--- a/src/lib/deploy/agent-restart-gate.ts
+++ b/src/lib/deploy/agent-restart-gate.ts
@@ -1,0 +1,26 @@
+import {
+  getDeployBlockReason,
+  type DeployWindowDependencies,
+} from './deploy-window.js';
+
+export interface AgentRestartGateInput {
+  initiator: string | undefined;
+  force: boolean;
+}
+
+export async function agentRestartBlockReason(
+  input: AgentRestartGateInput,
+  deps: Partial<DeployWindowDependencies> = {},
+): Promise<string | null> {
+  const initiator = input.initiator?.trim();
+  if (!initiator || input.force) return null;
+
+  const blockReason = await getDeployBlockReason(
+    initiator === 'flywheel-orchestrator'
+      ? { ...deps, getFlywheelActiveRunId: () => null }
+      : deps,
+  );
+  if (!blockReason) return null;
+
+  return `Restart refused. The active deployment gate says: "${blockReason}" This agent-issued restart would disconnect live sessions while that gate is active. Rerun with --force to bypass the gate.`;
+}

--- a/src/lib/deploy/deploy-window.ts
+++ b/src/lib/deploy/deploy-window.ts
@@ -13,7 +13,7 @@ import { loadReviewStatuses, type ReviewStatus } from '../review-status.js';
 import { readRestartLockHolder, type RestartLockHolder } from '../restart-lock.js';
 import { sessionExists } from '../tmux.js';
 
-interface DeployWindowDependencies {
+export interface DeployWindowDependencies {
   readonly loadReviewStatuses: () => Record<string, ReviewStatus>;
   readonly getFlywheelActiveRunId: () => string | null;
   readonly isMergeAgentRunning: () => Promise<boolean>;

--- a/sync-sources/skills/pan-reload/SKILL.md
+++ b/sync-sources/skills/pan-reload/SKILL.md
@@ -11,6 +11,7 @@ Use this after code changes that should run in the local Overdeck dashboard.
 
 ```bash
 pan reload
+pan reload --force   # explicitly bypass the agent deploy-window gate
 ```
 
 `pan reload` runs `bun install` and then `npm run build` first. If either fails, it leaves the current dashboard running and exits non-zero. If both succeed, it restarts the dashboard and waits for `http://127.0.0.1:3011/api/health`.
@@ -20,6 +21,7 @@ pan reload
 ## Options
 
 - `--skip-build` — restart the current bundle without running `bun install` or `npm run build`.
+- `--force` — bypass the deploy-window gate for an agent-issued reload. Without it, active verification, merge, post-merge, flywheel, restart, or `pan dev` ownership refuses the reload because it would disconnect live conversations and terminals.
 - `--health-timeout <ms>` — set the dashboard health-check budget. The default is `30000`.
 - `--no-deacon` — restart without Cloister/Deacon auto-start.
 

--- a/sync-sources/skills/pan-restart/SKILL.md
+++ b/sync-sources/skills/pan-restart/SKILL.md
@@ -32,6 +32,10 @@ pan restart
 pan restart --cliproxy
 pan restart --traefik
 pan restart --full       # nuclear — stops & restarts everything
+
+# Explicit force cases
+pan restart --force              # bypass the agent deploy-window gate
+pan restart --cliproxy --force   # redownload the pinned CLIProxy binary
 ```
 
 Each stage is health-gated: the command waits for `GET /api/health` (dashboard)
@@ -44,6 +48,12 @@ with a `[stage] reason` message on timeout.
   then polls until the health check passes.
 - `pan restart --dashboard` NEVER touches CLIProxy, Traefik, or TLDR — that
   scope contract is enforced by tests.
+- Agent-issued dashboard and full restarts consult the deploy-window gate before
+  acquiring the restart lock. Active verification, merge, post-merge, flywheel,
+  restart, or `pan dev` ownership refuses the restart because it would disconnect
+  live conversations and terminals; `--force` explicitly bypasses this gate.
+- For `--cliproxy`, `--force` has a separate meaning: it redownloads the binary at
+  the pinned version before restarting it.
 - If the dashboard restart fails, shared sidecars are left running so recovery
   is possible with another `pan restart` once the root cause is fixed.
 - NEVER use `pkill -f "node.*server"` — it can kill unrelated Node processes.

--- a/tests/unit/dashboard/ws-terminal-restart-broadcast.test.ts
+++ b/tests/unit/dashboard/ws-terminal-restart-broadcast.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  broadcastServerRestarting,
+  SERVER_RESTARTING_CLOSE_CODE,
+} from '../../../src/dashboard/server/ws-terminal.js';
+
+describe('terminal restart broadcast', () => {
+  it('closes only open clients with the server-restarting close code and reason', () => {
+    const firstOpenClient = { readyState: 1, close: vi.fn() };
+    const closedClient = { readyState: 3, close: vi.fn() };
+    const secondOpenClient = { readyState: 1, close: vi.fn() };
+
+    const clients = new Set([
+      firstOpenClient,
+      closedClient,
+      secondOpenClient,
+    ]);
+    const closedCount = broadcastServerRestarting(clients);
+
+    expect(closedCount).toBe(2);
+    expect(firstOpenClient.close).toHaveBeenCalledWith(
+      SERVER_RESTARTING_CLOSE_CODE,
+      'server-restarting',
+    );
+    expect(closedClient.close).not.toHaveBeenCalled();
+    expect(secondOpenClient.close).toHaveBeenCalledWith(
+      SERVER_RESTARTING_CLOSE_CODE,
+      'server-restarting',
+    );
+  });
+});

--- a/tests/unit/lib/deploy/agent-restart-gate.test.ts
+++ b/tests/unit/lib/deploy/agent-restart-gate.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { agentRestartBlockReason } from '../../../../src/lib/deploy/agent-restart-gate.js';
+import type { DeployWindowDependencies } from '../../../../src/lib/deploy/deploy-window.js';
+
+function clearDependencies() {
+  return {
+    loadReviewStatuses: vi.fn(() => ({})),
+    getFlywheelActiveRunId: vi.fn(() => null as string | null),
+    isMergeAgentRunning: vi.fn(async () => false),
+    pendingPostMergeExists: vi.fn(async () => false),
+    readRestartLockHolder: vi.fn(async () => null),
+    readDevSupervisorMarker: vi.fn(() => null),
+  } satisfies DeployWindowDependencies;
+}
+
+function expectNoDependencyCalls(deps: ReturnType<typeof clearDependencies>): void {
+  for (const dependency of Object.values(deps)) {
+    expect(dependency).not.toHaveBeenCalled();
+  }
+}
+
+describe('agentRestartBlockReason', () => {
+  it.each([undefined, '', '   '])(
+    'allows a restart without an initiator (%s) without consulting deploy gates',
+    async (initiator) => {
+      const deps = clearDependencies();
+
+      await expect(agentRestartBlockReason({ initiator, force: false }, deps)).resolves.toBeNull();
+      expectNoDependencyCalls(deps);
+    },
+  );
+
+  it('allows a forced agent restart without consulting deploy gates', async () => {
+    const deps = clearDependencies();
+
+    await expect(agentRestartBlockReason({ initiator: 'agent-pan-2772', force: true }, deps)).resolves.toBeNull();
+    expectNoDependencyCalls(deps);
+  });
+
+  it('refuses an agent restart with the active reason and force bypass explained', async () => {
+    const deps = clearDependencies();
+    deps.getFlywheelActiveRunId.mockReturnValue('RUN-42');
+
+    const result = await agentRestartBlockReason({ initiator: 'agent-pan-2772', force: false }, deps);
+
+    expect(result).toContain('"Deployment deferred because flywheel run RUN-42 owns deployment."');
+    expect(result).toContain('This agent-issued restart would disconnect live sessions while that gate is active.');
+    expect(result).toContain('Rerun with --force to bypass the gate.');
+  });
+
+  it('does not block the flywheel on its own active run', async () => {
+    const deps = clearDependencies();
+    deps.getFlywheelActiveRunId.mockReturnValue('RUN-42');
+
+    await expect(agentRestartBlockReason({
+      initiator: 'flywheel-orchestrator',
+      force: false,
+    }, deps)).resolves.toBeNull();
+    expect(deps.getFlywheelActiveRunId).not.toHaveBeenCalled();
+  });
+
+  it('still blocks the flywheel while verification is in flight', async () => {
+    const deps = clearDependencies();
+    deps.loadReviewStatuses.mockReturnValue({
+      'PAN-100': { issueId: 'PAN-100', verificationStatus: 'running' },
+    });
+    deps.getFlywheelActiveRunId.mockReturnValue('RUN-42');
+
+    const result = await agentRestartBlockReason({
+      initiator: 'flywheel-orchestrator',
+      force: false,
+    }, deps);
+
+    expect(result).toContain('"Deployment deferred because verification is in flight for PAN-100."');
+    expect(result).toContain('Rerun with --force to bypass the gate.');
+    expect(deps.getFlywheelActiveRunId).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
**Issue:** #2772

## Acceptance Criteria

- [ ] Pure time-based terminal reconnect policy module with unit tests
- [ ] Wire XTerminal to the time-based policy, replacing the 5-attempt budget
- [ ] Connection-status overlay with manual Reconnect button on exhaustion
- [ ] Broadcast close code 4503 'server-restarting' to all terminal clients on graceful shutdown
- [ ] Terminal panel treats close code 4503 as a planned restart
- [ ] agent-restart-gate helper: block agent restarts on deploy-window reasons
- [ ] Wire the agent gate into pan restart and its wrapper skill
- [ ] Wire the agent gate into pan reload (new --force flag) and its wrapper skill
- [ ] Document patient reconnect and restart close codes in CLAUDE.md