### PR TITLE
PAN-2822

### DIFF
--- a/docs/PIPELINE-MEMBERSHIP.md
+++ b/docs/PIPELINE-MEMBERSHIP.md
@@ -27,6 +27,12 @@ Agent state, tmux sessions, workspaces, and `review_status` are L5 liveness anno
 | `planned_backlog` | An open issue has an unmerged convention branch or durable vBRIEF but no open PR. |
 | `clean_terminal` | The issue is closed with no open PR, or it is open but has never started and has no durable plan. It is outside the pipeline. |
 
+### Display filtering (PAN-2822)
+
+The dashboard Issues pane has a display-only toggle for rows whose `planned_backlog` membership comes from the L6 durable-spec lens. The preference is visible by default and persists under the localStorage key `overdeck.ui.showPlannedBacklog`; disabling it hides only rows with the derived `specOnlyPlanned` DTO field set to `true`. Rows classified through the unmerged-branch or ready-label reasons remain visible.
+
+The toggle does not change `resolvePipelineMembership()` or any membership or resource API response. The server derives `specOnlyPlanned` from `PLANNED_BACKLOG_SPEC_ONLY_REASON`, and list surfaces apply the preference after receiving the unchanged resource data.
+
 `labelDrift` is `stale_present` when a phase label survives a terminal/closed lifecycle and `stale_absent` when an open PR has no phase label. It is `null` when the label agrees or no drift rule applies.
 
 ## Read doors

--- a/src/dashboard/frontend/src/components/CommandDeck/CommandDeck.test.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/CommandDeck.test.tsx
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { CommandDeck } from './index';
 import { useCommandDeckSelection } from '../../lib/commandDeckSelection';
 import { usePanesStore } from '../../lib/panesStore';
