### PR TITLE
fix(dashboard): re-home Pipeline Band audit marker to IssueDetailShell — un-red main (PAN-2969)

### DIFF
--- a/src/dashboard/frontend/src/components/issue-detail/IssueDetailShell.tsx
+++ b/src/dashboard/frontend/src/components/issue-detail/IssueDetailShell.tsx
@@ -76,7 +76,7 @@ export function IssueDetailShell({
   });
 
   return (
-    <div data-component="issue-detail-shell" className={className}>
+    <div data-component="issue-detail-shell" data-section="Pipeline Band" className={className}>
       <IssuePhaseRail
         issueId={issueId ?? undefined}
         activePhase={activePhase}

--- a/src/dashboard/frontend/src/components/issue-view/inventory.ts
+++ b/src/dashboard/frontend/src/components/issue-view/inventory.ts
@@ -56,7 +56,7 @@ export const ISSUE_VIEW_INVENTORY: readonly IssueViewInventoryEntry[] = [
   },
   { section: 'Stale-review warning', view: 'cockpit', home: 'src/dashboard/frontend/src/components/Stage/cockpit/IssueTreeLane.tsx' },
   { section: 'StatusNarrative', view: 'cockpit', home: 'src/dashboard/frontend/src/components/Stage/cockpit/StatusNarrative.tsx' },
-  { section: 'Pipeline Band', view: 'cockpit', home: 'src/dashboard/frontend/src/components/Stage/cockpit/IssueMissionControl.tsx' },
+  { section: 'Pipeline Band', view: 'cockpit', home: 'src/dashboard/frontend/src/components/issue-detail/IssueDetailShell.tsx' },
   { section: 'AgentsLane', view: 'cockpit', home: 'src/dashboard/frontend/src/components/Stage/cockpit/AgentsLane.tsx' },
   { section: 'SessionPanel', view: 'cockpit', home: 'src/dashboard/frontend/src/components/CommandDeck/SessionView/SessionPanel.tsx' },
   { section: 'StackDrawer', view: 'cockpit', home: 'src/dashboard/frontend/src/components/Stage/cockpit/AgentsLane.tsx' },

--- a/tests/unit/dashboard/frontend/issue-view-no-loss.test.ts
+++ b/tests/unit/dashboard/frontend/issue-view-no-loss.test.ts
@@ -79,7 +79,14 @@ function findHiddenCockpitSectionRules(
   });
 }
 
-const COCKPIT_SOURCE_TAGS = collectFiles(COCKPIT_COMPONENTS_ROOT, '.tsx')
+const COCKPIT_SOURCE_FILES = [...new Set([
+  ...collectFiles(COCKPIT_COMPONENTS_ROOT, '.tsx'),
+  ...ISSUE_VIEW_INVENTORY
+    .filter((entry) => entry.view === 'cockpit' && entry.home.endsWith('.tsx'))
+    .map((entry) => path.resolve(REPO_ROOT, entry.home)),
+])];
+
+const COCKPIT_SOURCE_TAGS = COCKPIT_SOURCE_FILES
   .filter((file) => !file.endsWith('.test.tsx'))
   .flatMap((file) => parseCockpitSectionTags(
     readFileSync(file, 'utf8'),


### PR DESCRIPTION
#2962 cockpit refactor consolidated the Pipeline Band section into IssueDetailShell but left its data-section marker behind + the no-loss inventory pointing at the old IssueMissionControl home. Fix re-homes the data-section marker to IssueDetailShell and updates the inventory — affordance preserved, no-loss audit green. 7th #2908/#2962 direct-push red-main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGKWkic5rTSFHv3545Sn1b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Pipeline Band section mapping so it is associated with the appropriate issue detail view.
  * Improved consistency in how Pipeline Band sections are identified across the issue cockpit.
* **Tests**
  * Expanded coverage to include all relevant cockpit views, helping prevent missing or incorrectly mapped sections in future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->