### PR TITLE
fix(cloister): gate patrol auto-deploys on CI conclusion and stamp deploy-patrol initiator (PAN-2924)

### DIFF
--- a/docs/OVERDECK_DEV_SOP.md
+++ b/docs/OVERDECK_DEV_SOP.md
@@ -82,8 +82,9 @@ running `buildCommit`; the app header shows `build stale ×N` when newer build-i
 
 The post-merge lifecycle and Deacon share the same deploy safety window. They defer while
 verification, merging, another restart, a pending post-merge lifecycle, or `pan dev` is active.
-Deacon also waits for the merge debounce interval, so a merge train produces one rebuild and
-restart instead of one per merge.
+Deacon also requires the `CI` workflow for the exact `origin/main` tip to complete successfully;
+pending, failed, or unreadable CI state defers deployment. It then waits for the merge debounce interval,
+so a merge train produces one rebuild and restart instead of one per merge.
 
 Configure the behavior in Cloister config:
 
@@ -96,8 +97,9 @@ deploy:
 Set `deploy.auto_deploy: false` for signal-only mode. Staleness remains visible in system health
 and the header, but Deacon does not start a deployment. On Linux, Deacon runs the reload in a
 transient systemd user unit with rate-limited failure recovery, so stopping the old dashboard cannot
-kill the reload through the dashboard's cgroup. Deployment output and retry failures are appended
-to `~/.overdeck/logs/auto-deploy.log`.
+kill the reload through the dashboard's cgroup. Patrol reloads stamp `deploy-patrol` as the restart
+initiator instead of inheriting the identity that launched the current dashboard. Deployment output
+and retry failures are appended to `~/.overdeck/logs/auto-deploy.log`.
 
 `pan reload` remains the manual deployment door. It builds first, preserves the running dashboard
 when the build fails, restarts the Node 22 bundle after a successful build, and waits for health.

