### PR TITLE
PAN-2931

### DIFF
--- a/src/cli/commands/__tests__/dashboard-cwd-guard.test.ts
+++ b/src/cli/commands/__tests__/dashboard-cwd-guard.test.ts
@@ -68,6 +68,26 @@ describe('resolvePrimaryDashboardIdentity', () => {
     );
     expect(child.unref).toHaveBeenCalled();
   });
+
+  it('returns a handle that stops the spawned systemd unit', () => {
+    processMocks.execFileSync.mockReturnValue(undefined);
+    vi.spyOn(Date, 'now').mockReturnValue(123456);
+
+    const handle = spawnDashboardDetached({
+      dashboardPort: 3010,
+      dashboardApiPort: 3011,
+      traefikEnabled: false,
+      traefikDomain: 'overdeck.localhost',
+    } as Parameters<typeof spawnDashboardDetached>[0]);
+    handle.stop();
+
+    expect(processMocks.execFileSync).toHaveBeenLastCalledWith(
+      'systemctl',
+      ['--user', 'stop', 'overdeck-dashboard-123456.service'],
+      { stdio: 'ignore' },
+    );
+    expect(processMocks.spawn).not.toHaveBeenCalled();
+  });
 });
 
 describe('refuseNonPrimaryDashboardCwd', () => {

--- a/src/cli/commands/restart.ts
+++ b/src/cli/commands/restart.ts
@@ -45,6 +45,7 @@ import {
   StageError,
   waitForDashboardHealth,
   stopDashboard,
+  type DashboardSpawnHandle,
   type PlatformConfig,
 } from '../../lib/platform-lifecycle.js';
 
@@ -169,7 +170,7 @@ function searchedBundlePaths(): string[] {
   return uniqueBundleCandidates().map(candidate => candidate.path);
 }
 
-export function spawnDashboardDetached(config: PlatformConfig, opts?: BootGateOptions): void {
+export function spawnDashboardDetached(config: PlatformConfig, opts?: BootGateOptions): DashboardSpawnHandle {
   const serverPath = resolveBundledServerPath();
   if (!existsSync(serverPath)) {
     throw new StageError({
@@ -201,7 +202,8 @@ export function spawnDashboardDetached(config: PlatformConfig, opts?: BootGateOp
   // and a conversation/flywheel-spawned one dies with that tmux pane's scope.
   // Run the server in its own transient systemd unit (same isolation the
   // shared tmux server gets, PAN-1798) so its lifecycle belongs to nobody.
-  if (spawnDashboardSystemdUnit(serverPath, fullEnv, identity.repoRoot)) return;
+  const systemdHandle = spawnDashboardSystemdUnit(serverPath, fullEnv, identity.repoRoot);
+  if (systemdHandle) return systemdHandle;
 
   const child = spawn(resolveNode22(), [serverPath], {
     cwd: identity.repoRoot,
@@ -214,6 +216,16 @@ export function spawnDashboardDetached(config: PlatformConfig, opts?: BootGateOp
     '[dashboard] WARNING (PAN-2804): could not start the dashboard via systemd-run. ' +
       'It shares the invoking process tree\'s cgroup; restarting that unit/scope will kill it.',
   );
+  return {
+    stop: () => {
+      if (!child.pid) return;
+      try {
+        process.kill(child.pid, 'SIGTERM');
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+      }
+    },
+  };
 }
 
 /** Valid systemd --setenv names; skips exported bash functions etc. */
@@ -223,17 +235,18 @@ function spawnDashboardSystemdUnit(
   serverPath: string,
   fullEnv: Record<string, string | undefined>,
   repoRoot: string,
-): boolean {
-  if (process.platform !== 'linux') return false;
+): DashboardSpawnHandle | null {
+  if (process.platform !== 'linux') return null;
   try {
     mkdirSync(dirname(DASHBOARD_LOG_FILE), { recursive: true });
+    const unitName = `overdeck-dashboard-${Date.now()}`;
     const setenvArgs = Object.entries(fullEnv)
       .filter(([k, v]) => v !== undefined && ENV_NAME_RE.test(k))
       .flatMap(([k, v]) => ['--setenv', `${k}=${v}`]);
     execFileSync(
       'systemd-run',
       [
-        '--user', '--unit', `overdeck-dashboard-${Date.now()}`,
+        '--user', '--unit', unitName,
         '--collect', '--quiet',
         // The dashboard is the orchestrator — shed agents before it (PAN-2500).
         '--property=ManagedOOMPreference=avoid',
@@ -246,9 +259,23 @@ function spawnDashboardSystemdUnit(
       ],
       { stdio: 'ignore' },
     );
-    return true;
+    return {
+      stop: () => {
+        const unit = `${unitName}.service`;
+        try {
+          execFileSync('systemctl', ['--user', 'stop', unit], { stdio: 'ignore' });
+        } catch (stopError) {
+          try {
+            execFileSync('systemctl', ['--user', 'is-active', '--quiet', unit], { stdio: 'ignore' });
+          } catch {
+            return; // The unit already exited and was collected.
+          }
+          throw stopError;
+        }
+      },
+    };
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -469,11 +496,16 @@ async function runFullRestart(
     installCliproxy: cliproxy.installCliproxySync,
   }));
 
-  spawnDashboardDetached(config, opts.bootGateOptions);
-  await Effect.runPromise(waitForDashboardHealth(config.dashboardApiPort, {
-    timeoutMs: opts.healthTimeoutMs,
-    expectedIdentity: resolvePrimaryDashboardIdentity(),
-  }));
+  const spawnedDashboard = spawnDashboardDetached(config, opts.bootGateOptions);
+  try {
+    await Effect.runPromise(waitForDashboardHealth(config.dashboardApiPort, {
+      timeoutMs: opts.healthTimeoutMs,
+      expectedIdentity: resolvePrimaryDashboardIdentity(),
+    }));
+  } catch (error) {
+    await spawnedDashboard.stop();
+    throw error;
+  }
 
   try {
     const { startSupervisorProcessSync } = await import('../../lib/supervisor.js');

--- a/src/dashboard/server/main.ts
+++ b/src/dashboard/server/main.ts
@@ -101,8 +101,6 @@ initDashboardLogFile();
 // spawn→listen window attributable. See server.ts for the matching listen mark.
 console.log(`[boot-timing] module graph loaded at +${Math.round(performance.now())}ms (since process start)`);
 console.log(`[overdeck] Boot gates: ${formatBootGateState(resolveBootGates())}`);
-startEventLoopMonitor();
-console.log('[overdeck] Event loop delay monitor started');
 
 // Ensure OVERDECK_HOME exists before any service that needs it (e.g. CacheService opening cache.db)
 await mkdir(getOverdeckHome(), { recursive: true });
@@ -111,9 +109,6 @@ await mkdir(getOverdeckHome(), { recursive: true });
 // Generates and persists a random token at <OVERDECK_HOME>/internal-token (mode 0600)
 // on first start; reused on subsequent starts. Used by /api/internal/pipeline/notify.
 ensureInternalTokenSync();
-
-void warnIfAutonomousMergeBackendUnavailable();
-void warnIfAppCannotMerge();
 
 // Prepare the managed tmux context exactly once, before any code path can spawn
 // tmux. After this call `buildTmuxArgs`, `buildTmuxCommandString`, and
@@ -125,6 +120,37 @@ await ensureManagedTmuxContextOnce();
 await initTrackerConfigCache().catch(err => {
   console.log('[tracker-config] Warning: failed to cache .overdeck.env:', err.message);
 });
+
+// A normal boot creates an EMPTY overdeck.db (fresh-install semantics). There is
+// NO legacy seed / db↔db migration — overdeck state is JSON/git-backed (PAN-1983).
+try {
+  const overdeckDbPath = getOverdeckDatabasePath();
+  if (!existsSync(overdeckDbPath)) {
+    createOverdeckDatabase({ dbPath: overdeckDbPath });
+    console.log(`[overdeck] Created overdeck.db at ${overdeckDbPath}`);
+  }
+} catch (err) {
+  // Non-fatal: dashboard continues with whatever data is in overdeck.db.
+  console.warn('[overdeck] Overdeck db init failed (non-fatal):', err);
+}
+
+// Bind the HTTP socket before starting any background service or the Deacon.
+// A bind failure is retried by server.ts and then terminates this process through
+// Effect's Node runtime; no headless orchestrator is allowed to survive it.
+const main = runServer.pipe(Effect.provide(ServerConfigLayer)) as Effect.Effect<never, unknown>;
+if (typeof Bun !== 'undefined') {
+  const { runMain } = await import('@effect/platform-bun/BunRuntime');
+  runMain(main as never);
+} else {
+  const { runMain } = await import('@effect/platform-node/NodeRuntime');
+  runMain(main as never);
+}
+await whenDashboardListening();
+
+startEventLoopMonitor();
+console.log('[overdeck] Event loop delay monitor started');
+void warnIfAutonomousMergeBackendUnavailable();
+void warnIfAppCannotMerge();
 
 // Start the shared IssueDataService — fire and forget.
 // It loads SQLite-cached data instantly and pushes an initial snapshot,
@@ -826,30 +852,4 @@ async function pruneClosedIssueReviewStatuses(): Promise<void> {
   if (removed > 0) {
     console.log(`[overdeck] Pruned ${removed} stale review-status entr${removed === 1 ? 'y' : 'ies'} for closed issues`);
   }
-}
-
-// ── Overdeck boot: create overdeck.db if needed ──────────────────────────────
-// A normal boot creates an EMPTY overdeck.db (fresh-install semantics). There is
-// NO legacy seed / db↔db migration — overdeck state is JSON/git-backed (PAN-1983).
-await (async () => {
-  try {
-    const overdeckDbPath = getOverdeckDatabasePath();
-    if (!existsSync(overdeckDbPath)) {
-      createOverdeckDatabase({ dbPath: overdeckDbPath });
-      console.log(`[overdeck] Created overdeck.db at ${overdeckDbPath}`);
-    }
-  } catch (err) {
-    // Non-fatal: dashboard continues with whatever data is in overdeck.db.
-    console.warn('[overdeck] Overdeck db init failed (non-fatal):', err);
-  }
-})();
-
-const main = runServer.pipe(Effect.provide(ServerConfigLayer)) as Effect.Effect<never, unknown>;
-
-if (typeof Bun !== 'undefined') {
-  const { runMain } = await import('@effect/platform-bun/BunRuntime');
-  runMain(main as never);
-} else {
-  const { runMain } = await import('@effect/platform-node/NodeRuntime');
-  runMain(main as never);
 }

--- a/src/dashboard/server/server-bind.ts
+++ b/src/dashboard/server/server-bind.ts
@@ -1,0 +1,28 @@
+import { Duration, Effect, Schedule } from 'effect';
+
+export function isAddressInUseError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  if ('code' in error && error.code === 'EADDRINUSE') return true;
+  return 'cause' in error && isAddressInUseError(error.cause);
+}
+
+const BIND_RETRY_DELAY_MS = 250;
+const BIND_RETRY_COUNT = 3;
+
+export function retryDashboardBind<A, E, R>(
+  bind: Effect.Effect<A, E, R>,
+  onRetry?: (attempt: number, delayMs: number) => void,
+): Effect.Effect<A, E, R> {
+  let failures = 0;
+  const observedBind = Effect.tapError(bind, (error) => Effect.sync(() => {
+    failures += 1;
+    if (failures <= BIND_RETRY_COUNT && isAddressInUseError(error)) {
+      onRetry?.(failures, BIND_RETRY_DELAY_MS);
+    }
+  }));
+  return Effect.retry(observedBind, {
+    times: BIND_RETRY_COUNT,
+    schedule: Schedule.spaced(Duration.millis(BIND_RETRY_DELAY_MS)),
+    while: isAddressInUseError,
+  });
+}

--- a/src/dashboard/server/server.ts
+++ b/src/dashboard/server/server.ts
@@ -77,6 +77,7 @@ import { internalEventsRouteLayer } from './routes/internal-events.js';
 import { dashboardCsrfToken, dashboardSessionCookieHeader, rejectUnauthorizedDashboardRequest, rejectUnauthorizedDashboardSessionMintRequest } from './routes/dashboard-auth.js';
 import { validateOrigin } from './routes/origin-validation.js';
 import { emitActivityEntrySync, emitActivityTtsSync } from '../../lib/activity-logger.js';
+import { retryDashboardBind } from './server-bind.js';
 
 // ─── Dual-runtime layers ──────────────────────────────────────────────────────
 
@@ -92,14 +93,22 @@ const HttpServerLive = Layer.unwrap(
       Effect.promise(() => import('@effect/platform-node/NodeHttpServer')),
       Effect.promise(() => import('node:http')),
     ]);
-    const nodeServer = NodeHttp.createServer();
-    setupTerminalWebSocket(nodeServer);
-    setupVoiceWebSocket(nodeServer);
-    setupAutoPresoWebSocket(nodeServer);
-    return NodeHttpServer.layer(() => nodeServer, {
+    const bind = retryDashboardBind(NodeHttpServer.make(() => {
+      const nodeServer = NodeHttp.createServer();
+      setupTerminalWebSocket(nodeServer);
+      setupVoiceWebSocket(nodeServer);
+      setupAutoPresoWebSocket(nodeServer);
+      return nodeServer;
+    }, {
       host: config.host,
       port: config.port,
+    }), (attempt, delayMs) => {
+      console.warn(`[overdeck] HTTP bind failed with EADDRINUSE; retry ${attempt}/3 in ${delayMs}ms`);
     });
+    return Layer.mergeAll(
+      Layer.effect(HttpServer.HttpServer)(bind),
+      NodeHttpServer.layerHttpServices,
+    );
   }),
 );
 

--- a/src/lib/platform-lifecycle.ts
+++ b/src/lib/platform-lifecycle.ts
@@ -295,20 +295,42 @@ export interface RestartResult {
   stage: 'traefik' | 'cliproxy' | 'dashboard' | 'full';
   success: boolean;
   failure?: StageFailure;
-}async function restartDashboardPromise(
+}
+
+export interface DashboardSpawnHandle {
+  stop: () => Promise<void> | void;
+}
+
+async function restartDashboardPromise(
   config: PlatformConfig,
-  startDashboardFn: () => Promise<void> | void,
+  startDashboardFn: () => Promise<DashboardSpawnHandle | void> | DashboardSpawnHandle | void,
   opts: {
     healthTimeoutMs?: number;
     expectedIdentity?: { repoRoot: string; mode: 'primary' | 'peer' };
   } = {},
 ): Promise<void> {
   await Effect.runPromise(stopDashboard(config));
-  await startDashboardFn();
-  await Effect.runPromise(waitForDashboardHealth(config.dashboardApiPort, {
-    timeoutMs: opts.healthTimeoutMs,
-    expectedIdentity: opts.expectedIdentity,
-  }));
+  const spawned = await startDashboardFn();
+  try {
+    await Effect.runPromise(waitForDashboardHealth(config.dashboardApiPort, {
+      timeoutMs: opts.healthTimeoutMs,
+      expectedIdentity: opts.expectedIdentity,
+    }));
+  } catch (error) {
+    if (spawned) {
+      try {
+        await spawned.stop();
+      } catch (stopError) {
+        const healthFailure = error instanceof Error ? error.message : String(error);
+        const stopFailure = stopError instanceof Error ? stopError.message : String(stopError);
+        throw new StageError({
+          stage: 'dashboard',
+          reason: `${healthFailure}; failed to reap unhealthy dashboard: ${stopFailure}`,
+        });
+      }
+    }
+    throw error;
+  }
 }async function restartCliproxyPromise(
   cliproxy: {
     stopCliproxy: () => void;
@@ -417,7 +439,7 @@ export const stopTraefik = (config: PlatformConfig): Effect.Effect<void, never> 
 /** Effect variant of {@link restartDashboard}. */
 export const restartDashboard = (
   config: PlatformConfig,
-  startDashboardFn: () => Promise<void> | void,
+  startDashboardFn: () => Promise<DashboardSpawnHandle | void> | DashboardSpawnHandle | void,
   opts: {
     healthTimeoutMs?: number;
     expectedIdentity?: { repoRoot: string; mode: 'primary' | 'peer' };

--- a/tests/unit/dashboard/server-bind.test.ts
+++ b/tests/unit/dashboard/server-bind.test.ts
@@ -1,0 +1,48 @@
+import { Effect } from 'effect';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  isAddressInUseError,
+  retryDashboardBind,
+} from '../../../src/dashboard/server/server-bind.js';
+
+describe('dashboard server bind', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retries a transient EADDRINUSE before succeeding', async () => {
+    let attempts = 0;
+    const bind = Effect.suspend(() => {
+      attempts += 1;
+      return attempts < 3
+        ? Effect.fail({ cause: Object.assign(new Error('address in use'), { code: 'EADDRINUSE' }) })
+        : Effect.succeed('bound');
+    });
+
+    const onRetry = vi.fn();
+    const result = Effect.runPromise(retryDashboardBind(bind, onRetry));
+    await vi.advanceTimersByTimeAsync(500);
+
+    await expect(result).resolves.toBe('bound');
+    expect(attempts).toBe(3);
+    expect(onRetry).toHaveBeenNthCalledWith(1, 1, 250);
+    expect(onRetry).toHaveBeenNthCalledWith(2, 2, 250);
+  });
+
+  it('does not retry a non-address bind failure', async () => {
+    const failure = { cause: Object.assign(new Error('permission denied'), { code: 'EACCES' }) };
+    let attempts = 0;
+    const bind = Effect.suspend(() => {
+      attempts += 1;
+      return Effect.fail(failure);
+    });
+
+    await expect(Effect.runPromise(retryDashboardBind(bind))).rejects.toBeDefined();
+    expect(attempts).toBe(1);
+    expect(isAddressInUseError(failure)).toBe(false);
+  });
+});

--- a/tests/unit/lib/platform-lifecycle.test.ts
+++ b/tests/unit/lib/platform-lifecycle.test.ts
@@ -69,17 +69,29 @@ describe('restartDashboard — scope contract', () => {
     expect(cliproxySpies.isCliproxyRunning).not.toHaveBeenCalled();
   });
 
-  it('throws StageError if health check never passes', async () => {
+  it('reaps the spawned dashboard if health check never passes', async () => {
+    vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout'] });
     vi.unstubAllGlobals();
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockRejectedValue(new Error('ECONNREFUSED')),
-    );
-    const startHook = vi.fn().mockResolvedValue(undefined);
+    const fetchMock = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    vi.stubGlobal('fetch', fetchMock);
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const startHook = vi.fn().mockResolvedValue({ stop });
 
-    await expect(Effect.runPromise(
-      restartDashboard(baseConfig, startHook, { healthTimeoutMs: 300 }),
-    )).rejects.toBeInstanceOf(StageError);
+    try {
+      const restart = Effect.runPromise(
+        restartDashboard(baseConfig, startHook, { healthTimeoutMs: 300 }),
+      );
+      while (fetchMock.mock.calls.length === 0) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+      const rejection = expect(restart).rejects.toBeInstanceOf(StageError);
+      await vi.advanceTimersByTimeAsync(500);
+
+      await rejection;
+      expect(stop).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 


### PR DESCRIPTION
**Issue:** #2931


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented dashboard processes from remaining active when restart health checks fail.
  - Improved dashboard startup reliability by retrying when the configured port is already in use.
  - Ensured startup monitoring begins only after the dashboard is listening.
  - Improved initialization timing and resilience for the dashboard database.

- **Tests**
  - Added coverage for port-conflict retries and dashboard cleanup after failed restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->