### PR TITLE
fix(workspace): narrow catch to unknown in stack-health.ts — clears red-main lint (PAN-2999)

### DIFF
--- a/src/lib/workspace/stack-health.ts
+++ b/src/lib/workspace/stack-health.ts
@@ -49,8 +49,8 @@ export function composeProjectNameForWorkspace(workspacePath: string, issueId: s
         );
       }
       return declared;
-    } catch (err: any) {
-      if (err?.message?.startsWith('Refusing workspace rebuild:')) throw err;
+    } catch (err: unknown) {
+      if (err instanceof Error && err.message.startsWith('Refusing workspace rebuild:')) throw err;
     }
   }
   return fallback;


### PR DESCRIPTION
Closes PAN-2999. Red-main fix: `catch (err: any)` → `catch (err: unknown)` with `err instanceof Error` narrowing at stack-health.ts:52 (introduced by #2908). Clears the `@typescript-eslint/no-explicit-any` lint failure blocking all merges. Behavior identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)