### PR TITLE
fix(deploy): supervise patrol auto-deploy via systemd-run and break stale dead-pid restart locks (PAN-2918)

### DIFF
--- a/docs/OVERDECK_DEV_SOP.md
+++ b/docs/OVERDECK_DEV_SOP.md
@@ -76,8 +76,10 @@ deploy:
 ```
 
 Set `deploy.auto_deploy: false` for signal-only mode. Staleness remains visible in system health
-and the header, but Deacon does not start a deployment. Detached deployment output is appended to
-`~/.overdeck/logs/auto-deploy.log`.
+and the header, but Deacon does not start a deployment. On Linux, Deacon runs the reload in a
+transient systemd user unit with rate-limited failure recovery, so stopping the old dashboard cannot
+kill the reload through the dashboard's cgroup. Deployment output and retry failures are appended
+to `~/.overdeck/logs/auto-deploy.log`.
 
 `pan reload` remains the manual deployment door. It builds first, preserves the running dashboard
 when the build fails, restarts the Node 22 bundle after a successful build, and waits for health.

--- a/src/lib/__tests__/restart-lock.test.ts
+++ b/src/lib/__tests__/restart-lock.test.ts
@@ -85,7 +85,14 @@ describe('restart lock', () => {
     expect(await Effect.runPromise(readRestartLockHolder())).toBeNull();
   });
 
-  it('reads the lock holder from disk', async () => {
+  it('clears a dead lock holder instead of blocking restart gates', async () => {
+    writeLock({ pid: 999_999_999, ts: Date.now(), caller: 'dead reader' });
+
+    expect(await Effect.runPromise(readRestartLockHolder())).toBeNull();
+    expect(existsSync(lockPath())).toBe(false);
+  });
+
+  it('reads the live lock holder from disk', async () => {
     writeLock({ pid: process.pid, ts: 123, caller: 'reader' });
 
     expect(await Effect.runPromise(readRestartLockHolder())).toEqual({ pid: process.pid, ts: 123, caller: 'reader' });

--- a/src/lib/cloister/deploy-patrol.ts
+++ b/src/lib/cloister/deploy-patrol.ts
@@ -12,6 +12,7 @@ import { loadCloisterConfigSync, type DeployConfig } from './config.js';
 
 const OBSERVATION_INTERVAL_MS = 30 * 60 * 1000;
 const DEPLOY_SPAWN_COOLDOWN_MS = 10 * 60 * 1000;
+const SYSTEMD_ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 interface DeployPatrolState {
   lastObservedBehind: number | null;
@@ -52,6 +53,32 @@ export interface ReloadRequest {
   readonly detached: true;
 }
 
+export function buildSystemdReloadArgs(
+  request: ReloadRequest,
+  now: number,
+  logPath: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  const setenvArgs = Object.entries(env)
+    .filter(([name, value]) => value !== undefined && SYSTEMD_ENV_NAME_RE.test(name))
+    .flatMap(([name, value]) => ['--setenv', `${name}=${value}`]);
+
+  return [
+    '--user', '--unit', `overdeck-auto-deploy-${now}`,
+    '--collect', '--quiet',
+    '--property=Restart=on-failure',
+    '--property=RestartSec=10s',
+    '--property=StartLimitBurst=2',
+    '--property=StartLimitIntervalSec=300s',
+    `--property=StandardOutput=append:${logPath}`,
+    `--property=StandardError=append:${logPath}`,
+    `--property=WorkingDirectory=${request.cwd}`,
+    ...setenvArgs,
+    request.command,
+    ...request.args,
+  ];
+}
+
 function shortSha(sha: string | null): string {
   return sha?.slice(0, 8) || 'unknown';
 }
@@ -79,8 +106,16 @@ export async function waitForChildSpawn(
   });
 }
 
+async function waitForChildExit(child: ChildProcess): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    child.once('error', reject);
+    child.once('close', (code) => resolve(code ?? 1));
+  });
+}
+
 async function spawnDetachedReload(request: ReloadRequest, now: number): Promise<void> {
   const logsDir = join(OVERDECK_HOME, 'logs');
+  const logPath = join(logsDir, 'auto-deploy.log');
   await mkdir(logsDir, { recursive: true });
   await writeFile(
     join(OVERDECK_HOME, 'dashboard-restarting.json'),
@@ -88,8 +123,31 @@ async function spawnDetachedReload(request: ReloadRequest, now: number): Promise
     'utf8',
   );
 
-  const log = await open(join(logsDir, 'auto-deploy.log'), 'a');
+  const log = await open(logPath, 'a');
   try {
+    if (process.platform === 'linux') {
+      let systemdFailure: string | null = null;
+      try {
+        const launcher = spawn(
+          'systemd-run',
+          buildSystemdReloadArgs(request, now, logPath),
+          {
+            cwd: request.cwd,
+            stdio: ['ignore', log.fd, log.fd],
+          },
+        );
+        const exitCode = await waitForChildExit(launcher);
+        if (exitCode === 0) return;
+        systemdFailure = `systemd-run exited ${exitCode}`;
+      } catch (error) {
+        systemdFailure = error instanceof Error ? error.message : String(error);
+      }
+      await log.appendFile(
+        `[auto-deploy] WARNING: ${systemdFailure}; falling back to an unsupervised detached reload.\n`,
+        'utf8',
+      );
+    }
+
     const child = spawn(
       request.command,
       [...request.args],

--- a/src/lib/restart-lock.ts
+++ b/src/lib/restart-lock.ts
@@ -101,7 +101,20 @@ async function acquireStaleBreaker(path: string): Promise<RestartLockHandle | nu
   }
   return null;
 }async function readRestartLockHolderPromise(): Promise<RestartLockHolder | null> {
-  return readHolderFromPath(restartLockPath());
+  const path = restartLockPath();
+  const observed = await readHolderFromPath(path);
+  if (!observed || isProcessAlive(observed.pid)) return observed;
+
+  const breaker = await acquireStaleBreaker(path);
+  if (!breaker) return observed;
+  try {
+    const current = await readHolderFromPath(path);
+    if (!matchesHolder(current, observed)) return current;
+    await unlinkIfExists(path);
+    return null;
+  } finally {
+    await breaker.release();
+  }
 }async function acquireRestartLockPromise(caller: string): Promise<RestartLockHandle | null> {
   const path = restartLockPath();
   await mkdir(dirname(path), { recursive: true });

--- a/tests/unit/lib/cloister/deploy-patrol.test.ts
+++ b/tests/unit/lib/cloister/deploy-patrol.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'node:events';
 
 import {
   _resetDeployPatrolForTests,
+  buildSystemdReloadArgs,
   runDeployPatrol,
   waitForChildSpawn,
 } from '../../../../src/lib/cloister/deploy-patrol.js';
@@ -135,6 +136,36 @@ describe('runDeployPatrol', () => {
     await runDeployPatrol(unknownCtx);
     expect(unknownCtx.spawnReload).not.toHaveBeenCalled();
     expect(unknownCtx.emitEntry).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('buildSystemdReloadArgs', () => {
+  it('runs the reload in a retrying unit outside the dashboard cgroup with captured output', () => {
+    const args = buildSystemdReloadArgs(
+      {
+        command: '/usr/bin/node',
+        args: ['/repo/dist/cli/index.js', 'reload', '--health-timeout', '120000'],
+        cwd: '/repo',
+        detached: true,
+      },
+      NOW,
+      '/home/test/.overdeck/logs/auto-deploy.log',
+      { PATH: '/usr/bin', 'BASH_FUNC_bad%%': '() { :; }' },
+    );
+
+    expect(args).toEqual([
+      '--user', '--unit', `overdeck-auto-deploy-${NOW}`,
+      '--collect', '--quiet',
+      '--property=Restart=on-failure',
+      '--property=RestartSec=10s',
+      '--property=StartLimitBurst=2',
+      '--property=StartLimitIntervalSec=300s',
+      '--property=StandardOutput=append:/home/test/.overdeck/logs/auto-deploy.log',
+      '--property=StandardError=append:/home/test/.overdeck/logs/auto-deploy.log',
+      '--property=WorkingDirectory=/repo',
+      '--setenv', 'PATH=/usr/bin',
+      '/usr/bin/node', '/repo/dist/cli/index.js', 'reload', '--health-timeout', '120000',
+    ]);
   });
 });
 


### PR DESCRIPTION
Strike for PAN-2918 (both legs of the 2026-07-19 outage): (1) patrol auto-deploy runs under systemd-run --user with Restart=on-failure and captured logs — a dead reload can no longer strand a killed server silently; (2) restart-lock holder is liveness-checked, dead holders are broken race-safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGKWkic5rTSFHv3545Sn1b