### PR TITLE
fix(test): align substrate smoke fixture with trailer query — un-red main (PAN-2929)

### DIFF
--- a/tests/integration/flywheel-substrate-smoke.test.ts
+++ b/tests/integration/flywheel-substrate-smoke.test.ts
@@ -318,7 +318,7 @@ describe('flywheel substrate bug smoke', () => {
       const query = url.searchParams.get('q') ?? '';
       if (url.pathname === '/search/issues' && query.includes('is:issue')) {
         return response({
-          items: query.includes('author:panopticon-agent[bot]')
+          items: query.includes('Flywheel-Filed-By:')
             ? [{
               number: 2001,
               title: 'Substrate bug',
@@ -326,7 +326,7 @@ describe('flywheel substrate bug smoke', () => {
               created_at: '2026-05-25T12:10:00.000Z',
               updated_at: '2026-05-25T12:10:00.000Z',
               labels: [{ name: 'substrate' }, { name: 'P1' }],
-              user: { login: 'panopticon-agent[bot]' },
+              user: { login: 'eltmon' },
             }]
             : [],
         });


### PR DESCRIPTION
82a6da7a13's poller rework queries by Flywheel-Filed-By trailer; the integration smoke test's mock still matched the retired author:panopticon-agent[bot] query and returned nothing. Aligns the fixture. Test-only, 2 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGKWkic5rTSFHv3545Sn1b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test scenarios to reflect current issue-search results and reported issue provenance.
  * Improved validation of downstream issue polling and lookup behavior using representative issue metadata.
  * Ensured smoke tests remain aligned with the expected workflow for identifying and processing filed issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->