### PR TITLE
PAN-2066

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 > **Note:** Universal and dev-scope engineering rules — async tmux, no execSync in server, fake timers for retry tests, worktree discipline, work-agents-via-pan, stash discipline, dashboard-Node22-only, single-deacon invariant, no-destructive-requests, file-path references, Karpathy rules — live in [`sync-sources/rules/`](sync-sources/rules/) and are folded into `~/.claude/CLAUDE.md` automatically via `pan sync`. This file holds **project-specific** guidance that doesn't apply outside this repo.
 
-> **Knowledge bundle (OKF):** Project knowledge lives in the OKF bundle at [`../overdeck-knowledge`](../overdeck-knowledge) (remote `eltmon/overdeck-knowledge`), pointed to by [`.okf.yml`](.okf.yml). Use `/okf extract "<query>"` to pull cited context, `/okf author`/`/okf sync`/`/okf study` to maintain it.
+> **Knowledge bundle (OKF):** Project knowledge lives in the OKF bundle at [`../overdeck-knowledge`](../overdeck-knowledge) (remote `eltmon/overdeck-knowledge`), pointed to by [`.okf.yml`](.okf.yml). Use `/okf extract "<query>"` to pull cited context and `/okf author`/`/okf sync`/`/okf study` to maintain it. `/okf open` and the dashboard **Knowledge** page provide a read-only OpenKnowledge viewer; edit through `/okf author` because the upstream v0.34 editor does not preserve YAML source formatting losslessly.
 
 ## Engineering Philosophy: No Bandaids
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 > **Note:** Universal and dev-scope engineering rules — async tmux, no execSync in server, fake timers for retry tests, worktree discipline, work-agents-via-pan, stash discipline, dashboard-Node22-only, single-deacon invariant, no-destructive-requests, file-path references, Karpathy rules — live in [`sync-sources/rules/`](sync-sources/rules/) and are folded into `~/.claude/CLAUDE.md` automatically via `pan sync`. This file holds **project-specific** guidance that doesn't apply outside this repo.
 
-> **Knowledge bundle (OKF):** Project knowledge lives in the OKF bundle at [`../overdeck-knowledge`](../overdeck-knowledge) (remote `eltmon/overdeck-knowledge`), pointed to by [`.okf.yml`](.okf.yml). Use `/okf extract "<query>"` to pull cited context and `/okf author`/`/okf sync`/`/okf study` to maintain it. `/okf open` and the dashboard **Knowledge** page provide a read-only OpenKnowledge viewer; edit through `/okf author` because the upstream v0.34 editor does not preserve YAML source formatting losslessly.
+> **Knowledge bundle (OKF):** Project knowledge lives in the OKF bundle at [`../overdeck-knowledge`](../overdeck-knowledge) (remote `eltmon/overdeck-knowledge`), pointed to by [`.okf.yml`](.okf.yml). Use `/okf extract "<query>"` to pull cited context and `/okf author`/`/okf sync`/`/okf study` to maintain it. `/okf open` and the dashboard **Knowledge** page run OpenKnowledge against a disposable read-only snapshot; edit through `/okf author` because the upstream v0.34 editor does not preserve YAML source formatting losslessly.
 
 ## Engineering Philosophy: No Bandaids
 

