### PR TITLE
fix(lint): drop stale source-introspection baseline entry — un-red main (PAN-2938)

### DIFF
--- a/scripts/source-introspection-baseline.txt
+++ b/scripts/source-introspection-baseline.txt
@@ -1,5 +1,4 @@
 11 src/dashboard/frontend/src/components/Settings/__tests__/SettingsPage.test.ts
-1 src/dashboard/frontend/src/components/__tests__/IssueAgentCard-harness.test.tsx
 1 src/dashboard/server/routes/__tests__/effect-patterns.test.ts
 1 src/dashboard/server/routes/__tests__/projects-register.test.ts
 1 src/lib/cloister/__tests__/lint-stub-ui.test.ts


### PR DESCRIPTION
caf515da3d's one-action-model refactor left a stale entry in the source-introspection baseline; lint fails main. Baseline-only change per the guard's own prescription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGKWkic5rTSFHv3545Sn1b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the recorded source introspection baseline by removing an outdated reference.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->