### PR TITLE
fix(cloister): authenticate the automatic work-agent spawn (PAN-2825)

### DIFF
--- a/src/dashboard/server/routes/__tests__/complete-planning.test.ts
+++ b/src/dashboard/server/routes/__tests__/complete-planning.test.ts
@@ -1,8 +1,19 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+
+const internalTokenMocks = vi.hoisted(() => ({
+  getInternalTokenSync: vi.fn(() => 'test-internal-token'),
+}));
+
+vi.mock('../../../../lib/internal-token.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../../../../lib/internal-token.js')>(),
+  getInternalTokenSync: internalTokenMocks.getInternalTokenSync,
+}));
+
+import { INTERNAL_TOKEN_HEADER } from '../../../../lib/internal-token.js';
 import {
   beginCompletePlanningLease,
   completePlanningArtifacts,
@@ -10,6 +21,7 @@ import {
   completePlanningAutoSpawnAndKill,
   completePlanningFilesToStage,
   completePlanningWorkspaceGitAddCommands,
+  resolveCompletePlanningTerminalStatus,
 } from '../../../../lib/overdeck/planning-promotion.js';
 import { applyStatusOverrides } from '../../../../lib/vbrief/io.js';
 import { lintPlanQuality, PlanQualityLintError } from '../../../../lib/vbrief/quality-lint.js';
@@ -384,7 +396,10 @@ describe('completePlanningArtifacts', () => {
     const fetchImpl: typeof fetch = async (input, init) => {
       expect(String(input)).toBe('http://127.0.0.1:3011/api/agents');
       expect(init?.method).toBe('POST');
-      expect(init?.headers).toMatchObject({ origin: 'http://127.0.0.1:3011' });
+      expect(init?.headers).toMatchObject({
+        origin: 'http://127.0.0.1:3011',
+        [INTERNAL_TOKEN_HEADER]: 'test-internal-token',
+      });
       expect(JSON.parse(String(init?.body))).toEqual({ issueId: 'PAN-1146', role: 'work' });
       return new Response(JSON.stringify({ success: true, agentId: 'agent-pan-1146' }), { status: 200 });
     };
@@ -400,10 +415,30 @@ describe('completePlanningArtifacts', () => {
     });
   });
 
+  it('classifies unauthorized auto-spawn responses and fails the terminal phase', async () => {
+    const result = await completePlanningAutoSpawn({
+      issueId: 'PAN-1146',
+      autoSpawn: true,
+      dashboardOrigin: 'http://127.0.0.1:3011',
+      fetchImpl: async (_input, init) => {
+        expect(init?.headers).toMatchObject({ [INTERNAL_TOKEN_HEADER]: 'test-internal-token' });
+        return new Response(JSON.stringify({ error: 'unauthorized' }), { status: 401 });
+      },
+    });
+
+    expect(result).toEqual({
+      workAgentSpawned: false,
+      workAgentError: 'unauthorized',
+      workAgentSkipReason: 'unauthorized',
+    });
+    expect(resolveCompletePlanningTerminalStatus(true, result)).toBe('failure');
+  });
+
   it('rebuilds the stack and starts work when the initial auto-spawn finds no healthy stack', async () => {
     const requests: string[] = [];
-    const fetchImpl: typeof fetch = async (input) => {
+    const fetchImpl: typeof fetch = async (input, init) => {
       requests.push(String(input));
+      expect(init?.headers).toMatchObject({ [INTERNAL_TOKEN_HEADER]: 'test-internal-token' });
       if (String(input).endsWith('/api/agents')) {
         return new Response(JSON.stringify({
           success: false,

--- a/src/lib/cloister/__tests__/orphan-proposed-reconciler.test.ts
+++ b/src/lib/cloister/__tests__/orphan-proposed-reconciler.test.ts
@@ -28,6 +28,10 @@ const childProcessMocks = vi.hoisted(() => ({
   }),
 }));
 
+const internalTokenMocks = vi.hoisted(() => ({
+  getInternalTokenSync: vi.fn(() => 'test-internal-token'),
+}));
+
 vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('child_process')>();
   return { ...actual, exec: childProcessMocks.exec };
@@ -35,6 +39,11 @@ vi.mock('child_process', async (importOriginal) => {
 
 vi.mock('../../activity-logger.js', () => ({
   emitActivityEntrySync: activityLogger.emitActivityEntrySync,
+}));
+
+vi.mock('../../internal-token.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../../internal-token.js')>(),
+  getInternalTokenSync: internalTokenMocks.getInternalTokenSync,
 }));
 
 vi.mock('../../review-status.js', () => ({
@@ -70,6 +79,7 @@ vi.mock('../../tasks/presence.js', () => ({
   },
 }));
 
+import { INTERNAL_TOKEN_HEADER } from '../../internal-token.js';
 import {
   clearOrphanProposedAttemptCooldowns,
   findOrphanProposedSpecsForReconciler,
@@ -585,8 +595,21 @@ describe('orphan proposed spec reconciler', () => {
     const [url, init] = fetchMock.mock.calls[0];
     expect(String(url)).toBe('http://127.0.0.1:3011/api/agents');
     expect(init?.method).toBe('POST');
-    expect(init?.headers).toMatchObject({ origin: 'http://127.0.0.1:3011' });
+    expect(init?.headers).toMatchObject({
+      origin: 'http://127.0.0.1:3011',
+      [INTERNAL_TOKEN_HEADER]: 'test-internal-token',
+    });
     expect(JSON.parse(String(init?.body))).toEqual({ issueId: 'PAN-3301', role: 'work' });
+  });
+
+  it('classifies unauthorized spawn responses explicitly', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ error: 'unauthorized' }), { status: 401 })));
+
+    await expect(spawnWorkAgentThroughAgentsEndpoint('PAN-3301', 'http://127.0.0.1:3011')).resolves.toEqual({
+      spawned: false,
+      skippedReason: 'unauthorized',
+      error: 'unauthorized',
+    });
   });
 
   // PAN-2520: the deacon dead-end path invokes rebuild-and-start when a respawn
@@ -601,7 +624,10 @@ describe('orphan proposed spec reconciler', () => {
     const [url, init] = fetchMock.mock.calls[0];
     expect(String(url)).toBe('http://127.0.0.1:3011/api/workspaces/PAN-3301/rebuild-and-start');
     expect(init?.method).toBe('POST');
-    expect(init?.headers).toMatchObject({ origin: 'http://127.0.0.1:3011' });
+    expect(init?.headers).toMatchObject({
+      origin: 'http://127.0.0.1:3011',
+      [INTERNAL_TOKEN_HEADER]: 'test-internal-token',
+    });
   });
 
   it('reports a failed rebuild-and-start without throwing', async () => {

--- a/src/lib/cloister/orphan-proposed-reconciler.ts
+++ b/src/lib/cloister/orphan-proposed-reconciler.ts
@@ -8,6 +8,7 @@ import { Effect } from 'effect';
 
 import { getAgentState, type AgentState } from '../agents.js';
 import { emitActivityEntrySync } from '../activity-logger.js';
+import { getInternalTokenSync, INTERNAL_TOKEN_HEADER } from '../internal-token.js';
 import { listProjects, resolveProjectFromIssueSync, type ProjectConfig } from '../projects.js';
 import { getReviewStatusSync, type ReviewStatus } from '../review-status.js';
 import { listSessionNames } from '../tmux.js';
@@ -234,6 +235,7 @@ function internalDashboardOrigin(): string {
 
 function classifySpawnSkip(status: number, body: Record<string, unknown>): string {
   const error = typeof body['error'] === 'string' ? body['error'] : '';
+  if (status === 401 || status === 403) return 'unauthorized';
   if (body['stackHealth'] || /workspace docker stack/i.test(error)) return 'stack-unhealthy';
   if (body['paused'] === true) return 'paused';
   if (body['troubled'] === true) return 'troubled';
@@ -244,11 +246,13 @@ function classifySpawnSkip(status: number, body: Record<string, unknown>): strin
 }
 
 export async function spawnWorkAgentThroughAgentsEndpoint(issueId: string, dashboardOrigin = internalDashboardOrigin()): Promise<SpawnWorkAgentResult> {
+  const internalToken = getInternalTokenSync();
   const response = await fetch(new URL('/api/agents', dashboardOrigin), {
     method: 'POST',
     headers: {
       'content-type': 'application/json',
       origin: dashboardOrigin,
+      ...(internalToken ? { [INTERNAL_TOKEN_HEADER]: internalToken } : {}),
     },
     body: JSON.stringify({ issueId, role: 'work' }),
   });
@@ -287,11 +291,16 @@ export async function triggerRebuildAndStart(
   issueId: string,
   dashboardOrigin = internalDashboardOrigin(),
 ): Promise<RebuildAndStartResult> {
+  const internalToken = getInternalTokenSync();
   const response = await fetch(
     new URL(`/api/workspaces/${encodeURIComponent(issueId)}/rebuild-and-start`, dashboardOrigin),
     {
       method: 'POST',
-      headers: { 'content-type': 'application/json', origin: dashboardOrigin },
+      headers: {
+        'content-type': 'application/json',
+        origin: dashboardOrigin,
+        ...(internalToken ? { [INTERNAL_TOKEN_HEADER]: internalToken } : {}),
+      },
     },
   );
   const body = await response.json().catch(() => ({})) as Record<string, unknown>;

--- a/src/lib/overdeck/planning-promotion.ts
+++ b/src/lib/overdeck/planning-promotion.ts
@@ -16,6 +16,7 @@ import { countPendingAskUserQuestionsForAgent } from '../agent-enrichment.js';
 import { getAgentStateSync, saveAgentStateSync } from '../agents.js';
 import { emitActivityEntrySync, emitActivityTtsSync } from '../activity-logger.js';
 import { createInFlightGuard } from '../cloister/in-flight-guard.js';
+import { getInternalTokenSync, INTERNAL_TOKEN_HEADER } from '../internal-token.js';
 import { checkPrdGateSync, asPanSpecDocument, findSpecByIssue, writeSpecDocument, writeSpecForIssue } from '../pan-dir/index.js';
 import { resolveAutoSpawnOnFinalize } from '../planning/spawn-planning-session.js';
 import { extractTeamPrefix, findProjectByPathSync, findProjectByTeamSync, resolveProjectFromIssueSync } from '../projects.js';
@@ -91,7 +92,7 @@ export interface CompletePlanningAutoSpawnResult {
   workAgentSpawned: boolean;
   workAgentSession?: string;
   workAgentError?: string;
-  workAgentSkipReason?: 'stack-unhealthy' | 'guardrails' | 'paused' | 'troubled' | 'spawn-failed';
+  workAgentSkipReason?: 'stack-unhealthy' | 'guardrails' | 'paused' | 'troubled' | 'unauthorized' | 'spawn-failed';
 }
 
 type CompletePlanningPhase = 'prdGate' | 'beadsMaterialize' | 'specWrite' | 'autoSpawn' | 'terminal';
@@ -268,11 +269,19 @@ function getInternalDashboardOrigin(): string {
 
 function classifyAutoSpawnSkip(status: number, body: Record<string, unknown>): NonNullable<CompletePlanningAutoSpawnResult['workAgentSkipReason']> {
   const error = typeof body['error'] === 'string' ? body['error'] : '';
+  if (status === 401 || status === 403) return 'unauthorized';
   if (body['stackHealth'] || /workspace docker stack/i.test(error)) return 'stack-unhealthy';
   if (body['paused'] === true) return 'paused';
   if (body['troubled'] === true) return 'troubled';
   if (body['guardrails'] || body['requiresAcknowledgement'] === true || status === 409) return 'guardrails';
   return 'spawn-failed';
+}
+
+export function resolveCompletePlanningTerminalStatus(
+  autoSpawnRequested: boolean,
+  autoSpawnResult: CompletePlanningAutoSpawnResult | null,
+): CompletePlanningPhaseStatus {
+  return autoSpawnRequested && autoSpawnResult?.workAgentSpawned !== true ? 'failure' : 'success';
 }
 
 export async function completePlanningAutoSpawn(options: {
@@ -287,6 +296,8 @@ export async function completePlanningAutoSpawn(options: {
   }
 
   const dashboardOrigin = options.dashboardOrigin ?? getInternalDashboardOrigin();
+  const internalToken = getInternalTokenSync();
+  const internalTokenHeaders = internalToken ? { [INTERNAL_TOKEN_HEADER]: internalToken } : {};
   emitCompletePlanningPhase(options.issueId, 'autoSpawn', 'start', 'posting work-agent spawn request', { dashboardOrigin });
   try {
     const response = await (options.fetchImpl ?? fetch)(new URL('/api/agents', dashboardOrigin), {
@@ -294,6 +305,7 @@ export async function completePlanningAutoSpawn(options: {
       headers: {
         'content-type': 'application/json',
         origin: dashboardOrigin,
+        ...internalTokenHeaders,
       },
       body: JSON.stringify({ issueId: options.issueId, role: 'work' }),
     });
@@ -319,7 +331,7 @@ export async function completePlanningAutoSpawn(options: {
         new URL(`/api/workspaces/${encodeURIComponent(options.issueId)}/rebuild-and-start`, dashboardOrigin),
         {
           method: 'POST',
-          headers: { origin: dashboardOrigin },
+          headers: { origin: dashboardOrigin, ...internalTokenHeaders },
         },
       );
       const recoveryBody = await recovery.json().catch(() => ({})) as Record<string, unknown>;
@@ -705,7 +717,7 @@ export async function completePlanningForIssue(options: {
       skipKill,
       sessionName,
     });
-    emitCompletePlanningPhase(id, 'terminal', 'success', autoSpawnResult?.workAgentSpawned ? 'planning complete and work agent spawn requested' : autoSpawnResult?.workAgentSkipReason ?? 'planning complete', {
+    emitCompletePlanningPhase(id, 'terminal', resolveCompletePlanningTerminalStatus(effectiveAutoSpawn, autoSpawnResult), autoSpawnResult?.workAgentSpawned ? 'planning complete and work agent spawn requested' : autoSpawnResult?.workAgentSkipReason ?? 'planning complete', {
       autoSpawn: effectiveAutoSpawn,
       workAgentSpawned: autoSpawnResult?.workAgentSpawned ?? false,
       workAgentSkipReason: autoSpawnResult?.workAgentSkipReason,

--- a/src/lib/overdeck/planning-promotion.ts
+++ b/src/lib/overdeck/planning-promotion.ts
@@ -297,7 +297,9 @@ export async function completePlanningAutoSpawn(options: {
 
   const dashboardOrigin = options.dashboardOrigin ?? getInternalDashboardOrigin();
   const internalToken = getInternalTokenSync();
-  const internalTokenHeaders = internalToken ? { [INTERNAL_TOKEN_HEADER]: internalToken } : {};
+  const internalTokenHeaders: Record<string, string> = internalToken
+    ? { [INTERNAL_TOKEN_HEADER]: internalToken }
+    : {};
   emitCompletePlanningPhase(options.issueId, 'autoSpawn', 'start', 'posting work-agent spawn request', { dashboardOrigin });
   try {
     const response = await (options.fetchImpl ?? fetch)(new URL('/api/agents', dashboardOrigin), {


### PR DESCRIPTION
Fixes #2825 — the plan→work autoSpawn handoff has been silently 401ing since a build containing 4697f17630 went live (~2026-07-16 midday).

## What was broken

`4697f17630` correctly added `rejectUnsafeDashboardMutationRequest` to `POST /api/agents`. But the server's own in-process callers post to that route with no credentials, so they got 401 `{"error":"unauthorized"}`. The skip classifier didn't recognize 401, folded it into generic `spawn-failed`, and the terminal phase then reported `status: 'success'` while carrying `workAgentSpawned: false` — so 16 hours of dead handoffs made no noise.

## What this changes

- **Authenticate both in-process spawn callers.** `completePlanningAutoSpawn` and the `rebuild-and-start` recovery POST now attach `INTERNAL_TOKEN_HEADER`. A second caller with the identical defect — `spawnWorkAgentThroughAgentsEndpoint` in `orphan-proposed-reconciler.ts` — is fixed the same way. That one matters: it is the backstop that recovers specs stranded at `proposed`, so it was 401ing exactly when it was needed.
- **Classify 401/403 as `unauthorized`** instead of generic `spawn-failed`, in both classifiers.
- **Stop reporting success on a failed spawn.** `resolveCompletePlanningTerminalStatus` emits `failure` when autoSpawn was requested but no agent started.

The auth guard stays — this fixes the callers, not the guard.

## Verification

- `complete-planning` — 15/15 passing (new coverage asserts the spawn POST carries the internal token and that a 401 yields a non-success terminal phase)
- `orphan-proposed-reconciler` — 27/27 passing
- typecheck clean (no new errors); lint passed

Landed as an operator-authorized strike: diff reviewed and gates re-run independently by the Flywheel orchestrator (RUN-65) before merge.