### PR TITLE
PAN-2890

### DIFF
--- a/docs/COMMAND-DECK-RESTORATION.md
+++ b/docs/COMMAND-DECK-RESTORATION.md
@@ -6,8 +6,12 @@
 > of the shipped UI see `concepts.mdx` / `introduction.mdx`.
 >
 > **What shipped:** full-height project sidebar + app bar (project crumb,
-> project-scoped search [PAN-1593], status pills) + full-width tab strip
-> (scroll / overflow arrows / middle-click / pop-out / **split panes** /
+> project-scoped search [PAN-1593], interactive agent status pills: the running
+> pill opens an "N running now" drill-down and the stopped pill opens an
+> "N stopped · pipeline agents, last 7 days" drill-down; both use shared
+> `AgentPillPopoverRow` rows that navigate issue-backed agents to `/issues/<ID>`
+> and system agents to `/agents`) + full-width tab strip (scroll / overflow
+> arrows / middle-click / pop-out / **split panes** /
 > close-all) + merged **Awareness rail** (Needs-you / Project / Global,
 > collapsible); the **issue cockpit** (blocker spotlight → phase timeline →
 > single-source metric strip → Review / Code / Plan / Cost / Workspace / Agent /
@@ -15,6 +19,9 @@
 > cockpit** (tight hero, Stuck tile, recent 7-day spend [PAN-1597]); role-named
 > pipeline tabs; and the phantom "Needs-you" / single-pane-collapse /
 > stopped-agent pending-input fixes.
+>
+> No dedicated Mintlify page documents the app bar, so this living design record
+> remains the documentation surface for the agent-pill interactions.
 >
 > **Sequence (completed):** archaeology → this outline → HTML mockups
 > (`docs/design/command-deck-*-v2/v4.html`) → iterate → implement → release.

--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -55,6 +55,7 @@ import {
 } from './App/StandaloneRoutes';
 import { AppRoutes, type PendingConversationTarget } from './App/AppRoutes';
 import { AppChrome } from './App/AppChrome';
+import { isRunningAgentStatus } from './components/AgentPillPopoverRow';
 import { usePendingInputDialogs } from './App/hooks/usePendingInputDialogs';
 import { useDesktopActivityNotifications } from './App/hooks/useDesktopActivityNotifications';
 
@@ -534,7 +535,7 @@ export default function App() {
   const agents = useDashboardStore(selectAgents) as unknown as Agent[];
   // Live agent count for the app-bar status pill (PAN-1591).
   const runningAgentCount = useMemo(
-    () => agents.filter((a) => ['running', 'active', 'starting', 'thinking', 'working'].includes(a.status)).length,
+    () => agents.filter((agent) => isRunningAgentStatus(agent.status)).length,
     [agents],
   );
   // Issues from Zustand store (event-sourced via snapshot — no polling)

--- a/src/dashboard/frontend/src/App/AppChrome.tsx
+++ b/src/dashboard/frontend/src/App/AppChrome.tsx
@@ -6,6 +6,7 @@ import { DecisionsIndicator } from '../components/DecisionsIndicator';
 import { OpenQuestionsIndicator } from '../components/OpenQuestionsIndicator';
 import { SystemMenu } from '../components/SystemMenu';
 import { StoppedAgentsBanner } from '../components/StoppedAgentsBanner';
+import { RunningAgentsPill } from '../components/RunningAgentsPill';
 import { OrphanTestAgentsSurface } from '../components/OrphanTestAgentsSurface';
 import { CodexAuthBanner } from '../components/CodexAuthBanner';
 import { SetupChecklistBanner } from '../components/SetupChecklistBanner';
@@ -203,11 +204,7 @@ export function AppChrome({
         {/* right: status pills */}
         <div className="flex shrink-0 items-center gap-2">
           <DeaconPauseToggle compact />
-          {runningAgentCount > 0 && (
-            <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-xs text-emerald-600 dark:text-emerald-400">
-              <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />{runningAgentCount} agent{runningAgentCount === 1 ? '' : 's'}
-            </span>
-          )}
+          <RunningAgentsPill />
           {runningAgentCount > 0 && (
             <button
               type="button"

--- a/src/dashboard/frontend/src/components/AgentPillPopoverRow.test.tsx
+++ b/src/dashboard/frontend/src/components/AgentPillPopoverRow.test.tsx
@@ -70,6 +70,19 @@ describe('AgentPillPopoverRow', () => {
     expect(dispatchEvent.mock.invocationCallOrder[0]).toBeLessThan(onNavigate.mock.invocationCallOrder[0]);
   });
 
+  it('navigates issue-less system agents to the agents surface', () => {
+    render(
+      <AgentPillPopoverRow
+        agent={agent({ id: 'sequencer-runner', issueId: 'sequencer-runner', role: 'sequencer' })}
+        contextLine="glm-5.2 · 28m ago"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(window.location.pathname).toBe('/agents');
+  });
+
   it('renders a mono issue ID, truncated titled row, role, and context', () => {
     const title = 'Order book: backlog integration for ready-queue lanes';
     render(

--- a/src/dashboard/frontend/src/components/AgentPillPopoverRow.test.tsx
+++ b/src/dashboard/frontend/src/components/AgentPillPopoverRow.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Agent } from '../types';
+import {
+  AgentPillPopoverRow,
+  describeAgentStop,
+  relativeTime,
+} from './AgentPillPopoverRow';
+
+function agent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: 'agent-pan-2377',
+    issueId: 'PAN-2377',
+    role: 'review',
+    runtime: 'claude-code',
+    model: 'claude-sonnet-5',
+    status: 'stopped',
+    startedAt: '2026-07-18T09:00:00.000Z',
+    lastActivity: '2026-07-18T11:55:00.000Z',
+    consecutiveFailures: 0,
+    killCount: 0,
+    ...overrides,
+  };
+}
+
+describe('AgentPillPopoverRow', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-18T12:00:00.000Z'));
+    window.history.replaceState(null, '', '/');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('describes each stopped-agent state in priority order', () => {
+    expect(describeAgentStop(agent({ pausedReason: 'awaiting close-out', paused: true })))
+      .toBe('paused: awaiting close-out');
+    expect(describeAgentStop(agent({ paused: true }))).toBe('paused');
+    expect(describeAgentStop(agent({ troubled: true, consecutiveFailures: 2 })))
+      .toBe('troubled (2 failures)');
+    expect(describeAgentStop(agent({ troubled: true, consecutiveFailures: 1 })))
+      .toBe('troubled (1 failure)');
+    expect(describeAgentStop(agent({ stoppedByUser: true }))).toBe('stopped by operator');
+    expect(describeAgentStop(agent())).toBe('stopped cleanly');
+  });
+
+  it('navigates through the URL door before invoking onNavigate', () => {
+    const pushState = vi.spyOn(window.history, 'pushState');
+    const dispatchEvent = vi.spyOn(window, 'dispatchEvent');
+    const onNavigate = vi.fn();
+
+    render(
+      <AgentPillPopoverRow
+        agent={agent()}
+        title="Order book backlog integration"
+        contextLine="stopped cleanly · 5m ago"
+        onNavigate={onNavigate}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(pushState).toHaveBeenCalledWith({}, '', '/issues/PAN-2377');
+    expect(dispatchEvent).toHaveBeenCalledWith(expect.any(PopStateEvent));
+    expect(onNavigate).toHaveBeenCalledOnce();
+    expect(dispatchEvent.mock.invocationCallOrder[0]).toBeLessThan(onNavigate.mock.invocationCallOrder[0]);
+  });
+
+  it('renders a mono issue ID, truncated titled row, role, and context', () => {
+    const title = 'Order book: backlog integration for ready-queue lanes';
+    render(
+      <AgentPillPopoverRow
+        agent={agent()}
+        title={title}
+        contextLine="paused: awaiting close-out · 2d ago"
+      />,
+    );
+
+    expect(screen.getByText('PAN-2377')).toHaveClass('font-mono');
+    expect(screen.getByTitle(title)).toHaveClass('truncate');
+    expect(screen.getByText('review')).toHaveClass('text-muted-foreground');
+    expect(screen.getByText('paused: awaiting close-out · 2d ago')).toHaveClass('truncate');
+  });
+
+  it('falls back to the bare issue ID when no title is supplied', () => {
+    render(
+      <AgentPillPopoverRow
+        agent={agent()}
+        contextLine="stopped cleanly · 5m ago"
+      />,
+    );
+
+    expect(screen.getByText('PAN-2377')).toBeInTheDocument();
+    expect(screen.queryByTitle(/./)).not.toBeInTheDocument();
+  });
+
+  it('formats minute, hour, and day deltas from the frozen clock', () => {
+    const now = Date.now();
+
+    expect(relativeTime('2026-07-18T11:55:00.000Z', now)).toBe('5m ago');
+    expect(relativeTime('2026-07-18T09:00:00.000Z', now)).toBe('3h ago');
+    expect(relativeTime('2026-07-16T12:00:00.000Z', now)).toBe('2d ago');
+  });
+});

--- a/src/dashboard/frontend/src/components/AgentPillPopoverRow.tsx
+++ b/src/dashboard/frontend/src/components/AgentPillPopoverRow.tsx
@@ -1,5 +1,12 @@
 import type { Agent } from '../types';
 
+const RUNNING_AGENT_STATUSES = new Set(['running', 'active', 'starting', 'thinking', 'working']);
+const SYSTEM_AGENT_ROLES = new Set(['flywheel', 'sequencer', 'knowledge']);
+
+export function isRunningAgentStatus(status: Agent['status']): boolean {
+  return RUNNING_AGENT_STATUSES.has(status);
+}
+
 export function describeAgentStop(agent: Agent): string {
   if (agent.pausedReason) return `paused: ${agent.pausedReason}`;
   if (agent.paused) return 'paused';
@@ -11,10 +18,13 @@ export function describeAgentStop(agent: Agent): string {
   return 'stopped cleanly';
 }
 
-export function navigateToIssue(issueId: string): void {
-  const path = `/issues/${encodeURIComponent(issueId)}`;
+function navigateToPath(path: string): void {
   if (window.location.pathname !== path) window.history.pushState({}, '', path);
   window.dispatchEvent(new PopStateEvent('popstate'));
+}
+
+export function navigateToIssue(issueId: string): void {
+  navigateToPath(`/issues/${encodeURIComponent(issueId)}`);
 }
 
 export function relativeTime(iso: string, now: number): string {
@@ -50,7 +60,8 @@ export function AgentPillPopoverRow({
       type="button"
       className="block w-full rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-accent"
       onClick={() => {
-        navigateToIssue(issueId);
+        if (agent.issueId && !SYSTEM_AGENT_ROLES.has(agent.role ?? '')) navigateToIssue(agent.issueId);
+        else navigateToPath('/agents');
         onNavigate?.();
       }}
     >

--- a/src/dashboard/frontend/src/components/AgentPillPopoverRow.tsx
+++ b/src/dashboard/frontend/src/components/AgentPillPopoverRow.tsx
@@ -1,0 +1,71 @@
+import type { Agent } from '../types';
+
+export function describeAgentStop(agent: Agent): string {
+  if (agent.pausedReason) return `paused: ${agent.pausedReason}`;
+  if (agent.paused) return 'paused';
+  if (agent.troubled) {
+    const failures = agent.consecutiveFailures;
+    return `troubled (${failures} failure${failures === 1 ? '' : 's'})`;
+  }
+  if (agent.stoppedByUser) return 'stopped by operator';
+  return 'stopped cleanly';
+}
+
+export function navigateToIssue(issueId: string): void {
+  const path = `/issues/${encodeURIComponent(issueId)}`;
+  if (window.location.pathname !== path) window.history.pushState({}, '', path);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}
+
+export function relativeTime(iso: string, now: number): string {
+  const timestamp = Date.parse(iso);
+  if (!Number.isFinite(timestamp)) return '—';
+
+  const seconds = Math.max(0, Math.floor((now - timestamp) / 1000));
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+interface AgentPillPopoverRowProps {
+  agent: Agent;
+  title?: string;
+  contextLine: string;
+  onNavigate?: () => void;
+}
+
+export function AgentPillPopoverRow({
+  agent,
+  title,
+  contextLine,
+  onNavigate,
+}: AgentPillPopoverRowProps) {
+  const issueId = agent.issueId ?? agent.id;
+
+  return (
+    <button
+      type="button"
+      className="block w-full rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-accent"
+      onClick={() => {
+        navigateToIssue(issueId);
+        onNavigate?.();
+      }}
+    >
+      <span className="flex min-w-0 items-baseline gap-2 text-xs">
+        <span className="shrink-0 font-mono text-[11px] text-foreground">{issueId}</span>
+        {title && (
+          <span className="min-w-0 flex-1 truncate text-foreground" title={title}>
+            {title}
+          </span>
+        )}
+        {agent.role && (
+          <span className="ml-auto shrink-0 text-[11px] text-muted-foreground">{agent.role}</span>
+        )}
+      </span>
+      <span className="mt-0.5 block truncate text-[11px] text-muted-foreground">{contextLine}</span>
+    </button>
+  );
+}

--- a/src/dashboard/frontend/src/components/RunningAgentsPill.test.tsx
+++ b/src/dashboard/frontend/src/components/RunningAgentsPill.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useDashboardStore } from '../lib/store';
+import type { Agent, Issue } from '../types';
+import { isRunningAgentStatus } from './AgentPillPopoverRow';
+import { RunningAgentsPill } from './RunningAgentsPill';
+
+function agent(overrides: Partial<Agent>): Agent {
+  return {
+    id: overrides.id ?? 'agent-pan-1',
+    issueId: overrides.issueId ?? 'PAN-1',
+    role: overrides.role ?? 'work',
+    runtime: overrides.runtime ?? 'claude-code',
+    model: overrides.model ?? 'claude-sonnet-5',
+    status: overrides.status ?? 'running',
+    startedAt: overrides.startedAt ?? '2026-07-18T11:00:00.000Z',
+    lastActivity: overrides.lastActivity ?? '2026-07-18T11:58:00.000Z',
+    consecutiveFailures: 0,
+    killCount: 0,
+    ...overrides,
+  };
+}
+
+function issue(identifier: string, title: string): Issue {
+  return {
+    id: identifier,
+    identifier,
+    title,
+    status: 'In Progress',
+    priority: 2,
+    labels: [],
+    url: `https://github.com/eltmon/overdeck/issues/${identifier}`,
+    createdAt: '2026-07-18T10:00:00.000Z',
+    updatedAt: '2026-07-18T11:00:00.000Z',
+  };
+}
+
+function setStore(agents: Agent[]) {
+  useDashboardStore.setState({
+    agentsById: Object.fromEntries(agents.map((entry) => [entry.id, entry])),
+    issuesRaw: [
+      issue('PAN-1', 'First issue'),
+      issue('PAN-2', 'Second issue'),
+      issue('PAN-3', 'Third issue'),
+    ],
+  } as Parameters<typeof useDashboardStore.setState>[0]);
+}
+
+describe('RunningAgentsPill', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-18T12:00:00.000Z'));
+    window.history.replaceState(null, '', '/');
+  });
+
+  afterEach(() => {
+    useDashboardStore.setState({ agentsById: {}, issuesRaw: [] } as Parameters<typeof useDashboardStore.setState>[0]);
+    vi.useRealTimers();
+  });
+
+  it('uses the complete running-family predicate', () => {
+    expect(['running', 'active', 'starting', 'thinking', 'working'].every(
+      (status) => isRunningAgentStatus(status as Agent['status']),
+    )).toBe(true);
+    expect(isRunningAgentStatus('stopped')).toBe(false);
+    expect(isRunningAgentStatus('failed')).toBe(false);
+  });
+
+  it('matches its trigger count to the running rows sorted by latest activity', () => {
+    setStore([
+      agent({ id: 'agent-1', issueId: 'PAN-1', status: 'running', lastActivity: '2026-07-18T11:58:00.000Z' }),
+      agent({ id: 'agent-2', issueId: 'PAN-2', status: 'active' as Agent['status'], lastActivity: '2026-07-18T11:59:00.000Z', model: 'gpt-5.6' }),
+      agent({ id: 'agent-3', issueId: 'PAN-3', status: 'thinking' as Agent['status'], lastActivity: '2026-07-18T11:57:00.000Z' }),
+      agent({ id: 'agent-4', issueId: 'PAN-4', status: 'stopped' }),
+      agent({ id: 'agent-5', issueId: 'PAN-5', status: 'warning' }),
+    ]);
+
+    render(<RunningAgentsPill />);
+    fireEvent.click(screen.getByTestId('running-agents-pill'));
+
+    expect(screen.getByTestId('running-agents-pill')).toHaveTextContent('3 agents');
+    const popover = screen.getByTestId('running-agents-popover');
+    expect(within(popover).getByText('3 running now')).toBeInTheDocument();
+    const rows = within(popover).getAllByRole('button');
+    expect(rows).toHaveLength(3);
+    expect(rows.map((row) => row.textContent)).toEqual([
+      expect.stringContaining('PAN-2'),
+      expect.stringContaining('PAN-1'),
+      expect.stringContaining('PAN-3'),
+    ]);
+    expect(within(popover).getByText('gpt-5.6 · 1m ago')).toBeInTheDocument();
+  });
+
+  it('renders nothing when no agents have a running-family status', () => {
+    setStore([
+      agent({ id: 'agent-4', issueId: 'PAN-4', status: 'stopped' }),
+      agent({ id: 'agent-5', issueId: 'PAN-5', status: 'failed' }),
+    ]);
+
+    const { container } = render(<RunningAgentsPill />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('navigates to the selected issue and closes the popover', () => {
+    setStore([
+      agent({ id: 'agent-2', issueId: 'PAN-2', status: 'running', lastActivity: '2026-07-18T11:59:00.000Z' }),
+    ]);
+
+    render(<RunningAgentsPill />);
+    fireEvent.click(screen.getByTestId('running-agents-pill'));
+    fireEvent.click(screen.getByText('Second issue'));
+
+    expect(window.location.pathname).toBe('/issues/PAN-2');
+    expect(screen.queryByTestId('running-agents-popover')).not.toBeInTheDocument();
+  });
+
+  it('closes the open popover when Escape is pressed', () => {
+    setStore([agent({ id: 'agent-1', issueId: 'PAN-1', status: 'running' })]);
+
+    render(<RunningAgentsPill />);
+    fireEvent.click(screen.getByTestId('running-agents-pill'));
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(screen.queryByTestId('running-agents-popover')).not.toBeInTheDocument();
+  });
+});

--- a/src/dashboard/frontend/src/components/RunningAgentsPill.tsx
+++ b/src/dashboard/frontend/src/components/RunningAgentsPill.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { selectAgents, selectIssues, useDashboardStore } from '../lib/store';
+import type { Agent, Issue } from '../types';
+import {
+  AgentPillPopoverRow,
+  isRunningAgentStatus,
+  relativeTime,
+} from './AgentPillPopoverRow';
+
+export function RunningAgentsPill() {
+  const agents = useDashboardStore(selectAgents) as unknown as Agent[];
+  const issues = useDashboardStore(selectIssues) as unknown as Issue[];
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  const runningAgents = useMemo(
+    () => agents
+      .filter((agent) => isRunningAgentStatus(agent.status))
+      .sort((a, b) => {
+        const aTime = Date.parse(a.lastActivity ?? a.startedAt);
+        const bTime = Date.parse(b.lastActivity ?? b.startedAt);
+        return bTime - aTime;
+      }),
+    [agents],
+  );
+
+  const issueTitleById = useMemo(
+    () => new Map(issues.map((issue) => [issue.identifier.toUpperCase(), issue.title])),
+    [issues],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (event: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(event.target as Node)) setOpen(false);
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  if (runningAgents.length === 0) return null;
+
+  return (
+    <div ref={wrapRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        aria-label={`${runningAgents.length} running agent${runningAgents.length === 1 ? '' : 's'} — click to view`}
+        data-testid="running-agents-pill"
+        className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-xs text-emerald-600 transition-colors hover:bg-emerald-500/20 dark:text-emerald-400"
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+        {runningAgents.length} agent{runningAgents.length === 1 ? '' : 's'}
+      </button>
+      {open && (
+        <div
+          data-testid="running-agents-popover"
+          className="absolute right-0 top-full z-50 mt-1.5 w-80 rounded-lg border border-border bg-card p-3 shadow-xl"
+        >
+          <div className="mb-2 text-xs font-semibold text-foreground">
+            {runningAgents.length} running now
+          </div>
+          <div className="max-h-64 overflow-y-auto">
+            {runningAgents.map((agent) => {
+              const activityAt = agent.lastActivity ?? agent.startedAt;
+              return (
+                <AgentPillPopoverRow
+                  key={agent.id}
+                  agent={agent}
+                  title={agent.issueId ? issueTitleById.get(agent.issueId.toUpperCase()) : undefined}
+                  contextLine={`${agent.model} · ${relativeTime(activityAt, Date.now())}`}
+                  onNavigate={() => setOpen(false)}
+                />
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/dashboard/frontend/src/components/StoppedAgentsBanner.tsx
+++ b/src/dashboard/frontend/src/components/StoppedAgentsBanner.tsx
@@ -6,6 +6,7 @@ import { useDashboardStore, selectAgents, selectIssues } from '../lib/store';
 import { classifyDashboardAgent } from '../lib/agent-classifier';
 import { Agent, type StartAgentResponse } from '../types';
 import { isCodexBlockedResponse, setPendingCodexSpawn } from '../lib/pending-codex-spawn';
+import { AgentPillPopoverRow, describeAgentStop, relativeTime } from './AgentPillPopoverRow';
 
 interface RestartResult {
   issueId: string;
@@ -36,10 +37,13 @@ export function StoppedAgentsBanner({ variant = 'banner' }: { variant?: 'banner'
 
   // issueId (upper-cased) → canonicalStatus, for the advanced-past-role check below.
   const issueStatusById = new Map<string, string>();
+  const issueTitleById = new Map<string, string>();
   for (const issue of issues) {
     const id = typeof issue['identifier'] === 'string' ? (issue['identifier'] as string).toUpperCase() : null;
     const status = typeof issue['canonicalStatus'] === 'string' ? (issue['canonicalStatus'] as string) : null;
+    const title = typeof issue['title'] === 'string' ? (issue['title'] as string) : null;
     if (id && status) issueStatusById.set(id, status);
+    if (id && title) issueTitleById.set(id, title);
   }
 
   // Show toast when an agent hits an API error (resolution transitions to 'api_error')
@@ -213,18 +217,29 @@ export function StoppedAgentsBanner({ variant = 'banner' }: { variant?: 'banner'
           {stoppedAgents.length} stopped
         </button>
         {popoverOpen && (
-          <div className="absolute right-0 top-full z-50 mt-1.5 w-72 rounded-lg border border-border bg-card p-3 shadow-xl">
+          <div
+            data-testid="stopped-agents-popover"
+            className="absolute right-0 top-full z-50 mt-1.5 w-80 rounded-lg border border-border bg-card p-3 shadow-xl"
+          >
             <div className="mb-2 flex items-center gap-1.5 text-xs font-semibold text-warning-foreground">
               <AlertTriangle className="h-3.5 w-3.5" />
-              {stoppedAgents.length} agent{stoppedAgents.length > 1 ? 's' : ''} stopped
+              {stoppedAgents.length} stopped · pipeline agents, last 7 days
             </div>
-            <div className="mb-3 max-h-40 overflow-y-auto">
-              {stoppedAgents.map((a) => (
-                <div key={a.id} className="flex items-center justify-between py-0.5 text-xs">
-                  <span className="font-mono text-foreground">{a.issueId || a.id}</span>
-                  {a.role && <span className="text-muted-foreground">{a.role}</span>}
-                </div>
-              ))}
+            <div className="mb-3 max-h-64 overflow-y-auto">
+              {stoppedAgents.map((agent) => {
+                const lastActivity = agent.lastActivity ? Date.parse(agent.lastActivity) : 0;
+                const startedAt = agent.startedAt ? Date.parse(agent.startedAt) : 0;
+                const activityAt = new Date(Math.max(lastActivity, startedAt)).toISOString();
+                return (
+                  <AgentPillPopoverRow
+                    key={agent.id}
+                    agent={agent}
+                    title={agent.issueId ? issueTitleById.get(agent.issueId.toUpperCase()) : undefined}
+                    contextLine={`${describeAgentStop(agent)} · ${relativeTime(activityAt, Date.now())}`}
+                    onNavigate={() => setPopoverOpen(false)}
+                  />
+                );
+              })}
             </div>
             {results && (
               <div className="mb-2 text-xs">

--- a/src/dashboard/frontend/src/components/__tests__/StoppedAgentsBanner.test.tsx
+++ b/src/dashboard/frontend/src/components/__tests__/StoppedAgentsBanner.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useDashboardStore } from '../../lib/store';
@@ -12,7 +12,8 @@ vi.mock('sonner', () => ({
   },
 }));
 
-const NOW_MS = Date.parse('2026-05-23T12:00:00.000Z');
+const NOW = new Date('2026-05-23T12:00:00.000Z');
+const NOW_MS = NOW.getTime();
 const RECENT_AT = new Date(NOW_MS - 60 * 60 * 1000).toISOString();
 const OLD_AT = new Date(NOW_MS - 8 * 24 * 60 * 60 * 1000).toISOString();
 
@@ -32,28 +33,52 @@ function agent(overrides: Partial<Agent> & Pick<Agent, 'id' | 'issueId' | 'statu
   };
 }
 
-function seedAgents(agents: Agent[]): void {
+function seedStore(agents: Agent[], issues: Array<Record<string, unknown>> = []): void {
   useDashboardStore.setState({
     agentsById: Object.fromEntries(agents.map((item) => [item.id, item])),
+    issuesRaw: issues,
   } as Parameters<typeof useDashboardStore.setState>[0]);
+}
+
+function stoppedAgents(): Agent[] {
+  return [
+    agent({
+      id: 'agent-pan-1420-stopped',
+      issueId: 'PAN-1420',
+      status: 'stopped',
+      hasLiveTmuxSession: false,
+      pausedReason: 'waiting for deploy',
+    }),
+    agent({
+      id: 'agent-pan-1422-stopped',
+      issueId: 'PAN-1422',
+      status: 'stopped',
+      hasLiveTmuxSession: false,
+      troubled: true,
+      consecutiveFailures: 2,
+      role: 'review',
+    }),
+  ];
 }
 
 describe('StoppedAgentsBanner', () => {
   beforeEach(() => {
-    vi.spyOn(Date, 'now').mockReturnValue(NOW_MS);
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    window.history.replaceState(null, '', '/');
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ id: 'agent-pan-1420' }), { status: 200 })));
-    seedAgents([]);
+    seedStore([]);
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
     vi.unstubAllGlobals();
-    seedAgents([]);
+    vi.useRealTimers();
+    seedStore([]);
   });
 
   it('renders and restarts only agents classified as stopped', async () => {
     const fetchMock = vi.mocked(fetch);
-    seedAgents([
+    seedStore([
       agent({
         id: 'agent-pan-1419-running',
         issueId: 'PAN-1419',
@@ -91,12 +116,69 @@ describe('StoppedAgentsBanner', () => {
     expect(banner).not.toHaveTextContent('PAN-1421');
     expect(banner).not.toHaveTextContent('PAN-AC-1');
 
-    fireEvent.click(screen.getByTestId('banner-restart-all'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('banner-restart-all'));
+      await vi.runAllTimersAsync();
+    });
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith('/api/agents', expect.objectContaining({
       method: 'POST',
       body: JSON.stringify({ issueId: 'PAN-1420' }),
     }));
+  });
+
+  it('renders titled stop context, bare-ID fallback, scope, and issue navigation', () => {
+    seedStore(stoppedAgents(), [
+      { identifier: 'PAN-1420', title: 'Known stopped issue', canonicalStatus: 'in_progress' },
+    ]);
+
+    render(<StoppedAgentsBanner variant="pill" />);
+    fireEvent.click(screen.getByTestId('stopped-agents-pill'));
+
+    const popover = screen.getByTestId('stopped-agents-popover');
+    expect(within(popover).getByText('2 stopped · pipeline agents, last 7 days')).toBeInTheDocument();
+    expect(within(popover).getByText('Known stopped issue')).toBeInTheDocument();
+    expect(within(popover).getByText('paused: waiting for deploy · 1h ago')).toBeInTheDocument();
+    expect(within(popover).getByText('PAN-1422')).toBeInTheDocument();
+    expect(within(popover).getByText('troubled (2 failures) · 1h ago')).toBeInTheDocument();
+
+    fireEvent.click(within(popover).getByText('Known stopped issue'));
+
+    expect(window.location.pathname).toBe('/issues/PAN-1420');
+    expect(screen.queryByTestId('stopped-agents-popover')).not.toBeInTheDocument();
+  });
+
+  it('preserves the pill trigger, list, results summary, and one restart per agent', async () => {
+    const fetchMock = vi.mocked(fetch);
+    seedStore(stoppedAgents(), [
+      { identifier: 'PAN-1420', title: 'Known stopped issue', canonicalStatus: 'in_progress' },
+    ]);
+
+    render(<StoppedAgentsBanner variant="pill" />);
+    const trigger = screen.getByTestId('stopped-agents-pill');
+    expect(trigger).toHaveTextContent('2 stopped');
+    fireEvent.click(trigger);
+
+    const popover = screen.getByTestId('stopped-agents-popover');
+    expect(within(popover).getAllByRole('button')).toHaveLength(3);
+    expect(within(popover).getByTestId('pill-restart-all')).toHaveTextContent('Restart all');
+
+    await act(async () => {
+      fireEvent.click(within(popover).getByTestId('pill-restart-all'));
+      await vi.runAllTimersAsync();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/agents', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ issueId: 'PAN-1420' }),
+    }));
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/agents', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ issueId: 'PAN-1422' }),
+    }));
+    expect(within(popover).getByText('✓ 2 restarted')).toBeInTheDocument();
+    expect(within(popover).getByTestId('pill-restart-all')).toHaveTextContent('Restart all');
   });
 });


### PR DESCRIPTION
**Issue:** #2890

## Acceptance Criteria

- [ ] Shared AgentPillPopoverRow component with stop-reason and navigation utils
- [ ] Running-agents pill becomes an interactive drill-down popover
- [ ] Stopped-agents popover rows gain title, stop reason, and scoped header
- [ ] Identify and resolve the 'Save Session' string sighting
- [ ] Document the interactive agent pills in COMMAND-DECK-RESTORATION.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a running-agents status pill showing active agent count and recent activity.
  - Added an interactive popover with agent status, model, timing, role, and issue context.
  - Selecting an issue opens its issue page; system agents open the agents view.
  - Improved stopped-agent details with clearer status context and timestamps.
  - Added project-scoped search and documented split-pane support in the app experience.

- **Documentation**
  - Updated the living design record with agent-pill interaction details and app-bar guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->