+import { usePlannedBacklogVisibility } from '../../hooks/usePlannedBacklogVisibility';
 
 vi.mock('./styles/command-deck.module.css', () => ({
   default: {
@@ -19,6 +20,9 @@ vi.mock('./styles/command-deck.module.css', () => ({
     segmentButton: 'segmentButton',
     segmentButtonActive: 'segmentButtonActive',
     segmentCount: 'segmentCount',
+    treeFilterRow: 'treeFilterRow',
+    treeFilterButton: 'treeFilterButton',
+    treeFilterButtonActive: 'treeFilterButtonActive',
     projectTree: 'projectTree',
     resizeHandle: 'resizeHandle',
     content: 'content',
@@ -432,6 +436,7 @@ describe('CommandDeck — project-scoped deck (PAN-1561)', () => {
     };
     useCommandDeckSelection.getState().clearAll();
     usePanesStore.setState({ panesByWorkspace: {}, activePaneByWorkspace: {} });
+    usePlannedBacklogVisibility.setState({ showPlannedBacklog: true });
     localStorage.clear();
   });
 
@@ -453,6 +458,66 @@ describe('CommandDeck — project-scoped deck (PAN-1561)', () => {
     const stage = screen.getByTestId('stage');
     expect(stage).toHaveAttribute('data-deck', 'test-project');
     expect(screen.getByTestId('activity-feed')).toHaveAttribute('data-issues', 'PAN-821');
+  });
+
+  it('toggles spec-only planned issues across the tree, count, and project home', async () => {
+    resourceProjectsResponse = [
+      {
+        issueId: 'PAN-821',
+        title: 'Active feature',
+        projectName: 'test-project',
+        branch: 'feature/pan-821',
+        status: 'running',
+        stateLabel: 'In Progress',
+        agentStatus: 'active',
+        hasPlanning: true,
+        hasPrd: true,
+        hasState: true,
+        isShadow: false,
+      },
+      {
+        issueId: 'PAN-2822',
+        title: 'Spec-only planned feature',
+        projectName: 'test-project',
+        branch: 'feature/pan-2822',
+        status: 'idle',
+        stateLabel: 'Planned',
+        agentStatus: null,
+        hasPlanning: true,
+        hasPrd: true,
+        hasState: false,
+        isShadow: false,
+        specOnlyPlanned: true,
+      },
+    ];
+    renderCommandDeck({ selectedProject: 'test-project' });
+
+    expect(await screen.findByTestId('feature-PAN-821')).toBeInTheDocument();
+    expect(screen.getByTestId('feature-PAN-2822')).toBeInTheDocument();
+
+    const toggle = screen.getByTestId('planned-backlog-toggle');
+    const issuesHeader = screen.getByText('Issues').parentElement!;
+    expect(toggle).toHaveClass('treeFilterButtonActive');
+    expect(within(issuesHeader).getByText('2')).toBeInTheDocument();
+    const initialHomeFeatures = latestStageProps.renderHome({}).props.features.map((feature: any) => feature.issueId);
+    expect(initialHomeFeatures).toHaveLength(2);
+    expect(initialHomeFeatures).toEqual(expect.arrayContaining(['PAN-821', 'PAN-2822']));
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(screen.queryByTestId('feature-PAN-2822')).not.toBeInTheDocument());
+    expect(screen.getByTestId('feature-PAN-821')).toBeInTheDocument();
+    expect(toggle).not.toHaveClass('treeFilterButtonActive');
+    expect(within(issuesHeader).getByText('1')).toBeInTheDocument();
+    expect(latestStageProps.renderHome({}).props.features.map((feature: any) => feature.issueId)).toEqual([
+      'PAN-821',
+    ]);
+
+    fireEvent.click(toggle);
+
+    expect(await screen.findByTestId('feature-PAN-2822')).toBeInTheDocument();
+    expect(toggle).toHaveClass('treeFilterButtonActive');
+    expect(within(issuesHeader).getByText('2')).toBeInTheDocument();
   });
 
   it('passes the immutable registration key to the project tree node', async () => {

--- a/src/dashboard/frontend/src/components/CommandDeck/IssuesPaneFilterRow.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/IssuesPaneFilterRow.tsx
@@ -1,0 +1,36 @@
+import type { TreeSessionFilter } from './ProjectTree/FeatureItem';
+import { usePlannedBacklogVisibility } from '../../hooks/usePlannedBacklogVisibility';
+import styles from './styles/command-deck.module.css';
+
+interface IssuesPaneFilterRowProps {
+  filter: TreeSessionFilter;
+  onFilterChange: (filter: TreeSessionFilter) => void;
+}
+
+export function IssuesPaneFilterRow({ filter, onFilterChange }: IssuesPaneFilterRowProps) {
+  const showPlannedBacklog = usePlannedBacklogVisibility((state) => state.showPlannedBacklog);
+  const toggleShowPlannedBacklog = usePlannedBacklogVisibility((state) => state.toggleShowPlannedBacklog);
+
+  return (
+    <div className={styles.treeFilterRow}>
+      {(['all', 'alive', 'failed'] as TreeSessionFilter[]).map((value) => (
+        <button
+          key={value}
+          onClick={() => onFilterChange(value)}
+          className={`${styles.treeFilterButton} ${filter === value ? styles.treeFilterButtonActive : ''}`}
+        >
+          {value === 'all' ? 'All' : value === 'alive' ? 'Alive' : 'Failed'}
+        </button>
+      ))}
+      <button
+        data-testid="planned-backlog-toggle"
+        title="Show spec-only planned items (planned_backlog)"
+        aria-pressed={showPlannedBacklog}
+        onClick={toggleShowPlannedBacklog}
+        className={`${styles.treeFilterButton} ${showPlannedBacklog ? styles.treeFilterButtonActive : ''}`}
+      >
+        Planned
+      </button>
+    </div>
+  );
+}

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ProjectNode.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/ProjectNode.tsx
@@ -69,6 +69,7 @@ export interface ProjectFeature {
   inProgressCount?: number;
   rawTrackerState?: string;
   readyForMerge?: boolean;
+  specOnlyPlanned?: boolean;
   sessions?: readonly SessionNode[];
   resourceSources?: ResourceSource[];
   resourceDetails?: ProjectFeatureResourceDetails;

--- a/src/dashboard/frontend/src/components/CommandDeck/index.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/index.tsx
@@ -10,7 +10,7 @@ import { ProjectHome } from '../Stage/ProjectHome';
 import { IssueOverview } from '../Stage/IssueOverview';
 import { SessionFeedSidebar } from '../sessionFeed/SessionFeedSidebar';
 import { usePanesStore } from '../../lib/panesStore';
-import { fetchProjects, isUnscopedConversation, NO_PROJECT_KEY, NO_PROJECT_LABEL } from './projectsData';
+import { fetchProjects, filterSpecOnlyPlanned, isUnscopedConversation, NO_PROJECT_KEY, NO_PROJECT_LABEL } from './projectsData';
 import { TasksDialog } from '../TasksDialog';
 import { PlanDialog } from '../PlanDialog';
 import { ConversationList, type Conversation } from './ConversationList';
@@ -32,6 +32,8 @@ import type { ProjectSessionTree, SessionTreeDelta } from '@overdeck/contracts';
 import styles from './styles/command-deck.module.css';
 import { fetchWithTimeout } from '../../lib/apiFetch';
 import { fetchRegisteredProjects, findRegisteredProject, isKnownProject, ProjectRegistryErrorState, UnknownProjectState } from './UnknownProjectState';
+import { IssuesPaneFilterRow } from './IssuesPaneFilterRow';
+import { usePlannedBacklogVisibility } from '../../hooks/usePlannedBacklogVisibility';
 
 async function fetchConversations(): Promise<Conversation[]> {
   const res = await fetchWithTimeout('/api/conversations');
@@ -211,6 +213,7 @@ export function CommandDeck({
   const sectionDragStartSplit = useRef(50);
   const sectionContainerRef = useRef<HTMLDivElement>(null);
   const [treeFilter, setTreeFilter] = useState<TreeSessionFilter>('all');
+  const showPlannedBacklog = usePlannedBacklogVisibility((state) => state.showPlannedBacklog);
   const [sidebarModel, setSidebarModel] = useState<string>(loadStoredModel);
   const [sidebarHarness, setSidebarHarness] = useState<Harness>(loadStoredHarness);
 
@@ -1208,6 +1211,10 @@ export function CommandDeck({
     if (!selectedProject) return null;
     return projectsWithSessions.find(p => p.name === selectedProject) ?? null;
   }, [projectsWithSessions, selectedProject]);
+  const visibleFeatures = useMemo(
+    () => filterSpecOnlyPlanned(selectedProjectData?.features ?? [], showPlannedBacklog),
+    [selectedProjectData, showPlannedBacklog],
+  );
 
   const selectedRegisteredProject = useMemo(
     () => findRegisteredProject(registeredProjects, selectedProject),
@@ -1343,21 +1350,14 @@ export function CommandDeck({
             <div className={styles.sectionHeader} onClick={toggleProjectsCollapsed}>
               {projectsCollapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
               <span className={styles.sectionTitle}>Issues</span>
-              <span className={styles.segmentCount}>{selectedProjectData?.features.length ?? 0}</span>
+              <span className={styles.segmentCount}>{visibleFeatures.length}</span>
             </div>
             {!projectsCollapsed && (
               <div className={styles.sectionBody}>
-                <div className={styles.treeFilterRow}>
-                  {(['all', 'alive', 'failed'] as TreeSessionFilter[]).map((f) => (
-                    <button
-                      key={f}
-                      onClick={() => setTreeFilter(f)}
-                      className={`${styles.treeFilterButton} ${treeFilter === f ? styles.treeFilterButtonActive : ''}`}
-                    >
-                      {f === 'all' ? 'All' : f === 'alive' ? 'Alive' : 'Failed'}
-                    </button>
-                  ))}
-                </div>
+                <IssuesPaneFilterRow
+                  filter={treeFilter}
+                  onFilterChange={setTreeFilter}
+                />
                 {!selectedProject ? (
                   <div className={styles.emptyProject}>Select a project to see its issues</div>
                 ) : isLoading && !selectedProjectData ? (
@@ -1370,7 +1370,7 @@ export function CommandDeck({
                   <ProjectNode
                     key={selectedProjectData.path} projectKey={selectedProjectData.key}
                     name={selectedProjectData.name}
-                    features={selectedProjectData.features}
+                    features={visibleFeatures}
                     selectedFeature={selectedFeature}
                     onSelectFeature={handleSelectFeature}
                     onSelectProject={handleSelectProject}
@@ -1449,7 +1449,7 @@ export function CommandDeck({
                   projectKey={selectedRegisteredProject?.key}
                   conversations={projectConvs}
                   onCreateConversation={createDeckConversation}
-                  features={selectedProjectData?.features}
+                  features={visibleFeatures}
                   issueCosts={issueCosts}
                   issueCostDetails={issueCostDetails}
                   onSelectFeature={(feature) => handleSelectFeature(feature.issueId)}

--- a/src/dashboard/frontend/src/components/CommandDeck/projectsData.ts
+++ b/src/dashboard/frontend/src/components/CommandDeck/projectsData.ts
@@ -35,6 +35,14 @@ export interface ProjectData {
   features: ProjectFeature[];
 }
 
+export function filterSpecOnlyPlanned(
+  features: ProjectFeature[],
+  showPlannedBacklog: boolean,
+): ProjectFeature[] {
+  if (showPlannedBacklog) return features;
+  return features.filter((feature) => feature.specOnlyPlanned !== true);
+}
+
 export function groupProjects(issues: ProjectFeature[]): ProjectData[] {
   const grouped = new Map<string, ProjectData>();
 

--- a/src/dashboard/frontend/src/components/Sidebar.tsx
+++ b/src/dashboard/frontend/src/components/Sidebar.tsx
@@ -7,11 +7,12 @@ import {
   Hammer, Loader2, History, Mic, FileText, ChevronDown, ChevronRight, MoreHorizontal, Shield, ListOrdered,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
-import { fetchProjects, isUnscopedConversation, NO_PROJECT_KEY, NO_PROJECT_LABEL, type RegisteredProjectLite } from './CommandDeck/projectsData';
+import { fetchProjects, filterSpecOnlyPlanned, isUnscopedConversation, NO_PROJECT_KEY, NO_PROJECT_LABEL, type RegisteredProjectLite } from './CommandDeck/projectsData';
 import { OverdeckMark } from './OverdeckMark';
 import { fetchConversations } from './CommandDeck/ConversationList';
 import { FreshnessIndicator } from './FreshnessIndicator';
 import { useTheme } from '../hooks/useTheme';
+import { usePlannedBacklogVisibility } from '../hooks/usePlannedBacklogVisibility';
 import { useDashboardStore, selectIssues, selectAgents } from '../lib/store';
 import { getPipelineIssuePhase } from '../lib/pipeline-state';
 import { fetchExperimentalFeaturesEnabled, isExperimentalTab } from '../lib/experimentalFeatures';
@@ -164,6 +165,7 @@ export function Sidebar({ activeTab, onTabChange, onSearchOpen, selectedProject 
     queryFn: fetchProjects,
     refetchInterval: 30000,
   });
+  const showPlannedBacklog = usePlannedBacklogVisibility((state) => state.showPlannedBacklog);
 
   // PAN-1561: the "No project" bucket appears once a conversation exists that
   // isn't under any registered project. These queries share keys with the
@@ -424,7 +426,8 @@ export function Sidebar({ activeTab, onTabChange, onSearchOpen, selectedProject 
               ) : (
                 projects.map((project) => {
                   const isActive = activeTab === 'command-deck' && selectedProject === project.name;
-                  const hasActivity = project.features.length > 0;
+                  const visibleFeatures = filterSpecOnlyPlanned(project.features, showPlannedBacklog);
+                  const hasActivity = visibleFeatures.length > 0;
                   return (
                     <button
                       key={project.path}
@@ -444,8 +447,8 @@ export function Sidebar({ activeTab, onTabChange, onSearchOpen, selectedProject 
                         aria-hidden="true"
                       />
                       <span className="truncate">{project.name}</span>
-                      {project.features.length > 0 && (
-                        <span className="ml-auto text-[11px] text-muted-foreground">{project.features.length}</span>
+                      {visibleFeatures.length > 0 && (
+                        <span className="ml-auto text-[11px] text-muted-foreground">{visibleFeatures.length}</span>
                       )}
                     </button>
                   );

--- a/src/dashboard/frontend/src/hooks/__tests__/usePlannedBacklogVisibility.test.ts
+++ b/src/dashboard/frontend/src/hooks/__tests__/usePlannedBacklogVisibility.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ProjectFeature } from '../../components/CommandDeck/ProjectTree/ProjectNode';
+import { filterSpecOnlyPlanned } from '../../components/CommandDeck/projectsData';
+
+const STORAGE_KEY = 'overdeck.ui.showPlannedBacklog';
+
+function feature(issueId: string, specOnlyPlanned?: boolean): ProjectFeature {
+  return {
+    issueId,
+    title: issueId,
+    projectName: 'overdeck',
+    branch: `feature/${issueId.toLowerCase()}`,
+    status: 'idle',
+    stateLabel: 'Idle',
+    agentStatus: null,
+    hasPlanning: false,
+    hasPrd: false,
+    hasState: false,
+    isShadow: false,
+    specOnlyPlanned,
+  };
+}
+
+describe('usePlannedBacklogVisibility', () => {
+  let stored: Record<string, string>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    stored = {};
+    global.localStorage = {
+      getItem: vi.fn((key: string) => stored[key] ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        stored[key] = value;
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete stored[key];
+      }),
+      clear: vi.fn(() => {
+        stored = {};
+      }),
+      length: 0,
+      key: vi.fn(() => null),
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('defaults to visible when the preference is missing or invalid', async () => {
+    const missing = await import('../usePlannedBacklogVisibility');
+    expect(missing.usePlannedBacklogVisibility.getState().showPlannedBacklog).toBe(true);
+
+    vi.resetModules();
+    stored[STORAGE_KEY] = 'invalid';
+    const invalid = await import('../usePlannedBacklogVisibility');
+    expect(invalid.usePlannedBacklogVisibility.getState().showPlannedBacklog).toBe(true);
+  });
+
+  it('keeps an in-memory preference when localStorage is unavailable', async () => {
+    vi.mocked(localStorage.getItem).mockImplementation(() => {
+      throw new Error('storage unavailable');
+    });
+    vi.mocked(localStorage.setItem).mockImplementation(() => {
+      throw new Error('storage unavailable');
+    });
+
+    const unavailable = await import('../usePlannedBacklogVisibility');
+    expect(unavailable.usePlannedBacklogVisibility.getState().showPlannedBacklog).toBe(true);
+
+    unavailable.usePlannedBacklogVisibility.getState().toggleShowPlannedBacklog();
+    expect(unavailable.usePlannedBacklogVisibility.getState().showPlannedBacklog).toBe(false);
+  });
+
+  it('persists toggles and restores them on a fresh store load', async () => {
+    const initial = await import('../usePlannedBacklogVisibility');
+
+    initial.usePlannedBacklogVisibility.getState().toggleShowPlannedBacklog();
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(STORAGE_KEY, 'false');
+    expect(initial.usePlannedBacklogVisibility.getState().showPlannedBacklog).toBe(false);
+
+    vi.resetModules();
+    const restored = await import('../usePlannedBacklogVisibility');
+    expect(restored.usePlannedBacklogVisibility.getState().showPlannedBacklog).toBe(false);
+
+    restored.usePlannedBacklogVisibility.getState().toggleShowPlannedBacklog();
+    expect(localStorage.setItem).toHaveBeenLastCalledWith(STORAGE_KEY, 'true');
+    expect(restored.usePlannedBacklogVisibility.getState().showPlannedBacklog).toBe(true);
+  });
+});
+
+describe('filterSpecOnlyPlanned', () => {
+  const features = [
+    feature('PAN-1', true),
+    feature('PAN-2', false),
+    feature('PAN-3'),
+  ];
+
+  it('returns the original feature array when planned backlog is visible', () => {
+    expect(filterSpecOnlyPlanned(features, true)).toBe(features);
+  });
+
+  it('hides only features explicitly marked spec-only planned', () => {
+    expect(filterSpecOnlyPlanned(features, false).map((item) => item.issueId)).toEqual([
+      'PAN-2',
+      'PAN-3',
+    ]);
+  });
+});

--- a/src/dashboard/frontend/src/hooks/usePlannedBacklogVisibility.ts
+++ b/src/dashboard/frontend/src/hooks/usePlannedBacklogVisibility.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+
+const STORAGE_KEY = 'overdeck.ui.showPlannedBacklog';
+
+function getStoredVisibility(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) !== 'false';
+  } catch {
+    return true;
+  }
+}
+
+interface PlannedBacklogVisibilityState {
+  showPlannedBacklog: boolean;
+  toggleShowPlannedBacklog: () => void;
+}
+
+export const usePlannedBacklogVisibility = create<PlannedBacklogVisibilityState>((set, get) => ({
+  showPlannedBacklog: getStoredVisibility(),
+
+  toggleShowPlannedBacklog: () => {
+    const showPlannedBacklog = !get().showPlannedBacklog;
+    try {
+      localStorage.setItem(STORAGE_KEY, String(showPlannedBacklog));
+    } catch {
+      // localStorage unavailable — keep the preference for this session
+    }
+    set({ showPlannedBacklog });
+  },
+}));

--- a/src/dashboard/frontend/src/pages/HomePage.test.tsx
+++ b/src/dashboard/frontend/src/pages/HomePage.test.tsx
@@ -1,10 +1,11 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AgentSnapshot, FeatureRegistryEntry, MemoryObservation, MemoryStatus } from '@overdeck/contracts';
 import { INITIAL_READ_MODEL_STATE } from '@overdeck/contracts';
 
 import { HomePage } from './HomePage';
+import { usePlannedBacklogVisibility } from '../hooks/usePlannedBacklogVisibility';
 import { useDashboardStore } from '../lib/store';
 
 function makeEntry(overrides: Partial<FeatureRegistryEntry> = {}): FeatureRegistryEntry {
@@ -118,6 +119,8 @@ function renderHomePage(props: Parameters<typeof HomePage>[0] = {}) {
 
 beforeEach(() => {
   resetDashboardStore();
+  usePlannedBacklogVisibility.setState({ showPlannedBacklog: true });
+  localStorage.clear();
 });
 
 afterEach(() => {
@@ -324,6 +327,40 @@ describe('HomePage', () => {
 
     fireEvent.click(projectButton);
     expect(onSelectProject).toHaveBeenCalledWith('overdeck');
+  });
+
+  it('filters spec-only planned rows from project activity counts', async () => {
+    vi.stubGlobal('fetch', homeFetchStub({
+      '/api/issues/resource-allocated': [{
+        issueId: 'PAN-2822',
+        title: 'Planned visibility toggle',
+        projectName: 'overdeck',
+        branch: '',
+        status: 'idle',
+        stateLabel: 'Idle',
+        agentStatus: null,
+        hasPlanning: true,
+        hasPrd: true,
+        hasState: false,
+        isShadow: false,
+        specOnlyPlanned: true,
+      }],
+      '/api/registered-projects': [{ key: 'overdeck', name: 'overdeck', path: '/home/eltmon/Projects/overdeck' }],
+    }));
+
+    renderHomePage();
+
+    const projectButton = await screen.findByTestId('home-project-overdeck');
+    const activityDot = projectButton.querySelector('[aria-hidden="true"]');
+    expect(within(projectButton).getByText('1')).toBeInTheDocument();
+    expect(activityDot).toHaveClass('bg-primary');
+
+    act(() => {
+      usePlannedBacklogVisibility.setState({ showPlannedBacklog: false });
+    });
+
+    expect(within(projectButton).queryByText('1')).not.toBeInTheDocument();
+    expect(activityDot).toHaveClass('bg-muted-foreground/30');
   });
 
   it('shows a no-projects empty state with a new-project CTA (PAN-1969)', async () => {

--- a/src/dashboard/frontend/src/pages/HomePage.tsx
+++ b/src/dashboard/frontend/src/pages/HomePage.tsx
@@ -5,7 +5,8 @@ import { NotificationClassBadge } from '../components/NotificationClassBadge';
 import { ActionStatusChip } from '../components/ActionStatusChip';
 import type { AgentSnapshot, FeatureRegistryEntry, MemoryHealthSnapshot, MemoryObservation, MemoryStatus, ReviewStatusSnapshot } from '@overdeck/contracts';
 import { WorkspaceStatusCard, type WorkspaceStatusStats } from '../components/CommandDeck/WorkspaceStatusCard';
-import { fetchProjects, type ProjectData } from '../components/CommandDeck/projectsData';
+import { fetchProjects, filterSpecOnlyPlanned, type ProjectData } from '../components/CommandDeck/projectsData';
+import { usePlannedBacklogVisibility } from '../hooks/usePlannedBacklogVisibility';
 import { useDashboardStore, selectLatestMemoryFailure } from '../lib/store';
 import { formatRelativeTime } from '../lib/formatRelativeTime';
 import { bucketByTime, type TimeBucketKey } from '../lib/timeBuckets';
@@ -113,6 +114,7 @@ export function HomePage({ onOpenWorkspaceHome, onNewProject, onSelectProject, o
     retry: false,
   });
   const projects: ProjectData[] = projectsQuery.data ?? [];
+  const showPlannedBacklog = usePlannedBacklogVisibility((state) => state.showPlannedBacklog);
   const issuesRaw = useDashboardStore((state) => state.issuesRaw);
   const statusByIssueId = useDashboardStore((state) => state.statusByIssueId);
   const observationsByIssueId = useDashboardStore((state) => state.observationsByIssueId);
@@ -246,7 +248,8 @@ export function HomePage({ onOpenWorkspaceHome, onNewProject, onSelectProject, o
             ) : projects.length > 0 ? (
               <ul className="divide-y divide-border rounded-lg border border-border">
                 {projects.map((project) => {
-                  const hasActivity = project.features.length > 0;
+                  const visibleFeatures = filterSpecOnlyPlanned(project.features, showPlannedBacklog);
+                  const hasActivity = visibleFeatures.length > 0;
                   return (
                     <li key={project.path}>
                       <button
@@ -261,7 +264,7 @@ export function HomePage({ onOpenWorkspaceHome, onNewProject, onSelectProject, o
                         />
                         <span className="truncate">{project.name}</span>
                         {hasActivity && (
-                          <span className="ml-auto text-xs text-muted-foreground">{project.features.length}</span>
+                          <span className="ml-auto text-xs text-muted-foreground">{visibleFeatures.length}</span>
                         )}
                       </button>
                     </li>

--- a/src/dashboard/server/services/resource-discovery.ts
+++ b/src/dashboard/server/services/resource-discovery.ts
@@ -15,7 +15,11 @@ import {
 } from '../../../lib/pan-dir/index.js';
 import { findSpecByIssue } from '../../../lib/pan-dir/specs.js';
 import { listProjectsSync, resolveProjectFromIssueSync, type ProjectConfig, type ResolvedProject } from '../../../lib/projects.js';
-import type { PipelineBucket, PipelineMembership } from '../../../lib/pipeline-membership.js';
+import {
+  PLANNED_BACKLOG_SPEC_ONLY_REASON,
+  type PipelineBucket,
+  type PipelineMembership,
+} from '../../../lib/pipeline-membership.js';
 import { listOpenPullRequestsSnapshot } from '../../../lib/pipeline-membership-gather.js';
 import { listSessionNames } from '../../../lib/tmux.js';
 import { loadReadyForMergeFlags } from '../review-status.js';
@@ -99,6 +103,8 @@ export interface ResourceAllocatedIssue {
   resourceDetails: ResourceDetails;
   taskTotals: TaskTotals | null;
   pipelineBucket?: PipelineBucket;
+  /** PAN-2822: planned_backlog caused solely by the L6 spec lens — display surfaces may hide these. */
+  specOnlyPlanned?: boolean;
   /** Live resource residue attached to a resolver-rejected terminal issue. */
   resourceDrift?: boolean;
 }
@@ -794,6 +800,8 @@ async function computeResourceAllocatedIssues(): Promise<InternalDiscoveredIssue
           resourceDetails: issue.resourceDetails,
           taskTotals: issue.taskTotals,
           pipelineBucket: membership.bucket,
+          specOnlyPlanned: membership.bucket === 'planned_backlog'
+            && membership.reasons.includes(PLANNED_BACKLOG_SPEC_ONLY_REASON),
           resourceDrift: !membership.inPipeline,
         } satisfies InternalDiscoveredIssue;
       });

--- a/src/lib/pipeline-membership.ts
+++ b/src/lib/pipeline-membership.ts
@@ -31,6 +31,8 @@ import type { PipelineBucket } from '@overdeck/contracts';
 
 export type { PipelineBucket } from '@overdeck/contracts';
 
+export const PLANNED_BACKLOG_SPEC_ONLY_REASON = 'open issue with a vBRIEF spec but no branch/PR — planned work whose plan encodes code paths that age; needs starting or re-planning';
+
 export interface IssueLensSignals {
   issueId: string;
   /** L3 — the GitHub issue state is open. */
@@ -145,7 +147,7 @@ export function resolvePipelineMembership(s: IssueLensSignals): PipelineMembersh
   if (s.hasVbriefSpec) {
     return result(
       'planned_backlog',
-      'open issue with a vBRIEF spec but no branch/PR — planned work whose plan encodes code paths that age; needs starting or re-planning',
+      PLANNED_BACKLOG_SPEC_ONLY_REASON,
     );
   }
   if (s.explicitlyReady) {

--- a/tests/unit/dashboard/server/services/resource-discovery.test.ts
+++ b/tests/unit/dashboard/server/services/resource-discovery.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Effect } from 'effect';
 
+import { PLANNED_BACKLOG_SPEC_ONLY_REASON } from '../../../../../src/lib/pipeline-membership.js';
+
 const mocks = vi.hoisted(() => ({
   execFile: vi.fn(),
   findSpecByIssue: vi.fn(),
@@ -92,12 +94,12 @@ import {
   sanitizeResourceAllocatedIssues,
 } from '../../../../../src/dashboard/server/services/resource-discovery.js';
 
-function membership(issueId: string, bucket = 'in_flight') {
+function membership(issueId: string, bucket = 'in_flight', reasons = ['test resolver verdict']) {
   return {
     issueId,
     inPipeline: true,
     bucket,
-    reasons: ['test resolver verdict'],
+    reasons,
     labelDrift: null,
     lenses: { L1_openPr: false, L2_unmergedBranch: true, L3_issueOpen: true, L4_phaseLabel: null },
   };
@@ -380,6 +382,39 @@ describe('resource-discovery terminal issue filtering', () => {
     expect(withOpenPr.map((issue) => issue.issueId)).toEqual(['PAN-2054']);
     expect(withOpenPr[0]?.resourceSources).toContain('pr');
     expect(withOpenPr[0]?.pipelineBucket).toBe('zombie_pr');
+  });
+});
+
+describe('resource-discovery planned backlog annotation', () => {
+  it('marks only spec-lens planned backlog rows as spec-only planned', async () => {
+    mocks.issueService.getIssues.mockReturnValue([
+      { identifier: 'PAN-2822', title: 'Spec-only planned', state: 'open', rawTrackerState: 'OPEN' },
+      { identifier: 'PAN-2823', title: 'Branch-backed planned', state: 'open', rawTrackerState: 'OPEN' },
+      { identifier: 'PAN-2824', title: 'Active work', state: 'in_progress', rawTrackerState: 'In Progress' },
+    ]);
+    mocks.listSessionNames.mockReturnValue(Effect.succeed([
+      'agent-pan-2822',
+      'agent-pan-2823',
+      'agent-pan-2824',
+    ]));
+    mocks.getPipelineMembershipForProjects.mockResolvedValue([
+      membership('PAN-2822', 'planned_backlog', [PLANNED_BACKLOG_SPEC_ONLY_REASON]),
+      membership('PAN-2823', 'planned_backlog', [
+        'open issue with an unmerged feature branch but no PR — needs a PR or disposition',
+      ]),
+      membership('PAN-2824', 'in_flight', ['open issue with an open PR — active work']),
+    ]);
+
+    const discovered = await discoverResourceAllocatedIssues();
+    const annotations = Object.fromEntries(
+      discovered.map((issue) => [issue.issueId, issue.specOnlyPlanned]),
+    );
+
+    expect(annotations).toEqual({
+      'PAN-2822': true,
+      'PAN-2823': false,
+      'PAN-2824': false,
+    });
   });
 });
 

--- a/tests/unit/lib/pipeline-membership-audit.test.ts
+++ b/tests/unit/lib/pipeline-membership-audit.test.ts
@@ -5,7 +5,11 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-import { resolvePipelineMembership, type IssueLensSignals } from '../../../src/lib/pipeline-membership.js';
+import {
+  PLANNED_BACKLOG_SPEC_ONLY_REASON,
+  resolvePipelineMembership,
+  type IssueLensSignals,
+} from '../../../src/lib/pipeline-membership.js';
 
 const root = resolve(fileURLToPath(new URL('../../..', import.meta.url)));
 const CONSUMERS = [
@@ -67,5 +71,25 @@ describe('pipeline membership no-loss audit', () => {
     ],
   ] as const)('classifies %s as %s', (_name, input, expectedBucket) => {
     expect(resolvePipelineMembership(input).bucket).toBe(expectedBucket);
+  });
+
+  it('identifies the spec-only planned backlog reason', () => {
+    const membership = resolvePipelineMembership(signals({ hasVbriefSpec: true }));
+
+    expect(membership.bucket).toBe('planned_backlog');
+    expect(membership.reasons).toContain(PLANNED_BACKLOG_SPEC_ONLY_REASON);
+    expect(PLANNED_BACKLOG_SPEC_ONLY_REASON).toBe(
+      'open issue with a vBRIEF spec but no branch/PR — planned work whose plan encodes code paths that age; needs starting or re-planning',
+    );
+  });
+
+  it('does not identify branch-backed planned backlog as spec-only', () => {
+    const membership = resolvePipelineMembership(signals({
+      hasConventionBranch: true,
+      branchUnmerged: true,
+    }));
+
+    expect(membership.bucket).toBe('planned_backlog');
+    expect(membership.reasons).not.toContain(PLANNED_BACKLOG_SPEC_ONLY_REASON);
   });
 });


### PR DESCRIPTION
**Issue:** #2822

## Acceptance Criteria

- [ ] Export the spec-lens planned_backlog reason as a named constant
- [ ] Annotate ResourceAllocatedIssue with a constant specOnlyPlanned boolean
- [ ] Planned-backlog visibility preference store and pure filter helper
- [ ] Issues pane toggle button and filtered rendering (tree, badge, cockpit swimlanes)
- [ ] Sidebar project rail counts respect the visibility preference
- [ ] HomePage project cards respect the visibility preference
- [ ] Document the display-only toggle in docs/PIPELINE-MEMBERSHIP.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Planned Backlog toggle to hide or show spec-only planned issues.
  * Applied the setting consistently across project trees, issue counts, activity indicators, badges, and home-stage lists.
  * Planned Backlog visibility is remembered between sessions.

* **Bug Fixes**
  * Other planned-backlog issues remain visible when spec-only items are hidden.
  * Filtering now updates displayed counts and activity indicators consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->