--- a/configuration/knowledge.mdx
+++ b/configuration/knowledge.mdx
@@ -28,7 +28,7 @@ pan knowledge open
 /okf open
 ```
 
-The first explicit open may install `@inkeep/open-knowledge` globally. Overdeck does not install it during `pan install`, dashboard startup, or any other unattended path.
+The first explicit open may install `@inkeep/open-knowledge` globally. Overdeck does not install it during `pan install`, dashboard startup, or any other unattended path. Repeated opens inspect OpenKnowledge's project lock and reuse the verified live URL instead of printing an unproven port.
 
 | Option | Effect |
 | --- | --- |
@@ -39,14 +39,16 @@ OpenKnowledge v0.34 requires Node.js 24 or newer. The Overdeck dashboard continu
 
 ## Dashboard Knowledge page
 
-Select **Knowledge** under **System** in the dashboard sidebar. The page shows the selected project's bundle state and starts one reusable viewer process for that project. Viewer HTTP and WebSocket traffic stays same-origin through `/knowledge-viewer/*`.
+Select **Knowledge** under **System** in the dashboard sidebar. The page shows the selected project's bundle state and starts one reusable viewer process for that project. Each project is routed through its own `knowledge-<hex>.<dashboard-domain>` origin, so OpenKnowledge's root `/api/*` and `/collab` traffic stays pinned to that project. The proxy accepts a viewer-specific credential minted by an authenticated dashboard request; dashboard cookies, authorization, CSRF tokens, internal headers, and upstream cookies never cross the subprocess boundary.
 
 If the viewer permits framing, its workspace appears directly on the page. If a future viewer version refuses framing through `X-Frame-Options` or Content Security Policy, the page shows an **Open viewer** link to the direct local URL instead.
 
 <Warning>
-  The embedded viewer is read-only in Overdeck. A v0.34 round-trip test changed
-  unrelated YAML formatting during an edit, so editing remains on the
-  PR-gated `/okf author` path.
+  Overdeck starts both dashboard and CLI viewers against a disposable snapshot
+  outside the canonical bundle. OpenKnowledge can accept edits inside that
+  projection, but those writes are discarded and cannot bypass the PR-gated
+  `/okf author` path. A v0.34 round-trip test made this boundary necessary by
+  changing unrelated YAML formatting during an edit.
 </Warning>
 
 To change knowledge, use the portable OKF workflow:

--- a/configuration/knowledge.mdx
+++ b/configuration/knowledge.mdx
@@ -1,0 +1,74 @@
+---
+title: Project Knowledge
+description: Configure OKF bundles and the progressive OpenKnowledge viewer
+---
+
+# Project Knowledge
+
+Overdeck resolves each project's Open Knowledge Format (OKF) bundle, injects cited concepts into agent context, and provides a local visual viewer. Knowledge changes stay in the bundle's normal Git and pull-request workflow.
+
+## Configure the bundle
+
+Set `knowledge_repo` on the project in `~/.overdeck/projects.yaml`, or add `.okf.yml` at the code-repository root:
+
+```yaml
+bundle: ../my-project-knowledge
+remote: git@github.com:example/my-project-knowledge.git
+```
+
+Resolution checks the registered project's `knowledge_repo` first, then `.okf.yml`. If neither points to a readable bundle, run `/okf init` to create or connect one.
+
+## Open the viewer
+
+Use either command from the project repository:
+
+```bash
+pan knowledge open
+# Equivalent skill command:
+/okf open
+```
+
+The first explicit open may install `@inkeep/open-knowledge` globally. Overdeck does not install it during `pan install`, dashboard startup, or any other unattended path.
+
+| Option | Effect |
+| --- | --- |
+| `--no-install` | Do not install the viewer; report how to install it when the `ok` executable is missing. |
+| `--no-browser` | Start the local viewer and print its URL without opening a browser. |
+
+OpenKnowledge v0.34 requires Node.js 24 or newer. The Overdeck dashboard continues to run under Node.js 22; only the separate `ok` subprocess uses Node.js 24+.
+
+## Dashboard Knowledge page
+
+Select **Knowledge** under **System** in the dashboard sidebar. The page shows the selected project's bundle state and starts one reusable viewer process for that project. Viewer HTTP and WebSocket traffic stays same-origin through `/knowledge-viewer/*`.
+
+If the viewer permits framing, its workspace appears directly on the page. If a future viewer version refuses framing through `X-Frame-Options` or Content Security Policy, the page shows an **Open viewer** link to the direct local URL instead.
+
+<Warning>
+  The embedded viewer is read-only in Overdeck. A v0.34 round-trip test changed
+  unrelated YAML formatting during an edit, so editing remains on the
+  PR-gated `/okf author` path.
+</Warning>
+
+To change knowledge, use the portable OKF workflow:
+
+```bash
+/okf author "focused topic"
+/okf sync --topic "focused topic"
+/okf validate --strict
+```
+
+## Optional MCP registration
+
+Opening the viewer never changes MCP or skill configuration. Overdeck initializes the viewer runtime with `ok init --no-mcp --no-skills`.
+
+To opt in, run the upstream command from the resolved bundle root:
+
+```bash
+ok init --mcp --no-skills --scope user
+```
+
+Choose `--scope project` for repository-local registration or `--scope both` for both locations. OpenKnowledge supports Claude Code (`~/.claude.json` or `.mcp.json`), Codex (`~/.codex/config.toml` or `.codex/config.toml`), and Cursor (`~/.cursor/mcp.json` or `.cursor/mcp.json`). Review the paths reported by `ok init`, then restart the client when required.
+
+## License boundary
+
+`@inkeep/open-knowledge` is licensed GPL-3.0-or-later. Overdeck is MIT-licensed and keeps the viewer at arm's length: it is installed separately, launched as an executable, and accessed over HTTP and WebSocket. No OpenKnowledge code is imported, linked, or bundled into `@overdeck/*`.

--- a/docs.json
+++ b/docs.json
@@ -98,6 +98,7 @@
             "group": "Configuration",
             "pages": [
               "configuration/projects",
+              "configuration/knowledge",
               "configuration/harnesses",
               "configuration/context-layers",
               "configuration/state-branch",

--- a/docs/ACKNOWLEDGEMENTS.md
+++ b/docs/ACKNOWLEDGEMENTS.md
@@ -1,0 +1,7 @@
+# Acknowledgements
+
+## OpenKnowledge
+
+Overdeck can progressively install and launch [`@inkeep/open-knowledge`](https://github.com/inkeep/open-knowledge), created by [Inkeep](https://inkeep.com/), as the visual viewer for Open Knowledge Format bundles.
+
+OpenKnowledge is licensed [`GPL-3.0-or-later`](https://github.com/inkeep/open-knowledge/blob/main/LICENSE). It is a separate global program and is not distributed inside the MIT-licensed `@overdeck/*` packages. Overdeck invokes its `ok` executable as a subprocess and communicates with it over HTTP and WebSocket; no OpenKnowledge code is imported, linked, or bundled into Overdeck.

--- a/docs/OKF-LANDSCAPE.md
+++ b/docs/OKF-LANDSCAPE.md
@@ -86,21 +86,27 @@ The integration is progressive:
 1. `pan install` does not install OpenKnowledge. The first explicit
    `pan knowledge open`, `/okf open`, or dashboard **Install viewer** action may
    install it globally; `--no-install` requires an existing installation.
-2. The server owns one viewer process per project, reuses healthy processes,
-   and proxies HTTP and WebSocket traffic through `/knowledge-viewer/*` so the
-   dashboard can embed the viewer without exposing a separate origin.
-3. The dashboard **Knowledge** page represents missing-bundle, not-installed,
+2. The server owns one viewer process per project, reuses healthy lock-reported
+   processes, and proxies every HTTP and WebSocket path through a project-keyed,
+   origin-isolated `knowledge-<hex>.<dashboard-domain>` host. Short-lived viewer
+   credentials never expose dashboard cookies or internal headers upstream.
+3. Every viewer runs against a disposable snapshot outside the canonical bundle.
+   OpenKnowledge may accept edits inside that projection, but those writes cannot
+   reach the PR-gated source and are discarded when the snapshot is refreshed.
+4. The dashboard **Knowledge** page represents missing-bundle, not-installed,
    installing, starting, embedded, and framing-blocked states. When framing is
    refused, it offers the viewer's direct local URL in a new tab.
-4. `ok init` MCP registration is always a separate opt-in action. Unattended
+5. `ok init` MCP registration is always a separate opt-in action. Unattended
    viewer initialization uses `--no-mcp --no-skills`, so opening the viewer
    never changes Claude Code, Codex, or Cursor configuration.
 
 The mandatory round-trip spike on OpenKnowledge v0.34.0 found source-format
 loss: editing only `description` also rewrote an unrelated inline YAML `tags`
-array. The integrated dashboard is therefore deliberately read-only. Operators
-browse and search there, then use `/okf author` for PR-gated edits that preserve
-unknown frontmatter and pass deterministic conformance checks. Lease-based
+array. The integrated dashboard is therefore mechanically read-only with respect
+to the canonical bundle: both the dashboard and CLI launch a disposable snapshot,
+so viewer edits are discarded rather than reaching source files. Operators browse
+and search there, then use `/okf author` for PR-gated edits that preserve unknown
+frontmatter and pass deterministic conformance checks. Lease-based
 writes and the advisory semantic auditor remain deferred capabilities rather
 than viewer responsibilities.
 
@@ -270,6 +276,7 @@ From the spec repo's issues/discussions (all open unless noted):
   viewer plan written into PAN-2066 as the preferred approach for items
   #1/#2/#4.
 - **2026-07-19** — progressive installation, `pan knowledge open`, `/okf open`,
-  server-owned lifecycle and same-origin proxying, and the dashboard Knowledge
+  server-owned lifecycle, origin-isolated proxying, and the dashboard Knowledge
   page implemented. The round-trip spike found YAML source-format churn, so the
-  viewer shipped read-only and MCP registration stayed explicitly opt-in.
+  viewer runs against a disposable read-only projection and MCP registration
+  stays explicitly opt-in.

--- a/docs/OKF-LANDSCAPE.md
+++ b/docs/OKF-LANDSCAPE.md
@@ -72,29 +72,37 @@ Key design decisions from the June 25–26 and July 7–9 sessions:
   theesfeld "prime directive" hook failure mode and Overdeck's
   no-ambient-subagent policy).
 
-### The viewer: filed, not built — coinstall inkeep/open-knowledge
+### The viewer: progressive, read-only OpenKnowledge integration
 
-**Yes, we opened a feature for an OKF viewer.** It lives as the
-"Preferred approach for #1/#2/#4" section of
-[PAN-2066](https://github.com/eltmon/overdeck/issues/2066) (open) — no
-standalone issue was filed. Decided 2026-07-14/15: adopt
-[`inkeep/open-knowledge`](https://github.com/inkeep/open-knowledge) (WYSIWYG
-markdown editor + graph wiki-link viewer + out-of-the-box MCP/agentic search)
-at arm's length rather than building our own `viz.html` / MCP server:
+[PAN-2066](https://github.com/eltmon/overdeck/issues/2066) adopted
+[`inkeep/open-knowledge`](https://github.com/inkeep/open-knowledge) for visual
+browsing, graph navigation, search, and optional MCP access. The GPL-3.0-or-later
+package remains an arm's-length global program: Overdeck never imports, links,
+or bundles it into the MIT-licensed `@overdeck/*` packages. Overdeck invokes the
+`ok` executable as a subprocess and communicates over HTTP and WebSocket.
 
-1. `pan install` optionally coinstalls `@inkeep/open-knowledge` (GPL-3.0 vs our
-   MIT is fine as **mere aggregation** — separate global binary, shelled out to,
-   never linked/imported into `@overdeck/*`; requires Node 24+).
-2. New `/okf open` (or `pan knowledge open`) verb resolving the bundle from
-   `.okf.yml` and shelling out to `ok start --open <bundle>`.
-3. Let `ok init` wire its MCP into harnesses to satisfy the read-server goal.
+The integration is progressive:
 
-It covers PAN-2066 items #2 (graph visualizer) and #4 (MCP read server) and
-dents #1 (hybrid search); Overdeck keeps the deterministic conformance gate,
-PR-gated writes, #3 lease mode, and #5 semantic auditor. **Blocking gate:**
-verify open-knowledge preserves frontmatter losslessly on save and leaves
-`index.md`/`log.md` untouched — if it churns frontmatter, the integration is
-blocked until it doesn't.
+1. `pan install` does not install OpenKnowledge. The first explicit
+   `pan knowledge open`, `/okf open`, or dashboard **Install viewer** action may
+   install it globally; `--no-install` requires an existing installation.
+2. The server owns one viewer process per project, reuses healthy processes,
+   and proxies HTTP and WebSocket traffic through `/knowledge-viewer/*` so the
+   dashboard can embed the viewer without exposing a separate origin.
+3. The dashboard **Knowledge** page represents missing-bundle, not-installed,
+   installing, starting, embedded, and framing-blocked states. When framing is
+   refused, it offers the viewer's direct local URL in a new tab.
+4. `ok init` MCP registration is always a separate opt-in action. Unattended
+   viewer initialization uses `--no-mcp --no-skills`, so opening the viewer
+   never changes Claude Code, Codex, or Cursor configuration.
+
+The mandatory round-trip spike on OpenKnowledge v0.34.0 found source-format
+loss: editing only `description` also rewrote an unrelated inline YAML `tags`
+array. The integrated dashboard is therefore deliberately read-only. Operators
+browse and search there, then use `/okf author` for PR-gated edits that preserve
+unknown frontmatter and pass deterministic conformance checks. Lease-based
+writes and the advisory semantic auditor remain deferred capabilities rather
+than viewer responsibilities.
 
 ### Our own bundle so far
 
@@ -261,3 +269,7 @@ From the spec repo's issues/discussions (all open unless noted):
 - **2026-07-14/15** — inkeep/open-knowledge licensing + integration analysis;
   viewer plan written into PAN-2066 as the preferred approach for items
   #1/#2/#4.
+- **2026-07-19** — progressive installation, `pan knowledge open`, `/okf open`,
+  server-owned lifecycle and same-origin proxying, and the dashboard Knowledge
+  page implemented. The round-trip spike found YAML source-format churn, so the
+  viewer shipped read-only and MCP registration stayed explicitly opt-in.

--- a/src/cli/commands/__tests__/knowledge.test.ts
+++ b/src/cli/commands/__tests__/knowledge.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Command } from 'commander';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const agentMocks = vi.hoisted(() => ({
   spawnRun: vi.fn(),
@@ -7,11 +7,16 @@ const agentMocks = vi.hoisted(() => ({
 
 const projectMocks = vi.hoisted(() => ({
   resolveProjectFromIssueSync: vi.fn(),
-  loadProjectsConfigSync: vi.fn(),
 }));
 
 const installerMocks = vi.hoisted(() => ({
   ensureMnemos: vi.fn(),
+  ensureOpenKnowledge: vi.fn(),
+  startOpenKnowledgeServer: vi.fn(),
+}));
+
+const memoryMocks = vi.hoisted(() => ({
+  resolveKnowledgeBundleRoot: vi.fn(),
 }));
 
 vi.mock('../../../lib/agents.js', () => ({
@@ -22,37 +27,55 @@ vi.mock('../../../lib/installers/mnemos.js', () => ({
   ensureMnemos: installerMocks.ensureMnemos,
 }));
 
-vi.mock('../../../lib/projects.js', () => ({
-  resolveProjectFromIssueSync: projectMocks.resolveProjectFromIssueSync,
-  loadProjectsConfigSync: projectMocks.loadProjectsConfigSync,
+vi.mock('../../../lib/installers/open-knowledge.js', () => ({
+  ensureOpenKnowledge: installerMocks.ensureOpenKnowledge,
+  startOpenKnowledgeServer: installerMocks.startOpenKnowledgeServer,
 }));
 
-import { buildKnowledgePrompt, configureKnowledgeCommand, knowledgeCommand } from '../knowledge.js';
+vi.mock('../../../lib/memory/injection.js', () => ({
+  resolveKnowledgeBundleRoot: memoryMocks.resolveKnowledgeBundleRoot,
+}));
+
+vi.mock('../../../lib/projects.js', () => ({
+  resolveProjectFromIssueSync: projectMocks.resolveProjectFromIssueSync,
+}));
+
+import {
+  buildKnowledgePrompt,
+  configureKnowledgeCommand,
+  knowledgeCommand,
+  knowledgeOpenCommand,
+} from '../knowledge.js';
 
 describe('knowledgeCommand', () => {
   beforeEach(() => {
     agentMocks.spawnRun.mockReset();
     projectMocks.resolveProjectFromIssueSync.mockReset();
-    projectMocks.loadProjectsConfigSync.mockReset();
     installerMocks.ensureMnemos.mockReset();
+    installerMocks.ensureOpenKnowledge.mockReset();
+    installerMocks.startOpenKnowledgeServer.mockReset();
+    memoryMocks.resolveKnowledgeBundleRoot.mockReset();
+
     projectMocks.resolveProjectFromIssueSync.mockReturnValue({
       projectKey: 'overdeck',
       projectName: 'Overdeck',
       projectPath: '/repo/overdeck',
       linearTeam: 'PAN',
     });
-    projectMocks.loadProjectsConfigSync.mockReturnValue({
-      projects: {
-        overdeck: {
-          name: 'Overdeck',
-          path: '/repo/overdeck',
-          knowledge_repo: 'knowledge',
-        },
-      },
-    });
+    memoryMocks.resolveKnowledgeBundleRoot.mockResolvedValue('/repo/overdeck/knowledge');
     installerMocks.ensureMnemos.mockResolvedValue({
       status: 'already-installed',
       path: '/home/eltmon/.overdeck/bin/mnemos',
+    });
+    installerMocks.ensureOpenKnowledge.mockResolvedValue({
+      status: 'already-installed',
+      command: 'ok',
+    });
+    installerMocks.startOpenKnowledgeServer.mockResolvedValue({
+      process: { unref: vi.fn() },
+      port: 39847,
+      apiPort: 8789,
+      url: 'http://127.0.0.1:39847',
     });
     agentMocks.spawnRun.mockResolvedValue({
       id: 'agent-pan-2468-knowledge',
@@ -60,25 +83,18 @@ describe('knowledgeCommand', () => {
     });
   });
 
-  it('registers help with id, focus, retro, model, and effort', () => {
+  it('registers maintenance options and the open subcommand', () => {
     const program = new Command();
     program.name('pan');
     const command = configureKnowledgeCommand(program);
+    const help = command.helpInformation();
 
-    expect(command.helpInformation()).toMatchInlineSnapshot(`
-      "Usage: pan knowledge [options] <id>
-
-      Spawn a knowledge agent to maintain the project OKF bundle
-
-      Options:
-        --focus <topic>   Run /okf study for a focused topic before syncing
-        --retro           Run /okf retro before syncing
-        --model <model>   Model override (defaults to roles.knowledge.model from
-                          config)
-        --effort <level>  Knowledge effort: low | medium | high | xhigh | max
-        -h, --help        display help for command
-      "
-    `);
+    expect(help).toContain('Usage: pan knowledge [options] [command] [id]');
+    expect(help).toContain('--focus <topic>');
+    expect(help).toContain('--retro');
+    expect(help).toContain('--model <model>');
+    expect(help).toContain('--effort <level>');
+    expect(help).toContain('open [options]');
   });
 
   it('builds the OKF command sequence from focus and retro options', () => {
@@ -100,6 +116,7 @@ describe('knowledgeCommand', () => {
     });
 
     expect(projectMocks.resolveProjectFromIssueSync).toHaveBeenCalledWith('PAN-2468');
+    expect(memoryMocks.resolveKnowledgeBundleRoot).toHaveBeenCalledWith({ projectPath: '/repo/overdeck' });
     expect(installerMocks.ensureMnemos).toHaveBeenCalledWith({
       bundlePath: '/repo/overdeck/knowledge',
     });
@@ -115,18 +132,9 @@ describe('knowledgeCommand', () => {
   });
 
   it('throws a clear /okf init error when no knowledge bundle is configured', async () => {
-    projectMocks.loadProjectsConfigSync.mockReturnValue({
-      projects: {
-        overdeck: {
-          name: 'Overdeck',
-          path: '/repo/overdeck',
-        },
-      },
-    });
+    memoryMocks.resolveKnowledgeBundleRoot.mockResolvedValue(null);
 
-    await expect(knowledgeCommand('pan-2468')).rejects.toThrow(
-      /Run `\/okf init`/,
-    );
+    await expect(knowledgeCommand('pan-2468')).rejects.toThrow(/Run `\/okf init`/);
 
     expect(agentMocks.spawnRun).not.toHaveBeenCalled();
   });
@@ -143,5 +151,66 @@ describe('knowledgeCommand', () => {
       workspace: '/repo/overdeck',
       prompt: expect.stringContaining('/okf sync'),
     }));
+  });
+
+  it('opens the configured bundle, auto-installs on explicit use, and launches the browser', async () => {
+    const unref = vi.fn();
+    const ensure = vi.fn(async () => ({ status: 'already-installed' as const, command: 'ok' as const }));
+    const start = vi.fn(async () => ({
+      process: { unref } as never,
+      port: 39847,
+      apiPort: 8789,
+      url: 'http://127.0.0.1:39847',
+    }));
+    const openBrowser = vi.fn(async () => {});
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await knowledgeOpenCommand({}, {
+      cwd: () => '/repo/overdeck',
+      ensure,
+      start,
+      openBrowser,
+    });
+
+    expect(memoryMocks.resolveKnowledgeBundleRoot).toHaveBeenCalledWith({ projectPath: '/repo/overdeck' });
+    expect(ensure).toHaveBeenCalledWith({ autoInstall: true });
+    expect(start).toHaveBeenCalledWith('/repo/overdeck/knowledge', { openBrowser: false });
+    expect(unref).toHaveBeenCalledOnce();
+    expect(openBrowser).toHaveBeenCalledWith('http://127.0.0.1:39847');
+    expect(log).toHaveBeenCalledWith('Knowledge viewer: http://127.0.0.1:39847');
+    log.mockRestore();
+  });
+
+  it('honors --no-install and --no-browser', async () => {
+    const unref = vi.fn();
+    const ensure = vi.fn(async () => ({ status: 'already-installed' as const, command: 'ok' as const }));
+    const start = vi.fn(async () => ({
+      process: { unref } as never,
+      port: 39847,
+      apiPort: 8789,
+      url: 'http://127.0.0.1:39847',
+    }));
+    const openBrowser = vi.fn(async () => {});
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await knowledgeOpenCommand({ install: false, browser: false }, {
+      cwd: () => '/repo/overdeck',
+      ensure,
+      start,
+      openBrowser,
+    });
+
+    expect(ensure).toHaveBeenCalledWith({ autoInstall: false });
+    expect(openBrowser).not.toHaveBeenCalled();
+    log.mockRestore();
+  });
+
+  it('rejects with /okf init guidance when open cannot resolve a bundle', async () => {
+    memoryMocks.resolveKnowledgeBundleRoot.mockResolvedValue(null);
+
+    await expect(knowledgeOpenCommand({ browser: false }, { cwd: () => '/repo/empty' })).rejects.toThrow(
+      'Run `/okf init` first',
+    );
+    expect(installerMocks.ensureOpenKnowledge).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/commands/__tests__/knowledge.test.ts
+++ b/src/cli/commands/__tests__/knowledge.test.ts
@@ -12,7 +12,7 @@ const projectMocks = vi.hoisted(() => ({
 const installerMocks = vi.hoisted(() => ({
   ensureMnemos: vi.fn(),
   ensureOpenKnowledge: vi.fn(),
-  startOpenKnowledgeServer: vi.fn(),
+  startReadOnlyOpenKnowledgeServer: vi.fn(),
 }));
 
 const memoryMocks = vi.hoisted(() => ({
@@ -29,7 +29,7 @@ vi.mock('../../../lib/installers/mnemos.js', () => ({
 
 vi.mock('../../../lib/installers/open-knowledge.js', () => ({
   ensureOpenKnowledge: installerMocks.ensureOpenKnowledge,
-  startOpenKnowledgeServer: installerMocks.startOpenKnowledgeServer,
+  startReadOnlyOpenKnowledgeServer: installerMocks.startReadOnlyOpenKnowledgeServer,
 }));
 
 vi.mock('../../../lib/memory/injection.js', () => ({
@@ -53,7 +53,7 @@ describe('knowledgeCommand', () => {
     projectMocks.resolveProjectFromIssueSync.mockReset();
     installerMocks.ensureMnemos.mockReset();
     installerMocks.ensureOpenKnowledge.mockReset();
-    installerMocks.startOpenKnowledgeServer.mockReset();
+    installerMocks.startReadOnlyOpenKnowledgeServer.mockReset();
     memoryMocks.resolveKnowledgeBundleRoot.mockReset();
 
     projectMocks.resolveProjectFromIssueSync.mockReturnValue({
@@ -71,11 +71,14 @@ describe('knowledgeCommand', () => {
       status: 'already-installed',
       command: 'ok',
     });
-    installerMocks.startOpenKnowledgeServer.mockResolvedValue({
+    installerMocks.startReadOnlyOpenKnowledgeServer.mockResolvedValue({
       process: { unref: vi.fn() },
+      owned: true,
+      reused: false,
       port: 39847,
       apiPort: 8789,
       url: 'http://127.0.0.1:39847',
+      runtimeBundlePath: '/runtime/read-only-snapshot',
     });
     agentMocks.spawnRun.mockResolvedValue({
       id: 'agent-pan-2468-knowledge',
@@ -158,9 +161,12 @@ describe('knowledgeCommand', () => {
     const ensure = vi.fn(async () => ({ status: 'already-installed' as const, command: 'ok' as const }));
     const start = vi.fn(async () => ({
       process: { unref } as never,
+      owned: true,
+      reused: false,
       port: 39847,
       apiPort: 8789,
       url: 'http://127.0.0.1:39847',
+      runtimeBundlePath: '/runtime/read-only-snapshot',
     }));
     const openBrowser = vi.fn(async () => {});
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -181,14 +187,43 @@ describe('knowledgeCommand', () => {
     log.mockRestore();
   });
 
+  it('reports and opens the verified URL when the upstream lock is reused', async () => {
+    const ensure = vi.fn(async () => ({ status: 'already-installed' as const, command: 'ok' as const }));
+    const start = vi.fn(async () => ({
+      process: null,
+      owned: false,
+      reused: true,
+      port: 39847,
+      apiPort: 8789,
+      url: 'http://127.0.0.1:39847',
+      runtimeBundlePath: '/runtime/read-only-snapshot',
+    }));
+    const openBrowser = vi.fn(async () => {});
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await knowledgeOpenCommand({}, {
+      cwd: () => '/repo/overdeck',
+      ensure,
+      start,
+      openBrowser,
+    });
+
+    expect(log).toHaveBeenCalledWith('Knowledge viewer: http://127.0.0.1:39847 (reused)');
+    expect(openBrowser).toHaveBeenCalledWith('http://127.0.0.1:39847');
+    log.mockRestore();
+  });
+
   it('honors --no-install and --no-browser', async () => {
     const unref = vi.fn();
     const ensure = vi.fn(async () => ({ status: 'already-installed' as const, command: 'ok' as const }));
     const start = vi.fn(async () => ({
       process: { unref } as never,
+      owned: true,
+      reused: false,
       port: 39847,
       apiPort: 8789,
       url: 'http://127.0.0.1:39847',
+      runtimeBundlePath: '/runtime/read-only-snapshot',
     }));
     const openBrowser = vi.fn(async () => {});
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -616,5 +616,6 @@ async function installCommand(options: InstallOptions): Promise<void> {
   }
 
   console.log(`  4. Create a workspace with ${chalk.cyan('pan workspace create <issue-id>')}`);
+  console.log(chalk.dim('  Knowledge viewer installs on first use via pan knowledge open.'));
   console.log('');
 }

--- a/src/cli/commands/knowledge.ts
+++ b/src/cli/commands/knowledge.ts
@@ -1,13 +1,17 @@
 import chalk from 'chalk';
 import ora from 'ora';
 import type { Command } from 'commander';
-import { readFile } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
-import { parse as parseYaml } from 'yaml';
 
 import { spawnRun } from '../../lib/agents.js';
 import { ensureMnemos } from '../../lib/installers/mnemos.js';
-import { loadProjectsConfigSync, resolveProjectFromIssueSync } from '../../lib/projects.js';
+import {
+  ensureOpenKnowledge,
+  startOpenKnowledgeServer,
+  type EnsureOpenKnowledgeResult,
+  type StartOpenKnowledgeServerResult,
+} from '../../lib/installers/open-knowledge.js';
+import { resolveKnowledgeBundleRoot } from '../../lib/memory/injection.js';
+import { resolveProjectFromIssueSync } from '../../lib/projects.js';
 import type { RoleEffort } from '../../lib/config-yaml.js';
 
 export interface KnowledgeOptions {
@@ -15,6 +19,18 @@ export interface KnowledgeOptions {
   retro?: boolean;
   model?: string;
   effort?: RoleEffort;
+}
+
+export interface KnowledgeOpenOptions {
+  install?: boolean;
+  browser?: boolean;
+}
+
+export interface KnowledgeOpenDependencies {
+  cwd?: () => string;
+  ensure?: (options: { autoInstall: boolean }) => Promise<EnsureOpenKnowledgeResult>;
+  start?: (bundlePath: string, options: { openBrowser: false }) => Promise<StartOpenKnowledgeServerResult>;
+  openBrowser?: (url: string) => Promise<void>;
 }
 
 function normalizeIssueId(issueId: string): string {
@@ -27,35 +43,6 @@ function quoteShellText(value: string): string {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function resolveBundlePath(projectPath: string, bundlePath: string): string {
-  return resolve(projectPath, bundlePath);
-}
-
-async function resolveKnowledgeBundlePath(projectKey: string, projectPath: string): Promise<string | null> {
-  const projectConfig = loadProjectsConfigSync().projects[projectKey];
-  if (typeof projectConfig?.knowledge_repo === 'string' && projectConfig.knowledge_repo.trim()) {
-    return resolveBundlePath(projectPath, projectConfig.knowledge_repo);
-  }
-
-  try {
-    const pointer = parseYaml(await readFile(join(projectPath, '.okf.yml'), 'utf8'));
-    if (isRecord(pointer) && typeof pointer.bundle === 'string' && pointer.bundle.trim()) {
-      return resolveBundlePath(projectPath, pointer.bundle);
-    }
-  } catch (error: unknown) {
-    if (error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return null;
-    }
-    throw error;
-  }
-
-  return null;
 }
 
 export function buildKnowledgePrompt(issueId: string, options: KnowledgeOptions = {}): string {
@@ -105,7 +92,7 @@ export async function knowledgeCommand(issueId: string, options: KnowledgeOption
       throw new Error(`No Overdeck project is configured for issue prefix in "${normalized}". Add the project to projects.yaml first.`);
     }
 
-    const bundlePath = await resolveKnowledgeBundlePath(project.projectKey, project.projectPath);
+    const bundlePath = await resolveKnowledgeBundleRoot({ projectPath: project.projectPath });
     if (!bundlePath) {
       throw new Error(
         `No OKF bundle is configured for ${project.projectName}. ` +
@@ -146,13 +133,64 @@ export async function knowledgeCommand(issueId: string, options: KnowledgeOption
   }
 }
 
+export async function knowledgeOpenCommand(
+  options: KnowledgeOpenOptions = {},
+  dependencies: KnowledgeOpenDependencies = {},
+): Promise<void> {
+  const cwd = dependencies.cwd?.() ?? process.cwd();
+  const bundlePath = await resolveKnowledgeBundleRoot({ projectPath: cwd });
+  if (!bundlePath) {
+    throw new Error('No OKF bundle is configured for this project. Run `/okf init` first, then retry `pan knowledge open`.');
+  }
+
+  const ensure = dependencies.ensure ?? ensureOpenKnowledge;
+  const start = dependencies.start ?? startOpenKnowledgeServer;
+  await ensure({ autoInstall: options.install !== false });
+  const viewer = await start(bundlePath, { openBrowser: false });
+  viewer.process.unref();
+
+  console.log(`Knowledge viewer: ${viewer.url}`);
+  if (options.browser === false) return;
+
+  try {
+    await (dependencies.openBrowser ?? openViewerInBrowser)(viewer.url);
+  } catch (error: unknown) {
+    console.warn(`Could not open the browser automatically: ${errorMessage(error)}`);
+  }
+}
+
+async function openViewerInBrowser(url: string): Promise<void> {
+  const [{ Effect }, { openBrowser }, { layer: nodeServicesLayer }] = await Promise.all([
+    import('effect'),
+    import('../../lib/browser.js'),
+    import('@effect/platform-node/NodeServices'),
+  ]);
+  await Effect.runPromise(openBrowser(url).pipe(Effect.provide(nodeServicesLayer)));
+}
+
 export function configureKnowledgeCommand(program: Command): Command {
-  return program
-    .command('knowledge <id>')
-    .description('Spawn a knowledge agent to maintain the project OKF bundle')
+  const command = program
+    .command('knowledge')
+    .description('Maintain or open the project OKF bundle')
+    .argument('[id]', 'Issue ID for a knowledge maintenance agent')
     .option('--focus <topic>', 'Run /okf study for a focused topic before syncing')
     .option('--retro', 'Run /okf retro before syncing')
     .option('--model <model>', 'Model override (defaults to roles.knowledge.model from config)')
     .option('--effort <level>', 'Knowledge effort: low | medium | high | xhigh | max')
-    .action((id: string, options: KnowledgeOptions) => knowledgeCommand(id, options));
+    .action((id: string | undefined, options: KnowledgeOptions) => {
+      if (!id) {
+        command.help();
+        return;
+      }
+      return knowledgeCommand(id, options);
+    });
+
+  command
+    .command('open')
+    .description('Open the project OKF bundle in the local knowledge viewer')
+    .option('--no-install', 'Do not install @inkeep/open-knowledge when the ok binary is missing')
+    .option('--no-browser', 'Start or reuse the viewer without opening a browser')
+    .action((options: KnowledgeOpenOptions) => knowledgeOpenCommand(options));
+
+  return command;
 }

--- a/src/cli/commands/knowledge.ts
+++ b/src/cli/commands/knowledge.ts
@@ -6,7 +6,7 @@ import { spawnRun } from '../../lib/agents.js';
 import { ensureMnemos } from '../../lib/installers/mnemos.js';
 import {
   ensureOpenKnowledge,
-  startOpenKnowledgeServer,
+  startReadOnlyOpenKnowledgeServer,
   type EnsureOpenKnowledgeResult,
   type StartOpenKnowledgeServerResult,
 } from '../../lib/installers/open-knowledge.js';
@@ -144,12 +144,12 @@ export async function knowledgeOpenCommand(
   }
 
   const ensure = dependencies.ensure ?? ensureOpenKnowledge;
-  const start = dependencies.start ?? startOpenKnowledgeServer;
+  const start = dependencies.start ?? startReadOnlyOpenKnowledgeServer;
   await ensure({ autoInstall: options.install !== false });
   const viewer = await start(bundlePath, { openBrowser: false });
-  viewer.process.unref();
+  viewer.process?.unref();
 
-  console.log(`Knowledge viewer: ${viewer.url}`);
+  console.log(`Knowledge viewer: ${viewer.url}${viewer.reused ? ' (reused)' : ''}`);
   if (options.browser === false) return;
 
   try {

--- a/src/dashboard/docker-compose.yml
+++ b/src/dashboard/docker-compose.yml
@@ -20,6 +20,10 @@ services:
       - "traefik.http.routers.overdeck.rule=Host(`overdeck.localhost`)"
       - "traefik.http.routers.overdeck.entrypoints=websecure"
       - "traefik.http.routers.overdeck.tls=true"
+      - "traefik.http.routers.overdeck-knowledge.rule=HostRegexp(`^knowledge-[a-f0-9]+\\.overdeck\\.localhost$`)"
+      - "traefik.http.routers.overdeck-knowledge.entrypoints=websecure"
+      - "traefik.http.routers.overdeck-knowledge.tls=true"
+      - "traefik.http.routers.overdeck-knowledge.service=overdeck"
       - "traefik.http.services.overdeck.loadbalancer.server.port=3000"
 
 networks:

--- a/src/dashboard/frontend/src/App/AppRoutes.tsx
+++ b/src/dashboard/frontend/src/App/AppRoutes.tsx
@@ -14,6 +14,7 @@ import { ResourcesPanel } from '../components/ResourcesPanel';
 import { GodViewPage } from '../components/GodView';
 import { DeaconActivityView } from '../components/DeaconActivityView';
 import { ContextPage } from '../components/context/ContextPage';
+import { KnowledgePage } from '../components/knowledge/KnowledgePage';
 import { ConversationsPage } from '../components/conversations/ConversationsPage';
 import { AutoPresoView } from '../components/autopreso/AutoPresoView';
 import { BootstrapGate } from '../components/BootstrapGate';
@@ -168,6 +169,11 @@ export function AppRoutes({
               onTabChange('agents');
             }}
           />
+        </div>
+      )}
+      {activeTab === 'knowledge' && (
+        <div className="w-full h-full overflow-hidden">
+          <KnowledgePage projectKey={selectedProjectKey} />
         </div>
       )}
       {activeTab === 'skills' && (

--- a/src/dashboard/frontend/src/App/routes.ts
+++ b/src/dashboard/frontend/src/App/routes.ts
@@ -12,6 +12,7 @@ export const TAB_PATHS: Record<Tab, string> = {
   flywheel: '/flywheel',
   backlog: '/backlog',
   resources: '/resources',
+  knowledge: '/knowledge',
   autopreso: '/autopreso',
   activity: '/activity',
   metrics: '/metrics',

--- a/src/dashboard/frontend/src/components/Header.tsx
+++ b/src/dashboard/frontend/src/components/Header.tsx
@@ -10,6 +10,7 @@ export type Tab =
   | 'flywheel'
   | 'backlog'
   | 'resources'
+  | 'knowledge'
   | 'skills'
   | 'context'
   | 'health'

--- a/src/dashboard/frontend/src/components/Sidebar.tsx
+++ b/src/dashboard/frontend/src/components/Sidebar.tsx
@@ -4,7 +4,7 @@ import {
   Home, LayoutGrid, Bot, Server,
   Terminal, BarChart3, DollarSign, HeartPulse, Cpu, Settings,
   Zap, Compass, GitBranch, GitMerge, ChevronsLeft, ChevronsRight, Sun, Moon, Menu,
-  Hammer, Loader2, History, Mic, FileText, ChevronDown, ChevronRight, MoreHorizontal, Shield, ListOrdered,
+  Hammer, Loader2, History, Mic, FileText, BookOpen, ChevronDown, ChevronRight, MoreHorizontal, Shield, ListOrdered,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { fetchProjects, filterSpecOnlyPlanned, isUnscopedConversation, NO_PROJECT_KEY, NO_PROJECT_LABEL, type RegisteredProjectLite } from './CommandDeck/projectsData';
@@ -117,6 +117,7 @@ const MORE_GROUPS: NavGroup[] = [
   {
     label: 'System',
     items: [
+      { id: 'knowledge' as Tab, label: 'Knowledge', icon: BookOpen },
       { id: 'skills' as Tab, label: 'Skills', icon: Cpu },
       { id: 'context' as Tab, label: 'Context', icon: FileText },
       { id: 'settings' as Tab, label: 'Settings', icon: Settings },

--- a/src/dashboard/frontend/src/components/knowledge/KnowledgePage.test.tsx
+++ b/src/dashboard/frontend/src/components/knowledge/KnowledgePage.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { TAB_PATHS } from '../../App/routes';
 import { KnowledgePage, knowledgeViewerPostureCopy } from './KnowledgePage';
@@ -26,6 +26,7 @@ function jsonResponse(body: unknown, ok = true): Response {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -114,7 +115,7 @@ describe('KnowledgePage', () => {
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
-  it('starts an installed idle viewer and transitions to ready', async () => {
+  it('starts an installed idle viewer and embeds the running workspace', async () => {
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
       if (String(input).includes('/start')) {
         return Promise.resolve(jsonResponse({
@@ -138,10 +139,72 @@ describe('KnowledgePage', () => {
 
     renderPage();
 
-    expect(await screen.findByText('Viewer ready')).toBeInTheDocument();
+    const iframe = await screen.findByTitle('OpenKnowledge viewer');
+    expect(iframe).toHaveAttribute('src', '/knowledge-viewer/?project=overdeck');
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/knowledge-viewer/start', expect.objectContaining({
       method: 'POST',
     })));
+  });
+
+  it('accepts a loaded iframe document as the embedded viewer', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+      projectKey: 'overdeck',
+      bundleConfigured: true,
+      installed: true,
+      starting: false,
+      running: true,
+      url: 'http://127.0.0.1:39847',
+    })));
+
+    renderPage();
+    const iframe = await screen.findByTitle('OpenKnowledge viewer');
+    Object.defineProperty(iframe, 'contentDocument', {
+      configurable: true,
+      value: {
+        location: { href: 'http://localhost/knowledge-viewer/' },
+        documentElement: { childElementCount: 1 },
+      },
+    });
+
+    vi.useFakeTimers();
+    fireEvent.load(iframe);
+    await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+
+    expect(screen.getByTestId('knowledge-viewer-embedded')).toBeInTheDocument();
+    expect(screen.queryByText('Loading knowledge workspace')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('knowledge-viewer-blocked')).not.toBeInTheDocument();
+  });
+
+  it('falls back to a direct link when the iframe document is blocked', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+      projectKey: 'overdeck',
+      bundleConfigured: true,
+      installed: true,
+      starting: false,
+      running: true,
+      url: 'http://127.0.0.1:39847',
+    })));
+
+    renderPage();
+    const iframe = await screen.findByTitle('OpenKnowledge viewer');
+    Object.defineProperty(iframe, 'contentDocument', {
+      configurable: true,
+      value: {
+        location: { href: 'about:blank' },
+        documentElement: { childElementCount: 0 },
+      },
+    });
+
+    vi.useFakeTimers();
+    fireEvent.load(iframe);
+    await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+
+    expect(screen.getByTestId('knowledge-viewer-blocked')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open viewer' })).toHaveAttribute(
+      'href',
+      'http://127.0.0.1:39847',
+    );
+    expect(screen.queryByTitle('OpenKnowledge viewer')).not.toBeInTheDocument();
   });
 
   it('uses the recorded lossy-spike posture copy', async () => {

--- a/src/dashboard/frontend/src/components/knowledge/KnowledgePage.test.tsx
+++ b/src/dashboard/frontend/src/components/knowledge/KnowledgePage.test.tsx
@@ -1,0 +1,163 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TAB_PATHS } from '../../App/routes';
+import { KnowledgePage, knowledgeViewerPostureCopy } from './KnowledgePage';
+
+function renderPage(projectKey = 'overdeck') {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <KnowledgePage projectKey={projectKey} />
+    </QueryClientProvider>,
+  );
+}
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: async () => body,
+  } as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('KnowledgePage', () => {
+  it('registers /knowledge without changing existing tab paths', () => {
+    const { knowledge, ...legacyPaths } = TAB_PATHS;
+    expect(knowledge).toBe('/knowledge');
+    expect(legacyPaths).toEqual({
+      home: '/',
+      pipeline: '/pipeline',
+      kanban: '/board',
+      'command-deck': '/command-deck',
+      agents: '/agents',
+      flywheel: '/flywheel',
+      backlog: '/backlog',
+      resources: '/resources',
+      autopreso: '/autopreso',
+      activity: '/activity',
+      metrics: '/metrics',
+      costs: '/costs',
+      skills: '/skills',
+      context: '/context',
+      health: '/health',
+      settings: '/settings',
+      'god-view': '/god-view',
+      deacon: '/deacon',
+      sessions: '/sessions',
+      'awaiting-merge': '/awaiting-merge',
+    });
+  });
+
+  it('renders /okf init guidance when no bundle is configured', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+      projectKey: 'overdeck',
+      bundleConfigured: false,
+      installed: false,
+      starting: false,
+      running: false,
+    })));
+
+    renderPage();
+
+    expect(await screen.findByText('No knowledge bundle configured')).toBeInTheDocument();
+    expect(screen.getByText('/okf init')).toBeInTheDocument();
+  });
+
+  it('renders an install action and shows progress while the explicit install is pending', async () => {
+    let resolveInstall!: (value: Response) => void;
+    const installResponse = new Promise<Response>((resolve) => { resolveInstall = resolve; });
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      if (String(input).includes('/install')) return installResponse;
+      return Promise.resolve(jsonResponse({
+        projectKey: 'overdeck',
+        bundleConfigured: true,
+        installed: false,
+        starting: false,
+        running: false,
+      }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderPage();
+    fireEvent.click(await screen.findByRole('button', { name: 'Install viewer' }));
+
+    expect(await screen.findByRole('button', { name: 'Installing viewer' })).toBeDisabled();
+    expect(fetchMock).toHaveBeenCalledWith('/api/knowledge-viewer/install', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ project: 'overdeck' }),
+    }));
+    resolveInstall(jsonResponse({ installed: true }));
+  });
+
+  it('renders the machine-active starting state', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+      projectKey: 'overdeck',
+      bundleConfigured: true,
+      installed: true,
+      starting: true,
+      running: false,
+    })));
+
+    renderPage();
+
+    expect(await screen.findByText('Starting knowledge viewer')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('starts an installed idle viewer and transitions to ready', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      if (String(input).includes('/start')) {
+        return Promise.resolve(jsonResponse({
+          projectKey: 'overdeck',
+          bundleConfigured: true,
+          installed: true,
+          starting: false,
+          running: true,
+          url: 'http://127.0.0.1:39847',
+        }));
+      }
+      return Promise.resolve(jsonResponse({
+        projectKey: 'overdeck',
+        bundleConfigured: true,
+        installed: true,
+        starting: false,
+        running: false,
+      }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderPage();
+
+    expect(await screen.findByText('Viewer ready')).toBeInTheDocument();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/knowledge-viewer/start', expect.objectContaining({
+      method: 'POST',
+    })));
+  });
+
+  it('uses the recorded lossy-spike posture copy', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+      projectKey: 'overdeck',
+      bundleConfigured: false,
+      installed: false,
+      starting: false,
+      running: false,
+    })));
+
+    renderPage();
+
+    expect(await screen.findByText(knowledgeViewerPostureCopy(false))).toHaveTextContent(
+      'View and search here; edit knowledge through /okf author',
+    );
+    expect(knowledgeViewerPostureCopy(true)).toContain('Browse, search, and edit');
+  });
+});

--- a/src/dashboard/frontend/src/components/knowledge/KnowledgePage.test.tsx
+++ b/src/dashboard/frontend/src/components/knowledge/KnowledgePage.test.tsx
@@ -2,7 +2,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { TAB_PATHS } from '../../App/routes';
-import { KnowledgePage, knowledgeViewerPostureCopy } from './KnowledgePage';
+import { KnowledgePage, knowledgeViewerPostureCopy, type KnowledgeViewerStatus } from './KnowledgePage';
+
+vi.mock('../../lib/wsTransport', () => ({
+  dashboardMutationJsonHeaders: vi.fn(async () => ({
+    'Content-Type': 'application/json',
+    'x-overdeck-csrf-token': 'test-csrf-token',
+  })),
+}));
 
 function renderPage(projectKey = 'overdeck') {
   const queryClient = new QueryClient({
@@ -11,11 +18,14 @@ function renderPage(projectKey = 'overdeck') {
       mutations: { retry: false },
     },
   });
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <KnowledgePage projectKey={projectKey} />
-    </QueryClientProvider>,
-  );
+  return {
+    queryClient,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <KnowledgePage projectKey={projectKey} />
+      </QueryClientProvider>,
+    ),
+  };
 }
 
 function jsonResponse(body: unknown, ok = true): Response {
@@ -23,6 +33,20 @@ function jsonResponse(body: unknown, ok = true): Response {
     ok,
     json: async () => body,
   } as Response;
+}
+
+function runningStatus(overrides: Partial<KnowledgeViewerStatus> = {}): KnowledgeViewerStatus {
+  return {
+    projectKey: 'overdeck',
+    bundleConfigured: true,
+    installed: true,
+    starting: false,
+    running: true,
+    url: 'http://127.0.0.1:39847',
+    proxyUrl: 'about:blank#knowledge-viewer',
+    embeddable: true,
+    ...overrides,
+  };
 }
 
 afterEach(() => {
@@ -74,7 +98,7 @@ describe('KnowledgePage', () => {
     expect(screen.getByText('/okf init')).toBeInTheDocument();
   });
 
-  it('renders an install action and shows progress while the explicit install is pending', async () => {
+  it('renders the binary diagnosis and sends an authenticated install mutation', async () => {
     let resolveInstall!: (value: Response) => void;
     const installResponse = new Promise<Response>((resolve) => { resolveInstall = resolve; });
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
@@ -85,16 +109,23 @@ describe('KnowledgePage', () => {
         installed: false,
         starting: false,
         running: false,
+        message: 'open-knowledge requires Node 24+',
       }));
     });
     vi.stubGlobal('fetch', fetchMock);
 
     renderPage();
-    fireEvent.click(await screen.findByRole('button', { name: 'Install viewer' }));
+    expect(await screen.findByText('open-knowledge requires Node 24+')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Install viewer' }));
 
     expect(await screen.findByRole('button', { name: 'Installing viewer' })).toBeDisabled();
     expect(fetchMock).toHaveBeenCalledWith('/api/knowledge-viewer/install', expect.objectContaining({
       method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-overdeck-csrf-token': 'test-csrf-token',
+      },
       body: JSON.stringify({ project: 'overdeck' }),
     }));
     resolveInstall(jsonResponse({ installed: true }));
@@ -115,18 +146,9 @@ describe('KnowledgePage', () => {
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
-  it('starts an installed idle viewer and embeds the running workspace', async () => {
+  it('starts an installed idle viewer and embeds the origin-isolated snapshot', async () => {
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
-      if (String(input).includes('/start')) {
-        return Promise.resolve(jsonResponse({
-          projectKey: 'overdeck',
-          bundleConfigured: true,
-          installed: true,
-          starting: false,
-          running: true,
-          url: 'http://127.0.0.1:39847',
-        }));
-      }
+      if (String(input).includes('/start')) return Promise.resolve(jsonResponse(runningStatus()));
       return Promise.resolve(jsonResponse({
         projectKey: 'overdeck',
         bundleConfigured: true,
@@ -140,71 +162,77 @@ describe('KnowledgePage', () => {
     renderPage();
 
     const iframe = await screen.findByTitle('OpenKnowledge viewer');
-    expect(iframe).toHaveAttribute('src', '/knowledge-viewer/?project=overdeck');
+    fireEvent.load(iframe);
+    expect(iframe).toHaveAttribute('src', 'about:blank#knowledge-viewer');
+    expect(iframe).toHaveAttribute('sandbox');
+    expect(screen.getByText(/Read-only snapshot/)).toBeInTheDocument();
+    expect(screen.queryByText('Loading knowledge workspace')).not.toBeInTheDocument();
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/knowledge-viewer/start', expect.objectContaining({
       method: 'POST',
+      credentials: 'include',
     })));
   });
 
-  it('accepts a loaded iframe document as the embedded viewer', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
-      projectKey: 'overdeck',
-      bundleConfigured: true,
-      installed: true,
-      starting: false,
-      running: true,
-      url: 'http://127.0.0.1:39847',
-    })));
+  it('uses the direct read-only snapshot fallback when framing is blocked', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(runningStatus({ embeddable: false }))));
 
     renderPage();
-    const iframe = await screen.findByTitle('OpenKnowledge viewer');
-    Object.defineProperty(iframe, 'contentDocument', {
-      configurable: true,
-      value: {
-        location: { href: 'http://localhost/knowledge-viewer/' },
-        documentElement: { childElementCount: 1 },
-      },
-    });
 
-    vi.useFakeTimers();
-    fireEvent.load(iframe);
-    await act(async () => { await vi.advanceTimersByTimeAsync(100); });
-
-    expect(screen.getByTestId('knowledge-viewer-embedded')).toBeInTheDocument();
-    expect(screen.queryByText('Loading knowledge workspace')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('knowledge-viewer-blocked')).not.toBeInTheDocument();
-  });
-
-  it('falls back to a direct link when the iframe document is blocked', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
-      projectKey: 'overdeck',
-      bundleConfigured: true,
-      installed: true,
-      starting: false,
-      running: true,
-      url: 'http://127.0.0.1:39847',
-    })));
-
-    renderPage();
-    const iframe = await screen.findByTitle('OpenKnowledge viewer');
-    Object.defineProperty(iframe, 'contentDocument', {
-      configurable: true,
-      value: {
-        location: { href: 'about:blank' },
-        documentElement: { childElementCount: 0 },
-      },
-    });
-
-    vi.useFakeTimers();
-    fireEvent.load(iframe);
-    await act(async () => { await vi.advanceTimersByTimeAsync(100); });
-
-    expect(screen.getByTestId('knowledge-viewer-blocked')).toBeInTheDocument();
+    expect(await screen.findByTestId('knowledge-viewer-blocked')).toBeInTheDocument();
+    expect(screen.getByText(/disposable read-only snapshot/)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Open viewer' })).toHaveAttribute(
       'href',
       'http://127.0.0.1:39847',
     );
     expect(screen.queryByTitle('OpenKnowledge viewer')).not.toBeInTheDocument();
+  });
+
+  it('automatically restarts after a previously running viewer crashes', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      if (String(input).includes('/start')) return Promise.resolve(jsonResponse(runningStatus()));
+      return Promise.resolve(jsonResponse(runningStatus()));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const { queryClient } = renderPage();
+    const iframe = await screen.findByTitle('OpenKnowledge viewer');
+    fireEvent.load(iframe);
+
+    await act(async () => {
+      queryClient.setQueryData(['knowledge-viewer-status', 'overdeck'], runningStatus({
+        running: false,
+        proxyUrl: undefined,
+        embeddable: undefined,
+      }));
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/knowledge-viewer/start', expect.objectContaining({
+      method: 'POST',
+    })));
+    expect(await screen.findByTitle('OpenKnowledge viewer')).toBeInTheDocument();
+  });
+
+  it('renders a retry action when restart fails', async () => {
+    let starts = 0;
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      if (String(input).includes('/start')) {
+        starts += 1;
+        return Promise.resolve(jsonResponse({ error: 'viewer exited' }, false));
+      }
+      return Promise.resolve(jsonResponse({
+        projectKey: 'overdeck',
+        bundleConfigured: true,
+        installed: true,
+        starting: false,
+        running: false,
+      }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderPage();
+    const retry = await screen.findByRole('button', { name: 'Retry viewer' });
+    expect(screen.getByText('viewer exited')).toBeInTheDocument();
+    fireEvent.click(retry);
+    await waitFor(() => expect(starts).toBe(2));
   });
 
   it('uses the recorded lossy-spike posture copy', async () => {

--- a/src/dashboard/frontend/src/components/knowledge/KnowledgePage.tsx
+++ b/src/dashboard/frontend/src/components/knowledge/KnowledgePage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { AlertCircle, BookOpen, Download, Loader2 } from 'lucide-react';
+import { dashboardMutationJsonHeaders } from '../../lib/wsTransport';
 import { fetchProjects } from '../CommandDeck/projectsData';
 
 export interface KnowledgeViewerStatus {
@@ -11,6 +12,8 @@ export interface KnowledgeViewerStatus {
   running: boolean;
   bundlePath?: string;
   url?: string;
+  proxyUrl?: string;
+  embeddable?: boolean;
   message?: string;
 }
 
@@ -19,23 +22,9 @@ interface KnowledgePageProps {
 }
 
 const KNOWLEDGE_VIEWER_EDITABLE = false;
-const EMBED_PROBE_DELAY_MS = 100;
 const EMBED_TIMEOUT_MS = 5_000;
 
 type EmbedState = 'loading' | 'ready' | 'blocked';
-
-export function iframeDocumentLoaded(iframe: HTMLIFrameElement): boolean {
-  try {
-    const document = iframe.contentDocument;
-    return Boolean(
-      document &&
-      document.location.href !== 'about:blank' &&
-      document.documentElement.childElementCount > 0,
-    );
-  } catch {
-    return false;
-  }
-}
 
 export function knowledgeViewerPostureCopy(editable = KNOWLEDGE_VIEWER_EDITABLE): string {
   return editable
@@ -44,7 +33,9 @@ export function knowledgeViewerPostureCopy(editable = KNOWLEDGE_VIEWER_EDITABLE)
 }
 
 async function fetchViewerStatus(projectKey: string): Promise<KnowledgeViewerStatus> {
-  const response = await fetch(`/api/knowledge-viewer/status?project=${encodeURIComponent(projectKey)}`);
+  const response = await fetch(`/api/knowledge-viewer/status?project=${encodeURIComponent(projectKey)}`, {
+    credentials: 'include',
+  });
   const body = await response.json() as KnowledgeViewerStatus & { error?: string };
   if (!response.ok) throw new Error(body.error || 'Knowledge viewer status could not be loaded');
   return body;
@@ -53,7 +44,8 @@ async function fetchViewerStatus(projectKey: string): Promise<KnowledgeViewerSta
 async function mutateViewer(action: 'install' | 'start', projectKey: string): Promise<KnowledgeViewerStatus> {
   const response = await fetch(`/api/knowledge-viewer/${action}`, {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    credentials: 'include',
+    headers: await dashboardMutationJsonHeaders(),
     body: JSON.stringify({ project: projectKey }),
   });
   const body = await response.json() as KnowledgeViewerStatus & { error?: string };
@@ -64,7 +56,7 @@ async function mutateViewer(action: 'install' | 'start', projectKey: string): Pr
 export function KnowledgePage({ projectKey }: KnowledgePageProps) {
   const queryClient = useQueryClient();
   const requestedStart = useRef<string | null>(null);
-  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const lastRunningProject = useRef<string | null>(null);
   const [embedState, setEmbedState] = useState<EmbedState>('loading');
   const projectsQuery = useQuery({
     queryKey: ['command-deck-projects'],
@@ -98,6 +90,22 @@ export function KnowledgePage({ projectKey }: KnowledgePageProps) {
 
   const status = statusQuery.data;
   useEffect(() => {
+    if (!activeProjectKey) {
+      lastRunningProject.current = null;
+      return;
+    }
+    if (status?.running) {
+      requestedStart.current = null;
+      lastRunningProject.current = activeProjectKey;
+      return;
+    }
+    if (lastRunningProject.current === activeProjectKey) {
+      requestedStart.current = null;
+      lastRunningProject.current = null;
+    }
+  }, [activeProjectKey, status?.running]);
+
+  useEffect(() => {
     if (!activeProjectKey || !status?.bundleConfigured || !status.installed || status.running || status.starting) return;
     if (requestedStart.current === activeProjectKey || startMutation.isPending) return;
     requestedStart.current = activeProjectKey;
@@ -107,22 +115,25 @@ export function KnowledgePage({ projectKey }: KnowledgePageProps) {
   useEffect(() => {
     setEmbedState('loading');
     if (!status?.running) return;
-    const timeout = window.setTimeout(() => {
-      if (!iframeRef.current || !iframeDocumentLoaded(iframeRef.current)) setEmbedState('blocked');
-    }, EMBED_TIMEOUT_MS);
+    if (status.embeddable === false || !status.proxyUrl) {
+      setEmbedState('blocked');
+      return;
+    }
+    const timeout = window.setTimeout(() => setEmbedState('blocked'), EMBED_TIMEOUT_MS);
     return () => window.clearTimeout(timeout);
-  }, [activeProjectKey, status?.running]);
+  }, [activeProjectKey, status?.embeddable, status?.proxyUrl, status?.running]);
 
-  const handleIframeLoad = useCallback(() => {
-    window.setTimeout(() => {
-      const iframe = iframeRef.current;
-      setEmbedState(iframe && iframeDocumentLoaded(iframe) ? 'ready' : 'blocked');
-    }, EMBED_PROBE_DELAY_MS);
-  }, []);
+  const handleIframeLoad = useCallback(() => setEmbedState('ready'), []);
+  const retryViewer = useCallback(() => {
+    requestedStart.current = activeProjectKey;
+    startMutation.reset();
+    startMutation.mutate();
+  }, [activeProjectKey, startMutation]);
 
   const loading = projectsQuery.isLoading || (Boolean(activeProjectKey) && statusQuery.isLoading);
   const error = projectsQuery.error ?? statusQuery.error ?? installMutation.error ?? startMutation.error;
   const starting = status?.starting || startMutation.isPending;
+  const embedBlocked = status?.running && (status.embeddable === false || !status.proxyUrl || embedState === 'blocked');
 
   return (
     <main className="h-full overflow-y-auto bg-background p-6" data-testid="knowledge-page">
@@ -151,6 +162,15 @@ export function KnowledgePage({ projectKey }: KnowledgePageProps) {
               <div>
                 <h2 className="text-sm font-medium text-foreground">Knowledge viewer unavailable</h2>
                 <p className="mt-1 text-sm text-muted-foreground">{error.message}</p>
+                {status?.bundleConfigured && status.installed && (
+                  <button
+                    type="button"
+                    onClick={retryViewer}
+                    className="mt-4 text-sm font-medium text-primary hover:underline"
+                  >
+                    Retry viewer
+                  </button>
+                )}
               </div>
             </div>
           </section>
@@ -170,6 +190,9 @@ export function KnowledgePage({ projectKey }: KnowledgePageProps) {
             <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
               OpenKnowledge is installed only after this explicit request. It runs as a separate local program.
             </p>
+            {status.message && (
+              <p className="mt-2 max-w-2xl font-mono text-xs text-muted-foreground">{status.message}</p>
+            )}
             <button
               type="button"
               onClick={() => installMutation.mutate()}
@@ -188,14 +211,30 @@ export function KnowledgePage({ projectKey }: KnowledgePageProps) {
           <ProgressState title="Starting knowledge viewer" />
         )}
 
-        {!loading && !error && status?.running && embedState === 'blocked' && (
+        {!loading && !error && status?.bundleConfigured && status.installed && !status.running && !starting && requestedStart.current === activeProjectKey && (
+          <section className="rounded-lg bg-card p-6" data-testid="knowledge-viewer-stopped">
+            <h2 className="text-sm font-medium text-foreground">Knowledge viewer stopped</h2>
+            <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+              The local viewer exited before it could reconnect. Restart the read-only snapshot to continue browsing.
+            </p>
+            <button
+              type="button"
+              onClick={retryViewer}
+              className="mt-4 text-sm font-medium text-primary hover:underline"
+            >
+              Restart viewer
+            </button>
+          </section>
+        )}
+
+        {!loading && !error && embedBlocked && (
           <section className="rounded-lg bg-card p-6" data-testid="knowledge-viewer-blocked">
             <div className="flex items-start gap-3">
               <AlertCircle className="mt-0.5 h-5 w-5 text-warning" aria-hidden="true" />
               <div>
                 <h2 className="text-sm font-medium text-foreground">Viewer opens in a separate tab</h2>
                 <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
-                  The local viewer refused dashboard framing. Open it directly to browse and search this bundle.
+                  The local viewer refused dashboard framing. Open its disposable read-only snapshot directly to browse and search.
                 </p>
                 {status.url && (
                   <a
@@ -212,20 +251,25 @@ export function KnowledgePage({ projectKey }: KnowledgePageProps) {
           </section>
         )}
 
-        {!loading && !error && status?.running && embedState !== 'blocked' && activeProjectKey && (
-          <section className="relative min-h-[70vh] overflow-hidden rounded-lg bg-card" data-testid="knowledge-viewer-embedded">
+        {!loading && !error && status?.running && status.proxyUrl && !embedBlocked && (
+          <section className="relative flex min-h-[70vh] flex-col overflow-hidden rounded-lg bg-card" data-testid="knowledge-viewer-embedded">
+            <div className="border-b border-border px-4 py-3">
+              <p className="text-xs text-muted-foreground">
+                Read-only snapshot — viewer edits are discarded. Use <span className="font-mono">/okf author</span> for durable changes.
+              </p>
+            </div>
             {embedState === 'loading' && (
-              <div className="absolute inset-0 z-10 flex items-center justify-center bg-card">
+              <div className="absolute inset-x-0 bottom-0 top-11 z-10 flex items-center justify-center bg-card">
                 <ProgressState title="Loading knowledge workspace" />
               </div>
             )}
             <iframe
-              ref={iframeRef}
               title="OpenKnowledge viewer"
-              src={`/knowledge-viewer/?project=${encodeURIComponent(activeProjectKey)}`}
+              src={status.proxyUrl}
+              sandbox="allow-downloads allow-forms allow-popups allow-same-origin allow-scripts"
               onLoad={handleIframeLoad}
               onError={() => setEmbedState('blocked')}
-              className="min-h-[70vh] w-full border-0 bg-background"
+              className="min-h-[66vh] w-full flex-1 border-0 bg-background"
             />
           </section>
         )}

--- a/src/dashboard/frontend/src/components/knowledge/KnowledgePage.tsx
+++ b/src/dashboard/frontend/src/components/knowledge/KnowledgePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { AlertCircle, BookOpen, Download, Loader2 } from 'lucide-react';
 import { fetchProjects } from '../CommandDeck/projectsData';
@@ -19,6 +19,23 @@ interface KnowledgePageProps {
 }
 
 const KNOWLEDGE_VIEWER_EDITABLE = false;
+const EMBED_PROBE_DELAY_MS = 100;
+const EMBED_TIMEOUT_MS = 5_000;
+
+type EmbedState = 'loading' | 'ready' | 'blocked';
+
+export function iframeDocumentLoaded(iframe: HTMLIFrameElement): boolean {
+  try {
+    const document = iframe.contentDocument;
+    return Boolean(
+      document &&
+      document.location.href !== 'about:blank' &&
+      document.documentElement.childElementCount > 0,
+    );
+  } catch {
+    return false;
+  }
+}
 
 export function knowledgeViewerPostureCopy(editable = KNOWLEDGE_VIEWER_EDITABLE): string {
   return editable
@@ -47,6 +64,8 @@ async function mutateViewer(action: 'install' | 'start', projectKey: string): Pr
 export function KnowledgePage({ projectKey }: KnowledgePageProps) {
   const queryClient = useQueryClient();
   const requestedStart = useRef<string | null>(null);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const [embedState, setEmbedState] = useState<EmbedState>('loading');
   const projectsQuery = useQuery({
     queryKey: ['command-deck-projects'],
     queryFn: fetchProjects,
@@ -85,13 +104,29 @@ export function KnowledgePage({ projectKey }: KnowledgePageProps) {
     startMutation.mutate();
   }, [activeProjectKey, startMutation, status]);
 
+  useEffect(() => {
+    setEmbedState('loading');
+    if (!status?.running) return;
+    const timeout = window.setTimeout(() => {
+      if (!iframeRef.current || !iframeDocumentLoaded(iframeRef.current)) setEmbedState('blocked');
+    }, EMBED_TIMEOUT_MS);
+    return () => window.clearTimeout(timeout);
+  }, [activeProjectKey, status?.running]);
+
+  const handleIframeLoad = useCallback(() => {
+    window.setTimeout(() => {
+      const iframe = iframeRef.current;
+      setEmbedState(iframe && iframeDocumentLoaded(iframe) ? 'ready' : 'blocked');
+    }, EMBED_PROBE_DELAY_MS);
+  }, []);
+
   const loading = projectsQuery.isLoading || (Boolean(activeProjectKey) && statusQuery.isLoading);
   const error = projectsQuery.error ?? statusQuery.error ?? installMutation.error ?? startMutation.error;
   const starting = status?.starting || startMutation.isPending;
 
   return (
     <main className="h-full overflow-y-auto bg-background p-6" data-testid="knowledge-page">
-      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6">
         <header>
           <div className="flex items-center gap-3">
             <BookOpen className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
@@ -153,12 +188,45 @@ export function KnowledgePage({ projectKey }: KnowledgePageProps) {
           <ProgressState title="Starting knowledge viewer" />
         )}
 
-        {!loading && !error && status?.running && (
-          <section className="rounded-lg bg-card p-6" data-testid="knowledge-viewer-ready">
-            <h2 className="text-sm font-medium text-foreground">Viewer ready</h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              The local viewer is running. The embedded knowledge workspace loads here.
-            </p>
+        {!loading && !error && status?.running && embedState === 'blocked' && (
+          <section className="rounded-lg bg-card p-6" data-testid="knowledge-viewer-blocked">
+            <div className="flex items-start gap-3">
+              <AlertCircle className="mt-0.5 h-5 w-5 text-warning" aria-hidden="true" />
+              <div>
+                <h2 className="text-sm font-medium text-foreground">Viewer opens in a separate tab</h2>
+                <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+                  The local viewer refused dashboard framing. Open it directly to browse and search this bundle.
+                </p>
+                {status.url && (
+                  <a
+                    href={status.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="mt-4 inline-flex text-sm font-medium text-primary hover:underline"
+                  >
+                    Open viewer
+                  </a>
+                )}
+              </div>
+            </div>
+          </section>
+        )}
+
+        {!loading && !error && status?.running && embedState !== 'blocked' && activeProjectKey && (
+          <section className="relative min-h-[70vh] overflow-hidden rounded-lg bg-card" data-testid="knowledge-viewer-embedded">
+            {embedState === 'loading' && (
+              <div className="absolute inset-0 z-10 flex items-center justify-center bg-card">
+                <ProgressState title="Loading knowledge workspace" />
+              </div>
+            )}
+            <iframe
+              ref={iframeRef}
+              title="OpenKnowledge viewer"
+              src={`/knowledge-viewer/?project=${encodeURIComponent(activeProjectKey)}`}
+              onLoad={handleIframeLoad}
+              onError={() => setEmbedState('blocked')}
+              className="min-h-[70vh] w-full border-0 bg-background"
+            />
           </section>
         )}
       </div>

--- a/src/dashboard/frontend/src/components/knowledge/KnowledgePage.tsx
+++ b/src/dashboard/frontend/src/components/knowledge/KnowledgePage.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { AlertCircle, BookOpen, Download, Loader2 } from 'lucide-react';
+import { fetchProjects } from '../CommandDeck/projectsData';
+
+export interface KnowledgeViewerStatus {
+  projectKey: string;
+  bundleConfigured: boolean;
+  installed: boolean;
+  starting: boolean;
+  running: boolean;
+  bundlePath?: string;
+  url?: string;
+  message?: string;
+}
+
+interface KnowledgePageProps {
+  projectKey?: string | null;
+}
+
+const KNOWLEDGE_VIEWER_EDITABLE = false;
+
+export function knowledgeViewerPostureCopy(editable = KNOWLEDGE_VIEWER_EDITABLE): string {
+  return editable
+    ? 'Browse, search, and edit this project knowledge bundle.'
+    : 'View and search here; edit knowledge through /okf author so changes stay PR-gated.';
+}
+
+async function fetchViewerStatus(projectKey: string): Promise<KnowledgeViewerStatus> {
+  const response = await fetch(`/api/knowledge-viewer/status?project=${encodeURIComponent(projectKey)}`);
+  const body = await response.json() as KnowledgeViewerStatus & { error?: string };
+  if (!response.ok) throw new Error(body.error || 'Knowledge viewer status could not be loaded');
+  return body;
+}
+
+async function mutateViewer(action: 'install' | 'start', projectKey: string): Promise<KnowledgeViewerStatus> {
+  const response = await fetch(`/api/knowledge-viewer/${action}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ project: projectKey }),
+  });
+  const body = await response.json() as KnowledgeViewerStatus & { error?: string };
+  if (!response.ok) throw new Error(body.error || `Knowledge viewer ${action} failed`);
+  return body;
+}
+
+export function KnowledgePage({ projectKey }: KnowledgePageProps) {
+  const queryClient = useQueryClient();
+  const requestedStart = useRef<string | null>(null);
+  const projectsQuery = useQuery({
+    queryKey: ['command-deck-projects'],
+    queryFn: fetchProjects,
+    enabled: !projectKey,
+    staleTime: 30_000,
+  });
+  const activeProjectKey = useMemo(
+    () => projectKey ?? projectsQuery.data?.[0]?.key ?? null,
+    [projectKey, projectsQuery.data],
+  );
+  const statusQuery = useQuery({
+    queryKey: ['knowledge-viewer-status', activeProjectKey],
+    queryFn: () => fetchViewerStatus(activeProjectKey!),
+    enabled: Boolean(activeProjectKey),
+    refetchInterval: 2_000,
+  });
+  const installMutation = useMutation({
+    mutationFn: () => mutateViewer('install', activeProjectKey!),
+    onSuccess: async () => {
+      requestedStart.current = null;
+      await queryClient.invalidateQueries({ queryKey: ['knowledge-viewer-status', activeProjectKey] });
+    },
+  });
+  const startMutation = useMutation({
+    mutationFn: () => mutateViewer('start', activeProjectKey!),
+    onSuccess: (status) => {
+      queryClient.setQueryData(['knowledge-viewer-status', activeProjectKey], status);
+    },
+  });
+
+  const status = statusQuery.data;
+  useEffect(() => {
+    if (!activeProjectKey || !status?.bundleConfigured || !status.installed || status.running || status.starting) return;
+    if (requestedStart.current === activeProjectKey || startMutation.isPending) return;
+    requestedStart.current = activeProjectKey;
+    startMutation.mutate();
+  }, [activeProjectKey, startMutation, status]);
+
+  const loading = projectsQuery.isLoading || (Boolean(activeProjectKey) && statusQuery.isLoading);
+  const error = projectsQuery.error ?? statusQuery.error ?? installMutation.error ?? startMutation.error;
+  const starting = status?.starting || startMutation.isPending;
+
+  return (
+    <main className="h-full overflow-y-auto bg-background p-6" data-testid="knowledge-page">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+        <header>
+          <div className="flex items-center gap-3">
+            <BookOpen className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+            <h1 className="text-xl font-medium text-foreground">Knowledge</h1>
+          </div>
+          <p className="mt-2 text-sm text-muted-foreground">{knowledgeViewerPostureCopy()}</p>
+        </header>
+
+        {loading && <ProgressState title="Loading knowledge configuration" />}
+
+        {!loading && !activeProjectKey && (
+          <EmptyState
+            title="No project is available"
+            description="Register a project before opening its knowledge bundle."
+          />
+        )}
+
+        {!loading && error && (
+          <section className="rounded-lg bg-card p-6" role="alert">
+            <div className="flex items-start gap-3">
+              <AlertCircle className="mt-0.5 h-5 w-5 text-destructive" aria-hidden="true" />
+              <div>
+                <h2 className="text-sm font-medium text-foreground">Knowledge viewer unavailable</h2>
+                <p className="mt-1 text-sm text-muted-foreground">{error.message}</p>
+              </div>
+            </div>
+          </section>
+        )}
+
+        {!loading && !error && status && !status.bundleConfigured && (
+          <EmptyState
+            title="No knowledge bundle configured"
+            description="Create or connect the project knowledge bundle, then return here."
+            command="/okf init"
+          />
+        )}
+
+        {!loading && !error && status?.bundleConfigured && !status.installed && (
+          <section className="rounded-lg bg-card p-6">
+            <h2 className="text-sm font-medium text-foreground">Install the local knowledge viewer</h2>
+            <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+              OpenKnowledge is installed only after this explicit request. It runs as a separate local program.
+            </p>
+            <button
+              type="button"
+              onClick={() => installMutation.mutate()}
+              disabled={installMutation.isPending}
+              className="mt-5 inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-opacity disabled:opacity-50"
+            >
+              {installMutation.isPending
+                ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                : <Download className="h-4 w-4" aria-hidden="true" />}
+              {installMutation.isPending ? 'Installing viewer' : 'Install viewer'}
+            </button>
+          </section>
+        )}
+
+        {!loading && !error && status?.bundleConfigured && status.installed && starting && (
+          <ProgressState title="Starting knowledge viewer" />
+        )}
+
+        {!loading && !error && status?.running && (
+          <section className="rounded-lg bg-card p-6" data-testid="knowledge-viewer-ready">
+            <h2 className="text-sm font-medium text-foreground">Viewer ready</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              The local viewer is running. The embedded knowledge workspace loads here.
+            </p>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function ProgressState({ title }: { title: string }) {
+  return (
+    <section className="rounded-lg bg-card p-6" role="status">
+      <div className="flex items-center gap-3">
+        <Loader2 className="h-5 w-5 animate-spin text-info" aria-hidden="true" />
+        <div>
+          <h2 className="text-sm font-medium text-foreground">{title}</h2>
+          <p className="mt-1 text-sm text-muted-foreground">This usually takes a few seconds.</p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function EmptyState({ title, description, command }: { title: string; description: string; command?: string }) {
+  return (
+    <section className="rounded-lg bg-card p-6">
+      <h2 className="text-sm font-medium text-foreground">{title}</h2>
+      <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+      {command && (
+        <code className="mt-4 inline-block rounded-sm bg-muted px-2 py-1 font-mono text-xs text-foreground">
+          {command}
+        </code>
+      )}
+    </section>
+  );
+}

--- a/src/dashboard/server/main.ts
+++ b/src/dashboard/server/main.ts
@@ -73,6 +73,7 @@ import { startEventLoopMonitor, stopEventLoopMonitor } from './services/event-lo
 import { formatBootGateState, resolveBootGates } from '../../lib/boot-gates.js';
 import { startBootReconciliation } from '../../lib/cloister/boot-reconciliation.js';
 import { startDeaconChild, stopDeaconChild } from './services/deacon-supervisor.js';
+import { stopAllKnowledgeViewers } from './services/knowledge-viewer.js';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { Layer } from 'effect';
@@ -661,6 +662,7 @@ const handleShutdownSignal = async (signal: NodeJS.Signals) => {
   stopCostReconcileService();
   stopStaleCheckRetriggerService();
   stopRestartAnnouncer();
+  await stopAllKnowledgeViewers().catch((err) => console.warn('[knowledge-viewer] shutdown failed:', err?.message ?? err));
   await stopDeaconChild().catch((err) => console.warn('[deacon-supervisor] child shutdown failed:', err?.message ?? err));
   try {
     // Reap only quality-gate trees owned by this dashboard process. Normal

--- a/src/dashboard/server/routes/knowledge-viewer.ts
+++ b/src/dashboard/server/routes/knowledge-viewer.ts
@@ -1,0 +1,335 @@
+import http from 'node:http';
+import type { Socket } from 'node:net';
+import { Effect, Layer } from 'effect';
+import { HttpRouter, HttpServerRequest, HttpServerResponse } from 'effect/unstable/http';
+import { WebSocket, WebSocketServer } from 'ws';
+import { ensureOpenKnowledge } from '../../../lib/installers/open-knowledge.js';
+import {
+  getKnowledgeViewerStatus,
+  getOrStartViewer,
+  type KnowledgeViewerStatus,
+} from '../services/knowledge-viewer.js';
+import { jsonResponse } from '../http-helpers.js';
+import { httpHandler } from './http-handler.js';
+import { validateOriginHeaders } from './origin-validation.js';
+
+export interface KnowledgeViewerRouteDependencies {
+  getStatus?: (projectKey: string) => Promise<KnowledgeViewerStatus>;
+  ensure?: (options: { autoInstall: true }) => Promise<unknown>;
+  start?: (projectKey: string) => Promise<KnowledgeViewerStatus>;
+  fetchImpl?: typeof fetch;
+}
+
+export interface KnowledgeViewerProxyRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string | undefined>;
+  body?: Uint8Array;
+}
+
+export interface KnowledgeViewerProxyResponse {
+  status: number;
+  headers: Record<string, string>;
+  body: Uint8Array;
+}
+
+export interface KnowledgeViewerRouteHandlers {
+  status(projectKey: string): Promise<KnowledgeViewerStatus>;
+  install(projectKey: string): Promise<KnowledgeViewerStatus>;
+  start(projectKey: string): Promise<KnowledgeViewerStatus>;
+  resolveTarget(requestUrl: string): Promise<string | null>;
+  proxyHttp(request: KnowledgeViewerProxyRequest): Promise<KnowledgeViewerProxyResponse>;
+}
+
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
+
+export function createKnowledgeViewerRouteHandlers(
+  dependencies: KnowledgeViewerRouteDependencies = {},
+): KnowledgeViewerRouteHandlers {
+  const getStatus = dependencies.getStatus ?? getKnowledgeViewerStatus;
+  const ensure = dependencies.ensure ?? ((options) => ensureOpenKnowledge(options));
+  const startViewer = dependencies.start ?? getOrStartViewer;
+  const fetchImpl = dependencies.fetchImpl ?? fetch;
+  let activeTarget: { projectKey: string; url: string } | null = null;
+
+  async function status(projectKey: string): Promise<KnowledgeViewerStatus> {
+    const result = await getStatus(projectKey);
+    if (result.running && result.url) activeTarget = { projectKey, url: result.url };
+    return result;
+  }
+
+  async function install(projectKey: string): Promise<KnowledgeViewerStatus> {
+    await ensure({ autoInstall: true });
+    return status(projectKey);
+  }
+
+  async function start(projectKey: string): Promise<KnowledgeViewerStatus> {
+    const result = await startViewer(projectKey);
+    if (result.running && result.url) activeTarget = { projectKey, url: result.url };
+    return result;
+  }
+
+  async function resolveTarget(requestUrl: string): Promise<string | null> {
+    const url = new URL(requestUrl, 'http://localhost');
+    const projectKey = url.searchParams.get('project');
+    if (projectKey) {
+      const result = await status(projectKey);
+      if (result.running && result.url) return result.url;
+      return null;
+    }
+    return activeTarget?.url ?? null;
+  }
+
+  async function proxyHttp(request: KnowledgeViewerProxyRequest): Promise<KnowledgeViewerProxyResponse> {
+    const target = await resolveTarget(request.url);
+    if (!target) throw new Error('Knowledge viewer is not running. Start it before opening /knowledge-viewer/.');
+
+    const upstreamUrl = knowledgeViewerUpstreamUrl(request.url, target, false);
+    const method = request.method.toUpperCase();
+    const response = await fetchImpl(upstreamUrl, {
+      method,
+      headers: filterRequestHeaders(request.headers),
+      body: method === 'GET' || method === 'HEAD' || !request.body ? undefined : Buffer.from(request.body),
+      redirect: 'manual',
+    });
+    const body = new Uint8Array(await response.arrayBuffer());
+    const headers = filterResponseHeaders(response.headers);
+    const location = response.headers.get('location');
+    if (location) headers.location = rewriteLocation(location, upstreamUrl, target);
+
+    return { status: response.status, headers, body };
+  }
+
+  return { status, install, start, resolveTarget, proxyHttp };
+}
+
+export function knowledgeViewerUpstreamUrl(
+  requestUrl: string,
+  targetUrl: string,
+  websocket: boolean,
+): string {
+  const incoming = new URL(requestUrl, 'http://localhost');
+  incoming.searchParams.delete('project');
+  const suffix = incoming.pathname.slice('/knowledge-viewer'.length) || '/';
+  const target = new URL(targetUrl);
+  target.protocol = websocket ? (target.protocol === 'https:' ? 'wss:' : 'ws:') : target.protocol;
+  target.pathname = suffix.startsWith('/') ? suffix : `/${suffix}`;
+  target.search = incoming.search;
+  target.hash = '';
+  return target.toString();
+}
+
+function filterRequestHeaders(headers: Record<string, string | undefined>): Record<string, string> {
+  const filtered: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    const lower = name.toLowerCase();
+    if (!value || HOP_BY_HOP_HEADERS.has(lower) || lower === 'host' || lower === 'content-length') continue;
+    filtered[lower] = value;
+  }
+  return filtered;
+}
+
+function filterResponseHeaders(headers: Headers): Record<string, string> {
+  const filtered: Record<string, string> = {};
+  headers.forEach((value, name) => {
+    if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) filtered[name] = value;
+  });
+  return filtered;
+}
+
+function rewriteLocation(location: string, upstreamUrl: string, targetUrl: string): string {
+  const resolved = new URL(location, upstreamUrl);
+  const target = new URL(targetUrl);
+  if (resolved.origin !== target.origin) return location;
+  return `/knowledge-viewer${resolved.pathname}${resolved.search}${resolved.hash}`;
+}
+
+function projectFromRequestUrl(requestUrl: string): string | null {
+  return new URL(requestUrl, 'http://localhost').searchParams.get('project');
+}
+
+function parseProjectBody(text: string): string | null {
+  try {
+    const parsed = JSON.parse(text) as { project?: unknown };
+    return typeof parsed.project === 'string' && parsed.project.trim() ? parsed.project.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+function proxyResponse(response: KnowledgeViewerProxyResponse): HttpServerResponse.HttpServerResponse {
+  return HttpServerResponse.uint8Array(response.body, {
+    status: response.status,
+    headers: response.headers,
+  });
+}
+
+const handlers = createKnowledgeViewerRouteHandlers();
+
+const statusRoute = HttpRouter.add(
+  'GET',
+  '/api/knowledge-viewer/status',
+  httpHandler(Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const projectKey = projectFromRequestUrl(request.url);
+    if (!projectKey) return jsonResponse({ error: 'project query parameter is required' }, { status: 400 });
+    return jsonResponse(yield* Effect.promise(() => handlers.status(projectKey)));
+  })),
+);
+
+const installRoute = HttpRouter.add(
+  'POST',
+  '/api/knowledge-viewer/install',
+  httpHandler(Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const projectKey = parseProjectBody(yield* request.text);
+    if (!projectKey) return jsonResponse({ error: 'project is required in the request body' }, { status: 400 });
+    try {
+      return jsonResponse(yield* Effect.promise(() => handlers.install(projectKey)));
+    } catch (error) {
+      return jsonResponse({ error: errorMessage(error) }, { status: 500 });
+    }
+  })),
+);
+
+const startRoute = HttpRouter.add(
+  'POST',
+  '/api/knowledge-viewer/start',
+  httpHandler(Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const projectKey = parseProjectBody(yield* request.text);
+    if (!projectKey) return jsonResponse({ error: 'project is required in the request body' }, { status: 400 });
+    try {
+      const result = yield* Effect.promise(() => handlers.start(projectKey));
+      return jsonResponse(result, { status: result.running ? 200 : 409 });
+    } catch (error) {
+      return jsonResponse({ error: errorMessage(error) }, { status: 500 });
+    }
+  })),
+);
+
+const proxyRoute = HttpRouter.add(
+  '*',
+  '/knowledge-viewer/*',
+  httpHandler(Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const requestUrl = new URL(request.url, 'http://localhost');
+    if (requestUrl.pathname === '/knowledge-viewer') {
+      return HttpServerResponse.redirect(`/knowledge-viewer/${requestUrl.search}`);
+    }
+    const method = request.method.toUpperCase();
+    const body = method === 'GET' || method === 'HEAD'
+      ? undefined
+      : new Uint8Array(yield* request.arrayBuffer);
+    try {
+      return proxyResponse(yield* Effect.promise(() => handlers.proxyHttp({
+        url: request.url,
+        method,
+        headers: request.headers,
+        ...(body ? { body } : {}),
+      })));
+    } catch (error) {
+      return jsonResponse({ error: errorMessage(error) }, { status: 503 });
+    }
+  })),
+);
+
+export const knowledgeViewerRouteLayer = Layer.mergeAll(
+  statusRoute,
+  installRoute,
+  startRoute,
+  proxyRoute,
+);
+
+export function setupKnowledgeViewerWebSocketProxy(
+  server: http.Server,
+  routeHandlers: KnowledgeViewerRouteHandlers = handlers,
+): void {
+  const wss = new WebSocketServer({ noServer: true });
+  const originalOn = server.on.bind(server);
+
+  server.on = function(event: string, listener: (...args: unknown[]) => void) {
+    if (event === 'upgrade') {
+      const wrapped = (request: http.IncomingMessage, socket: Socket, head: Buffer) => {
+        const url = new URL(request.url || '', `http://${request.headers.host}`);
+        if (url.pathname.startsWith('/knowledge-viewer/')) return;
+        (listener as (req: http.IncomingMessage, socket: Socket, head: Buffer) => void)(request, socket, head);
+      };
+      return originalOn(event, wrapped as never);
+    }
+    return originalOn(event, listener as never);
+  } as typeof server.on;
+
+  originalOn('upgrade', (request: http.IncomingMessage, socket: Socket, head: Buffer) => {
+    const url = new URL(request.url || '', `http://${request.headers.host}`);
+    if (!url.pathname.startsWith('/knowledge-viewer/')) return;
+
+    const origin = validateOriginHeaders(request.headers, request.method ?? 'GET');
+    if (!origin.ok) {
+      rejectUpgrade(socket, 403, origin.error);
+      return;
+    }
+
+    void routeHandlers.resolveTarget(request.url || '/knowledge-viewer/').then((target) => {
+      if (!target) {
+        rejectUpgrade(socket, 503, 'Knowledge viewer is not running');
+        return;
+      }
+      wss.handleUpgrade(request, socket, head, (client) => {
+        bridgeWebSocket(client, request, knowledgeViewerUpstreamUrl(request.url || '/knowledge-viewer/', target, true));
+      });
+    }).catch((error) => rejectUpgrade(socket, 502, errorMessage(error)));
+  });
+}
+
+function bridgeWebSocket(client: WebSocket, request: http.IncomingMessage, upstreamUrl: string): void {
+  const protocols = (request.headers['sec-websocket-protocol'] ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const upstream = new WebSocket(upstreamUrl, protocols.length > 0 ? protocols : undefined, {
+    headers: { origin: new URL(upstreamUrl).origin.replace(/^ws/, 'http') },
+  });
+  const queued: Array<{ data: Buffer; binary: boolean }> = [];
+
+  client.on('message', (data, binary) => {
+    const payload = Buffer.isBuffer(data) ? data : Buffer.from(data as ArrayBuffer);
+    if (upstream.readyState === WebSocket.OPEN) upstream.send(payload, { binary });
+    else queued.push({ data: payload, binary });
+  });
+  upstream.once('open', () => {
+    for (const message of queued.splice(0)) upstream.send(message.data, { binary: message.binary });
+  });
+  upstream.on('message', (data, binary) => {
+    if (client.readyState === WebSocket.OPEN) client.send(data, { binary });
+  });
+  upstream.on('close', (code, reason) => {
+    if (client.readyState === WebSocket.OPEN) client.close(code, reason.toString());
+  });
+  upstream.on('error', () => {
+    if (client.readyState === WebSocket.OPEN) client.close(1011, 'knowledge-viewer-upstream-error');
+  });
+  client.on('close', () => {
+    if (upstream.readyState === WebSocket.OPEN || upstream.readyState === WebSocket.CONNECTING) upstream.close();
+  });
+}
+
+function rejectUpgrade(socket: Socket, status: number, message: string): void {
+  socket.write(`HTTP/1.1 ${status} ${message}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`);
+  socket.destroy();
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export default knowledgeViewerRouteLayer;

--- a/src/dashboard/server/routes/knowledge-viewer.ts
+++ b/src/dashboard/server/routes/knowledge-viewer.ts
@@ -1,4 +1,6 @@
+import { randomBytes, timingSafeEqual } from 'node:crypto';
 import http from 'node:http';
+import https from 'node:https';
 import type { Socket } from 'node:net';
 import { Effect, Layer } from 'effect';
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from 'effect/unstable/http';
@@ -7,49 +9,66 @@ import { ensureOpenKnowledge } from '../../../lib/installers/open-knowledge.js';
 import {
   getKnowledgeViewerStatus,
   getOrStartViewer,
+  invalidateKnowledgeViewerInstallationCache,
   type KnowledgeViewerStatus,
 } from '../services/knowledge-viewer.js';
 import { jsonResponse } from '../http-helpers.js';
 import { httpHandler } from './http-handler.js';
+import {
+  rejectUnauthorizedDashboardRequest,
+  rejectUnsafeDashboardMutationRequest,
+} from './dashboard-auth.js';
 import { validateOriginHeaders } from './origin-validation.js';
 
 export interface KnowledgeViewerRouteDependencies {
   getStatus?: (projectKey: string) => Promise<KnowledgeViewerStatus>;
   ensure?: (options: { autoInstall: true }) => Promise<unknown>;
   start?: (projectKey: string) => Promise<KnowledgeViewerStatus>;
-  fetchImpl?: typeof fetch;
-}
-
-export interface KnowledgeViewerProxyRequest {
-  url: string;
-  method: string;
-  headers: Record<string, string | undefined>;
-  body?: Uint8Array;
-}
-
-export interface KnowledgeViewerProxyResponse {
-  status: number;
-  headers: Record<string, string>;
-  body: Uint8Array;
+  invalidateInstallationCache?: () => void;
 }
 
 export interface KnowledgeViewerRouteHandlers {
   status(projectKey: string): Promise<KnowledgeViewerStatus>;
   install(projectKey: string): Promise<KnowledgeViewerStatus>;
   start(projectKey: string): Promise<KnowledgeViewerStatus>;
-  resolveTarget(requestUrl: string): Promise<string | null>;
-  proxyHttp(request: KnowledgeViewerProxyRequest): Promise<KnowledgeViewerProxyResponse>;
+  resolveTarget(projectKey: string): Promise<string | null>;
 }
 
-const HOP_BY_HOP_HEADERS = new Set([
-  'connection',
-  'keep-alive',
-  'proxy-authenticate',
-  'proxy-authorization',
-  'te',
-  'trailer',
-  'transfer-encoding',
-  'upgrade',
+const VIEWER_HOST_PREFIX = 'knowledge-';
+const VIEWER_ACCESS_COOKIE = 'overdeck_knowledge_viewer';
+const MAX_QUEUED_WEBSOCKET_MESSAGES = 128;
+const MAX_QUEUED_WEBSOCKET_BYTES = 1024 * 1024;
+const MAX_CONFIG_RESPONSE_BYTES = 64 * 1024;
+const viewerAccessTokens = new Map<string, string>();
+
+const REQUEST_HEADER_ALLOWLIST = new Set([
+  'accept',
+  'accept-language',
+  'cache-control',
+  'content-type',
+  'if-match',
+  'if-modified-since',
+  'if-none-match',
+  'if-unmodified-since',
+  'range',
+  'user-agent',
+]);
+
+const RESPONSE_HEADER_ALLOWLIST = new Set([
+  'accept-ranges',
+  'cache-control',
+  'content-disposition',
+  'content-language',
+  'content-length',
+  'content-range',
+  'content-security-policy',
+  'content-type',
+  'etag',
+  'expires',
+  'last-modified',
+  'location',
+  'vary',
+  'x-frame-options',
 ]);
 
 export function createKnowledgeViewerRouteHandlers(
@@ -58,58 +77,28 @@ export function createKnowledgeViewerRouteHandlers(
   const getStatus = dependencies.getStatus ?? getKnowledgeViewerStatus;
   const ensure = dependencies.ensure ?? ((options) => ensureOpenKnowledge(options));
   const startViewer = dependencies.start ?? getOrStartViewer;
-  const fetchImpl = dependencies.fetchImpl ?? fetch;
-  let activeTarget: { projectKey: string; url: string } | null = null;
+  const invalidateInstallationCache = dependencies.invalidateInstallationCache ?? invalidateKnowledgeViewerInstallationCache;
 
   async function status(projectKey: string): Promise<KnowledgeViewerStatus> {
-    const result = await getStatus(projectKey);
-    if (result.running && result.url) activeTarget = { projectKey, url: result.url };
-    return result;
+    return getStatus(projectKey);
   }
 
   async function install(projectKey: string): Promise<KnowledgeViewerStatus> {
     await ensure({ autoInstall: true });
+    invalidateInstallationCache();
     return status(projectKey);
   }
 
   async function start(projectKey: string): Promise<KnowledgeViewerStatus> {
-    const result = await startViewer(projectKey);
-    if (result.running && result.url) activeTarget = { projectKey, url: result.url };
-    return result;
+    return startViewer(projectKey);
   }
 
-  async function resolveTarget(requestUrl: string): Promise<string | null> {
-    const url = new URL(requestUrl, 'http://localhost');
-    const projectKey = url.searchParams.get('project');
-    if (projectKey) {
-      const result = await status(projectKey);
-      if (result.running && result.url) return result.url;
-      return null;
-    }
-    return activeTarget?.url ?? null;
+  async function resolveTarget(projectKey: string): Promise<string | null> {
+    const result = await status(projectKey);
+    return result.running && result.url ? result.url : null;
   }
 
-  async function proxyHttp(request: KnowledgeViewerProxyRequest): Promise<KnowledgeViewerProxyResponse> {
-    const target = await resolveTarget(request.url);
-    if (!target) throw new Error('Knowledge viewer is not running. Start it before opening /knowledge-viewer/.');
-
-    const upstreamUrl = knowledgeViewerUpstreamUrl(request.url, target, false);
-    const method = request.method.toUpperCase();
-    const response = await fetchImpl(upstreamUrl, {
-      method,
-      headers: filterRequestHeaders(request.headers),
-      body: method === 'GET' || method === 'HEAD' || !request.body ? undefined : Buffer.from(request.body),
-      redirect: 'manual',
-    });
-    const body = new Uint8Array(await response.arrayBuffer());
-    const headers = filterResponseHeaders(response.headers);
-    const location = response.headers.get('location');
-    if (location) headers.location = rewriteLocation(location, upstreamUrl, target);
-
-    return { status: response.status, headers, body };
-  }
-
-  return { status, install, start, resolveTarget, proxyHttp };
+  return { status, install, start, resolveTarget };
 }
 
 export function knowledgeViewerUpstreamUrl(
@@ -118,39 +107,77 @@ export function knowledgeViewerUpstreamUrl(
   websocket: boolean,
 ): string {
   const incoming = new URL(requestUrl, 'http://localhost');
-  incoming.searchParams.delete('project');
-  const suffix = incoming.pathname.slice('/knowledge-viewer'.length) || '/';
+  incoming.searchParams.delete('access');
   const target = new URL(targetUrl);
   target.protocol = websocket ? (target.protocol === 'https:' ? 'wss:' : 'ws:') : target.protocol;
-  target.pathname = suffix.startsWith('/') ? suffix : `/${suffix}`;
+  target.pathname = incoming.pathname || '/';
   target.search = incoming.search;
   target.hash = '';
   return target.toString();
 }
 
-function filterRequestHeaders(headers: Record<string, string | undefined>): Record<string, string> {
-  const filtered: Record<string, string> = {};
+export function knowledgeViewerHost(projectKey: string, dashboardHost: string): string {
+  const parsed = splitHostAndPort(dashboardHost);
+  const baseHost = isIpAddress(parsed.hostname) ? 'localhost' : parsed.hostname;
+  const encodedProject = Buffer.from(projectKey, 'utf8').toString('hex');
+  return `${VIEWER_HOST_PREFIX}${encodedProject}.${baseHost}${parsed.port ? `:${parsed.port}` : ''}`;
+}
+
+export function projectFromKnowledgeViewerHost(host: string | undefined): string | null {
+  if (!host) return null;
+  const { hostname } = splitHostAndPort(host);
+  const firstDot = hostname.indexOf('.');
+  if (firstDot < 0) return null;
+  const label = hostname.slice(0, firstDot);
+  if (!label.startsWith(VIEWER_HOST_PREFIX)) return null;
+  const encoded = label.slice(VIEWER_HOST_PREFIX.length);
+  if (!encoded || encoded.length % 2 !== 0 || !/^[a-f0-9]+$/.test(encoded)) return null;
+  try {
+    const projectKey = Buffer.from(encoded, 'hex').toString('utf8');
+    return Buffer.from(projectKey, 'utf8').toString('hex') === encoded ? projectKey : null;
+  } catch {
+    return null;
+  }
+}
+
+export function knowledgeViewerProxyUrl(projectKey: string, dashboardHost: string): string {
+  const token = viewerAccessTokens.get(projectKey) ?? randomBytes(32).toString('base64url');
+  viewerAccessTokens.set(projectKey, token);
+  const host = knowledgeViewerHost(projectKey, dashboardHost);
+  return `//${host}/?access=${encodeURIComponent(token)}`;
+}
+
+export function resetKnowledgeViewerAccessTokensForTests(): void {
+  viewerAccessTokens.clear();
+}
+
+export function filterKnowledgeViewerRequestHeaders(
+  headers: http.IncomingHttpHeaders | Record<string, string | string[] | undefined>,
+): Record<string, string | string[]> {
+  const filtered: Record<string, string | string[]> = {};
   for (const [name, value] of Object.entries(headers)) {
     const lower = name.toLowerCase();
-    if (!value || HOP_BY_HOP_HEADERS.has(lower) || lower === 'host' || lower === 'content-length') continue;
+    if (!value || !REQUEST_HEADER_ALLOWLIST.has(lower)) continue;
     filtered[lower] = value;
   }
   return filtered;
 }
 
-function filterResponseHeaders(headers: Headers): Record<string, string> {
-  const filtered: Record<string, string> = {};
-  headers.forEach((value, name) => {
-    if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) filtered[name] = value;
-  });
+export function filterKnowledgeViewerResponseHeaders(
+  headers: http.IncomingHttpHeaders | Headers,
+): Record<string, string | string[]> {
+  const filtered: Record<string, string | string[]> = {};
+  if (headers instanceof Headers) {
+    headers.forEach((value, name) => {
+      if (RESPONSE_HEADER_ALLOWLIST.has(name.toLowerCase())) filtered[name.toLowerCase()] = value;
+    });
+    return filtered;
+  }
+  for (const [name, value] of Object.entries(headers)) {
+    if (!value || !RESPONSE_HEADER_ALLOWLIST.has(name.toLowerCase())) continue;
+    filtered[name.toLowerCase()] = value;
+  }
   return filtered;
-}
-
-function rewriteLocation(location: string, upstreamUrl: string, targetUrl: string): string {
-  const resolved = new URL(location, upstreamUrl);
-  const target = new URL(targetUrl);
-  if (resolved.origin !== target.origin) return location;
-  return `/knowledge-viewer${resolved.pathname}${resolved.search}${resolved.hash}`;
 }
 
 function projectFromRequestUrl(requestUrl: string): string | null {
@@ -166,11 +193,13 @@ function parseProjectBody(text: string): string | null {
   }
 }
 
-function proxyResponse(response: KnowledgeViewerProxyResponse): HttpServerResponse.HttpServerResponse {
-  return HttpServerResponse.uint8Array(response.body, {
-    status: response.status,
-    headers: response.headers,
-  });
+function withProxyUrl(
+  status: KnowledgeViewerStatus,
+  request: HttpServerRequest.HttpServerRequest,
+): KnowledgeViewerStatus {
+  const host = request.headers.host;
+  if (!status.running || !status.url || !host) return status;
+  return { ...status, proxyUrl: knowledgeViewerProxyUrl(status.projectKey, host) };
 }
 
 const handlers = createKnowledgeViewerRouteHandlers();
@@ -180,9 +209,12 @@ const statusRoute = HttpRouter.add(
   '/api/knowledge-viewer/status',
   httpHandler(Effect.gen(function* () {
     const request = yield* HttpServerRequest.HttpServerRequest;
+    const authError = rejectUnauthorizedDashboardRequest(request);
+    if (authError) return authError;
     const projectKey = projectFromRequestUrl(request.url);
     if (!projectKey) return jsonResponse({ error: 'project query parameter is required' }, { status: 400 });
-    return jsonResponse(yield* Effect.promise(() => handlers.status(projectKey)));
+    const status = yield* Effect.promise(() => handlers.status(projectKey));
+    return jsonResponse(withProxyUrl(status, request));
   })),
 );
 
@@ -191,10 +223,13 @@ const installRoute = HttpRouter.add(
   '/api/knowledge-viewer/install',
   httpHandler(Effect.gen(function* () {
     const request = yield* HttpServerRequest.HttpServerRequest;
+    const authError = rejectUnsafeDashboardMutationRequest(request);
+    if (authError) return authError;
     const projectKey = parseProjectBody(yield* request.text);
     if (!projectKey) return jsonResponse({ error: 'project is required in the request body' }, { status: 400 });
     try {
-      return jsonResponse(yield* Effect.promise(() => handlers.install(projectKey)));
+      const status = yield* Effect.promise(() => handlers.install(projectKey));
+      return jsonResponse(withProxyUrl(status, request));
     } catch (error) {
       return jsonResponse({ error: errorMessage(error) }, { status: 500 });
     }
@@ -206,40 +241,32 @@ const startRoute = HttpRouter.add(
   '/api/knowledge-viewer/start',
   httpHandler(Effect.gen(function* () {
     const request = yield* HttpServerRequest.HttpServerRequest;
+    const authError = rejectUnsafeDashboardMutationRequest(request);
+    if (authError) return authError;
     const projectKey = parseProjectBody(yield* request.text);
     if (!projectKey) return jsonResponse({ error: 'project is required in the request body' }, { status: 400 });
     try {
-      const result = yield* Effect.promise(() => handlers.start(projectKey));
-      return jsonResponse(result, { status: result.running ? 200 : 409 });
+      const status = yield* Effect.promise(() => handlers.start(projectKey));
+      return jsonResponse(withProxyUrl(status, request), { status: status.running ? 200 : 409 });
     } catch (error) {
       return jsonResponse({ error: errorMessage(error) }, { status: 500 });
     }
   })),
 );
 
-const proxyRoute = HttpRouter.add(
-  '*',
+const legacyProxyRedirectRoute = HttpRouter.add(
+  'GET',
   '/knowledge-viewer/*',
   httpHandler(Effect.gen(function* () {
     const request = yield* HttpServerRequest.HttpServerRequest;
-    const requestUrl = new URL(request.url, 'http://localhost');
-    if (requestUrl.pathname === '/knowledge-viewer') {
-      return HttpServerResponse.redirect(`/knowledge-viewer/${requestUrl.search}`);
-    }
-    const method = request.method.toUpperCase();
-    const body = method === 'GET' || method === 'HEAD'
-      ? undefined
-      : new Uint8Array(yield* request.arrayBuffer);
-    try {
-      return proxyResponse(yield* Effect.promise(() => handlers.proxyHttp({
-        url: request.url,
-        method,
-        headers: request.headers,
-        ...(body ? { body } : {}),
-      })));
-    } catch (error) {
-      return jsonResponse({ error: errorMessage(error) }, { status: 503 });
-    }
+    const authError = rejectUnauthorizedDashboardRequest(request);
+    if (authError) return authError;
+    const projectKey = projectFromRequestUrl(request.url);
+    if (!projectKey) return jsonResponse({ error: 'project query parameter is required' }, { status: 400 });
+    const status = yield* Effect.promise(() => handlers.status(projectKey));
+    const result = withProxyUrl(status, request);
+    if (!result.proxyUrl) return jsonResponse({ error: 'Knowledge viewer is not running' }, { status: 503 });
+    return HttpServerResponse.redirect(result.proxyUrl);
   })),
 );
 
@@ -247,10 +274,10 @@ export const knowledgeViewerRouteLayer = Layer.mergeAll(
   statusRoute,
   installRoute,
   startRoute,
-  proxyRoute,
+  legacyProxyRedirectRoute,
 );
 
-export function setupKnowledgeViewerWebSocketProxy(
+export function setupKnowledgeViewerProxy(
   server: http.Server,
   routeHandlers: KnowledgeViewerRouteHandlers = handlers,
 ): void {
@@ -258,10 +285,20 @@ export function setupKnowledgeViewerWebSocketProxy(
   const originalOn = server.on.bind(server);
 
   server.on = function(event: string, listener: (...args: unknown[]) => void) {
+    if (event === 'request') {
+      const wrapped = (request: http.IncomingMessage, response: http.ServerResponse) => {
+        const projectKey = projectFromKnowledgeViewerHost(request.headers.host);
+        if (projectKey) {
+          void proxyKnowledgeViewerHttp(request, response, projectKey, routeHandlers);
+          return;
+        }
+        (listener as (req: http.IncomingMessage, res: http.ServerResponse) => void)(request, response);
+      };
+      return originalOn(event, wrapped as never);
+    }
     if (event === 'upgrade') {
       const wrapped = (request: http.IncomingMessage, socket: Socket, head: Buffer) => {
-        const url = new URL(request.url || '', `http://${request.headers.host}`);
-        if (url.pathname.startsWith('/knowledge-viewer/')) return;
+        if (projectFromKnowledgeViewerHost(request.headers.host)) return;
         (listener as (req: http.IncomingMessage, socket: Socket, head: Buffer) => void)(request, socket, head);
       };
       return originalOn(event, wrapped as never);
@@ -270,25 +307,147 @@ export function setupKnowledgeViewerWebSocketProxy(
   } as typeof server.on;
 
   originalOn('upgrade', (request: http.IncomingMessage, socket: Socket, head: Buffer) => {
-    const url = new URL(request.url || '', `http://${request.headers.host}`);
-    if (!url.pathname.startsWith('/knowledge-viewer/')) return;
-
-    const origin = validateOriginHeaders(request.headers, request.method ?? 'GET');
-    if (!origin.ok) {
-      rejectUpgrade(socket, 403, origin.error);
+    const projectKey = projectFromKnowledgeViewerHost(request.headers.host);
+    if (!projectKey) return;
+    const access = authorizeViewerRequest(request, projectKey);
+    if (!access.ok) {
+      rejectUpgrade(socket, 401, 'Unauthorized');
+      return;
+    }
+    if (!viewerOriginIsAllowed(request)) {
+      rejectUpgrade(socket, 403, 'Invalid origin');
       return;
     }
 
-    void routeHandlers.resolveTarget(request.url || '/knowledge-viewer/').then((target) => {
+    void routeHandlers.resolveTarget(projectKey).then((target) => {
       if (!target) {
         rejectUpgrade(socket, 503, 'Knowledge viewer is not running');
         return;
       }
       wss.handleUpgrade(request, socket, head, (client) => {
-        bridgeWebSocket(client, request, knowledgeViewerUpstreamUrl(request.url || '/knowledge-viewer/', target, true));
+        bridgeWebSocket(client, request, knowledgeViewerUpstreamUrl(request.url || '/', target, true));
       });
     }).catch((error) => rejectUpgrade(socket, 502, errorMessage(error)));
   });
+}
+
+async function proxyKnowledgeViewerHttp(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+  projectKey: string,
+  routeHandlers: KnowledgeViewerRouteHandlers,
+): Promise<void> {
+  const access = authorizeViewerRequest(request, projectKey);
+  if (!access.ok) {
+    writeJsonError(response, 401, 'unauthorized');
+    return;
+  }
+
+  const target = await routeHandlers.resolveTarget(projectKey);
+  if (!target) {
+    writeJsonError(response, 503, 'Knowledge viewer is not running');
+    return;
+  }
+
+  const upstreamUrl = knowledgeViewerUpstreamUrl(request.url || '/', target, false);
+  const transport = upstreamUrl.startsWith('https:') ? https : http;
+  const upstreamRequest = transport.request(upstreamUrl, {
+    method: request.method,
+    headers: filterKnowledgeViewerRequestHeaders(request.headers),
+  }, (upstreamResponse) => {
+    const headers = filterKnowledgeViewerResponseHeaders(upstreamResponse.headers);
+    headers['referrer-policy'] = 'no-referrer';
+    const location = upstreamResponse.headers.location;
+    if (location) headers.location = rewriteLocation(location, upstreamUrl, target);
+    if (access.grantCookie) {
+      headers['set-cookie'] = viewerCookieHeader(access.token, request);
+    }
+    const pathname = new URL(request.url || '/', 'http://localhost').pathname;
+    if (pathname === '/api/config') {
+      void proxyKnowledgeViewerConfigResponse(request, response, upstreamResponse, headers);
+      return;
+    }
+    response.writeHead(upstreamResponse.statusCode ?? 502, headers);
+    upstreamResponse.pipe(response);
+  });
+
+  upstreamRequest.on('error', (error) => {
+    if (!response.headersSent) writeJsonError(response, 502, errorMessage(error));
+    else response.destroy(error);
+  });
+  request.on('aborted', () => upstreamRequest.destroy());
+  request.pipe(upstreamRequest);
+}
+
+async function proxyKnowledgeViewerConfigResponse(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+  upstreamResponse: http.IncomingMessage,
+  headers: http.OutgoingHttpHeaders,
+): Promise<void> {
+  try {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    for await (const chunk of upstreamResponse) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      size += buffer.length;
+      if (size > MAX_CONFIG_RESPONSE_BYTES) {
+        throw new Error('open-knowledge config response exceeded 64 KiB');
+      }
+      chunks.push(buffer);
+    }
+
+    const config = JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>;
+    const host = request.headers.host;
+    if (!host) throw new Error('knowledge viewer request host is missing');
+    const secure = firstHeader(request.headers['x-forwarded-proto']) === 'https' || 'encrypted' in request.socket;
+    if (typeof config.collabUrl === 'string') {
+      const collabUrl = new URL(config.collabUrl);
+      config.collabUrl = `${secure ? 'wss' : 'ws'}://${host}${collabUrl.pathname}${collabUrl.search}`;
+    }
+    if (typeof config.previewUrl === 'string') {
+      const previewUrl = new URL(config.previewUrl);
+      config.previewUrl = `${secure ? 'https' : 'http'}://${host}${previewUrl.pathname}${previewUrl.search}`;
+    }
+
+    const body = Buffer.from(JSON.stringify(config));
+    headers['content-length'] = body.length;
+    response.writeHead(upstreamResponse.statusCode ?? 502, headers);
+    response.end(body);
+  } catch (error) {
+    if (!response.headersSent) writeJsonError(response, 502, errorMessage(error));
+    else response.destroy(error instanceof Error ? error : undefined);
+  }
+}
+
+function authorizeViewerRequest(
+  request: http.IncomingMessage,
+  projectKey: string,
+): { ok: true; token: string; grantCookie: boolean } | { ok: false } {
+  const expected = viewerAccessTokens.get(projectKey);
+  if (!expected) return { ok: false };
+  const url = new URL(request.url || '/', 'http://localhost');
+  const queryToken = url.searchParams.get('access');
+  const cookieToken = cookieValue(request.headers.cookie, VIEWER_ACCESS_COOKIE);
+  if (constantTimeEqual(queryToken, expected)) return { ok: true, token: expected, grantCookie: true };
+  if (constantTimeEqual(cookieToken, expected)) return { ok: true, token: expected, grantCookie: false };
+  return { ok: false };
+}
+
+function viewerOriginIsAllowed(request: http.IncomingMessage): boolean {
+  const origin = request.headers.origin;
+  if (origin) {
+    try {
+      if (new URL(origin).host === request.headers.host) return true;
+    } catch {
+      return false;
+    }
+  }
+  return validateOriginHeaders(request.headers, request.method ?? 'GET').ok;
+}
+
+function viewerCookieHeader(token: string, _request: http.IncomingMessage): string {
+  return `${VIEWER_ACCESS_COOKIE}=${encodeURIComponent(token)}; HttpOnly; SameSite=None; Secure; Path=/`;
 }
 
 function bridgeWebSocket(client: WebSocket, request: http.IncomingMessage, upstreamUrl: string): void {
@@ -300,14 +459,28 @@ function bridgeWebSocket(client: WebSocket, request: http.IncomingMessage, upstr
     headers: { origin: new URL(upstreamUrl).origin.replace(/^ws/, 'http') },
   });
   const queued: Array<{ data: Buffer; binary: boolean }> = [];
+  let queuedBytes = 0;
 
   client.on('message', (data, binary) => {
     const payload = Buffer.isBuffer(data) ? data : Buffer.from(data as ArrayBuffer);
-    if (upstream.readyState === WebSocket.OPEN) upstream.send(payload, { binary });
-    else queued.push({ data: payload, binary });
+    if (upstream.readyState === WebSocket.OPEN) {
+      upstream.send(payload, { binary });
+      return;
+    }
+    if (
+      queued.length >= MAX_QUEUED_WEBSOCKET_MESSAGES ||
+      queuedBytes + payload.byteLength > MAX_QUEUED_WEBSOCKET_BYTES
+    ) {
+      client.close(1009, 'knowledge-viewer-queue-limit');
+      upstream.terminate();
+      return;
+    }
+    queued.push({ data: payload, binary });
+    queuedBytes += payload.byteLength;
   });
   upstream.once('open', () => {
     for (const message of queued.splice(0)) upstream.send(message.data, { binary: message.binary });
+    queuedBytes = 0;
   });
   upstream.on('message', (data, binary) => {
     if (client.readyState === WebSocket.OPEN) client.send(data, { binary });
@@ -321,6 +494,52 @@ function bridgeWebSocket(client: WebSocket, request: http.IncomingMessage, upstr
   client.on('close', () => {
     if (upstream.readyState === WebSocket.OPEN || upstream.readyState === WebSocket.CONNECTING) upstream.close();
   });
+}
+
+function rewriteLocation(location: string, upstreamUrl: string, targetUrl: string): string {
+  const resolved = new URL(location, upstreamUrl);
+  const target = new URL(targetUrl);
+  if (resolved.origin !== target.origin) return location;
+  return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+}
+
+function splitHostAndPort(host: string): { hostname: string; port: string } {
+  try {
+    const parsed = new URL(`http://${host}`);
+    return { hostname: parsed.hostname.toLowerCase(), port: parsed.port };
+  } catch {
+    return { hostname: host.toLowerCase(), port: '' };
+  }
+}
+
+function isIpAddress(hostname: string): boolean {
+  return /^\d{1,3}(?:\.\d{1,3}){3}$/.test(hostname) || hostname.includes(':');
+}
+
+function cookieValue(cookieHeader: string | undefined, name: string): string | null {
+  if (!cookieHeader) return null;
+  for (const part of cookieHeader.split(';')) {
+    const [key, ...rest] = part.trim().split('=');
+    if (key === name) return decodeURIComponent(rest.join('='));
+  }
+  return null;
+}
+
+function constantTimeEqual(value: string | null, expected: string): boolean {
+  if (!value) return false;
+  const actualBuffer = Buffer.from(value);
+  const expectedBuffer = Buffer.from(expected);
+  return actualBuffer.length === expectedBuffer.length && timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+function firstHeader(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function writeJsonError(response: http.ServerResponse, status: number, message: string): void {
+  const body = JSON.stringify({ error: message });
+  response.writeHead(status, { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) });
+  response.end(body);
 }
 
 function rejectUpgrade(socket: Socket, status: number, message: string): void {

--- a/src/dashboard/server/server.ts
+++ b/src/dashboard/server/server.ts
@@ -34,6 +34,7 @@ import { WorkspaceServiceLive } from './services/workspace-service.js';
 import { OpenRouterServiceLive } from './services/openrouter-service.js';
 import { PanOpenLive } from './services/open.js';
 import { setupTerminalWebSocket } from './ws-terminal.js';
+import { knowledgeViewerRouteLayer, setupKnowledgeViewerWebSocketProxy } from './routes/knowledge-viewer.js';
 import { setupVoiceWebSocket } from './ws-voice.js';
 import { setupAutoPresoWebSocket } from './ws-autopreso.js';
 import { websocketRpcRouteLayer } from './ws-rpc.js'
@@ -96,6 +97,7 @@ const HttpServerLive = Layer.unwrap(
     const bind = retryDashboardBind(NodeHttpServer.make(() => {
       const nodeServer = NodeHttp.createServer();
       setupTerminalWebSocket(nodeServer);
+      setupKnowledgeViewerWebSocketProxy(nodeServer);
       setupVoiceWebSocket(nodeServer);
       setupAutoPresoWebSocket(nodeServer);
       return nodeServer;
@@ -351,6 +353,7 @@ export const makeRoutesLayer = Layer.mergeAll(
   tieredCalloutsRouteLayer,
   backlogRouteLayer,
   internalEventsRouteLayer,
+  knowledgeViewerRouteLayer,
   staticRouteLayer,
 );
 

--- a/src/dashboard/server/server.ts
+++ b/src/dashboard/server/server.ts
@@ -34,7 +34,7 @@ import { WorkspaceServiceLive } from './services/workspace-service.js';
 import { OpenRouterServiceLive } from './services/openrouter-service.js';
 import { PanOpenLive } from './services/open.js';
 import { setupTerminalWebSocket } from './ws-terminal.js';
-import { knowledgeViewerRouteLayer, setupKnowledgeViewerWebSocketProxy } from './routes/knowledge-viewer.js';
+import { knowledgeViewerRouteLayer, setupKnowledgeViewerProxy } from './routes/knowledge-viewer.js';
 import { setupVoiceWebSocket } from './ws-voice.js';
 import { setupAutoPresoWebSocket } from './ws-autopreso.js';
 import { websocketRpcRouteLayer } from './ws-rpc.js'
@@ -97,7 +97,7 @@ const HttpServerLive = Layer.unwrap(
     const bind = retryDashboardBind(NodeHttpServer.make(() => {
       const nodeServer = NodeHttp.createServer();
       setupTerminalWebSocket(nodeServer);
-      setupKnowledgeViewerWebSocketProxy(nodeServer);
+      setupKnowledgeViewerProxy(nodeServer);
       setupVoiceWebSocket(nodeServer);
       setupAutoPresoWebSocket(nodeServer);
       return nodeServer;

--- a/src/dashboard/server/services/knowledge-viewer.ts
+++ b/src/dashboard/server/services/knowledge-viewer.ts
@@ -1,0 +1,250 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import {
+  ensureOpenKnowledge,
+  OpenKnowledgeError,
+  startOpenKnowledgeServer,
+  type EnsureOpenKnowledgeResult,
+  type StartOpenKnowledgeServerResult,
+} from '../../../lib/installers/open-knowledge.js';
+import { resolveKnowledgeBundleRoot } from '../../../lib/memory/injection.js';
+import { loadProjectsConfigSync } from '../../../lib/projects.js';
+
+export interface KnowledgeViewerStatus {
+  projectKey: string;
+  bundleConfigured: boolean;
+  installed: boolean;
+  starting: boolean;
+  running: boolean;
+  bundlePath?: string;
+  port?: number;
+  apiPort?: number;
+  url?: string;
+  message?: string;
+}
+
+export interface KnowledgeViewerService {
+  getStatus(projectKey: string): Promise<KnowledgeViewerStatus>;
+  getOrStartViewer(projectKey: string): Promise<KnowledgeViewerStatus>;
+  stopAll(): Promise<void>;
+}
+
+export interface KnowledgeViewerDependencies {
+  resolveBundle?: (projectKey: string) => Promise<string | null>;
+  ensure?: (options: { autoInstall: false }) => Promise<EnsureOpenKnowledgeResult>;
+  start?: (bundlePath: string, options: { openBrowser: false }) => Promise<StartOpenKnowledgeServerResult>;
+  stop?: (bundlePath: string) => Promise<void>;
+  fetchImpl?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+  retryDelayMs?: number;
+  maxHealthAttempts?: number;
+}
+
+interface ViewerEntry {
+  bundlePath: string;
+  process: ChildProcess;
+  port: number;
+  apiPort: number;
+  url: string;
+  exited: boolean;
+}
+
+const DEFAULT_RETRY_DELAY_MS = 250;
+const DEFAULT_MAX_HEALTH_ATTEMPTS = 40;
+
+export function createKnowledgeViewerService(
+  dependencies: KnowledgeViewerDependencies = {},
+): KnowledgeViewerService {
+  const resolveBundle = dependencies.resolveBundle ?? resolveBundleForProject;
+  const ensure = dependencies.ensure ?? ((options) => ensureOpenKnowledge(options));
+  const start = dependencies.start ?? ((bundlePath, options) => startOpenKnowledgeServer(bundlePath, options));
+  const stop = dependencies.stop ?? stopOpenKnowledgeWithSpawn;
+  const fetchImpl = dependencies.fetchImpl ?? fetch;
+  const sleep = dependencies.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const retryDelayMs = dependencies.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+  const maxHealthAttempts = dependencies.maxHealthAttempts ?? DEFAULT_MAX_HEALTH_ATTEMPTS;
+  const entries = new Map<string, ViewerEntry>();
+  const starts = new Map<string, Promise<KnowledgeViewerStatus>>();
+
+  async function getStatus(projectKey: string): Promise<KnowledgeViewerStatus> {
+    const bundlePath = await resolveBundle(projectKey);
+    if (!bundlePath) {
+      return unavailableStatus(projectKey, starts.has(projectKey), 'No OKF bundle is configured. Run `/okf init` first.');
+    }
+
+    let installed = true;
+    let installMessage: string | undefined;
+    try {
+      await ensure({ autoInstall: false });
+    } catch (error) {
+      installed = false;
+      installMessage = errorMessage(error);
+    }
+
+    const entry = entries.get(projectKey);
+    if (entry && isProcessLive(entry) && await isViewerHealthy(entry.url, fetchImpl)) {
+      return {
+        projectKey,
+        bundleConfigured: true,
+        installed,
+        starting: starts.has(projectKey),
+        running: true,
+        bundlePath,
+        port: entry.port,
+        apiPort: entry.apiPort,
+        url: entry.url,
+        ...(installMessage ? { message: installMessage } : {}),
+      };
+    }
+    if (entry) await stopEntry(projectKey, entry);
+
+    return {
+      projectKey,
+      bundleConfigured: true,
+      installed,
+      starting: starts.has(projectKey),
+      running: false,
+      bundlePath,
+      ...(installMessage ? { message: installMessage } : {}),
+    };
+  }
+
+  function getOrStartViewer(projectKey: string): Promise<KnowledgeViewerStatus> {
+    const inFlight = starts.get(projectKey);
+    if (inFlight) return inFlight;
+
+    const promise = startViewer(projectKey).finally(() => {
+      if (starts.get(projectKey) === promise) starts.delete(projectKey);
+    });
+    starts.set(projectKey, promise);
+    return promise;
+  }
+
+  async function startViewer(projectKey: string): Promise<KnowledgeViewerStatus> {
+    const status = await getStatus(projectKey);
+    if (!status.bundleConfigured || !status.installed || status.running) return status;
+
+    const started = await start(status.bundlePath!, { openBrowser: false });
+    const entry: ViewerEntry = {
+      bundlePath: status.bundlePath!,
+      process: started.process,
+      port: started.port,
+      apiPort: started.apiPort,
+      url: started.url,
+      exited: false,
+    };
+    entries.set(projectKey, entry);
+    started.process.once('exit', () => {
+      entry.exited = true;
+      if (entries.get(projectKey) === entry) entries.delete(projectKey);
+    });
+
+    try {
+      await waitForViewerHealth(started.url, fetchImpl, sleep, retryDelayMs, maxHealthAttempts);
+    } catch (error) {
+      await stopEntry(projectKey, entry);
+      throw error;
+    }
+
+    return {
+      projectKey,
+      bundleConfigured: true,
+      installed: true,
+      starting: false,
+      running: true,
+      bundlePath: entry.bundlePath,
+      port: entry.port,
+      apiPort: entry.apiPort,
+      url: entry.url,
+    };
+  }
+
+  async function stopEntry(projectKey: string, entry: ViewerEntry): Promise<void> {
+    if (entries.get(projectKey) === entry) entries.delete(projectKey);
+    try {
+      await stop(entry.bundlePath);
+    } catch {
+      // The tracked child is still ours to terminate when the `ok stop` helper fails.
+    }
+    if (isProcessLive(entry)) entry.process.kill('SIGTERM');
+  }
+
+  async function stopAll(): Promise<void> {
+    await Promise.allSettled(starts.values());
+    starts.clear();
+    const active = [...entries.entries()];
+    entries.clear();
+    await Promise.all(active.map(async ([projectKey, entry]) => stopEntry(projectKey, entry)));
+  }
+
+  return { getStatus, getOrStartViewer, stopAll };
+}
+
+async function resolveBundleForProject(projectKey: string): Promise<string | null> {
+  const project = loadProjectsConfigSync().projects[projectKey];
+  if (!project) return null;
+  return resolveKnowledgeBundleRoot({ projectPath: project.path });
+}
+
+function unavailableStatus(projectKey: string, starting: boolean, message: string): KnowledgeViewerStatus {
+  return {
+    projectKey,
+    bundleConfigured: false,
+    installed: false,
+    starting,
+    running: false,
+    message,
+  };
+}
+
+function isProcessLive(entry: ViewerEntry): boolean {
+  return !entry.exited && entry.process.exitCode == null;
+}
+
+async function isViewerHealthy(url: string, fetchImpl: typeof fetch): Promise<boolean> {
+  try {
+    const response = await fetchImpl(url, { method: 'GET' });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForViewerHealth(
+  url: string,
+  fetchImpl: typeof fetch,
+  sleep: (ms: number) => Promise<void>,
+  retryDelayMs: number,
+  maxAttempts: number,
+): Promise<void> {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    if (await isViewerHealthy(url, fetchImpl)) return;
+    if (attempt < maxAttempts) await sleep(retryDelayMs);
+  }
+  throw new OpenKnowledgeError(`open-knowledge viewer did not become healthy at ${url}`);
+}
+
+async function stopOpenKnowledgeWithSpawn(bundlePath: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn('ok', ['--cwd', bundlePath, 'stop'], { stdio: 'ignore' });
+    child.once('error', reject);
+    child.once('exit', (code) => {
+      if (code === 0) resolve();
+      else reject(new OpenKnowledgeError(`ok stop exited with code ${code}`));
+    });
+  });
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+const defaultKnowledgeViewerService = createKnowledgeViewerService();
+
+export const getKnowledgeViewerStatus = (projectKey: string): Promise<KnowledgeViewerStatus> =>
+  defaultKnowledgeViewerService.getStatus(projectKey);
+
+export const getOrStartViewer = (projectKey: string): Promise<KnowledgeViewerStatus> =>
+  defaultKnowledgeViewerService.getOrStartViewer(projectKey);
+
+export const stopAllKnowledgeViewers = (): Promise<void> =>
+  defaultKnowledgeViewerService.stopAll();

--- a/src/dashboard/server/services/knowledge-viewer.ts
+++ b/src/dashboard/server/services/knowledge-viewer.ts
@@ -1,8 +1,7 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import {
   ensureOpenKnowledge,
-  OpenKnowledgeError,
-  startOpenKnowledgeServer,
+  startReadOnlyOpenKnowledgeServer,
   type EnsureOpenKnowledgeResult,
   type StartOpenKnowledgeServerResult,
 } from '../../../lib/installers/open-knowledge.js';
@@ -19,12 +18,15 @@ export interface KnowledgeViewerStatus {
   port?: number;
   apiPort?: number;
   url?: string;
+  proxyUrl?: string;
+  embeddable?: boolean;
   message?: string;
 }
 
 export interface KnowledgeViewerService {
   getStatus(projectKey: string): Promise<KnowledgeViewerStatus>;
   getOrStartViewer(projectKey: string): Promise<KnowledgeViewerStatus>;
+  invalidateInstallationCache(): void;
   stopAll(): Promise<void>;
 }
 
@@ -34,36 +36,35 @@ export interface KnowledgeViewerDependencies {
   start?: (bundlePath: string, options: { openBrowser: false }) => Promise<StartOpenKnowledgeServerResult>;
   stop?: (bundlePath: string) => Promise<void>;
   fetchImpl?: typeof fetch;
-  sleep?: (ms: number) => Promise<void>;
-  retryDelayMs?: number;
-  maxHealthAttempts?: number;
 }
 
 interface ViewerEntry {
   bundlePath: string;
-  process: ChildProcess;
+  runtimeBundlePath: string;
+  process: ChildProcess | null;
+  owned: boolean;
   port: number;
   apiPort: number;
   url: string;
   exited: boolean;
 }
 
-const DEFAULT_RETRY_DELAY_MS = 250;
-const DEFAULT_MAX_HEALTH_ATTEMPTS = 40;
+interface ViewerProbe {
+  healthy: boolean;
+  embeddable: boolean;
+}
 
 export function createKnowledgeViewerService(
   dependencies: KnowledgeViewerDependencies = {},
 ): KnowledgeViewerService {
   const resolveBundle = dependencies.resolveBundle ?? resolveBundleForProject;
   const ensure = dependencies.ensure ?? ((options) => ensureOpenKnowledge(options));
-  const start = dependencies.start ?? ((bundlePath, options) => startOpenKnowledgeServer(bundlePath, options));
+  const start = dependencies.start ?? ((bundlePath, options) => startReadOnlyOpenKnowledgeServer(bundlePath, options));
   const stop = dependencies.stop ?? stopOpenKnowledgeWithSpawn;
   const fetchImpl = dependencies.fetchImpl ?? fetch;
-  const sleep = dependencies.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
-  const retryDelayMs = dependencies.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
-  const maxHealthAttempts = dependencies.maxHealthAttempts ?? DEFAULT_MAX_HEALTH_ATTEMPTS;
   const entries = new Map<string, ViewerEntry>();
   const starts = new Map<string, Promise<KnowledgeViewerStatus>>();
+  let installedCache: EnsureOpenKnowledgeResult | null = null;
 
   async function getStatus(projectKey: string): Promise<KnowledgeViewerStatus> {
     const bundlePath = await resolveBundle(projectKey);
@@ -74,26 +75,30 @@ export function createKnowledgeViewerService(
     let installed = true;
     let installMessage: string | undefined;
     try {
-      await ensure({ autoInstall: false });
+      installedCache ??= await ensure({ autoInstall: false });
     } catch (error) {
       installed = false;
       installMessage = errorMessage(error);
     }
 
     const entry = entries.get(projectKey);
-    if (entry && isProcessLive(entry) && await isViewerHealthy(entry.url, fetchImpl)) {
-      return {
-        projectKey,
-        bundleConfigured: true,
-        installed,
-        starting: starts.has(projectKey),
-        running: true,
-        bundlePath,
-        port: entry.port,
-        apiPort: entry.apiPort,
-        url: entry.url,
-        ...(installMessage ? { message: installMessage } : {}),
-      };
+    if (entry && isProcessLive(entry)) {
+      const probe = await probeViewer(entry.url, fetchImpl);
+      if (probe.healthy) {
+        return {
+          projectKey,
+          bundleConfigured: true,
+          installed,
+          starting: starts.has(projectKey),
+          running: true,
+          bundlePath,
+          port: entry.port,
+          apiPort: entry.apiPort,
+          url: entry.url,
+          embeddable: probe.embeddable,
+          ...(installMessage ? { message: installMessage } : {}),
+        };
+      }
     }
     if (entry) await stopEntry(projectKey, entry);
 
@@ -123,26 +128,33 @@ export function createKnowledgeViewerService(
     const status = await getStatus(projectKey);
     if (!status.bundleConfigured || !status.installed || status.running) return status;
 
-    const started = await start(status.bundlePath!, { openBrowser: false });
+    let started: StartOpenKnowledgeServerResult;
+    try {
+      started = await start(status.bundlePath!, { openBrowser: false });
+    } catch (error) {
+      installedCache = null;
+      throw error;
+    }
     const entry: ViewerEntry = {
       bundlePath: status.bundlePath!,
+      runtimeBundlePath: started.runtimeBundlePath,
       process: started.process,
+      owned: started.owned,
       port: started.port,
       apiPort: started.apiPort,
       url: started.url,
       exited: false,
     };
     entries.set(projectKey, entry);
-    started.process.once('exit', () => {
+    started.process?.once('exit', () => {
       entry.exited = true;
       if (entries.get(projectKey) === entry) entries.delete(projectKey);
     });
 
-    try {
-      await waitForViewerHealth(started.url, fetchImpl, sleep, retryDelayMs, maxHealthAttempts);
-    } catch (error) {
+    const probe = await probeViewer(started.url, fetchImpl);
+    if (!probe.healthy) {
       await stopEntry(projectKey, entry);
-      throw error;
+      throw new Error(`open-knowledge viewer did not remain healthy at ${started.url}`);
     }
 
     return {
@@ -155,17 +167,23 @@ export function createKnowledgeViewerService(
       port: entry.port,
       apiPort: entry.apiPort,
       url: entry.url,
+      embeddable: probe.embeddable,
     };
   }
 
   async function stopEntry(projectKey: string, entry: ViewerEntry): Promise<void> {
     if (entries.get(projectKey) === entry) entries.delete(projectKey);
+    if (!entry.owned) return;
     try {
-      await stop(entry.bundlePath);
+      await stop(entry.runtimeBundlePath);
     } catch {
       // The tracked child is still ours to terminate when the `ok stop` helper fails.
     }
-    if (isProcessLive(entry)) entry.process.kill('SIGTERM');
+    if (isProcessLive(entry)) entry.process?.kill('SIGTERM');
+  }
+
+  function invalidateInstallationCache(): void {
+    installedCache = null;
   }
 
   async function stopAll(): Promise<void> {
@@ -176,7 +194,7 @@ export function createKnowledgeViewerService(
     await Promise.all(active.map(async ([projectKey, entry]) => stopEntry(projectKey, entry)));
   }
 
-  return { getStatus, getOrStartViewer, stopAll };
+  return { getStatus, getOrStartViewer, invalidateInstallationCache, stopAll };
 }
 
 async function resolveBundleForProject(projectKey: string): Promise<string | null> {
@@ -197,30 +215,28 @@ function unavailableStatus(projectKey: string, starting: boolean, message: strin
 }
 
 function isProcessLive(entry: ViewerEntry): boolean {
-  return !entry.exited && entry.process.exitCode == null;
+  return entry.process === null || (!entry.exited && entry.process.exitCode == null);
 }
 
-async function isViewerHealthy(url: string, fetchImpl: typeof fetch): Promise<boolean> {
+async function probeViewer(url: string, fetchImpl: typeof fetch): Promise<ViewerProbe> {
   try {
     const response = await fetchImpl(url, { method: 'GET' });
-    return response.ok;
+    return {
+      healthy: response.ok,
+      embeddable: response.ok && responseAllowsEmbedding(response.headers),
+    };
   } catch {
-    return false;
+    return { healthy: false, embeddable: false };
   }
 }
 
-async function waitForViewerHealth(
-  url: string,
-  fetchImpl: typeof fetch,
-  sleep: (ms: number) => Promise<void>,
-  retryDelayMs: number,
-  maxAttempts: number,
-): Promise<void> {
-  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    if (await isViewerHealthy(url, fetchImpl)) return;
-    if (attempt < maxAttempts) await sleep(retryDelayMs);
-  }
-  throw new OpenKnowledgeError(`open-knowledge viewer did not become healthy at ${url}`);
+function responseAllowsEmbedding(headers: Headers): boolean {
+  const frameOptions = headers.get('x-frame-options')?.trim().toLowerCase();
+  if (frameOptions === 'deny' || frameOptions === 'sameorigin') return false;
+  const csp = headers.get('content-security-policy')?.toLowerCase() ?? '';
+  const frameAncestors = csp.match(/(?:^|;)\s*frame-ancestors\s+([^;]+)/)?.[1]?.trim();
+  if (!frameAncestors) return true;
+  return frameAncestors !== "'none'" && frameAncestors !== "'self'";
 }
 
 async function stopOpenKnowledgeWithSpawn(bundlePath: string): Promise<void> {
@@ -229,7 +245,7 @@ async function stopOpenKnowledgeWithSpawn(bundlePath: string): Promise<void> {
     child.once('error', reject);
     child.once('exit', (code) => {
       if (code === 0) resolve();
-      else reject(new OpenKnowledgeError(`ok stop exited with code ${code}`));
+      else reject(new Error(`ok stop exited with code ${code}`));
     });
   });
 }
@@ -245,6 +261,9 @@ export const getKnowledgeViewerStatus = (projectKey: string): Promise<KnowledgeV
 
 export const getOrStartViewer = (projectKey: string): Promise<KnowledgeViewerStatus> =>
   defaultKnowledgeViewerService.getOrStartViewer(projectKey);
+
+export const invalidateKnowledgeViewerInstallationCache = (): void =>
+  defaultKnowledgeViewerService.invalidateInstallationCache();
 
 export const stopAllKnowledgeViewers = (): Promise<void> =>
   defaultKnowledgeViewerService.stopAll();

--- a/src/lib/installers/__tests__/open-knowledge.test.ts
+++ b/src/lib/installers/__tests__/open-knowledge.test.ts
@@ -1,9 +1,13 @@
 import { EventEmitter } from 'node:events';
 import type { ChildProcess } from 'node:child_process';
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ensureOpenKnowledge,
   OpenKnowledgeError,
+  prepareOpenKnowledgeSnapshot,
   startOpenKnowledgeServer,
   type CommandResult,
 } from '../open-knowledge.js';
@@ -125,18 +129,33 @@ describe('ensureOpenKnowledge', () => {
 });
 
 describe('startOpenKnowledgeServer', () => {
-  it('initializes without MCP or skills and starts with distinct pinned API and UI ports', async () => {
+  const missingStatus = {
+    server: { name: 'server', state: 'missing', alive: false },
+    ui: { name: 'ui', state: 'missing', alive: false },
+  };
+  const liveStatus = {
+    server: { name: 'server', state: 'alive', alive: true, port: 8789 },
+    ui: { name: 'ui', state: 'alive', alive: true, port: 39847 },
+  };
+
+  it('initializes without MCP or skills and waits for the actual live ports', async () => {
     const runCommand = vi.fn(async () => success());
     const child = new EventEmitter() as ChildProcess;
+    Object.defineProperty(child, 'exitCode', { value: null, writable: true });
     child.kill = vi.fn(() => true);
     const spawnProcess = vi.fn((_command, _args, _options) => {
       queueMicrotask(() => child.emit('spawn'));
       return child;
     });
+    const getStatus = vi.fn()
+      .mockResolvedValueOnce(missingStatus)
+      .mockResolvedValueOnce(liveStatus);
 
     const result = await startOpenKnowledgeServer('/tmp/knowledge', {
       runCommand,
       spawnProcess,
+      getStatus,
+      fetchImpl: vi.fn(async () => new Response('ok')),
       isInitialized: async () => false,
       getAvailablePorts: async () => [8789, 39847],
     });
@@ -165,26 +184,86 @@ describe('startOpenKnowledgeServer', () => {
       '--mode',
       'browser',
     ], { stdio: 'ignore' });
-    expect(result).toEqual({ process: child, port: 39847, apiPort: 8789, url: 'http://127.0.0.1:39847' });
+    expect(result).toEqual({
+      process: child,
+      owned: true,
+      reused: false,
+      port: 39847,
+      apiPort: 8789,
+      url: 'http://127.0.0.1:39847',
+      runtimeBundlePath: '/tmp/knowledge',
+    });
+  });
+
+  it('reuses a healthy lock-reported viewer and returns its verified URL', async () => {
+    const spawnProcess = vi.fn();
+
+    const result = await startOpenKnowledgeServer('/tmp/knowledge', {
+      getStatus: async () => liveStatus,
+      fetchImpl: vi.fn(async () => new Response('ok')),
+      spawnProcess,
+    });
+
+    expect(spawnProcess).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      process: null,
+      owned: false,
+      reused: true,
+      port: 39847,
+      apiPort: 8789,
+      url: 'http://127.0.0.1:39847',
+      runtimeBundlePath: '/tmp/knowledge',
+    });
   });
 
   it('adds --open only for an explicit browser-opening request', async () => {
     const child = new EventEmitter() as ChildProcess;
+    Object.defineProperty(child, 'exitCode', { value: null, writable: true });
     child.kill = vi.fn(() => true);
     const spawnProcess = vi.fn((_command, _args, _options) => {
       queueMicrotask(() => child.emit('spawn'));
       return child;
     });
+    const getStatus = vi.fn()
+      .mockResolvedValueOnce(missingStatus)
+      .mockResolvedValueOnce(liveStatus);
 
     await startOpenKnowledgeServer('/tmp/knowledge', {
       apiPort: 8789,
       uiPort: 39847,
       openBrowser: true,
       spawnProcess,
+      getStatus,
+      fetchImpl: vi.fn(async () => new Response('ok')),
       isInitialized: async () => true,
     });
 
     expect(spawnProcess.mock.calls[0]?.[1]).toContain('--open');
     expect(spawnProcess.mock.calls[0]?.[1]).not.toContain('--no-open');
+  });
+});
+
+describe('prepareOpenKnowledgeSnapshot', () => {
+  it('creates a disposable projection that cannot mutate the canonical bundle', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-knowledge-snapshot-'));
+    const source = join(root, 'source');
+    const snapshots = join(root, 'snapshots');
+    await mkdir(join(source, '.git'), { recursive: true });
+    await mkdir(join(source, '.ok'), { recursive: true });
+    await writeFile(join(source, 'concept.md'), 'canonical\n');
+    await writeFile(join(source, '.git', 'config'), 'git metadata\n');
+    await writeFile(join(source, '.ok', 'config.yml'), 'runtime metadata\n');
+
+    try {
+      const snapshot = await prepareOpenKnowledgeSnapshot(source, snapshots);
+      await writeFile(join(snapshot, 'concept.md'), 'viewer edit\n');
+
+      expect(await readFile(join(source, 'concept.md'), 'utf8')).toBe('canonical\n');
+      expect(await readFile(join(snapshot, 'concept.md'), 'utf8')).toBe('viewer edit\n');
+      await expect(access(join(snapshot, '.git', 'HEAD'))).resolves.toBeUndefined();
+      await expect(access(join(snapshot, '.ok'))).rejects.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/src/lib/installers/__tests__/open-knowledge.test.ts
+++ b/src/lib/installers/__tests__/open-knowledge.test.ts
@@ -1,0 +1,190 @@
+import { EventEmitter } from 'node:events';
+import type { ChildProcess } from 'node:child_process';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ensureOpenKnowledge,
+  OpenKnowledgeError,
+  startOpenKnowledgeServer,
+  type CommandResult,
+} from '../open-knowledge.js';
+
+const success = (stdout = ''): CommandResult => ({ stdout, stderr: '' });
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('ensureOpenKnowledge', () => {
+  it('returns already-installed without invoking the installer when ok --version succeeds', async () => {
+    const runCommand = vi.fn(async () => success('0.34.0\n'));
+    const installOpenKnowledge = vi.fn(async () => {});
+
+    const result = await ensureOpenKnowledge({ runCommand, installOpenKnowledge });
+
+    expect(result).toEqual({ status: 'already-installed', command: 'ok' });
+    expect(runCommand).toHaveBeenCalledOnce();
+    expect(runCommand).toHaveBeenCalledWith('ok', ['--version']);
+    expect(installOpenKnowledge).not.toHaveBeenCalled();
+  });
+
+  it('installs a missing binary and resolves after the health check succeeds', async () => {
+    let healthChecks = 0;
+    const runCommand = vi.fn(async (command: string, args: string[]) => {
+      if (command === 'ok' && args[0] === '--version') {
+        healthChecks += 1;
+        if (healthChecks < 3) throw new Error('missing');
+        return success('0.34.0\n');
+      }
+      return success();
+    });
+    const installOpenKnowledge = vi.fn(async () => {});
+
+    const resultPromise = ensureOpenKnowledge({
+      autoInstall: true,
+      retryDelayMs: 100,
+      maxHealthAttempts: 3,
+      runCommand,
+      installOpenKnowledge,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    const result = await resultPromise;
+
+    expect(result).toEqual({ status: 'installed', command: 'ok' });
+    expect(installOpenKnowledge).toHaveBeenCalledOnce();
+    expect(healthChecks).toBe(3);
+  });
+
+  it('rejects with the manual install command when auto-install is disabled', async () => {
+    const runCommand = vi.fn(async () => {
+      throw new Error('missing');
+    });
+
+    await expect(ensureOpenKnowledge({ autoInstall: false, runCommand })).rejects.toThrow(
+      'npm install -g @inkeep/open-knowledge',
+    );
+  });
+
+  it('uses npm global install by default when auto-install is enabled', async () => {
+    let installed = false;
+    const runCommand = vi.fn(async (command: string, args: string[]) => {
+      if (command === 'npm') {
+        installed = true;
+        return success();
+      }
+      if (command === 'ok' && args[0] === '--version') {
+        if (!installed) throw new Error('missing');
+        return success('0.34.0\n');
+      }
+      return success();
+    });
+
+    const result = await ensureOpenKnowledge({ autoInstall: true, runCommand });
+
+    expect(result.status).toBe('installed');
+    expect(runCommand).toHaveBeenCalledWith('npm', ['install', '-g', '@inkeep/open-knowledge']);
+  });
+
+  it('reports the exact Node 24 diagnosis when installation fails under Node 22', async () => {
+    const runCommand = vi.fn(async (command: string) => {
+      if (command === 'node') return success('v22.22.0\n');
+      throw new Error('missing');
+    });
+    const installOpenKnowledge = vi.fn(async () => {
+      throw new Error('unsupported engine');
+    });
+
+    await expect(ensureOpenKnowledge({ autoInstall: true, runCommand, installOpenKnowledge })).rejects.toThrow(
+      "open-knowledge requires Node 24+; found v22.22.0. Install Node 24+ or run '/okf open --no-install' after installing manually.",
+    );
+  });
+
+  it('reports a health-check failure when install completes but ok never becomes available', async () => {
+    const runCommand = vi.fn(async (command: string) => {
+      if (command === 'node') return success('v24.17.0\n');
+      throw new Error('missing');
+    });
+    const installOpenKnowledge = vi.fn(async () => {});
+
+    const resultPromise = ensureOpenKnowledge({
+      autoInstall: true,
+      retryDelayMs: 100,
+      maxHealthAttempts: 2,
+      runCommand,
+      installOpenKnowledge,
+    });
+    const rejection = expect(resultPromise).rejects.toBeInstanceOf(OpenKnowledgeError);
+
+    await vi.advanceTimersByTimeAsync(100);
+    await rejection;
+  });
+});
+
+describe('startOpenKnowledgeServer', () => {
+  it('initializes without MCP or skills and starts with distinct pinned API and UI ports', async () => {
+    const runCommand = vi.fn(async () => success());
+    const child = new EventEmitter() as ChildProcess;
+    child.kill = vi.fn(() => true);
+    const spawnProcess = vi.fn((_command, _args, _options) => {
+      queueMicrotask(() => child.emit('spawn'));
+      return child;
+    });
+
+    const result = await startOpenKnowledgeServer('/tmp/knowledge', {
+      runCommand,
+      spawnProcess,
+      isInitialized: async () => false,
+      getAvailablePorts: async () => [8789, 39847],
+    });
+
+    expect(runCommand).toHaveBeenCalledWith('ok', [
+      '--cwd',
+      '/tmp/knowledge',
+      'init',
+      '--no-mcp',
+      '--no-skills',
+      '--local-only',
+      '--content-dir',
+      '.',
+      '--json',
+    ]);
+    expect(spawnProcess).toHaveBeenCalledWith('ok', [
+      '--cwd',
+      '/tmp/knowledge',
+      'start',
+      '--port',
+      '8789',
+      '--ui-port',
+      '39847',
+      '--host',
+      '127.0.0.1',
+      '--mode',
+      'browser',
+    ], { stdio: 'ignore' });
+    expect(result).toEqual({ process: child, port: 39847, apiPort: 8789, url: 'http://127.0.0.1:39847' });
+  });
+
+  it('adds --open only for an explicit browser-opening request', async () => {
+    const child = new EventEmitter() as ChildProcess;
+    child.kill = vi.fn(() => true);
+    const spawnProcess = vi.fn((_command, _args, _options) => {
+      queueMicrotask(() => child.emit('spawn'));
+      return child;
+    });
+
+    await startOpenKnowledgeServer('/tmp/knowledge', {
+      apiPort: 8789,
+      uiPort: 39847,
+      openBrowser: true,
+      spawnProcess,
+      isInitialized: async () => true,
+    });
+
+    expect(spawnProcess.mock.calls[0]?.[1]).toContain('--open');
+    expect(spawnProcess.mock.calls[0]?.[1]).not.toContain('--no-open');
+  });
+});

--- a/src/lib/installers/open-knowledge.ts
+++ b/src/lib/installers/open-knowledge.ts
@@ -1,0 +1,262 @@
+import { spawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
+import { access } from 'node:fs/promises';
+import { createServer } from 'node:net';
+import { join } from 'node:path';
+
+const OPEN_KNOWLEDGE_PACKAGE = '@inkeep/open-knowledge';
+const MANUAL_INSTALL_COMMAND = `npm install -g ${OPEN_KNOWLEDGE_PACKAGE}`;
+
+export interface CommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+export type CommandRunner = (command: string, args: string[]) => Promise<CommandResult>;
+export type SpawnProcess = (command: string, args: string[], options: SpawnOptions) => ChildProcess;
+
+export interface EnsureOpenKnowledgeOptions {
+  autoInstall?: boolean;
+  retryDelayMs?: number;
+  maxHealthAttempts?: number;
+  runCommand?: CommandRunner;
+  installOpenKnowledge?: () => Promise<void>;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface EnsureOpenKnowledgeResult {
+  status: 'already-installed' | 'installed';
+  command: 'ok';
+}
+
+export interface StartOpenKnowledgeServerOptions {
+  apiPort?: number;
+  uiPort?: number;
+  host?: string;
+  mode?: 'browser' | 'app';
+  openBrowser?: boolean;
+  initializeIfNeeded?: boolean;
+  runCommand?: CommandRunner;
+  spawnProcess?: SpawnProcess;
+  isInitialized?: (bundlePath: string) => Promise<boolean>;
+  getAvailablePorts?: (count: number, host: string) => Promise<number[]>;
+}
+
+export interface StartOpenKnowledgeServerResult {
+  process: ChildProcess;
+  port: number;
+  apiPort: number;
+  url: string;
+}
+
+export class OpenKnowledgeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OpenKnowledgeError';
+  }
+}
+
+export async function ensureOpenKnowledge(
+  options: EnsureOpenKnowledgeOptions = {},
+): Promise<EnsureOpenKnowledgeResult> {
+  const runCommand = options.runCommand ?? runCommandWithSpawn;
+
+  if (await openKnowledgeBinaryWorks(runCommand)) {
+    return { status: 'already-installed', command: 'ok' };
+  }
+
+  if (!options.autoInstall) {
+    throw new OpenKnowledgeError(`open-knowledge is not installed. Install it manually with \`${MANUAL_INSTALL_COMMAND}\`.`);
+  }
+
+  try {
+    await (options.installOpenKnowledge ?? (() => installOpenKnowledgeWithNpm(runCommand)))();
+  } catch (error) {
+    throw await installationError(error, runCommand);
+  }
+
+  const sleep = options.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const retryDelayMs = options.retryDelayMs ?? 500;
+  const maxHealthAttempts = options.maxHealthAttempts ?? 10;
+
+  for (let attempt = 1; attempt <= maxHealthAttempts; attempt += 1) {
+    if (await openKnowledgeBinaryWorks(runCommand)) {
+      return { status: 'installed', command: 'ok' };
+    }
+    if (attempt < maxHealthAttempts) await sleep(retryDelayMs);
+  }
+
+  throw await installationError(new Error('the ok binary did not pass `ok --version` after installation'), runCommand);
+}
+
+export async function startOpenKnowledgeServer(
+  bundlePath: string,
+  options: StartOpenKnowledgeServerOptions = {},
+): Promise<StartOpenKnowledgeServerResult> {
+  const runCommand = options.runCommand ?? runCommandWithSpawn;
+  const isInitialized = options.isInitialized ?? openKnowledgeIsInitialized;
+
+  if (!(await isInitialized(bundlePath))) {
+    if (options.initializeIfNeeded === false) {
+      throw new OpenKnowledgeError(`open-knowledge is not initialized for ${bundlePath}. Run \`ok init\` first.`);
+    }
+    await runCommand('ok', [
+      '--cwd',
+      bundlePath,
+      'init',
+      '--no-mcp',
+      '--no-skills',
+      '--local-only',
+      '--content-dir',
+      '.',
+      '--json',
+    ]);
+  }
+
+  const host = options.host ?? '127.0.0.1';
+  const missingPortCount = Number(options.apiPort === undefined) + Number(options.uiPort === undefined);
+  const availablePorts = missingPortCount > 0
+    ? await (options.getAvailablePorts ?? findAvailablePorts)(missingPortCount, host)
+    : [];
+  const apiPort = options.apiPort ?? availablePorts.shift();
+  const uiPort = options.uiPort ?? availablePorts.shift();
+
+  if (apiPort === undefined || uiPort === undefined || apiPort === uiPort) {
+    throw new OpenKnowledgeError('Could not allocate distinct API and UI ports for open-knowledge.');
+  }
+
+  const args = [
+    '--cwd',
+    bundlePath,
+    'start',
+    '--port',
+    String(apiPort),
+    '--ui-port',
+    String(uiPort),
+    '--host',
+    host,
+    '--mode',
+    options.mode ?? 'browser',
+  ];
+  if (options.openBrowser) args.push('--open');
+
+  const spawnProcess = options.spawnProcess ?? ((command, commandArgs, spawnOptions) => spawn(command, commandArgs, spawnOptions));
+  const child = spawnProcess('ok', args, { stdio: 'ignore' });
+  await waitForSpawn(child);
+
+  return {
+    process: child,
+    port: uiPort,
+    apiPort,
+    url: `http://${formatUrlHost(host)}:${uiPort}`,
+  };
+}
+
+async function openKnowledgeBinaryWorks(runCommand: CommandRunner): Promise<boolean> {
+  try {
+    await runCommand('ok', ['--version']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function installOpenKnowledgeWithNpm(runCommand: CommandRunner): Promise<void> {
+  await runCommand('npm', ['install', '-g', OPEN_KNOWLEDGE_PACKAGE]);
+}
+
+async function installationError(error: unknown, runCommand: CommandRunner): Promise<OpenKnowledgeError> {
+  const version = await readNodeVersion(runCommand);
+  const major = version ? Number.parseInt(version.replace(/^v/, '').split('.')[0] ?? '', 10) : Number.NaN;
+
+  if (version && Number.isFinite(major) && major < 24) {
+    return new OpenKnowledgeError(
+      `open-knowledge requires Node 24+; found ${version}. Install Node 24+ or run '/okf open --no-install' after installing manually.`,
+    );
+  }
+
+  const detail = error instanceof Error ? error.message : String(error);
+  return new OpenKnowledgeError(`Failed to install open-knowledge with \`${MANUAL_INSTALL_COMMAND}\`: ${detail}`);
+}
+
+async function readNodeVersion(runCommand: CommandRunner): Promise<string | null> {
+  try {
+    const result = await runCommand('node', ['--version']);
+    return result.stdout.trim() || result.stderr.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function openKnowledgeIsInitialized(bundlePath: string): Promise<boolean> {
+  try {
+    await access(join(bundlePath, '.ok', 'config.yml'));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findAvailablePorts(count: number, host: string): Promise<number[]> {
+  const servers = Array.from({ length: count }, () => createServer());
+  try {
+    return await Promise.all(servers.map((server) => new Promise<number>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, host, () => {
+        const address = server.address();
+        if (!address || typeof address === 'string') {
+          reject(new OpenKnowledgeError('Could not resolve an available open-knowledge port.'));
+          return;
+        }
+        resolve(address.port);
+      });
+    })));
+  } finally {
+    await Promise.all(servers.map((server) => new Promise<void>((resolve) => {
+      if (!server.listening) {
+        resolve();
+        return;
+      }
+      server.close(() => resolve());
+    })));
+  }
+}
+
+async function waitForSpawn(child: ChildProcess): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => {
+      child.removeListener('spawn', onSpawn);
+      reject(error);
+    };
+    const onSpawn = () => {
+      child.removeListener('error', onError);
+      resolve();
+    };
+    child.once('error', onError);
+    child.once('spawn', onSpawn);
+  });
+}
+
+async function runCommandWithSpawn(command: string, args: string[]): Promise<CommandResult> {
+  return new Promise<CommandResult>((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout?.setEncoding('utf8');
+    child.stderr?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => { stdout += chunk; });
+    child.stderr?.on('data', (chunk: string) => { stderr += chunk; });
+    child.once('error', reject);
+    child.once('exit', (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      reject(new OpenKnowledgeError(`${command} ${args.join(' ')} exited with code ${code}: ${stderr.trim()}`));
+    });
+  });
+}
+
+function formatUrlHost(host: string): string {
+  return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+}

--- a/src/lib/installers/open-knowledge.ts
+++ b/src/lib/installers/open-knowledge.ts
@@ -1,10 +1,14 @@
 import { spawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
-import { access } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { access, cp, mkdir, mkdtemp, realpath, rename, rm } from 'node:fs/promises';
 import { createServer } from 'node:net';
-import { join } from 'node:path';
+import { dirname, join, relative, sep } from 'node:path';
+import { getOverdeckHome } from '../paths.js';
 
 const OPEN_KNOWLEDGE_PACKAGE = '@inkeep/open-knowledge';
 const MANUAL_INSTALL_COMMAND = `npm install -g ${OPEN_KNOWLEDGE_PACKAGE}`;
+const DEFAULT_START_RETRY_DELAY_MS = 250;
+const DEFAULT_START_MAX_ATTEMPTS = 40;
 
 export interface CommandResult {
   stdout: string;
@@ -28,6 +32,19 @@ export interface EnsureOpenKnowledgeResult {
   command: 'ok';
 }
 
+export interface OpenKnowledgeProcessStatus {
+  name: string;
+  state: string;
+  alive: boolean;
+  pid?: number;
+  port?: number;
+}
+
+export interface OpenKnowledgeStatus {
+  server: OpenKnowledgeProcessStatus;
+  ui: OpenKnowledgeProcessStatus;
+}
+
 export interface StartOpenKnowledgeServerOptions {
   apiPort?: number;
   uiPort?: number;
@@ -35,17 +52,30 @@ export interface StartOpenKnowledgeServerOptions {
   mode?: 'browser' | 'app';
   openBrowser?: boolean;
   initializeIfNeeded?: boolean;
+  retryDelayMs?: number;
+  maxHealthAttempts?: number;
   runCommand?: CommandRunner;
   spawnProcess?: SpawnProcess;
   isInitialized?: (bundlePath: string) => Promise<boolean>;
   getAvailablePorts?: (count: number, host: string) => Promise<number[]>;
+  getStatus?: (bundlePath: string) => Promise<OpenKnowledgeStatus>;
+  fetchImpl?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface StartReadOnlyOpenKnowledgeServerOptions extends StartOpenKnowledgeServerOptions {
+  snapshotRoot?: string;
+  prepareSnapshot?: (bundlePath: string, snapshotRoot?: string) => Promise<string>;
 }
 
 export interface StartOpenKnowledgeServerResult {
-  process: ChildProcess;
+  process: ChildProcess | null;
+  owned: boolean;
+  reused: boolean;
   port: number;
   apiPort: number;
   url: string;
+  runtimeBundlePath: string;
 }
 
 export class OpenKnowledgeError extends Error {
@@ -88,13 +118,97 @@ export async function ensureOpenKnowledge(
   throw await installationError(new Error('the ok binary did not pass `ok --version` after installation'), runCommand);
 }
 
+export async function startReadOnlyOpenKnowledgeServer(
+  bundlePath: string,
+  options: StartReadOnlyOpenKnowledgeServerOptions = {},
+): Promise<StartOpenKnowledgeServerResult> {
+  const prepareSnapshot = options.prepareSnapshot ?? prepareOpenKnowledgeSnapshot;
+  const runtimeBundlePath = await readOnlyOpenKnowledgeSnapshotPath(bundlePath, options.snapshotRoot);
+  const getStatus = options.getStatus ?? ((path) => getOpenKnowledgeStatus(path, options.runCommand));
+  const existing = await getStatus(runtimeBundlePath);
+  if (!liveStatus(existing)) {
+    await prepareSnapshot(bundlePath, options.snapshotRoot);
+  }
+  return startOpenKnowledgeServer(runtimeBundlePath, { ...options, getStatus });
+}
+
+export async function prepareOpenKnowledgeSnapshot(
+  bundlePath: string,
+  snapshotRoot = join(getOverdeckHome(), 'cache', 'knowledge-viewer'),
+): Promise<string> {
+  const source = await realpath(bundlePath);
+  const destination = await readOnlyOpenKnowledgeSnapshotPath(source, snapshotRoot);
+  const parent = dirname(destination);
+  await mkdir(parent, { recursive: true });
+  const temporaryRoot = await mkdtemp(join(parent, '.snapshot-'));
+  const temporaryBundle = join(temporaryRoot, 'bundle');
+
+  try {
+    await cp(source, temporaryBundle, {
+      recursive: true,
+      dereference: true,
+      filter: (path) => {
+        const relativePath = relative(source, path);
+        if (!relativePath) return true;
+        const firstSegment = relativePath.split(sep)[0];
+        return firstSegment !== '.git' && firstSegment !== '.ok';
+      },
+    });
+    await runCommandWithSpawn('git', ['init', '--quiet', temporaryBundle]);
+    await rm(destination, { recursive: true, force: true });
+    await rename(temporaryBundle, destination);
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true });
+  }
+
+  return destination;
+}
+
+export async function readOnlyOpenKnowledgeSnapshotPath(
+  bundlePath: string,
+  snapshotRoot = join(getOverdeckHome(), 'cache', 'knowledge-viewer'),
+): Promise<string> {
+  let resolved = bundlePath;
+  try {
+    resolved = await realpath(bundlePath);
+  } catch {
+    // A not-yet-created snapshot still has a stable path derived from its source string.
+  }
+  const key = createHash('sha256').update(resolved).digest('hex').slice(0, 24);
+  return join(snapshotRoot, key, 'bundle');
+}
+
+export async function getOpenKnowledgeStatus(
+  bundlePath: string,
+  runCommand: CommandRunner = runCommandWithSpawn,
+): Promise<OpenKnowledgeStatus> {
+  try {
+    const result = await runCommand('ok', ['--cwd', bundlePath, 'status', '--json']);
+    const parsed = JSON.parse(result.stdout) as Partial<OpenKnowledgeStatus>;
+    return {
+      server: normalizeProcessStatus(parsed.server, 'server'),
+      ui: normalizeProcessStatus(parsed.ui, 'ui'),
+    };
+  } catch {
+    return missingStatus();
+  }
+}
+
 export async function startOpenKnowledgeServer(
   bundlePath: string,
   options: StartOpenKnowledgeServerOptions = {},
 ): Promise<StartOpenKnowledgeServerResult> {
   const runCommand = options.runCommand ?? runCommandWithSpawn;
-  const isInitialized = options.isInitialized ?? openKnowledgeIsInitialized;
+  const getStatus = options.getStatus ?? ((path) => getOpenKnowledgeStatus(path, runCommand));
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const sleep = options.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const retryDelayMs = options.retryDelayMs ?? DEFAULT_START_RETRY_DELAY_MS;
+  const maxHealthAttempts = options.maxHealthAttempts ?? DEFAULT_START_MAX_ATTEMPTS;
+  const existing = await getStatus(bundlePath);
+  const reused = await readyResult(existing, options.host ?? '127.0.0.1', fetchImpl);
+  if (reused) return { ...reused, process: null, owned: false, reused: true, runtimeBundlePath: bundlePath };
 
+  const isInitialized = options.isInitialized ?? openKnowledgeIsInitialized;
   if (!(await isInitialized(bundlePath))) {
     if (options.initializeIfNeeded === false) {
       throw new OpenKnowledgeError(`open-knowledge is not initialized for ${bundlePath}. Run \`ok init\` first.`);
@@ -143,11 +257,62 @@ export async function startOpenKnowledgeServer(
   const child = spawnProcess('ok', args, { stdio: 'ignore' });
   await waitForSpawn(child);
 
+  for (let attempt = 1; attempt <= maxHealthAttempts; attempt += 1) {
+    if (child.exitCode != null) {
+      throw new OpenKnowledgeError(`open-knowledge exited before becoming ready (code ${child.exitCode})`);
+    }
+    const status = await getStatus(bundlePath);
+    const ready = await readyResult(status, host, fetchImpl);
+    if (ready) {
+      return { ...ready, process: child, owned: true, reused: false, runtimeBundlePath: bundlePath };
+    }
+    if (attempt < maxHealthAttempts) await sleep(retryDelayMs);
+  }
+
+  child.kill('SIGTERM');
+  throw new OpenKnowledgeError(`open-knowledge viewer did not become healthy for ${bundlePath}`);
+}
+
+function liveStatus(status: OpenKnowledgeStatus): boolean {
+  return status.server.alive && status.ui.alive && Number.isInteger(status.server.port) && Number.isInteger(status.ui.port);
+}
+
+async function readyResult(
+  status: OpenKnowledgeStatus,
+  host: string,
+  fetchImpl: typeof fetch,
+): Promise<Omit<StartOpenKnowledgeServerResult, 'process' | 'owned' | 'reused' | 'runtimeBundlePath'> | null> {
+  if (!liveStatus(status)) return null;
+  const apiPort = status.server.port!;
+  const port = status.ui.port!;
+  const url = `http://${formatUrlHost(host)}:${port}`;
+  try {
+    const response = await fetchImpl(url, { method: 'GET' });
+    if (!response.ok) return null;
+  } catch {
+    return null;
+  }
+  return { port, apiPort, url };
+}
+
+function normalizeProcessStatus(
+  value: OpenKnowledgeProcessStatus | undefined,
+  name: string,
+): OpenKnowledgeProcessStatus {
+  if (!value || typeof value !== 'object') return { name, state: 'missing', alive: false };
   return {
-    process: child,
-    port: uiPort,
-    apiPort,
-    url: `http://${formatUrlHost(host)}:${uiPort}`,
+    name,
+    state: typeof value.state === 'string' ? value.state : 'missing',
+    alive: value.alive === true,
+    ...(Number.isInteger(value.pid) ? { pid: value.pid } : {}),
+    ...(Number.isInteger(value.port) ? { port: value.port } : {}),
+  };
+}
+
+function missingStatus(): OpenKnowledgeStatus {
+  return {
+    server: { name: 'server', state: 'missing', alive: false },
+    ui: { name: 'ui', state: 'missing', alive: false },
   };
 }
 

--- a/src/lib/memory/injection.ts
+++ b/src/lib/memory/injection.ts
@@ -7,7 +7,7 @@ import { ensureParentDir, resolveRagRunsFile, resolveStatusFile } from './paths.
 import { expandMemoryQuery, type QueryExpansionCall, type QueryExpansionResult } from './query-expansion.js';
 import { searchMemory, type MemorySearchHit } from './search.js';
 import { isMemoryKnowledgeIndexEnabled, isMemoryPromptTimeInjectionEnabled } from './settings.js';
-import { loadProjectsConfigSync, resolveProjectFromIssueSync } from '../projects.js';
+import { findProjectByPathSync, loadProjectsConfigSync, resolveProjectFromIssueSync } from '../projects.js';
 
 export const PROMPT_TIME_MEMORY_BUDGETS = {
   status: 2000,
@@ -462,14 +462,25 @@ async function readKnowledgeIndex(identity: MemoryIdentity): Promise<string | nu
   return lines.join('\n');
 }
 
-async function resolveKnowledgeBundleRoot(identity: MemoryIdentity): Promise<string | null> {
-  const resolved = resolveProjectFromIssueSync(identity.issueId);
-  if (!resolved) return null;
+export async function resolveKnowledgeBundleRoot(
+  identity: MemoryIdentity | { projectPath: string },
+): Promise<string | null> {
+  let projectPath: string;
+  let knowledgeRepo: string | undefined;
 
-  const config = loadProjectsConfigSync().projects[resolved.projectKey];
-  const projectPath = resolved.projectPath;
-  if (typeof config?.knowledge_repo === 'string' && config.knowledge_repo.trim()) {
-    return resolvePath(projectPath, config.knowledge_repo);
+  if ('issueId' in identity) {
+    const resolved = resolveProjectFromIssueSync(identity.issueId);
+    if (!resolved) return null;
+    projectPath = resolved.projectPath;
+    knowledgeRepo = loadProjectsConfigSync().projects[resolved.projectKey]?.knowledge_repo;
+  } else {
+    const project = findProjectByPathSync(identity.projectPath);
+    projectPath = project?.path ?? identity.projectPath;
+    knowledgeRepo = project?.knowledge_repo;
+  }
+
+  if (typeof knowledgeRepo === 'string' && knowledgeRepo.trim()) {
+    return resolvePath(projectPath, knowledgeRepo);
   }
 
   try {

--- a/sync-sources/skills/okf/README.md
+++ b/sync-sources/skills/okf/README.md
@@ -61,6 +61,7 @@ The copied skill remains portable. Its core scripts do not import Overdeck and r
 | Command | Summary |
 | --- | --- |
 | `/okf init` | Create or connect the knowledge bundle and pointer file. |
+| `/okf open [--no-install] [--no-browser]` | Open the configured bundle in the local visual knowledge viewer. |
 | `/okf author "<topic>"` | Write or update one concept for one idea. |
 | `/okf convert <path>` | Convert existing docs into OKF without destructive edits. |
 | `/okf sync [--topic "<focus>"]` | Update concepts from code or documentation diffs. |

--- a/sync-sources/skills/okf/SKILL.md
+++ b/sync-sources/skills/okf/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: okf
-description: Maintain a project knowledge wiki in Open Knowledge Format with /okf init, author, convert, sync, study, retro, extract, validate, lint, and embed.
+description: Maintain a project knowledge wiki in Open Knowledge Format with /okf init, open, author, convert, sync, study, retro, extract, validate, lint, and embed.
 triggers:
   - /okf
   - okf
@@ -26,6 +26,7 @@ The bundle is the source of truth. Keep changes small, cited, and PR-gated. Dete
 | Command | Purpose | Primary references |
 | --- | --- | --- |
 | `/okf init` | Create or connect a project knowledge bundle. | `references/workflow.md`, `references/spec.md` |
+| `/okf open [--no-install] [--no-browser]` | Open the configured bundle in the local visual knowledge viewer. | `references/overdeck.md` |
 | `/okf author "<topic>"` | Write or refresh one focused concept. | `templates/concept.md`, `references/taxonomy.md`, `references/model-bridges.md` |
 | `/okf convert <path>` | Convert existing docs into OKF concepts without deleting originals. | `references/conversion.md` |
 | `/okf sync [--topic "<focus>"]` | Update concepts from code or documentation changes. | `references/workflow.md`, `references/model-bridges.md` |
@@ -79,6 +80,15 @@ Create a knowledge bundle and pointer file.
 - Write `.okf.yml` at the code repo root with `bundle: ../<project>-knowledge` and `remote: <created remote>`; for `--local`, point `bundle:` at the local subdirectory and omit companion repo creation.
 - Add exactly one discovery line to `CLAUDE.md` or `AGENTS.md`, preserving it without duplication on repeated init.
 - Future resolution order is host project config `knowledge_repo`, then `.okf.yml`, then a clear error telling the user to run `/okf init`.
+
+## `/okf open [--no-install] [--no-browser]`
+
+Open the configured bundle in the local visual knowledge viewer.
+
+- Resolve the bundle from `.okf.yml`; under Overdeck, the canonical resolver also honors the project's `knowledge_repo` setting.
+- When `pan` is available, delegate to `pan knowledge open` and pass through `--no-install` and `--no-browser`.
+- By default, an explicit open request progressively installs the separately licensed GPL-3.0 `@inkeep/open-knowledge` program. `--no-install` requires an existing `ok` binary instead.
+- The viewer is an arm's-length subprocess served over HTTP. Never import, require, or bundle `@inkeep/open-knowledge` into the portable OKF scripts or Overdeck packages.
 
 ## `/okf author "<topic>"`
 

--- a/sync-sources/skills/okf/SKILL.md
+++ b/sync-sources/skills/okf/SKILL.md
@@ -88,7 +88,8 @@ Open the configured bundle in the local visual knowledge viewer.
 - Resolve the bundle from `.okf.yml`; under Overdeck, the canonical resolver also honors the project's `knowledge_repo` setting.
 - When `pan` is available, delegate to `pan knowledge open` and pass through `--no-install` and `--no-browser`.
 - By default, an explicit open request progressively installs the separately licensed GPL-3.0 `@inkeep/open-knowledge` program. `--no-install` requires an existing `ok` binary instead.
-- The viewer is an arm's-length subprocess served over HTTP. Never import, require, or bundle `@inkeep/open-knowledge` into the portable OKF scripts or Overdeck packages.
+- The viewer is an arm's-length subprocess served over HTTP. Overdeck launches it against a disposable snapshot, reuses healthy lock-reported processes, and never lets viewer edits touch the canonical PR-gated bundle.
+- Never import, require, or bundle `@inkeep/open-knowledge` into the portable OKF scripts or Overdeck packages.
 
 ## `/okf author "<topic>"`
 

--- a/sync-sources/skills/okf/docs/USAGE.md
+++ b/sync-sources/skills/okf/docs/USAGE.md
@@ -16,6 +16,21 @@ Create a knowledge bundle.
 - `--dir <path>`: use any external directory.
 - `--local <subdir>`: create an in-repo bundle.
 
+## `/okf open [--no-install] [--no-browser]`
+
+Open the configured bundle in the local visual viewer.
+
+```bash
+/okf open
+/okf open --no-install
+/okf open --no-browser
+```
+
+- Resolves the bundle from `.okf.yml` (or Overdeck's `knowledge_repo` setting).
+- Delegates to `pan knowledge open` when Overdeck is available.
+- Progressively installs the separate GPL-3.0 `ok` program only after the explicit open request; `--no-install` opts out.
+- `--no-browser` starts or reuses the viewer and prints its URL without launching a browser.
+
 ## `/okf author "<topic>"`
 
 Write or update one concept.

--- a/sync-sources/skills/okf/references/overdeck.md
+++ b/sync-sources/skills/okf/references/overdeck.md
@@ -11,6 +11,28 @@ Overdeck is available only when:
 
 Detection is by command execution, never by Python or TypeScript imports.
 
+## Optional OpenKnowledge MCP Registration
+
+The dashboard viewer and `pan knowledge open` never register an MCP server. Their unattended initialization always uses `ok init --no-mcp --no-skills`, so opening the viewer cannot change an editor or agent configuration.
+
+MCP registration is a separate, explicit operator action. From the resolved knowledge-bundle root, run:
+
+```bash
+ok init --mcp --no-skills --scope user
+```
+
+Use `--scope project` for repository-local configuration, or `--scope both` for both locations. OpenKnowledge v0.34 writes the supported native formats:
+
+| Client | User scope | Project scope |
+| --- | --- | --- |
+| Claude Code | `~/.claude.json` | `.mcp.json` |
+| Codex | `~/.codex/config.toml` | `.codex/config.toml` |
+| Cursor | `~/.cursor/mcp.json` | `.cursor/mcp.json` |
+
+OpenKnowledge registers only clients it detects. Start or install the intended client, then rerun the explicit command if its config root was previously absent. Review the reported paths before restarting the client; registration is opt-in and Overdeck never performs it automatically.
+
+`/okf init` and `ok init` are different commands: `/okf init` creates or connects an OKF knowledge bundle, while the upstream `ok init` command scaffolds OpenKnowledge's local `.ok/` runtime files and optionally registers MCP clients.
+
 ## Retro Feedstock
 
 When Overdeck is detected, `/okf retro` may mine observations for the issue:

--- a/sync-sources/skills/pan-knowledge/SKILL.md
+++ b/sync-sources/skills/pan-knowledge/SKILL.md
@@ -9,6 +9,7 @@ triggers:
   - knowledge sync
   - knowledge study
   - knowledge retro
+  - knowledge open
 allowed-tools:
   - Bash
   - Read
@@ -30,6 +31,8 @@ pan knowledge PAN-123 --focus "auth flow"    # Study a topic, then sync
 pan knowledge PAN-123 --retro                # Capture retro knowledge, then sync
 pan knowledge PAN-123 --model claude-sonnet-5  # Override the knowledge role model
 pan knowledge PAN-123 --effort high          # Raise reasoning effort for the agent
+pan knowledge open                           # Open this project's OKF bundle in the viewer
+pan knowledge open --no-install --no-browser # Never install or launch a browser
 ```
 
 ## What It Does
@@ -50,6 +53,12 @@ The agent runs a sequence of `/okf` commands depending on the flags you pass:
 The command first tries to ensure `mnemos` is available on `PATH` (installing it
 on demand if necessary) and ingest the resolved bundle. If mnemos is unavailable,
 it resolves the installed `okf` skill and falls back to its bundled `scripts/` directory.
+
+`pan knowledge open` resolves the current project's bundle through
+`projects.yaml` or `.okf.yml`, progressively installs the separately licensed
+`@inkeep/open-knowledge` program when needed, starts or reuses its local viewer,
+and opens the URL. Use `--no-install` to require a preinstalled `ok` binary and
+`--no-browser` to print the URL without launching a browser.
 
 ## When to Use
 

--- a/sync-sources/skills/pan-knowledge/SKILL.md
+++ b/sync-sources/skills/pan-knowledge/SKILL.md
@@ -56,8 +56,9 @@ it resolves the installed `okf` skill and falls back to its bundled `scripts/` d
 
 `pan knowledge open` resolves the current project's bundle through
 `projects.yaml` or `.okf.yml`, progressively installs the separately licensed
-`@inkeep/open-knowledge` program when needed, starts or reuses its local viewer,
-and opens the URL. Use `--no-install` to require a preinstalled `ok` binary and
+`@inkeep/open-knowledge` program when needed, starts or reuses a verified viewer
+against a disposable snapshot, and opens the URL. Viewer edits never touch the
+canonical PR-gated bundle. Use `--no-install` to require a preinstalled `ok` binary and
 `--no-browser` to print the URL without launching a browser.
 
 ## When to Use

--- a/sync-sources/templates/traefik/dynamic/overdeck.yml.template
+++ b/sync-sources/templates/traefik/dynamic/overdeck.yml.template
@@ -30,6 +30,16 @@ http:
       service: overdeck-api
       tls: {}
 
+    # Origin-isolated OpenKnowledge viewers. The dashboard server derives the
+    # project from the hex-encoded host label and proxies every root-relative
+    # HTTP/WebSocket path to that project's viewer process.
+    overdeck-knowledge-viewer:
+      rule: "HostRegexp(`^knowledge-[a-f0-9]+\\.{{TRAEFIK_DOMAIN}}$`)"
+      entryPoints:
+        - websecure
+      service: overdeck-api
+      tls: {}
+
     # Published HTML artifacts
     overdeck-artifacts:
       rule: "Host(`artifacts.{{TRAEFIK_DOMAIN}}`) && PathPrefix(`/a/`)"

--- a/tests/unit/dashboard/server/routes/knowledge-viewer.test.ts
+++ b/tests/unit/dashboard/server/routes/knowledge-viewer.test.ts
@@ -1,0 +1,130 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createKnowledgeViewerRouteHandlers,
+  knowledgeViewerUpstreamUrl,
+} from '../../../../../src/dashboard/server/routes/knowledge-viewer.js';
+import type { KnowledgeViewerStatus } from '../../../../../src/dashboard/server/services/knowledge-viewer.js';
+
+const runningStatus = (overrides: Partial<KnowledgeViewerStatus> = {}): KnowledgeViewerStatus => ({
+  projectKey: 'overdeck',
+  bundleConfigured: true,
+  installed: true,
+  starting: false,
+  running: true,
+  bundlePath: '/repo/knowledge',
+  port: 39847,
+  apiPort: 8789,
+  url: 'http://127.0.0.1:39847',
+  ...overrides,
+});
+
+describe('knowledge viewer route handlers', () => {
+  it('returns truthful status from the viewer service', async () => {
+    const getStatus = vi.fn(async () => runningStatus({ running: false, url: undefined, port: undefined }));
+    const handlers = createKnowledgeViewerRouteHandlers({ getStatus });
+
+    await expect(handlers.status('overdeck')).resolves.toMatchObject({
+      projectKey: 'overdeck',
+      bundleConfigured: true,
+      installed: true,
+      running: false,
+    });
+    expect(getStatus).toHaveBeenCalledWith('overdeck');
+  });
+
+  it('installs only through an explicit auto-install request and then refreshes status', async () => {
+    const ensure = vi.fn(async () => ({ status: 'installed', command: 'ok' }));
+    const getStatus = vi.fn(async () => runningStatus({ running: false, url: undefined, port: undefined }));
+    const handlers = createKnowledgeViewerRouteHandlers({ ensure, getStatus });
+
+    const result = await handlers.install('overdeck');
+
+    expect(ensure).toHaveBeenCalledWith({ autoInstall: true });
+    expect(getStatus).toHaveBeenCalledWith('overdeck');
+    expect(result.installed).toBe(true);
+  });
+
+  it('starts or reuses the viewer and makes it the active proxy target', async () => {
+    const start = vi.fn(async () => runningStatus());
+    const handlers = createKnowledgeViewerRouteHandlers({ start });
+
+    const result = await handlers.start('overdeck');
+
+    expect(result.running).toBe(true);
+    expect(start).toHaveBeenCalledWith('overdeck');
+    await expect(handlers.resolveTarget('/knowledge-viewer/')).resolves.toBe('http://127.0.0.1:39847');
+  });
+
+  it('proxies HTTP bytes and preserves framing headers for the frontend fallback decision', async () => {
+    const fetchImpl = vi.fn(async () => new Response('viewer html', {
+      status: 200,
+      headers: {
+        'content-type': 'text/html',
+        'x-frame-options': 'DENY',
+        'content-security-policy': "frame-ancestors 'none'",
+      },
+    }));
+    const handlers = createKnowledgeViewerRouteHandlers({
+      start: async () => runningStatus(),
+      fetchImpl,
+    });
+    await handlers.start('overdeck');
+
+    const response = await handlers.proxyHttp({
+      url: '/knowledge-viewer/assets/index.js?cache=1',
+      method: 'GET',
+      headers: { host: 'overdeck.localhost', accept: '*/*' },
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith('http://127.0.0.1:39847/assets/index.js?cache=1', expect.objectContaining({
+      method: 'GET',
+      headers: { accept: '*/*' },
+      redirect: 'manual',
+    }));
+    expect(new TextDecoder().decode(response.body)).toBe('viewer html');
+    expect(response.headers['x-frame-options']).toBe('DENY');
+    expect(response.headers['content-security-policy']).toBe("frame-ancestors 'none'");
+  });
+
+  it('rewrites upstream redirects back under the same-origin proxy prefix', async () => {
+    const handlers = createKnowledgeViewerRouteHandlers({
+      start: async () => runningStatus(),
+      fetchImpl: async () => new Response(null, {
+        status: 302,
+        headers: { location: 'http://127.0.0.1:39847/settings?tab=sync' },
+      }),
+    });
+    await handlers.start('overdeck');
+
+    const response = await handlers.proxyHttp({
+      url: '/knowledge-viewer/',
+      method: 'GET',
+      headers: {},
+    });
+
+    expect(response.headers.location).toBe('/knowledge-viewer/settings?tab=sync');
+  });
+
+  it('maps HTTP and WebSocket paths while stripping the dashboard-only project selector', () => {
+    expect(knowledgeViewerUpstreamUrl(
+      '/knowledge-viewer/socket?project=overdeck&token=abc',
+      'http://127.0.0.1:39847',
+      false,
+    )).toBe('http://127.0.0.1:39847/socket?token=abc');
+    expect(knowledgeViewerUpstreamUrl(
+      '/knowledge-viewer/socket?project=overdeck&token=abc',
+      'http://127.0.0.1:39847',
+      true,
+    )).toBe('ws://127.0.0.1:39847/socket?token=abc');
+  });
+
+  it('is composed before the SPA fallback and installs its WebSocket upgrade hook', async () => {
+    const serverPath = fileURLToPath(new URL('../../../../../src/dashboard/server/server.ts', import.meta.url));
+    const source = await readFile(serverPath, 'utf8');
+
+    expect(source).toContain('setupKnowledgeViewerWebSocketProxy(nodeServer);');
+    expect(source.indexOf('knowledgeViewerRouteLayer,')).toBeLessThan(source.indexOf('staticRouteLayer,'));
+  });
+});

