### PR TITLE
PAN-2731

### DIFF
--- a/src/lib/__tests__/agents-spawn-supervisor.test.ts
+++ b/src/lib/__tests__/agents-spawn-supervisor.test.ts
@@ -394,7 +394,11 @@ describe('spawnAgent PTY supervisor wiring', () => {
       });
 
       expect(openaiState.harness).toBe('codex');
+      expect(openaiState.lastActivity).toBeUndefined();
+      expect(openaiState.costSoFar).toBeUndefined();
       expect(kimiState.harness).toBe('ohmypi');
+      expect(kimiState.lastActivity).toEqual(expect.any(String));
+      expect(kimiState.costSoFar).toBe(0);
       expect(resolveHarnessMock).toHaveBeenCalledWith({ explicit: undefined, role: 'work', model: 'gpt-5.5' });
       expect(resolveHarnessMock).toHaveBeenCalledWith({ explicit: undefined, role: 'work', model: 'kimi-k2.6' });
       expect(prepareHarnessLaunchMock).toHaveBeenCalledWith('codex');

--- a/src/lib/agents/agent-state.ts
+++ b/src/lib/agents/agent-state.ts
@@ -814,7 +814,9 @@ export function markAgentRunning(state: AgentState, options?: { preserveFailureT
   assertAgentCanTransitionToRunning(state);
   const oldStatus = state.status;
   state.status = 'running';
-  state.lastActivity = new Date().toISOString();
+  // Codex activity comes from app-server notifications or rollout JSONL. A
+  // synthetic spawn timestamp becomes permanently stale in the TUI fallback.
+  if (state.harness !== 'codex') state.lastActivity = new Date().toISOString();
   if (options?.preserveFailureTracking !== true) {
     clearFailureTrackingFields(state);
   }

--- a/src/lib/agents/spawn.ts
+++ b/src/lib/agents/spawn.ts
@@ -195,7 +195,7 @@ export async function spawnRun(issueId: string, role: Role, options: SpawnRunOpt
     modelSpawnKey,
     status: 'starting',
     startedAt: new Date().toISOString(),
-    costSoFar: 0,
+    ...(resolvedHarness === 'codex' ? {} : { costSoFar: 0 }),
     hostOverride: options.allowHost || undefined,
     slotIndex: options.slotIndex,
     slotItemId: options.slotItemId,
@@ -517,7 +517,7 @@ export async function spawnAgent(options: SpawnOptions): Promise<AgentState> {
     modelSpawnKey,
     status: 'starting',
     startedAt: new Date().toISOString(),
-    costSoFar: 0,
+    ...(resolvedHarness === 'codex' ? {} : { costSoFar: 0 }),
     hostOverride: options.allowHost || undefined,
     sessionId: createFreshSessionIdentity(agentId, resolvedHarness),
   };

--- a/tests/unit/lib/agents/agent-state-gate.test.ts
+++ b/tests/unit/lib/agents/agent-state-gate.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   decideResumeGate,
   getAgentResumeGateBlockReason,
+  markAgentRunning,
+  type AgentState,
   type ResumeGateBlock,
 } from '../../../../src/lib/agents/agent-state.js';
 
@@ -35,6 +37,30 @@ describe('getAgentResumeGateBlockReason', () => {
       reason: 'agent is in failure backoff (2 failures)',
       consecutiveFailures: 2,
     });
+  });
+});
+
+describe('markAgentRunning', () => {
+  function state(harness: AgentState['harness']): AgentState {
+    return {
+      id: `agent-${harness}`,
+      issueId: 'PAN-2731',
+      workspace: '/tmp/workspace',
+      harness,
+      status: 'starting',
+      startedAt: '2026-07-15T15:22:04.971Z',
+    };
+  }
+
+  it('does not invent a Codex lastActivity timestamp before observed activity', () => {
+    const codex = state('codex');
+    const claude = state('claude-code');
+
+    markAgentRunning(codex);
+    markAgentRunning(claude);
+
+    expect(codex.lastActivity).toBeUndefined();
+    expect(claude.lastActivity).toEqual(expect.any(String));
   });
 });
 


### PR DESCRIPTION
**Issue:** #2731


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent activity tracking so Codex sessions don’t show activity before any activity is observed.
  * Prevented Codex sessions from displaying an initial cost value when no cost data is available.
  * Preserved existing activity and cost information when agents transition to a running state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->