### PR TITLE
PAN-2252

### DIFF
--- a/docs/OVERDECK_DEV_SOP.md
+++ b/docs/OVERDECK_DEV_SOP.md
@@ -53,6 +53,8 @@ The supervisor also polls the Qwen TTS daemon every 10 seconds when TTS is enabl
 
 The latest restart outcome is written to `${OVERDECK_HOME}/restart-status.json`. `pan status` renders that state, including failures and watchdog give-up alarms.
 
+`pan up`, `pan reload`, and dashboard-starting `pan restart` scopes refuse to run from a non-primary checkout, including workspace and handoff worktrees. They exit with code 2 and name the primary checkout to use. Their post-boot health gates also require `/api/health` to report the expected `repoRoot` and `mode`; a 200 response from a different server fails as `port held by non-primary server (cwd=…, mode=…)`. This prevents the workspace-peer port-squatting incident class tracked by [PAN-2252](https://github.com/eltmon/overdeck/issues/2252).
+
 ## Automatic deployment after merges
 
 Production builds embed their Git commit and build time. Deacon compares that commit with

--- a/src/cli/commands/__tests__/dashboard-cwd-guard.test.ts
+++ b/src/cli/commands/__tests__/dashboard-cwd-guard.test.ts
@@ -1,9 +1,25 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { refuseNonPrimaryDashboardCwd } from '../restart.js';
+const processMocks = vi.hoisted(() => ({
+  execFileSync: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+vi.mock('child_process', async (importActual) => ({
+  ...(await importActual<typeof import('child_process')>()),
+  execFileSync: processMocks.execFileSync,
+  spawn: processMocks.spawn,
+}));
+
+import {
+  refuseNonPrimaryDashboardCwd,
+  resolveBundledServerPath,
+  resolvePrimaryDashboardIdentity,
+  spawnDashboardDetached,
+} from '../restart.js';
 
 const fixtureRoots: string[] = [];
 
@@ -15,10 +31,43 @@ function createFixture(prefix: string): string {
 
 afterEach(() => {
   process.exitCode = undefined;
+  vi.clearAllMocks();
   vi.restoreAllMocks();
   for (const root of fixtureRoots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+describe('resolvePrimaryDashboardIdentity', () => {
+  it('derives the checkout root from the resolved dashboard bundle', () => {
+    const serverPath = resolveBundledServerPath();
+
+    expect(resolvePrimaryDashboardIdentity()).toEqual({
+      repoRoot: resolve(serverPath, '..', '..', '..'),
+      mode: 'primary',
+    });
+  });
+
+  it('starts the dashboard with the identity root as its working directory', () => {
+    const child = { unref: vi.fn() };
+    processMocks.execFileSync.mockImplementation(() => { throw new Error('systemd unavailable'); });
+    processMocks.spawn.mockReturnValue(child);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    spawnDashboardDetached({
+      dashboardPort: 3010,
+      dashboardApiPort: 3011,
+      traefikEnabled: false,
+      traefikDomain: 'overdeck.localhost',
+    } as Parameters<typeof spawnDashboardDetached>[0]);
+
+    expect(processMocks.spawn).toHaveBeenCalledWith(
+      expect.any(String),
+      [resolveBundledServerPath()],
+      expect.objectContaining({ cwd: resolvePrimaryDashboardIdentity().repoRoot }),
+    );
+    expect(child.unref).toHaveBeenCalled();
+  });
 });
 
 describe('refuseNonPrimaryDashboardCwd', () => {

--- a/src/cli/commands/__tests__/dashboard-cwd-guard.test.ts
+++ b/src/cli/commands/__tests__/dashboard-cwd-guard.test.ts
@@ -1,0 +1,70 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { refuseNonPrimaryDashboardCwd } from '../restart.js';
+
+const fixtureRoots: string[] = [];
+
+function createFixture(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  fixtureRoots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  process.exitCode = undefined;
+  vi.restoreAllMocks();
+  for (const root of fixtureRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('refuseNonPrimaryDashboardCwd', () => {
+  it('refuses a linked worktree and names its primary checkout', () => {
+    const fixtureRoot = createFixture('pan-dashboard-cwd-linked-');
+    const repoRoot = join(fixtureRoot, 'hoff-gh-quota');
+    const cwd = join(repoRoot, 'src', 'cli');
+    const primaryRoot = join(fixtureRoot, 'primary');
+    mkdirSync(cwd, { recursive: true });
+    writeFileSync(join(repoRoot, '.git'), `gitdir: ${join(primaryRoot, '.git', 'worktrees', 'hoff-gh-quota')}\n`);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(refuseNonPrimaryDashboardCwd(cwd, 'restart')).toBe(true);
+    expect(process.exitCode).toBe(2);
+    expect(error).toHaveBeenCalledWith(expect.stringContaining(
+      `Run this command from the primary checkout at ${primaryRoot}.`,
+    ));
+  });
+
+  it('allows primary clones and directories outside git repositories', () => {
+    const fixtureRoot = createFixture('pan-dashboard-cwd-primary-');
+    const primaryRoot = join(fixtureRoot, 'primary');
+    const primaryCwd = join(primaryRoot, 'src');
+    const noGitCwd = join(fixtureRoot, 'no-git', 'src');
+    mkdirSync(join(primaryRoot, '.git'), { recursive: true });
+    mkdirSync(primaryCwd, { recursive: true });
+    mkdirSync(noGitCwd, { recursive: true });
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(refuseNonPrimaryDashboardCwd(primaryCwd, 'restart')).toBe(false);
+    expect(refuseNonPrimaryDashboardCwd(noGitCwd, 'restart')).toBe(false);
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('preserves workspace refusal and derives the primary checkout', () => {
+    const fixtureRoot = createFixture('pan-dashboard-cwd-workspace-');
+    const repoRoot = join(fixtureRoot, 'workspaces', 'feature-pan-2252');
+    const cwd = join(repoRoot, 'src', 'cli');
+    mkdirSync(join(repoRoot, '.git'), { recursive: true });
+    mkdirSync(cwd, { recursive: true });
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(refuseNonPrimaryDashboardCwd(cwd, 'restart')).toBe(true);
+    expect(process.exitCode).toBe(2);
+    expect(error).toHaveBeenCalledWith(expect.stringContaining(
+      `Run this command from the primary checkout at ${fixtureRoot}.`,
+    ));
+  });
+});

--- a/src/cli/commands/__tests__/reload.test.ts
+++ b/src/cli/commands/__tests__/reload.test.ts
@@ -10,7 +10,9 @@ const mocks = vi.hoisted(() => ({
   restartDashboard: vi.fn(),
   stopDashboard: vi.fn(),
   writeRestartStatus: vi.fn(),
+  refuseNonPrimaryDashboardCwd: vi.fn(),
   resolveBundledServerPath: vi.fn(),
+  resolvePrimaryDashboardIdentity: vi.fn(),
   spawnDashboardDetached: vi.fn(),
   exec: vi.fn(),
   spawn: vi.fn(),
@@ -60,7 +62,9 @@ vi.mock('../../../lib/restart-status.js', () => ({
 }));
 
 vi.mock('../restart.js', () => ({
+  refuseNonPrimaryDashboardCwd: mocks.refuseNonPrimaryDashboardCwd,
   resolveBundledServerPath: mocks.resolveBundledServerPath,
+  resolvePrimaryDashboardIdentity: mocks.resolvePrimaryDashboardIdentity,
   spawnDashboardDetached: mocks.spawnDashboardDetached,
 }));
 
@@ -143,7 +147,9 @@ describe('reloadCommand', () => {
     });
     mocks.restartDashboard.mockReturnValue(Effect.succeed(undefined));
     mocks.writeRestartStatus.mockReturnValue(Effect.succeed(undefined));
+    mocks.refuseNonPrimaryDashboardCwd.mockReturnValue(false);
     mocks.resolveBundledServerPath.mockReturnValue('/tmp/server.js');
+    mocks.resolvePrimaryDashboardIdentity.mockReturnValue({ repoRoot: '/repo', mode: 'primary' });
     mocks.readDevSupervisorMarker.mockReturnValue(null);
     mocks.devSupervisorRefusalLines.mockReturnValue([]);
     mocks.agentRestartBlockReason.mockResolvedValue(null);

--- a/src/cli/commands/reload.ts
+++ b/src/cli/commands/reload.ts
@@ -11,6 +11,7 @@ import { agentRestartBlockReason } from '../../lib/deploy/agent-restart-gate.js'
 import {
   refuseNonPrimaryDashboardCwd,
   resolveBundledServerPath,
+  resolvePrimaryDashboardIdentity,
   spawnDashboardDetached,
 } from './restart.js';
 
@@ -289,7 +290,7 @@ export async function reloadCommand(options: ReloadOptions): Promise<void> {
 
     await Effect.runPromise(restartDashboard(config, () => spawnDashboardDetached(config, { deacon: options.deacon }), {
       healthTimeoutMs,
-      expectedIdentity: { repoRoot, mode: 'primary' },
+      expectedIdentity: resolvePrimaryDashboardIdentity(),
     }));
     await recordReloadStatus(startedAt, true);
     console.log(chalk.green('✓ Dashboard reloaded and healthy'));

--- a/src/cli/commands/reload.ts
+++ b/src/cli/commands/reload.ts
@@ -8,7 +8,11 @@ import { acquireRestartLock, readRestartLockHolder } from '../../lib/restart-loc
 import { readPlatformConfigSync, restartDashboard, StageError } from '../../lib/platform-lifecycle.js';
 import { writeRestartStatus } from '../../lib/restart-status.js';
 import { agentRestartBlockReason } from '../../lib/deploy/agent-restart-gate.js';
-import { resolveBundledServerPath, spawnDashboardDetached } from './restart.js';
+import {
+  refuseNonPrimaryDashboardCwd,
+  resolveBundledServerPath,
+  spawnDashboardDetached,
+} from './restart.js';
 
 export interface ReloadOptions {
   skipBuild?: boolean;
@@ -191,6 +195,8 @@ export async function reloadCommand(options: ReloadOptions): Promise<void> {
     process.exitCode = 2;
     return;
   }
+
+  if (refuseNonPrimaryDashboardCwd(process.cwd(), 'reload')) return;
 
   const restartInitiator = process.env.OVERDECK_AGENT_ID;
   if (restartInitiator) {

--- a/src/cli/commands/restart.ts
+++ b/src/cli/commands/restart.ts
@@ -150,6 +150,13 @@ export function resolveBundledServerPath(): string {
     ?? candidates[0].path;
 }
 
+export function resolvePrimaryDashboardIdentity(): { repoRoot: string; mode: 'primary' } {
+  return {
+    repoRoot: resolve(resolveBundledServerPath(), '..', '..', '..'),
+    mode: 'primary',
+  };
+}
+
 function searchedBundlePaths(): string[] {
   return uniqueBundleCandidates().map(candidate => candidate.path);
 }
@@ -179,15 +186,17 @@ export function spawnDashboardDetached(config: PlatformConfig, opts?: BootGateOp
     PORT: String(config.dashboardApiPort),
     OVERDECK_MODE: 'production',
   };
+  const identity = resolvePrimaryDashboardIdentity();
 
   // PAN-2804: a plain detached spawn stays in the INVOKER's cgroup — a
   // watchdog-spawned dashboard dies when overdeck-supervisor.service restarts,
   // and a conversation/flywheel-spawned one dies with that tmux pane's scope.
   // Run the server in its own transient systemd unit (same isolation the
   // shared tmux server gets, PAN-1798) so its lifecycle belongs to nobody.
-  if (spawnDashboardSystemdUnit(serverPath, fullEnv)) return;
+  if (spawnDashboardSystemdUnit(serverPath, fullEnv, identity.repoRoot)) return;
 
   const child = spawn(resolveNode22(), [serverPath], {
+    cwd: identity.repoRoot,
     detached: true,
     stdio: openDashboardLogStdio(),
     env: fullEnv,
@@ -202,7 +211,11 @@ export function spawnDashboardDetached(config: PlatformConfig, opts?: BootGateOp
 /** Valid systemd --setenv names; skips exported bash functions etc. */
 const ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
-function spawnDashboardSystemdUnit(serverPath: string, fullEnv: Record<string, string | undefined>): boolean {
+function spawnDashboardSystemdUnit(
+  serverPath: string,
+  fullEnv: Record<string, string | undefined>,
+  repoRoot: string,
+): boolean {
   if (process.platform !== 'linux') return false;
   try {
     mkdirSync(dirname(DASHBOARD_LOG_FILE), { recursive: true });
@@ -219,7 +232,7 @@ function spawnDashboardSystemdUnit(serverPath: string, fullEnv: Record<string, s
         `--property=StandardOutput=append:${DASHBOARD_LOG_FILE}`,
         `--property=StandardError=append:${DASHBOARD_LOG_FILE}`,
         // /api/health identity derives repoRoot from the server's cwd; keep it.
-        `--property=WorkingDirectory=${process.cwd()}`,
+        `--property=WorkingDirectory=${repoRoot}`,
         ...setenvArgs,
         resolveNode22(), serverPath,
       ],
@@ -334,7 +347,7 @@ export async function restartCommand(options: RestartOptions): Promise<void> {
 
         await Effect.runPromise(restartDashboard(config, () => spawnDashboardDetached(config, options), {
           healthTimeoutMs,
-          expectedIdentity: { repoRoot: process.cwd(), mode: 'primary' },
+          expectedIdentity: resolvePrimaryDashboardIdentity(),
         }));
         await recordRestartStatus(startedAt, true);
         console.log(chalk.green('✓ Dashboard restarted and healthy'));
@@ -451,7 +464,7 @@ async function runFullRestart(
   spawnDashboardDetached(config, opts.bootGateOptions);
   await Effect.runPromise(waitForDashboardHealth(config.dashboardApiPort, {
     timeoutMs: opts.healthTimeoutMs,
-    expectedIdentity: { repoRoot: process.cwd(), mode: 'primary' },
+    expectedIdentity: resolvePrimaryDashboardIdentity(),
   }));
 
   try {

--- a/src/cli/commands/restart.ts
+++ b/src/cli/commands/restart.ts
@@ -23,7 +23,7 @@ import { dirname, join, parse, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { existsSync, mkdirSync } from 'fs';
 import {
-  isLinkedWorktreeRoot,
+  isNonPrimaryCheckoutRoot,
   isWorkspaceRepoRoot,
   primaryRootFromLinkedWorktree,
 } from '../../dashboard/server/identity.js';
@@ -91,7 +91,7 @@ export function refuseNonPrimaryDashboardCwd(cwd: string, verb: string): boolean
   if (!repoRoot) return false;
 
   const isWorkspace = isWorkspaceRepoRoot(repoRoot);
-  if (!isWorkspace && !isLinkedWorktreeRoot(repoRoot)) return false;
+  if (!isNonPrimaryCheckoutRoot(repoRoot)) return false;
 
   const primaryRepoRoot = primaryRootFromLinkedWorktree(repoRoot) ??
     (isWorkspace ? dirname(dirname(repoRoot)) : null);

--- a/src/cli/commands/restart.ts
+++ b/src/cli/commands/restart.ts
@@ -22,7 +22,11 @@ import { execFileSync, spawn } from 'child_process';
 import { dirname, join, parse, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { existsSync, mkdirSync } from 'fs';
-import { isWorkspaceRepoRoot } from '../../dashboard/server/identity.js';
+import {
+  isLinkedWorktreeRoot,
+  isWorkspaceRepoRoot,
+  primaryRootFromLinkedWorktree,
+} from '../../dashboard/server/identity.js';
 
 import { acquireRestartLock, readRestartLockHolder, type RestartLockHandle } from '../../lib/restart-lock.js';
 import { writeRestartStatus } from '../../lib/restart-status.js';
@@ -80,14 +84,22 @@ export function resolveGitRepoRoot(cwd: string): string | null {
   }
 }
 
-function refuseWorkspaceDashboardRestart(cwd: string): boolean {
-  const repoRoot = resolveGitRepoRoot(cwd);
-  if (!repoRoot || !isWorkspaceRepoRoot(repoRoot)) return false;
+export function refuseNonPrimaryDashboardCwd(cwd: string, verb: string): boolean {
+  if (existsSync('/.dockerenv')) return false;
 
-  const primaryRepoRoot = dirname(dirname(repoRoot));
+  const repoRoot = resolveGitRepoRoot(cwd);
+  if (!repoRoot) return false;
+
+  const isWorkspace = isWorkspaceRepoRoot(repoRoot);
+  if (!isWorkspace && !isLinkedWorktreeRoot(repoRoot)) return false;
+
+  const primaryRepoRoot = primaryRootFromLinkedWorktree(repoRoot) ??
+    (isWorkspace ? dirname(dirname(repoRoot)) : null);
+  const primaryGuidance = primaryRepoRoot
+    ? ` Run this command from the primary checkout at ${primaryRepoRoot}.`
+    : '';
   console.error(chalk.red(
-    `Refusing to restart the host dashboard from workspace checkout ${repoRoot}. ` +
-      `Run this command from the primary checkout at ${primaryRepoRoot}.`,
+    `Refusing to ${verb} the host dashboard from non-primary checkout ${repoRoot}.${primaryGuidance}`,
   ));
   process.exitCode = 2;
   return true;
@@ -256,7 +268,7 @@ export async function shouldRunManualSupervisorCycle(env: NodeJS.ProcessEnv = pr
 export async function restartCommand(options: RestartOptions): Promise<void> {
   const startedAt = Date.now();
   const scope = resolveScope(options);
-  if ((scope === 'dashboard' || scope === 'full') && refuseWorkspaceDashboardRestart(process.cwd())) {
+  if ((scope === 'dashboard' || scope === 'full') && refuseNonPrimaryDashboardCwd(process.cwd(), 'restart')) {
     return;
   }
   const config = readPlatformConfigSync();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -655,7 +655,7 @@ program
   .option('--no-resume', 'Disable agent auto-resume (now the default; flag kept for explicitness)')
   .option('--no-open', 'Do not open the dashboard app/browser after startup')
   .option('--seed-from-legacy', 'Seed a fresh local database from the legacy database (copy conversations + reconstruct in-flight agents/issues). Default is an empty local database.')
-  .action(async (options) => { if ((await import('./commands/restart.js')).refuseNonPrimaryDashboardCwd(process.cwd(), 'start')) return;
+  .action(async (options) => { const restartModule = await import('./commands/restart.js'); if (restartModule.refuseNonPrimaryDashboardCwd(process.cwd(), 'start')) return;
     const noResume = isNoResumeCliOptionEnabled(options);
     const bootGates = resolveBootGates(options);
     const { spawn, execSync, exec } = await import('child_process');
@@ -1010,7 +1010,7 @@ program
       // Run in background
       const { openDashboardLogStdio } = await import('../lib/platform-lifecycle.js');
       const child = spawn(node22, [bundledServer], {
-            detached: true,
+            detached: true, cwd: restartModule.resolvePrimaryDashboardIdentity().repoRoot,
             stdio: openDashboardLogStdio(),
             env: {
               ...dashboardBootEnv,
@@ -1050,7 +1050,7 @@ program
           traefikDomain,
           dashboardPort,
           dashboardApiPort,
-          expectedIdentity: { repoRoot: process.cwd(), mode: 'primary' },
+          expectedIdentity: restartModule.resolvePrimaryDashboardIdentity(),
         });
         readyUrl = resolved.readyUrl;
         apiUrl = resolved.apiUrl;
@@ -1081,7 +1081,7 @@ program
     } else {
       // Run in foreground
       const child = spawn(node22, [bundledServer], {
-            stdio: 'inherit',
+            stdio: 'inherit', cwd: restartModule.resolvePrimaryDashboardIdentity().repoRoot,
             env: {
               ...dashboardBootEnv,
               ...dashboardOriginEnv,
@@ -1105,7 +1105,7 @@ program
           traefikEnabled,
           traefikDomain,
           dashboardPort,
-          dashboardApiPort,
+          dashboardApiPort, expectedIdentity: restartModule.resolvePrimaryDashboardIdentity(),
         });
         readyUrl = resolved.readyUrl;
         apiUrl = resolved.apiUrl;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -655,7 +655,7 @@ program
   .option('--no-resume', 'Disable agent auto-resume (now the default; flag kept for explicitness)')
   .option('--no-open', 'Do not open the dashboard app/browser after startup')
   .option('--seed-from-legacy', 'Seed a fresh local database from the legacy database (copy conversations + reconstruct in-flight agents/issues). Default is an empty local database.')
-  .action(async (options) => {
+  .action(async (options) => { if ((await import('./commands/restart.js')).refuseNonPrimaryDashboardCwd(process.cwd(), 'start')) return;
     const noResume = isNoResumeCliOptionEnabled(options);
     const bootGates = resolveBootGates(options);
     const { spawn, execSync, exec } = await import('child_process');

--- a/src/dashboard/server/config.ts
+++ b/src/dashboard/server/config.ts
@@ -14,7 +14,7 @@ import { Effect, Layer, Context } from 'effect';
 import { loadOverdeckEnvSync } from '../../lib/env-loader.js';
 import {
   getDashboardIdentity,
-  isWorkspaceRepoRoot,
+  isNonPrimaryCheckoutRoot,
   readHostDashboardApiPort,
   shouldRefuseHostDashboardPort,
 } from './identity.js';
@@ -99,7 +99,7 @@ export const ServerConfigLayer = Layer.effect(
       console.error(`[overdeck] ${msg}`);
       throw new ServerConfigError('API_PORT', msg);
     }
-    const overrideAllowed = overrideRequested && !isWorkspaceRepoRoot(identity.repoRoot);
+    const overrideAllowed = overrideRequested && !isNonPrimaryCheckoutRoot(identity.repoRoot);
     if (
       shouldRefuseHostDashboardPort({
         repoRoot: identity.repoRoot,

--- a/src/dashboard/server/identity.ts
+++ b/src/dashboard/server/identity.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { cwd } from 'node:process';
 import { relative, resolve, sep } from 'node:path';
 
@@ -24,6 +24,28 @@ export function getDashboardIdentity(): DashboardIdentity {
 
 export function isWorkspaceRepoRoot(repoRoot: string): boolean {
   return /(^|\/)workspaces\/feature-[^/]+$/i.test(repoRoot.replaceAll('\\', '/'));
+}
+
+export function isLinkedWorktreeRoot(repoRoot: string): boolean {
+  try {
+    return statSync(resolve(repoRoot, '.git')).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export function primaryRootFromLinkedWorktree(repoRoot: string): string | null {
+  try {
+    const match = readFileSync(resolve(repoRoot, '.git'), 'utf-8').match(/^gitdir:\s*(.+)$/m);
+    const gitDir = match?.[1]?.trim().replaceAll('\\', '/');
+    if (!gitDir) return null;
+
+    const worktreeMarker = '/.git/worktrees/';
+    const markerIndex = gitDir.indexOf(worktreeMarker);
+    return markerIndex === -1 ? null : gitDir.slice(0, markerIndex);
+  } catch {
+    return null;
+  }
 }
 
 function isSameOrInside(parent: string, candidate: string): boolean {
@@ -62,6 +84,7 @@ export function shouldRefuseHostDashboardPort(input: {
   }
   if (input.mode === 'peer') return true;
 
+  if (isLinkedWorktreeRoot(repoRoot)) return true;
   if (isWorkspaceRepoRoot(repoRoot)) return true;
 
   const workspacesDir = resolve(repoRoot, '..');

--- a/src/dashboard/server/identity.ts
+++ b/src/dashboard/server/identity.ts
@@ -53,6 +53,11 @@ function isSameOrInside(parent: string, candidate: string): boolean {
   return rel === '' || (!rel.startsWith('..') && !rel.startsWith(sep));
 }
 
+export function isNonPrimaryCheckoutRoot(repoRoot: string): boolean {
+  const resolvedRoot = resolve(repoRoot);
+  return isLinkedWorktreeRoot(resolvedRoot) || isWorkspaceRepoRoot(resolvedRoot);
+}
+
 export function readHostDashboardApiPort(defaultPort = 3011): number {
   if (!existsSync(CONFIG_FILE)) return defaultPort;
   try {
@@ -83,9 +88,7 @@ export function shouldRefuseHostDashboardPort(input: {
     return false;
   }
   if (input.mode === 'peer') return true;
-
-  if (isLinkedWorktreeRoot(repoRoot)) return true;
-  if (isWorkspaceRepoRoot(repoRoot)) return true;
+  if (isNonPrimaryCheckoutRoot(repoRoot)) return true;
 
   const workspacesDir = resolve(repoRoot, '..');
   return workspacesDir.endsWith(`${sep}workspaces`) && isSameOrInside(workspacesDir, repoRoot);

--- a/sync-sources/skills/pan-restart/SKILL.md
+++ b/sync-sources/skills/pan-restart/SKILL.md
@@ -42,6 +42,18 @@ Each stage is health-gated: the command waits for `GET /api/health` (dashboard)
 or port binding (CLIProxy) to succeed before reporting `✓`, and exits non-zero
 with a `[stage] reason` message on timeout.
 
+## Identity guard
+
+When `pan restart` would restart the dashboard, it refuses to run from a
+non-primary checkout: either a workspace worktree or any linked Git worktree,
+including a handoff worktree. It exits with code 2 and names the primary
+checkout where the command must run.
+
+The post-boot health gate verifies both `repoRoot` and `mode` from
+`GET /api/health`. If another server holds the port, the command reports
+`port held by non-primary server (cwd=…, mode=…)`; a 200 response from the wrong
+server is a failure, not a successful restart.
+
 ## Important Notes
 
 - `pan restart` is idempotent: it stops the old listener(s), starts a new one,

--- a/sync-sources/skills/pan-up/SKILL.md
+++ b/sync-sources/skills/pan-up/SKILL.md
@@ -67,6 +67,18 @@ pan up --no-resume
 pan up --no-open
 ```
 
+## Identity guard
+
+`pan up` refuses to run when the current directory is inside a non-primary
+checkout: either a workspace worktree or any linked Git worktree, including a
+handoff worktree. It exits with code 2 and names the primary checkout where the
+command must run.
+
+After startup, the health gate verifies both `repoRoot` and `mode` from
+`GET /api/health`. If another server holds the port, the command reports
+`port held by non-primary server (cwd=…, mode=…)`; a 200 response from the wrong
+server is a failure, not a successful start.
+
 ## Desktop App
 
 `pan up` opens the Overdeck Electron desktop app if it is installed in one of

--- a/tests/unit/dashboard/config.test.ts
+++ b/tests/unit/dashboard/config.test.ts
@@ -6,8 +6,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { Effect } from 'effect';
 import { parse as parseYaml } from 'yaml';
 import { ServerConfig, ServerConfigLayer, ServerConfigError } from '../../../src/dashboard/server/config.js';
@@ -209,6 +210,21 @@ describe('ServerConfig', () => {
         await expect(getConfig()).resolves.toMatchObject({ port: 3011 });
       },
     );
+
+    it('refuses the primary-port escape hatch from a linked worktree', async () => {
+      const repoRoot = mkdtempSync(join(tmpdir(), 'pan-config-linked-worktree-'));
+      try {
+        writeFileSync(join(repoRoot, '.git'), 'gitdir: /primary/.git/worktrees/handoff\n');
+        identityMock.current = { repoRoot, mode: 'primary' };
+        process.env['OVERDECK_AGENT_ID'] = 'conv-20260709-6371';
+
+        await expect(getConfig()).rejects.toThrow(
+          `Refusing to bind host dashboard port 3011 from repoRoot=${repoRoot}`,
+        );
+      } finally {
+        rmSync(repoRoot, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('optional API keys', () => {

--- a/tests/unit/dashboard/identity.test.ts
+++ b/tests/unit/dashboard/identity.test.ts
@@ -1,8 +1,14 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import { getBuildInfo } from '../../../src/lib/deploy/build-info.js';
 import {
   getDashboardIdentity,
+  isLinkedWorktreeRoot,
+  primaryRootFromLinkedWorktree,
   shouldRefuseHostDashboardPort,
 } from '../../../src/dashboard/server/identity.js';
 
@@ -18,6 +24,37 @@ describe('dashboard build identity', () => {
       buildCommit: null,
       builtAt: null,
     });
+  });
+});
+
+describe('linked git worktree identity', () => {
+  it('detects a linked worktree and resolves its primary root', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'pan-linked-worktree-'));
+    try {
+      writeFileSync(join(repoRoot, '.git'), 'gitdir: /primary/.git/worktrees/x\n');
+
+      expect(isLinkedWorktreeRoot(repoRoot)).toBe(true);
+      expect(primaryRootFromLinkedWorktree(repoRoot)).toBe('/primary');
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects primary repositories and directories without git metadata', () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), 'pan-primary-repo-'));
+    try {
+      const primaryRoot = join(fixtureRoot, 'primary');
+      const noGitRoot = join(fixtureRoot, 'no-git');
+      mkdirSync(join(primaryRoot, '.git'), { recursive: true });
+      mkdirSync(noGitRoot);
+
+      expect(isLinkedWorktreeRoot(primaryRoot)).toBe(false);
+      expect(primaryRootFromLinkedWorktree(primaryRoot)).toBeNull();
+      expect(isLinkedWorktreeRoot(noGitRoot)).toBe(false);
+      expect(primaryRootFromLinkedWorktree(noGitRoot)).toBeNull();
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
   });
 });
 
@@ -60,6 +97,30 @@ describe('dashboard identity port guard', () => {
       hostDashboardApiPort: 3011,
       runningInContainer: false,
     })).toBe(false);
+  });
+
+  it('refuses a linked worktree on the host port except inside a container', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'hoff-linked-worktree-'));
+    try {
+      writeFileSync(join(repoRoot, '.git'), 'gitdir: /primary/.git/worktrees/hoff\n');
+      const input = {
+        repoRoot,
+        mode: 'primary' as const,
+        port: 3011,
+        hostDashboardApiPort: 3011,
+      };
+
+      expect(shouldRefuseHostDashboardPort({
+        ...input,
+        runningInContainer: false,
+      })).toBe(true);
+      expect(shouldRefuseHostDashboardPort({
+        ...input,
+        runningInContainer: true,
+      })).toBe(false);
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
   });
 
   it('allows a peer dashboard on the host dashboard API port inside a container', () => {


### PR DESCRIPTION
**Issue:** #2252

## Acceptance Criteria

- [ ] Detect linked git worktrees in identity.ts and extend the host-port bind refusal
- [ ] Generalize the restart cwd guard into a shared refuseNonPrimaryDashboardCwd
- [ ] pan up refuses to run from a non-primary checkout before any host side effects
- [ ] pan reload refuses to run from a non-primary checkout before the restart lock
- [ ] Derive dashboard identity from the bundle root and verify it on every boot path
- [ ] Document the non-primary refusal and identity gate in pan-up/pan-restart skills and the dev SOP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safety checks to `pan up`, `pan reload`, and dashboard-starting `pan restart`, preventing execution from non-primary checkouts.
  - Added clearer guidance identifying the required primary checkout when commands are refused.
  - Strengthened dashboard startup health checks to verify the expected server identity and reject responses from an incorrect server.

- **Documentation**
  - Updated command documentation and development guidance with the new identity safeguards and health-check behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->