### PR TITLE
fix(dashboard): restore parseProcessTable export — un-red main (PAN-2925)

### DIFF
--- a/src/dashboard/server/routes/resources/agents-stats.ts
+++ b/src/dashboard/server/routes/resources/agents-stats.ts
@@ -177,6 +177,23 @@ export function getAgentStatsSnapshotEffect(
   });
 }
 
+export function parseProcessTable(psTable: string): AgentProcessRecord[] {
+  return psTable
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .flatMap((line) => {
+      const match = line.match(/^(\d+)\s+(\d+)\s+([0-9.]+)\s+(\d+)$/);
+      if (!match) return [];
+      return [{
+        pid: Number(match[1]),
+        ppid: Number(match[2]),
+        cpuPercent: Number(match[3]),
+        rssBytes: Number(match[4]) * 1024,
+      }];
+    });
+}
+
 async function readBatchedProcessTable(): Promise<AgentProcessRecord[]> {
   const census = await getRuntimeCensus();
   return [...census.processesByPid.values()].map((process) => ({

--- a/tests/unit/dashboard/routes/resources-agents.test.ts
+++ b/tests/unit/dashboard/routes/resources-agents.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   buildAgentStatsSnapshot,
   getAgentStatsSnapshotEffect,
+  parseProcessTable,
   type AgentCostEvent,
   type AgentProcessRecord,
   type MinimalAgentState,
@@ -51,6 +52,16 @@ describe('agent resource stats payload', () => {
       hypotheticalUsdPerHour: 1.5,
       totalUsd: 0,
     });
+  });
+
+  it('keeps the legacy four-column process parser available through the resources barrel', () => {
+    expect(parseProcessTable([
+      ' 100 1 2.5 1024',
+      ' 101 100 7.0 2048',
+    ].join('\n'))).toEqual([
+      { pid: 100, ppid: 1, cpuPercent: 2.5, rssBytes: 1024 * 1024 },
+      { pid: 101, ppid: 100, cpuPercent: 7, rssBytes: 2048 * 1024 },
+    ]);
   });
 
   it('sums a four-process pid tree from one batched process parse', async () => {


### PR DESCRIPTION
Minimal red-main fix: 1522726084 imports parseProcessTable from routes/resources/agents-stats.ts which did not export it; every CI job failed at Build. Restores the export + regression test. Strike commit published by the flywheel orchestrator (agent's local gates passed for build/typecheck/lint/regression; the PR CI is the arbiter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGKWkic5rTSFHv3545Sn1b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored compatibility for parsing legacy four-column process data.
  * Improved conversion of CPU and memory values into accurate process statistics.

* **Tests**
  * Added coverage to verify process identifiers, CPU percentages, and memory conversion are parsed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->