### PR TITLE
PAN-2987

### DIFF
--- a/src/lib/webhook-handlers.ts
+++ b/src/lib/webhook-handlers.ts
@@ -3,6 +3,7 @@
  *
  * Dispatches verified webhook events to per-type handlers that update
  * review_status blockerReasons based on GitHub-native merge blockers.
+ * Advisory checks such as CodeRabbit are excluded because they must never gate merges.
  */
 
 import { Effect } from 'effect';
@@ -191,6 +192,14 @@ const KNOWN_NOT_MERGEABLE_STATES = new Set(['blocked', 'behind']);
 /** `gh` statusCheckRollup conclusions/states that count as a failing required check. */
 export const FAILING_CHECK_CONCLUSIONS = new Set(['FAILURE', 'ERROR', 'TIMED_OUT', 'CANCELLED', 'ACTION_REQUIRED', 'STARTUP_FAILURE', 'STALE']);
 
+/** Lowercase check-name prefixes that provide advisory context but never gate merges. */
+export const ADVISORY_CHECK_NAMES = new Set(['coderabbit']);
+
+function isAdvisoryCheckName(name: string | null | undefined): boolean {
+  const normalized = name?.trim().toLowerCase().replace(/[^a-z0-9]/g, '');
+  return normalized != null && [...ADVISORY_CHECK_NAMES].some((advisory) => normalized.startsWith(advisory));
+}
+
 const pendingReconciliation = new Set<string>();
 const reconciliationTimeouts = new Map<string, NodeJS.Timeout>();
 
@@ -264,13 +273,19 @@ export async function refreshMergeStateFromGitHub(issueId: string, repo: string,
         mergeable?: string | null;
         mergeStateStatus?: string | null;
         isDraft?: boolean;
-        statusCheckRollup?: Array<{ conclusion?: string | null; state?: string | null }>;
+        statusCheckRollup?: Array<{
+          name?: string | null;
+          context?: string | null;
+          conclusion?: string | null;
+          state?: string | null;
+        }>;
       };
       mergeable = (pr.mergeable ?? '').toUpperCase();
       mergeState = (pr.mergeStateStatus ?? '').toUpperCase();
       isDraft = pr.isDraft === true;
-      checksFailed = (pr.statusCheckRollup ?? []).some((c) =>
-        FAILING_CHECK_CONCLUSIONS.has((c.conclusion || c.state || '').toUpperCase()),
+      checksFailed = (pr.statusCheckRollup ?? []).some((check) =>
+        !isAdvisoryCheckName(check.name ?? check.context)
+        && FAILING_CHECK_CONCLUSIONS.has((check.conclusion || check.state || '').toUpperCase()),
       );
     }
 