--- a/src/lib/cloister/deploy-patrol.ts
+++ b/src/lib/cloister/deploy-patrol.ts
@@ -1,6 +1,6 @@
 import { open, mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { spawn } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
 
 import { emitActivityEntrySync, emitActivityTtsSync } from '../activity-logger.js';
@@ -12,6 +12,9 @@ import { loadCloisterConfigSync, type DeployConfig } from './config.js';
 
 const OBSERVATION_INTERVAL_MS = 30 * 60 * 1000;
 const DEPLOY_SPAWN_COOLDOWN_MS = 10 * 60 * 1000;
+const DEPLOY_PATROL_INITIATOR = 'deploy-patrol';
+const CI_WORKFLOW_FILE = 'ci.yml';
+const CI_RUN_FIELDS = 'databaseId,status,conclusion,headSha,attempt,createdAt';
 const SYSTEMD_ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 interface DeployPatrolState {
@@ -35,10 +38,25 @@ const state: DeployPatrolState = {
 type EmitEntry = typeof emitActivityEntrySync;
 type EmitTts = typeof emitActivityTtsSync;
 
+export interface DeployCiState {
+  readonly status: 'green' | 'pending' | 'red' | 'unknown';
+  readonly reason?: string;
+}
+
+interface DeployCiRun {
+  readonly databaseId: number;
+  readonly status: string;
+  readonly conclusion: string | null;
+  readonly headSha: string;
+  readonly attempt: number;
+  readonly createdAt: string;
+}
+
 export interface DeployPatrolContext {
   readonly repoRoot: string;
   readonly config: DeployConfig;
   readonly computeStaleness?: () => Promise<BuildStaleness>;
+  readonly getCiState?: (sha: string) => Promise<DeployCiState>;
   readonly getBlockReason?: () => Promise<string | null>;
   readonly spawnReload?: (request: ReloadRequest) => Promise<void>;
   readonly emitEntry?: EmitEntry;
@@ -51,6 +69,64 @@ export interface ReloadRequest {
   readonly args: readonly string[];
   readonly cwd: string;
   readonly detached: true;
+  readonly initiator: string;
+}
+
+function reloadEnvironment(request: ReloadRequest, env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return { ...env, OVERDECK_AGENT_ID: request.initiator };
+}
+
+function execGh(args: readonly string[], cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile('gh', [...args], { cwd, encoding: 'utf8', timeout: 30_000 }, (error, stdout) => {
+      if (error) reject(error);
+      else resolve(stdout);
+    });
+  });
+}
+
+export async function getDeployCiState(
+  repoRoot: string,
+  sha: string,
+  runGh: (args: readonly string[], cwd: string) => Promise<string> = execGh,
+): Promise<DeployCiState> {
+  try {
+    const runs = JSON.parse(await runGh([
+      'run', 'list',
+      '--branch', 'main',
+      '--commit', sha,
+      '--workflow', CI_WORKFLOW_FILE,
+      '--limit', '10',
+      '--json', CI_RUN_FIELDS,
+    ], repoRoot)) as DeployCiRun[];
+    const run = runs.find((candidate) => candidate.headSha === sha);
+    const tip = shortSha(sha);
+
+    if (!run) {
+      return {
+        status: 'pending',
+        reason: `Automatic deployment deferred because CI has not started for origin/main ${tip}.`,
+      };
+    }
+    if (run.status !== 'completed') {
+      return {
+        status: 'pending',
+        reason: `Automatic deployment deferred because CI is ${run.status} for origin/main ${tip}.`,
+      };
+    }
+    if (run.conclusion !== 'success') {
+      return {
+        status: 'red',
+        reason: `Automatic deployment blocked because CI concluded ${run.conclusion || 'without a result'} for origin/main ${tip}.`,
+      };
+    }
+    return { status: 'green' };
+  } catch (error) {
+    return {
+      status: 'unknown',
+      reason: `Automatic deployment deferred because CI status for origin/main ${shortSha(sha)} could not be read: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
 }
 
 export function buildSystemdReloadArgs(
@@ -59,7 +135,7 @@ export function buildSystemdReloadArgs(
   logPath: string,
   env: NodeJS.ProcessEnv = process.env,
 ): string[] {
-  const setenvArgs = Object.entries(env)
+  const setenvArgs = Object.entries(reloadEnvironment(request, env))
     .filter(([name, value]) => value !== undefined && SYSTEMD_ENV_NAME_RE.test(name))
     .flatMap(([name, value]) => ['--setenv', `${name}=${value}`]);
 
@@ -154,6 +230,7 @@ async function spawnDetachedReload(request: ReloadRequest, now: number): Promise
       {
         cwd: request.cwd,
         detached: request.detached,
+        env: reloadEnvironment(request, process.env),
         stdio: ['ignore', log.fd, log.fd],
       },
     );
@@ -170,6 +247,21 @@ function clearState(): void {
   state.lastDeferralAt = 0;
   state.lastDeploySpawnAt = 0;
   state.unknownObserved = false;
+}
+
+function emitDeferral(reason: string, now: number, emitEntry: EmitEntry): void {
+  if (
+    state.lastDeferralReason === reason &&
+    now - state.lastDeferralAt < OBSERVATION_INTERVAL_MS
+  ) return;
+
+  emitEntry({
+    source: 'deploy-script',
+    level: 'warn',
+    message: reason,
+  });
+  state.lastDeferralReason = reason;
+  state.lastDeferralAt = now;
 }
 
 export async function runDeployPatrol(context: DeployPatrolContext): Promise<void> {
@@ -220,20 +312,23 @@ export async function runDeployPatrol(context: DeployPatrolContext): Promise<voi
   ) return;
   if (state.lastDeploySpawnAt > 0 && now - state.lastDeploySpawnAt < DEPLOY_SPAWN_COOLDOWN_MS) return;
 
+  if (!staleness.originMainSha) {
+    emitDeferral('Automatic deployment deferred because the origin/main commit is unknown.', now, emitEntry);
+    return;
+  }
+  const ciState = await (context.getCiState ?? ((sha) => getDeployCiState(context.repoRoot, sha)))(staleness.originMainSha);
+  if (ciState.status !== 'green') {
+    emitDeferral(
+      ciState.reason ?? `Automatic deployment deferred because CI is ${ciState.status} for origin/main ${shortSha(staleness.originMainSha)}.`,
+      now,
+      emitEntry,
+    );
+    return;
+  }
+
   const blockReason = await (context.getBlockReason ?? getDeployBlockReason)();
   if (blockReason) {
-    if (
-      state.lastDeferralReason !== blockReason ||
-      now - state.lastDeferralAt >= OBSERVATION_INTERVAL_MS
-    ) {
-      emitEntry({
-        source: 'deploy-script',
-        level: 'warn',
-        message: blockReason,
-      });
-      state.lastDeferralReason = blockReason;
-      state.lastDeferralAt = now;
-    }
+    emitDeferral(blockReason, now, emitEntry);
     return;
   }
 
@@ -242,6 +337,7 @@ export async function runDeployPatrol(context: DeployPatrolContext): Promise<voi
     args: [join(context.repoRoot, 'dist/cli/index.js'), 'reload', '--health-timeout', '120000'],
     cwd: context.repoRoot,
     detached: true,
+    initiator: DEPLOY_PATROL_INITIATOR,
   };
   await (context.spawnReload ?? ((request) => spawnDetachedReload(request, now)))(reloadRequest);
   state.lastDeploySpawnAt = now;

--- a/tests/unit/lib/cloister/deploy-patrol.test.ts
+++ b/tests/unit/lib/cloister/deploy-patrol.test.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'node:events';
 import {
   _resetDeployPatrolForTests,
   buildSystemdReloadArgs,
+  getDeployCiState,
   runDeployPatrol,
   waitForChildSpawn,
 } from '../../../../src/lib/cloister/deploy-patrol.js';
@@ -30,6 +31,7 @@ function context(staleness: BuildStaleness = stale()) {
     repoRoot: '/repo',
     config: { auto_deploy: true, debounce_minutes: 5 },
     computeStaleness: vi.fn(async () => staleness),
+    getCiState: vi.fn(async () => ({ status: 'green' as const })),
     getBlockReason: vi.fn(async () => null),
     spawnReload: vi.fn(async () => undefined),
     emitEntry: vi.fn(),
@@ -48,6 +50,58 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+describe('getDeployCiState', () => {
+  const sha = 'origin123456789';
+
+  it('requires a successful CI workflow run for the exact origin/main tip', async () => {
+    const runGh = vi.fn(async () => JSON.stringify([{
+      databaseId: 42,
+      status: 'completed',
+      conclusion: 'success',
+      headSha: sha,
+      attempt: 1,
+      createdAt: '2026-07-15T11:55:00Z',
+    }]));
+
+    await expect(getDeployCiState('/repo', sha, runGh)).resolves.toEqual({ status: 'green' });
+    expect(runGh).toHaveBeenCalledWith([
+      'run', 'list',
+      '--branch', 'main',
+      '--commit', sha,
+      '--workflow', 'ci.yml',
+      '--limit', '10',
+      '--json', 'databaseId,status,conclusion,headSha,attempt,createdAt',
+    ], '/repo');
+  });
+
+  it.each([
+    ['in_progress', null, 'pending'],
+    ['completed', 'failure', 'red'],
+  ] as const)('classifies a %s CI run with conclusion %s as %s', async (status, conclusion, expected) => {
+    const runGh = vi.fn(async () => JSON.stringify([{
+      databaseId: 42,
+      status,
+      conclusion,
+      headSha: sha,
+      attempt: 1,
+      createdAt: '2026-07-15T11:55:00Z',
+    }]));
+
+    await expect(getDeployCiState('/repo', sha, runGh)).resolves.toEqual(expect.objectContaining({
+      status: expected,
+    }));
+  });
+
+  it('fails closed when CI cannot be read', async () => {
+    const runGh = vi.fn(async () => { throw new Error('GitHub unavailable'); });
+
+    await expect(getDeployCiState('/repo', sha, runGh)).resolves.toEqual({
+      status: 'unknown',
+      reason: expect.stringContaining('GitHub unavailable'),
+    });
+  });
+});
+
 describe('runDeployPatrol', () => {
   it('starts one reload and announces it when the safety window is clear', async () => {
     const ctx = context();
@@ -59,12 +113,44 @@ describe('runDeployPatrol', () => {
       args: ['/repo/dist/cli/index.js', 'reload', '--health-timeout', '120000'],
       cwd: '/repo',
       detached: true,
+      initiator: 'deploy-patrol',
     });
     expect(ctx.emitEntry).toHaveBeenCalledWith(expect.objectContaining({
       message: expect.stringContaining('Automatic deployment started'),
     }));
     expect(ctx.emitTts).toHaveBeenCalledWith(expect.objectContaining({
       utterance: 'Automatic dashboard deployment started.',
+    }));
+  });
+
+  it('defers while CI for the origin/main tip is pending', async () => {
+    const ctx = context();
+    ctx.getCiState.mockResolvedValue({
+      status: 'pending',
+      reason: 'Automatic deployment deferred because CI is still in progress for origin/main origin12.',
+    });
+
+    await runDeployPatrol(ctx);
+    await runDeployPatrol(ctx);
+
+    expect(ctx.spawnReload).not.toHaveBeenCalled();
+    expect(ctx.getBlockReason).not.toHaveBeenCalled();
+    expect(ctx.emitEntry.mock.calls.filter(([entry]) => entry.message.includes('CI is still in progress'))).toHaveLength(1);
+  });
+
+  it('defers when CI for the origin/main tip is red', async () => {
+    const ctx = context();
+    ctx.getCiState.mockResolvedValue({
+      status: 'red',
+      reason: 'Automatic deployment blocked because CI failed for origin/main origin12.',
+    });
+
+    await runDeployPatrol(ctx);
+
+    expect(ctx.spawnReload).not.toHaveBeenCalled();
+    expect(ctx.getBlockReason).not.toHaveBeenCalled();
+    expect(ctx.emitEntry).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('CI failed'),
     }));
   });
 
@@ -147,10 +233,11 @@ describe('buildSystemdReloadArgs', () => {
         args: ['/repo/dist/cli/index.js', 'reload', '--health-timeout', '120000'],
         cwd: '/repo',
         detached: true,
+        initiator: 'deploy-patrol',
       },
       NOW,
       '/home/test/.overdeck/logs/auto-deploy.log',
-      { PATH: '/usr/bin', 'BASH_FUNC_bad%%': '() { :; }' },
+      { PATH: '/usr/bin', OVERDECK_AGENT_ID: 'flywheel-orchestrator', 'BASH_FUNC_bad%%': '() { :; }' },
     );
 
     expect(args).toEqual([
@@ -164,6 +251,7 @@ describe('buildSystemdReloadArgs', () => {
       '--property=StandardError=append:/home/test/.overdeck/logs/auto-deploy.log',
       '--property=WorkingDirectory=/repo',
       '--setenv', 'PATH=/usr/bin',
+      '--setenv', 'OVERDECK_AGENT_ID=deploy-patrol',
       '/usr/bin/node', '/repo/dist/cli/index.js', 'reload', '--health-timeout', '120000',
     ]);
   });


### PR DESCRIPTION
Both legs from the red-deploy incident: (1) the patrol resolves the tip's CI state via gh (green/pending/red/unknown) and defers deploys until green — no more shipping red builds; (2) the patrol's reload child runs with OVERDECK_AGENT_ID=deploy-patrol so restart-status attribution is honest. +90 lines of tests, SOP doc updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGKWkic5rTSFHv3545Sn1b