### PR TITLE
PAN-2865

### DIFF
--- a/src/dashboard/server/routes/__tests__/jsonl-resolver.test.ts
+++ b/src/dashboard/server/routes/__tests__/jsonl-resolver.test.ts
@@ -15,6 +15,8 @@ import { encodeClaudeProjectDir } from '../../../../lib/paths.js';
 
 const AGENT_ID = 'agent-pan-830';
 const WORKSPACE_PATH = '/home/testuser/Projects/overdeck/workspaces/feature-pan-830';
+const STRIKE_AGENT_ID = 'strike-pan-2857';
+const STRIKE_WORKSPACE_PATH = '/home/testuser/Projects/overdeck/workspaces/feature-pan-2857-strike';
 const CLAUDE_SESSION_ID = '9d08794c-3973-4f83-92cf-234ae618258a';
 
 let testDir: string;
@@ -182,6 +184,32 @@ describe('resolveJsonlPath (PAN-830)', () => {
     });
 
     expect(path).toBe(join(projectDir, `${CLAUDE_SESSION_ID}.jsonl`));
+  });
+
+  it('prefers a stopped strike agent recorded workspace over the caller convention path', async () => {
+    const diagnostics: string[] = [];
+    const strikeAgentDir = join(agentsDir, STRIKE_AGENT_ID);
+    const projectDir = join(claudeProjectsDir, encodeClaudeProjectDir(STRIKE_WORKSPACE_PATH));
+    const jsonlPath = join(projectDir, `${CLAUDE_SESSION_ID}.jsonl`);
+    await mkdir(strikeAgentDir, { recursive: true });
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(join(strikeAgentDir, 'state.json'), JSON.stringify({
+      harness: 'claude-code',
+      status: 'stopped',
+      workspace: STRIKE_WORKSPACE_PATH,
+    }));
+    await writeFile(join(strikeAgentDir, 'session.id'), CLAUDE_SESSION_ID);
+    await writeFile(jsonlPath, '{"type":"event"}\n');
+
+    const path = await resolveJsonlPath(STRIKE_AGENT_ID, '/home/testuser/Projects/overdeck/workspaces/feature-pan-2857', {
+      agentsDirOverride: agentsDir,
+      claudeProjectsDirOverride: claudeProjectsDir,
+      logDiagnostic: (_agentId, message) => diagnostics.push(message),
+    });
+
+    expect(path).toBe(jsonlPath);
+    expect(diagnostics).toEqual([expect.stringContaining(`resolved harness=claude-code sessionId=${CLAUDE_SESSION_ID}`)]);
+    expect(diagnostics.join('\n')).not.toContain('jsonl-missing');
   });
 
   it('returns null when claudeSessionId resolves but file does not exist', async () => {

--- a/src/dashboard/server/routes/jsonl-resolver.ts
+++ b/src/dashboard/server/routes/jsonl-resolver.ts
@@ -393,8 +393,10 @@ export async function resolveJsonlPath(
     return null;
   }
 
+  const recordedWorkspace = (await readRecordedState(agentId, opts)).workspace;
+  const effectiveWorkspacePath = recordedWorkspace ?? workspacePath;
   const projectsRoot = opts.claudeProjectsDirOverride ?? join(homedir(), '.claude', 'projects');
-  const encodedDir = encodeClaudeProjectDir(workspacePath);
+  const encodedDir = encodeClaudeProjectDir(effectiveWorkspacePath);
   const jsonlPath = join(projectsRoot, encodedDir, `${claudeSessionId}.jsonl`);
   if (await pathExists(jsonlPath)) {
     logTranscriptResolution(
@@ -409,7 +411,7 @@ export async function resolveJsonlPath(
     agentId,
     `missing-jsonl:${jsonlPath}`,
     `failed harness=${harness ?? 'claude-code'} reason=jsonl-missing sessionId=${claudeSessionId} `
-      + `workspace=${workspacePath} expectedPath=${jsonlPath}`,
+      + `workspace=${effectiveWorkspacePath} expectedPath=${jsonlPath}`,
     opts,
   );
   return null;

--- a/src/dashboard/server/routes/projects.ts
+++ b/src/dashboard/server/routes/projects.ts
@@ -150,9 +150,9 @@ export function getSessionTreeWorkspacePath(
   projectPath: string,
   sessionId: string,
 ): string {
+  if (sessionId.toLowerCase() === `strike-${issueLower.toLowerCase()}`) return join(projectPath, 'workspaces', `feature-${issueLower}-strike`);
   const slotNumber = getSlotWorkSessionNumber(sessionId, issueLower);
-  if (slotNumber === null) return baseWorkspacePath;
-  return join(projectPath, 'workspaces', `feature-${issueLower}-slot-${slotNumber}`);
+  return slotNumber === null ? baseWorkspacePath : join(projectPath, 'workspaces', `feature-${issueLower}-slot-${slotNumber}`);
 }
 
 export function compareSessionTreeSessionIds(a: string, b: string, issueLower: string): number {

--- a/src/lib/agent-enrichment.ts
+++ b/src/lib/agent-enrichment.ts
@@ -181,13 +181,19 @@ function getProjectPathByPrefix(issuePrefix: string): string {
     const trimmed = paneCwd.trim()
     if (trimmed && existsSync(trimmed)) return trimmed
   } catch {}
-  const issueId = agentId.replace(/^(agent-|planning-)/, '').toUpperCase()
+  const isStrikeAgent = agentId.startsWith('strike-')
+  const issueId = agentId.replace(/^(agent-|planning-|strike-)/, '').toUpperCase()
   const prefix = extractPrefixSync(issueId)
   if (!prefix) return null
   try {
     const projectPath = getProjectPathByPrefix(prefix)
-    const workspacePath = join(projectPath, 'workspaces', `feature-${issueId.toLowerCase()}`)
-    if (existsSync(workspacePath)) return workspacePath
+    const workspaceNames = isStrikeAgent
+      ? [`feature-${issueId.toLowerCase()}-strike`, `feature-${issueId.toLowerCase()}`]
+      : [`feature-${issueId.toLowerCase()}`]
+    for (const workspaceName of workspaceNames) {
+      const workspacePath = join(projectPath, 'workspaces', workspaceName)
+      if (existsSync(workspacePath)) return workspacePath
+    }
     return projectPath
   } catch {
     return null

--- a/tests/lib/agent-enrichment-jsonl-identity.test.ts
+++ b/tests/lib/agent-enrichment-jsonl-identity.test.ts
@@ -20,6 +20,8 @@ const fakeHome = mkdtempSync(join(tmpdir(), 'pan-jsonl-identity-'));
 
 /** Agent id → its own pinned session id, as `session.id` on disk would report. */
 const ownSessionIds = new Map<string, string>();
+const recordedWorkspaces = new Map<string, string | null>();
+const PROJECT_ROOT = join(fakeHome, 'Projects', 'overdeck');
 
 vi.mock('os', async (importOriginal) => {
   const actual = await importOriginal<typeof import('os')>();
@@ -30,7 +32,21 @@ vi.mock('os', async (importOriginal) => {
 // whole two-door state stack, which this test says nothing about.
 vi.mock('../../src/lib/agents.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/lib/agents.js')>();
-  return { ...actual, getAgentStateSync: (id: string) => ({ id, workspace: WORKSPACE }) };
+  return {
+    ...actual,
+    getAgentStateSync: (id: string) => {
+      const workspace = recordedWorkspaces.has(id) ? recordedWorkspaces.get(id) : WORKSPACE;
+      return workspace ? { id, workspace } : null;
+    },
+  };
+});
+
+vi.mock('../../src/lib/projects.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/lib/projects.js')>();
+  return {
+    ...actual,
+    resolveProjectFromIssueSync: () => ({ projectPath: PROJECT_ROOT }),
+  };
 });
 
 vi.mock('../../src/lib/agents/activity.js', async (importOriginal) => {
@@ -42,7 +58,7 @@ const WORKSPACE = '/home/eltmon/Projects/overdeck';
 const OWN_SESSION = '5f5168f3-7e17-4aed-9fe2-2bbb622e4acd';
 const OTHER_SESSION = 'ceba1402-1e09-436f-aa3d-6dd2b6a4c202';
 
-const { getAgentJsonlPath, getClaudeProjectDir } = await import('../../src/lib/agent-enrichment.js');
+const { getAgentJsonlPath, getAgentWorkspace, getClaudeProjectDir } = await import('../../src/lib/agent-enrichment.js');
 const { Effect } = await import('effect');
 
 /** Populate the shared project dir; `newest` gets the latest mtime. */
@@ -59,10 +75,24 @@ beforeEach(() => {
   rmSync(fakeHome, { recursive: true, force: true });
   mkdirSync(fakeHome, { recursive: true });
   ownSessionIds.clear();
+  recordedWorkspaces.clear();
 });
 
 afterEach(() => {
   rmSync(fakeHome, { recursive: true, force: true });
+});
+
+describe('getAgentWorkspace()', () => {
+  it('derives the strike layout when recorded state and tmux are unavailable', async () => {
+    const strikeWorkspace = join(PROJECT_ROOT, 'workspaces', 'feature-pan-2857-strike');
+    mkdirSync(join(PROJECT_ROOT, 'workspaces', 'feature-pan-2857'), { recursive: true });
+    mkdirSync(strikeWorkspace, { recursive: true });
+    recordedWorkspaces.set('strike-pan-2857', null);
+
+    const resolved = await Effect.runPromise(getAgentWorkspace('strike-pan-2857'));
+
+    expect(resolved).toBe(strikeWorkspace);
+  });
 });
 
 describe('getAgentJsonlPath()', () => {

--- a/tests/unit/dashboard/server/routes/projects.test.ts
+++ b/tests/unit/dashboard/server/routes/projects.test.ts
@@ -83,7 +83,11 @@ vi.mock('../../../../../src/lib/vbrief/io.js', () => ({
   isPlanningComplete: mockIsPlanningComplete,
 }));
 
-import { fetchProjectSessionTree, getSlotWorkSessionNumber } from '../../../../../src/dashboard/server/routes/projects.ts';
+import {
+  fetchProjectSessionTree,
+  getSessionTreeWorkspacePath,
+  getSlotWorkSessionNumber,
+} from '../../../../../src/dashboard/server/routes/projects.ts';
 import { listProjectsSync } from '../../../../../src/lib/projects.js';
 import { listSessionNames } from '../../../../../src/lib/tmux.js';
 import { getAgentRuntimeState } from '../../../../../src/lib/agents.js';
@@ -163,6 +167,15 @@ describe('fetchProjectSessionTree', () => {
     expect(getSlotWorkSessionNumber('agent-pan-2203-slot-1', 'pan-2203')).toBe(1);
     expect(getSlotWorkSessionNumber('agent-pan-2203-slot-2', 'pan-2203')).toBe(2);
     expect(getSlotWorkSessionNumber('agent-pan-2203-2', 'pan-2203')).toBeNull();
+  });
+
+  it('derives the strike workspace for strike session tree nodes', () => {
+    expect(getSessionTreeWorkspacePath(
+      'pan-2857',
+      '/tmp/overdeck/workspaces/feature-pan-2857',
+      '/tmp/overdeck',
+      'strike-pan-2857',
+    )).toBe('/tmp/overdeck/workspaces/feature-pan-2857-strike');
   });
 
   it('aggregates sessions for active feature workspaces', async () => {


### PR DESCRIPTION
**Issue:** #2865


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transcript discovery for strike sessions by using the workspace recorded in the session state when available.
  - Correctly resolves strike session tree paths to their dedicated strike workspaces.
  - Improved workspace detection for strike agents, including fallback handling for alternate workspace layouts.
  - Reduced false “JSONL missing” diagnostics when the session transcript is available.

- **Tests**
  - Added coverage for strike workspace selection, session paths, and transcript resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->