@@ -355,12 +370,14 @@ export async function refreshMergeStateFromGitHub(issueId: string, repo: string,
 
   const repo = payload.repository!.full_name;
   const sourceKey = `check_run:${run.name ?? String(run.id ?? 'unknown')}`;
+  const isAdvisory = isAdvisoryCheckName(run.name);
 
   for (const pr of run.pull_requests) {
     const issueId = issueIdFromBranch(pr.head.ref);
     if (!issueId) continue;
 
     bumpIssuePrTabCacheGeneration(issueId);
+    if (isAdvisory) continue;
 
     const status = await loadAndValidateStatus(issueId, repo, pr.number, pr.head.sha);
     if (!status) continue;
@@ -626,11 +643,13 @@ async function handlePullRequestReviewThreadPromise(payload: WebhookPayload): Pr
   const repo = payload.repository!.full_name;
   const context = payload.context ?? 'default';
   const sourceKey = `status:${context}`;
+  const isAdvisory = isAdvisoryCheckName(context);
 
   for (const branch of branches) {
     const issueId = issueIdFromBranch(branch.name);
     if (issueId) {
       bumpIssuePrTabCacheGeneration(issueId);
+      if (isAdvisory) continue;
 
       const status = await loadAndValidateStatus(issueId, repo, undefined, payload.sha);
       if (!status) continue;

--- a/tests/unit/lib/webhook-handlers.test.ts
+++ b/tests/unit/lib/webhook-handlers.test.ts
@@ -244,6 +244,21 @@ describe('handleCheckRun', () => {
     }));
   });
 
+  it('ignores advisory CodeRabbit check run failures', async () => {
+    mockGetReviewStatus.mockReturnValue({ blockerReasons: [] });
+
+    await Effect.runPromise(handleCheckRun(makePayload({
+      check_run: {
+        name: 'CodeRabbitAI',
+        status: 'completed',
+        conclusion: 'failure',
+        pull_requests: [{ number: 1, head: { ref: 'feature/pan-123' } }],
+      },
+    })));
+
+    expect(mockSetReviewStatus).not.toHaveBeenCalled();
+  });
+
   it('processes all PRs in check_run, not just the first', async () => {
     mockGetReviewStatus.mockReturnValue({ blockerReasons: [] });
 
@@ -798,6 +813,18 @@ describe('handlePullRequestReviewThread', () => {
 });
 
 describe('handleStatus', () => {
+  it('ignores advisory CodeRabbit status failures', async () => {
+    mockGetReviewStatus.mockReturnValue({ blockerReasons: [] });
+
+    await Effect.runPromise(handleStatus(makePayload({
+      context: 'CodeRabbit',
+      state: 'failure',
+      branches: [{ name: 'feature/pan-333' }],
+    })));
+
+    expect(mockSetReviewStatus).not.toHaveBeenCalled();
+  });
+
   it('adds failing_checks blocker on status failure', async () => {
     mockGetReviewStatus.mockReturnValue({ blockerReasons: [] });
 
@@ -1024,14 +1051,17 @@ describe('refreshMergeStateFromGitHub (PAN-2265)', () => {
     }));
   });
 
-  it('falls back to gh pr view when the App is not configured', async () => {
+  it('ignores advisory CodeRabbit failures in the gh status rollup', async () => {
     mockIsGitHubAppConfigured.mockReturnValue(false);
     mockGetReviewStatus.mockReturnValue({ blockerReasons: [] });
     ghPrViewStdout = JSON.stringify({
-      mergeable: 'CONFLICTING',
-      mergeStateStatus: 'DIRTY',
+      mergeable: 'MERGEABLE',
+      mergeStateStatus: 'UNSTABLE',
       isDraft: false,
-      statusCheckRollup: [{ conclusion: 'FAILURE' }],
+      statusCheckRollup: [
+        { name: 'test', conclusion: 'SUCCESS' },
+        { context: 'CodeRabbit', state: 'FAILURE' },
+      ],
     });
     mockExecFile.mockImplementation((...args: unknown[]) => {
       const cb = args[args.length - 1] as (err: unknown, res: { stdout: string; stderr: string }) => void;
@@ -1040,12 +1070,57 @@ describe('refreshMergeStateFromGitHub (PAN-2265)', () => {
 
     await refreshMergeStateFromGitHub('PAN-4', 'test-owner/test-repo', 42);
 
+    expect(mockSetReviewStatus).not.toHaveBeenCalled();
+  });
+
+  it('keeps real check failures blocking when CodeRabbit also fails', async () => {
+    mockIsGitHubAppConfigured.mockReturnValue(false);
+    mockGetReviewStatus.mockReturnValue({ blockerReasons: [] });
+    ghPrViewStdout = JSON.stringify({
+      mergeable: 'MERGEABLE',
+      mergeStateStatus: 'UNSTABLE',
+      isDraft: false,
+      statusCheckRollup: [
+        { name: 'test', conclusion: 'FAILURE' },
+        { context: 'CodeRabbit', state: 'FAILURE' },
+      ],
+    });
+    mockExecFile.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (err: unknown, res: { stdout: string; stderr: string }) => void;
+      cb(null, { stdout: ghPrViewStdout, stderr: '' });
+    });
+
+    await refreshMergeStateFromGitHub('PAN-5', 'test-owner/test-repo', 42);
+
+    expect(mockSetReviewStatus).toHaveBeenCalledWith('PAN-5', expect.objectContaining({
+      blockerReasons: expect.arrayContaining([
+        expect.objectContaining({ type: 'failing_checks' }),
+      ]),
+    }));
+  });
+
+  it('falls back to gh pr view when the App is not configured', async () => {
+    mockIsGitHubAppConfigured.mockReturnValue(false);
+    mockGetReviewStatus.mockReturnValue({ blockerReasons: [] });
+    ghPrViewStdout = JSON.stringify({
+      mergeable: 'CONFLICTING',
+      mergeStateStatus: 'DIRTY',
+      isDraft: false,
+      statusCheckRollup: [{ name: 'test', conclusion: 'FAILURE' }],
+    });
+    mockExecFile.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (err: unknown, res: { stdout: string; stderr: string }) => void;
+      cb(null, { stdout: ghPrViewStdout, stderr: '' });
+    });
+
+    await refreshMergeStateFromGitHub('PAN-6', 'test-owner/test-repo', 42);
+
     expect(mockGetPullRequestState).not.toHaveBeenCalled();
     expect(mockExecFile).toHaveBeenCalled();
     const [cmd, ghArgs] = mockExecFile.mock.calls[0] as [string, string[]];
     expect(cmd).toBe('gh');
     expect(ghArgs).toContain('view');
-    expect(mockSetReviewStatus).toHaveBeenCalledWith('PAN-4', expect.objectContaining({
+    expect(mockSetReviewStatus).toHaveBeenCalledWith('PAN-6', expect.objectContaining({
       blockerReasons: expect.arrayContaining([
         expect.objectContaining({ type: 'merge_conflict' }),
         expect.objectContaining({ type: 'failing_checks' }),


### PR DESCRIPTION
**Issue:** #2987


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Advisory CodeRabbit checks no longer block merge readiness when they fail.
  * Advisory failures are excluded from recorded failing-check blockers across webhook and status updates.
  * Genuine required-check failures continue to block merges as expected.

* **Tests**
  * Added coverage for advisory-only failures and scenarios combining advisory and required-check failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->