### PR TITLE
fix(test): exempt the OKF landscape survey from the beads audit (PAN-2833)

### DIFF
--- a/tests/unit/lib/vbrief/beads-removal-no-loss.test.ts
+++ b/tests/unit/lib/vbrief/beads-removal-no-loss.test.ts
@@ -17,7 +17,13 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..
 const TEXT_EXTENSIONS = new Set(['.js', '.json', '.md', '.mdx', '.mjs', '.ts', '.tsx']);
 const SCAN_ROOTS = ['src', 'sync-sources', 'configuration', 'reference'];
 const LIVE_DOC_ROOTS = ['docs'];
-const EXCLUDED_DOC_PREFIXES = ['docs/history/', 'docs/prds/', 'docs/research/', 'docs/FLYWHEEL-STATE.md'];
+const EXCLUDED_DOC_PREFIXES = [
+  'docs/history/',
+  'docs/prds/',
+  'docs/research/',
+  'docs/FLYWHEEL-STATE.md',
+  'docs/OKF-LANDSCAPE.md',
+];
 
 interface Finding {
   file: string;


### PR DESCRIPTION
Fixes #2833 — main is RED. Unblocks every open PR.

## What was broken

`53fb6b8303` added `docs/OKF-LANDSCAPE.md`, an ecosystem landscape survey. Line 182 is a markdown table row describing the **external** beads project's `beads-sync` branch. The PAN-2648 no-loss audit scans `docs/` for `/BeadsRollup|beads-(?:rollup|sync)(?:-service|-singleton)?/i` and matched that prose — reading a comparative survey's mention of a third-party tool as a dependency.

`d1c0e5fb4b` was the last green commit; every commit since inherits the failing `test` check.

## The fix

Add `docs/OKF-LANDSCAPE.md` to `EXCLUDED_DOC_PREFIXES`, alongside the existing `docs/history/`, `docs/prds/`, `docs/research/`, and `docs/FLYWHEEL-STATE.md`. Those exemptions exist for exactly this category: narrative/research docs that legitimately name beads. A landscape survey is research prose.

The beads mention is deliberately left intact — naming the tool is the entire point of a comparative survey. The audit was wrong here, not the doc.

## Verification

- `npx vitest run tests/unit/lib/vbrief/beads-removal-no-loss.test.ts` → **6/6 passing**
- **The guard still has teeth**: injecting `beads-sync-service` into a scanned path (`src/lib/`) still fails the audit, confirming the exemption is scoped to survey prose and does not blunt the real dependency check.

Landed as an operator-authorized strike: diff reviewed and gates re-run independently by the Flywheel orchestrator (RUN-65) before merge.

## Follow-up

The audit greps prose for tool names, so any future doc discussing beads reddens main. Worth scoping the doc scan to dependency/instructional contexts, or keeping third-party comparison prose under the already-exempt `docs/research/`.