--- a/tests/unit/dashboard/server/routes/knowledge-viewer.test.ts
+++ b/tests/unit/dashboard/server/routes/knowledge-viewer.test.ts
@@ -1,42 +1,132 @@
+import http from 'node:http';
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it, vi } from 'vitest';
+import { Effect } from 'effect';
+import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { _resetInternalTokenCacheForTests } from '../../../../../src/lib/internal-token.js';
 import {
   createKnowledgeViewerRouteHandlers,
+  filterKnowledgeViewerRequestHeaders,
+  filterKnowledgeViewerResponseHeaders,
+  knowledgeViewerHost,
+  knowledgeViewerProxyUrl,
+  knowledgeViewerRouteLayer,
   knowledgeViewerUpstreamUrl,
+  projectFromKnowledgeViewerHost,
+  resetKnowledgeViewerAccessTokensForTests,
+  setupKnowledgeViewerProxy,
 } from '../../../../../src/dashboard/server/routes/knowledge-viewer.js';
+import {
+  DASHBOARD_CSRF_HEADER,
+  DASHBOARD_SESSION_COOKIE,
+  _resetDashboardSessionTokenForTests,
+} from '../../../../../src/dashboard/server/routes/dashboard-auth.js';
+import { _resetTrustedOriginsForTests } from '../../../../../src/dashboard/server/routes/origin-validation.js';
 import type { KnowledgeViewerStatus } from '../../../../../src/dashboard/server/services/knowledge-viewer.js';
 
