### PR TITLE
fix(dashboard): align issue-view inventory with drawer refactor rename — un-red main (PAN-2943)

### DIFF
--- a/src/dashboard/frontend/src/components/issue-view/inventory.ts
+++ b/src/dashboard/frontend/src/components/issue-view/inventory.ts
@@ -37,7 +37,7 @@ export const ISSUE_VIEW_INVENTORY: readonly IssueViewInventoryEntry[] = [
   { section: 'DrawerActiveAgent', view: 'console', home: 'src/dashboard/frontend/src/components/issue-view/ActiveAgentPanel.tsx' },
   { section: 'DrawerPausedBanner', view: 'console', home: 'src/dashboard/frontend/src/components/drawer/IssueDrawer.tsx' },
   { section: 'DrawerVerificationGates', view: 'console', home: 'src/dashboard/frontend/src/components/issue-view/VerificationGates.tsx' },
-  { section: 'SpecialistStrip', view: 'console', home: 'src/dashboard/frontend/src/components/issue-detail/SpecialistStrip.tsx' },
+  { section: 'DrawerReviewSpecialists', view: 'console', home: 'src/dashboard/frontend/src/components/issue-detail/SpecialistStrip.tsx' },
   { section: 'DrawerTasksList', view: 'console', home: 'src/dashboard/frontend/src/components/TasksPanel.tsx' },
   { section: 'DrawerPlanPanel / XBriefViewer', view: 'console', home: 'src/dashboard/frontend/src/components/xbrief/XBriefViewer.tsx' },
   { section: 'DrawerArtifactsPanel', view: 'console', home: 'src/dashboard/frontend/src/components/drawer/DrawerArtifactsPanel.tsx' },


### PR DESCRIPTION
0dfc7eae24's conversation-first drawer renamed the SpecialistStrip data-section to DrawerReviewSpecialists but left the issue-view no-loss inventory unchanged — the audit gate failed main exactly as designed. One-line inventory alignment. 5th same-day occurrence of the PAN-2940 direct-push pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGKWkic5rTSFHv3545Sn1b