### PR TITLE
PAN-2869: shared harness-binary resolver — fix false 'missing claude' + conversation execvp on PATH-degraded launches

### DIFF
--- a/src/dashboard/server/routes/__tests__/conversations-supervisor.test.ts
+++ b/src/dashboard/server/routes/__tests__/conversations-supervisor.test.ts
@@ -12,6 +12,7 @@ import { dirname, join } from 'node:path';
 let overdeckHome: string;
 let channelsEnabled = false;
 let createSupervisorSocket = false;
+let resolvedHarnessBinary: string | null = '/usr/bin/claude';
 let dismissDevChannelsDialogMock: ReturnType<typeof vi.fn>;
 let createSessionCalls: Array<{ session: string; command: string }> = [];
 
@@ -29,6 +30,22 @@ vi.mock('../../../../lib/agents.js', () => {
     getProviderAuthMode: vi.fn().mockResolvedValue('anthropic'),
   };
 });
+
+vi.mock('../../../../lib/harness-binary.js', () => ({
+  prepareHarnessLaunch: vi.fn(async (harness: string) => {
+    if (!resolvedHarnessBinary) {
+      const name = harness === 'claude-code' ? 'Claude Code' : harness === 'ohmypi' ? 'OhMyPi' : 'Codex CLI';
+      throw new Error(
+        `${name} executable was not found. Install ${name} or add its installation directory to PATH, then restart Overdeck. No terminal session was created.`,
+      );
+    }
+    const directory = dirname(resolvedHarnessBinary);
+    return {
+      binaryPath: resolvedHarnessBinary,
+      pathExport: `export PATH='${directory}':"$PATH"`,
+    };
+  }),
+}));
 
 vi.mock('../../../../lib/config-yaml.js', () => ({
   isClaudeCodeChannelsEnabled: vi.fn(() => channelsEnabled),
@@ -108,6 +125,7 @@ describe('spawnConversationSession PTY supervisor wiring', () => {
     delete process.env.PAN_DOCKER;
     delete process.env.OVERDECK_DOCKER_WORKSPACE;
     createSupervisorSocket = false;
+    resolvedHarnessBinary = '/usr/bin/claude';
     createSessionCalls = [];
   });
 
@@ -119,8 +137,9 @@ describe('spawnConversationSession PTY supervisor wiring', () => {
     delete process.env.OVERDECK_DOCKER_WORKSPACE;
   });
 
-  it('wraps Claude Code conversations with the PTY supervisor and waits for its socket', async () => {
+  it('launches a PATH-invisible Claude binary through the shared resolver', async () => {
     createSupervisorSocket = true;
+    resolvedHarnessBinary = '/home/test/.local/bin/claude';
     const { spawnConversationSession } = await import('../../../../lib/overdeck/conversation-runtime.js');
 
     await spawnConversationSession(
@@ -135,12 +154,40 @@ describe('spawnConversationSession PTY supervisor wiring', () => {
     );
 
     const launcher = launcherFor('conv-supervisor-test');
+    expect(launcher).toContain("export PATH='/home/test/.local/bin':\"$PATH\"");
     expect(launcher).toContain("export OVERDECK_AGENT_ID='conv-supervisor-test'");
     expect(launcher).toContain("node '");
     expect(launcher).toContain("/dist/pty-supervisor.js' claude --model claude-sonnet-4-6");
     expect(existsSync(join(overdeckHome, 'agents', 'conv-supervisor-test', 'pty-token'))).toBe(true);
     expect((statSync(join(overdeckHome, 'sockets', 'pty-conv-supervisor-test.sock')).mode & 0o777)).toBe(0o600);
     expect(dismissDevChannelsDialogMock).not.toHaveBeenCalled();
+  });
+
+  it('reports a missing harness before creating a tmux session', async () => {
+    resolvedHarnessBinary = null;
+    const { spawnConversationSession } = await import('../../../../lib/overdeck/conversation-runtime.js');
+
+    let error: unknown;
+    try {
+      await spawnConversationSession(
+        'conv-missing-harness-test',
+        tmpdir(),
+        'session-missing-harness-test',
+        'claude-sonnet-4-6',
+        undefined,
+        'PAN-2869',
+        false,
+        'claude-code',
+      );
+    } catch (cause) {
+      error = cause;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('Install Claude Code or add its installation directory to PATH');
+    expect((error as Error).message).not.toContain('execvp');
+    expect(createSessionCalls).toEqual([]);
+    expect(existsSync(conversationDir('conv-missing-harness-test'))).toBe(false);
   });
 
   it('launches Codex app-server conversations without the PTY supervisor', async () => {

--- a/src/dashboard/server/routes/misc/planning.ts
+++ b/src/dashboard/server/routes/misc/planning.ts
@@ -10,6 +10,7 @@ import { getClaudePermissionFlagsStringSync } from '../../../../lib/claude-permi
 import { loadConfigSync as loadYamlConfig, resolveModel } from '../../../../lib/config-yaml.js';
 import { workspaceContextFile } from '../../../../lib/context-layers/layers.js';
 import { extractPrefixSync } from '../../../../lib/issue-id.js';
+import { prepareHarnessLaunch } from '../../../../lib/harness-binary.js';
 import { generateLauncherScriptSync } from '../../../../lib/launcher-generator.js';
 import { PAN_CONTINUE_FILENAME, PAN_DIRNAME } from '../../../../lib/pan-dir/types.js';
 import { extractTeamPrefix, findProjectByTeamSync } from '../../../../lib/projects.js';
@@ -271,6 +272,7 @@ Continue the PLANNING session. Do NOT implement anything.
         await writeFile(continuationPromptPath, continuationPrompt);
 
         const agentCwd = workspacePath;
+        const harnessLaunch = await prepareHarnessLaunch('claude-code');
 
         if (existsSync(outputFile)) {
           const backupPath = join(planningDir, `output-${Date.now()}.jsonl`);
@@ -298,6 +300,7 @@ Continue the PLANNING session. Do NOT implement anything.
             role: 'plan',
             workingDir: agentCwd,
             baseCommand: msgCmdWithArgs,
+            extraEnvExports: [harnessLaunch.pathExport],
             appendSystemPromptFiles: await claudePlanningSystemPromptFiles(agentCwd),
             promptInline: `Please read the continuation prompt at ${continuationPromptPath} and continue the planning session.`,
           }),

--- a/src/lib/__tests__/agent-state-role.test.ts
+++ b/src/lib/__tests__/agent-state-role.test.ts
@@ -5,6 +5,23 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Effect } from 'effect';
 import type { AgentState } from '../agents.js';
 
+// Spawn/resume flows preflight the harness binary; CI runners have no claude/omp
+// installed, so stub the filesystem probes while keeping the pure helpers real.
+vi.mock('../harness-binary.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../harness-binary.js')>();
+  const fakePath = (harness: Parameters<typeof actual.harnessBinaryName>[0]) =>
+    `/home/test/.local/bin/${actual.harnessBinaryName(harness)}`;
+  return {
+    ...actual,
+    resolveHarnessBinary: vi.fn(async (harness) => fakePath(harness)),
+    requireHarnessBinary: vi.fn(async (harness) => fakePath(harness)),
+    prepareHarnessLaunch: vi.fn(async (harness) => ({
+      binaryPath: fakePath(harness),
+      pathExport: `export PATH='/home/test/.local/bin':"$PATH"`,
+    })),
+  };
+});
+
 let tempHome: string;
 
 function ensurePtySupervisorArtifact(): void {

--- a/src/lib/__tests__/agents-spawn-supervisor.test.ts
+++ b/src/lib/__tests__/agents-spawn-supervisor.test.ts
@@ -13,6 +13,7 @@ let packageRootDir: string;
 let createSessionMock: ReturnType<typeof vi.fn>;
 let sendRawKeystrokeMock: ReturnType<typeof vi.fn>;
 let resolveHarnessMock: ReturnType<typeof vi.fn>;
+let prepareHarnessLaunchMock: ReturnType<typeof vi.fn>;
 let emitAgentEventMock: ReturnType<typeof vi.fn>;
 let ensureLifecycleHooksMock: ReturnType<typeof vi.fn>;
 let capturePaneText: string;
@@ -49,12 +50,19 @@ function mockSpawnDependencies(): void {
   resolveHarnessMock = vi.fn(async ({ explicit, model }: { explicit?: string; model: string }) => {
     if (explicit) return explicit;
     if (model === 'gpt-5.5') return 'codex';
-    if (model === 'kimi-k2.6') return 'pi';
+    if (model === 'kimi-k2.6') return 'ohmypi';
     return 'claude-code';
   });
+  prepareHarnessLaunchMock = vi.fn(async (harness: string) => ({
+    binaryPath: `/home/test/.local/bin/${harness === 'claude-code' ? 'claude' : harness === 'ohmypi' ? 'omp' : 'codex'}`,
+    pathExport: `export PATH='/home/test/.local/bin':"$PATH"`,
+  }));
 
   vi.doMock('../harness-resolve.js', () => ({
     resolveHarness: resolveHarnessMock,
+  }));
+  vi.doMock('../harness-binary.js', () => ({
+    prepareHarnessLaunch: prepareHarnessLaunchMock,
   }));
   vi.doMock('../agent-runtime.js', () => ({
     emitAgentEvent: emitAgentEventMock,
@@ -196,6 +204,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.doUnmock('../harness-resolve.js');
+  vi.doUnmock('../harness-binary.js');
   vi.doUnmock('../agent-runtime.js');
   vi.doUnmock('../agents/hook-readiness.js');
   vi.doUnmock('../agent-runtime-mirror.js');
@@ -385,9 +394,11 @@ describe('spawnAgent PTY supervisor wiring', () => {
       });
 
       expect(openaiState.harness).toBe('codex');
-      expect(kimiState.harness).toBe('pi');
+      expect(kimiState.harness).toBe('ohmypi');
       expect(resolveHarnessMock).toHaveBeenCalledWith({ explicit: undefined, role: 'work', model: 'gpt-5.5' });
       expect(resolveHarnessMock).toHaveBeenCalledWith({ explicit: undefined, role: 'work', model: 'kimi-k2.6' });
+      expect(prepareHarnessLaunchMock).toHaveBeenCalledWith('codex');
+      expect(prepareHarnessLaunchMock).toHaveBeenCalledWith('ohmypi');
     } finally {
       delete process.env.KIMI_API_KEY;
     }

--- a/src/lib/__tests__/harness-binary.test.ts
+++ b/src/lib/__tests__/harness-binary.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  harnessPathExport,
+  prepareHarnessLaunch,
+  resolveExecutable,
+} from '../harness-binary.js';
+
+function executableAccess(executablePaths: readonly string[]) {
+  const executable = new Set(executablePaths);
+  return vi.fn(async (path: string) => {
+    if (!executable.has(path)) throw Object.assign(new Error('not executable'), { code: 'EACCES' });
+  });
+}
+
+describe('resolveExecutable', () => {
+  it('prefers the supplied PATH and returns an absolute executable path', async () => {
+    const accessExecutable = executableAccess(['/opt/tools/claude', '/home/test/.local/bin/claude']);
+    const runCommand = vi.fn();
+
+    await expect(resolveExecutable('claude', {
+      pathValue: '/opt/tools:/usr/bin',
+      home: '/home/test',
+      accessExecutable,
+      runCommand,
+    })).resolves.toBe('/opt/tools/claude');
+
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['~/.local/bin', '/home/test/.local/bin/claude'],
+    ['~/.claude/local', '/home/test/.claude/local/claude'],
+    ['~/.npm-global/bin', '/home/test/.npm-global/bin/claude'],
+    ['~/.bun/bin', '/home/test/.bun/bin/claude'],
+  ])('finds an executable in %s when the server PATH omits it', async (_label, candidate) => {
+    const runCommand = vi.fn(async (command: string) => command === 'npm' ? '/opt/npm-prefix\n' : '');
+
+    await expect(resolveExecutable('claude', {
+      pathValue: '/usr/bin',
+      home: '/home/test',
+      accessExecutable: executableAccess([candidate]),
+      runCommand,
+      allowLoginShell: false,
+    })).resolves.toBe(candidate);
+  });
+
+  it('checks the global npm prefix between npm-global and Bun', async () => {
+    const attempts: string[] = [];
+    const accessExecutable = vi.fn(async (path: string) => {
+      attempts.push(path);
+      if (path !== '/opt/npm-prefix/bin/claude') throw new Error('missing');
+    });
+    const runCommand = vi.fn(async () => '/opt/npm-prefix\n');
+
+    await expect(resolveExecutable('claude', {
+      pathValue: '/usr/bin',
+      home: '/home/test',
+      accessExecutable,
+      runCommand,
+      allowLoginShell: false,
+    })).resolves.toBe('/opt/npm-prefix/bin/claude');
+
+    expect(attempts).toEqual([
+      '/usr/bin/claude',
+      '/home/test/.local/bin/claude',
+      '/home/test/.claude/local/claude',
+      '/home/test/.npm-global/bin/claude',
+      '/opt/npm-prefix/bin/claude',
+    ]);
+  });
+
+  it('uses the login shell only after all directory candidates fail', async () => {
+    const runCommand = vi.fn(async (command: string, args: string[]) => {
+      if (command === 'npm') throw new Error('npm missing');
+      expect(command).toBe('/bin/zsh');
+      expect(args).toEqual(['-lc', 'command -v claude']);
+      return '/custom/login/bin/claude\n';
+    });
+
+    await expect(resolveExecutable('claude', {
+      pathValue: '/usr/bin',
+      home: '/home/test',
+      shell: '/bin/zsh',
+      accessExecutable: executableAccess(['/custom/login/bin/claude']),
+      runCommand,
+    })).resolves.toBe('/custom/login/bin/claude');
+  });
+
+  it('rejects relative and non-executable login-shell results', async () => {
+    const runCommand = vi.fn(async (command: string) => command === 'npm' ? '' : 'aliases/claude\n');
+
+    await expect(resolveExecutable('claude', {
+      pathValue: '',
+      home: '/home/test',
+      shell: '/bin/sh',
+      accessExecutable: executableAccess([]),
+      runCommand,
+    })).resolves.toBeNull();
+  });
+});
+
+describe('prepareHarnessLaunch', () => {
+  it('returns a launcher PATH export for the resolved harness directory', async () => {
+    await expect(prepareHarnessLaunch('claude-code', {
+      pathValue: '/usr/bin',
+      home: '/home/test',
+      accessExecutable: executableAccess(['/home/test/.local/bin/claude']),
+      runCommand: vi.fn(async () => ''),
+      allowLoginShell: false,
+    })).resolves.toEqual({
+      binaryPath: '/home/test/.local/bin/claude',
+      pathExport: "export PATH='/home/test/.local/bin':\"$PATH\"",
+    });
+  });
+
+  it('throws an actionable error without raw exec output when the harness is absent', async () => {
+    let error: unknown;
+    try {
+      await prepareHarnessLaunch('claude-code', {
+        pathValue: '/usr/bin',
+        home: '/home/test',
+        accessExecutable: executableAccess([]),
+        runCommand: vi.fn(async () => { throw new Error('execvp(3) failed: No such file or directory'); }),
+        allowLoginShell: false,
+      });
+    } catch (cause) {
+      error = cause;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('Install Claude Code or add its installation directory to PATH');
+    expect((error as Error).message).not.toContain('execvp');
+  });
+
+  it('quotes harness directories in PATH exports', () => {
+    expect(harnessPathExport("/home/test/O'Reilly/bin/claude"))
+      .toBe("export PATH='/home/test/O'\\''Reilly/bin':\"$PATH\"");
+  });
+});

--- a/src/lib/__tests__/harness-resolve.test.ts
+++ b/src/lib/__tests__/harness-resolve.test.ts
@@ -20,15 +20,14 @@ vi.mock('../providers.js', () => ({
 }));
 vi.mock('../config-yaml.js', () => ({ loadConfigSync: configMock.loadConfigSync }));
 vi.mock('../agents.js', () => ({ getProviderAuthMode: vi.fn(async () => 'apikey') }));
-// Make `command -v omp` succeed so hasHarnessBinary('ohmypi') returns true in all tests.
+// Make the harness-binary probe succeed so hasHarnessBinary('ohmypi') returns
+// true in all tests regardless of what is installed on the host/CI runner.
 // Tests that never reach the binary check (they throw earlier) are unaffected.
-vi.mock('child_process', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('child_process')>();
+vi.mock('../harness-binary.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../harness-binary.js')>();
   return {
     ...actual,
-    exec: vi.fn((cmd: string, callback: (err: null | Error, stdout: string, stderr: string) => void) => {
-      callback(null, '/usr/local/bin/omp', '');
-    }),
+    resolveHarnessBinary: vi.fn(async (harness) => `/usr/local/bin/${actual.harnessBinaryName(harness)}`),
   };
 });
 

--- a/src/lib/__tests__/system-prerequisites.test.ts
+++ b/src/lib/__tests__/system-prerequisites.test.ts
@@ -5,8 +5,11 @@ import { collectSetupDiagnostics, checkSystemPrerequisites, PREREQUISITES } from
 // PAN-774: host-tool setup checklist served by GET /api/prerequisites.
 
 describe('checkSystemPrerequisites', () => {
-  it('reports found tools with their first version line', async () => {
-    const report = await checkSystemPrerequisites(async (cmd) => `${cmd} 1.2.3\nextra noise\n`);
+  const resolveAll = async (command: string) => `/resolved/bin/${command}`;
+
+  it('probes resolved absolute paths and reports their first version line', async () => {
+    const probe = async (cmd: string) => `${cmd.split('/').at(-1)} 1.2.3\nextra noise\n`;
+    const report = await checkSystemPrerequisites(probe, resolveAll);
 
     expect(report.allRequiredFound).toBe(true);
     expect(report.checks).toHaveLength(PREREQUISITES.length);
@@ -14,21 +17,36 @@ describe('checkSystemPrerequisites', () => {
     expect(tmux).toMatchObject({ found: true, version: 'tmux 1.2.3', required: true });
   });
 
-  it('flags missing required tools and keeps optional misses non-blocking', async () => {
-    const report = await checkSystemPrerequisites(async (cmd) => {
-      if (cmd === 'tmux') throw Object.assign(new Error('spawn tmux ENOENT'), { code: 'ENOENT' });
-      if (cmd === 'docker') throw Object.assign(new Error('spawn docker ENOENT'), { code: 'ENOENT' });
-      return `${cmd} 9.9.9`;
+  it('accepts Claude when the shared resolver finds it outside the server PATH', async () => {
+    const resolver = async (command: string) => command === 'claude'
+      ? '/home/test/.local/bin/claude'
+      : `/usr/bin/${command}`;
+    const probe = async (cmd: string) => `${cmd} 1.2.3`;
+
+    const report = await checkSystemPrerequisites(probe, resolver);
+
+    expect(report.checks.find((check) => check.id === 'claude')).toMatchObject({
+      found: true,
+      version: '/home/test/.local/bin/claude 1.2.3',
     });
+  });
+
+  it('flags missing required tools and keeps optional misses non-blocking', async () => {
+    const missingTmuxAndDocker = async (command: string) =>
+      command === 'tmux' || command === 'docker' ? null : `/resolved/bin/${command}`;
+    const report = await checkSystemPrerequisites(
+      async (cmd) => `${cmd} 9.9.9`,
+      missingTmuxAndDocker,
+    );
 
     expect(report.allRequiredFound).toBe(false);
     expect(report.checks.find((check) => check.id === 'tmux')).toMatchObject({ found: false, version: null });
     expect(report.checks.find((check) => check.id === 'docker')).toMatchObject({ found: false, required: false });
 
-    const onlyOptionalMissing = await checkSystemPrerequisites(async (cmd) => {
-      if (cmd === 'docker' || cmd === 'codex') throw new Error('ENOENT');
-      return `${cmd} 9.9.9`;
-    });
+    const onlyOptionalMissing = await checkSystemPrerequisites(
+      async (cmd) => `${cmd} 9.9.9`,
+      async (command) => command === 'docker' || command === 'codex' ? null : `/resolved/bin/${command}`,
+    );
     expect(onlyOptionalMissing.allRequiredFound).toBe(true);
   });
 

--- a/src/lib/agents/messaging.ts
+++ b/src/lib/agents/messaging.ts
@@ -4,6 +4,7 @@ import { Effect } from 'effect';
 import { emitActivityEntrySync } from '../activity-logger.js';
 import { BLANKED_PROVIDER_ENV } from '../child-env.js';
 import { generateLauncherScriptSync } from '../launcher-generator.js';
+import { prepareHarnessLaunch } from '../harness-binary.js';
 import { appendOperatorInterventionEvent } from '../operator-interventions.js';
 import { logAgentLifecycleSync } from '../persistent-logger.js';
 import { getProviderForModelSync, setupCredentialFileAuthSync, clearCredentialFileAuthSync } from '../providers.js';
@@ -240,6 +241,7 @@ export async function messageAgent(
     // emitted a launcher that would crash on resume for any Pi role agent.
     const resumeModel = agentState.model || 'claude-sonnet-4-6';
     const fallbackHarness = agentState.harness ?? 'claude-code';
+    const harnessLaunch = await prepareHarnessLaunch(fallbackHarness);
     const { assertWorkspaceStackHealthyForSpawn } = await import('../agents.js');
     await assertWorkspaceStackHealthyForSpawn(
       agentState.issueId || normalizedId.replace(/^agent-/, '').toUpperCase(),
@@ -260,6 +262,7 @@ export async function messageAgent(
       changeDir: false,
       setTerminalEnv: true,
       providerExports,
+      extraEnvExports: [harnessLaunch.pathExport],
       baseCommand: await getRoleRuntimeBaseCommand(
         resumeModel,
         normalizedId,

--- a/src/lib/agents/recovery.ts
+++ b/src/lib/agents/recovery.ts
@@ -7,6 +7,7 @@ import { sendGracefulRestartWarning } from '../graceful-restart.js';
 import { checkHookSync, generateFixedPointPromptSync } from '../hooks.js';
 import { generateLauncherScriptSync } from '../launcher-generator.js';
 import { resolveHarness } from '../harness-resolve.js';
+import { prepareHarnessLaunch } from '../harness-binary.js';
 import { normalizeModelOverrideSync, requireModelOverrideSync } from '../model-validation.js';
 import { logAgentLifecycleSync } from '../persistent-logger.js';
 import { getProviderForModelSync, setupCredentialFileAuthSync, clearCredentialFileAuthSync } from '../providers.js';
@@ -99,18 +100,20 @@ export async function restartAgent(
     return { success: false, error: reason };
   }
 
-  if (graceful && await Effect.runPromise(sessionExists(normalizedId))) {
-    await sendGracefulRestartWarning(normalizedId, agentState.harness, agentState.workspace);
-  }
-
-  await Effect.runPromise(stopAgent(normalizedId));
-
   const effectiveModel = newModel || requireModelOverrideSync(agentState.model || 'claude-sonnet-4-6');
   const effectiveHarness = await resolveHarness({
     explicit: newHarness ?? agentState.harness,
     role: agentState.role,
     model: effectiveModel,
   });
+  const harnessLaunch = await prepareHarnessLaunch(effectiveHarness);
+
+  if (graceful && await Effect.runPromise(sessionExists(normalizedId))) {
+    await sendGracefulRestartWarning(normalizedId, agentState.harness, agentState.workspace);
+  }
+
+  await Effect.runPromise(stopAgent(normalizedId));
+
   if (newModel && newModel !== agentState.model) {
     agentState.model = newModel;
   }
@@ -132,6 +135,7 @@ export async function restartAgent(
       harness: effectiveHarness,
       useSupervisor: supervisorLaunch.useSupervisor,
       supervisorScriptPath: supervisorLaunch.supervisorScriptPath,
+      extraEnvExports: [harnessLaunch.pathExport],
     });
 
     const launcherScript = join(getAgentDir(normalizedId), 'launcher.sh');
@@ -311,6 +315,7 @@ export async function recoverAgent(
   // and route through getRoleRuntimeBaseCommand so review/test/ship don't get
   // resurrected as work agents.
   const recoveryHarness: RuntimeName = normalizeHarness(state.harness ?? null) ?? 'claude-code';
+  const harnessLaunch = await prepareHarnessLaunch(recoveryHarness);
   const recoverySupervisorLaunch = await prepareSupervisorForRelaunch(normalizedId, state, state.model, recoveryHarness);
   saveAgentStateSync(state);
 
@@ -327,6 +332,7 @@ export async function recoverAgent(
       role: recoveryRole,
       isPlanning: recoveryRole === 'plan',
       harness: 'ohmypi',
+      extraEnvExports: [harnessLaunch.pathExport],
     });
     const launcherScript = join(getAgentDir(normalizedId), 'launcher.sh');
     await writeLauncherScriptAtomic(launcherScript, launcherContent);
@@ -361,6 +367,7 @@ export async function recoverAgent(
     changeDir: false,
     setTerminalEnv: true,
     providerExports: (await getProviderExportsForModel(state.model)).trimEnd(),
+    extraEnvExports: [harnessLaunch.pathExport],
     baseCommand: await getRoleRuntimeBaseCommand(state.model, normalizedId, recoveryRole, recoveryHarness),
     appendSystemPromptFiles: await claudeSystemPromptFiles(state.workspace, recoveryHarness),
     ...(recoveryHarness === 'codex' ? {} : { promptInline: recoveryPrompt }),

--- a/src/lib/agents/resume.ts
+++ b/src/lib/agents/resume.ts
@@ -6,6 +6,7 @@ import { emitActivityEntrySync } from '../activity-logger.js';
 import { BLANKED_PROVIDER_ENV } from '../child-env.js';
 import { buildCompactRecoverySeedMessage } from '../context-overflow.js';
 import { resolveHarness } from '../harness-resolve.js';
+import { prepareHarnessLaunch } from '../harness-binary.js';
 import { normalizeModelOverrideSync, requireModelOverrideSync } from '../model-validation.js';
 import { getOverdeckDatabaseSync } from '../overdeck/infra.js';
 import { sessionFilePath } from '../paths.js';
@@ -315,6 +316,7 @@ export async function resumeAgent(agentId: string, message?: string, opts?: { mo
       role: agentState.role,
       model,
     });
+    const harnessLaunch = await prepareHarnessLaunch(effectiveHarness);
     const legacyHarnessMigrated =
       !hasSessionOrigin && priorHarness !== undefined && priorHarness !== effectiveHarness;
     agentState.harness = effectiveHarness;
@@ -401,6 +403,7 @@ export async function resumeAgent(agentId: string, message?: string, opts?: { mo
       harness: effectiveHarness,
       useSupervisor: supervisorLaunch.useSupervisor,
       supervisorScriptPath: supervisorLaunch.supervisorScriptPath,
+      extraEnvExports: [harnessLaunch.pathExport],
     });
 
     const launcherScript = join(getAgentDir(normalizedId), 'launcher.sh');

--- a/src/lib/agents/spawn.ts
+++ b/src/lib/agents/spawn.ts
@@ -16,6 +16,7 @@ import { generateLauncherScriptSync } from '../launcher-generator.js';
 import { getProviderForModelSync, setupCredentialFileAuthSync, clearCredentialFileAuthSync } from '../providers.js';
 import { resetPipelineVerdictsForWorkStartSync } from '../review-status.js';
 import { resolveHarness } from '../harness-resolve.js';
+import { prepareHarnessLaunch } from '../harness-binary.js';
 import { assertCodexNativeAuthForSpawn } from '../codex-auth.js';
 import type { ModelId } from '../settings.js';
 import type { RuntimeName } from '../runtimes/types.js';
@@ -164,6 +165,7 @@ export async function spawnRun(issueId: string, role: Role, options: SpawnRunOpt
     role,
     model: selectedModel,
   });
+  const harnessLaunch = await prepareHarnessLaunch(resolvedHarness);
   // PAN-2285: never launch a fresh Codex agent when native Codex auth is
   // missing/expired/burned — it would wedge silently in a 401 loop.
   assertCodexNativeAuthForSpawn(resolvedHarness, listAgentStates());
@@ -318,7 +320,7 @@ export async function spawnRun(issueId: string, role: Role, options: SpawnRunOpt
   if (options.reviewSynthesisAgentId) state.reviewSynthesisAgentId = options.reviewSynthesisAgentId;
   if (options.reviewOutputPath) state.reviewOutputPath = options.reviewOutputPath;
 
-  const extraEnvExports = [...flywheelEnvExports(flywheelEnv), ...(options.extraEnvExports ?? [])];
+  const extraEnvExports = [harnessLaunch.pathExport, ...flywheelEnvExports(flywheelEnv), ...(options.extraEnvExports ?? [])];
   if (role === 'knowledge' && !extraEnvExports.includes('export PATH="$HOME/.overdeck/bin:$PATH"')) {
     extraEnvExports.push('export PATH="$HOME/.overdeck/bin:$PATH"');
   }
@@ -499,6 +501,7 @@ export async function spawnAgent(options: SpawnOptions): Promise<AgentState> {
     role,
     model: selectedModel,
   });
+  const harnessLaunch = await prepareHarnessLaunch(resolvedHarness);
   // PAN-2285: never launch a fresh Codex agent when native Codex auth is
   // missing/expired/burned — it would wedge silently in a 401 loop.
   assertCodexNativeAuthForSpawn(resolvedHarness, listAgentStates());
@@ -677,7 +680,7 @@ export async function spawnAgent(options: SpawnOptions): Promise<AgentState> {
     supervisorScriptPath: supervisorLaunch.supervisorScriptPath,
     harness: state.harness ?? 'claude-code',
     sessionId: state.sessionId,
-    extraEnvExports: flywheelEnvExports(flywheelEnv),
+    extraEnvExports: [harnessLaunch.pathExport, ...flywheelEnvExports(flywheelEnv)],
     effort: options.effort,
   });
 

--- a/src/lib/cloister/__tests__/inspect-agent.test.ts
+++ b/src/lib/cloister/__tests__/inspect-agent.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   loadConfigSync: vi.fn(),
   loadPrdDraft: vi.fn(),
   mkdirSync: vi.fn(),
+  prepareHarnessLaunch: vi.fn(),
   readFileSync: vi.fn(),
   readWorkspacePlanSync: vi.fn(),
   setReviewStatusSync: vi.fn(),
@@ -59,6 +60,10 @@ vi.mock('../../review-status.js', () => ({
 
 vi.mock('../../bd-mutex.js', () => ({
   withBdMutex: <T>(effect: T) => effect,
+}));
+
+vi.mock('../../harness-binary.js', () => ({
+  prepareHarnessLaunch: mocks.prepareHarnessLaunch,
 }));
 
 vi.mock('../../launcher-generator.js', () => ({
@@ -120,6 +125,10 @@ describe('spawnInspectAgent', () => {
     mocks.getDiffStats.mockReturnValue(Effect.succeed('diff stats'));
     mocks.getCurrentHead.mockReturnValue(Effect.succeed('fedcba9876543210'));
     mocks.getProviderEnvForModel.mockResolvedValue({});
+    mocks.prepareHarnessLaunch.mockResolvedValue({
+      binaryPath: '/home/test/.local/bin/claude',
+      pathExport: `export PATH='/home/test/.local/bin':"$PATH"`,
+    });
     mocks.generateLauncherScriptSync.mockReturnValue('#!/usr/bin/env bash\n');
     mocks.saveAgentState.mockReturnValue(Effect.succeed(undefined));
     mocks.loadConfigSync.mockReturnValue({ config: {} });
@@ -165,8 +174,11 @@ describe('spawnInspectAgent', () => {
       message: 'Spawned inspect for PAN-1613 item workspace-b95lw',
     }));
     expect(result.skipped).toBeUndefined();
+    expect(mocks.prepareHarnessLaunch).toHaveBeenCalledWith('claude-code');
     expect(mocks.sessionExists).toHaveBeenCalledWith('inspect-pan-1613-workspace-b95lw');
-    expect(mocks.generateLauncherScriptSync).toHaveBeenCalled();
+    expect(mocks.generateLauncherScriptSync).toHaveBeenCalledWith(expect.objectContaining({
+      extraEnvExports: [`export PATH='/home/test/.local/bin':"$PATH"`],
+    }));
     expect(mocks.createSession).toHaveBeenCalledWith(
       'inspect-pan-1613-workspace-b95lw',
       '/workspace',
@@ -178,6 +190,28 @@ describe('spawnInspectAgent', () => {
       inspectBeadId: 'workspace-b95lw',
       inspectOwnerSession: 'inspect-pan-1613-workspace-b95lw',
     }));
+  });
+
+  it('does not create a tmux session when Claude is missing', async () => {
+    mocks.prepareHarnessLaunch.mockRejectedValue(
+      new Error('Claude Code executable was not found. Install Claude Code or add its installation directory to PATH, then restart Overdeck. No terminal session was created.'),
+    );
+
+    const result = await Effect.runPromise(spawnInspectAgent({
+      projectKey: 'overdeck',
+      projectPath: '/repo',
+      issueId: 'PAN-2869',
+      itemId: 'workspace-b95lw',
+      workspace: '/workspace',
+    }));
+
+    expect(result).toEqual(expect.objectContaining({
+      success: false,
+      error: expect.stringContaining('Install Claude Code or add its installation directory to PATH'),
+    }));
+    expect(result.error).not.toContain('execvp');
+    expect(mocks.sessionExists).not.toHaveBeenCalled();
+    expect(mocks.createSession).not.toHaveBeenCalled();
   });
 
   it('writes a minimal state.json so the inspect agent is enumerable', async () => {

--- a/src/lib/cloister/inspect-agent.ts
+++ b/src/lib/cloister/inspect-agent.ts
@@ -22,6 +22,7 @@ import {
   saveCheckpoint,
 } from './inspect-checkpoints.js';
 import { setReviewStatusSync } from '../review-status.js';
+import { prepareHarnessLaunch } from '../harness-binary.js';
 import { generateLauncherScriptSync } from '../launcher-generator.js';
 import {
   createSession,
@@ -197,6 +198,8 @@ async function spawnInspectAgentPromise(
     const supervisorRoute = await routeInspectToStandingSupervisorIfEnabled(context);
     if (supervisorRoute) return supervisorRoute;
 
+    const harnessLaunch = await prepareHarnessLaunch('claude-code');
+
     if (await Effect.runPromise(sessionExists(tmuxSession))) {
       // Stale session left behind by a previous inspection run — clear it.
       await Effect.runPromise(killSession(tmuxSession)).catch(() => {});
@@ -240,6 +243,7 @@ async function spawnInspectAgentPromise(
         workingDir: context.workspace,
         setTerminalEnv: true,
         unsetProviderEnv: true,
+        extraEnvExports: [harnessLaunch.pathExport],
         providerExports: Object.entries(providerEnv)
           .map(([k, v]) => `export ${k}='${v.replace(/'/g, "'\"'\"'")}'`)
           .join('\n') + (Object.keys(providerEnv).length ? '\n' : ''),

--- a/src/lib/harness-binary.ts
+++ b/src/lib/harness-binary.ts
@@ -1,0 +1,163 @@
+import { execFile } from 'node:child_process';
+import { constants } from 'node:fs';
+import { access } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { delimiter, dirname, isAbsolute, join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+
+import type { RuntimeName } from './runtimes/types.js';
+
+const execFileAsync = promisify(execFile);
+const SAFE_BINARY_NAME = /^[A-Za-z0-9._+-]+$/;
+
+export const HARNESS_BINARY_BY_RUNTIME: Record<RuntimeName, string> = {
+  'claude-code': 'claude',
+  ohmypi: 'omp',
+  codex: 'codex',
+};
+
+export type ExecutableCommandRunner = (command: string, args: string[]) => Promise<string>;
+
+export interface ExecutableResolutionOptions {
+  pathValue?: string;
+  home?: string;
+  cwd?: string;
+  shell?: string;
+  allowLoginShell?: boolean;
+  accessExecutable?: (path: string) => Promise<void>;
+  runCommand?: ExecutableCommandRunner;
+}
+
+const defaultRunCommand: ExecutableCommandRunner = async (command, args) => {
+  const { stdout } = await execFileAsync(command, args, {
+    encoding: 'utf-8',
+    timeout: 10_000,
+  });
+  return stdout;
+};
+
+async function firstExecutable(
+  directories: readonly string[],
+  binary: string,
+  accessExecutable: (path: string) => Promise<void>,
+): Promise<string | null> {
+  const seen = new Set<string>();
+  for (const directory of directories) {
+    if (!directory) continue;
+    const candidate = join(directory, binary);
+    if (seen.has(candidate)) continue;
+    seen.add(candidate);
+    try {
+      await accessExecutable(candidate);
+      return candidate;
+    } catch {
+      // Keep searching in the documented order.
+    }
+  }
+  return null;
+}
+
+/** Resolve an executable to an absolute, executable path outside the server's inherited PATH alone. */
+export async function resolveExecutable(
+  binary: string,
+  options: ExecutableResolutionOptions = {},
+): Promise<string | null> {
+  if (!SAFE_BINARY_NAME.test(binary)) {
+    throw new Error(`Invalid executable name: ${binary}`);
+  }
+
+  const cwd = options.cwd ?? process.cwd();
+  const home = resolve(cwd, options.home ?? homedir());
+  const pathValue = options.pathValue ?? process.env['PATH'] ?? '';
+  const accessExecutable = options.accessExecutable ?? ((path: string) => access(path, constants.X_OK));
+  const runCommand = options.runCommand ?? defaultRunCommand;
+
+  const pathDirectories = pathValue
+    .split(delimiter)
+    .filter(Boolean)
+    .map((directory) => isAbsolute(directory) ? directory : resolve(cwd, directory));
+  const pathMatch = await firstExecutable(pathDirectories, binary, accessExecutable);
+  if (pathMatch) return pathMatch;
+
+  const fixedCandidates = [
+    join(home, '.local', 'bin'),
+    join(home, '.claude', 'local'),
+    join(home, '.npm-global', 'bin'),
+  ];
+  const fixedMatch = await firstExecutable(fixedCandidates, binary, accessExecutable);
+  if (fixedMatch) return fixedMatch;
+
+  try {
+    const npmPrefix = (await runCommand('npm', ['prefix', '-g'])).trim().split('\n')[0]?.trim();
+    if (npmPrefix) {
+      const npmMatch = await firstExecutable([join(resolve(cwd, npmPrefix), 'bin')], binary, accessExecutable);
+      if (npmMatch) return npmMatch;
+    }
+  } catch {
+    // npm is optional; continue to the remaining resolution sources.
+  }
+
+  const bunMatch = await firstExecutable([join(home, '.bun', 'bin')], binary, accessExecutable);
+  if (bunMatch) return bunMatch;
+
+  if (options.allowLoginShell !== false) {
+    const shell = options.shell ?? process.env['SHELL'];
+    if (shell) {
+      try {
+        const shellResult = (await runCommand(shell, ['-lc', `command -v ${binary}`]))
+          .trim()
+          .split('\n')[0]
+          ?.trim();
+        if (shellResult && isAbsolute(shellResult)) {
+          await accessExecutable(shellResult);
+          return shellResult;
+        }
+      } catch {
+        // A login shell is the final optional fallback.
+      }
+    }
+  }
+
+  return null;
+}
+
+export function harnessBinaryName(harness: RuntimeName): string {
+  return HARNESS_BINARY_BY_RUNTIME[harness];
+}
+
+export async function resolveHarnessBinary(
+  harness: RuntimeName,
+  options?: ExecutableResolutionOptions,
+): Promise<string | null> {
+  return resolveExecutable(harnessBinaryName(harness), options);
+}
+
+export async function requireHarnessBinary(
+  harness: RuntimeName,
+  options?: ExecutableResolutionOptions,
+): Promise<string> {
+  const binary = harnessBinaryName(harness);
+  const resolved = await resolveExecutable(binary, options);
+  if (resolved) return resolved;
+
+  const harnessName = harness === 'claude-code' ? 'Claude Code' : harness === 'ohmypi' ? 'OhMyPi' : 'Codex CLI';
+  throw new Error(
+    `${harnessName} executable "${binary}" was not found. Install ${harnessName} or add its installation directory to PATH, then restart Overdeck. No terminal session was created.`,
+  );
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function harnessPathExport(resolvedBinary: string): string {
+  return `export PATH=${shellQuote(dirname(resolvedBinary))}:"$PATH"`;
+}
+
+export async function prepareHarnessLaunch(
+  harness: RuntimeName,
+  options?: ExecutableResolutionOptions,
+): Promise<{ binaryPath: string; pathExport: string }> {
+  const binaryPath = await requireHarnessBinary(harness, options);
+  return { binaryPath, pathExport: harnessPathExport(binaryPath) };
+}

--- a/src/lib/harness-resolve.ts
+++ b/src/lib/harness-resolve.ts
@@ -1,16 +1,10 @@
-import { exec } from 'child_process';
-import { promisify } from 'util';
 import { canUseHarnessSync, canUseModelWithAuthSync } from './harness-policy.js';
+import { harnessBinaryName, resolveHarnessBinary } from './harness-binary.js';
 import { getBuiltInDefaultHarness, getProviderForModelSync } from './providers.js';
 import type { RuntimeName } from './runtimes/types.js';
 import type { Role } from './agents.js';
 import { loadConfigSync as loadYamlConfig } from './config-yaml.js';
 
-const execAsync = promisify(exec);
-const BINARY_BY_HARNESS: Partial<Record<RuntimeName, string>> = {
-  ohmypi: 'omp',
-  codex: 'codex',
-};
 const harnessAvailabilityCache = new Map<RuntimeName, Promise<boolean>>();
 const builtInDefaultNoticeProviders = new Set<string>();
 
@@ -39,16 +33,14 @@ async function getProviderAuthModeForModel(model: string) {
 }
 
 async function hasHarnessBinary(harness: RuntimeName): Promise<boolean> {
-  const binary = BINARY_BY_HARNESS[harness];
-  if (!binary) return true;
+  // Claude Code availability is enforced by the shared launch preflight. Keep
+  // the native fallback decision here independent of whether Claude is installed.
+  if (harness === 'claude-code') return true;
 
   const cached = harnessAvailabilityCache.get(harness);
   if (cached) return cached;
 
-  const check = execAsync(`command -v ${binary}`).then(
-    () => true,
-    () => false
-  );
+  const check = resolveHarnessBinary(harness).then((resolved) => resolved !== null);
   harnessAvailabilityCache.set(harness, check);
   return check;
 }
@@ -108,7 +100,7 @@ export async function resolveHarness(input: ResolveHarnessInput): Promise<Runtim
   }
 
   if (!(await hasHarnessBinary(winner))) {
-    const binary = BINARY_BY_HARNESS[winner];
+    const binary = harnessBinaryName(winner);
     // PAN-1871 — never silently fall back to claude-code from a non-native
     // (CLIProxy) model whose own binary is missing at spawn. Silently routing
     // kimi onto claude-code is what leaked PAN-1845. Fail loudly so the cause is

--- a/src/lib/overdeck/conversation-runtime.ts
+++ b/src/lib/overdeck/conversation-runtime.ts
@@ -50,6 +50,7 @@ import { isClaudeCodeChannelsEnabled, loadConfigSync } from '../config-yaml.js';
 import { writePtyToken } from '../pty-token.js';
 import { canUseHarnessSync } from '../harness-policy.js';
 import { resolveHarness } from '../harness-resolve.js';
+import { prepareHarnessLaunch } from '../harness-binary.js';
 import { getProviderForModelSync, piProviderForModel, UnknownModelError } from '../providers.js';
 import { getOhmypiCodexAuthStatus } from '../ohmypi-codex-auth.js';
 import type { RuntimeName } from '../runtimes/types.js';
@@ -509,6 +510,7 @@ export async function spawnConversationSession(
   plainFork = false,
 ): Promise<void> {
   const behavior = getHarnessBehavior(harness);
+  const harnessLaunch = await prepareHarnessLaunch(harness);
   const stateDir = join(getOverdeckHome(), 'conversations', tmuxSession);
   await mkdir(stateDir, { recursive: true });
   clearReadySignal(tmuxSession);
@@ -640,6 +642,7 @@ export async function spawnConversationSession(
       unsetProviderEnv: true,
       overdeckEnv: { ...(issueId ? { issueId } : {}), ...((piFields || codexFields || useSupervisor) ? { agentId: tmuxSession } : {}) },
       extraEnvExports: [
+        harnessLaunch.pathExport,
         `export OVERDECK_DASHBOARD_URL="http://127.0.0.1:${process.env['API_PORT'] ?? process.env['PORT'] ?? '3011'}"`,
       ],
       providerExports: providerExportsStr || undefined,

--- a/src/lib/planning/spawn-planning-session.ts
+++ b/src/lib/planning/spawn-planning-session.ts
@@ -32,6 +32,7 @@ import { deliverInitialPromptWithRetry, getAgentRuntimeBaseCommand, getProviderE
 import { getCodexLauncherFields, getOhmypiLauncherFields } from '../agents/runtime-command.js';
 import { loadConfigSync, resolveModel } from '../config-yaml.js';
 import { resolveHarness } from '../harness-resolve.js';
+import { prepareHarnessLaunch } from '../harness-binary.js';
 import { getHarnessBehavior } from '../runtimes/behavior.js';
 import type { RuntimeName } from '../runtimes/types.js';
 import { generateLauncherScriptSync } from '../launcher-generator.js';
@@ -605,6 +606,7 @@ export async function spawnPlanningSession(opts: SpawnPlanningOptions): Promise<
     }
     const planningModel = modelOverride || settingsModel;
     const effectiveHarness = await resolvePlanningSessionHarness(planningModel, opts.harness);
+    const harnessLaunch = await prepareHarnessLaunch(effectiveHarness);
     console.log(`[start-planning] Final planning model: ${planningModel} (override=${modelOverride || '(none)'} settings=${settingsModel} source=${modelSource}) harness=${effectiveHarness}`);
 
     // Discover and copy PRD files to workspace
@@ -681,6 +683,7 @@ export async function spawnPlanningSession(opts: SpawnPlanningOptions): Promise<
         setTerminalEnv: true,
         overdeckEnv: { agentId: sessionName, issueId: issue.identifier, sessionType: 'plan' },
         providerExports,
+        extraEnvExports: [harnessLaunch.pathExport],
         promptFile,
         baseCommand: cmdWithArgs,
         appendSystemPromptFiles: await claudePlanningSystemPromptFiles(workspacePath, effectiveHarness),

--- a/src/lib/runtime/claude.ts
+++ b/src/lib/runtime/claude.ts
@@ -22,6 +22,7 @@ import { FsError } from '../errors.js';
 import { generateLauncherScriptSync } from '../launcher-generator.js';
 import { getClaudePermissionFlagsSync } from '../claude-permissions.js';
 import { ensureSessionContextBriefingFile } from '../briefing-freshness.js';
+import { prepareHarnessLaunch, resolveHarnessBinary } from '../harness-binary.js';
 
 const CLAUDE_DIR = join(homedir(), '.claude');
 
@@ -42,23 +43,19 @@ export function createClaudeAdapterSync(): RuntimeAdapterLegacy {
     config,
 
     async isAvailable(): Promise<boolean> {
-      try {
-        const { execa } = await import('execa');
-        const result = await execa('which', ['claude']);
-        console.log(`[claude-invoke] purpose=runtime-check | model=n/a | source=runtime/claude.ts:isAvailable | command="which claude" | available=${result.exitCode === 0}`);
-        return result.exitCode === 0;
-      } catch {
-        console.log(`[claude-invoke] purpose=runtime-check | model=n/a | source=runtime/claude.ts:isAvailable | command="which claude" | available=false`);
-        return false;
-      }
+      const resolved = await resolveHarnessBinary('claude-code');
+      console.log(`[claude-invoke] purpose=runtime-check | model=n/a | source=runtime/claude.ts:isAvailable | command="resolve claude" | available=${resolved !== null}`);
+      return resolved !== null;
     },
 
     async getVersion(): Promise<string | null> {
       try {
+        const resolved = await resolveHarnessBinary('claude-code');
+        if (!resolved) return null;
         const { execa } = await import('execa');
-        const result = await execa('claude', ['--version']);
+        const result = await execa(resolved, ['--version']);
         const version = result.stdout.trim();
-        console.log(`[claude-invoke] purpose=runtime-check | model=n/a | source=runtime/claude.ts:getVersion | command="claude --version" | version="${version}"`);
+        console.log(`[claude-invoke] purpose=runtime-check | model=n/a | source=runtime/claude.ts:getVersion | command="${resolved} --version" | version="${version}"`);
         return version;
       } catch {
         console.log(`[claude-invoke] purpose=runtime-check | model=n/a | source=runtime/claude.ts:getVersion | command="claude --version" | version=null`);
@@ -75,6 +72,7 @@ export function createClaudeAdapterSync(): RuntimeAdapterLegacy {
 
     async spawnAgent(id: string, options: AgentSpawnOptions): Promise<boolean> {
       try {
+        const harnessLaunch = await prepareHarnessLaunch('claude-code');
         const { execa } = await import('execa');
         const { mkdirSync, writeFileSync } = await import('fs');
         const { join } = await import('path');
@@ -110,6 +108,7 @@ export function createClaudeAdapterSync(): RuntimeAdapterLegacy {
             promptFile,
             baseCommand: 'claude',
             appendSystemPromptFiles: [await ensureSessionContextBriefingFile()],
+            extraEnvExports: [harnessLaunch.pathExport],
             extraArgs: args.length > 0 ? args.join(' ') : undefined,
           }),
           { mode: 0o755 },

--- a/src/lib/runtimes/__tests__/ohmypi.test.ts
+++ b/src/lib/runtimes/__tests__/ohmypi.test.ts
@@ -4,6 +4,15 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+const harnessMocks = vi.hoisted(() => ({
+  prepareHarnessLaunch: vi.fn(async () => ({
+    binaryPath: '/home/test/.local/bin/omp',
+    pathExport: `export PATH='/home/test/.local/bin':"$PATH"`,
+  })),
+}))
+
+vi.mock('../../harness-binary.js', () => harnessMocks)
+
 import { OhmypiRuntimeSync, createOhmypiRuntimeSync, OhmypiSpawnTimeout } from '../ohmypi.js'
 import { getGlobalRegistry, getRuntime, setGlobalRegistry, RuntimeRegistry } from '../index.js'
 import { createClaudeCodeRuntimeSync } from '../claude-code.js'

--- a/src/lib/runtimes/__tests__/pi.test.ts
+++ b/src/lib/runtimes/__tests__/pi.test.ts
@@ -4,6 +4,15 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+const harnessMocks = vi.hoisted(() => ({
+  prepareHarnessLaunch: vi.fn(async () => ({
+    binaryPath: '/home/test/.local/bin/omp',
+    pathExport: `export PATH='/home/test/.local/bin':"$PATH"`,
+  })),
+}))
+
+vi.mock('../../harness-binary.js', () => harnessMocks)
+
 import { PiRuntimeSync, createPiRuntimeSync, PiSpawnTimeout } from '../pi.js'
 import { getGlobalRegistry, getRuntime, setGlobalRegistry, RuntimeRegistry } from '../index.js'
 import { createClaudeCodeRuntimeSync } from '../claude-code.js'

--- a/src/lib/runtimes/codex.ts
+++ b/src/lib/runtimes/codex.ts
@@ -36,6 +36,7 @@ import type {
 import { CODEX_BEHAVIOR } from './behavior.js'
 import { tmuxCreateSession, tmuxKillSession, tmuxSessionExists } from './tmux-cli.js'
 import { TmuxError, ProcessSpawnError, ProcessTimeoutError } from '../errors.js'
+import { prepareHarnessLaunch } from '../harness-binary.js'
 import { parseCodexSessionSync } from '../cost-parsers/codex-parser.js'
 
 const execAsync = promisify(exec)
@@ -750,6 +751,7 @@ export class CodexRuntimeSync implements AgentRuntimeSync {
   }
 
   async spawnAgent(config: SpawnConfig & { codexHome?: string; codexSandboxMode?: string }): Promise<Agent> {
+    const harnessLaunch = await prepareHarnessLaunch('codex')
     const agentId = config.agentId
 
     // Per-agent CODEX_HOME: ~/.overdeck/agents/<id>/codex-home
@@ -760,7 +762,7 @@ export class CodexRuntimeSync implements AgentRuntimeSync {
 
     // 2. Build the codex exec command — shell-quote every interpolated value.
     const sandbox = toCodexSandboxValue(config.codexSandboxMode)
-    const tokens: string[] = ['codex', 'exec']
+    const tokens: string[] = [shellQuote(harnessLaunch.binaryPath), 'exec']
     if (config.model) tokens.push('-m', shellQuote(config.model))
     tokens.push('-c', 'approval_policy=never')
     tokens.push('-s', shellQuote(sandbox))

--- a/src/lib/runtimes/ohmypi.ts
+++ b/src/lib/runtimes/ohmypi.ts
@@ -45,6 +45,7 @@ import type {
 import { OHMYPI_BEHAVIOR } from './behavior.js'
 import { sessionExists, killSession, createSession, listSessionsSync } from '../tmux.js'
 import { parseOhmypiSessionSync } from '../cost-parsers/ohmypi-parser.js'
+import { prepareHarnessLaunch } from '../harness-binary.js'
 import { generateLauncherScriptSync } from '../launcher-generator.js'
 import { createOhmypiFifo, destroyOhmypiFifoSync, writeOhmypiCommandSync, ohmypiFifoPaths, OhmypiNotReady } from './ohmypi-fifo.js'
 import { ProcessSpawnError, ProcessTimeoutError, TmuxError } from '../errors.js'
@@ -328,6 +329,7 @@ export class OhmypiRuntimeSync implements AgentRuntimeSync {
       throw new Error('OhmypiRuntime.spawnAgent requires piExtensionPath in config')
     }
 
+    const harnessLaunch = await prepareHarnessLaunch('ohmypi')
     const agentId = config.agentId
     const dir = agentDirFor(agentId)
     const sessionDir = ohmypiSessionDirFor(agentId)
@@ -361,6 +363,7 @@ export class OhmypiRuntimeSync implements AgentRuntimeSync {
       resumeSessionId,
       overdeckEnv: { agentId },
       setTerminalEnv: true,
+      extraEnvExports: [harnessLaunch.pathExport],
       trapHup: true,
     })
 

--- a/src/lib/runtimes/pi.ts
+++ b/src/lib/runtimes/pi.ts
@@ -45,6 +45,7 @@ import type {
 import { OHMYPI_BEHAVIOR } from './behavior.js'
 import { sessionExists, killSession, createSession, listSessionsSync } from '../tmux.js'
 import { parsePiSessionSync } from '../cost-parsers/pi-parser.js'
+import { prepareHarnessLaunch } from '../harness-binary.js'
 import { generateLauncherScriptSync } from '../launcher-generator.js'
 import { createPiFifo, destroyPiFifoSync, writePiCommandSync, piFifoPaths, PiNotReady } from './pi-fifo.js'
 import { ProcessSpawnError, ProcessTimeoutError, TmuxError } from '../errors.js'
@@ -334,6 +335,7 @@ export class PiRuntimeSync {
       throw new Error('PiRuntime.spawnAgent requires piExtensionPath in config')
     }
 
+    const harnessLaunch = await prepareHarnessLaunch('ohmypi')
     const agentId = config.agentId
     const dir = agentDirFor(agentId)
     const sessionDir = piSessionDirFor(agentId)
@@ -378,6 +380,7 @@ export class PiRuntimeSync {
       resumeSessionId,
       overdeckEnv: { agentId },
       setTerminalEnv: true,
+      extraEnvExports: [harnessLaunch.pathExport],
       trapHup: true,
     })
 

--- a/src/lib/system-prerequisites.ts
+++ b/src/lib/system-prerequisites.ts
@@ -3,23 +3,21 @@
  *
  * Overdeck drives host tools — tmux sessions, the Claude Code CLI, git — that
  * no install flavor bundles (the desktop app ships only the dashboard). The
- * checks run from the SERVER process, so what they see on PATH is exactly what
- * spawned agents and conversations will see; a tool missing here is a tool
- * whose spawn will fail. Served by GET /api/prerequisites and rendered by the
- * frontend SetupChecklistBanner.
+ * checks and harness launchers share one executable resolver so a GUI-started
+ * dashboard with a minimal PATH cannot accept or reject a harness differently
+ * from the process it later launches. Served by GET /api/prerequisites and
+ * rendered by the frontend SetupChecklistBanner.
  *
- * Detection runs `<cmd> <versionArg>` directly (ENOENT = not installed),
- * which both proves the tool is executable and captures its version in one
+ * Detection resolves an absolute executable path before running its version
  * probe. Install hints are copyable commands, not actions — installing system
  * packages needs sudo/user consent, so Overdeck never runs them itself.
  */
 
 import { execFile } from 'node:child_process';
-import { access } from 'node:fs/promises';
-import { constants } from 'node:fs';
 import { homedir } from 'node:os';
-import { delimiter, join } from 'node:path';
 import { promisify } from 'node:util';
+
+import { resolveExecutable } from './harness-binary.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -168,6 +166,7 @@ export const PREREQUISITES: readonly PrerequisiteDefinition[] = [
 ];
 
 export type PrerequisiteProbe = (cmd: string, args: string[]) => Promise<string>;
+export type PrerequisiteResolver = (command: string) => Promise<string | null>;
 
 const defaultProbe: PrerequisiteProbe = async (cmd, args) => {
   const { stdout } = await execFileAsync(cmd, args, { encoding: 'utf-8', timeout: 10_000 });
@@ -193,52 +192,24 @@ function failureKind(error: unknown): string {
   return 'probe failed';
 }
 
-async function executablePath(command: string, pathValue: string): Promise<string | null> {
-  for (const directory of pathValue.split(delimiter).filter(Boolean)) {
-    const candidate = join(directory, command);
-    try {
-      await access(candidate, constants.X_OK);
-      return redactHome(candidate);
-    } catch {
-      // Continue through PATH. Diagnostics must remain best-effort.
-    }
-  }
-  return null;
-}
-
 /** Build a bounded, secret-free support report from the dashboard process environment. */
 export async function collectSetupDiagnostics(overdeckVersion: string): Promise<SetupDiagnosticsReport> {
   const pathValue = process.env['PATH'] ?? '';
   const toolLines = await Promise.all(PREREQUISITES.map(async ({ id, versionArgs }) => {
-    const resolvedPath = await executablePath(id, pathValue);
+    const resolvedPath = await resolveExecutable(id, { pathValue });
+    if (!resolvedPath) return `✗ ${id}: command not found`;
     try {
-      const output = await defaultProbe(id, versionArgs);
-      return `✓ ${id}: ${firstLine(output) ?? 'version unavailable'} — ${resolvedPath ?? 'path unresolved'}`;
+      const output = await defaultProbe(resolvedPath, versionArgs);
+      return `✓ ${id}: ${firstLine(output) ?? 'version unavailable'} — ${redactHome(resolvedPath)}`;
     } catch (error) {
-      return `✗ ${id}: ${failureKind(error)}${resolvedPath ? ` — ${resolvedPath}` : ''}`;
+      return `✗ ${id}: ${failureKind(error)} — ${redactHome(resolvedPath)}`;
     }
   }));
 
-  const claudeCandidates = [
-    join(homedir(), '.local', 'bin', 'claude'),
-    join(homedir(), '.npm-global', 'bin', 'claude'),
-    join(homedir(), '.bun', 'bin', 'claude'),
-  ];
-  const candidateLines = await Promise.all(claudeCandidates.map(async (candidate) => {
-    try {
-      await access(candidate, constants.X_OK);
-      return `- ${redactHome(candidate)}: executable`;
-    } catch {
-      return `- ${redactHome(candidate)}: missing`;
-    }
-  }));
-  const claudeOnPath = await executablePath('claude', pathValue);
-  const candidateFound = candidateLines.some((line) => line.endsWith(': executable'));
-  const likelyCause = !claudeOnPath && candidateFound
-    ? 'Claude appears to be installed, but its directory is absent from the dashboard server PATH. Restart Overdeck after correcting PATH.'
-    : !claudeOnPath
-      ? 'The dashboard server cannot find a Claude executable on PATH or in the common user install locations checked.'
-      : 'Claude is visible on the dashboard server PATH; use the probe result above if startup still fails.';
+  const claudePath = await resolveExecutable('claude', { pathValue });
+  const likelyCause = claudePath
+    ? 'Claude resolved to an executable path; conversation and agent launchers will prepend that directory to PATH.'
+    : 'Claude was not found on the server PATH, in common user install locations, under the global npm prefix, or through the login shell.';
 
   const markdown = [
     '## Overdeck setup diagnostics',
@@ -254,9 +225,8 @@ export async function collectSetupDiagnostics(overdeckVersion: string): Promise<
     ...toolLines,
     '',
     '### Claude lookup',
-    `Dashboard PATH lookup: ${claudeOnPath ?? 'not found'}`,
-    'Common user install locations:',
-    ...candidateLines,
+    `Shared resolver: ${claudePath ? redactHome(claudePath) : 'not found'}`,
+    'Lookup order: server PATH → ~/.local/bin → ~/.claude/local → ~/.npm-global/bin → global npm prefix/bin → ~/.bun/bin → login shell',
     '',
     `Likely cause: ${likelyCause}`,
     '',
@@ -268,11 +238,14 @@ export async function collectSetupDiagnostics(overdeckVersion: string): Promise<
 
 export async function checkSystemPrerequisites(
   probe: PrerequisiteProbe = defaultProbe,
+  resolver: PrerequisiteResolver = resolveExecutable,
 ): Promise<PrerequisitesReport> {
   const checks = await Promise.all(
     PREREQUISITES.map(async ({ versionArgs, ...definition }): Promise<PrerequisiteCheck> => {
       try {
-        const output = await probe(definition.id, versionArgs);
+        const executable = await resolver(definition.id);
+        if (!executable) return { ...definition, found: false, version: null };
+        const output = await probe(executable, versionArgs);
         return { ...definition, found: true, version: firstLine(output) };
       } catch {
         return { ...definition, found: false, version: null };

--- a/tests/unit/lib/harness-resolve.test.ts
+++ b/tests/unit/lib/harness-resolve.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => ({
   loadConfigSync: vi.fn(),
   canUseHarnessSync: vi.fn(),
   getProviderAuthMode: vi.fn(),
-  exec: vi.fn(),
+  resolveHarnessBinary: vi.fn(),
 }));
 
 vi.mock('../../../src/lib/config-yaml.js', () => ({
@@ -24,8 +24,9 @@ vi.mock('../../../src/lib/agents.js', () => ({
   getProviderAuthMode: mocks.getProviderAuthMode,
 }));
 
-vi.mock('child_process', () => ({
-  exec: mocks.exec,
+vi.mock('../../../src/lib/harness-binary.js', () => ({
+  harnessBinaryName: (harness: RuntimeName) => harness === 'ohmypi' ? 'omp' : harness === 'codex' ? 'codex' : 'claude',
+  resolveHarnessBinary: mocks.resolveHarnessBinary,
 }));
 
 function setConfig(config: { roles?: Record<string, { harness?: RuntimeName }>; providerHarnesses?: Record<string, RuntimeName> }) {
@@ -38,16 +39,7 @@ function setConfig(config: { roles?: Record<string, { harness?: RuntimeName }>; 
 }
 
 function setBinaryAvailable(available: boolean) {
-  mocks.exec.mockImplementation((_command: string, optionsOrCallback: unknown, maybeCallback?: unknown) => {
-    const callback = typeof optionsOrCallback === 'function' ? optionsOrCallback : maybeCallback;
-    if (typeof callback !== 'function') return {} as never;
-    if (available) {
-      callback(null, '/usr/bin/harness\n', '');
-    } else {
-      callback(new Error('not found'), '', '');
-    }
-    return {} as never;
-  });
+  mocks.resolveHarnessBinary.mockResolvedValue(available ? '/usr/bin/harness' : null);
 }
 
 async function loadSubject() {
@@ -108,7 +100,7 @@ describe('resolveHarness', () => {
 
     await expect(resolveHarness({ model: 'glm5.2' })).rejects.toThrow('Unknown model "glm5.2". Did you mean "glm-5.2"?');
     expect(mocks.canUseHarnessSync).not.toHaveBeenCalled();
-    expect(mocks.exec).not.toHaveBeenCalled();
+    expect(mocks.resolveHarnessBinary).not.toHaveBeenCalled();
   });
 
   it('passes the resolved provider-default winner through the harness policy gate', async () => {
@@ -122,7 +114,7 @@ describe('resolveHarness', () => {
     await expect(resolveHarness({ explicit: 'ohmypi', model: 'claude-sonnet-4-6' })).rejects.toThrow('blocked');
 
     expect(mocks.canUseHarnessSync).toHaveBeenCalledWith('claude-code', 'claude-sonnet-4-6', 'subscription');
-    expect(mocks.exec).not.toHaveBeenCalled();
+    expect(mocks.resolveHarnessBinary).not.toHaveBeenCalled();
   });
 
   it('falls back to claude-code when a native model’s provider-default harness is policy-denied (only after checking the fallback)', async () => {
@@ -149,7 +141,7 @@ describe('resolveHarness', () => {
     await expect(resolveHarness({ model: 'gpt-5.5' })).rejects.toThrow('needs a ChatGPT/Codex subscription sign-in');
 
     expect(mocks.canUseHarnessSync).not.toHaveBeenCalled();
-    expect(mocks.exec).not.toHaveBeenCalled();
+    expect(mocks.resolveHarnessBinary).not.toHaveBeenCalled();
   });
 
   it('refuses to silently fall back to claude-code when a non-native model’s harness binary is missing (PAN-1871)', async () => {
@@ -161,7 +153,7 @@ describe('resolveHarness', () => {
     // binary must fail loudly rather than degrade onto claude-code/CLIProxy.
     await expect(resolveHarness({ model: 'gpt-5.5' })).rejects.toThrow('has no installed codex binary at spawn');
 
-    expect(mocks.exec).toHaveBeenCalledWith('command -v codex', expect.any(Function));
+    expect(mocks.resolveHarnessBinary).toHaveBeenCalledWith('codex');
   });
 
   it('logs the built-in provider-default notice once per provider', async () => {


### PR DESCRIPTION
Fixes #2869 (release-blocking for v0.45.22).

One shared harness-binary resolver now backs both the prerequisite check and every spawn path, so "check says installed" and "exec actually works" can never disagree:

- New resolver tries the current PATH, then well-known install locations (~/.local/bin, ~/.claude/local, ~/.npm-global/bin, npm global prefix bin, ~/.bun/bin).
- `checkSystemPrerequisites()` uses it — claude installed but PATH-invisible (GUI/AppImage launches) no longer flags the false "missing required tool: claude" setup banner.
- Conversation and agent launchers receive the resolved binary and a PATH export, eliminating the raw tmux `execvp(3) failed` death.
- Genuinely-missing binary now returns an actionable structured error ("Install X or add its directory to PATH") with no tmux session created.
- Covers claude, pi, and codex harnesses + planning spawns; unit tests for resolver candidates, PATH preference, and the missing-binary error.

Review: implementation reviewed against the issue spec by the orchestrating conversation (operator-authorized flow); typecheck/lint/changed-tests green locally; full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)