-const runningStatus = (overrides: Partial<KnowledgeViewerStatus> = {}): KnowledgeViewerStatus => ({
-  projectKey: 'overdeck',
+const runningStatus = (projectKey = 'overdeck', overrides: Partial<KnowledgeViewerStatus> = {}): KnowledgeViewerStatus => ({
+  projectKey,
   bundleConfigured: true,
   installed: true,
   starting: false,
   running: true,
-  bundlePath: '/repo/knowledge',
+  bundlePath: `/repo/${projectKey}-knowledge`,
   port: 39847,
   apiPort: 8789,
   url: 'http://127.0.0.1:39847',
+  embeddable: true,
   ...overrides,
 });
 
+async function routeResponse(path: string, init: RequestInit = {}) {
+  const request = HttpServerRequest.fromWeb(new Request(`http://overdeck.localhost${path}`, init));
+  const response = await Effect.runPromise(
+    Effect.scoped(
+      Effect.flatMap(HttpRouter.toHttpEffect(knowledgeViewerRouteLayer), (app) =>
+        Effect.provideService(app, HttpServerRequest.HttpServerRequest, request)
+      ),
+    ),
+  );
+  const responseBody = response.body as { body?: Uint8Array } | null;
+  const text = responseBody?.body ? new TextDecoder().decode(responseBody.body) : '';
+  return { status: response.status, body: text ? JSON.parse(text) as { error?: string } : null };
+}
+
+async function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') reject(new Error('server address unavailable'));
+      else resolve(address.port);
+    });
+  });
+}
+
+async function close(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+async function hostRequest(
+  port: number,
+  host: string,
+  path: string,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; headers: http.IncomingHttpHeaders; body: string }> {
+  return new Promise((resolve, reject) => {
+    const request = http.request({ host: '127.0.0.1', port, path, headers: { host, ...headers } }, (response) => {
+      const chunks: Buffer[] = [];
+      response.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+      response.on('end', () => resolve({
+        status: response.statusCode ?? 0,
+        headers: response.headers,
+        body: Buffer.concat(chunks).toString('utf8'),
+      }));
+    });
+    request.once('error', reject);
+    request.end();
+  });
+}
+
+beforeEach(() => {
+  process.env.OVERDECK_INTERNAL_TOKEN = 'test-internal-token';
+  process.env.OVERDECK_DASHBOARD_SESSION_TOKEN = 'test-session-token';
+  process.env.OVERDECK_DASHBOARD_CSRF_TOKEN = 'test-csrf-token';
+  process.env.DASHBOARD_URL = 'https://overdeck.localhost';
+  _resetInternalTokenCacheForTests();
+  _resetDashboardSessionTokenForTests();
+  _resetTrustedOriginsForTests();
+  resetKnowledgeViewerAccessTokensForTests();
+});
+
+afterEach(() => {
+  delete process.env.OVERDECK_INTERNAL_TOKEN;
+  delete process.env.OVERDECK_DASHBOARD_SESSION_TOKEN;
+  delete process.env.OVERDECK_DASHBOARD_CSRF_TOKEN;
+  delete process.env.DASHBOARD_URL;
+  _resetInternalTokenCacheForTests();
+  _resetDashboardSessionTokenForTests();
+  _resetTrustedOriginsForTests();
+  resetKnowledgeViewerAccessTokensForTests();
+});
+
 describe('knowledge viewer route handlers', () => {
-  it('returns truthful status from the viewer service', async () => {
-    const getStatus = vi.fn(async () => runningStatus({ running: false, url: undefined, port: undefined }));
+  it('resolves proxy targets by immutable project identity', async () => {
+    const getStatus = vi.fn(async (projectKey: string) => runningStatus(projectKey, {
+      url: projectKey === 'alpha' ? 'http://127.0.0.1:4101' : 'http://127.0.0.1:4102',
+    }));
     const handlers = createKnowledgeViewerRouteHandlers({ getStatus });
 
-    await expect(handlers.status('overdeck')).resolves.toMatchObject({
-      projectKey: 'overdeck',
-      bundleConfigured: true,
-      installed: true,
-      running: false,
-    });
-    expect(getStatus).toHaveBeenCalledWith('overdeck');
+    await expect(handlers.resolveTarget('alpha')).resolves.toBe('http://127.0.0.1:4101');
+    await expect(handlers.resolveTarget('beta')).resolves.toBe('http://127.0.0.1:4102');
+    expect(getStatus).toHaveBeenNthCalledWith(1, 'alpha');
+    expect(getStatus).toHaveBeenNthCalledWith(2, 'beta');
   });
 
   it('installs only through an explicit auto-install request and then refreshes status', async () => {
     const ensure = vi.fn(async () => ({ status: 'installed', command: 'ok' }));
-    const getStatus = vi.fn(async () => runningStatus({ running: false, url: undefined, port: undefined }));
+    const getStatus = vi.fn(async () => runningStatus('overdeck', { running: false, url: undefined, port: undefined }));
     const handlers = createKnowledgeViewerRouteHandlers({ ensure, getStatus });
 
     const result = await handlers.install('overdeck');
@@ -46,85 +136,187 @@ describe('knowledge viewer route handlers', () => {
     expect(result.installed).toBe(true);
   });
 
-  it('starts or reuses the viewer and makes it the active proxy target', async () => {
-    const start = vi.fn(async () => runningStatus());
-    const handlers = createKnowledgeViewerRouteHandlers({ start });
-
-    const result = await handlers.start('overdeck');
-
-    expect(result.running).toBe(true);
-    expect(start).toHaveBeenCalledWith('overdeck');
-    await expect(handlers.resolveTarget('/knowledge-viewer/')).resolves.toBe('http://127.0.0.1:39847');
-  });
-
-  it('proxies HTTP bytes and preserves framing headers for the frontend fallback decision', async () => {
-    const fetchImpl = vi.fn(async () => new Response('viewer html', {
-      status: 200,
-      headers: {
-        'content-type': 'text/html',
-        'x-frame-options': 'DENY',
-        'content-security-policy': "frame-ancestors 'none'",
-      },
-    }));
-    const handlers = createKnowledgeViewerRouteHandlers({
-      start: async () => runningStatus(),
-      fetchImpl,
-    });
-    await handlers.start('overdeck');
-
-    const response = await handlers.proxyHttp({
-      url: '/knowledge-viewer/assets/index.js?cache=1',
-      method: 'GET',
-      headers: { host: 'overdeck.localhost', accept: '*/*' },
-    });
-
-    expect(fetchImpl).toHaveBeenCalledWith('http://127.0.0.1:39847/assets/index.js?cache=1', expect.objectContaining({
-      method: 'GET',
-      headers: { accept: '*/*' },
-      redirect: 'manual',
-    }));
-    expect(new TextDecoder().decode(response.body)).toBe('viewer html');
-    expect(response.headers['x-frame-options']).toBe('DENY');
-    expect(response.headers['content-security-policy']).toBe("frame-ancestors 'none'");
-  });
-
-  it('rewrites upstream redirects back under the same-origin proxy prefix', async () => {
-    const handlers = createKnowledgeViewerRouteHandlers({
-      start: async () => runningStatus(),
-      fetchImpl: async () => new Response(null, {
-        status: 302,
-        headers: { location: 'http://127.0.0.1:39847/settings?tab=sync' },
-      }),
-    });
-    await handlers.start('overdeck');
-
-    const response = await handlers.proxyHttp({
-      url: '/knowledge-viewer/',
-      method: 'GET',
-      headers: {},
-    });
-
-    expect(response.headers.location).toBe('/knowledge-viewer/settings?tab=sync');
-  });
-
-  it('maps HTTP and WebSocket paths while stripping the dashboard-only project selector', () => {
+  it('maps root-relative HTTP and WebSocket paths without leaking access tokens upstream', () => {
     expect(knowledgeViewerUpstreamUrl(
-      '/knowledge-viewer/socket?project=overdeck&token=abc',
+      '/api/config?access=secret&cache=1',
       'http://127.0.0.1:39847',
       false,
-    )).toBe('http://127.0.0.1:39847/socket?token=abc');
+    )).toBe('http://127.0.0.1:39847/api/config?cache=1');
     expect(knowledgeViewerUpstreamUrl(
-      '/knowledge-viewer/socket?project=overdeck&token=abc',
+      '/collab?access=secret&room=abc',
       'http://127.0.0.1:39847',
       true,
-    )).toBe('ws://127.0.0.1:39847/socket?token=abc');
+    )).toBe('ws://127.0.0.1:39847/collab?room=abc');
   });
 
-  it('is composed before the SPA fallback and installs its WebSocket upgrade hook', async () => {
+  it('encodes the project in an origin-isolated viewer host', () => {
+    const host = knowledgeViewerHost('overdeck', 'overdeck.localhost');
+    expect(host).toBe('knowledge-6f7665726465636b.overdeck.localhost');
+    expect(projectFromKnowledgeViewerHost(host)).toBe('overdeck');
+    expect(projectFromKnowledgeViewerHost('knowledge-not-hex.overdeck.localhost')).toBeNull();
+  });
+
+  it('uses explicit header allowlists at the third-party process boundary', () => {
+    expect(filterKnowledgeViewerRequestHeaders({
+      accept: 'text/html',
+      cookie: 'overdeck_session=secret',
+      authorization: 'Bearer secret',
+      'x-overdeck-internal-token': 'secret',
+      'x-overdeck-csrf-token': 'secret',
+      referer: 'https://overdeck.localhost/?token=secret',
+    })).toEqual({ accept: 'text/html' });
+
+    expect(filterKnowledgeViewerResponseHeaders(new Headers({
+      'content-type': 'text/html',
+      'set-cookie': 'overdeck_session=attacker',
+      'x-frame-options': 'DENY',
+      'x-overdeck-internal-token': 'secret',
+    }))).toEqual({
+      'content-type': 'text/html',
+      'x-frame-options': 'DENY',
+    });
+  });
+});
+
+describe('knowledge viewer authorization gates', () => {
+  it('rejects status without dashboard authorization', async () => {
+    const response = await routeResponse('/api/knowledge-viewer/status?project=overdeck');
+    expect(response).toMatchObject({ status: 401, body: { error: 'unauthorized' } });
+  });
+
+  it('rejects mutation requests with the wrong content type', async () => {
+    const response = await routeResponse('/api/knowledge-viewer/install', {
+      method: 'POST',
+      headers: { cookie: `${DASHBOARD_SESSION_COOKIE}=test-session-token`, 'content-type': 'text/plain' },
+      body: JSON.stringify({ project: 'overdeck' }),
+    });
+    expect(response).toMatchObject({ status: 400, body: { error: 'Content-Type must be application/json' } });
+  });
+
+  it('rejects mutation requests from an invalid origin', async () => {
+    const response = await routeResponse('/api/knowledge-viewer/start', {
+      method: 'POST',
+      headers: {
+        cookie: `${DASHBOARD_SESSION_COOKIE}=test-session-token`,
+        'content-type': 'application/json',
+        origin: 'https://evil.example.com',
+        [DASHBOARD_CSRF_HEADER]: 'test-csrf-token',
+      },
+      body: JSON.stringify({ project: 'overdeck' }),
+    });
+    expect(response).toMatchObject({ status: 403, body: { error: 'Invalid origin' } });
+  });
+
+  it('rejects mutation requests without a valid CSRF token', async () => {
+    const response = await routeResponse('/api/knowledge-viewer/start', {
+      method: 'POST',
+      headers: {
+        cookie: `${DASHBOARD_SESSION_COOKIE}=test-session-token`,
+        'content-type': 'application/json',
+        origin: 'https://overdeck.localhost',
+      },
+      body: JSON.stringify({ project: 'overdeck' }),
+    });
+    expect(response).toMatchObject({ status: 403, body: { error: 'Invalid CSRF token' } });
+  });
+});
+
+describe('origin-isolated knowledge viewer proxy', () => {
+  it('requires delegated access and keeps root API traffic pinned to the host project', async () => {
+    const upstreamAlpha = http.createServer((request, response) => {
+      response.setHeader('content-type', 'application/json');
+      response.setHeader('set-cookie', 'overdeck_session=attacker');
+      response.end(JSON.stringify({ project: 'alpha', path: request.url }));
+    });
+    const upstreamBeta = http.createServer((request, response) => {
+      response.setHeader('content-type', 'application/json');
+      response.end(JSON.stringify({ project: 'beta', path: request.url }));
+    });
+    const alphaPort = await listen(upstreamAlpha);
+    const betaPort = await listen(upstreamBeta);
+    const handlers = createKnowledgeViewerRouteHandlers({
+      getStatus: async (projectKey) => runningStatus(projectKey, {
+        url: `http://127.0.0.1:${projectKey === 'alpha' ? alphaPort : betaPort}`,
+      }),
+    });
+    const proxy = http.createServer();
+    setupKnowledgeViewerProxy(proxy, handlers);
+    proxy.on('request', (_request, response) => {
+      response.writeHead(404);
+      response.end();
+    });
+    const proxyPort = await listen(proxy);
+
+    try {
+      const alphaProxy = new URL(`http:${knowledgeViewerProxyUrl('alpha', `localhost:${proxyPort}`)}`);
+      const betaProxy = new URL(`http:${knowledgeViewerProxyUrl('beta', `localhost:${proxyPort}`)}`);
+
+      const unauthorized = await hostRequest(proxyPort, alphaProxy.host, '/api/config');
+      expect(unauthorized.status).toBe(401);
+
+      const alpha = await hostRequest(proxyPort, alphaProxy.host, `/api/config${alphaProxy.search}`);
+      expect(alpha.status).toBe(200);
+      expect(JSON.parse(alpha.body)).toEqual({ project: 'alpha', path: '/api/config' });
+      expect(alpha.headers['set-cookie']?.[0]).toContain('overdeck_knowledge_viewer=');
+      expect(alpha.headers['set-cookie']?.[0]).toContain('SameSite=None');
+      expect(alpha.headers['set-cookie']?.[0]).toContain('Secure');
+      expect(alpha.headers['set-cookie']?.join(';')).not.toContain('attacker');
+
+      const cookie = alpha.headers['set-cookie']?.[0]?.split(';')[0] ?? '';
+      const alphaCollab = await hostRequest(proxyPort, alphaProxy.host, '/collab?room=one', { cookie });
+      expect(JSON.parse(alphaCollab.body)).toEqual({ project: 'alpha', path: '/collab?room=one' });
+
+      const beta = await hostRequest(proxyPort, betaProxy.host, `/api/config${betaProxy.search}`);
+      expect(JSON.parse(beta.body)).toEqual({ project: 'beta', path: '/api/config' });
+    } finally {
+      await Promise.all([close(proxy), close(upstreamAlpha), close(upstreamBeta)]);
+    }
+  });
+
+  it('rewrites OpenKnowledge config URLs through the isolated viewer origin', async () => {
+    const upstream = http.createServer((_request, response) => {
+      response.setHeader('content-type', 'application/json');
+      response.end(JSON.stringify({
+        collabUrl: 'ws://127.0.0.1:8789/collab?room=one',
+        previewUrl: 'http://127.0.0.1:8789/preview',
+        port: 8789,
+      }));
+    });
+    const upstreamPort = await listen(upstream);
+    const handlers = createKnowledgeViewerRouteHandlers({
+      getStatus: async (projectKey) => runningStatus(projectKey, { url: `http://127.0.0.1:${upstreamPort}` }),
+    });
+    const proxy = http.createServer();
+    setupKnowledgeViewerProxy(proxy, handlers);
+    proxy.on('request', (_request, response) => {
+      response.writeHead(404);
+      response.end();
+    });
+    const proxyPort = await listen(proxy);
+
+    try {
+      const proxyUrl = new URL(`http:${knowledgeViewerProxyUrl('alpha', `localhost:${proxyPort}`)}`);
+      const result = await hostRequest(proxyPort, proxyUrl.host, `/api/config${proxyUrl.search}`, {
+        'x-forwarded-proto': 'https',
+      });
+
+      expect(result.status).toBe(200);
+      expect(JSON.parse(result.body)).toEqual({
+        collabUrl: `wss://${proxyUrl.host}/collab?room=one`,
+        previewUrl: `https://${proxyUrl.host}/preview`,
+        port: 8789,
+      });
+      expect(result.headers['content-length']).toBe(String(Buffer.byteLength(result.body)));
+    } finally {
+      await Promise.all([close(proxy), close(upstream)]);
+    }
+  });
+
+  it('is installed before Effect request and WebSocket listeners', async () => {
     const serverPath = fileURLToPath(new URL('../../../../../src/dashboard/server/server.ts', import.meta.url));
     const source = await readFile(serverPath, 'utf8');
 
-    expect(source).toContain('setupKnowledgeViewerWebSocketProxy(nodeServer);');
+    expect(source).toContain('setupKnowledgeViewerProxy(nodeServer);');
     expect(source.indexOf('knowledgeViewerRouteLayer,')).toBeLessThan(source.indexOf('staticRouteLayer,'));
   });
 });

--- a/tests/unit/dashboard/server/services/knowledge-viewer.test.ts
+++ b/tests/unit/dashboard/server/services/knowledge-viewer.test.ts
@@ -2,11 +2,11 @@ import { EventEmitter } from 'node:events';
 import type { ChildProcess } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createKnowledgeViewerService } from '../../../../../src/dashboard/server/services/knowledge-viewer.js';
 
-function response(ok: boolean): Response {
-  return { ok } as Response;
+function response(ok: boolean, headers: Record<string, string> = {}): Response {
+  return { ok, headers: new Headers(headers) } as Response;
 }
 
 function fakeChild(): ChildProcess {
@@ -16,38 +16,32 @@ function fakeChild(): ChildProcess {
   return child;
 }
 
-beforeEach(() => {
-  vi.useFakeTimers();
-});
-
-afterEach(() => {
-  vi.useRealTimers();
-});
+function startResult(child: ChildProcess | null, overrides: Record<string, unknown> = {}) {
+  return {
+    process: child,
+    owned: child !== null,
+    reused: child === null,
+    port: 39847,
+    apiPort: 8789,
+    url: 'http://127.0.0.1:39847',
+    runtimeBundlePath: '/runtime/read-only-snapshot',
+    ...overrides,
+  };
+}
 
 describe('knowledge viewer service', () => {
-  it('spawns the viewer and returns its URL after the health check passes', async () => {
+  it('spawns the read-only viewer and returns its embeddable URL', async () => {
     const child = fakeChild();
-    const health = [false, true];
-    const fetchImpl = vi.fn(async () => response(health.shift() ?? true));
-    const start = vi.fn(async () => ({
-      process: child,
-      port: 39847,
-      apiPort: 8789,
-      url: 'http://127.0.0.1:39847',
-    }));
+    const start = vi.fn(async () => startResult(child));
     const service = createKnowledgeViewerService({
       resolveBundle: async () => '/repo/knowledge',
       ensure: async () => ({ status: 'already-installed', command: 'ok' }),
       start,
       stop: async () => {},
-      fetchImpl,
-      retryDelayMs: 100,
-      maxHealthAttempts: 2,
+      fetchImpl: vi.fn(async () => response(true)),
     });
 
-    const resultPromise = service.getOrStartViewer('overdeck');
-    await vi.advanceTimersByTimeAsync(100);
-    const result = await resultPromise;
+    const result = await service.getOrStartViewer('overdeck');
 
     expect(result).toEqual({
       projectKey: 'overdeck',
@@ -59,21 +53,18 @@ describe('knowledge viewer service', () => {
       port: 39847,
       apiPort: 8789,
       url: 'http://127.0.0.1:39847',
+      embeddable: true,
     });
-    expect(start).toHaveBeenCalledOnce();
+    expect(start).toHaveBeenCalledWith('/repo/knowledge', { openBrowser: false });
   });
 
   it('reuses one healthy process for concurrent and subsequent starts', async () => {
     const child = fakeChild();
-    const start = vi.fn(async () => ({
-      process: child,
-      port: 39847,
-      apiPort: 8789,
-      url: 'http://127.0.0.1:39847',
-    }));
+    const start = vi.fn(async () => startResult(child));
+    const ensure = vi.fn(async () => ({ status: 'already-installed' as const, command: 'ok' as const }));
     const service = createKnowledgeViewerService({
       resolveBundle: async () => '/repo/knowledge',
-      ensure: async () => ({ status: 'already-installed', command: 'ok' }),
+      ensure,
       start,
       stop: async () => {},
       fetchImpl: vi.fn(async () => response(true)),
@@ -85,16 +76,14 @@ describe('knowledge viewer service', () => {
     ]);
     const subsequent = await service.getOrStartViewer('overdeck');
 
-    expect(first.url).toBe('http://127.0.0.1:39847');
     expect(concurrent.url).toBe(first.url);
     expect(subsequent.url).toBe(first.url);
     expect(start).toHaveBeenCalledOnce();
+    expect(ensure).toHaveBeenCalledOnce();
   });
 
   it('returns typed unavailable states for a missing bundle or binary', async () => {
-    const noBundle = createKnowledgeViewerService({
-      resolveBundle: async () => null,
-    });
+    const noBundle = createKnowledgeViewerService({ resolveBundle: async () => null });
     const noBinary = createKnowledgeViewerService({
       resolveBundle: async () => '/repo/knowledge',
       ensure: async () => {
@@ -116,57 +105,81 @@ describe('knowledge viewer service', () => {
     });
   });
 
-  it('rejects a health timeout and stops the failed process', async () => {
+  it('stops an owned process when its post-start health probe fails', async () => {
     const child = fakeChild();
     const stop = vi.fn(async () => {});
     const service = createKnowledgeViewerService({
       resolveBundle: async () => '/repo/knowledge',
       ensure: async () => ({ status: 'already-installed', command: 'ok' }),
-      start: async () => ({
-        process: child,
-        port: 39847,
-        apiPort: 8789,
-        url: 'http://127.0.0.1:39847',
-      }),
+      start: async () => startResult(child),
       stop,
       fetchImpl: vi.fn(async () => response(false)),
-      retryDelayMs: 100,
-      maxHealthAttempts: 2,
     });
 
-    const resultPromise = service.getOrStartViewer('overdeck');
-    const rejection = expect(resultPromise).rejects.toThrow(
-      'open-knowledge viewer did not become healthy at http://127.0.0.1:39847',
+    await expect(service.getOrStartViewer('overdeck')).rejects.toThrow(
+      'open-knowledge viewer did not remain healthy at http://127.0.0.1:39847',
     );
-    await vi.advanceTimersByTimeAsync(100);
-    await rejection;
 
-    expect(stop).toHaveBeenCalledWith('/repo/knowledge');
+    expect(stop).toHaveBeenCalledWith('/runtime/read-only-snapshot');
     expect(child.kill).toHaveBeenCalledWith('SIGTERM');
   });
 
-  it('stops all tracked viewers during shutdown', async () => {
-    const child = fakeChild();
-    const stop = vi.fn(async () => {});
-    const service = createKnowledgeViewerService({
+  it('stops only viewer processes owned by this dashboard', async () => {
+    const ownedChild = fakeChild();
+    const stopOwned = vi.fn(async () => {});
+    const owned = createKnowledgeViewerService({
       resolveBundle: async () => '/repo/knowledge',
       ensure: async () => ({ status: 'already-installed', command: 'ok' }),
-      start: async () => ({
-        process: child,
-        port: 39847,
-        apiPort: 8789,
-        url: 'http://127.0.0.1:39847',
-      }),
-      stop,
+      start: async () => startResult(ownedChild),
+      stop: stopOwned,
+      fetchImpl: vi.fn(async () => response(true)),
+    });
+    await owned.getOrStartViewer('overdeck');
+    await owned.stopAll();
+    expect(stopOwned).toHaveBeenCalledWith('/runtime/read-only-snapshot');
+
+    const stopReused = vi.fn(async () => {});
+    const reused = createKnowledgeViewerService({
+      resolveBundle: async () => '/repo/knowledge',
+      ensure: async () => ({ status: 'already-installed', command: 'ok' }),
+      start: async () => startResult(null),
+      stop: stopReused,
+      fetchImpl: vi.fn(async () => response(true)),
+    });
+    await reused.getOrStartViewer('overdeck');
+    await reused.stopAll();
+    expect(stopReused).not.toHaveBeenCalled();
+  });
+
+  it('caches a successful binary probe until explicitly invalidated', async () => {
+    const ensure = vi.fn(async () => ({ status: 'already-installed' as const, command: 'ok' as const }));
+    const service = createKnowledgeViewerService({
+      resolveBundle: async () => '/repo/knowledge',
+      ensure,
       fetchImpl: vi.fn(async () => response(true)),
     });
 
-    await service.getOrStartViewer('overdeck');
-    await service.stopAll();
+    await service.getStatus('overdeck');
+    await service.getStatus('overdeck');
+    expect(ensure).toHaveBeenCalledOnce();
 
-    expect(stop).toHaveBeenCalledOnce();
-    expect(stop).toHaveBeenCalledWith('/repo/knowledge');
-    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    service.invalidateInstallationCache();
+    await service.getStatus('overdeck');
+    expect(ensure).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports framing headers as an embed-blocked status', async () => {
+    const service = createKnowledgeViewerService({
+      resolveBundle: async () => '/repo/knowledge',
+      ensure: async () => ({ status: 'already-installed', command: 'ok' }),
+      start: async () => startResult(null),
+      fetchImpl: vi.fn(async () => response(true, { 'x-frame-options': 'SAMEORIGIN' })),
+    });
+
+    await expect(service.getOrStartViewer('overdeck')).resolves.toMatchObject({
+      running: true,
+      embeddable: false,
+    });
   });
 
   it('is registered in the dashboard graceful-shutdown path', async () => {

--- a/tests/unit/dashboard/server/services/knowledge-viewer.test.ts
+++ b/tests/unit/dashboard/server/services/knowledge-viewer.test.ts
@@ -1,0 +1,179 @@
+import { EventEmitter } from 'node:events';
+import type { ChildProcess } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createKnowledgeViewerService } from '../../../../../src/dashboard/server/services/knowledge-viewer.js';
+
+function response(ok: boolean): Response {
+  return { ok } as Response;
+}
+
+function fakeChild(): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  Object.defineProperty(child, 'exitCode', { value: null, writable: true });
+  child.kill = vi.fn(() => true);
+  return child;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('knowledge viewer service', () => {
+  it('spawns the viewer and returns its URL after the health check passes', async () => {
+    const child = fakeChild();
+    const health = [false, true];
+    const fetchImpl = vi.fn(async () => response(health.shift() ?? true));
+    const start = vi.fn(async () => ({
+      process: child,
+      port: 39847,
+      apiPort: 8789,
+      url: 'http://127.0.0.1:39847',
+    }));
+    const service = createKnowledgeViewerService({
+      resolveBundle: async () => '/repo/knowledge',
+      ensure: async () => ({ status: 'already-installed', command: 'ok' }),
+      start,
+      stop: async () => {},
+      fetchImpl,
+      retryDelayMs: 100,
+      maxHealthAttempts: 2,
+    });
+
+    const resultPromise = service.getOrStartViewer('overdeck');
+    await vi.advanceTimersByTimeAsync(100);
+    const result = await resultPromise;
+
+    expect(result).toEqual({
+      projectKey: 'overdeck',
+      bundleConfigured: true,
+      installed: true,
+      starting: false,
+      running: true,
+      bundlePath: '/repo/knowledge',
+      port: 39847,
+      apiPort: 8789,
+      url: 'http://127.0.0.1:39847',
+    });
+    expect(start).toHaveBeenCalledOnce();
+  });
+
+  it('reuses one healthy process for concurrent and subsequent starts', async () => {
+    const child = fakeChild();
+    const start = vi.fn(async () => ({
+      process: child,
+      port: 39847,
+      apiPort: 8789,
+      url: 'http://127.0.0.1:39847',
+    }));
+    const service = createKnowledgeViewerService({
+      resolveBundle: async () => '/repo/knowledge',
+      ensure: async () => ({ status: 'already-installed', command: 'ok' }),
+      start,
+      stop: async () => {},
+      fetchImpl: vi.fn(async () => response(true)),
+    });
+
+    const [first, concurrent] = await Promise.all([
+      service.getOrStartViewer('overdeck'),
+      service.getOrStartViewer('overdeck'),
+    ]);
+    const subsequent = await service.getOrStartViewer('overdeck');
+
+    expect(first.url).toBe('http://127.0.0.1:39847');
+    expect(concurrent.url).toBe(first.url);
+    expect(subsequent.url).toBe(first.url);
+    expect(start).toHaveBeenCalledOnce();
+  });
+
+  it('returns typed unavailable states for a missing bundle or binary', async () => {
+    const noBundle = createKnowledgeViewerService({
+      resolveBundle: async () => null,
+    });
+    const noBinary = createKnowledgeViewerService({
+      resolveBundle: async () => '/repo/knowledge',
+      ensure: async () => {
+        throw new Error('install with npm install -g @inkeep/open-knowledge');
+      },
+    });
+
+    await expect(noBundle.getOrStartViewer('overdeck')).resolves.toMatchObject({
+      bundleConfigured: false,
+      installed: false,
+      running: false,
+      message: expect.stringContaining('/okf init'),
+    });
+    await expect(noBinary.getOrStartViewer('overdeck')).resolves.toMatchObject({
+      bundleConfigured: true,
+      installed: false,
+      running: false,
+      message: expect.stringContaining('npm install -g'),
+    });
+  });
+
+  it('rejects a health timeout and stops the failed process', async () => {
+    const child = fakeChild();
+    const stop = vi.fn(async () => {});
+    const service = createKnowledgeViewerService({
+      resolveBundle: async () => '/repo/knowledge',
+      ensure: async () => ({ status: 'already-installed', command: 'ok' }),
+      start: async () => ({
+        process: child,
+        port: 39847,
+        apiPort: 8789,
+        url: 'http://127.0.0.1:39847',
+      }),
+      stop,
+      fetchImpl: vi.fn(async () => response(false)),
+      retryDelayMs: 100,
+      maxHealthAttempts: 2,
+    });
+
+    const resultPromise = service.getOrStartViewer('overdeck');
+    const rejection = expect(resultPromise).rejects.toThrow(
+      'open-knowledge viewer did not become healthy at http://127.0.0.1:39847',
+    );
+    await vi.advanceTimersByTimeAsync(100);
+    await rejection;
+
+    expect(stop).toHaveBeenCalledWith('/repo/knowledge');
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('stops all tracked viewers during shutdown', async () => {
+    const child = fakeChild();
+    const stop = vi.fn(async () => {});
+    const service = createKnowledgeViewerService({
+      resolveBundle: async () => '/repo/knowledge',
+      ensure: async () => ({ status: 'already-installed', command: 'ok' }),
+      start: async () => ({
+        process: child,
+        port: 39847,
+        apiPort: 8789,
+        url: 'http://127.0.0.1:39847',
+      }),
+      stop,
+      fetchImpl: vi.fn(async () => response(true)),
+    });
+
+    await service.getOrStartViewer('overdeck');
+    await service.stopAll();
+
+    expect(stop).toHaveBeenCalledOnce();
+    expect(stop).toHaveBeenCalledWith('/repo/knowledge');
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('is registered in the dashboard graceful-shutdown path', async () => {
+    const mainPath = fileURLToPath(new URL('../../../../../src/dashboard/server/main.ts', import.meta.url));
+    const source = await readFile(mainPath, 'utf8');
+
+    expect(source).toContain("import { stopAllKnowledgeViewers } from './services/knowledge-viewer.js';");
+    expect(source).toContain('await stopAllKnowledgeViewers().catch');
+  });
+});

--- a/tests/unit/lib/cloister/memory-governor.test.ts
+++ b/tests/unit/lib/cloister/memory-governor.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const readProcMemoryMock = vi.fn();
 const loadConfigSyncMock = vi.fn();
@@ -68,9 +68,23 @@ import {
   shed,
   type GovernorReserves,
 } from '../../../../src/lib/cloister/memory-governor.js';
-import { getResourceStacks, type ResourceStack, type StackContainerResource } from '../../../../src/dashboard/server/routes/resources/stacks.js';
+import {
+  getResourceStacks,
+  resetResourceStackReviewStatusReaderForTests,
+  setResourceStackReviewStatusReaderForTests,
+  type ResourceStack,
+  type StackContainerResource,
+} from '../../../../src/dashboard/server/routes/resources/stacks.js';
 
 const GIB = 1024 ** 3;
+
+beforeEach(() => {
+  setResourceStackReviewStatusReaderForTests(() => null);
+});
+
+afterEach(() => {
+  resetResourceStackReviewStatusReaderForTests();
+});
 
 describe('classifyMemoryPressure', () => {
   const thresholds = { warningBytes: 4 * GIB, criticalBytes: 2 * GIB };

--- a/tests/unit/lib/overdeck/no-loss-matrix.ts
+++ b/tests/unit/lib/overdeck/no-loss-matrix.ts
@@ -316,6 +316,11 @@ export const NO_LOSS_MATRIX: MatrixEntry[] = [
   { surface: 'POST /api/issues/:id/beads/:itemId/inspect',          kind: 'http', disposition: 'RELOCATE',    door: 'Agents (work.inspect)' },
   { surface: 'POST /api/issues/:id/generate-tasks',                 kind: 'http', disposition: 'WRITE',       door: 'IssueWriter.advance("working") fallback path' },
 
+  // ── knowledge-viewer.ts ───────────────────────────────────────────────────
+  { surface: 'GET /api/knowledge-viewer/status',                    kind: 'http', disposition: 'OUT_OF_SCOPE', door: 'Optional OpenKnowledge subprocess status; outside 8 remodel domains' },
+  { surface: 'POST /api/knowledge-viewer/install',                  kind: 'http', disposition: 'OUT_OF_SCOPE', door: 'Progressive third-party viewer installation; outside 8 remodel domains' },
+  { surface: 'POST /api/knowledge-viewer/start',                    kind: 'http', disposition: 'OUT_OF_SCOPE', door: 'Optional OpenKnowledge subprocess lifecycle; outside 8 remodel domains' },
+
   // ── metrics.ts ────────────────────────────────────────────────────────────
   { surface: 'GET /api/metrics/summary',                  kind: 'http', disposition: 'AGGREGATE',   door: 'Issues + Agents + Merge' },
   { surface: 'GET /api/metrics/costs',                    kind: 'http', disposition: 'READ',        door: 'CostResolver.summary("day")' },

--- a/tests/unit/lib/overdeck/no-loss-matrix.ts
+++ b/tests/unit/lib/overdeck/no-loss-matrix.ts
@@ -320,6 +320,7 @@ export const NO_LOSS_MATRIX: MatrixEntry[] = [
   { surface: 'GET /api/knowledge-viewer/status',                    kind: 'http', disposition: 'OUT_OF_SCOPE', door: 'Optional OpenKnowledge subprocess status; outside 8 remodel domains' },
   { surface: 'POST /api/knowledge-viewer/install',                  kind: 'http', disposition: 'OUT_OF_SCOPE', door: 'Progressive third-party viewer installation; outside 8 remodel domains' },
   { surface: 'POST /api/knowledge-viewer/start',                    kind: 'http', disposition: 'OUT_OF_SCOPE', door: 'Optional OpenKnowledge subprocess lifecycle; outside 8 remodel domains' },
+  { surface: 'GET /knowledge-viewer/*',                              kind: 'http', disposition: 'OUT_OF_SCOPE', door: 'Authenticated compatibility redirect to the origin-isolated viewer host' },
 
   // ── metrics.ts ────────────────────────────────────────────────────────────
   { surface: 'GET /api/metrics/summary',                  kind: 'http', disposition: 'AGGREGATE',   door: 'Issues + Agents + Merge' },


### PR DESCRIPTION
**Issue:** #2066

## Acceptance Criteria

- [ ] Round-trip verification spike: does open-knowledge preserve frontmatter losslessly?
- [ ] ensureOpenKnowledge() progressive installer with Node-24 diagnosis
- [ ] pan knowledge open subcommand (+ wrapper skill, + pan install pointer)
- [ ] /okf open verb documentation in the okf skill
- [ ] Dashboard viewer lifecycle service (spawn / health / reuse / shutdown kill)
- [ ] Knowledge-viewer API routes + same-origin reverse proxy (HTTP + WS)
- [ ] Knowledge tab + page with no-bundle / not-installed / starting states
- [ ] Embedded viewer iframe + embed-blocked fallback + Playwright self-verification
- [ ] MCP wiring documentation (ok init, opt-in)
- [ ] User-facing docs: knowledge.mdx, OKF-LANDSCAPE, CLAUDE.md, acknowledgements
- [ ] Close-out bookkeeping: FR-mapping comment + successor issue for deferred #3/#5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Knowledge** page to the dashboard for viewing project knowledge bundles.
  * Introduced **`pan knowledge open`** and **`/okf open`** to install (on first use), start, and open a **read-only** local viewer.
  * Implemented viewer status tracking, embed attempt with **fallback to an external “Open viewer” link** when framing is blocked.
* **Documentation**
  * Added “Project Knowledge” guidance, expanded OKF command/workflow instructions, and clarified licensing/MCP registration boundaries.
* **Bug Fixes**
  * Improved user-facing behavior when bundles are missing or the viewer is unavailable, including clearer `/okf init` guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->