### PR TITLE
PAN-2619

### DIFF
--- a/src/dashboard/frontend/src/App.test.tsx
+++ b/src/dashboard/frontend/src/App.test.tsx
@@ -129,6 +129,7 @@ vi.mock('./lib/store', () => ({
   selectAgents: (state: { agents: unknown[] }) => state.agents,
   selectChannelPermissionRequests: (state: { channelPermissionRequestsById?: Record<string, unknown> }) =>
     Object.values(state.channelPermissionRequestsById ?? {}),
+  selectPendingInputSubjects: () => [],
   selectIssues: (state: { issues: unknown[] }) => state.issues,
   selectDashboardLifecycle: (state: { dashboardLifecycle: { active: boolean } }) => state.dashboardLifecycle,
   selectAgentsWithPendingAskUserQuestion: (state: { agentsWithPendingAskUserQuestion?: unknown[] }) =>

--- a/src/dashboard/frontend/src/components/XTerminal.test.tsx
+++ b/src/dashboard/frontend/src/components/XTerminal.test.tsx
@@ -179,7 +179,7 @@ describe('XTerminal', () => {
   it('allows the terminal frame to shrink inside constrained flex layouts (PAN-2619)', () => {
     const { container } = render(<XTerminal sessionName="test-session" />);
     const frame = container.firstElementChild;
-    const terminalSurface = container.querySelector('.absolute.inset-2');
+    const terminalSurface = container.querySelector('.xterm-host');
 
     expect(frame).toHaveClass('min-w-0', 'min-h-0', 'overflow-hidden');
     expect(terminalSurface).not.toHaveStyle({ padding: '8px' });
@@ -339,7 +339,7 @@ describe('XTerminal', () => {
       expect(MockWebSocket.instances).toHaveLength(1);
     });
 
-    const terminalSurface = container.querySelector('.absolute.inset-2') as HTMLDivElement | null;
+    const terminalSurface = container.querySelector('.xterm-host') as HTMLDivElement | null;
     expect(terminalSurface).toBeTruthy();
 
     fireEvent.contextMenu(terminalSurface!, { clientX: 32, clientY: 64 });
@@ -356,7 +356,7 @@ describe('XTerminal', () => {
 
     const term = (Terminal as unknown as { instances: Array<{ selection: string }> }).instances[0];
     term.selection = 'selected output';
-    const terminalSurface = container.querySelector('.absolute.inset-2') as HTMLDivElement;
+    const terminalSurface = container.querySelector('.xterm-host') as HTMLDivElement;
     const rightMouseDown = new MouseEvent('mousedown', { button: 2, bubbles: true, cancelable: true });
     const stopPropagation = vi.spyOn(rightMouseDown, 'stopPropagation');
 
@@ -384,7 +384,7 @@ describe('XTerminal', () => {
       expect(MockWebSocket.instances).toHaveLength(1);
     });
 
-    const terminalSurface = container.querySelector('.absolute.inset-2') as HTMLDivElement | null;
+    const terminalSurface = container.querySelector('.xterm-host') as HTMLDivElement | null;
     fireEvent.contextMenu(terminalSurface!, { clientX: 32, clientY: 64 });
     fireEvent.click(await screen.findByText('Paste'));
 

--- a/src/dashboard/frontend/src/components/XTerminal.test.tsx
+++ b/src/dashboard/frontend/src/components/XTerminal.test.tsx
@@ -176,13 +176,24 @@ describe('XTerminal', () => {
     });
   });
 
-  it('allows the terminal frame to shrink inside constrained flex layouts (PAN-2619)', () => {
+  it('keeps padding off the measured terminal host (PAN-2619)', async () => {
     const { container } = render(<XTerminal sessionName="test-session" />);
     const frame = container.firstElementChild;
-    const terminalSurface = container.querySelector('.xterm-host');
+    const terminalHost = container.querySelector('.xterm-host') as HTMLDivElement;
+    const terminalMock = Terminal as unknown as {
+      instances: Array<{ open: ReturnType<typeof vi.fn> }>;
+    };
+
+    await waitFor(() => {
+      expect(terminalMock.instances).toHaveLength(1);
+    });
+    const term = terminalMock.instances[0];
 
     expect(frame).toHaveClass('min-w-0', 'min-h-0', 'overflow-hidden');
-    expect(terminalSurface).not.toHaveStyle({ padding: '8px' });
+    expect(terminalHost).toHaveClass('xterm-host', 'absolute', 'inset-0');
+    expect(term.open).toHaveBeenCalledWith(terminalHost);
+    // FitAddon subtracts padding from the generated .xterm element, not this measured host.
+    expect(terminalHost.style.padding).toBe('');
   });
 
   it('loads auto-copy setting from localStorage', async () => {

--- a/src/dashboard/frontend/src/components/XTerminal.tsx
+++ b/src/dashboard/frontend/src/components/XTerminal.tsx
@@ -889,7 +889,7 @@ export function XTerminal({ sessionName, token, onDisconnect, autoCopyOnSelect: 
       {/* Terminal container */}
       <div
         ref={terminalRef}
-        className="absolute inset-2"
+        className="absolute inset-0 xterm-host"
         onClick={handleClick}
         tabIndex={0}
         style={{

--- a/src/dashboard/frontend/src/index.css
+++ b/src/dashboard/frontend/src/index.css
@@ -199,6 +199,11 @@ body::after {
   line-height: 1.5;
 }
 
+/* FitAddon measures the parent box but subtracts padding from .xterm only. */
+.xterm-host .xterm {
+  padding: 8px;
+}
+
 /* ─── Semantic badge/status backgrounds (opacity variants via color-mix) ─── */
 /* These provide theme-aware opacity backgrounds for status badges and pills. */
 @layer utilities {


### PR DESCRIPTION
**Issue:** #2619

## Acceptance Criteria

- [ ] Move terminal padding from the measured container onto the .xterm element
- [ ] Unit regression test: measured container must never carry inline padding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal layout sizing and spacing for a more consistent display.
  * Preserved terminal padding without affecting fit and resize calculations.
  * Updated context-menu and clipboard error interactions to work reliably with the revised terminal layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->