### PR TITLE
fix(test): align review-reset session expectation with agent-id call shape (PAN-2951)

### DIFF
--- a/tests/cli/commands/review-reset.test.ts
+++ b/tests/cli/commands/review-reset.test.ts
@@ -45,7 +45,7 @@ describe('resetReviewCommand (pan review reset)', () => {
       expect.stringContaining('/api/review/PAN-2/reset'),
       expect.objectContaining({ method: 'POST' }),
     );
-    expect(resetSessionMock).toHaveBeenCalledWith('PAN-2');
+    expect(resetSessionMock).toHaveBeenCalledWith('agent-pan-2-review');
   });
 
   it('session: false behaves like default', async () => {


### PR DESCRIPTION
The overnight series changed resetSession to receive the review agent id (agent-pan-2-review) instead of the bare issue id; the test's mock expectation still asserted 'PAN-2'. One-line alignment — un-reds main. 5th PAN-2940 occurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGKWkic5rTSFHv3545Sn1b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated review reset behavior to use the correct session identifier when resetting a review session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->