### PR TITLE
PAN-2445

### DIFF
--- a/docs/FLYWHEEL.md
+++ b/docs/FLYWHEEL.md
@@ -131,6 +131,12 @@ The Flywheel lifecycle is exposed as `pan flywheel` commands and mirrored by das
 
 Cloister owns the singleton gate. Only one Flywheel run may be active for a Overdeck home at a time. If a second start request arrives, it should fail with a clear active-run response instead of spawning a competing orchestrator. Pause and resume operate on that same saved run record, not on a new run.
 
+### Autonomous planning permission and staffing
+
+The reactive lifecycle scheduler treats permission and staffing as separate operator controls. With `flywheel.auto_pickup_backlog` off, an issue in stale `in_planning` state receives no autonomous planning spawn unless it has the case-insensitive `released` label; enabling auto-pickup grants that permission. Parked, vetoed, and objection labels still block dispatch, and unavailable tracker labels fail closed. A refusal emits a warning and a durable needs-you trip instead of silently starting work.
+
+After permission passes, the scheduler reuses a model recorded on the current or legacy planning agent, then tries the optional scalar `roles.plan.autonomousModel`. If neither resolves, it records a needs-you refusal; it never falls through to the ordinary `roles.plan.model`. The operator can authorize autonomous planning by fixing the labels or pickup posture and configure its staffing with `roles.plan.autonomousModel`, or bypass this autonomous path deliberately with `pan plan`.
+
 For local stack startup, Deacon/Cloister should be running before starting or resuming the Flywheel; see [`OVERDECK_DEV_SOP.md`](./OVERDECK_DEV_SOP.md#deacon-and-flywheel-startup-order).
 
 Run artifacts live under the Flywheel home:

--- a/docs/MODEL-CALLS.md
+++ b/docs/MODEL-CALLS.md
@@ -40,6 +40,8 @@ These are the live, agent-spawning calls that drive plan/work/review/test/ship/f
 
 **Notes on pipeline costs:** Pipeline agents run inside Claude Code / Pi / Codex harnesses. Their spend is captured by the per-harness cost parsers (`src/lib/cost-parsers/*`) and recorded with the model id as the source, not a `background:` tag.
 
+Operator-initiated planning through `pan plan`, dashboard planning, or `pan start` auto-planning uses the ordinary `roles.plan.model` resolution above. A fresh autonomous planning dispatch from the reactive lifecycle scheduler uses a separate, fail-closed chain: the model recorded on the current plan agent, then the legacy planning agent, then the optional scalar `roles.plan.autonomousModel`. If none resolves, the scheduler refuses the spawn and records a needs-you trip; it never falls through to `roles.plan.model` or its `workhorse:expensive` default.
+
 ---
 
 ## B. Background / silent AI calls

--- a/src/lib/cloister/__tests__/autonomous-plan-dispatch.test.ts
+++ b/src/lib/cloister/__tests__/autonomous-plan-dispatch.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import {
+  LEGACY_PARKED_LABELS,
+  OBJECTION_LABEL,
+  PARKED_LABEL,
+  RELEASED_LABEL,
+  VETOED_LABEL,
+} from '../../backlog/pickup.js';
+import type { NormalizedConfig } from '../../config-yaml.js';
+import {
+  decideAutonomousPlanDispatch,
+  type AutonomousPlanDispatchInput,
+} from '../autonomous-plan-dispatch.js';
+
+const WORKHORSES: NonNullable<NormalizedConfig['workhorses']> = {
+  expensive: 'claude-opus-4-8',
+  mid: 'claude-sonnet-5',
+  cheap: 'claude-haiku-4-5',
+};
+
+function input(overrides: Partial<AutonomousPlanDispatchInput> = {}): AutonomousPlanDispatchInput {
+  return {
+    autoPickupBacklog: false,
+    labels: [RELEASED_LABEL],
+    workhorses: WORKHORSES,
+    ...overrides,
+  };
+}
+
+describe('decideAutonomousPlanDispatch', () => {
+  it('fails closed when tracker labels are unavailable even with auto-pickup enabled', () => {
+    const decision = decideAutonomousPlanDispatch(input({
+      autoPickupBacklog: true,
+      labels: null,
+      recordedModel: 'gpt-5.5',
+    }));
+
+    expect(decision).toMatchObject({ allow: false, code: 'labels-unavailable' });
+    expect(decision.reason).toContain('run pan plan manually');
+  });
+
+  it.each([
+    [PARKED_LABEL, 'parked'],
+    [LEGACY_PARKED_LABELS[0].toUpperCase(), 'parked'],
+    [LEGACY_PARKED_LABELS[1], 'parked'],
+    [VETOED_LABEL, 'vetoed'],
+    [OBJECTION_LABEL, 'objection'],
+  ] as const)('blocks %s before release or staffing can allow dispatch', (label, code) => {
+    const decision = decideAutonomousPlanDispatch(input({
+      autoPickupBacklog: true,
+      labels: [RELEASED_LABEL.toUpperCase(), label],
+      recordedModel: 'gpt-5.5',
+      autonomousModel: 'workhorse:cheap',
+    }));
+
+    expect(decision).toMatchObject({ allow: false, code });
+    expect(decision.reason).toContain('run pan plan manually');
+  });
+
+  it('applies blocker precedence before staffing and in parked, vetoed, objection order', () => {
+    expect(decideAutonomousPlanDispatch(input({
+      autoPickupBacklog: true,
+      labels: [RELEASED_LABEL, OBJECTION_LABEL, VETOED_LABEL, PARKED_LABEL],
+      recordedModel: 'gpt-5.5',
+    }))).toMatchObject({ allow: false, code: 'parked' });
+
+    expect(decideAutonomousPlanDispatch(input({
+      autoPickupBacklog: true,
+      labels: [RELEASED_LABEL, OBJECTION_LABEL, VETOED_LABEL],
+      recordedModel: 'gpt-5.5',
+    }))).toMatchObject({ allow: false, code: 'vetoed' });
+  });
+
+  it('requires release when auto-pickup is disabled', () => {
+    const decision = decideAutonomousPlanDispatch(input({
+      labels: ['ready'],
+      recordedModel: 'gpt-5.5',
+    }));
+
+    expect(decision).toMatchObject({ allow: false, code: 'not-released' });
+    expect(decision.reason).toContain('released label or enable auto-pickup');
+  });
+
+  it('accepts a case-insensitive released label', () => {
+    expect(decideAutonomousPlanDispatch(input({
+      labels: [RELEASED_LABEL.toUpperCase()],
+      recordedModel: 'gpt-5.5',
+    }))).toEqual({ allow: true, model: 'gpt-5.5', modelSource: 'recorded' });
+  });
+
+  it('uses auto-pickup as the release posture', () => {
+    expect(decideAutonomousPlanDispatch(input({
+      autoPickupBacklog: true,
+      labels: [],
+      recordedModel: 'gpt-5.5',
+    }))).toEqual({ allow: true, model: 'gpt-5.5', modelSource: 'recorded' });
+  });
+
+  it('prefers the recorded model without resolving the configured autonomous model', () => {
+    expect(decideAutonomousPlanDispatch(input({
+      recordedModel: 'gpt-5.5',
+      autonomousModel: 'workhorse:missing',
+    }))).toEqual({ allow: true, model: 'gpt-5.5', modelSource: 'recorded' });
+  });
+
+  it('dereferences the configured autonomous workhorse model', () => {
+    expect(decideAutonomousPlanDispatch(input({
+      autonomousModel: 'workhorse:cheap',
+    }))).toEqual({
+      allow: true,
+      model: 'claude-haiku-4-5',
+      modelSource: 'autonomousModel',
+    });
+  });
+
+  it('refuses dispatch when no autonomous model is configured', () => {
+    const decision = decideAutonomousPlanDispatch(input());
+
+    expect(decision).toMatchObject({ allow: false, code: 'no-autonomous-model' });
+    expect(decision.reason).toContain('Set roles.plan.autonomousModel or run pan plan manually');
+  });
+
+  it('refuses dispatch when the configured autonomous model cannot be dereferenced', () => {
+    const decision = decideAutonomousPlanDispatch(input({
+      autonomousModel: 'workhorse:missing',
+    }));
+
+    expect(decision).toMatchObject({ allow: false, code: 'no-autonomous-model' });
+    expect(decision.reason).toContain('valid roles.plan.autonomousModel');
+  });
+});

--- a/src/lib/cloister/__tests__/reactive-scheduler.test.ts
+++ b/src/lib/cloister/__tests__/reactive-scheduler.test.ts
@@ -1,6 +1,35 @@
 import { Effect } from 'effect';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const autonomousPlanMock = vi.hoisted(() => ({
+  autoPickupBacklog: false,
+  labels: ['released'] as readonly string[] | null,
+  recordedModel: undefined as string | undefined,
+  autonomousModel: 'workhorse:cheap' as string | undefined,
+}));
+
+vi.mock('../autonomous-plan-dispatch.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../autonomous-plan-dispatch.js')>();
+  return {
+    ...actual,
+    gatherAutonomousPlanDispatchInput: vi.fn(async () => ({
+      autoPickupBacklog: autonomousPlanMock.autoPickupBacklog,
+      labels: autonomousPlanMock.labels,
+      recordedModel: autonomousPlanMock.recordedModel,
+      autonomousModel: autonomousPlanMock.autonomousModel,
+      workhorses: {
+        expensive: 'claude-opus-4-8',
+        mid: 'claude-sonnet-5',
+        cheap: 'claude-haiku-4-5',
+      },
+    })),
+  };
+});
+
+vi.mock('../dead-end-trip.js', () => ({
+  recordDeadEndNeedsYou: vi.fn(async () => undefined),
+}));
+
 vi.mock('../../agents.js', async () => {
   const { Effect } = await import('effect');
   const effectMock = (initial?: unknown) => {
@@ -205,8 +234,10 @@ vi.mock('../../tmux.js', async () => {
   };
 });
 
+import { emitActivityEntrySync } from '../../activity-logger.js';
 import { listRunningAgentsSync, listRunningAgents, spawnRun, getAgentState, getAgentStateSync, resumeAgent } from '../../agents.js';
 import { sessionExists, killSession, sessionExistsSync } from '../../tmux.js';
+import { recordDeadEndNeedsYou } from '../dead-end-trip.js';
 import { spawnReviewRoleForIssue } from '../review-agent.js';
 import { dispatchTestAgentAndNotify } from '../test-agent-queue.js';
 import { isIssueClosed } from '../issue-closed.js';
@@ -233,6 +264,10 @@ describe('reactive Cloister scheduler', () => {
     vi.mocked(killSession).mockResolvedValue(undefined);
     vi.mocked(isIssueClosed).mockResolvedValue(false);
     vi.mocked(getReviewStatusSync).mockReturnValue(undefined as any);
+    autonomousPlanMock.autoPickupBacklog = false;
+    autonomousPlanMock.labels = ['released'];
+    autonomousPlanMock.recordedModel = undefined;
+    autonomousPlanMock.autonomousModel = 'workhorse:cheap';
     mockHeadSha = 'newhead1';
   });
 
@@ -250,6 +285,63 @@ describe('reactive Cloister scheduler', () => {
     expect(stateToRole('shipping')).toBeNull();
     expect(stateToRole('closed')).toBeNull();
     expect(stateToRole('canceled')).toBeNull();
+  });
+
+  it('refuses autonomous planning without release and records a warning needs-you trip', async () => {
+    autonomousPlanMock.labels = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await Effect.runPromise(onIssueStateChange('PAN-503', 'in_planning'));
+
+    const refusalText = 'Autonomous planning dispatch was refused because the issue is not released';
+    expect(spawnRun).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining(refusalText));
+    expect(emitActivityEntrySync).toHaveBeenCalledWith({
+      source: 'cloister',
+      level: 'warn',
+      message: expect.stringContaining(refusalText),
+      issueId: 'PAN-503',
+    });
+    expect(recordDeadEndNeedsYou).toHaveBeenCalledWith(
+      'PAN-503',
+      'autonomous-plan-dispatch',
+      'in_planning',
+      expect.stringContaining(refusalText),
+    );
+
+    logSpy.mockRestore();
+  });
+
+  it('passes the concrete configured autonomous planning model to spawnRun', async () => {
+    await Effect.runPromise(onIssueStateChange('PAN-503', 'in_planning'));
+
+    expect(spawnRun).toHaveBeenCalledWith('PAN-503', 'plan', {
+      prompt: expect.stringContaining('PLAN TASK for PAN-503'),
+      model: 'claude-haiku-4-5',
+    });
+  });
+
+  it('prefers the recorded planning model over roles.plan.autonomousModel', async () => {
+    autonomousPlanMock.recordedModel = 'gpt-5.5';
+
+    await Effect.runPromise(onIssueStateChange('PAN-503', 'in_planning'));
+
+    expect(spawnRun).toHaveBeenCalledWith('PAN-503', 'plan', {
+      prompt: expect.stringContaining('PLAN TASK for PAN-503'),
+      model: 'gpt-5.5',
+    });
+  });
+
+  it('keeps work-role dispatch unchanged and does not apply autonomous planning staffing', async () => {
+    autonomousPlanMock.labels = [];
+    autonomousPlanMock.autonomousModel = undefined;
+
+    await Effect.runPromise(onIssueStateChange('PAN-503', 'in_progress'));
+
+    expect(spawnRun).toHaveBeenCalledWith('PAN-503', 'work', {
+      prompt: expect.stringContaining('WORK TASK for PAN-503'),
+    });
+    expect(recordDeadEndNeedsYou).not.toHaveBeenCalled();
   });
 
   it('starts the review role for an issue state transition via the wrapper', async () => {

--- a/src/lib/cloister/autonomous-plan-dispatch.ts
+++ b/src/lib/cloister/autonomous-plan-dispatch.ts
@@ -1,3 +1,5 @@
+import { Effect } from 'effect';
+import { getAgentState } from '../agents.js';
 import {
   LEGACY_PARKED_LABELS,
   OBJECTION_LABEL,
@@ -5,7 +7,8 @@ import {
   RELEASED_LABEL,
   VETOED_LABEL,
 } from '../backlog/pickup.js';
-import { derefWorkhorse, type NormalizedConfig } from '../config-yaml.js';
+import { derefWorkhorse, loadConfigSync, type NormalizedConfig } from '../config-yaml.js';
+import { isFlywheelAutoPickupBacklog } from '../database/app-settings.js';
 
 export interface AutonomousPlanDispatchInput {
   autoPickupBacklog: boolean;
@@ -32,6 +35,52 @@ export type AutonomousPlanDispatchDecision =
         | 'no-autonomous-model';
       reason: string;
     };
+
+export async function gatherAutonomousPlanDispatchInput(
+  issueId: string,
+): Promise<AutonomousPlanDispatchInput> {
+  const normalizedIssueId = issueId.trim().toUpperCase();
+  const issueLower = normalizedIssueId.toLowerCase();
+  let labels: readonly string[] | null = null;
+
+  try {
+    // Keep this lazy require aligned with buildClassifyLookups: a static import
+    // creates a lib → dashboard layering edge.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { getSharedIssueService } = require('../../dashboard/server/services/issue-service-singleton.js') as typeof import('../../dashboard/server/services/issue-service-singleton.js');
+    const issue = (getSharedIssueService().getIssues() as Array<Record<string, unknown>>)
+      .find((candidate) => (
+        typeof candidate['identifier'] === 'string'
+        && candidate['identifier'].toUpperCase() === normalizedIssueId
+      ));
+    if (issue) {
+      const rawLabels = Array.isArray(issue['labels']) ? issue['labels'] as unknown[] : [];
+      labels = rawLabels
+        .map((label) => (
+          typeof label === 'string' ? label : ((label as { name?: string })?.name ?? '')
+        ))
+        .filter((label): label is string => Boolean(label));
+    }
+  } catch {
+    // The scheduler cannot prove blocker labels are absent without the issue service.
+  }
+
+  const currentState = await Effect.runPromise(getAgentState(`agent-${issueLower}-plan`));
+  const legacyState = currentState?.model
+    ? null
+    : await Effect.runPromise(getAgentState(`planning-${issueLower}`));
+  const config = loadConfigSync().config;
+
+  return {
+    autoPickupBacklog: isFlywheelAutoPickupBacklog(),
+    labels,
+    recordedModel: currentState?.model ?? legacyState?.model,
+    autonomousModel: typeof config.roles?.plan?.autonomousModel === 'string'
+      ? config.roles.plan.autonomousModel
+      : undefined,
+    workhorses: config.workhorses,
+  };
+}
 
 export function decideAutonomousPlanDispatch(
   input: AutonomousPlanDispatchInput,

--- a/src/lib/cloister/autonomous-plan-dispatch.ts
+++ b/src/lib/cloister/autonomous-plan-dispatch.ts
@@ -1,0 +1,118 @@
+import {
+  LEGACY_PARKED_LABELS,
+  OBJECTION_LABEL,
+  PARKED_LABEL,
+  RELEASED_LABEL,
+  VETOED_LABEL,
+} from '../backlog/pickup.js';
+import { derefWorkhorse, type NormalizedConfig } from '../config-yaml.js';
+
+export interface AutonomousPlanDispatchInput {
+  autoPickupBacklog: boolean;
+  labels: readonly string[] | null;
+  recordedModel?: string;
+  autonomousModel?: string;
+  workhorses: NormalizedConfig['workhorses'];
+}
+
+export type AutonomousPlanDispatchDecision =
+  | {
+      allow: true;
+      model: string;
+      modelSource: 'recorded' | 'autonomousModel';
+    }
+  | {
+      allow: false;
+      code:
+        | 'not-released'
+        | 'parked'
+        | 'vetoed'
+        | 'objection'
+        | 'labels-unavailable'
+        | 'no-autonomous-model';
+      reason: string;
+    };
+
+export function decideAutonomousPlanDispatch(
+  input: AutonomousPlanDispatchInput,
+): AutonomousPlanDispatchDecision {
+  if (input.labels === null) {
+    return {
+      allow: false,
+      code: 'labels-unavailable',
+      reason:
+        'Autonomous planning dispatch was refused because tracker labels are unavailable, so parked, vetoed, and objection state cannot be verified. Restore label access or run pan plan manually.',
+    };
+  }
+
+  const labels = new Set(input.labels.map((label) => label.toLowerCase()));
+  const hasLabel = (label: string): boolean => labels.has(label);
+
+  if (hasLabel(PARKED_LABEL) || LEGACY_PARKED_LABELS.some(hasLabel)) {
+    return {
+      allow: false,
+      code: 'parked',
+      reason:
+        'Autonomous planning dispatch was refused because the issue is parked. Remove the parked label before releasing the issue or enabling auto-pickup, then set roles.plan.autonomousModel; alternatively, run pan plan manually.',
+    };
+  }
+
+  if (hasLabel(VETOED_LABEL)) {
+    return {
+      allow: false,
+      code: 'vetoed',
+      reason:
+        'Autonomous planning dispatch was refused because the issue is vetoed. Remove the veto before releasing the issue or enabling auto-pickup, then set roles.plan.autonomousModel; alternatively, run pan plan manually.',
+    };
+  }
+
+  if (hasLabel(OBJECTION_LABEL)) {
+    return {
+      allow: false,
+      code: 'objection',
+      reason:
+        'Autonomous planning dispatch was refused because the issue has an open objection. Resolve the objection before releasing the issue or enabling auto-pickup, then set roles.plan.autonomousModel; alternatively, run pan plan manually.',
+    };
+  }
+
+  if (!input.autoPickupBacklog && !hasLabel(RELEASED_LABEL)) {
+    return {
+      allow: false,
+      code: 'not-released',
+      reason:
+        'Autonomous planning dispatch was refused because the issue is not released and auto-pickup is disabled. Add the released label or enable auto-pickup, then set roles.plan.autonomousModel; alternatively, run pan plan manually.',
+    };
+  }
+
+  if (input.recordedModel) {
+    return {
+      allow: true,
+      model: input.recordedModel,
+      modelSource: 'recorded',
+    };
+  }
+
+  if (input.autonomousModel) {
+    try {
+      return {
+        allow: true,
+        model: derefWorkhorse(
+          input.autonomousModel,
+          { workhorses: input.workhorses },
+          'roles.plan.autonomousModel',
+        ),
+        modelSource: 'autonomousModel',
+      };
+    } catch {
+      // Invalid autonomous staffing is a policy refusal, not permission to fall
+      // through to the normal plan-role model.
+    }
+  }
+
+  return {
+    allow: false,
+    code: 'no-autonomous-model',
+    reason:
+      'Autonomous planning dispatch was refused because no recorded planning model or valid roles.plan.autonomousModel is available. Set roles.plan.autonomousModel or run pan plan manually; the issue must also be released or auto-pickup must be enabled for autonomous dispatch.',
+  };
+}

--- a/src/lib/cloister/autonomous-plan-dispatch.ts
+++ b/src/lib/cloister/autonomous-plan-dispatch.ts
@@ -8,7 +8,7 @@ import {
   VETOED_LABEL,
 } from '../backlog/pickup.js';
 import { derefWorkhorse, loadConfigSync, type NormalizedConfig } from '../config-yaml.js';
-import { isFlywheelAutoPickupBacklog } from '../database/app-settings.js';
+import { isFlywheelAutoPickupBacklog } from '../overdeck/control-settings.js';
 
 export interface AutonomousPlanDispatchInput {
   autoPickupBacklog: boolean;

--- a/src/lib/cloister/service-reactive.ts
+++ b/src/lib/cloister/service-reactive.ts
@@ -7,6 +7,11 @@ import type { Role } from '../agents.js';
 import { emitActivityEntrySync } from '../activity-logger.js';
 import { resolveProjectFromIssueSync } from '../projects.js';
 import { sessionExists, killSession } from '../tmux.js';
+import {
+  decideAutonomousPlanDispatch,
+  gatherAutonomousPlanDispatchInput,
+} from './autonomous-plan-dispatch.js';
+import { recordDeadEndNeedsYou } from './dead-end-trip.js';
 import { isIssueClosed } from './issue-closed.js';
 import { shouldSkipDispatchAsMerged } from './merge-verification.js';
 
@@ -302,6 +307,32 @@ async function resolveWorkspaceForIssue(issueId: string): Promise<string | null>
     }
 
     const { spawnRun } = await import('../agents.js');
+    if (role === 'plan') {
+      const decision = decideAutonomousPlanDispatch(
+        await gatherAutonomousPlanDispatchInput(normalizedIssueId),
+      );
+      if (!decision.allow) {
+        const message = `${normalizedIssueId}: ${decision.reason}`;
+        console.log(`[cloister] ${message}`);
+        emitActivityEntrySync({ source: 'cloister', level: 'warn', message, issueId: normalizedIssueId });
+        await recordDeadEndNeedsYou(
+          normalizedIssueId,
+          'autonomous-plan-dispatch',
+          newState,
+          message,
+        );
+        return;
+      }
+      const run = await spawnRun(normalizedIssueId, 'plan', {
+        prompt: buildReactiveRolePrompt(normalizedIssueId, newState, 'plan'),
+        model: decision.model,
+      });
+      const message = `${normalizedIssueId}: ${role} role started from lifecycle state '${newState}' as ${run.id}`;
+      console.log(`[cloister] ${message}`);
+      emitActivityEntrySync({ source: 'cloister', level: 'info', message, issueId: normalizedIssueId });
+      return;
+    }
+
     const run = await spawnRun(normalizedIssueId, role, {
       prompt: buildReactiveRolePrompt(normalizedIssueId, newState, role),
     });

--- a/src/lib/config-yaml/__tests__/planning-config.test.ts
+++ b/src/lib/config-yaml/__tests__/planning-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { mergeConfigs } from '../merge.js';
+import { DEFAULT_ROLES } from '../roles.js';
 import type { YamlConfig } from '../schema.js';
 
 describe('planning.default_mode config (PAN-2407)', () => {
@@ -35,5 +36,54 @@ describe('planning.default_mode config (PAN-2407)', () => {
     const { config: normalized } = mergeConfigs(config);
 
     expect(normalized.planning).toBeUndefined();
+  });
+});
+
+describe('roles.plan.autonomousModel config', () => {
+  it('round-trips a scalar workhorse reference', () => {
+    const config = {
+      roles: {
+        plan: {
+          autonomousModel: 'workhorse:cheap',
+        },
+      },
+    } as unknown as YamlConfig;
+
+    const { config: normalized } = mergeConfigs(config);
+
+    expect(normalized.roles?.plan?.autonomousModel).toBe('workhorse:cheap');
+  });
+
+  it('does not inject an autonomous planning model by default', () => {
+    const { config: normalized } = mergeConfigs({} as YamlConfig);
+
+    expect(normalized.roles?.plan?.autonomousModel).toBeUndefined();
+    expect(DEFAULT_ROLES.plan).not.toHaveProperty('autonomousModel');
+  });
+
+  it('rejects a dangling workhorse reference with the field path', () => {
+    const config = {
+      roles: {
+        plan: {
+          autonomousModel: 'workhorse:nonexistent',
+        },
+      },
+    } as unknown as YamlConfig;
+
+    expect(() => mergeConfigs(config)).toThrow('roles.plan.autonomousModel');
+  });
+
+  it('rejects a model distribution', () => {
+    const config = {
+      roles: {
+        plan: {
+          autonomousModel: [{ model: 'workhorse:cheap', weight: 100 }],
+        },
+      },
+    } as unknown as YamlConfig;
+
+    expect(() => mergeConfigs(config)).toThrow(
+      'roles.plan.autonomousModel must be a scalar model reference',
+    );
   });
 });

--- a/src/lib/config-yaml/roles.ts
+++ b/src/lib/config-yaml/roles.ts
@@ -282,6 +282,9 @@ function validateRoleFields(role: Role, roleConfig: RoleConfig): void {
       }
     }
   }
+  if (roleConfig.autonomousModel !== undefined && typeof roleConfig.autonomousModel !== 'string') {
+    throw new Error(`config.yaml: roles.${role}.autonomousModel must be a scalar model reference`);
+  }
   if (roleConfig.harness !== undefined && roleConfig.harness !== 'claude-code' && roleConfig.harness !== 'ohmypi' && roleConfig.harness !== 'codex') {
     throw new Error(`config.yaml: roles.${role}.harness must be claude-code, ohmypi, or codex`);
   }
@@ -325,6 +328,9 @@ export function validateRoleModelRefs(config: NormalizedConfig): void {
 
   for (const [role, roleConfig] of Object.entries(config.roles ?? {}) as Array<[Role, RoleConfig]>) {
     validateRoleFields(role, roleConfig);
+    if (typeof roleConfig.autonomousModel === 'string') {
+      derefWorkhorse(roleConfig.autonomousModel, config, `roles.${role}.autonomousModel`);
+    }
     if (Array.isArray(roleConfig.model)) {
       // Validate each distribution entry's model ref is resolvable.
       for (let i = 0; i < roleConfig.model.length; i++) {

--- a/src/lib/config-yaml/schema.ts
+++ b/src/lib/config-yaml/schema.ts
@@ -365,6 +365,8 @@ export type FlywheelScope = 'pan-only' | 'all-tracked-projects';
 
 export interface RoleConfig {
   model: RoleModelRef;
+  /** Explicit scalar staffing model for autonomous planning dispatch. */
+  autonomousModel?: RoleModelRef;
   harness?: 'claude-code' | 'ohmypi' | 'codex';
   effort?: RoleEffort;
   mode?: ReviewMode;


### PR DESCRIPTION
**Issue:** #2445

## Acceptance Criteria

- [ ] Pure autonomous-plan-dispatch decision module with unit test matrix
- [ ] Add roles.plan.autonomousModel config field with fail-loud validation and no default
- [ ] Wire posture gate + staffing into the reactive scheduler's plan dispatch with needs-you refusal
- [ ] Document autonomous planning gate and roles.plan.autonomousModel in MODEL-CALLS.md and FLYWHEEL.md