### PR TITLE
PAN-2997

### DIFF
--- a/docs/CODEX-AUTH.md
+++ b/docs/CODEX-AUTH.md
@@ -234,3 +234,4 @@ This means the refresh token was consumed elsewhere. The detection system will r
 - [CONFIGURATION.md](./CONFIGURATION.md) — General provider and API key configuration
 - [TESTING-PROVIDERS.md](./TESTING-PROVIDERS.md) — Provider connectivity testing
 - [MODEL_ROUTING.md](./MODEL_ROUTING.md) — How work types map to providers
+- [LINEAR-MCP-AUTH.md](./LINEAR-MCP-AUTH.md) — The same top-banner intervention for Linear MCP OAuth, plus automatic wake of blocked agents after re-auth

--- a/docs/LINEAR-MCP-AUTH.md
+++ b/docs/LINEAR-MCP-AUTH.md
@@ -200,11 +200,18 @@ has not yet been notified:
     one server-executed command list. The pre-branch liveness check is NOT
     treated as proof of acceptance: the pane can die in the shell-to-branch
     handoff, and tmux reports `send-keys` into a remain-on-exit corpse as
-    success. So after the command, the target is re-read — if the pane died
-    or its pid changed around the Enter, the terminal marker is ROLLED BACK,
-    the pending claim restored, and `KeyedSubmitTargetDeadError` is thrown.
-    The outbox entry stays `pending` and a later pass re-drives the wake
-    after the agent resumes — recovery never suppresses a wake that did not
+    success. So after the command, the target is re-read — and the key may
+    only become terminal when BOTH target reads succeeded, BOTH report a live
+    pane, and the pid identity matches (an unreadable pre-target fails
+    CLOSED: the pane could have been replaced without its pasted content).
+    If the target was lost around the Enter, the terminal marker is ROLLED
+    BACK as a verified transition: a POISON breadcrumb is written first (so a
+    failed rollback can never leave a false terminal honorable), the rollback
+    runs and is verified, and `KeyedSubmitTargetDeadError` is thrown. A later
+    keyed call that finds the breadcrumb repairs the markers before anything
+    else — it never returns `deduplicated` from a poisoned terminal. The
+    outbox entry stays `pending` and a later pass re-drives the wake after
+    the agent resumes — recovery never suppresses a wake that did not
     demonstrably reach a live harness. A failed Enter aborts the command
     list before the terminal transition, and concurrent or post-crash
     callers lose the server-side condition, so no stray Enter can land in a

--- a/docs/LINEAR-MCP-AUTH.md
+++ b/docs/LINEAR-MCP-AUTH.md
@@ -163,18 +163,44 @@ has not yet been notified:
   before sending and records the acknowledgment — with the real outcome
   (`delivered`, `queued`, or `failed`) — as part of its own protocol on every
   path, so every acknowledged send has a receipt.
+- **The side effect itself is deduplicated by key at the delivery door.** The
+  outbox makes an *incomplete* first delivery replayable, but it cannot help
+  a *completed* delivery whose ack was lost to a dashboard crash — that is
+  why the wake key (`linear-mcp-auth-wake:<lifecycleId>`) is also threaded
+  through `messageAgentWithOutcome` into `deliverAgentMessage`, where the
+  crash-independent components deduplicate the injection itself:
+  - **PTY supervisor** keeps a per-server set of delivered keys. Its own exit
+    kills the agent with it (H1 lifecycle), so an in-memory set is exactly as
+    durable as the side effect it guards: a replay after a dashboard crash
+    hits the surviving supervisor and gets `{ deduplicated: true }` instead
+    of a second PTY write; a replay after the agent itself died is a
+    legitimate first delivery to the resumed session. A
+    `record-delivered` operation lets paths that bypass the supervisor
+    (resume kickoff prompts) still register the key.
+  - **tmux fallback** marks a per-session user option in the same
+    server-side `if-shell` command that pastes (`sendKeysDedup`), so the
+    check, paste, and mark are one atomic step the tmux server executes —
+    a dashboard exit cannot interrupt it. A deduplicated replay sends no
+    stray Enter, because the composer may hold unrelated operator text.
+  - **Keyed mail backups** use a deterministic filename, so a replayed send
+    overwrites the same durable backup instead of stacking a second copy.
+  - Channels, codex app-server, and ACP tiers receive the key as advisory
+    metadata only; they are unreachable for this feature because the
+    detection hook is Claude-Code-only.
 - **Recovery semantics.** An agent stays in the wake set until a completion
   DomainEvent lands. When a pass finds no completion, it reads the keyed
   entry (one exact-path async read — no directory scans, no content or
   timestamp matching): `acknowledged` suppresses the replay and the pass only
   retries the completion record, replaying the recorded outcome faithfully
   (`queued` is never upgraded to `delivered`); `pending` or missing means the
-  send was never acknowledged, so it is (re)driven. The result is exactly one
-  acknowledged delivery per agent per lifecycle across every crash window:
-  crash before the entry → driven once; crash after a send whose ack never
-  landed → replayed once (correct — unacknowledged); crash after the ack →
-  never replayed. Lifecycle B's entry is independent of lifecycle A's, so an
-  identical wake message in an adjacent lifecycle is never suppressed.
+  send was never acknowledged, so it is (re)driven — and when the original
+  send had in fact completed before the crash, the door-level dedup makes
+  that replay a no-op for the agent. The result is exactly one visible
+  delivery per agent per lifecycle across every crash window: crash before
+  the entry → driven once; crash after a send whose ack never landed →
+  replayed, but deduplicated at the door; crash after the ack → never
+  replayed. Lifecycle B's entry and key are independent of lifecycle A's, so
+  an identical wake message in an adjacent lifecycle is never suppressed.
 - **Drain-until-stable.** The wake pass loops: after waking one completed
   lifecycle it re-reads the fold, so a lifecycle that completed while
   deliveries were in flight gets its own wake round inside the same coalesced

--- a/docs/LINEAR-MCP-AUTH.md
+++ b/docs/LINEAR-MCP-AUTH.md
@@ -214,17 +214,20 @@ has not yet been notified:
     the real content into the replacement pane rather than completing with a
     blank Enter. If the target was lost around the Enter, the terminal
     marker is ROLLED BACK as a verified transition and
-    `KeyedSubmitTargetDeadError` is thrown. Poison reads and every
-    verification read (repair, rollback, post-clear) are strict: a failed
-    read aborts as `KeyedMarkerVerificationError` with the breadcrumb
+    `KeyedSubmitTargetDeadError` is thrown. Every safety-critical read —
+    the initial poison read, repair and rollback verification, and the
+    post-clear verification — is strict: a rejected read aborts as
+    `KeyedMarkerVerificationError` (cause preserved) with the breadcrumb
     authoritative, never converted to empty state. Every poison-clear failure
     — the clear command, the post-clear verification read, or a surviving
-    breadcrumb — is the same recoverable class, so a repair that stops
-    before any delivery is never recorded as terminal `failed`. The outbox
-    entry stays `pending` on every recoverable failure and a later pass
-    re-drives the wake after the agent resumes — recovery never suppresses a
-    wake that did not demonstrably reach a live harness holding the real
-    content. A failed Enter aborts the command
+    breadcrumb — is the same recoverable class, so a transient failure
+    before any side effect or a repair that stops mid-way is never recorded
+    as terminal `failed`. (A genuinely missing target is classified upstream
+    at the messageAgent stopped/zombie layer, which resumes and re-delivers.)
+    The outbox entry stays `pending` on every recoverable failure and a later
+    pass re-drives the wake after the agent resumes — recovery never
+    suppresses a wake that did not demonstrably reach a live harness holding
+    the real content. A failed Enter aborts the command
     list before the terminal transition, and concurrent or post-crash
     callers lose the server-side condition, so no stray Enter can land in a
     composer holding unrelated operator text.

--- a/docs/LINEAR-MCP-AUTH.md
+++ b/docs/LINEAR-MCP-AUTH.md
@@ -1,0 +1,144 @@
+# Linear MCP Auth Intervention (PAN-2997)
+
+When an agent's Linear MCP OAuth session is missing or expired, the agent can
+only print an authorization URL into its own transcript and block — easy to
+miss. Overdeck surfaces that state as **one global dashboard intervention**: a
+top banner listing every blocked agent, the OAuth action, and two completion
+paths, followed by an automatic wake of each blocked agent once authentication
+is healthy again.
+
+Related: [CODEX-AUTH.md](./CODEX-AUTH.md) — the same top-banner treatment for
+GPT/Codex OAuth failures.
+
+## Detection: the hook contract
+
+`sync-sources/hooks/linear-mcp-auth-hook` is a Claude Code **PostToolUse** hook
+registered with matcher `mcp__linear__.*` (see `HOOK_SCRIPT_NAMES` and
+`OVERDECK_HOOK_REGISTRATIONS` in `src/lib/claude-hooks-registration.ts`). It
+never breaks Claude Code — every failure mode exits 0 silently.
+
+The hook emits heartbeat events via `pan_emit_event` (see
+`sync-sources/hooks/pan-hook-lib.sh`). Its emitted `kind` strings are a
+load-bearing contract with the ingestion layer — a copy-edit that renames them
+silently breaks detection:
+
+- `linear_mcp_auth_required` — emitted when:
+  - `mcp__linear__authenticate` returns; the first
+    `https://linear.app/oauth/authorize…` URL in the tool response is extracted
+    into `authUrl` (`null` when extraction fails); or
+  - any `mcp__linear__*` tool response matches an auth-error pattern
+    (`requires authentication|not authenticated|unauthorized|401`), with
+    `authUrl: null`.
+  - Each required emission touches the marker file
+    `${OVERDECK_HOME}/agents/<agentId>/linear-mcp-auth-pending`.
+- `linear_mcp_auth_healthy` — emitted only when a `mcp__linear__*` response is
+  clean **and** the marker file exists; the marker is deleted on emit. A clean
+  response with no marker emits nothing (no event spam on healthy agents).
+
+The server-side ingestion (`bodyToEvent`, linear-mcp-heartbeat-ingestion) maps
+these heartbeat kinds onto the domain events below, enriching each with the
+agent's `issueId`.
+
+## Domain events and payloads
+
+Canonical definitions live in `src/lib/linear-mcp-auth.ts`
+(`LinearMcpAuthEventInput`). Four event types:
+
+| Type | Payload | Emitted by |
+| --- | --- | --- |
+| `linear_mcp_auth.required` | `{ agentId, issueId, authUrl, expiresAt }` | Hook heartbeat ingestion |
+| `linear_mcp_auth.healthy` | `{ agentId, issueId, source: 'hook' \| 'operator' }` | Hook heartbeat ingestion, or the operator via `POST /api/linear-mcp-auth/complete` |
+| `linear_mcp_auth.notified` | `{ agentId, issueId, outcome: 'delivered' \| 'queued' \| 'failed' }` | The wake pass, after messaging a blocked agent |
+| `linear_mcp_auth.callback_relayed` | `{ agentId, issueId }` | `POST /api/linear-mcp-auth/callback`, after relaying a callback URL |
+
+## Lifecycle fold semantics
+
+`foldLinearMcpAuthEvents` in `src/lib/linear-mcp-auth.ts` reduces the event log
+into one **open lifecycle** plus the last completed one:
+
+- **One open lifecycle.** The first `required` event opens it; every later
+  `required` dedups into it — agents are keyed by `agentId`, so repeated auth
+  failures from the same agent update its row instead of minting a new OAuth
+  request, and additional agents join the same intervention.
+- **authUrl ownership.** The most recent `required` event carrying a non-null
+  `authUrl` owns the intervention's authorization URL (`authUrlAgentId`). The
+  URL is the agent-generated OAuth link the operator opens.
+- **Expiry TTL.** URLs expire after `LINEAR_MCP_AUTH_URL_TTL_MS` (30 minutes)
+  from declaration unless the event carries its own `expiresAt`. The
+  projection reports `status: 'expired'` once the TTL passes; the link
+  refreshes automatically the next time a blocked agent emits a fresh
+  `required` with a new URL.
+- **Close.** Any `linear_mcp_auth.healthy` event closes the open lifecycle
+  (it becomes `lastCompleted`, and the projection returns to `status:
+  'none'`). `notified` events stamp `notifiedAt` on the agent row in whichever
+  lifecycle is current; `callback_relayed` is record-keeping only.
+- **Projection.** `resolveLinearMcpAuthIntervention()` serves `GET
+  /api/linear-mcp-auth` with `{ status, authUrl, authUrlAgentId,
+  authUrlExpiresAt, declaredAt, blockedAgents[] }`. Because the fold reads the
+  durable event store, banner state survives dashboard restarts.
+
+## Banner states
+
+`src/dashboard/frontend/src/components/LinearMcpAuthBanner.tsx` (mounted in
+`AppChrome.tsx` under `CodexAuthBanner`; polling hook
+`src/dashboard/frontend/src/hooks/useLinearMcpAuthStatus.ts` — 5s while an
+intervention is active, 30s when idle):
+
+- **none** — banner hidden.
+- **active with authUrl** — "Linear authentication required" header, the
+  blocked-agent list with issue links, and an "Open Linear authorization"
+  anchor naming the owning agent.
+- **active without authUrl** — waiting-for-URL copy: no blocked agent has
+  produced an authorization URL yet.
+- **expired** — copy stating the link expired and refreshes automatically when
+  a blocked agent generates a fresh one.
+
+## Operator completion flows
+
+Two ways to resolve the intervention from the banner:
+
+1. **Callback relay.** The operator opens the authorization URL, approves in
+   the browser, and Linear redirects to a localhost callback URL. On a remote
+   session the callback page fails to load — the operator copies the URL from
+   the address bar into the banner's callback field, which POSTs it to
+   `/api/linear-mcp-auth/callback`. The server validates it (localhost URL
+   with `code` and `state` parameters), then messages the URL-owning agent
+   with the exact `mcp__linear__complete_authentication` call to make, and
+   appends a `callback_relayed` event.
+2. **Mark completed.** If the operator authorized another way (e.g. `claude
+   mcp login linear`), the banner's "Mark completed" button POSTs to
+   `/api/linear-mcp-auth/complete`, which appends a `healthy` event with
+   `source: 'operator'`, closing the lifecycle. Blocked agents are woken to
+   re-check; the banner returns if authentication is still broken.
+
+## Wake semantics
+
+When a lifecycle closes, `processLinearMcpAuthWake()` (coalesced, one global
+run at a time) messages every blocked agent in the completed lifecycle that
+has not yet been notified:
+
+- Delivery goes through the sanctioned delivery door (`messageAgentWithOutcome`
+  in `src/lib/agents/messaging.ts`) — never raw tmux keystrokes.
+- The message (`LINEAR_MCP_AUTH_WAKE_COPY`) tells the agent to re-check Linear
+  access with one lightweight read and resume its canonical task, and not to
+  retry in a loop if it still fails.
+- Each attempt is recorded as a `linear_mcp_auth.notified` event with outcome
+  `delivered`, `queued`, or `failed`, so an agent is woken at most once per
+  lifecycle.
+- **Boot recovery:** the Cloister service runs the wake pass on startup
+  (`src/lib/cloister/service.ts`) and on every `linear_mcp_auth.healthy`
+  domain event (`src/lib/cloister/service-reactive.ts`), so an agent that was
+  stopped when auth completed — or a dashboard that restarted mid-flow — still
+  gets its wake on the next pass.
+
+## Tests
+
+- `tests/scripts/linear-mcp-auth-hook.test.ts` — hook contract: URL
+  extraction, auth-error → required, marker-deduped healthy, silent exit on
+  garbage.
+- `src/lib/__tests__/linear-mcp-auth*.test.ts` — fold, projection, wake set,
+  and wake outcomes.
+- `src/dashboard/server/routes/__tests__/linear-mcp-auth.test.ts` — the three
+  routes, callback validation, origin checks.
+- `src/dashboard/frontend/src/components/LinearMcpAuthBanner.test.tsx` —
+  banner states and both completion flows.

--- a/docs/LINEAR-MCP-AUTH.md
+++ b/docs/LINEAR-MCP-AUTH.md
@@ -196,21 +196,25 @@ has not yet been notified:
     PENDING marker are one atomic server-side `if-shell` step, and the
     submission itself is a second single `if-shell` — only when PENDING is
     present, TERMINAL is absent, AND the pane is alive does the server send
-    the Enter and then flip TERMINAL and clear PENDING, in that order, inside
-    one server-executed command list. The pre-branch liveness check is NOT
-    treated as proof of acceptance: the pane can die in the shell-to-branch
-    handoff, and tmux reports `send-keys` into a remain-on-exit corpse as
-    success. So after the command, the target is re-read — and the key may
-    only become terminal when BOTH target reads succeeded, BOTH report a live
-    pane, and the pid identity matches (an unreadable pre-target fails
-    CLOSED: the pane could have been replaced without its pasted content).
-    If the target was lost around the Enter, the terminal marker is ROLLED
-    BACK as a verified transition: a POISON breadcrumb is written first (so a
-    failed rollback can never leave a false terminal honorable), the rollback
-    runs and is verified, and `KeyedSubmitTargetDeadError` is thrown. A later
-    keyed call that finds the breadcrumb repairs the markers before anything
-    else — it never returns `deduplicated` from a poisoned terminal. The
-    outbox entry stays `pending` and a later pass re-drives the wake after
+    the Enter and then set the POISON breadcrumb and the TERMINAL marker and
+    clear PENDING, all inside one server-executed command list. The terminal
+    is therefore PROVISIONAL from the moment it exists: a dashboard crash
+    anywhere leaves poison+terminal together, and the breadcrumb forces any
+    later keyed call to repair (roll back to pending, verify, lift the
+    breadcrumb) instead of honoring the marker as a dedup. The pre-branch
+    liveness check is NOT treated as proof of acceptance: the pane can die in
+    the shell-to-branch handoff, and tmux reports `send-keys` into a
+    remain-on-exit corpse as success. So after the command, the target is
+    re-read — and the key may only lose its provisional status when BOTH
+    target reads succeeded, BOTH report a live pane, and the pid identity
+    matches (an unreadable pre-target fails CLOSED: the pane could have been
+    replaced without its pasted content). If the target was lost around the
+    Enter, the terminal marker is ROLLED BACK as a verified transition and
+    `KeyedSubmitTargetDeadError` is thrown. Poison reads are fail-closed (a
+    failed read aborts rather than being interpreted as "no poison") and
+    poison clears are verified (a stale breadcrumb must never invalidate a
+    legitimate terminal on a later replay). The outbox entry stays `pending`
+    on every recoverable failure and a later pass re-drives the wake after
     the agent resumes — recovery never suppresses a wake that did not
     demonstrably reach a live harness. A failed Enter aborts the command
     list before the terminal transition, and concurrent or post-crash

--- a/docs/LINEAR-MCP-AUTH.md
+++ b/docs/LINEAR-MCP-AUTH.md
@@ -58,7 +58,7 @@ Canonical definitions live in `src/lib/linear-mcp-auth.ts`
 | --- | --- | --- |
 | `linear_mcp_auth.required` | `{ agentId, issueId, authUrl, expiresAt }` | Hook heartbeat ingestion |
 | `linear_mcp_auth.healthy` | `{ agentId, issueId, source: 'hook' \| 'operator' }` | Hook heartbeat ingestion, or the operator via `POST /api/linear-mcp-auth/complete` |
-| `linear_mcp_auth.notified` | `{ agentId, issueId, outcome: 'delivering' \| 'delivered' \| 'queued' \| 'failed', lifecycleId }` | The wake pass: a durable `delivering` claim before delivery, then the completion record after |
+| `linear_mcp_auth.notified` | `{ agentId, issueId, outcome: 'delivered' \| 'queued' \| 'failed', lifecycleId }` | The wake pass, after the outbox records the delivery outcome. (The decodable `delivering` literal is a legacy value from the pre-outbox iteration and is ignored by the fold.) |
 | `linear_mcp_auth.callback_relayed` | `{ agentId, issueId }` | `POST /api/linear-mcp-auth/callback`, after relaying a callback URL |
 
 ## Lifecycle fold semantics
@@ -154,24 +154,27 @@ has not yet been notified:
 - The message (`LINEAR_MCP_AUTH_WAKE_COPY`) tells the agent to re-check Linear
   access with one lightweight read and resume its canonical task, and not to
   retry in a loop if it still fails.
-- Each delivery is claimed **before** it is sent: a `linear_mcp_auth.notified`
-  event with outcome `delivering` and the owning `lifecycleId` is appended
-  first, then the message goes out, then a completion record (`delivered`,
-  `queued`, or `failed`) is appended. The `(lifecycleId, agentId)` claim is
-  the deterministic delivery key an interrupted attempt resumes from. A claim
-  is **not terminal** — the agent stays in the wake set until a completion
-  lands — so a crash after the claim but before the send still produces
-  exactly one eventual delivery.
-- **Outbox reconciliation.** Every non-throwing path through
-  `messageAgentWithOutcome` backs the message up to the agent's durable mail
-  queue. When recovery (boot or a later pass) finds a claim without a
-  completion, it checks that outbox via `agentHasMailContentSince()`: a mail
-  file containing the wake copy at or after the claim timestamp proves the
-  acknowledged send durably landed, so the ledger is completed **without
-  re-sending** — a crash after an acknowledged send never produces a second
-  delivery. Mail absent means the send never durably happened, so the wake is
-  driven then. If the claim itself cannot be recorded, the delivery is
-  skipped for that pass rather than risk an unreconciled replay.
+- Each delivery goes through the **keyed wake outbox**: one JSON entry per
+  `(lifecycleId, agentId)` at
+  `~/.overdeck/agents/<agentId>/linear-mcp-wake/<lifecycleId>.json`, carrying
+  the intended message, a `pending`/`acknowledged` state, and the recorded
+  outcome. Writes are temp-file + rename (atomic on POSIX) and all I/O is
+  async. The delivery wrapper (`deliverWakeWithOutbox`) creates the entry
+  before sending and records the acknowledgment — with the real outcome
+  (`delivered`, `queued`, or `failed`) — as part of its own protocol on every
+  path, so every acknowledged send has a receipt.
+- **Recovery semantics.** An agent stays in the wake set until a completion
+  DomainEvent lands. When a pass finds no completion, it reads the keyed
+  entry (one exact-path async read — no directory scans, no content or
+  timestamp matching): `acknowledged` suppresses the replay and the pass only
+  retries the completion record, replaying the recorded outcome faithfully
+  (`queued` is never upgraded to `delivered`); `pending` or missing means the
+  send was never acknowledged, so it is (re)driven. The result is exactly one
+  acknowledged delivery per agent per lifecycle across every crash window:
+  crash before the entry → driven once; crash after a send whose ack never
+  landed → replayed once (correct — unacknowledged); crash after the ack →
+  never replayed. Lifecycle B's entry is independent of lifecycle A's, so an
+  identical wake message in an adjacent lifecycle is never suppressed.
 - **Drain-until-stable.** The wake pass loops: after waking one completed
   lifecycle it re-reads the fold, so a lifecycle that completed while
   deliveries were in flight gets its own wake round inside the same coalesced
@@ -179,7 +182,7 @@ has not yet been notified:
   rounds schedules its own follow-up run with bounded exponential backoff
   (1s doubling to 60s; healthy triggers that arrived mid-run received the
   same coalesced promise, so no external retry is guaranteed, and a
-  persistent EventStore failure cannot become a hot retry loop).
+  persistent failure cannot become a hot retry loop).
 - **Boot recovery:** the Cloister service runs the wake pass on startup
   (`src/lib/cloister/service.ts`) and on every `linear_mcp_auth.healthy`
   domain event (`src/lib/cloister/service-reactive.ts`), so an agent that was

--- a/docs/LINEAR-MCP-AUTH.md
+++ b/docs/LINEAR-MCP-AUTH.md
@@ -191,32 +191,36 @@ has not yet been notified:
     `pending`, and a later wake pass retries the SAME key at the SAME tier,
     where the supervisor's reservation/delivered set deduplicates it. Only a
     received non-2xx (a definitive, purged failure) may fall back to tmux.
-  - **tmux fallback** uses two-phase per-session markers owned by the tmux
-    server (`sendKeysDedup` + `completeKeyedSubmit`): the paste and the
-    PENDING marker are one atomic server-side `if-shell` step, and the
-    submission itself is a second single `if-shell` — only when PENDING is
-    present, TERMINAL is absent, AND the pane is alive does the server send
-    the Enter and then set the POISON breadcrumb and the TERMINAL marker and
-    clear PENDING, all inside one server-executed command list. The terminal
-    is therefore PROVISIONAL from the moment it exists: a dashboard crash
-    anywhere leaves poison+terminal together, and the breadcrumb forces any
-    later keyed call to repair (roll back to pending, verify, lift the
-    breadcrumb) instead of honoring the marker as a dedup. The pre-branch
-    liveness check is NOT treated as proof of acceptance: the pane can die in
-    the shell-to-branch handoff, and tmux reports `send-keys` into a
-    remain-on-exit corpse as success. So after the command, the target is
-    re-read — and the key may only lose its provisional status when BOTH
-    target reads succeeded, BOTH report a live pane, and the pid identity
-    matches (an unreadable pre-target fails CLOSED: the pane could have been
-    replaced without its pasted content). If the target was lost around the
-    Enter, the terminal marker is ROLLED BACK as a verified transition and
-    `KeyedSubmitTargetDeadError` is thrown. Poison reads are fail-closed (a
-    failed read aborts rather than being interpreted as "no poison") and
-    poison clears are verified (a stale breadcrumb must never invalidate a
-    legitimate terminal on a later replay). The outbox entry stays `pending`
-    on every recoverable failure and a later pass re-drives the wake after
-    the agent resumes — recovery never suppresses a wake that did not
-    demonstrably reach a live harness. A failed Enter aborts the command
+  - **tmux fallback** uses per-session markers owned by the tmux server
+    (`sendKeysDedup` + `completeKeyedSubmit`): the paste, the PENDING claim,
+    AND the receiving pane's pid (TARGET, via `set-option -F '#{pane_pid}'`)
+    are one atomic server-side `if-shell` step, and the submission itself is
+    a second single `if-shell` — only when PENDING is present, TERMINAL is
+    absent, the pane is alive, AND the current pane IS the recorded paste
+    target does the server send the Enter and then set the POISON breadcrumb
+    and the TERMINAL marker and clear PENDING, all inside one server-executed
+    command list. The terminal is therefore PROVISIONAL from the moment it
+    exists: a dashboard crash anywhere leaves poison+terminal together, and
+    the breadcrumb forces any later keyed call to repair (roll back to
+    pending, verify, lift the breadcrumb) instead of honoring the marker as
+    a dedup. The pre-branch liveness check is NOT treated as proof of
+    acceptance: the pane can die in the shell-to-branch handoff, and tmux
+    reports `send-keys` into a remain-on-exit corpse as success. So after the
+    command, the target is re-read — and the key may only lose its
+    provisional status when BOTH target reads succeeded, BOTH report a live
+    pane, and the pid identity matches (an unreadable pre-target fails
+    CLOSED). A pane that was REPLACED around or after the paste no longer
+    matches the recorded target: the submit refuses, and recovery RE-PASTES
+    the real content into the replacement pane rather than completing with a
+    blank Enter. If the target was lost around the Enter, the terminal
+    marker is ROLLED BACK as a verified transition and
+    `KeyedSubmitTargetDeadError` is thrown. Poison reads and every
+    verification read (repair, rollback, post-clear) are strict: a failed
+    read aborts as `KeyedMarkerVerificationError` with the breadcrumb
+    authoritative, never converted to empty state. The outbox entry stays
+    `pending` on every recoverable failure and a later pass re-drives the
+    wake after the agent resumes — recovery never suppresses a wake that did
+    not demonstrably reach a live harness holding the real content. A failed Enter aborts the command
     list before the terminal transition, and concurrent or post-crash
     callers lose the server-side condition, so no stray Enter can land in a
     composer holding unrelated operator text.

--- a/docs/LINEAR-MCP-AUTH.md
+++ b/docs/LINEAR-MCP-AUTH.md
@@ -168,25 +168,53 @@ has not yet been notified:
   a *completed* delivery whose ack was lost to a dashboard crash — that is
   why the wake key (`linear-mcp-auth-wake:<lifecycleId>`) is also threaded
   through `messageAgentWithOutcome` into `deliverAgentMessage`, where the
-  crash-independent components deduplicate the injection itself:
-  - **PTY supervisor** keeps a per-server set of delivered keys. Its own exit
-    kills the agent with it (H1 lifecycle), so an in-memory set is exactly as
-    durable as the side effect it guards: a replay after a dashboard crash
-    hits the surviving supervisor and gets `{ deduplicated: true }` instead
-    of a second PTY write; a replay after the agent itself died is a
-    legitimate first delivery to the resumed session. A
-    `record-delivered` operation lets paths that bypass the supervisor
-    (resume kickoff prompts) still register the key.
-  - **tmux fallback** marks a per-session user option in the same
-    server-side `if-shell` command that pastes (`sendKeysDedup`), so the
-    check, paste, and mark are one atomic step the tmux server executes —
-    a dashboard exit cannot interrupt it. A deduplicated replay sends no
-    stray Enter, because the composer may hold unrelated operator text.
-  - **Keyed mail backups** use a deterministic filename, so a replayed send
-    overwrites the same durable backup instead of stacking a second copy.
-  - Channels, codex app-server, and ACP tiers receive the key as advisory
-    metadata only; they are unreachable for this feature because the
-    detection hook is Claude-Code-only.
+  crash-independent components deduplicate the injection itself. Only tiers
+  whose crash-independent component enforces the key across the COMPLETE
+  visible side effect may carry a keyed message; the others acknowledge
+  receipt without enforcing the key, so keyed payloads bypass them entirely
+  (auto mode skips them; requesting one explicitly with a key is a loud
+  error, not a silent downgrade):
+  - **PTY supervisor** keeps a per-server set of delivered keys and reserves
+    a key synchronously before injecting, so two concurrent same-key requests
+    coalesce onto one injection instead of racing past the dedup check. Its
+    own exit kills the agent with it (H1 lifecycle), so an in-memory set is
+    exactly as durable as the side effect it guards: a replay after a
+    dashboard crash hits the surviving supervisor and gets
+    `{ deduplicated: true }` instead of a second PTY write; a replay after
+    the agent itself died is a legitimate first delivery to the resumed
+    session. The supervisor's single request covers content AND the
+    standalone Enter, so the key completes only after the full submission.
+  - **tmux fallback** uses two-phase per-session markers owned by the tmux
+    server (`sendKeysDedup` + `completeKeyedSubmit`): the paste and the
+    PENDING marker are one atomic server-side `if-shell` step, the standalone
+    Enter follows after the settle window, and only then does the key flip
+    TERMINAL (pending cleared in the same server-side command). A replay that
+    finds PENDING completes the prior attempt's submission WITHOUT
+    re-pasting; a TERMINAL marker suppresses the replay entirely — a
+    dashboard crash anywhere in the transaction neither loses nor duplicates
+    the wake.
+  - **Monitor mail (PAN-3015) never carries keyed deliveries.** The monitor
+    claims a mail file by renaming it before emitting, so a monitor exit
+    between claim and emit would lose the wake and a post-emit/pre-ack crash
+    would replay it — the spool cannot enforce the key across the
+    model-visible side effect. Keyed messages skip the monitor tier and use
+    the supervisor/tmux door; keyed payloads are also never written as mail
+    backups, because a monitor started later would drain the file as a second
+    visible copy.
+  - **Resume paths (suspended/stopped/zombie)** never let a keyed message
+    ride the resume kickoff prompt: the kickoff is delivered by components
+    that cannot enforce the key. The agent is resumed with its bare
+    auto-continue prompt and the keyed message then goes through the keyed
+    door of the new session.
+  - **Remote agents** run the same two-phase marker protocol against the
+    REMOTE tmux server (`sendToRemoteAgentKeyed`), which is the
+    crash-independent component for a remote session.
+  - Channels, codex app-server, and ACP tiers cannot enforce a key and are
+    rejected for keyed payloads. Keyed Linear wakes only target Claude Code
+    agents anyway — the detection hook is Claude-Code-only.
+  - **Keyed mail queueing** (paused/gated agents) uses a deterministic
+    filename, so a replayed send overwrites the same durable entry instead of
+    stacking a second copy; the outcome is recorded honestly as `queued`.
 - **Recovery semantics.** An agent stays in the wake set until a completion
   DomainEvent lands. When a pass finds no completion, it reads the keyed
   entry (one exact-path async read — no directory scans, no content or

--- a/docs/LINEAR-MCP-AUTH.md
+++ b/docs/LINEAR-MCP-AUTH.md
@@ -58,7 +58,7 @@ Canonical definitions live in `src/lib/linear-mcp-auth.ts`
 | --- | --- | --- |
 | `linear_mcp_auth.required` | `{ agentId, issueId, authUrl, expiresAt }` | Hook heartbeat ingestion |
 | `linear_mcp_auth.healthy` | `{ agentId, issueId, source: 'hook' \| 'operator' }` | Hook heartbeat ingestion, or the operator via `POST /api/linear-mcp-auth/complete` |
-| `linear_mcp_auth.notified` | `{ agentId, issueId, outcome: 'delivered' \| 'queued' \| 'failed', lifecycleId }` | The wake pass, after messaging a blocked agent |
+| `linear_mcp_auth.notified` | `{ agentId, issueId, outcome: 'delivering' \| 'delivered' \| 'queued' \| 'failed', lifecycleId }` | The wake pass: a durable `delivering` claim before delivery, then the completion record after |
 | `linear_mcp_auth.callback_relayed` | `{ agentId, issueId }` | `POST /api/linear-mcp-auth/callback`, after relaying a callback URL |
 
 ## Lifecycle fold semantics
@@ -92,9 +92,14 @@ into one **open lifecycle** plus the last completed one:
   'none'`). `callback_relayed` is record-keeping only.
 - **Bounded complete reads.** The fold never queries event types with the
   store's per-type cap — repeated failures would push earlier blocked agents
-  out of a 100-event window. It anchors on healthy-event boundaries and reads
-  forward with a sequence predicate, expanding the anchor until the last
-  completed lifecycle is fully reconstructed.
+  out of a 100-event window — and it never runs a generic full-history read
+  either: the projection is maintained incrementally. Each read fetches only
+  auth-typed events newer than the covered sequence through
+  `EventStore.queryByTypesSince`, an indexed SQL query that applies the type
+  predicate and sequence bound in the database, so the banner's 5–30s polling
+  path typically reads zero rows and never materializes unrelated retained
+  history. If retention compaction or a purge leaves the store behind the
+  covered sequence, the projection restarts from scratch.
 - **Projection.** `resolveLinearMcpAuthIntervention()` serves `GET
   /api/linear-mcp-auth` with `{ status, authUrl, authUrlAgentId,
   authUrlExpiresAt, declaredAt, blockedAgents[] }`; the route enriches each
@@ -149,14 +154,25 @@ has not yet been notified:
 - The message (`LINEAR_MCP_AUTH_WAKE_COPY`) tells the agent to re-check Linear
   access with one lightweight read and resume its canonical task, and not to
   retry in a loop if it still fails.
-- Each attempt is recorded as a `linear_mcp_auth.notified` event with outcome
-  `delivered`, `queued`, or `failed` and the owning `lifecycleId`, so an agent
-  is woken at most once per lifecycle.
+- Each delivery is claimed **before** it is sent: a `linear_mcp_auth.notified`
+  event with outcome `delivering` and the owning `lifecycleId` is appended
+  first, then the message goes out, then a completion record (`delivered`,
+  `queued`, or `failed`) is appended. The `(lifecycleId, agentId)` claim is
+  the deterministic delivery key that makes the wake **crash-idempotent**: a
+  crash after the claim — including after a successful send whose completion
+  record never commits — is visible to boot recovery, so the delivery is
+  never replayed. This is at-most-once by design; the residual lost-wake
+  window (crash between claim and send) self-heals when the still-blocked
+  agent's next failed Linear call opens a fresh lifecycle. If the claim
+  itself cannot be recorded, the delivery is skipped for that pass rather
+  than risk a replay.
 - **Drain-until-stable.** The wake pass loops: after waking one completed
   lifecycle it re-reads the fold, so a lifecycle that completed while
   deliveries were in flight gets its own wake round inside the same coalesced
   run instead of being swallowed by it. A pass that cannot stabilize after 10
-  rounds logs and defers to the next trigger.
+  rounds schedules its own follow-up run (healthy triggers that arrived
+  mid-run received the same coalesced promise, so no external retry is
+  guaranteed).
 - **Boot recovery:** the Cloister service runs the wake pass on startup
   (`src/lib/cloister/service.ts`) and on every `linear_mcp_auth.healthy`
   domain event (`src/lib/cloister/service-reactive.ts`), so an agent that was

--- a/docs/LINEAR-MCP-AUTH.md
+++ b/docs/LINEAR-MCP-AUTH.md
@@ -197,22 +197,28 @@ has not yet been notified:
     submission itself is a second single `if-shell` — only when PENDING is
     present, TERMINAL is absent, AND the pane is alive does the server send
     the Enter and then flip TERMINAL and clear PENDING, in that order, inside
-    one server-executed command list. A pane that died during the settle
-    window fails the liveness condition: NO marker changes and NO Enter, so a
-    wake that never landed is never recorded as delivered — the submit throws
-    `KeyedSubmitTargetDeadError`, the outbox entry stays `pending`, and a
-    later pass re-drives the wake after the agent resumes. A failed Enter
-    aborts the command list before the terminal transition, and concurrent or
-    post-crash callers lose the server-side condition, so no stray Enter can
-    land in a composer holding unrelated operator text.
-  - **Monitor mail (PAN-3015) never carries keyed deliveries.** The monitor
-    claims a mail file by renaming it before emitting, so a monitor exit
-    between claim and emit would lose the wake and a post-emit/pre-ack crash
-    would replay it — the spool cannot enforce the key across the
+    one server-executed command list. The pre-branch liveness check is NOT
+    treated as proof of acceptance: the pane can die in the shell-to-branch
+    handoff, and tmux reports `send-keys` into a remain-on-exit corpse as
+    success. So after the command, the target is re-read — if the pane died
+    or its pid changed around the Enter, the terminal marker is ROLLED BACK,
+    the pending claim restored, and `KeyedSubmitTargetDeadError` is thrown.
+    The outbox entry stays `pending` and a later pass re-drives the wake
+    after the agent resumes — recovery never suppresses a wake that did not
+    demonstrably reach a live harness. A failed Enter aborts the command
+    list before the terminal transition, and concurrent or post-crash
+    callers lose the server-side condition, so no stray Enter can land in a
+    composer holding unrelated operator text.
+  - **Monitor mail spool (PAN-3015) never carries keyed deliveries.** The
+    monitor claims a mail file by renaming it before emitting, so a monitor
+    exit between claim and emit would lose the wake and a post-emit/pre-ack
+    crash would replay it — the spool cannot enforce the key across the
     model-visible side effect. Keyed messages skip the monitor tier and use
     the supervisor/tmux door; keyed payloads are also never written as mail
-    backups, because a monitor started later would drain the file as a second
-    visible copy.
+    backups on delivered paths, because a monitor started later would drain
+    the file as a second visible copy. (The one mail file a keyed delivery
+    can still produce is the **gated-agent queue** below — a separate
+    mechanism from the monitor spool.)
   - **Resume paths (suspended/stopped/zombie)** never let a keyed message
     ride the resume kickoff prompt: the kickoff is delivered by components
     that cannot enforce the key. The agent is resumed with its bare
@@ -226,9 +232,12 @@ has not yet been notified:
   - Channels, codex app-server, and ACP tiers cannot enforce a key and are
     rejected for keyed payloads. Keyed Linear wakes only target Claude Code
     agents anyway — the detection hook is Claude-Code-only.
-  - **Keyed mail queueing** (paused/gated agents) uses a deterministic
-    filename, so a replayed send overwrites the same durable entry instead of
-    stacking a second copy; the outcome is recorded honestly as `queued`.
+  - **Gated-agent mail queue** (paused/troubled/operator-stopped agents)
+    uses a deterministic keyed filename, so a replayed send overwrites the
+    same durable entry instead of stacking a second copy; the outcome is
+    recorded honestly as `queued`. This is the only mail path keyed payloads
+    take, and it is distinct from the monitor spool: the message is enqueued
+    at most once and the wake is never reported as delivered.
 - **Recovery semantics.** An agent stays in the wake set until a completion
   DomainEvent lands. When a pass finds no completion, it reads the keyed
   entry (one exact-path async read — no directory scans, no content or

--- a/docs/LINEAR-MCP-AUTH.md
+++ b/docs/LINEAR-MCP-AUTH.md
@@ -195,12 +195,16 @@ has not yet been notified:
     server (`sendKeysDedup` + `completeKeyedSubmit`): the paste and the
     PENDING marker are one atomic server-side `if-shell` step, and the
     submission itself is a second single `if-shell` — only when PENDING is
-    present and TERMINAL absent does the server flip TERMINAL, clear PENDING,
-    and send the Enter, in that order, inside one server-executed command
-    list. Exactly one caller can become the completer; concurrent or
-    post-crash callers lose the server-side condition and send nothing, so no
-    stray Enter can land in a composer holding unrelated operator text, and a
-    retried transaction never has to decide whether a prior Enter landed.
+    present, TERMINAL is absent, AND the pane is alive does the server send
+    the Enter and then flip TERMINAL and clear PENDING, in that order, inside
+    one server-executed command list. A pane that died during the settle
+    window fails the liveness condition: NO marker changes and NO Enter, so a
+    wake that never landed is never recorded as delivered — the submit throws
+    `KeyedSubmitTargetDeadError`, the outbox entry stays `pending`, and a
+    later pass re-drives the wake after the agent resumes. A failed Enter
+    aborts the command list before the terminal transition, and concurrent or
+    post-crash callers lose the server-side condition, so no stray Enter can
+    land in a composer holding unrelated operator text.
   - **Monitor mail (PAN-3015) never carries keyed deliveries.** The monitor
     claims a mail file by renaming it before emitting, so a monitor exit
     between claim and emit would lose the wake and a post-emit/pre-ack crash

--- a/docs/LINEAR-MCP-AUTH.md
+++ b/docs/LINEAR-MCP-AUTH.md
@@ -158,21 +158,28 @@ has not yet been notified:
   event with outcome `delivering` and the owning `lifecycleId` is appended
   first, then the message goes out, then a completion record (`delivered`,
   `queued`, or `failed`) is appended. The `(lifecycleId, agentId)` claim is
-  the deterministic delivery key that makes the wake **crash-idempotent**: a
-  crash after the claim — including after a successful send whose completion
-  record never commits — is visible to boot recovery, so the delivery is
-  never replayed. This is at-most-once by design; the residual lost-wake
-  window (crash between claim and send) self-heals when the still-blocked
-  agent's next failed Linear call opens a fresh lifecycle. If the claim
-  itself cannot be recorded, the delivery is skipped for that pass rather
-  than risk a replay.
+  the deterministic delivery key an interrupted attempt resumes from. A claim
+  is **not terminal** — the agent stays in the wake set until a completion
+  lands — so a crash after the claim but before the send still produces
+  exactly one eventual delivery.
+- **Outbox reconciliation.** Every non-throwing path through
+  `messageAgentWithOutcome` backs the message up to the agent's durable mail
+  queue. When recovery (boot or a later pass) finds a claim without a
+  completion, it checks that outbox via `agentHasMailContentSince()`: a mail
+  file containing the wake copy at or after the claim timestamp proves the
+  acknowledged send durably landed, so the ledger is completed **without
+  re-sending** — a crash after an acknowledged send never produces a second
+  delivery. Mail absent means the send never durably happened, so the wake is
+  driven then. If the claim itself cannot be recorded, the delivery is
+  skipped for that pass rather than risk an unreconciled replay.
 - **Drain-until-stable.** The wake pass loops: after waking one completed
   lifecycle it re-reads the fold, so a lifecycle that completed while
   deliveries were in flight gets its own wake round inside the same coalesced
   run instead of being swallowed by it. A pass that cannot stabilize after 10
-  rounds schedules its own follow-up run (healthy triggers that arrived
-  mid-run received the same coalesced promise, so no external retry is
-  guaranteed).
+  rounds schedules its own follow-up run with bounded exponential backoff
+  (1s doubling to 60s; healthy triggers that arrived mid-run received the
+  same coalesced promise, so no external retry is guaranteed, and a
+  persistent EventStore failure cannot become a hot retry loop).
 - **Boot recovery:** the Cloister service runs the wake pass on startup
   (`src/lib/cloister/service.ts`) and on every `linear_mcp_auth.healthy`
   domain event (`src/lib/cloister/service-reactive.ts`), so an agent that was

--- a/docs/LINEAR-MCP-AUTH.md
+++ b/docs/LINEAR-MCP-AUTH.md
@@ -184,15 +184,23 @@ has not yet been notified:
     the agent itself died is a legitimate first delivery to the resumed
     session. The supervisor's single request covers content AND the
     standalone Enter, so the key completes only after the full submission.
+    If the keyed request's RESPONSE is lost (timeout/reset), the outcome is
+    ambiguous — the supervisor may have injected — so the dashboard does NOT
+    cross to the tmux tier (its key store is independent); it raises an
+    `AmbiguousKeyedDeliveryError` instead, the wake outbox entry stays
+    `pending`, and a later wake pass retries the SAME key at the SAME tier,
+    where the supervisor's reservation/delivered set deduplicates it. Only a
+    received non-2xx (a definitive, purged failure) may fall back to tmux.
   - **tmux fallback** uses two-phase per-session markers owned by the tmux
     server (`sendKeysDedup` + `completeKeyedSubmit`): the paste and the
-    PENDING marker are one atomic server-side `if-shell` step, the standalone
-    Enter follows after the settle window, and only then does the key flip
-    TERMINAL (pending cleared in the same server-side command). A replay that
-    finds PENDING completes the prior attempt's submission WITHOUT
-    re-pasting; a TERMINAL marker suppresses the replay entirely — a
-    dashboard crash anywhere in the transaction neither loses nor duplicates
-    the wake.
+    PENDING marker are one atomic server-side `if-shell` step, and the
+    submission itself is a second single `if-shell` — only when PENDING is
+    present and TERMINAL absent does the server flip TERMINAL, clear PENDING,
+    and send the Enter, in that order, inside one server-executed command
+    list. Exactly one caller can become the completer; concurrent or
+    post-crash callers lose the server-side condition and send nothing, so no
+    stray Enter can land in a composer holding unrelated operator text, and a
+    retried transaction never has to decide whether a prior Enter landed.
   - **Monitor mail (PAN-3015) never carries keyed deliveries.** The monitor
     claims a mail file by renaming it before emitting, so a monitor exit
     between claim and emit would lose the wake and a post-emit/pre-ack crash
@@ -208,7 +216,9 @@ has not yet been notified:
     door of the new session.
   - **Remote agents** run the same two-phase marker protocol against the
     REMOTE tmux server (`sendToRemoteAgentKeyed`), which is the
-    crash-independent component for a remote session.
+    crash-independent component for a remote session. The production executor
+    throws on any non-zero SSH exit — a failed write, paste, or Enter-submit
+    is never acknowledged as delivery.
   - Channels, codex app-server, and ACP tiers cannot enforce a key and are
     rejected for keyed payloads. Keyed Linear wakes only target Claude Code
     agents anyway — the detection hook is Claude-Code-only.

--- a/docs/LINEAR-MCP-AUTH.md
+++ b/docs/LINEAR-MCP-AUTH.md
@@ -12,10 +12,15 @@ GPT/Codex OAuth failures.
 
 ## Detection: the hook contract
 
-`sync-sources/hooks/linear-mcp-auth-hook` is a Claude Code **PostToolUse** hook
-registered with matcher `mcp__linear__.*` (see `HOOK_SCRIPT_NAMES` and
-`OVERDECK_HOOK_REGISTRATIONS` in `src/lib/claude-hooks-registration.ts`). It
-never breaks Claude Code — every failure mode exits 0 silently.
+`sync-sources/hooks/linear-mcp-auth-hook` is a Claude Code hook registered with
+matcher `mcp__linear__.*` for **both** `PostToolUse` and `PostToolUseFailure`
+(see `HOOK_SCRIPT_NAMES` and `OVERDECK_HOOK_REGISTRATIONS` in
+`src/lib/claude-hooks-registration.ts`). This dual registration is load-bearing:
+`PostToolUse` fires only after a tool call *succeeds*, so a failed MCP call —
+the motivating OAuth-expired case — never reaches a `PostToolUse`-only hook.
+Failures arrive as `PostToolUseFailure` with a top-level `error` field and no
+`tool_response`. The hook never breaks Claude Code — every failure mode exits
+0 silently.
 
 The hook emits heartbeat events via `pan_emit_event` (see
 `sync-sources/hooks/pan-hook-lib.sh`). Its emitted `kind` strings are a
@@ -25,10 +30,15 @@ silently breaks detection:
 - `linear_mcp_auth_required` — emitted when:
   - `mcp__linear__authenticate` returns; the first
     `https://linear.app/oauth/authorize…` URL in the tool response is extracted
-    into `authUrl` (`null` when extraction fails); or
-  - any `mcp__linear__*` tool response matches an auth-error pattern
-    (`requires authentication|not authenticated|unauthorized|401`), with
-    `authUrl: null`.
+    into `authUrl` (`null` when extraction fails);
+  - a `PostToolUseFailure` event's `error` text matches the auth classifier
+    (`requires authentication|not authenticated|unauthorized`, or `401` with a
+    non-identifier boundary so `MIN-401`-style data can never match); or
+  - a successful `PostToolUse` payload is error-shaped (`isError: true` or an
+    `error` member) AND matches the same classifier. Ordinary successful
+    result data — issue identifiers, titles mentioning 401s or "unauthorized"
+    — is never auth-classified: it clears a pending intervention instead of
+    raising a false one.
   - Each required emission touches the marker file
     `${OVERDECK_HOME}/agents/<agentId>/linear-mcp-auth-pending`.
 - `linear_mcp_auth_healthy` — emitted only when a `mcp__linear__*` response is
@@ -48,7 +58,7 @@ Canonical definitions live in `src/lib/linear-mcp-auth.ts`
 | --- | --- | --- |
 | `linear_mcp_auth.required` | `{ agentId, issueId, authUrl, expiresAt }` | Hook heartbeat ingestion |
 | `linear_mcp_auth.healthy` | `{ agentId, issueId, source: 'hook' \| 'operator' }` | Hook heartbeat ingestion, or the operator via `POST /api/linear-mcp-auth/complete` |
-| `linear_mcp_auth.notified` | `{ agentId, issueId, outcome: 'delivered' \| 'queued' \| 'failed' }` | The wake pass, after messaging a blocked agent |
+| `linear_mcp_auth.notified` | `{ agentId, issueId, outcome: 'delivered' \| 'queued' \| 'failed', lifecycleId }` | The wake pass, after messaging a blocked agent |
 | `linear_mcp_auth.callback_relayed` | `{ agentId, issueId }` | `POST /api/linear-mcp-auth/callback`, after relaying a callback URL |
 
 ## Lifecycle fold semantics
@@ -59,7 +69,16 @@ into one **open lifecycle** plus the last completed one:
 - **One open lifecycle.** The first `required` event opens it; every later
   `required` dedups into it — agents are keyed by `agentId`, so repeated auth
   failures from the same agent update its row instead of minting a new OAuth
-  request, and additional agents join the same intervention.
+  request, and additional agents join the same intervention. Each lifecycle
+  gets a durable correlation id (`seq-<n>`, the sequence of the `required`
+  event that opened it).
+- **Correlated notifications.** `notified` events carry the `lifecycleId` of
+  the lifecycle whose wake pass produced them, and the fold applies a
+  notification only to that lifecycle. Without this, a delayed delivery record
+  from lifecycle A could be stamped onto a newer lifecycle B for the same
+  agent, permanently suppressing B's wake. (Records written before this
+  correlation existed carry no `lifecycleId` and apply to the current
+  lifecycle as before.)
 - **authUrl ownership.** The most recent `required` event carrying a non-null
   `authUrl` owns the intervention's authorization URL (`authUrlAgentId`). The
   URL is the agent-generated OAuth link the operator opens.
@@ -70,12 +89,19 @@ into one **open lifecycle** plus the last completed one:
   `required` with a new URL.
 - **Close.** Any `linear_mcp_auth.healthy` event closes the open lifecycle
   (it becomes `lastCompleted`, and the projection returns to `status:
-  'none'`). `notified` events stamp `notifiedAt` on the agent row in whichever
-  lifecycle is current; `callback_relayed` is record-keeping only.
+  'none'`). `callback_relayed` is record-keeping only.
+- **Bounded complete reads.** The fold never queries event types with the
+  store's per-type cap — repeated failures would push earlier blocked agents
+  out of a 100-event window. It anchors on healthy-event boundaries and reads
+  forward with a sequence predicate, expanding the anchor until the last
+  completed lifecycle is fully reconstructed.
 - **Projection.** `resolveLinearMcpAuthIntervention()` serves `GET
   /api/linear-mcp-auth` with `{ status, authUrl, authUrlAgentId,
-  authUrlExpiresAt, declaredAt, blockedAgents[] }`. Because the fold reads the
-  durable event store, banner state survives dashboard restarts.
+  authUrlExpiresAt, declaredAt, blockedAgents[] }`; the route enriches each
+  blocked agent with `issueUrl`, its canonical tracker URL from the issues
+  read door (Linear web URL, GitHub html_url), so the banner can link every
+  issue. Because the fold reads the durable event store, banner state
+  survives dashboard restarts.
 
 ## Banner states
 
@@ -86,12 +112,13 @@ intervention is active, 30s when idle):
 
 - **none** — banner hidden.
 - **active with authUrl** — "Linear authentication required" header, the
-  blocked-agent list with issue links, and an "Open Linear authorization"
-  anchor naming the owning agent.
+  blocked-agent list with links to their canonical issue URLs, and an "Open
+  Linear authorization" anchor naming the owning agent.
 - **active without authUrl** — waiting-for-URL copy: no blocked agent has
   produced an authorization URL yet.
 - **expired** — copy stating the link expired and refreshes automatically when
-  a blocked agent generates a fresh one.
+  a blocked agent generates a fresh one; the stale authorization action is not
+  rendered, so the operator cannot start a flow the UI knows cannot complete.
 
 ## Operator completion flows
 
@@ -123,8 +150,13 @@ has not yet been notified:
   access with one lightweight read and resume its canonical task, and not to
   retry in a loop if it still fails.
 - Each attempt is recorded as a `linear_mcp_auth.notified` event with outcome
-  `delivered`, `queued`, or `failed`, so an agent is woken at most once per
-  lifecycle.
+  `delivered`, `queued`, or `failed` and the owning `lifecycleId`, so an agent
+  is woken at most once per lifecycle.
+- **Drain-until-stable.** The wake pass loops: after waking one completed
+  lifecycle it re-reads the fold, so a lifecycle that completed while
+  deliveries were in flight gets its own wake round inside the same coalesced
+  run instead of being swallowed by it. A pass that cannot stabilize after 10
+  rounds logs and defers to the next trigger.
 - **Boot recovery:** the Cloister service runs the wake pass on startup
   (`src/lib/cloister/service.ts`) and on every `linear_mcp_auth.healthy`
   domain event (`src/lib/cloister/service-reactive.ts`), so an agent that was

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -627,6 +627,9 @@ export const LinearMcpAuthNotifiedEvent = Schema.Struct({
     agentId: Schema.String,
     issueId: Schema.NullOr(Schema.String),
     outcome: Schema.Literals(["delivered", "queued", "failed"]),
+    // Correlates this record to the lifecycle whose wake pass produced it;
+    // absent only in events written before PAN-2997 review cycle 2.
+    lifecycleId: Schema.optional(Schema.String),
   }),
 })
 export type LinearMcpAuthNotifiedEvent = typeof LinearMcpAuthNotifiedEvent.Type

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -594,6 +594,54 @@ export const OperatorInterventionEvent = Schema.Struct({
 })
 export type OperatorInterventionEvent = typeof OperatorInterventionEvent.Type
 
+export const LinearMcpAuthRequiredEvent = Schema.Struct({
+  type: Schema.Literal("linear_mcp_auth.required"),
+  sequence: SequenceNumber,
+  timestamp: Schema.String,
+  payload: Schema.Struct({
+    agentId: Schema.String,
+    issueId: Schema.NullOr(Schema.String),
+    authUrl: Schema.NullOr(Schema.String),
+    expiresAt: Schema.NullOr(Schema.String),
+  }),
+})
+export type LinearMcpAuthRequiredEvent = typeof LinearMcpAuthRequiredEvent.Type
+
+export const LinearMcpAuthHealthyEvent = Schema.Struct({
+  type: Schema.Literal("linear_mcp_auth.healthy"),
+  sequence: SequenceNumber,
+  timestamp: Schema.String,
+  payload: Schema.Struct({
+    agentId: Schema.String,
+    issueId: Schema.NullOr(Schema.String),
+    source: Schema.Literals(["hook", "operator"]),
+  }),
+})
+export type LinearMcpAuthHealthyEvent = typeof LinearMcpAuthHealthyEvent.Type
+
+export const LinearMcpAuthNotifiedEvent = Schema.Struct({
+  type: Schema.Literal("linear_mcp_auth.notified"),
+  sequence: SequenceNumber,
+  timestamp: Schema.String,
+  payload: Schema.Struct({
+    agentId: Schema.String,
+    issueId: Schema.NullOr(Schema.String),
+    outcome: Schema.Literals(["delivered", "queued", "failed"]),
+  }),
+})
+export type LinearMcpAuthNotifiedEvent = typeof LinearMcpAuthNotifiedEvent.Type
+
+export const LinearMcpAuthCallbackRelayedEvent = Schema.Struct({
+  type: Schema.Literal("linear_mcp_auth.callback_relayed"),
+  sequence: SequenceNumber,
+  timestamp: Schema.String,
+  payload: Schema.Struct({
+    agentId: Schema.String,
+    issueId: Schema.NullOr(Schema.String),
+  }),
+})
+export type LinearMcpAuthCallbackRelayedEvent = typeof LinearMcpAuthCallbackRelayedEvent.Type
+
 export const SubstrateBugFiledEvent = Schema.Struct({
   type: Schema.Literal("substrate.bug_filed"),
   sequence: SequenceNumber,
@@ -1229,6 +1277,10 @@ export const DomainEvent = Schema.Union([
   PipelineVerificationFailedEvent,
   IssueTransitionedEvent,
   OperatorInterventionEvent,
+  LinearMcpAuthRequiredEvent,
+  LinearMcpAuthHealthyEvent,
+  LinearMcpAuthNotifiedEvent,
+  LinearMcpAuthCallbackRelayedEvent,
   SubstrateBugFiledEvent,
   ReviewReviewerStartedEvent,
   ReviewReviewerCompletedEvent,

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -626,9 +626,12 @@ export const LinearMcpAuthNotifiedEvent = Schema.Struct({
   payload: Schema.Struct({
     agentId: Schema.String,
     issueId: Schema.NullOr(Schema.String),
-    outcome: Schema.Literals(["delivered", "queued", "failed"]),
-    // Correlates this record to the lifecycle whose wake pass produced it;
-    // absent only in events written before PAN-2997 review cycle 2.
+    // 'delivering' is the durable pre-delivery claim (PAN-2997 review cycle
+    // 3): it makes the wake crash-idempotent — a crash after the claim never
+    // replays the delivery at boot recovery. lifecycleId correlates this
+    // record to the lifecycle whose wake pass produced it; absent only in
+    // events written before PAN-2997 review cycle 2.
+    outcome: Schema.Literals(["delivering", "delivered", "queued", "failed"]),
     lifecycleId: Schema.optional(Schema.String),
   }),
 })

--- a/roles/plan.md
+++ b/roles/plan.md
@@ -38,6 +38,8 @@ hooks:
 
 Research-only agent that produces an executable plan for an issue. Never writes implementation code.
 
+If a Linear MCP tool call fails with an authentication error: call `mcp__linear__authenticate` ONCE, state the returned authorization URL in one sentence, then stop and wait — Overdeck is notified automatically and will wake you when authentication is restored. Do not retry the tool in a loop and do not improvise other auth commands. When you receive a "Linear MCP authentication has been restored" message, re-check with one lightweight Linear read and resume your canonical task.
+
 ## Outputs
 
 1. **PRD draft** at `.pan/drafts/<ISSUE-ID>.md` in your workspace — **created FIRST, before the xBRIEF, whenever a canonical one does not already exist.** `pan plan finalize` enforces this (PRD-first gate, minimum 20 lines) and promotes your workspace draft to `drafts/<issue>.md` on `overdeck-state` through the draft write door; you never write to the state worktree directly. The xBRIEF is *lowered from* the PRD, never invented alongside it. Write the PRD to the standard in `.claude/rules/prd-authoring.md`: executable by a cheaper model with no re-research — glossary first, verified file/line references with grep-anchor quotes, before/after snippets, numbered work items, numbered FR-/NFR- requirements, decisions made in the doc, intersecting repo rules restated, **a documentation work item naming the exact doc files the change touches**, mechanically checkable acceptance criteria. If a PRD already exists, verify it is still accurate against the current code before lowering it; correct drifted references in place.

--- a/roles/work.md
+++ b/roles/work.md
@@ -62,6 +62,8 @@ pan monitor
 
 Run it in the background (`run_in_background`), never in the foreground — it blocks forever by design. Messages from the operator and the pipeline then arrive as `[overdeck:agent-message]` blocks in background output instead of being typed into your prompt. Long messages are truncated; run `pan inbox` to read the full body. Do not kill the monitor to "clean up" — it is your delivery channel.
 
+If a Linear MCP tool call fails with an authentication error: call `mcp__linear__authenticate` ONCE, state the returned authorization URL in one sentence, then stop and wait — Overdeck is notified automatically and will wake you when authentication is restored. Do not retry the tool in a loop and do not improvise other auth commands. When you receive a "Linear MCP authentication has been restored" message, re-check with one lightweight Linear read and resume your canonical task.
+
 ## Per-Task Workflow
 
 For every item:

--- a/src/dashboard/frontend/src/App/AppChrome.tsx
+++ b/src/dashboard/frontend/src/App/AppChrome.tsx
@@ -10,6 +10,7 @@ import { RunningAgentsPill } from '../components/RunningAgentsPill';
 import { OrphanTestAgentsSurface } from '../components/OrphanTestAgentsSurface';
 import { CodexAuthBanner } from '../components/CodexAuthBanner';
 import { InotifyPressureBanner } from '../components/InotifyPressureBanner';
+import { LinearMcpAuthBanner } from '../components/LinearMcpAuthBanner';
 import { SetupChecklistBanner } from '../components/SetupChecklistBanner';
 import { SyncRequiredBanner } from '../components/SyncRequiredBanner';
 import { SystemHealthPill } from '../components/SystemHealthPill';
@@ -91,6 +92,9 @@ export function AppChrome({
         {/* inotify file-watcher budget nearly exhausted — new dev servers
             would fail with ENOSPC (PAN-3063) */}
         <InotifyPressureBanner />
+
+        {/* Linear MCP Auth Banner — shown when agents are blocked on Linear OAuth (PAN-2997) */}
+        <LinearMcpAuthBanner />
       </div>
 
       {/* Dashboard Restart Banner — shown during a planned restart (post-merge deploy, pan restart) */}

--- a/src/dashboard/frontend/src/components/LinearMcpAuthBanner.test.tsx
+++ b/src/dashboard/frontend/src/components/LinearMcpAuthBanner.test.tsx
@@ -28,6 +28,7 @@ function intervention(overrides: Partial<LinearMcpAuthStatus> = {}): LinearMcpAu
         declaredAt: '2026-07-21T23:00:00Z',
         expiresAt: '2026-07-22T01:00:00Z',
         notifiedAt: null,
+        issueUrl: 'https://linear.app/mind-your-now/issue/MIN-852/habits-full-bug-audit',
       },
       {
         agentId: 'agent-pan-2997',
@@ -35,6 +36,7 @@ function intervention(overrides: Partial<LinearMcpAuthStatus> = {}): LinearMcpAu
         declaredAt: '2026-07-21T23:05:00Z',
         expiresAt: '2026-07-22T01:00:00Z',
         notifiedAt: null,
+        issueUrl: null,
       },
     ],
     ...overrides,
@@ -78,10 +80,12 @@ describe('LinearMcpAuthBanner', () => {
     expect(screen.getByText('agent-min-852')).toBeInTheDocument();
     expect(screen.getByText('agent-pan-2997')).toBeInTheDocument();
 
-    // PAN-prefixed issues resolve to a GitHub link; Linear issues fall back to plain text.
+    // Every blocked agent's issue renders as a link: the server-projected
+    // canonical URL for Linear issues, the derived GitHub URL for PAN ones.
+    const minLink = screen.getByRole('link', { name: 'MIN-852' });
+    expect(minLink).toHaveAttribute('href', 'https://linear.app/mind-your-now/issue/MIN-852/habits-full-bug-audit');
     const panLink = screen.getByRole('link', { name: 'PAN-2997' });
     expect(panLink).toHaveAttribute('href', 'https://github.com/eltmon/overdeck/issues/2997');
-    expect(screen.getByText('agent-min-852').closest('li')?.textContent).toContain('MIN-852');
 
     const openAuth = screen.getByRole('link', { name: /Open Linear authorization/ });
     expect(openAuth).toHaveAttribute('href', 'https://linear.app/oauth/authorize?client_id=test&state=abc');
@@ -89,10 +93,11 @@ describe('LinearMcpAuthBanner', () => {
     expect(openAuth.textContent).toContain('agent-min-852');
   });
 
-  it('shows the expired state copy when the authorization link expired', () => {
+  it('shows the expired state copy and no actionable stale link when the authorization link expired', () => {
     setIntervention(intervention({ status: 'expired' }));
     render(<LinearMcpAuthBanner />);
     expect(screen.getByText(/This authorization link expired/)).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Open Linear authorization/ })).not.toBeInTheDocument();
   });
 
   it('shows the waiting-for-URL state when no agent has produced an authorization URL', () => {

--- a/src/dashboard/frontend/src/components/LinearMcpAuthBanner.test.tsx
+++ b/src/dashboard/frontend/src/components/LinearMcpAuthBanner.test.tsx
@@ -1,0 +1,136 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LinearMcpAuthBanner } from './LinearMcpAuthBanner';
+import { useLinearMcpAuthStatus, type LinearMcpAuthStatus } from '../hooks/useLinearMcpAuthStatus';
+
+vi.mock('../hooks/useLinearMcpAuthStatus', () => ({
+  useLinearMcpAuthStatus: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const mockAuthStatus = vi.mocked(useLinearMcpAuthStatus);
+
+function intervention(overrides: Partial<LinearMcpAuthStatus> = {}): LinearMcpAuthStatus {
+  return {
+    status: 'active',
+    authUrl: 'https://linear.app/oauth/authorize?client_id=test&state=abc',
+    authUrlAgentId: 'agent-min-852',
+    authUrlExpiresAt: '2026-07-22T01:00:00Z',
+    declaredAt: '2026-07-21T23:00:00Z',
+    blockedAgents: [
+      {
+        agentId: 'agent-min-852',
+        issueId: 'MIN-852',
+        declaredAt: '2026-07-21T23:00:00Z',
+        expiresAt: '2026-07-22T01:00:00Z',
+        notifiedAt: null,
+      },
+      {
+        agentId: 'agent-pan-2997',
+        issueId: 'PAN-2997',
+        declaredAt: '2026-07-21T23:05:00Z',
+        expiresAt: '2026-07-22T01:00:00Z',
+        notifiedAt: null,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function setIntervention(value: LinearMcpAuthStatus | undefined) {
+  mockAuthStatus.mockReturnValue({ data: value } as ReturnType<typeof useLinearMcpAuthStatus>);
+}
+
+describe('LinearMcpAuthBanner', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, relayedTo: 'agent-min-852' }),
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when the projection status is none', () => {
+    setIntervention(intervention({ status: 'none', blockedAgents: [] }));
+    const { container } = render(<LinearMcpAuthBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing before the status query resolves', () => {
+    setIntervention(undefined);
+    const { container } = render(<LinearMcpAuthBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders every blocked agent with an issue link and the open-authorization action', () => {
+    setIntervention(intervention());
+    render(<LinearMcpAuthBanner />);
+
+    expect(screen.getByText(/Linear authentication required/)).toBeInTheDocument();
+    expect(screen.getByText('agent-min-852')).toBeInTheDocument();
+    expect(screen.getByText('agent-pan-2997')).toBeInTheDocument();
+
+    // PAN-prefixed issues resolve to a GitHub link; Linear issues fall back to plain text.
+    const panLink = screen.getByRole('link', { name: 'PAN-2997' });
+    expect(panLink).toHaveAttribute('href', 'https://github.com/eltmon/overdeck/issues/2997');
+    expect(screen.getByText('agent-min-852').closest('li')?.textContent).toContain('MIN-852');
+
+    const openAuth = screen.getByRole('link', { name: /Open Linear authorization/ });
+    expect(openAuth).toHaveAttribute('href', 'https://linear.app/oauth/authorize?client_id=test&state=abc');
+    expect(openAuth).toHaveAttribute('target', '_blank');
+    expect(openAuth.textContent).toContain('agent-min-852');
+  });
+
+  it('shows the expired state copy when the authorization link expired', () => {
+    setIntervention(intervention({ status: 'expired' }));
+    render(<LinearMcpAuthBanner />);
+    expect(screen.getByText(/This authorization link expired/)).toBeInTheDocument();
+  });
+
+  it('shows the waiting-for-URL state when no agent has produced an authorization URL', () => {
+    setIntervention(intervention({ authUrl: null, authUrlAgentId: null }));
+    render(<LinearMcpAuthBanner />);
+    expect(screen.getByText(/Waiting for a blocked agent to produce an authorization URL/)).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Open Linear authorization/ })).not.toBeInTheDocument();
+  });
+
+  it('submits the entered callback URL to the callback route', async () => {
+    setIntervention(intervention());
+    render(<LinearMcpAuthBanner />);
+
+    fireEvent.change(screen.getByPlaceholderText(/Paste the localhost callback URL/), {
+      target: { value: 'http://localhost:48271/callback?code=abc&state=xyz' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Submit callback URL/ }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/linear-mcp-auth/callback', expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ callbackUrl: 'http://localhost:48271/callback?code=abc&state=xyz' }),
+      }));
+    });
+  });
+
+  it('mark-completed POSTs to the complete route and explains the wake consequence', async () => {
+    setIntervention(intervention());
+    render(<LinearMcpAuthBanner />);
+
+    expect(screen.getByText(/blocked agents will be woken to re-check/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Mark completed/ }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/linear-mcp-auth/complete', expect.objectContaining({
+        method: 'POST',
+      }));
+    });
+  });
+});

--- a/src/dashboard/frontend/src/components/LinearMcpAuthBanner.tsx
+++ b/src/dashboard/frontend/src/components/LinearMcpAuthBanner.tsx
@@ -1,0 +1,158 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { AlertTriangle, Loader2, ExternalLink, CheckCircle2 } from 'lucide-react';
+import { useLinearMcpAuthStatus } from '../hooks/useLinearMcpAuthStatus';
+import { trackerIssueUrl } from '../lib/issueLinks';
+
+/**
+ * Global intervention banner for Linear MCP OAuth (PAN-2997). Any agent whose
+ * Linear MCP session expired emits a structured event; the server folds those
+ * into one intervention and this banner is the operator's single place to act
+ * on it — instead of the authorization URL being buried in one agent's
+ * transcript.
+ */
+export function LinearMcpAuthBanner() {
+  const { data: intervention } = useLinearMcpAuthStatus();
+  const [callbackUrl, setCallbackUrl] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [completing, setCompleting] = useState(false);
+
+  if (!intervention || intervention.status === 'none') return null;
+
+  const blockedAgents = intervention.blockedAgents ?? [];
+
+  const handleCallbackSubmit = async () => {
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/linear-mcp-auth/callback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ callbackUrl }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(body.error || `Failed to relay callback URL (${res.status})`);
+      }
+      toast.success(`Callback URL relayed to ${body.relayedTo ?? 'the blocked agent'} — it will finish the OAuth flow.`);
+      setCallbackUrl('');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to relay callback URL');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleMarkCompleted = async () => {
+    setCompleting(true);
+    try {
+      const res = await fetch('/api/linear-mcp-auth/complete', { method: 'POST' });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Failed to mark Linear auth completed (${res.status})`);
+      }
+      toast.success('Marked Linear authentication healthy — blocked agents are being woken to re-check.');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to mark Linear auth completed');
+    } finally {
+      setCompleting(false);
+    }
+  };
+
+  return (
+    <div className="bg-warning/10 border-b-2 border-warning/40 px-4 py-3 flex flex-col gap-2 shrink-0">
+      <div className="flex items-center gap-3">
+        <AlertTriangle className="w-5 h-5 text-warning-foreground shrink-0" />
+        <p className="text-warning-foreground text-sm font-semibold flex-1">
+          Linear authentication required — {blockedAgents.length} agent{blockedAgents.length === 1 ? '' : 's'} blocked on Linear MCP OAuth.
+        </p>
+        {intervention.authUrl && (
+          <a
+            href={intervention.authUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="px-3 py-1.5 bg-warning/20 hover:bg-warning/30 text-warning-foreground text-sm font-semibold rounded-md transition-colors shrink-0 flex items-center gap-1.5"
+          >
+            <ExternalLink className="w-3.5 h-3.5" />
+            Open Linear authorization{intervention.authUrlAgentId ? ` (from ${intervention.authUrlAgentId})` : ''}
+          </a>
+        )}
+        <button
+          onClick={handleMarkCompleted}
+          disabled={completing}
+          className="px-3 py-1.5 bg-warning/20 hover:bg-warning/30 text-warning-foreground text-sm font-semibold rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed shrink-0 flex items-center gap-1.5"
+        >
+          {completing ? (
+            <>
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              Marking…
+            </>
+          ) : (
+            <>
+              <CheckCircle2 className="w-3.5 h-3.5" />
+              Mark completed
+            </>
+          )}
+        </button>
+      </div>
+
+      {blockedAgents.length > 0 && (
+        <ul className="text-warning-foreground text-sm pl-8 flex flex-col gap-0.5">
+          {blockedAgents.map((agent) => {
+            const issueUrl = agent.issueId ? trackerIssueUrl(agent.issueId) : null;
+            return (
+              <li key={agent.agentId}>
+                <span className="font-semibold">{agent.agentId}</span>
+                {agent.issueId && (
+                  <>
+                    {' — '}
+                    {issueUrl ? (
+                      <a href={issueUrl} target="_blank" rel="noreferrer" className="underline hover:opacity-80">
+                        {agent.issueId}
+                      </a>
+                    ) : (
+                      agent.issueId
+                    )}
+                  </>
+                )}
+                {agent.notifiedAt && <span className="opacity-80"> (woken, re-checking)</span>}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {intervention.status === 'expired' ? (
+        <p className="text-warning-foreground text-sm pl-8 opacity-80">
+          This authorization link expired — it refreshes automatically when a blocked agent generates a fresh one.
+        </p>
+      ) : !intervention.authUrl ? (
+        <p className="text-warning-foreground text-sm pl-8 opacity-80">
+          Waiting for a blocked agent to produce an authorization URL — it appears here as soon as one does.
+        </p>
+      ) : null}
+
+      <div className="flex items-center gap-2 pl-8">
+        <input
+          type="text"
+          value={callbackUrl}
+          onChange={(event) => setCallbackUrl(event.target.value)}
+          placeholder="Paste the localhost callback URL here"
+          className="flex-1 max-w-xl px-2 py-1.5 text-sm rounded-md bg-background border border-warning/40 text-foreground placeholder:text-muted-foreground"
+        />
+        <button
+          onClick={handleCallbackSubmit}
+          disabled={submitting || callbackUrl.trim() === ''}
+          className="px-3 py-1.5 bg-warning/20 hover:bg-warning/30 text-warning-foreground text-sm font-semibold rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
+        >
+          {submitting ? 'Relaying…' : 'Submit callback URL'}
+        </button>
+      </div>
+      <p className="text-warning-foreground text-xs pl-8 opacity-80">
+        After authorizing in your browser, Linear redirects to a localhost URL. On a remote session the callback page
+        fails to load — copy the URL from the address bar and paste it above; it is relayed to the blocked agent to
+        finish the flow. If you authorized another way (e.g. <code>claude mcp login linear</code>), use Mark completed:
+        blocked agents will be woken to re-check Linear access, and this banner returns if authentication is still broken.
+      </p>
+    </div>
+  );
+}

--- a/src/dashboard/frontend/src/components/LinearMcpAuthBanner.tsx
+++ b/src/dashboard/frontend/src/components/LinearMcpAuthBanner.tsx
@@ -65,7 +65,7 @@ export function LinearMcpAuthBanner() {
         <p className="text-warning-foreground text-sm font-semibold flex-1">
           Linear authentication required — {blockedAgents.length} agent{blockedAgents.length === 1 ? '' : 's'} blocked on Linear MCP OAuth.
         </p>
-        {intervention.authUrl && (
+        {intervention.authUrl && intervention.status === 'active' && (
           <a
             href={intervention.authUrl}
             target="_blank"
@@ -98,7 +98,7 @@ export function LinearMcpAuthBanner() {
       {blockedAgents.length > 0 && (
         <ul className="text-warning-foreground text-sm pl-8 flex flex-col gap-0.5">
           {blockedAgents.map((agent) => {
-            const issueUrl = agent.issueId ? trackerIssueUrl(agent.issueId) : null;
+            const issueUrl = agent.issueUrl ?? (agent.issueId ? trackerIssueUrl(agent.issueId) : null);
             return (
               <li key={agent.agentId}>
                 <span className="font-semibold">{agent.agentId}</span>

--- a/src/dashboard/frontend/src/hooks/useLinearMcpAuthStatus.ts
+++ b/src/dashboard/frontend/src/hooks/useLinearMcpAuthStatus.ts
@@ -1,0 +1,39 @@
+import { useQuery } from '@tanstack/react-query';
+
+export interface LinearMcpAuthBlockedAgent {
+  agentId: string;
+  issueId: string | null;
+  declaredAt: string;
+  expiresAt: string;
+  notifiedAt: string | null;
+}
+
+export interface LinearMcpAuthStatus {
+  status: 'none' | 'active' | 'expired';
+  authUrl: string | null;
+  authUrlAgentId: string | null;
+  authUrlExpiresAt: string | null;
+  declaredAt: string | null;
+  blockedAgents: LinearMcpAuthBlockedAgent[];
+}
+
+export async function fetchLinearMcpAuthStatus(): Promise<LinearMcpAuthStatus> {
+  const res = await fetch('/api/linear-mcp-auth');
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Failed to fetch Linear MCP auth status (${res.status}): ${body}`);
+  }
+  return res.json();
+}
+
+export function useLinearMcpAuthStatus() {
+  return useQuery<LinearMcpAuthStatus>({
+    queryKey: ['linear-mcp-auth'],
+    queryFn: fetchLinearMcpAuthStatus,
+    // Poll fast while an intervention is on screen so state changes (expired
+    // link, new blocked agent, cleared banner) show up promptly; back off
+    // when there is nothing to act on. Same active/idle shape as the codex
+    // auth pollers.
+    refetchInterval: (query) => (query.state.data?.status === 'none' ? 30_000 : 5_000),
+  });
+}

--- a/src/dashboard/frontend/src/hooks/useLinearMcpAuthStatus.ts
+++ b/src/dashboard/frontend/src/hooks/useLinearMcpAuthStatus.ts
@@ -6,6 +6,9 @@ export interface LinearMcpAuthBlockedAgent {
   declaredAt: string;
   expiresAt: string;
   notifiedAt: string | null;
+  /** Canonical tracker URL projected by the server (Linear web URL, GitHub
+   * html_url); null when the issue cannot be resolved. */
+  issueUrl?: string | null;
 }
 
 export interface LinearMcpAuthStatus {

--- a/src/dashboard/server/event-store.ts
+++ b/src/dashboard/server/event-store.ts
@@ -57,6 +57,13 @@ export interface EventStore {
   queryByType(type: string, limit?: number): StoredEvent[];
   /** Return the latest event per payload.issueId for a given event type. */
   queryLatestPerIssue(type: string): StoredEvent[];
+  /**
+   * Return events whose type is in `types` and whose sequence is greater than
+   * `afterSequence`, oldest first. The type predicate and the sequence bound
+   * are both applied in SQL, so callers reconstructing a typed projection
+   * never materialize unrelated retained history the way `readFrom(0)` does.
+   */
+  queryByTypesSince(types: string[], afterSequence: number): StoredEvent[];
   /** Subscribe to live events. Returns an unsubscribe function. */
   subscribe(fn: EventSubscriber): Unsubscribe;
   /** Run 7-day retention compaction. Called at startup. */
@@ -345,6 +352,19 @@ export function createEventStore(db: DbAdapter): EventStore {
     return queryLatestPerIssueStmt.all([type]).map(rowToStored);
   }
 
+  function queryByTypesSince(types: string[], afterSequence: number): StoredEvent[] {
+    if (types.length === 0) return [];
+    // The IN-list arity varies per call, so this statement is prepared per
+    // call — still an indexed type/sequence lookup, and polls typically
+    // return zero rows.
+    const placeholders = types.map(() => '?').join(', ');
+    const stmt = db.prepare<EventRow>(
+      `SELECT sequence, type, timestamp, payload FROM events WHERE sequence > ? AND type IN (${placeholders}) ORDER BY sequence ASC`,
+    );
+    const rows = stmt.all([afterSequence, ...types]);
+    return rows.map(rowToStored);
+  }
+
   function emitStored(event: StoredEvent): void {
     emitter.emit('event', event);
   }
@@ -356,6 +376,7 @@ export function createEventStore(db: DbAdapter): EventStore {
     readFrom,
     queryByType,
     queryLatestPerIssue,
+    queryByTypesSince,
     subscribe,
     compact,
     purgeType,

--- a/src/dashboard/server/routes/__tests__/linear-mcp-auth.test.ts
+++ b/src/dashboard/server/routes/__tests__/linear-mcp-auth.test.ts
@@ -1,0 +1,159 @@
+import { Effect } from 'effect';
+import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  appendCallbackRelayed: vi.fn(),
+  appendHealthy: vi.fn(),
+  messageAgent: vi.fn(),
+  resolve: vi.fn(),
+}));
+
+vi.mock('../../../../lib/agents/messaging.js', () => ({
+  messageAgent: mocks.messageAgent,
+}));
+
+vi.mock('../../../../lib/linear-mcp-auth.js', () => ({
+  appendLinearMcpAuthCallbackRelayedEvent: mocks.appendCallbackRelayed,
+  appendLinearMcpAuthHealthyEvent: mocks.appendHealthy,
+  resolveLinearMcpAuthIntervention: mocks.resolve,
+}));
+
+import {
+  LINEAR_MCP_AUTH_CALLBACK_COPY_PREFIX,
+  linearMcpAuthRouteLayer,
+} from '../linear-mcp-auth.js';
+import { _resetTrustedOriginsForTests } from '../origin-validation.js';
+
+const NONE = {
+  status: 'none',
+  authUrl: null,
+  authUrlAgentId: null,
+  authUrlExpiresAt: null,
+  declaredAt: null,
+  blockedAgents: [],
+};
+
+const ACTIVE = {
+  status: 'active',
+  authUrl: 'https://linear.app/oauth/authorize?state=auth-state',
+  authUrlAgentId: 'agent-min-852',
+  authUrlExpiresAt: '2026-07-21T12:30:00.000Z',
+  declaredAt: '2026-07-21T12:00:00.000Z',
+  blockedAgents: [{
+    agentId: 'agent-min-852',
+    issueId: 'MIN-852',
+    declaredAt: '2026-07-21T12:00:00.000Z',
+    expiresAt: '2026-07-21T12:30:00.000Z',
+    notifiedAt: null,
+  }],
+};
+
+async function request(
+  method: 'GET' | 'POST',
+  path: string,
+  body?: Record<string, unknown>,
+  includeOrigin = true,
+) {
+  const headers = new Headers();
+  if (includeOrigin) headers.set('origin', 'http://localhost:3011');
+  if (body !== undefined) headers.set('content-type', 'application/json');
+  const webRequest = new Request(`http://localhost:3011${path}`, {
+    method,
+    headers,
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+  const httpRequest = HttpServerRequest.fromWeb(webRequest);
+  const response = await Effect.runPromise(
+    Effect.scoped(
+      Effect.flatMap(HttpRouter.toHttpEffect(linearMcpAuthRouteLayer), app =>
+        Effect.provideService(app, HttpServerRequest.HttpServerRequest, httpRequest)),
+    ),
+  );
+  const responseBody = response.body as { body?: Uint8Array } | null;
+  const text = responseBody?.body ? new TextDecoder().decode(responseBody.body) : '{}';
+  return { status: response.status, body: JSON.parse(text) as Record<string, unknown> };
+}
+
+describe('Linear MCP auth routes', () => {
+  beforeEach(() => {
+    process.env.PORT = '3011';
+    delete process.env.DASHBOARD_URL;
+    delete process.env.OVERDECK_TRUSTED_ORIGINS;
+    _resetTrustedOriginsForTests();
+    mocks.appendCallbackRelayed.mockReset().mockResolvedValue(1);
+    mocks.appendHealthy.mockReset().mockResolvedValue(1);
+    mocks.messageAgent.mockReset().mockResolvedValue(undefined);
+    mocks.resolve.mockReset().mockResolvedValue(NONE);
+  });
+
+  it('GET returns the projection without side effects', async () => {
+    mocks.resolve.mockResolvedValue(ACTIVE);
+
+    const result = await request('GET', '/api/linear-mcp-auth');
+
+    expect(result).toEqual({ status: 200, body: ACTIVE });
+    expect(mocks.messageAgent).not.toHaveBeenCalled();
+    expect(mocks.appendCallbackRelayed).not.toHaveBeenCalled();
+    expect(mocks.appendHealthy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'https://evil.example/callback?code=abc&state=xyz',
+    'http://localhost:43110/callback?code=abc',
+    'http://127.0.0.1:43110/callback?state=xyz',
+  ])('POST callback rejects invalid URL %s', async (callbackUrl) => {
+    const result = await request('POST', '/api/linear-mcp-auth/callback', { callbackUrl });
+
+    expect(result.status).toBe(400);
+    expect(mocks.messageAgent).not.toHaveBeenCalled();
+  });
+
+  it('POST callback rejects when no agent owns an authorization URL', async () => {
+    const result = await request('POST', '/api/linear-mcp-auth/callback', {
+      callbackUrl: 'http://localhost:43110/callback?code=abc&state=xyz',
+    });
+
+    expect(result.status).toBe(409);
+    expect(mocks.messageAgent).not.toHaveBeenCalled();
+  });
+
+  it('POST callback relays the exact URL and records callback_relayed', async () => {
+    mocks.resolve.mockResolvedValue(ACTIVE);
+    const callbackUrl = 'http://localhost:43110/callback?code=abc&state=xyz';
+
+    const result = await request('POST', '/api/linear-mcp-auth/callback', { callbackUrl });
+
+    expect(result).toEqual({
+      status: 200,
+      body: { success: true, relayedTo: 'agent-min-852' },
+    });
+    expect(mocks.messageAgent).toHaveBeenCalledWith(
+      'agent-min-852',
+      `${LINEAR_MCP_AUTH_CALLBACK_COPY_PREFIX} ${callbackUrl} — then re-check Linear access and resume your canonical task.`,
+      'linear-mcp-auth-callback',
+    );
+    expect(mocks.appendCallbackRelayed).toHaveBeenCalledWith({
+      agentId: 'agent-min-852',
+      issueId: 'MIN-852',
+    });
+  });
+
+  it('POST complete records operator-source healthy', async () => {
+    const result = await request('POST', '/api/linear-mcp-auth/complete');
+
+    expect(result).toEqual({ status: 200, body: { success: true } });
+    expect(mocks.appendHealthy).toHaveBeenCalledWith({
+      agentId: 'operator',
+      issueId: null,
+      source: 'operator',
+    });
+  });
+
+  it('POST mutations reject requests without an origin', async () => {
+    const result = await request('POST', '/api/linear-mcp-auth/complete', undefined, false);
+
+    expect(result.status).toBe(403);
+    expect(mocks.appendHealthy).not.toHaveBeenCalled();
+  });
+});

--- a/src/dashboard/server/routes/__tests__/linear-mcp-auth.test.ts
+++ b/src/dashboard/server/routes/__tests__/linear-mcp-auth.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   appendHealthy: vi.fn(),
   messageAgent: vi.fn(),
   resolve: vi.fn(),
+  getIssues: vi.fn(),
 }));
 
 vi.mock('../../../../lib/agents/messaging.js', () => ({
@@ -17,6 +18,10 @@ vi.mock('../../../../lib/linear-mcp-auth.js', () => ({
   appendLinearMcpAuthCallbackRelayedEvent: mocks.appendCallbackRelayed,
   appendLinearMcpAuthHealthyEvent: mocks.appendHealthy,
   resolveLinearMcpAuthIntervention: mocks.resolve,
+}));
+
+vi.mock('../../services/issue-service-singleton.js', () => ({
+  getSharedIssueService: vi.fn(() => ({ getIssues: mocks.getIssues })),
 }));
 
 import {
@@ -85,6 +90,7 @@ describe('Linear MCP auth routes', () => {
     mocks.appendHealthy.mockReset().mockResolvedValue(1);
     mocks.messageAgent.mockReset().mockResolvedValue(undefined);
     mocks.resolve.mockReset().mockResolvedValue(NONE);
+    mocks.getIssues.mockReset().mockReturnValue([]);
   });
 
   it('GET returns the projection without side effects', async () => {
@@ -92,10 +98,31 @@ describe('Linear MCP auth routes', () => {
 
     const result = await request('GET', '/api/linear-mcp-auth');
 
-    expect(result).toEqual({ status: 200, body: ACTIVE });
+    expect(result).toEqual({
+      status: 200,
+      body: {
+        ...ACTIVE,
+        blockedAgents: [{ ...ACTIVE.blockedAgents[0], issueUrl: null }],
+      },
+    });
     expect(mocks.messageAgent).not.toHaveBeenCalled();
     expect(mocks.appendCallbackRelayed).not.toHaveBeenCalled();
     expect(mocks.appendHealthy).not.toHaveBeenCalled();
+  });
+
+  it('GET enriches each blocked agent with its canonical tracker URL', async () => {
+    mocks.resolve.mockResolvedValue(ACTIVE);
+    mocks.getIssues.mockReturnValue([
+      { identifier: 'MIN-852', url: 'https://linear.app/mind-your-now/issue/MIN-852/habits-full-bug-audit' },
+    ]);
+
+    const result = await request('GET', '/api/linear-mcp-auth');
+
+    expect(result.status).toBe(200);
+    expect((result.body['blockedAgents'] as Array<Record<string, unknown>>)[0]).toMatchObject({
+      agentId: 'agent-min-852',
+      issueUrl: 'https://linear.app/mind-your-now/issue/MIN-852/habits-full-bug-audit',
+    });
   });
 
   it.each([

--- a/src/dashboard/server/routes/agents/runtime-events.ts
+++ b/src/dashboard/server/routes/agents/runtime-events.ts
@@ -52,12 +52,24 @@ export const getAgentHealthHistoryRoute = HttpRouter.add(
 //   {kind: "resolution_set",    resolution, resolutionCount}
 //   {kind: "current_issue_set", currentIssue?}
 //   {kind: "context_saturation_changed", contextSaturatedAt?}
+//   {kind: "linear_mcp_auth_required", authUrl?, expiresAt?}
+//   {kind: "linear_mcp_auth_healthy"}
 
-function emitAgentRuntimeEvent(id: string, body: Record<string, unknown>, timestamp: string) {
+export function emitAgentRuntimeEvent(id: string, body: Record<string, unknown>, timestamp: string) {
   return Effect.gen(function* () {
+    let eventBody = body;
+    if (body['kind'] === 'linear_mcp_auth_required' || body['kind'] === 'linear_mcp_auth_healthy') {
+      const { AgentStateService } = yield* Effect.promise(
+        () => import('../../services/agent-state-service.js'),
+      );
+      const agentState = yield* AgentStateService;
+      const snapshot = yield* agentState.get(id);
+      eventBody = { ...body, issueId: snapshot?.currentIssue ?? null };
+    }
+
     let raw: Record<string, unknown> | null;
     try {
-      raw = bodyToEvent(id, body, timestamp);
+      raw = bodyToEvent(id, eventBody, timestamp);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'invalid heartbeat payload';
       return { ok: false as const, response: jsonResponse({ success: false, error: message }, { status: 400 }) };

--- a/src/dashboard/server/routes/linear-mcp-auth.ts
+++ b/src/dashboard/server/routes/linear-mcp-auth.ts
@@ -5,7 +5,9 @@ import {
   appendLinearMcpAuthCallbackRelayedEvent,
   appendLinearMcpAuthHealthyEvent,
   resolveLinearMcpAuthIntervention,
+  type LinearMcpAuthIntervention,
 } from '../../../lib/linear-mcp-auth.js';
+import { getSharedIssueService } from '../services/issue-service-singleton.js';
 import { jsonResponse } from '../http-helpers.js';
 import { httpHandler } from './http-handler.js';
 import { validateOrigin } from './origin-validation.js';
@@ -43,12 +45,41 @@ function callbackCopy(callbackUrl: string): string {
   return `${LINEAR_MCP_AUTH_CALLBACK_COPY_PREFIX} ${callbackUrl} — then re-check Linear access and resume your canonical task.`;
 }
 
+/**
+ * Attach each blocked agent's canonical tracker URL (Linear web URL, GitHub
+ * html_url) from the issues read door so the banner can link every blocked
+ * agent's issue — including Linear-tracked ones the frontend cannot derive a
+ * URL for. Best-effort: an unresolvable issue falls back to null and the
+ * banner renders its own fallback.
+ */
+function withIssueUrls(intervention: LinearMcpAuthIntervention): LinearMcpAuthIntervention {
+  let urlByIdentifier: Map<string, string>;
+  try {
+    urlByIdentifier = new Map();
+    const issues = getSharedIssueService().getIssues({ includeCompleted: true }) as Array<{ identifier?: unknown; url?: unknown }>;
+    for (const issue of issues) {
+      if (typeof issue.identifier === 'string' && typeof issue.url === 'string' && issue.url !== '') {
+        urlByIdentifier.set(issue.identifier.toLowerCase(), issue.url);
+      }
+    }
+  } catch {
+    return intervention;
+  }
+  return {
+    ...intervention,
+    blockedAgents: intervention.blockedAgents.map(agent => ({
+      ...agent,
+      issueUrl: agent.issueId ? urlByIdentifier.get(agent.issueId.toLowerCase()) ?? null : null,
+    })),
+  };
+}
+
 const getLinearMcpAuthRoute = HttpRouter.add(
   'GET',
   '/api/linear-mcp-auth',
   httpHandler(Effect.gen(function* () {
     const intervention = yield* Effect.promise(() => resolveLinearMcpAuthIntervention());
-    return jsonResponse(intervention);
+    return jsonResponse(withIssueUrls(intervention));
   })),
 );
 

--- a/src/dashboard/server/routes/linear-mcp-auth.ts
+++ b/src/dashboard/server/routes/linear-mcp-auth.ts
@@ -1,0 +1,108 @@
+import { Effect, Layer } from 'effect';
+import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
+import { messageAgent } from '../../../lib/agents/messaging.js';
+import {
+  appendLinearMcpAuthCallbackRelayedEvent,
+  appendLinearMcpAuthHealthyEvent,
+  resolveLinearMcpAuthIntervention,
+} from '../../../lib/linear-mcp-auth.js';
+import { jsonResponse } from '../http-helpers.js';
+import { httpHandler } from './http-handler.js';
+import { validateOrigin } from './origin-validation.js';
+
+export const LINEAR_MCP_AUTH_CALLBACK_COPY_PREFIX = 'The operator completed the Linear OAuth authorization in their browser. Finish the flow now: call mcp__linear__complete_authentication with callback_url set to exactly this URL:';
+
+const readJsonBody = Effect.gen(function* () {
+  const request = yield* HttpServerRequest.HttpServerRequest;
+  const text = yield* request.text;
+  return text ? JSON.parse(text) as Record<string, unknown> : {};
+});
+
+function rejectInvalidOrigin(request: HttpServerRequest.HttpServerRequest): ReturnType<typeof jsonResponse> | null {
+  const originCheck = validateOrigin(request);
+  if (!originCheck.ok) {
+    return jsonResponse({ error: originCheck.error }, { status: 403 });
+  }
+  return null;
+}
+
+export function isValidLinearMcpCallbackUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    const localHost = url.hostname === 'localhost' || url.hostname === '127.0.0.1';
+    return url.protocol === 'http:'
+      && localHost
+      && !!url.searchParams.get('code')
+      && !!url.searchParams.get('state');
+  } catch {
+    return false;
+  }
+}
+
+function callbackCopy(callbackUrl: string): string {
+  return `${LINEAR_MCP_AUTH_CALLBACK_COPY_PREFIX} ${callbackUrl} — then re-check Linear access and resume your canonical task.`;
+}
+
+const getLinearMcpAuthRoute = HttpRouter.add(
+  'GET',
+  '/api/linear-mcp-auth',
+  httpHandler(Effect.gen(function* () {
+    const intervention = yield* Effect.promise(() => resolveLinearMcpAuthIntervention());
+    return jsonResponse(intervention);
+  })),
+);
+
+const postLinearMcpAuthCallbackRoute = HttpRouter.add(
+  'POST',
+  '/api/linear-mcp-auth/callback',
+  httpHandler(Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const originError = rejectInvalidOrigin(request);
+    if (originError) return originError;
+
+    const body = yield* readJsonBody;
+    const callbackUrl = typeof body['callbackUrl'] === 'string' ? body['callbackUrl'] : '';
+    if (!isValidLinearMcpCallbackUrl(callbackUrl)) {
+      return jsonResponse({ success: false, error: 'callbackUrl must be a localhost OAuth callback URL with code and state parameters' }, { status: 400 });
+    }
+
+    const intervention = yield* Effect.promise(() => resolveLinearMcpAuthIntervention());
+    if (intervention.authUrlAgentId === null) {
+      return jsonResponse({ success: false, error: 'No blocked agent owns the active Linear authorization URL' }, { status: 409 });
+    }
+
+    yield* Effect.promise(() => messageAgent(
+      intervention.authUrlAgentId!,
+      callbackCopy(callbackUrl),
+      'linear-mcp-auth-callback',
+    ));
+    yield* Effect.promise(() => appendLinearMcpAuthCallbackRelayedEvent({
+      agentId: intervention.authUrlAgentId!,
+      issueId: intervention.blockedAgents.find(agent => agent.agentId === intervention.authUrlAgentId)?.issueId ?? null,
+    }));
+    return jsonResponse({ success: true, relayedTo: intervention.authUrlAgentId });
+  })),
+);
+
+const postLinearMcpAuthCompleteRoute = HttpRouter.add(
+  'POST',
+  '/api/linear-mcp-auth/complete',
+  httpHandler(Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const originError = rejectInvalidOrigin(request);
+    if (originError) return originError;
+
+    yield* Effect.promise(() => appendLinearMcpAuthHealthyEvent({
+      agentId: 'operator',
+      issueId: null,
+      source: 'operator',
+    }));
+    return jsonResponse({ success: true });
+  })),
+);
+
+export const linearMcpAuthRouteLayer = Layer.mergeAll(
+  getLinearMcpAuthRoute,
+  postLinearMcpAuthCallbackRoute,
+  postLinearMcpAuthCompleteRoute,
+);

--- a/src/dashboard/server/server.ts
+++ b/src/dashboard/server/server.ts
@@ -68,6 +68,7 @@ import { webhooksRouteLayer } from './routes/webhooks.js';
 import { hooksRouteLayer } from './routes/hooks.js';
 import { diffsRouteLayer } from './routes/diffs.js';
 import { codexAuthRouteLayer } from './routes/codex-auth.js';
+import { linearMcpAuthRouteLayer } from './routes/linear-mcp-auth.js';
 import { terminalsRouteLayer } from './routes/terminals.js';
 import { discoveredSessionsRouteLayer } from './routes/discovered-sessions.js';
 import { flywheelRouteLayer } from './routes/flywheel.js';
@@ -360,6 +361,7 @@ export const makeRoutesLayer = Layer.mergeAll(
   hooksRouteLayer,
   diffsRouteLayer,
   codexAuthRouteLayer,
+  linearMcpAuthRouteLayer,
   terminalsRouteLayer,
   discoveredSessionsRouteLayer,
   flywheelRouteLayer,

--- a/src/dashboard/server/services/agent-event-utils.ts
+++ b/src/dashboard/server/services/agent-event-utils.ts
@@ -150,6 +150,27 @@ export const bodyToEvent = (
           contextSaturatedAt: source['contextSaturatedAt'] as string | undefined,
         },
       };
+    case 'linear_mcp_auth_required':
+      return {
+        type: 'linear_mcp_auth.required',
+        timestamp,
+        payload: {
+          agentId,
+          issueId: source['issueId'] ?? null,
+          authUrl: source['authUrl'] ?? null,
+          expiresAt: source['expiresAt'] ?? null,
+        },
+      };
+    case 'linear_mcp_auth_healthy':
+      return {
+        type: 'linear_mcp_auth.healthy',
+        timestamp,
+        payload: {
+          agentId,
+          issueId: source['issueId'] ?? null,
+          source: 'hook',
+        },
+      };
     default:
       return null;
   }

--- a/src/lib/__tests__/deliver-agent-message.test.ts
+++ b/src/lib/__tests__/deliver-agent-message.test.ts
@@ -35,8 +35,8 @@ vi.mock('../tmux.js', () => ({
 }));
 
 vi.mock('../tmux-dedup.js', () => ({
-  sendKeysDedup: vi.fn(async () => 'delivered'),
-  sendEnterKey: vi.fn(async () => undefined),
+  sendKeysDedup: vi.fn(async () => 'pasted'),
+  completeKeyedSubmit: vi.fn(async () => undefined),
 }));
 
 vi.mock('../paths.js', async (importOriginal) => {
@@ -555,32 +555,87 @@ describe('channel bridge delivery', () => {
     }
   });
 
-  it('uses the atomic tmux dedup path for keyed tmux deliveries (PAN-2997)', async () => {
+  it('uses the two-phase tmux dedup path for keyed tmux deliveries (PAN-2997)', async () => {
     const agentId = 'agent-dedup-tmux';
     writeAgentState(agentId, { channelsEnabled: false, deliveryMethod: 'tmux' });
-    const { sendKeysDedup, sendEnterKey } = await import('../tmux-dedup.js');
+    const { sendKeysDedup, completeKeyedSubmit } = await import('../tmux-dedup.js');
     vi.mocked(sendKeysDedup).mockClear();
-    vi.mocked(sendEnterKey).mockClear();
+    vi.mocked(completeKeyedSubmit).mockClear();
 
     const result = await deliverAgentMessage(agentId, 'wake', 'caller-wake', 'tmux', { dedupKey: 'wake:seq-1' });
 
     expect(result).toEqual({ ok: true, path: 'tmux', deduplicated: false });
     expect(vi.mocked(sendKeysDedup)).toHaveBeenCalledWith(agentId, 'wake', 'wake:seq-1', 'caller-wake');
-    expect(vi.mocked(sendEnterKey)).toHaveBeenCalledWith(agentId);
+    expect(vi.mocked(completeKeyedSubmit)).toHaveBeenCalledWith(agentId, 'wake:seq-1');
+  });
+
+  it('completes a crashed pending tmux submission WITHOUT re-pasting (PAN-2997 cycle 7)', async () => {
+    const agentId = 'agent-dedup-tmux-pending';
+    writeAgentState(agentId, { channelsEnabled: false, deliveryMethod: 'tmux' });
+    const { sendKeysDedup, completeKeyedSubmit } = await import('../tmux-dedup.js');
+    vi.mocked(sendKeysDedup).mockClear();
+    vi.mocked(completeKeyedSubmit).mockClear();
+    vi.mocked(sendKeysDedup).mockResolvedValueOnce('submit-pending');
+
+    const result = await deliverAgentMessage(agentId, 'wake', 'caller-wake', 'tmux', { dedupKey: 'wake:seq-1' });
+
+    expect(result).toEqual({ ok: true, path: 'tmux', deduplicated: false });
+    expect(vi.mocked(completeKeyedSubmit)).toHaveBeenCalledWith(agentId, 'wake:seq-1');
   });
 
   it('sends no Enter when the tmux dedup path reports a prior delivery (PAN-2997)', async () => {
     const agentId = 'agent-dedup-tmux-replay';
     writeAgentState(agentId, { channelsEnabled: false, deliveryMethod: 'tmux' });
-    const { sendKeysDedup, sendEnterKey } = await import('../tmux-dedup.js');
+    const { sendKeysDedup, completeKeyedSubmit } = await import('../tmux-dedup.js');
     vi.mocked(sendKeysDedup).mockClear();
-    vi.mocked(sendEnterKey).mockClear();
+    vi.mocked(completeKeyedSubmit).mockClear();
     vi.mocked(sendKeysDedup).mockResolvedValueOnce('deduplicated');
 
     const result = await deliverAgentMessage(agentId, 'wake', 'caller-wake', 'tmux', { dedupKey: 'wake:seq-1' });
 
     expect(result).toEqual({ ok: true, path: 'tmux', deduplicated: true });
-    expect(vi.mocked(sendEnterKey)).not.toHaveBeenCalled();
+    expect(vi.mocked(completeKeyedSubmit)).not.toHaveBeenCalled();
+  });
+
+  it('keyed deliveries SKIP the Channels tier in auto mode and land on keyed tmux (PAN-2997 cycle 7)', async () => {
+    const agentId = 'agent-dedup-channels-skip';
+    writeAgentState(agentId, { channelsEnabled: true });
+    // No supervisor socket — auto mode would normally fall to Channels, which
+    // acknowledges without enforcing the key. The keyed cascade must bypass it.
+    const channelSocketPath = join(socketDir, `agent-${agentId}.sock`);
+    const channelCapture: { lastBody?: string } = {};
+    const channelServer = await startFakeBridge(channelSocketPath, { status: 200, body: 'ok', capture: channelCapture });
+    const { sendKeysDedup, completeKeyedSubmit } = await import('../tmux-dedup.js');
+    vi.mocked(sendKeysDedup).mockClear();
+    vi.mocked(completeKeyedSubmit).mockClear();
+    try {
+      const result = await deliverAgentMessage(agentId, 'wake', 'caller-wake', undefined, { dedupKey: 'wake:seq-1' });
+
+      expect(result).toMatchObject({ ok: true, path: 'tmux', deduplicated: false });
+      expect(channelCapture.lastBody).toBeUndefined();
+      expect(vi.mocked(sendKeysDedup)).toHaveBeenCalledWith(agentId, 'wake', 'wake:seq-1', 'caller-wake');
+      expect(vi.mocked(completeKeyedSubmit)).toHaveBeenCalledWith(agentId, 'wake:seq-1');
+    } finally {
+      await new Promise<void>((r) => channelServer.close(() => r()));
+    }
+  });
+
+  it('rejects an explicit keyed Channels request instead of delivering unenforced (PAN-2997 cycle 7)', async () => {
+    const agentId = 'agent-dedup-channels-explicit';
+    writeAgentState(agentId, { channelsEnabled: true });
+
+    await expect(
+      deliverAgentMessage(agentId, 'wake', 'caller-wake', 'channels', { dedupKey: 'wake:seq-1' }),
+    ).rejects.toThrow(/Channels tier cannot enforce a dedup key/);
+  });
+
+  it('rejects keyed delivery to an ACP target (PAN-2997 cycle 7)', async () => {
+    const agentId = 'agent-dedup-acp';
+    writeAgentState(agentId, { harness: 'acp' });
+
+    await expect(
+      deliverAgentMessage(agentId, 'wake', 'caller-wake', undefined, { dedupKey: 'wake:seq-1' }),
+    ).rejects.toThrow(/ACP tier cannot enforce a dedup key/);
   });
 
   it('codex work agents use live-session delivery instead of exec resume', async () => {

--- a/src/lib/__tests__/deliver-agent-message.test.ts
+++ b/src/lib/__tests__/deliver-agent-message.test.ts
@@ -37,6 +37,12 @@ vi.mock('../tmux.js', () => ({
 vi.mock('../tmux-dedup.js', () => ({
   sendKeysDedup: vi.fn(async () => 'pasted'),
   completeKeyedSubmit: vi.fn(async () => undefined),
+  KeyedSubmitTargetDeadError: class KeyedSubmitTargetDeadError extends Error {
+    constructor(sessionName: string, dedupKey: string) {
+      super(`dead pane for ${sessionName} key ${dedupKey}`);
+      this.name = 'KeyedSubmitTargetDeadError';
+    }
+  },
 }));
 
 vi.mock('../paths.js', async (importOriginal) => {
@@ -686,6 +692,19 @@ describe('channel bridge delivery', () => {
     } finally {
       await new Promise<void>((r) => server.close(() => r()));
     }
+  });
+
+  it('propagates a dead-pane keyed submit failure instead of acknowledging delivery (cycle 9)', async () => {
+    const agentId = 'agent-dedup-dead-pane';
+    writeAgentState(agentId, { channelsEnabled: false, deliveryMethod: 'tmux' });
+    const { completeKeyedSubmit, KeyedSubmitTargetDeadError } = await import('../tmux-dedup.js');
+    vi.mocked(completeKeyedSubmit).mockRejectedValueOnce(
+      new (KeyedSubmitTargetDeadError as unknown as new (s: string, k: string) => Error)(agentId, 'wake:seq-1'),
+    );
+
+    await expect(
+      deliverAgentMessage(agentId, 'wake', 'caller-wake', 'tmux', { dedupKey: 'wake:seq-1' }),
+    ).rejects.toThrow(/dead pane/);
   });
 
   it('codex work agents use live-session delivery instead of exec resume', async () => {

--- a/src/lib/__tests__/deliver-agent-message.test.ts
+++ b/src/lib/__tests__/deliver-agent-message.test.ts
@@ -79,6 +79,9 @@ interface FakeBridgeOptions {
   status: number;
   body: string;
   delayMs?: number;
+  /** Accept the request, then destroy the connection WITHOUT responding —
+   * simulates a lost/reset response after possible server-side acceptance. */
+  drop?: boolean;
   capture?: { lastBody?: string; lastHeaders?: Record<string, string> };
 }
 
@@ -125,7 +128,9 @@ function startFakeBridge(socketPath: string, opts: FakeBridgeOptions): Promise<N
             opts.body;
           sock.end(resp);
         };
-        if (opts.delayMs) {
+        if (opts.drop) {
+          sock.destroy();
+        } else if (opts.delayMs) {
           setTimeout(respond, opts.delayMs);
         } else {
           respond();
@@ -636,6 +641,51 @@ describe('channel bridge delivery', () => {
     await expect(
       deliverAgentMessage(agentId, 'wake', 'caller-wake', undefined, { dedupKey: 'wake:seq-1' }),
     ).rejects.toThrow(/ACP tier cannot enforce a dedup key/);
+  });
+
+  it('does NOT cross to tmux when the keyed supervisor response is lost (ambiguous — cycle 8)', async () => {
+    const agentId = 'agent-dedup-ambiguous';
+    writeAgentState(agentId, { channelsEnabled: false });
+    await writePtyToken(agentId);
+    const socketPath = join(socketDir, `pty-${agentId}.sock`);
+    const capture: { lastBody?: string } = {};
+    // The bridge accepts the keyed request (so the supervisor MAY have
+    // injected) and then drops the connection without a response.
+    const server = await startFakeBridge(socketPath, { status: 200, body: 'ok', drop: true, capture });
+    const { sendKeysDedup } = await import('../tmux-dedup.js');
+    vi.mocked(sendKeysDedup).mockClear();
+    try {
+      await expect(
+        deliverAgentMessage(agentId, 'wake', 'caller-wake', undefined, { dedupKey: 'wake:seq-1' }),
+      ).rejects.toThrow(/ambiguous keyed delivery/);
+      // The request reached the supervisor…
+      expect(capture.lastBody).toBeDefined();
+      // …and the tmux tier — with its independent key store — was never touched.
+      expect(vi.mocked(sendKeysDedup)).not.toHaveBeenCalled();
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
+  it('falls back to keyed tmux on a DEFINITIVE supervisor 502 (response received — cycle 8)', async () => {
+    const agentId = 'agent-dedup-definitive';
+    writeAgentState(agentId, { channelsEnabled: false });
+    await writePtyToken(agentId);
+    const socketPath = join(socketDir, `pty-${agentId}.sock`);
+    const server = await startFakeBridge(socketPath, { status: 502, body: 'input echo confirmation failed' });
+    const { sendKeysDedup, completeKeyedSubmit } = await import('../tmux-dedup.js');
+    vi.mocked(sendKeysDedup).mockClear();
+    vi.mocked(completeKeyedSubmit).mockClear();
+    try {
+      const result = await deliverAgentMessage(agentId, 'wake', 'caller-wake', undefined, { dedupKey: 'wake:seq-1' });
+
+      expect(result).toMatchObject({ ok: true, path: 'tmux', deduplicated: false });
+      expect(result.failure).toContain('502');
+      expect(vi.mocked(sendKeysDedup)).toHaveBeenCalledWith(agentId, 'wake', 'wake:seq-1', 'caller-wake');
+      expect(vi.mocked(completeKeyedSubmit)).toHaveBeenCalledWith(agentId, 'wake:seq-1');
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
   });
 
   it('codex work agents use live-session delivery instead of exec resume', async () => {

--- a/src/lib/__tests__/deliver-agent-message.test.ts
+++ b/src/lib/__tests__/deliver-agent-message.test.ts
@@ -34,6 +34,11 @@ vi.mock('../tmux.js', () => ({
   waitForClaudePrompt: vi.fn(async () => true),
 }));
 
+vi.mock('../tmux-dedup.js', () => ({
+  sendKeysDedup: vi.fn(async () => 'delivered'),
+  sendEnterKey: vi.fn(async () => undefined),
+}));
+
 vi.mock('../paths.js', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
   return {
@@ -525,6 +530,57 @@ describe('channel bridge delivery', () => {
     } finally {
       await new Promise<void>((r) => server.close(() => r()));
     }
+  });
+
+  it('threads dedupKey to the supervisor and surfaces deduplication (PAN-2997)', async () => {
+    const agentId = 'agent-dedup';
+    writeAgentState(agentId, { channelsEnabled: false });
+    await writePtyToken(agentId);
+    const socketPath = join(socketDir, `pty-${agentId}.sock`);
+    const capture: { lastBody?: string } = {};
+    const server = await startFakeBridge(socketPath, {
+      status: 200,
+      body: JSON.stringify({ ok: true, deduplicated: true }),
+      capture,
+    });
+    try {
+      const result = await deliverAgentMessage(agentId, 'wake', 'caller-wake', undefined, { dedupKey: 'wake:seq-1' });
+      expect(result).toEqual({ ok: true, path: 'supervisor', deduplicated: true });
+      expect(JSON.parse(capture.lastBody!)).toMatchObject({
+        content: 'wake',
+        dedupKey: 'wake:seq-1',
+      });
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
+  it('uses the atomic tmux dedup path for keyed tmux deliveries (PAN-2997)', async () => {
+    const agentId = 'agent-dedup-tmux';
+    writeAgentState(agentId, { channelsEnabled: false, deliveryMethod: 'tmux' });
+    const { sendKeysDedup, sendEnterKey } = await import('../tmux-dedup.js');
+    vi.mocked(sendKeysDedup).mockClear();
+    vi.mocked(sendEnterKey).mockClear();
+
+    const result = await deliverAgentMessage(agentId, 'wake', 'caller-wake', 'tmux', { dedupKey: 'wake:seq-1' });
+
+    expect(result).toEqual({ ok: true, path: 'tmux', deduplicated: false });
+    expect(vi.mocked(sendKeysDedup)).toHaveBeenCalledWith(agentId, 'wake', 'wake:seq-1', 'caller-wake');
+    expect(vi.mocked(sendEnterKey)).toHaveBeenCalledWith(agentId);
+  });
+
+  it('sends no Enter when the tmux dedup path reports a prior delivery (PAN-2997)', async () => {
+    const agentId = 'agent-dedup-tmux-replay';
+    writeAgentState(agentId, { channelsEnabled: false, deliveryMethod: 'tmux' });
+    const { sendKeysDedup, sendEnterKey } = await import('../tmux-dedup.js');
+    vi.mocked(sendKeysDedup).mockClear();
+    vi.mocked(sendEnterKey).mockClear();
+    vi.mocked(sendKeysDedup).mockResolvedValueOnce('deduplicated');
+
+    const result = await deliverAgentMessage(agentId, 'wake', 'caller-wake', 'tmux', { dedupKey: 'wake:seq-1' });
+
+    expect(result).toEqual({ ok: true, path: 'tmux', deduplicated: true });
+    expect(vi.mocked(sendEnterKey)).not.toHaveBeenCalled();
   });
 
   it('codex work agents use live-session delivery instead of exec resume', async () => {

--- a/src/lib/__tests__/linear-mcp-auth-wake.test.ts
+++ b/src/lib/__tests__/linear-mcp-auth-wake.test.ts
@@ -6,12 +6,14 @@ const mocks = vi.hoisted(() => ({
   appendAsync: vi.fn(),
   messageAgent: vi.fn(),
   queryByType: vi.fn(),
+  readFrom: vi.fn(),
 }));
 
 vi.mock('../../dashboard/server/event-store.js', () => ({
   initEventStore: vi.fn(async () => ({
     appendAsync: mocks.appendAsync,
     queryByType: mocks.queryByType,
+    readFrom: mocks.readFrom,
   })),
 }));
 
@@ -62,10 +64,16 @@ describe('Linear MCP auth wake processor', () => {
     mocks.messageAgent.mockReset();
     mocks.messageAgent.mockResolvedValue('delivered');
     mocks.queryByType.mockReset();
-    mocks.queryByType.mockImplementation((type: string) => (
+    mocks.queryByType.mockImplementation((type: string, limit = 100) => (
       events
         .filter(event => event.type === type)
-        .sort((a, b) => b.sequence - a.sequence)
+        .sort((a, b) => a.sequence - b.sequence)
+        .slice(-limit)
+    ));
+    mocks.readFrom.mockImplementation((fromSequence: number) => (
+      events
+        .filter(event => event.sequence > fromSequence && event.type !== 'issues.snapshot')
+        .sort((a, b) => a.sequence - b.sequence)
     ));
     mocks.appendAsync.mockReset();
     mocks.appendAsync.mockImplementation(async (event: Omit<DomainEvent, 'sequence'>) => {
@@ -94,6 +102,7 @@ describe('Linear MCP auth wake processor', () => {
       agentId: 'agent-min-852',
       issueId: 'MIN-852',
       outcome: 'delivered',
+      lifecycleId: 'seq-1',
     });
   });
 
@@ -115,6 +124,7 @@ describe('Linear MCP auth wake processor', () => {
       'delivered',
       'delivered',
     ]);
+    expect(notifiedEvents().every(event => event.payload['lifecycleId'] === 'seq-1')).toBe(true);
   });
 
   it('records queued when messageAgent routes a stopped or gated agent to mail', async () => {
@@ -155,5 +165,29 @@ describe('Linear MCP auth wake processor', () => {
       'linear-mcp-auth-wake',
     );
     expect(notifiedEvents()).toHaveLength(1);
+  });
+
+  it('drains a lifecycle that completes while an earlier wake pass is still delivering', async () => {
+    // Review repro: lifecycle A closes and its wake pass starts; lifecycle B
+    // for the same agent opens and closes while A's delivery is in flight.
+    // The pass must not swallow B's healthy — it drains until stable and
+    // wakes B too, and A's delayed notification record may not mark B handled.
+    events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
+
+    mocks.messageAgent.mockImplementation(async () => {
+      // Mid-delivery, the agent fails again and the operator re-auths:
+      // lifecycle B opens and closes behind the in-flight pass.
+      if (events.some(event => event.type === 'linear_mcp_auth.required' && event.sequence >= 3) === false) {
+        events.push(required(3, 'agent-min-852', 'MIN-852'), healthy(4));
+      }
+      return 'delivered';
+    });
+
+    await processLinearMcpAuthWake();
+
+    // Two wake rounds: one for lifecycle seq-1, one for lifecycle seq-3.
+    expect(mocks.messageAgent).toHaveBeenCalledTimes(2);
+    const lifecycleIds = notifiedEvents().map(event => event.payload['lifecycleId']);
+    expect(lifecycleIds).toEqual(['seq-1', 'seq-3']);
   });
 });

--- a/src/lib/__tests__/linear-mcp-auth-wake.test.ts
+++ b/src/lib/__tests__/linear-mcp-auth-wake.test.ts
@@ -1,10 +1,11 @@
 import type { DomainEvent } from '@overdeck/contracts';
 import { Effect } from 'effect';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   appendAsync: vi.fn(),
   getLatestSequence: vi.fn(),
+  hasMail: vi.fn(),
   messageAgent: vi.fn(),
   queryByTypesSince: vi.fn(),
 }));
@@ -19,6 +20,7 @@ vi.mock('../../dashboard/server/event-store.js', () => ({
 
 vi.mock('../agents/messaging.js', () => ({
   messageAgentWithOutcome: mocks.messageAgent,
+  agentHasMailContentSince: mocks.hasMail,
 }));
 
 import { handleCloisterDomainEvent } from '../cloister/service-reactive.js';
@@ -55,6 +57,15 @@ function healthy(sequence: number): TestEvent {
   };
 }
 
+function claim(sequence: number, agentId: string, issueId: string, lifecycleId: string): TestEvent {
+  return {
+    sequence,
+    type: 'linear_mcp_auth.notified',
+    timestamp: `2026-07-21T12:00:0${sequence}.000Z`,
+    payload: { agentId, issueId, outcome: 'delivering', lifecycleId },
+  };
+}
+
 function notifiedEvents(): TestEvent[] {
   return events.filter(event => event.type === 'linear_mcp_auth.notified');
 }
@@ -69,6 +80,8 @@ describe('Linear MCP auth wake processor', () => {
     _resetLinearMcpAuthProjectionCacheForTests();
     mocks.messageAgent.mockReset();
     mocks.messageAgent.mockResolvedValue('delivered');
+    mocks.hasMail.mockReset();
+    mocks.hasMail.mockReturnValue(false);
     mocks.queryByTypesSince.mockReset();
     mocks.queryByTypesSince.mockImplementation((types: string[], afterSequence: number) => (
       events
@@ -88,6 +101,10 @@ describe('Linear MCP auth wake processor', () => {
       });
       return sequence;
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('reacts to healthy by claiming, delivering one wake, and recording its outcome', async () => {
@@ -179,15 +196,45 @@ describe('Linear MCP auth wake processor', () => {
     expect(notifiedEvents()).toHaveLength(2);
   });
 
+  it('delivers exactly once when the process died after the claim but before the send', async () => {
+    // The interrupted state: claim committed, no mail backup, no completion.
+    // Boot recovery must drive the send — zero deliveries would strand the
+    // blocked agent.
+    events.push(
+      required(1, 'agent-min-852', 'MIN-852'),
+      healthy(2),
+      claim(3, 'agent-min-852', 'MIN-852', 'seq-1'),
+    );
+    mocks.hasMail.mockReturnValue(false);
+
+    await processLinearMcpAuthWake();
+
+    expect(mocks.messageAgent).toHaveBeenCalledOnce();
+    expect(mocks.messageAgent).toHaveBeenCalledWith(
+      'agent-min-852',
+      LINEAR_MCP_AUTH_WAKE_COPY,
+      'linear-mcp-auth-wake',
+    );
+    expect(completionEvents()).toHaveLength(1);
+    expect(completionEvents()[0]?.payload['outcome']).toBe('delivered');
+  });
+
   it('does not replay a delivered wake when the process dies before the completion record lands', async () => {
-    // Crash window: the claim is durable, delivery succeeds, but the
-    // completion append never commits (process exit). Boot recovery must see
-    // the claim and skip re-delivery — at most one wake per agent per
-    // lifecycle.
+    // Crash window: claim committed, acknowledged send happened (the durable
+    // mail backup exists), but the completion append never committed. Boot
+    // recovery reconciles the claim against the outbox and completes the
+    // ledger WITHOUT a second delivery.
     events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
 
-    let completionAppendFailed = false;
+    // Every non-throwing messageAgent path backs the message up to the mail
+    // queue — simulate that side effect on the mock.
+    mocks.messageAgent.mockImplementation(async () => {
+      mocks.hasMail.mockReturnValue(true);
+      return 'delivered';
+    });
+
     const realAppend = mocks.appendAsync.getMockImplementation();
+    let completionAppendFailed = false;
     mocks.appendAsync.mockImplementation(async (event: Omit<DomainEvent, 'sequence'>) => {
       const payload = (event as { payload?: { outcome?: string } }).payload;
       if (!completionAppendFailed && payload?.outcome === 'delivered') {
@@ -200,19 +247,46 @@ describe('Linear MCP auth wake processor', () => {
     await processLinearMcpAuthWake();
     expect(mocks.messageAgent).toHaveBeenCalledOnce();
 
-    // Boot recovery runs the same entry point.
+    // Boot recovery runs the same entry point; the mail backup proves the
+    // acknowledged send, so no replay.
     await processLinearMcpAuthWake();
     expect(mocks.messageAgent).toHaveBeenCalledOnce();
+    // The interrupted claim got its completion record this time.
+    expect(completionEvents()).toHaveLength(1);
+    expect(completionEvents()[0]?.payload['outcome']).toBe('delivered');
   });
 
   it('skips delivery when the durable claim cannot be recorded', async () => {
+    vi.useFakeTimers();
     events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
     mocks.appendAsync.mockRejectedValue(new Error('database is locked'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
 
     await expect(processLinearMcpAuthWake()).resolves.toBeUndefined();
 
-    // No claim, no delivery — an unclaimed send could replay after a crash.
+    // No claim, no delivery — an unreconciled send could replay after a crash.
     expect(mocks.messageAgent).not.toHaveBeenCalled();
+  });
+
+  it('backs off follow-up runs when the wake set never stabilizes', async () => {
+    vi.useFakeTimers();
+    const timeoutSpy = vi.spyOn(global, 'setTimeout');
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
+    // Claims always fail, so every pass retries and no pass stabilizes.
+    mocks.appendAsync.mockRejectedValue(new Error('database is locked'));
+
+    await processLinearMcpAuthWake();
+    const callsAfterFirstRun = mocks.appendAsync.mock.calls.length;
+    expect(callsAfterFirstRun).toBeGreaterThan(0);
+
+    // The follow-up is scheduled with exponential backoff, not a hot 1s loop.
+    await vi.advanceTimersByTimeAsync(1000);
+    const callsAfterFirstFollowUp = mocks.appendAsync.mock.calls.length;
+    expect(callsAfterFirstFollowUp).toBeGreaterThan(callsAfterFirstRun);
+
+    const delays = timeoutSpy.mock.calls.map(call => call[1]);
+    expect(delays).toEqual([1000, 2000]);
   });
 
   it('drains a lifecycle that completes while an earlier wake pass is still delivering', async () => {

--- a/src/lib/__tests__/linear-mcp-auth-wake.test.ts
+++ b/src/lib/__tests__/linear-mcp-auth-wake.test.ts
@@ -1,11 +1,13 @@
 import type { DomainEvent } from '@overdeck/contracts';
 import { Effect } from 'effect';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   appendAsync: vi.fn(),
   getLatestSequence: vi.fn(),
-  hasMail: vi.fn(),
   messageAgent: vi.fn(),
   queryByTypesSince: vi.fn(),
 }));
@@ -20,7 +22,6 @@ vi.mock('../../dashboard/server/event-store.js', () => ({
 
 vi.mock('../agents/messaging.js', () => ({
   messageAgentWithOutcome: mocks.messageAgent,
-  agentHasMailContentSince: mocks.hasMail,
 }));
 
 import { handleCloisterDomainEvent } from '../cloister/service-reactive.js';
@@ -37,7 +38,19 @@ interface TestEvent {
   payload: Record<string, unknown>;
 }
 
+interface OutboxEntryFixture {
+  lifecycleId: string;
+  agentId: string;
+  message: string;
+  state: 'pending' | 'acknowledged';
+  outcome?: string;
+  createdAt: string;
+  acknowledgedAt?: string;
+}
+
 let events: TestEvent[] = [];
+let overdeckHome: string;
+let previousHome: string | undefined;
 
 function required(sequence: number, agentId: string, issueId: string): TestEvent {
   return {
@@ -57,31 +70,53 @@ function healthy(sequence: number): TestEvent {
   };
 }
 
-function claim(sequence: number, agentId: string, issueId: string, lifecycleId: string): TestEvent {
-  return {
-    sequence,
-    type: 'linear_mcp_auth.notified',
-    timestamp: `2026-07-21T12:00:0${sequence}.000Z`,
-    payload: { agentId, issueId, outcome: 'delivering', lifecycleId },
-  };
-}
-
 function notifiedEvents(): TestEvent[] {
   return events.filter(event => event.type === 'linear_mcp_auth.notified');
 }
 
-function completionEvents(): TestEvent[] {
-  return notifiedEvents().filter(event => event.payload['outcome'] !== 'delivering');
+function outboxPath(agentId: string, lifecycleId: string): string {
+  return join(overdeckHome, 'agents', agentId, 'linear-mcp-wake', `${lifecycleId}.json`);
+}
+
+function seedOutbox(agentId: string, entry: OutboxEntryFixture): void {
+  const path = outboxPath(agentId, entry.lifecycleId);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(entry), 'utf-8');
+}
+
+function readOutbox(agentId: string, lifecycleId: string): OutboxEntryFixture {
+  return JSON.parse(readFileSync(outboxPath(agentId, lifecycleId), 'utf-8')) as OutboxEntryFixture;
+}
+
+function pendingEntry(lifecycleId: string, agentId: string): OutboxEntryFixture {
+  return {
+    lifecycleId,
+    agentId,
+    message: LINEAR_MCP_AUTH_WAKE_COPY,
+    state: 'pending',
+    createdAt: '2026-07-21T12:00:10.000Z',
+  };
+}
+
+function acknowledgedEntry(lifecycleId: string, agentId: string, outcome: string): OutboxEntryFixture {
+  return {
+    ...pendingEntry(lifecycleId, agentId),
+    state: 'acknowledged',
+    outcome,
+    acknowledgedAt: '2026-07-21T12:00:11.000Z',
+  };
 }
 
 describe('Linear MCP auth wake processor', () => {
   beforeEach(() => {
     events = [];
     _resetLinearMcpAuthProjectionCacheForTests();
+    previousHome = process.env.OVERDECK_HOME;
+    overdeckHome = mkdtempSync(join(tmpdir(), 'overdeck-linear-wake-'));
+    process.env.OVERDECK_HOME = overdeckHome;
+
     mocks.messageAgent.mockReset();
     mocks.messageAgent.mockResolvedValue('delivered');
-    mocks.hasMail.mockReset();
-    mocks.hasMail.mockReturnValue(false);
     mocks.queryByTypesSince.mockReset();
     mocks.queryByTypesSince.mockImplementation((types: string[], afterSequence: number) => (
       events
@@ -104,10 +139,16 @@ describe('Linear MCP auth wake processor', () => {
   });
 
   afterEach(() => {
+    if (previousHome === undefined) {
+      delete process.env.OVERDECK_HOME;
+    } else {
+      process.env.OVERDECK_HOME = previousHome;
+    }
+    rmSync(overdeckHome, { recursive: true, force: true });
     vi.useRealTimers();
   });
 
-  it('reacts to healthy by claiming, delivering one wake, and recording its outcome', async () => {
+  it('reacts to healthy by delivering one wake and recording its outcome and receipt', async () => {
     events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
 
     await Effect.runPromise(handleCloisterDomainEvent({ type: 'linear_mcp_auth.healthy' }));
@@ -118,20 +159,17 @@ describe('Linear MCP auth wake processor', () => {
       LINEAR_MCP_AUTH_WAKE_COPY,
       'linear-mcp-auth-wake',
     );
-    const notified = notifiedEvents();
-    expect(notified).toHaveLength(2);
-    // Durable claim first, completion record second — both for lifecycle seq-1.
-    expect(notified[0]?.payload).toEqual({
-      agentId: 'agent-min-852',
-      issueId: 'MIN-852',
-      outcome: 'delivering',
-      lifecycleId: 'seq-1',
-    });
-    expect(notified[1]?.payload).toEqual({
+    expect(notifiedEvents()).toHaveLength(1);
+    expect(notifiedEvents()[0]?.payload).toEqual({
       agentId: 'agent-min-852',
       issueId: 'MIN-852',
       outcome: 'delivered',
       lifecycleId: 'seq-1',
+    });
+    // The keyed outbox receipt is acknowledged with the same outcome.
+    expect(readOutbox('agent-min-852', 'seq-1')).toMatchObject({
+      state: 'acknowledged',
+      outcome: 'delivered',
     });
   });
 
@@ -149,7 +187,7 @@ describe('Linear MCP auth wake processor', () => {
       'agent-min-852',
       'agent-pan-2997',
     ]);
-    expect(completionEvents().map(event => event.payload['outcome'])).toEqual([
+    expect(notifiedEvents().map(event => event.payload['outcome'])).toEqual([
       'delivered',
       'delivered',
     ]);
@@ -162,7 +200,11 @@ describe('Linear MCP auth wake processor', () => {
 
     await processLinearMcpAuthWake();
 
-    expect(completionEvents()[0]?.payload['outcome']).toBe('queued');
+    expect(notifiedEvents()[0]?.payload['outcome']).toBe('queued');
+    expect(readOutbox('agent-min-852', 'seq-1')).toMatchObject({
+      state: 'acknowledged',
+      outcome: 'queued',
+    });
   });
 
   it('records failed when the agent no longer exists', async () => {
@@ -170,7 +212,11 @@ describe('Linear MCP auth wake processor', () => {
     mocks.messageAgent.mockRejectedValue(new Error('Agent agent-min-852 not running'));
 
     await expect(processLinearMcpAuthWake()).resolves.toBeUndefined();
-    expect(completionEvents()[0]?.payload['outcome']).toBe('failed');
+    expect(notifiedEvents()[0]?.payload['outcome']).toBe('failed');
+    expect(readOutbox('agent-min-852', 'seq-1')).toMatchObject({
+      state: 'acknowledged',
+      outcome: 'failed',
+    });
   });
 
   it('does not send another wake after notified events have been recorded', async () => {
@@ -180,7 +226,7 @@ describe('Linear MCP auth wake processor', () => {
     await processLinearMcpAuthWake();
 
     expect(mocks.messageAgent).toHaveBeenCalledOnce();
-    expect(notifiedEvents()).toHaveLength(2);
+    expect(notifiedEvents()).toHaveLength(1);
   });
 
   it('recovers pending wake work recorded before server boot', async () => {
@@ -193,78 +239,114 @@ describe('Linear MCP auth wake processor', () => {
       LINEAR_MCP_AUTH_WAKE_COPY,
       'linear-mcp-auth-wake',
     );
-    expect(notifiedEvents()).toHaveLength(2);
+    expect(notifiedEvents()).toHaveLength(1);
   });
 
   it('delivers exactly once when the process died after the claim but before the send', async () => {
-    // The interrupted state: claim committed, no mail backup, no completion.
-    // Boot recovery must drive the send — zero deliveries would strand the
-    // blocked agent.
+    // Crash state: a pending outbox entry exists (the claim) but the send
+    // never ran. Recovery must drive it — zero deliveries strands the agent.
+    events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
+    seedOutbox('agent-min-852', pendingEntry('seq-1', 'agent-min-852'));
+
+    await processLinearMcpAuthWake();
+
+    expect(mocks.messageAgent).toHaveBeenCalledOnce();
+    expect(readOutbox('agent-min-852', 'seq-1')).toMatchObject({
+      state: 'acknowledged',
+      outcome: 'delivered',
+    });
+    expect(notifiedEvents()).toHaveLength(1);
+    expect(notifiedEvents()[0]?.payload['outcome']).toBe('delivered');
+  });
+
+  it('resumes an unacknowledged entry after a post-send/pre-receipt crash', async () => {
+    // Crash state: the send happened but the ack write never landed, so the
+    // entry is still pending. That send was never acknowledged — replaying
+    // it once is the defined recovery semantic.
+    events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
+    seedOutbox('agent-min-852', pendingEntry('seq-1', 'agent-min-852'));
+
+    await processLinearMcpAuthWake();
+
+    expect(mocks.messageAgent).toHaveBeenCalledOnce();
+    expect(readOutbox('agent-min-852', 'seq-1')).toMatchObject({
+      state: 'acknowledged',
+      outcome: 'delivered',
+    });
+    expect(notifiedEvents()).toHaveLength(1);
+  });
+
+  it('does not replay an acknowledged wake when the process died before the completion event landed', async () => {
+    // Crash state: acknowledged receipt exists, but the completion DomainEvent
+    // was never appended. Recovery completes the ledger WITHOUT re-sending.
+    events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
+    seedOutbox('agent-min-852', acknowledgedEntry('seq-1', 'agent-min-852', 'delivered'));
+
+    await processLinearMcpAuthWake();
+
+    expect(mocks.messageAgent).not.toHaveBeenCalled();
+    expect(notifiedEvents()).toHaveLength(1);
+    expect(notifiedEvents()[0]?.payload).toEqual({
+      agentId: 'agent-min-852',
+      issueId: 'MIN-852',
+      outcome: 'delivered',
+      lifecycleId: 'seq-1',
+    });
+  });
+
+  it('replays the recorded queued outcome on recovery instead of upgrading it to delivered', async () => {
+    // Crash state: the send was queued for a stopped agent and acknowledged,
+    // but the completion event never landed. Recovery must record 'queued',
+    // not a falsified 'delivered'.
+    events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
+    seedOutbox('agent-min-852', acknowledgedEntry('seq-1', 'agent-min-852', 'queued'));
+
+    await processLinearMcpAuthWake();
+
+    expect(mocks.messageAgent).not.toHaveBeenCalled();
+    expect(notifiedEvents()[0]?.payload['outcome']).toBe('queued');
+  });
+
+  it('never suppresses a new lifecycle behind an identical acknowledged wake from the previous one', async () => {
+    // Lifecycle A is fully done (acknowledged receipt + completion event).
+    // Lifecycle B needs the same wake copy. The receipts are keyed per
+    // lifecycle, so A's acknowledgment must not mark B handled.
     events.push(
       required(1, 'agent-min-852', 'MIN-852'),
       healthy(2),
-      claim(3, 'agent-min-852', 'MIN-852', 'seq-1'),
+      required(3, 'agent-min-852', 'MIN-852'),
+      healthy(4),
     );
-    mocks.hasMail.mockReturnValue(false);
-
-    await processLinearMcpAuthWake();
-
-    expect(mocks.messageAgent).toHaveBeenCalledOnce();
-    expect(mocks.messageAgent).toHaveBeenCalledWith(
-      'agent-min-852',
-      LINEAR_MCP_AUTH_WAKE_COPY,
-      'linear-mcp-auth-wake',
-    );
-    expect(completionEvents()).toHaveLength(1);
-    expect(completionEvents()[0]?.payload['outcome']).toBe('delivered');
-  });
-
-  it('does not replay a delivered wake when the process dies before the completion record lands', async () => {
-    // Crash window: claim committed, acknowledged send happened (the durable
-    // mail backup exists), but the completion append never committed. Boot
-    // recovery reconciles the claim against the outbox and completes the
-    // ledger WITHOUT a second delivery.
-    events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
-
-    // Every non-throwing messageAgent path backs the message up to the mail
-    // queue — simulate that side effect on the mock.
-    mocks.messageAgent.mockImplementation(async () => {
-      mocks.hasMail.mockReturnValue(true);
-      return 'delivered';
-    });
-
-    const realAppend = mocks.appendAsync.getMockImplementation();
-    let completionAppendFailed = false;
-    mocks.appendAsync.mockImplementation(async (event: Omit<DomainEvent, 'sequence'>) => {
-      const payload = (event as { payload?: { outcome?: string } }).payload;
-      if (!completionAppendFailed && payload?.outcome === 'delivered') {
-        completionAppendFailed = true;
-        throw new Error('process exited before commit');
-      }
-      return realAppend?.(event) ?? 0;
+    seedOutbox('agent-min-852', acknowledgedEntry('seq-1', 'agent-min-852', 'delivered'));
+    events.push({
+      sequence: 5,
+      type: 'linear_mcp_auth.notified',
+      timestamp: '2026-07-21T12:00:12.000Z',
+      payload: { agentId: 'agent-min-852', issueId: 'MIN-852', outcome: 'delivered', lifecycleId: 'seq-1' },
     });
 
     await processLinearMcpAuthWake();
-    expect(mocks.messageAgent).toHaveBeenCalledOnce();
 
-    // Boot recovery runs the same entry point; the mail backup proves the
-    // acknowledged send, so no replay.
-    await processLinearMcpAuthWake();
+    // Exactly one send — for lifecycle seq-3. A's receipt suppressed nothing.
     expect(mocks.messageAgent).toHaveBeenCalledOnce();
-    // The interrupted claim got its completion record this time.
-    expect(completionEvents()).toHaveLength(1);
-    expect(completionEvents()[0]?.payload['outcome']).toBe('delivered');
+    expect(readOutbox('agent-min-852', 'seq-3')).toMatchObject({
+      state: 'acknowledged',
+      outcome: 'delivered',
+    });
+    expect(notifiedEvents().map(event => event.payload['lifecycleId'])).toEqual(['seq-1', 'seq-3']);
   });
 
-  it('skips delivery when the durable claim cannot be recorded', async () => {
+  it('skips delivery when the outbox receipt cannot be written', async () => {
     vi.useFakeTimers();
-    events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
-    mocks.appendAsync.mockRejectedValue(new Error('database is locked'));
     vi.spyOn(console, 'error').mockImplementation(() => {});
+    events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
+    // The agent dir is a FILE, so mkdir of the outbox dir fails every pass.
+    mkdirSync(join(overdeckHome, 'agents'), { recursive: true });
+    writeFileSync(join(overdeckHome, 'agents', 'agent-min-852'), 'not a directory');
 
     await expect(processLinearMcpAuthWake()).resolves.toBeUndefined();
 
-    // No claim, no delivery — an unreconciled send could replay after a crash.
+    // No receipt, no delivery — an unreceipted send could replay after a crash.
     expect(mocks.messageAgent).not.toHaveBeenCalled();
   });
 
@@ -273,27 +355,32 @@ describe('Linear MCP auth wake processor', () => {
     const timeoutSpy = vi.spyOn(global, 'setTimeout');
     vi.spyOn(console, 'error').mockImplementation(() => {});
     events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
-    // Claims always fail, so every pass retries and no pass stabilizes.
+    // Completion appends always fail, so the agent never leaves the wake set.
+    // The acknowledged receipt means the door is still only called once.
     mocks.appendAsync.mockRejectedValue(new Error('database is locked'));
 
     await processLinearMcpAuthWake();
+    expect(mocks.messageAgent).toHaveBeenCalledOnce();
     const callsAfterFirstRun = mocks.appendAsync.mock.calls.length;
     expect(callsAfterFirstRun).toBeGreaterThan(0);
 
-    // The follow-up is scheduled with exponential backoff, not a hot 1s loop.
     await vi.advanceTimersByTimeAsync(1000);
-    const callsAfterFirstFollowUp = mocks.appendAsync.mock.calls.length;
-    expect(callsAfterFirstFollowUp).toBeGreaterThan(callsAfterFirstRun);
+    // The scheduled follow-up is in flight behind real fs I/O; join it
+    // through the coalescer (same promise if running, a fresh identical run
+    // if it already settled) so the assertions see a completed pass.
+    await processLinearMcpAuthWake();
+    expect(mocks.appendAsync.mock.calls.length).toBeGreaterThan(callsAfterFirstRun);
+    expect(mocks.messageAgent).toHaveBeenCalledOnce();
 
     const delays = timeoutSpy.mock.calls.map(call => call[1]);
-    expect(delays).toEqual([1000, 2000]);
+    expect(delays.slice(0, 2)).toEqual([1000, 2000]);
   });
 
   it('drains a lifecycle that completes while an earlier wake pass is still delivering', async () => {
     // Review repro: lifecycle A closes and its wake pass starts; lifecycle B
     // for the same agent opens and closes while A's delivery is in flight.
     // The pass must not swallow B's healthy — it drains until stable and
-    // wakes B too, and A's notification records may not mark B handled.
+    // wakes B too, and A's completion records may not mark B handled.
     events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
 
     mocks.messageAgent.mockImplementation(async () => {
@@ -309,10 +396,7 @@ describe('Linear MCP auth wake processor', () => {
 
     // Two wake rounds: one for lifecycle seq-1, one for lifecycle seq-3.
     expect(mocks.messageAgent).toHaveBeenCalledTimes(2);
-    const completionLifecycleIds = completionEvents().map(event => event.payload['lifecycleId']);
+    const completionLifecycleIds = notifiedEvents().map(event => event.payload['lifecycleId']);
     expect(completionLifecycleIds).toEqual(['seq-1', 'seq-3']);
-    // Each lifecycle got its own claim + completion pair.
-    expect(notifiedEvents().filter(event => event.payload['lifecycleId'] === 'seq-1')).toHaveLength(2);
-    expect(notifiedEvents().filter(event => event.payload['lifecycleId'] === 'seq-3')).toHaveLength(2);
   });
 });

--- a/src/lib/__tests__/linear-mcp-auth-wake.test.ts
+++ b/src/lib/__tests__/linear-mcp-auth-wake.test.ts
@@ -158,6 +158,7 @@ describe('Linear MCP auth wake processor', () => {
       'agent-min-852',
       LINEAR_MCP_AUTH_WAKE_COPY,
       'linear-mcp-auth-wake',
+      { dedupKey: 'linear-mcp-auth-wake:seq-1' },
     );
     expect(notifiedEvents()).toHaveLength(1);
     expect(notifiedEvents()[0]?.payload).toEqual({
@@ -238,6 +239,7 @@ describe('Linear MCP auth wake processor', () => {
       'agent-min-852',
       LINEAR_MCP_AUTH_WAKE_COPY,
       'linear-mcp-auth-wake',
+      { dedupKey: 'linear-mcp-auth-wake:seq-1' },
     );
     expect(notifiedEvents()).toHaveLength(1);
   });

--- a/src/lib/__tests__/linear-mcp-auth-wake.test.ts
+++ b/src/lib/__tests__/linear-mcp-auth-wake.test.ts
@@ -25,6 +25,7 @@ vi.mock('../agents/messaging.js', () => ({
 }));
 
 import { handleCloisterDomainEvent } from '../cloister/service-reactive.js';
+import { AmbiguousKeyedDeliveryError } from '../agents/delivery.js';
 import {
   LINEAR_MCP_AUTH_WAKE_COPY,
   _resetLinearMcpAuthProjectionCacheForTests,
@@ -376,6 +377,54 @@ describe('Linear MCP auth wake processor', () => {
 
     const delays = timeoutSpy.mock.calls.map(call => call[1]);
     expect(delays.slice(0, 2)).toEqual([1000, 2000]);
+  });
+
+  it('retries the same key within the run after an AMBIGUOUS keyed delivery failure, never recording a terminal failed (cycle 8)', async () => {
+    events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
+    // The first attempt's outcome is UNKNOWN (e.g. the supervisor's answer was
+    // lost): the outbox entry must stay pending, not terminal 'failed'.
+    mocks.messageAgent.mockRejectedValueOnce(
+      new AmbiguousKeyedDeliveryError('agent-min-852', 'linear-mcp-auth-wake', 'socket POST timeout'),
+    );
+
+    await processLinearMcpAuthWake();
+
+    // A later pass in the same run re-drove the SAME keyed wake — the door
+    // deduplicates it if the first attempt did in fact land.
+    expect(mocks.messageAgent).toHaveBeenCalledTimes(2);
+    expect(mocks.messageAgent.mock.calls[1]).toEqual([
+      'agent-min-852',
+      LINEAR_MCP_AUTH_WAKE_COPY,
+      'linear-mcp-auth-wake',
+      { dedupKey: 'linear-mcp-auth-wake:seq-1' },
+    ]);
+    // Exactly one completion was recorded, with the real outcome — 'failed'
+    // never appears for an ambiguous attempt.
+    expect(notifiedEvents()).toHaveLength(1);
+    expect(notifiedEvents()[0]?.payload['outcome']).toBe('delivered');
+    expect(readOutbox('agent-min-852', 'seq-1')).toMatchObject({
+      state: 'acknowledged',
+      outcome: 'delivered',
+    });
+  });
+
+  it('leaves the wake pending with no completion record while the keyed delivery stays ambiguous (cycle 8)', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
+    mocks.messageAgent.mockRejectedValue(
+      new AmbiguousKeyedDeliveryError('agent-min-852', 'linear-mcp-auth-wake', 'socket POST timeout'),
+    );
+
+    await processLinearMcpAuthWake();
+
+    // No terminal outcome was recorded on any of the bounded retries, and the
+    // outbox entry is still pending — boot recovery or a later healthy event
+    // will re-drive the same key.
+    expect(notifiedEvents()).toHaveLength(0);
+    expect(readOutbox('agent-min-852', 'seq-1')).toMatchObject({ state: 'pending' });
+    expect(mocks.messageAgent.mock.calls.length).toBeGreaterThan(1);
+    expect(mocks.messageAgent.mock.calls.every(call => call[3]?.dedupKey === 'linear-mcp-auth-wake:seq-1')).toBe(true);
   });
 
   it('drains a lifecycle that completes while an earlier wake pass is still delivering', async () => {

--- a/src/lib/__tests__/linear-mcp-auth-wake.test.ts
+++ b/src/lib/__tests__/linear-mcp-auth-wake.test.ts
@@ -26,6 +26,7 @@ vi.mock('../agents/messaging.js', () => ({
 
 import { handleCloisterDomainEvent } from '../cloister/service-reactive.js';
 import { AmbiguousKeyedDeliveryError } from '../agents/delivery.js';
+import { KeyedSubmitTargetDeadError } from '../tmux-dedup.js';
 import {
   LINEAR_MCP_AUTH_WAKE_COPY,
   _resetLinearMcpAuthProjectionCacheForTests,
@@ -425,6 +426,34 @@ describe('Linear MCP auth wake processor', () => {
     expect(readOutbox('agent-min-852', 'seq-1')).toMatchObject({ state: 'pending' });
     expect(mocks.messageAgent.mock.calls.length).toBeGreaterThan(1);
     expect(mocks.messageAgent.mock.calls.every(call => call[3]?.dedupKey === 'linear-mcp-auth-wake:seq-1')).toBe(true);
+  });
+
+  it('leaves the wake pending and retries after the tmux target dies mid-delivery (cycle 9)', async () => {
+    events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
+    // The pane died between paste and submit: NO Enter was sent and the key
+    // was deliberately left non-terminal — this must not become terminal
+    // 'failed' any more than it may become 'delivered'.
+    mocks.messageAgent.mockRejectedValueOnce(
+      new KeyedSubmitTargetDeadError('agent-min-852', 'linear-mcp-auth-wake:seq-1'),
+    );
+
+    await processLinearMcpAuthWake();
+
+    // A later pass in the same run re-drove the same keyed wake (by then the
+    // agent has resumed) and exactly one completion was recorded.
+    expect(mocks.messageAgent).toHaveBeenCalledTimes(2);
+    expect(mocks.messageAgent.mock.calls[1]).toEqual([
+      'agent-min-852',
+      LINEAR_MCP_AUTH_WAKE_COPY,
+      'linear-mcp-auth-wake',
+      { dedupKey: 'linear-mcp-auth-wake:seq-1' },
+    ]);
+    expect(notifiedEvents()).toHaveLength(1);
+    expect(notifiedEvents()[0]?.payload['outcome']).toBe('delivered');
+    expect(readOutbox('agent-min-852', 'seq-1')).toMatchObject({
+      state: 'acknowledged',
+      outcome: 'delivered',
+    });
   });
 
   it('drains a lifecycle that completes while an earlier wake pass is still delivering', async () => {

--- a/src/lib/__tests__/linear-mcp-auth-wake.test.ts
+++ b/src/lib/__tests__/linear-mcp-auth-wake.test.ts
@@ -1,0 +1,159 @@
+import type { DomainEvent } from '@overdeck/contracts';
+import { Effect } from 'effect';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  appendAsync: vi.fn(),
+  messageAgent: vi.fn(),
+  queryByType: vi.fn(),
+}));
+
+vi.mock('../../dashboard/server/event-store.js', () => ({
+  initEventStore: vi.fn(async () => ({
+    appendAsync: mocks.appendAsync,
+    queryByType: mocks.queryByType,
+  })),
+}));
+
+vi.mock('../agents/messaging.js', () => ({
+  messageAgentWithOutcome: mocks.messageAgent,
+}));
+
+import { handleCloisterDomainEvent } from '../cloister/service-reactive.js';
+import {
+  LINEAR_MCP_AUTH_WAKE_COPY,
+  processLinearMcpAuthWake,
+} from '../linear-mcp-auth.js';
+
+interface TestEvent {
+  sequence: number;
+  type: string;
+  timestamp: string;
+  payload: Record<string, unknown>;
+}
+
+let events: TestEvent[] = [];
+
+function required(sequence: number, agentId: string, issueId: string): TestEvent {
+  return {
+    sequence,
+    type: 'linear_mcp_auth.required',
+    timestamp: `2026-07-21T12:00:0${sequence}.000Z`,
+    payload: { agentId, issueId, authUrl: null, expiresAt: null },
+  };
+}
+
+function healthy(sequence: number): TestEvent {
+  return {
+    sequence,
+    type: 'linear_mcp_auth.healthy',
+    timestamp: `2026-07-21T12:00:0${sequence}.000Z`,
+    payload: { agentId: 'operator', issueId: null, source: 'operator' },
+  };
+}
+
+function notifiedEvents(): TestEvent[] {
+  return events.filter(event => event.type === 'linear_mcp_auth.notified');
+}
+
+describe('Linear MCP auth wake processor', () => {
+  beforeEach(() => {
+    events = [];
+    mocks.messageAgent.mockReset();
+    mocks.messageAgent.mockResolvedValue('delivered');
+    mocks.queryByType.mockReset();
+    mocks.queryByType.mockImplementation((type: string) => (
+      events
+        .filter(event => event.type === type)
+        .sort((a, b) => b.sequence - a.sequence)
+    ));
+    mocks.appendAsync.mockReset();
+    mocks.appendAsync.mockImplementation(async (event: Omit<DomainEvent, 'sequence'>) => {
+      const sequence = events.reduce((max, candidate) => Math.max(max, candidate.sequence), 0) + 1;
+      events.push({
+        ...(event as unknown as Omit<TestEvent, 'sequence'>),
+        sequence,
+      });
+      return sequence;
+    });
+  });
+
+  it('reacts to healthy by delivering one wake and recording its outcome', async () => {
+    events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
+
+    await Effect.runPromise(handleCloisterDomainEvent({ type: 'linear_mcp_auth.healthy' }));
+
+    expect(mocks.messageAgent).toHaveBeenCalledOnce();
+    expect(mocks.messageAgent).toHaveBeenCalledWith(
+      'agent-min-852',
+      LINEAR_MCP_AUTH_WAKE_COPY,
+      'linear-mcp-auth-wake',
+    );
+    expect(notifiedEvents()).toHaveLength(1);
+    expect(notifiedEvents()[0]?.payload).toEqual({
+      agentId: 'agent-min-852',
+      issueId: 'MIN-852',
+      outcome: 'delivered',
+    });
+  });
+
+  it('wakes every agent in the completed lifecycle exactly once', async () => {
+    events.push(
+      required(1, 'agent-min-852', 'MIN-852'),
+      required(2, 'agent-pan-2997', 'PAN-2997'),
+      healthy(3),
+    );
+
+    await processLinearMcpAuthWake();
+
+    expect(mocks.messageAgent).toHaveBeenCalledTimes(2);
+    expect(mocks.messageAgent.mock.calls.map(call => call[0])).toEqual([
+      'agent-min-852',
+      'agent-pan-2997',
+    ]);
+    expect(notifiedEvents().map(event => event.payload['outcome'])).toEqual([
+      'delivered',
+      'delivered',
+    ]);
+  });
+
+  it('records queued when messageAgent routes a stopped or gated agent to mail', async () => {
+    events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
+    mocks.messageAgent.mockResolvedValue('queued');
+
+    await processLinearMcpAuthWake();
+
+    expect(notifiedEvents()[0]?.payload['outcome']).toBe('queued');
+  });
+
+  it('records failed when the agent no longer exists', async () => {
+    events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
+    mocks.messageAgent.mockRejectedValue(new Error('Agent agent-min-852 not running'));
+
+    await expect(processLinearMcpAuthWake()).resolves.toBeUndefined();
+    expect(notifiedEvents()[0]?.payload['outcome']).toBe('failed');
+  });
+
+  it('does not send another wake after notified events have been recorded', async () => {
+    events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
+
+    await processLinearMcpAuthWake();
+    await processLinearMcpAuthWake();
+
+    expect(mocks.messageAgent).toHaveBeenCalledOnce();
+    expect(notifiedEvents()).toHaveLength(1);
+  });
+
+  it('recovers pending wake work recorded before server boot', async () => {
+    events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
+
+    await processLinearMcpAuthWake();
+
+    expect(mocks.messageAgent).toHaveBeenCalledWith(
+      'agent-min-852',
+      LINEAR_MCP_AUTH_WAKE_COPY,
+      'linear-mcp-auth-wake',
+    );
+    expect(notifiedEvents()).toHaveLength(1);
+  });
+});

--- a/src/lib/__tests__/linear-mcp-auth-wake.test.ts
+++ b/src/lib/__tests__/linear-mcp-auth-wake.test.ts
@@ -4,16 +4,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   appendAsync: vi.fn(),
+  getLatestSequence: vi.fn(),
   messageAgent: vi.fn(),
-  queryByType: vi.fn(),
-  readFrom: vi.fn(),
+  queryByTypesSince: vi.fn(),
 }));
 
 vi.mock('../../dashboard/server/event-store.js', () => ({
   initEventStore: vi.fn(async () => ({
     appendAsync: mocks.appendAsync,
-    queryByType: mocks.queryByType,
-    readFrom: mocks.readFrom,
+    getLatestSequence: mocks.getLatestSequence,
+    queryByTypesSince: mocks.queryByTypesSince,
   })),
 }));
 
@@ -24,6 +24,7 @@ vi.mock('../agents/messaging.js', () => ({
 import { handleCloisterDomainEvent } from '../cloister/service-reactive.js';
 import {
   LINEAR_MCP_AUTH_WAKE_COPY,
+  _resetLinearMcpAuthProjectionCacheForTests,
   processLinearMcpAuthWake,
 } from '../linear-mcp-auth.js';
 
@@ -58,22 +59,25 @@ function notifiedEvents(): TestEvent[] {
   return events.filter(event => event.type === 'linear_mcp_auth.notified');
 }
 
+function completionEvents(): TestEvent[] {
+  return notifiedEvents().filter(event => event.payload['outcome'] !== 'delivering');
+}
+
 describe('Linear MCP auth wake processor', () => {
   beforeEach(() => {
     events = [];
+    _resetLinearMcpAuthProjectionCacheForTests();
     mocks.messageAgent.mockReset();
     mocks.messageAgent.mockResolvedValue('delivered');
-    mocks.queryByType.mockReset();
-    mocks.queryByType.mockImplementation((type: string, limit = 100) => (
+    mocks.queryByTypesSince.mockReset();
+    mocks.queryByTypesSince.mockImplementation((types: string[], afterSequence: number) => (
       events
-        .filter(event => event.type === type)
+        .filter(event => event.sequence > afterSequence && types.includes(event.type))
         .sort((a, b) => a.sequence - b.sequence)
-        .slice(-limit)
     ));
-    mocks.readFrom.mockImplementation((fromSequence: number) => (
-      events
-        .filter(event => event.sequence > fromSequence && event.type !== 'issues.snapshot')
-        .sort((a, b) => a.sequence - b.sequence)
+    mocks.getLatestSequence.mockReset();
+    mocks.getLatestSequence.mockImplementation(() => (
+      events.reduce((max, candidate) => Math.max(max, candidate.sequence), 0)
     ));
     mocks.appendAsync.mockReset();
     mocks.appendAsync.mockImplementation(async (event: Omit<DomainEvent, 'sequence'>) => {
@@ -86,7 +90,7 @@ describe('Linear MCP auth wake processor', () => {
     });
   });
 
-  it('reacts to healthy by delivering one wake and recording its outcome', async () => {
+  it('reacts to healthy by claiming, delivering one wake, and recording its outcome', async () => {
     events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
 
     await Effect.runPromise(handleCloisterDomainEvent({ type: 'linear_mcp_auth.healthy' }));
@@ -97,8 +101,16 @@ describe('Linear MCP auth wake processor', () => {
       LINEAR_MCP_AUTH_WAKE_COPY,
       'linear-mcp-auth-wake',
     );
-    expect(notifiedEvents()).toHaveLength(1);
-    expect(notifiedEvents()[0]?.payload).toEqual({
+    const notified = notifiedEvents();
+    expect(notified).toHaveLength(2);
+    // Durable claim first, completion record second — both for lifecycle seq-1.
+    expect(notified[0]?.payload).toEqual({
+      agentId: 'agent-min-852',
+      issueId: 'MIN-852',
+      outcome: 'delivering',
+      lifecycleId: 'seq-1',
+    });
+    expect(notified[1]?.payload).toEqual({
       agentId: 'agent-min-852',
       issueId: 'MIN-852',
       outcome: 'delivered',
@@ -120,7 +132,7 @@ describe('Linear MCP auth wake processor', () => {
       'agent-min-852',
       'agent-pan-2997',
     ]);
-    expect(notifiedEvents().map(event => event.payload['outcome'])).toEqual([
+    expect(completionEvents().map(event => event.payload['outcome'])).toEqual([
       'delivered',
       'delivered',
     ]);
@@ -133,7 +145,7 @@ describe('Linear MCP auth wake processor', () => {
 
     await processLinearMcpAuthWake();
 
-    expect(notifiedEvents()[0]?.payload['outcome']).toBe('queued');
+    expect(completionEvents()[0]?.payload['outcome']).toBe('queued');
   });
 
   it('records failed when the agent no longer exists', async () => {
@@ -141,7 +153,7 @@ describe('Linear MCP auth wake processor', () => {
     mocks.messageAgent.mockRejectedValue(new Error('Agent agent-min-852 not running'));
 
     await expect(processLinearMcpAuthWake()).resolves.toBeUndefined();
-    expect(notifiedEvents()[0]?.payload['outcome']).toBe('failed');
+    expect(completionEvents()[0]?.payload['outcome']).toBe('failed');
   });
 
   it('does not send another wake after notified events have been recorded', async () => {
@@ -151,7 +163,7 @@ describe('Linear MCP auth wake processor', () => {
     await processLinearMcpAuthWake();
 
     expect(mocks.messageAgent).toHaveBeenCalledOnce();
-    expect(notifiedEvents()).toHaveLength(1);
+    expect(notifiedEvents()).toHaveLength(2);
   });
 
   it('recovers pending wake work recorded before server boot', async () => {
@@ -164,14 +176,50 @@ describe('Linear MCP auth wake processor', () => {
       LINEAR_MCP_AUTH_WAKE_COPY,
       'linear-mcp-auth-wake',
     );
-    expect(notifiedEvents()).toHaveLength(1);
+    expect(notifiedEvents()).toHaveLength(2);
+  });
+
+  it('does not replay a delivered wake when the process dies before the completion record lands', async () => {
+    // Crash window: the claim is durable, delivery succeeds, but the
+    // completion append never commits (process exit). Boot recovery must see
+    // the claim and skip re-delivery — at most one wake per agent per
+    // lifecycle.
+    events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
+
+    let completionAppendFailed = false;
+    const realAppend = mocks.appendAsync.getMockImplementation();
+    mocks.appendAsync.mockImplementation(async (event: Omit<DomainEvent, 'sequence'>) => {
+      const payload = (event as { payload?: { outcome?: string } }).payload;
+      if (!completionAppendFailed && payload?.outcome === 'delivered') {
+        completionAppendFailed = true;
+        throw new Error('process exited before commit');
+      }
+      return realAppend?.(event) ?? 0;
+    });
+
+    await processLinearMcpAuthWake();
+    expect(mocks.messageAgent).toHaveBeenCalledOnce();
+
+    // Boot recovery runs the same entry point.
+    await processLinearMcpAuthWake();
+    expect(mocks.messageAgent).toHaveBeenCalledOnce();
+  });
+
+  it('skips delivery when the durable claim cannot be recorded', async () => {
+    events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
+    mocks.appendAsync.mockRejectedValue(new Error('database is locked'));
+
+    await expect(processLinearMcpAuthWake()).resolves.toBeUndefined();
+
+    // No claim, no delivery — an unclaimed send could replay after a crash.
+    expect(mocks.messageAgent).not.toHaveBeenCalled();
   });
 
   it('drains a lifecycle that completes while an earlier wake pass is still delivering', async () => {
     // Review repro: lifecycle A closes and its wake pass starts; lifecycle B
     // for the same agent opens and closes while A's delivery is in flight.
     // The pass must not swallow B's healthy — it drains until stable and
-    // wakes B too, and A's delayed notification record may not mark B handled.
+    // wakes B too, and A's notification records may not mark B handled.
     events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
 
     mocks.messageAgent.mockImplementation(async () => {
@@ -187,7 +235,10 @@ describe('Linear MCP auth wake processor', () => {
 
     // Two wake rounds: one for lifecycle seq-1, one for lifecycle seq-3.
     expect(mocks.messageAgent).toHaveBeenCalledTimes(2);
-    const lifecycleIds = notifiedEvents().map(event => event.payload['lifecycleId']);
-    expect(lifecycleIds).toEqual(['seq-1', 'seq-3']);
+    const completionLifecycleIds = completionEvents().map(event => event.payload['lifecycleId']);
+    expect(completionLifecycleIds).toEqual(['seq-1', 'seq-3']);
+    // Each lifecycle got its own claim + completion pair.
+    expect(notifiedEvents().filter(event => event.payload['lifecycleId'] === 'seq-1')).toHaveLength(2);
+    expect(notifiedEvents().filter(event => event.payload['lifecycleId'] === 'seq-3')).toHaveLength(2);
   });
 });

--- a/src/lib/__tests__/linear-mcp-auth-wake.test.ts
+++ b/src/lib/__tests__/linear-mcp-auth-wake.test.ts
@@ -26,7 +26,7 @@ vi.mock('../agents/messaging.js', () => ({
 
 import { handleCloisterDomainEvent } from '../cloister/service-reactive.js';
 import { AmbiguousKeyedDeliveryError } from '../agents/delivery.js';
-import { KeyedSubmitTargetDeadError } from '../tmux-dedup.js';
+import { KeyedMarkerVerificationError, KeyedSubmitTargetDeadError } from '../tmux-dedup.js';
 import {
   LINEAR_MCP_AUTH_WAKE_COPY,
   _resetLinearMcpAuthProjectionCacheForTests,
@@ -441,6 +441,32 @@ describe('Linear MCP auth wake processor', () => {
 
     // A later pass in the same run re-drove the same keyed wake (by then the
     // agent has resumed) and exactly one completion was recorded.
+    expect(mocks.messageAgent).toHaveBeenCalledTimes(2);
+    expect(mocks.messageAgent.mock.calls[1]).toEqual([
+      'agent-min-852',
+      LINEAR_MCP_AUTH_WAKE_COPY,
+      'linear-mcp-auth-wake',
+      { dedupKey: 'linear-mcp-auth-wake:seq-1' },
+    ]);
+    expect(notifiedEvents()).toHaveLength(1);
+    expect(notifiedEvents()[0]?.payload['outcome']).toBe('delivered');
+    expect(readOutbox('agent-min-852', 'seq-1')).toMatchObject({
+      state: 'acknowledged',
+      outcome: 'delivered',
+    });
+  });
+
+  it('leaves the wake pending and retries when marker verification fails mid-recovery (cycle 13)', async () => {
+    events.push(required(1, 'agent-min-852', 'MIN-852'), healthy(2));
+    // A safety-critical marker read failed during repair/rollback: the marker
+    // state is unproven, the breadcrumb stays authoritative, and the outbox
+    // must stay pending — never terminal 'failed', never 'delivered'.
+    mocks.messageAgent.mockRejectedValueOnce(
+      new KeyedMarkerVerificationError('agent-min-852', 'rollback verification of key "linear-mcp-auth-wake:seq-1"'),
+    );
+
+    await processLinearMcpAuthWake();
+
     expect(mocks.messageAgent).toHaveBeenCalledTimes(2);
     expect(mocks.messageAgent.mock.calls[1]).toEqual([
       'agent-min-852',

--- a/src/lib/__tests__/linear-mcp-auth.test.ts
+++ b/src/lib/__tests__/linear-mcp-auth.test.ts
@@ -297,6 +297,30 @@ describe('Linear MCP auth intervention fold', () => {
     });
   });
 
+  it('keeps a claimed-but-uncompleted agent in the wake set', async () => {
+    // A 'delivering' claim is not terminal: recovery must resume it (against
+    // the mail outbox), not treat the agent as handled.
+    useEvents([
+      requiredEvent(1, 'agent-min-852', 'MIN-852'),
+      healthyEvent(2),
+      event(3, 'linear_mcp_auth.notified', '2026-07-21T12:05:01.000Z', {
+        agentId: 'agent-min-852',
+        issueId: 'MIN-852',
+        outcome: 'delivering',
+        lifecycleId: 'seq-1',
+      }),
+    ]);
+
+    await expect(computeLinearMcpAuthWakeSet()).resolves.toEqual({
+      lifecycleId: 'seq-1',
+      agents: [expect.objectContaining({
+        agentId: 'agent-min-852',
+        claimedAt: '2026-07-21T12:05:01.000Z',
+        notifiedAt: null,
+      })],
+    });
+  });
+
   it('applies legacy notifications without a lifecycle id to the current lifecycle', async () => {
     useEvents([
       requiredEvent(1, 'agent-min-852', 'MIN-852'),

--- a/src/lib/__tests__/linear-mcp-auth.test.ts
+++ b/src/lib/__tests__/linear-mcp-auth.test.ts
@@ -297,9 +297,9 @@ describe('Linear MCP auth intervention fold', () => {
     });
   });
 
-  it('keeps a claimed-but-uncompleted agent in the wake set', async () => {
-    // A 'delivering' claim is not terminal: recovery must resume it (against
-    // the mail outbox), not treat the agent as handled.
+  it('does not treat a legacy delivering claim as a completion', async () => {
+    // 'delivering' rows from earlier iterations are not completions: the
+    // agent stays in the wake set (resumption is keyed by the outbox).
     useEvents([
       requiredEvent(1, 'agent-min-852', 'MIN-852'),
       healthyEvent(2),
@@ -315,7 +315,6 @@ describe('Linear MCP auth intervention fold', () => {
       lifecycleId: 'seq-1',
       agents: [expect.objectContaining({
         agentId: 'agent-min-852',
-        claimedAt: '2026-07-21T12:05:01.000Z',
         notifiedAt: null,
       })],
     });

--- a/src/lib/__tests__/linear-mcp-auth.test.ts
+++ b/src/lib/__tests__/linear-mcp-auth.test.ts
@@ -1,0 +1,186 @@
+import type { StoredEvent } from '../../dashboard/server/event-store.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const eventStoreMocks = vi.hoisted(() => ({
+  appendAsync: vi.fn(),
+  queryByType: vi.fn(),
+}));
+
+vi.mock('../../dashboard/server/event-store.js', () => ({
+  initEventStore: vi.fn(async () => eventStoreMocks),
+}));
+
+import {
+  LINEAR_MCP_AUTH_URL_TTL_MS,
+  computeLinearMcpAuthWakeSet,
+  resolveLinearMcpAuthIntervention,
+} from '../linear-mcp-auth.js';
+
+function event(
+  sequence: number,
+  type: StoredEvent['type'],
+  timestamp: string,
+  payload: Record<string, unknown>,
+): StoredEvent {
+  return { sequence, type, timestamp, payload };
+}
+
+function useEvents(events: StoredEvent[]): void {
+  eventStoreMocks.queryByType.mockImplementation((type: string) => (
+    events
+      .filter(candidate => candidate.type === type)
+      .sort((a, b) => b.sequence - a.sequence)
+  ));
+}
+
+describe('Linear MCP auth intervention fold', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-21T12:00:00.000Z'));
+    eventStoreMocks.appendAsync.mockReset();
+    eventStoreMocks.queryByType.mockReset();
+    useEvents([]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('projects one blocked agent with the default expiry', async () => {
+    useEvents([
+      event(1, 'linear_mcp_auth.required', '2026-07-21T12:00:00.000Z', {
+        agentId: 'agent-min-852',
+        issueId: 'MIN-852',
+        authUrl: null,
+        expiresAt: null,
+      }),
+    ]);
+
+    await expect(resolveLinearMcpAuthIntervention()).resolves.toEqual({
+      status: 'active',
+      authUrl: null,
+      authUrlAgentId: null,
+      authUrlExpiresAt: null,
+      declaredAt: '2026-07-21T12:00:00.000Z',
+      blockedAgents: [{
+        agentId: 'agent-min-852',
+        issueId: 'MIN-852',
+        declaredAt: '2026-07-21T12:00:00.000Z',
+        expiresAt: '2026-07-21T12:30:00.000Z',
+        notifiedAt: null,
+      }],
+    });
+  });
+
+  it('deduplicates multiple agents and tracks the latest authorization URL owner', async () => {
+    useEvents([
+      event(1, 'linear_mcp_auth.required', '2026-07-21T12:00:00.000Z', {
+        agentId: 'agent-min-852',
+        issueId: 'MIN-852',
+        authUrl: 'https://linear.app/oauth/authorize?state=first',
+        expiresAt: '2026-07-21T12:20:00.000Z',
+      }),
+      event(2, 'linear_mcp_auth.required', '2026-07-21T12:05:00.000Z', {
+        agentId: 'agent-pan-2997',
+        issueId: 'PAN-2997',
+        authUrl: 'https://linear.app/oauth/authorize?state=second',
+        expiresAt: '2026-07-21T12:35:00.000Z',
+      }),
+    ]);
+
+    const intervention = await resolveLinearMcpAuthIntervention();
+
+    expect(intervention).toMatchObject({
+      status: 'active',
+      authUrl: 'https://linear.app/oauth/authorize?state=second',
+      authUrlAgentId: 'agent-pan-2997',
+      authUrlExpiresAt: '2026-07-21T12:35:00.000Z',
+      declaredAt: '2026-07-21T12:00:00.000Z',
+    });
+    expect(intervention.blockedAgents.map(agent => agent.agentId)).toEqual([
+      'agent-min-852',
+      'agent-pan-2997',
+    ]);
+  });
+
+  it('changes to expired at the default TTL and returns to active after a fresh required event', async () => {
+    const events = [
+      event(1, 'linear_mcp_auth.required', '2026-07-21T12:00:00.000Z', {
+        agentId: 'agent-min-852',
+        issueId: 'MIN-852',
+        authUrl: 'https://linear.app/oauth/authorize?state=first',
+        expiresAt: null,
+      }),
+    ];
+    useEvents(events);
+
+    await vi.advanceTimersByTimeAsync(LINEAR_MCP_AUTH_URL_TTL_MS + 1);
+    await expect(resolveLinearMcpAuthIntervention()).resolves.toMatchObject({ status: 'expired' });
+
+    events.push(event(2, 'linear_mcp_auth.required', '2026-07-21T12:30:00.001Z', {
+      agentId: 'agent-min-852',
+      issueId: 'MIN-852',
+      authUrl: 'https://linear.app/oauth/authorize?state=refreshed',
+      expiresAt: null,
+    }));
+    useEvents(events);
+
+    await expect(resolveLinearMcpAuthIntervention()).resolves.toMatchObject({
+      status: 'active',
+      authUrl: 'https://linear.app/oauth/authorize?state=refreshed',
+      authUrlExpiresAt: '2026-07-21T13:00:00.001Z',
+    });
+  });
+
+  it('applies notifications after close to the last completed lifecycle', async () => {
+    useEvents([
+      event(1, 'linear_mcp_auth.required', '2026-07-21T12:00:00.000Z', {
+        agentId: 'agent-min-852',
+        issueId: 'MIN-852',
+        authUrl: null,
+        expiresAt: null,
+      }),
+      event(2, 'linear_mcp_auth.healthy', '2026-07-21T12:05:00.000Z', {
+        agentId: 'agent-min-852',
+        issueId: 'MIN-852',
+        source: 'hook',
+      }),
+      event(3, 'linear_mcp_auth.notified', '2026-07-21T12:05:01.000Z', {
+        agentId: 'agent-min-852',
+        issueId: 'MIN-852',
+        outcome: 'delivered',
+      }),
+    ]);
+
+    await expect(resolveLinearMcpAuthIntervention()).resolves.toMatchObject({ status: 'none' });
+    await expect(computeLinearMcpAuthWakeSet()).resolves.toEqual([]);
+  });
+
+  it('keeps the wake set empty when a duplicate healthy event arrives after notification', async () => {
+    useEvents([
+      event(1, 'linear_mcp_auth.required', '2026-07-21T12:00:00.000Z', {
+        agentId: 'agent-min-852',
+        issueId: 'MIN-852',
+        authUrl: null,
+        expiresAt: null,
+      }),
+      event(2, 'linear_mcp_auth.healthy', '2026-07-21T12:05:00.000Z', {
+        agentId: 'agent-min-852',
+        issueId: 'MIN-852',
+        source: 'hook',
+      }),
+      event(3, 'linear_mcp_auth.notified', '2026-07-21T12:05:01.000Z', {
+        agentId: 'agent-min-852',
+        issueId: 'MIN-852',
+        outcome: 'delivered',
+      }),
+      event(4, 'linear_mcp_auth.healthy', '2026-07-21T12:05:02.000Z', {
+        agentId: 'agent-min-852',
+        issueId: 'MIN-852',
+        source: 'hook',
+      }),
+    ]);
+
+    await expect(computeLinearMcpAuthWakeSet()).resolves.toEqual([]);
+  });
+});

--- a/src/lib/__tests__/linear-mcp-auth.test.ts
+++ b/src/lib/__tests__/linear-mcp-auth.test.ts
@@ -1,10 +1,13 @@
 import type { StoredEvent } from '../../dashboard/server/event-store.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+// Deliberately NO readFrom/queryByType on the mock store: the fold must read
+// only the auth-typed lifecycle slice through queryByTypesSince. Any call to
+// the generic full-history readers throws a TypeError and fails the test.
 const eventStoreMocks = vi.hoisted(() => ({
   appendAsync: vi.fn(),
-  queryByType: vi.fn(),
-  readFrom: vi.fn(),
+  queryByTypesSince: vi.fn(),
+  getLatestSequence: vi.fn(),
 }));
 
 vi.mock('../../dashboard/server/event-store.js', () => ({
@@ -13,6 +16,7 @@ vi.mock('../../dashboard/server/event-store.js', () => ({
 
 import {
   LINEAR_MCP_AUTH_URL_TTL_MS,
+  _resetLinearMcpAuthProjectionCacheForTests,
   computeLinearMcpAuthWakeSet,
   resolveLinearMcpAuthIntervention,
 } from '../linear-mcp-auth.js';
@@ -45,19 +49,15 @@ function healthyEvent(sequence: number, timestamp = '2026-07-21T12:05:00.000Z'):
   });
 }
 
-/** Mirrors the real store: queryByType returns the most recent `limit`
- * events in ascending order; readFrom returns everything after a sequence. */
+/** Mirrors the real query: type predicate and sequence bound both applied. */
 function useEvents(events: StoredEvent[]): void {
-  eventStoreMocks.queryByType.mockImplementation((type: string, limit = 100) => (
+  eventStoreMocks.queryByTypesSince.mockImplementation((types: string[], afterSequence: number) => (
     events
-      .filter(candidate => candidate.type === type)
+      .filter(candidate => candidate.sequence > afterSequence && types.includes(candidate.type))
       .sort((a, b) => a.sequence - b.sequence)
-      .slice(-limit)
   ));
-  eventStoreMocks.readFrom.mockImplementation((fromSequence: number) => (
-    events
-      .filter(candidate => candidate.sequence > fromSequence && candidate.type !== 'issues.snapshot')
-      .sort((a, b) => a.sequence - b.sequence)
+  eventStoreMocks.getLatestSequence.mockImplementation(() => (
+    events.reduce((max, candidate) => Math.max(max, candidate.sequence), 0)
   ));
 }
 
@@ -66,8 +66,9 @@ describe('Linear MCP auth intervention fold', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-07-21T12:00:00.000Z'));
     eventStoreMocks.appendAsync.mockReset();
-    eventStoreMocks.queryByType.mockReset();
-    eventStoreMocks.readFrom.mockReset();
+    eventStoreMocks.queryByTypesSince.mockReset();
+    eventStoreMocks.getLatestSequence.mockReset();
+    _resetLinearMcpAuthProjectionCacheForTests();
     useEvents([]);
   });
 
@@ -188,6 +189,69 @@ describe('Linear MCP auth intervention fold', () => {
 
     expect(intervention.blockedAgents.map(agent => agent.agentId)).toContain('agent-min-852');
     expect(intervention.blockedAgents).toHaveLength(2);
+  });
+
+  it('reads only the auth-typed slice even alongside a large unrelated event population', async () => {
+    // Regression: the polling path must never materialize unrelated retained
+    // history. The mock store has no readFrom at all, and queryByTypesSince
+    // applies both predicates, so any full-table read fails this test.
+    const events: StoredEvent[] = [requiredEvent(1, 'agent-min-852', 'MIN-852')];
+    for (let sequence = 2; sequence <= 5000; sequence++) {
+      events.push(event(sequence, 'agent.activity_changed', '2026-07-21T12:00:00.000Z', { agentId: 'agent-other' }));
+    }
+    events.push(healthyEvent(5001));
+    useEvents(events);
+
+    const intervention = await resolveLinearMcpAuthIntervention();
+
+    expect(intervention.status).toBe('none');
+    // Every delta query carries the auth type predicate — unrelated events
+    // are filtered in SQL, never in JS.
+    for (const call of eventStoreMocks.queryByTypesSince.mock.calls) {
+      expect(call[0]).toEqual(expect.arrayContaining([
+        'linear_mcp_auth.required',
+        'linear_mcp_auth.healthy',
+        'linear_mcp_auth.notified',
+        'linear_mcp_auth.callback_relayed',
+      ]));
+    }
+  });
+
+  it('advances the projection incrementally instead of refolding history per poll', async () => {
+    const events = [
+      requiredEvent(1, 'agent-min-852', 'MIN-852'),
+    ];
+    useEvents(events);
+
+    await resolveLinearMcpAuthIntervention();
+    await resolveLinearMcpAuthIntervention();
+
+    const calls = eventStoreMocks.queryByTypesSince.mock.calls;
+    expect(calls).toHaveLength(2);
+    // The second poll asks only for events after the first covered sequence.
+    expect(calls[0]?.[1]).toBe(0);
+    expect(calls[1]?.[1]).toBe(1);
+
+    events.push(healthyEvent(2));
+    useEvents(events);
+    await expect(resolveLinearMcpAuthIntervention()).resolves.toMatchObject({ status: 'none' });
+    expect(eventStoreMocks.queryByTypesSince.mock.calls[2]?.[1]).toBe(1);
+  });
+
+  it('rebuilds the projection when retention compaction empties the events table', async () => {
+    const events = [requiredEvent(1, 'agent-min-852', 'MIN-852')];
+    useEvents(events);
+    await resolveLinearMcpAuthIntervention();
+
+    // Retention compaction (or a purge) removed everything: the store's
+    // latest sequence is now behind the covered sequence, so the cached
+    // prefix is stale and the projection must restart from scratch.
+    useEvents([]);
+
+    await expect(resolveLinearMcpAuthIntervention()).resolves.toMatchObject({
+      status: 'none',
+      blockedAgents: [],
+    });
   });
 
   it('applies a delayed notification only to its own lifecycle, never to a newer one', async () => {

--- a/src/lib/__tests__/linear-mcp-auth.test.ts
+++ b/src/lib/__tests__/linear-mcp-auth.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const eventStoreMocks = vi.hoisted(() => ({
   appendAsync: vi.fn(),
   queryByType: vi.fn(),
+  readFrom: vi.fn(),
 }));
 
 vi.mock('../../dashboard/server/event-store.js', () => ({
@@ -25,11 +26,38 @@ function event(
   return { sequence, type, timestamp, payload };
 }
 
+function requiredEvent(
+  sequence: number,
+  agentId: string,
+  issueId: string,
+  authUrl: string | null = null,
+  expiresAt: string | null = null,
+  timestamp = '2026-07-21T12:00:00.000Z',
+): StoredEvent {
+  return event(sequence, 'linear_mcp_auth.required', timestamp, { agentId, issueId, authUrl, expiresAt });
+}
+
+function healthyEvent(sequence: number, timestamp = '2026-07-21T12:05:00.000Z'): StoredEvent {
+  return event(sequence, 'linear_mcp_auth.healthy', timestamp, {
+    agentId: 'operator',
+    issueId: null,
+    source: 'operator',
+  });
+}
+
+/** Mirrors the real store: queryByType returns the most recent `limit`
+ * events in ascending order; readFrom returns everything after a sequence. */
 function useEvents(events: StoredEvent[]): void {
-  eventStoreMocks.queryByType.mockImplementation((type: string) => (
+  eventStoreMocks.queryByType.mockImplementation((type: string, limit = 100) => (
     events
       .filter(candidate => candidate.type === type)
-      .sort((a, b) => b.sequence - a.sequence)
+      .sort((a, b) => a.sequence - b.sequence)
+      .slice(-limit)
+  ));
+  eventStoreMocks.readFrom.mockImplementation((fromSequence: number) => (
+    events
+      .filter(candidate => candidate.sequence > fromSequence && candidate.type !== 'issues.snapshot')
+      .sort((a, b) => a.sequence - b.sequence)
   ));
 }
 
@@ -39,6 +67,7 @@ describe('Linear MCP auth intervention fold', () => {
     vi.setSystemTime(new Date('2026-07-21T12:00:00.000Z'));
     eventStoreMocks.appendAsync.mockReset();
     eventStoreMocks.queryByType.mockReset();
+    eventStoreMocks.readFrom.mockReset();
     useEvents([]);
   });
 
@@ -48,12 +77,7 @@ describe('Linear MCP auth intervention fold', () => {
 
   it('projects one blocked agent with the default expiry', async () => {
     useEvents([
-      event(1, 'linear_mcp_auth.required', '2026-07-21T12:00:00.000Z', {
-        agentId: 'agent-min-852',
-        issueId: 'MIN-852',
-        authUrl: null,
-        expiresAt: null,
-      }),
+      requiredEvent(1, 'agent-min-852', 'MIN-852'),
     ]);
 
     await expect(resolveLinearMcpAuthIntervention()).resolves.toEqual({
@@ -74,18 +98,8 @@ describe('Linear MCP auth intervention fold', () => {
 
   it('deduplicates multiple agents and tracks the latest authorization URL owner', async () => {
     useEvents([
-      event(1, 'linear_mcp_auth.required', '2026-07-21T12:00:00.000Z', {
-        agentId: 'agent-min-852',
-        issueId: 'MIN-852',
-        authUrl: 'https://linear.app/oauth/authorize?state=first',
-        expiresAt: '2026-07-21T12:20:00.000Z',
-      }),
-      event(2, 'linear_mcp_auth.required', '2026-07-21T12:05:00.000Z', {
-        agentId: 'agent-pan-2997',
-        issueId: 'PAN-2997',
-        authUrl: 'https://linear.app/oauth/authorize?state=second',
-        expiresAt: '2026-07-21T12:35:00.000Z',
-      }),
+      requiredEvent(1, 'agent-min-852', 'MIN-852', 'https://linear.app/oauth/authorize?state=first', '2026-07-21T12:20:00.000Z'),
+      requiredEvent(2, 'agent-pan-2997', 'PAN-2997', 'https://linear.app/oauth/authorize?state=second', '2026-07-21T12:35:00.000Z', '2026-07-21T12:05:00.000Z'),
     ]);
 
     const intervention = await resolveLinearMcpAuthIntervention();
@@ -105,24 +119,14 @@ describe('Linear MCP auth intervention fold', () => {
 
   it('changes to expired at the default TTL and returns to active after a fresh required event', async () => {
     const events = [
-      event(1, 'linear_mcp_auth.required', '2026-07-21T12:00:00.000Z', {
-        agentId: 'agent-min-852',
-        issueId: 'MIN-852',
-        authUrl: 'https://linear.app/oauth/authorize?state=first',
-        expiresAt: null,
-      }),
+      requiredEvent(1, 'agent-min-852', 'MIN-852', 'https://linear.app/oauth/authorize?state=first'),
     ];
     useEvents(events);
 
     await vi.advanceTimersByTimeAsync(LINEAR_MCP_AUTH_URL_TTL_MS + 1);
     await expect(resolveLinearMcpAuthIntervention()).resolves.toMatchObject({ status: 'expired' });
 
-    events.push(event(2, 'linear_mcp_auth.required', '2026-07-21T12:30:00.001Z', {
-      agentId: 'agent-min-852',
-      issueId: 'MIN-852',
-      authUrl: 'https://linear.app/oauth/authorize?state=refreshed',
-      expiresAt: null,
-    }));
+    events.push(requiredEvent(2, 'agent-min-852', 'MIN-852', 'https://linear.app/oauth/authorize?state=refreshed', null, '2026-07-21T12:30:00.001Z'));
     useEvents(events);
 
     await expect(resolveLinearMcpAuthIntervention()).resolves.toMatchObject({
@@ -134,53 +138,115 @@ describe('Linear MCP auth intervention fold', () => {
 
   it('applies notifications after close to the last completed lifecycle', async () => {
     useEvents([
-      event(1, 'linear_mcp_auth.required', '2026-07-21T12:00:00.000Z', {
-        agentId: 'agent-min-852',
-        issueId: 'MIN-852',
-        authUrl: null,
-        expiresAt: null,
-      }),
-      event(2, 'linear_mcp_auth.healthy', '2026-07-21T12:05:00.000Z', {
-        agentId: 'agent-min-852',
-        issueId: 'MIN-852',
-        source: 'hook',
-      }),
+      requiredEvent(1, 'agent-min-852', 'MIN-852'),
+      healthyEvent(2),
       event(3, 'linear_mcp_auth.notified', '2026-07-21T12:05:01.000Z', {
         agentId: 'agent-min-852',
         issueId: 'MIN-852',
         outcome: 'delivered',
+        lifecycleId: 'seq-1',
       }),
     ]);
 
     await expect(resolveLinearMcpAuthIntervention()).resolves.toMatchObject({ status: 'none' });
-    await expect(computeLinearMcpAuthWakeSet()).resolves.toEqual([]);
+    await expect(computeLinearMcpAuthWakeSet()).resolves.toEqual({
+      lifecycleId: 'seq-1',
+      agents: [],
+    });
   });
 
   it('keeps the wake set empty when a duplicate healthy event arrives after notification', async () => {
     useEvents([
-      event(1, 'linear_mcp_auth.required', '2026-07-21T12:00:00.000Z', {
+      requiredEvent(1, 'agent-min-852', 'MIN-852'),
+      healthyEvent(2),
+      event(3, 'linear_mcp_auth.notified', '2026-07-21T12:05:01.000Z', {
         agentId: 'agent-min-852',
         issueId: 'MIN-852',
-        authUrl: null,
-        expiresAt: null,
+        outcome: 'delivered',
+        lifecycleId: 'seq-1',
       }),
-      event(2, 'linear_mcp_auth.healthy', '2026-07-21T12:05:00.000Z', {
+      healthyEvent(4, '2026-07-21T12:05:02.000Z'),
+    ]);
+
+    await expect(computeLinearMcpAuthWakeSet()).resolves.toEqual({
+      lifecycleId: 'seq-1',
+      agents: [],
+    });
+  });
+
+  it('keeps every blocked agent visible and wakeable past 100 required events', async () => {
+    // Regression: the old fold queried each event type with the store's
+    // default 100-event cap, so enough repeated failures from one agent
+    // pushed another agent's declaration out of the reconstruction window.
+    const events: StoredEvent[] = [requiredEvent(1, 'agent-min-852', 'MIN-852')];
+    for (let sequence = 2; sequence <= 150; sequence++) {
+      events.push(requiredEvent(sequence, 'agent-pan-2997', 'PAN-2997'));
+    }
+    useEvents(events);
+
+    const intervention = await resolveLinearMcpAuthIntervention();
+
+    expect(intervention.blockedAgents.map(agent => agent.agentId)).toContain('agent-min-852');
+    expect(intervention.blockedAgents).toHaveLength(2);
+  });
+
+  it('applies a delayed notification only to its own lifecycle, never to a newer one', async () => {
+    // The review's stranding sequence: required(A) → healthy(A) → required(B,
+    // same agent) → healthy(B) → notified(A). Lifecycle B must remain
+    // unwoken — A's delayed record may not mark B handled.
+    useEvents([
+      requiredEvent(1, 'agent-min-852', 'MIN-852'),
+      healthyEvent(2, '2026-07-21T12:01:00.000Z'),
+      requiredEvent(3, 'agent-min-852', 'MIN-852', null, null, '2026-07-21T12:02:00.000Z'),
+      healthyEvent(4, '2026-07-21T12:03:00.000Z'),
+      event(5, 'linear_mcp_auth.notified', '2026-07-21T12:03:30.000Z', {
         agentId: 'agent-min-852',
         issueId: 'MIN-852',
-        source: 'hook',
+        outcome: 'delivered',
+        lifecycleId: 'seq-1',
       }),
+    ]);
+
+    // B (seq-3) is the last completed lifecycle and its agent was never
+    // notified — the wake set must still contain it.
+    await expect(computeLinearMcpAuthWakeSet()).resolves.toEqual({
+      lifecycleId: 'seq-3',
+      agents: [expect.objectContaining({ agentId: 'agent-min-852', notifiedAt: null })],
+    });
+  });
+
+  it('ignores a notification whose lifecycle id matches no known lifecycle', async () => {
+    useEvents([
+      requiredEvent(1, 'agent-min-852', 'MIN-852'),
+      healthyEvent(2),
+      event(3, 'linear_mcp_auth.notified', '2026-07-21T12:05:01.000Z', {
+        agentId: 'agent-min-852',
+        issueId: 'MIN-852',
+        outcome: 'delivered',
+        lifecycleId: 'seq-999',
+      }),
+    ]);
+
+    await expect(computeLinearMcpAuthWakeSet()).resolves.toEqual({
+      lifecycleId: 'seq-1',
+      agents: [expect.objectContaining({ agentId: 'agent-min-852', notifiedAt: null })],
+    });
+  });
+
+  it('applies legacy notifications without a lifecycle id to the current lifecycle', async () => {
+    useEvents([
+      requiredEvent(1, 'agent-min-852', 'MIN-852'),
+      healthyEvent(2),
       event(3, 'linear_mcp_auth.notified', '2026-07-21T12:05:01.000Z', {
         agentId: 'agent-min-852',
         issueId: 'MIN-852',
         outcome: 'delivered',
       }),
-      event(4, 'linear_mcp_auth.healthy', '2026-07-21T12:05:02.000Z', {
-        agentId: 'agent-min-852',
-        issueId: 'MIN-852',
-        source: 'hook',
-      }),
     ]);
 
-    await expect(computeLinearMcpAuthWakeSet()).resolves.toEqual([]);
+    await expect(computeLinearMcpAuthWakeSet()).resolves.toEqual({
+      lifecycleId: 'seq-1',
+      agents: [],
+    });
   });
 });

--- a/src/lib/__tests__/message-agent-interventions.test.ts
+++ b/src/lib/__tests__/message-agent-interventions.test.ts
@@ -1,5 +1,5 @@
 import { Effect } from 'effect';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -54,6 +54,27 @@ vi.mock('../paths.js', async (importOriginal) => {
     },
   };
 });
+
+// PAN-3015 monitor tier is mocked so tests can flip liveness per case.
+vi.mock('../agents/monitor-transport.js', () => ({
+  isMonitorLive: vi.fn(() => false),
+  formatMailFileContent: vi.fn(
+    (body: string, source: string, date: Date) =>
+      `# Message\n\nsource: ${source}\ndate: ${date.toISOString()}\n\n${body}\n`,
+  ),
+}));
+
+vi.mock('../tmux-dedup.js', () => ({
+  sendKeysDedup: vi.fn(async () => 'pasted'),
+  completeKeyedSubmit: vi.fn(async () => undefined),
+}));
+
+// Resume is mocked at its source module so the agents barrel re-exports the
+// mock to messaging.ts's dynamic import.
+vi.mock('../agents/resume.js', () => ({
+  resumeAgent: vi.fn(async () => ({ success: true, messageDelivered: true })),
+  buildCompactRecoverySeed: vi.fn(() => null),
+}));
 
 import { messageAgent } from '../agents.js';
 import { sendKeys } from '../tmux.js';
@@ -124,5 +145,86 @@ describe('messageAgent operator interventions', () => {
     expect(sendKeys).toHaveBeenCalledWith('agent-pan-1487', 'hello without issue');
     expect(interventionMocks.appendOperatorInterventionEvent).not.toHaveBeenCalled();
     expect(debugSpy).toHaveBeenCalledWith('[agents] Skipping tell intervention for agent-pan-1487; state.json has no issueId');
+  });
+});
+
+describe('messageAgent monitor tier vs keyed deliveries (PAN-2997 cycle 7)', () => {
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'pan-message-agent-'));
+    stateDir = join(tmpHome, 'agents');
+    mkdirSync(stateDir, { recursive: true });
+    process.env.OVERDECK_HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    delete process.env.OVERDECK_HOME;
+    rmSync(tmpHome, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('BYPASSES the live monitor tier for a keyed delivery and uses the keyed door', async () => {
+    const { isMonitorLive } = await import('../agents/monitor-transport.js');
+    const { sendKeysDedup, completeKeyedSubmit } = await import('../tmux-dedup.js');
+    vi.mocked(isMonitorLive).mockReturnValue(true);
+    vi.mocked(sendKeysDedup).mockClear();
+    vi.mocked(completeKeyedSubmit).mockClear();
+    writeAgentState('agent-pan-2997');
+
+    const result = await messageAgent('agent-pan-2997', 'Linear auth is healthy — recheck', 'linear-mcp-auth-wake', {
+      dedupKey: 'linear-mcp-auth-wake:lifecycle-1',
+    });
+
+    // The keyed door enforced the delivery; the monitor mail spool never saw it.
+    expect(result.delivered).toBe(true);
+    expect(result.reason).not.toBe('monitor');
+    expect(vi.mocked(sendKeysDedup)).toHaveBeenCalledWith(
+      'agent-pan-2997',
+      'Linear auth is healthy — recheck',
+      'linear-mcp-auth-wake:lifecycle-1',
+      'messageAgent:linear-mcp-auth-wake',
+    );
+    expect(vi.mocked(completeKeyedSubmit)).toHaveBeenCalledWith('agent-pan-2997', 'linear-mcp-auth-wake:lifecycle-1');
+    expect(existsSync(join(stateDir, 'agent-pan-2997', 'mail'))).toBe(false);
+  });
+
+  it('still routes UNKEYED mid-session tells through a live monitor', async () => {
+    const { isMonitorLive } = await import('../agents/monitor-transport.js');
+    const { sendKeysDedup } = await import('../tmux-dedup.js');
+    vi.mocked(isMonitorLive).mockReturnValue(true);
+    vi.mocked(sendKeysDedup).mockClear();
+    writeAgentState('agent-pan-3015');
+
+    const result = await messageAgent('agent-pan-3015', 'ordinary tell', 'internal');
+
+    expect(result).toMatchObject({ delivered: true, queuedToMail: true, reason: 'monitor' });
+    expect(vi.mocked(sendKeysDedup)).not.toHaveBeenCalled();
+    expect(existsSync(join(stateDir, 'agent-pan-3015', 'mail'))).toBe(true);
+  });
+
+  it('resumes a STOPPED agent bare and delivers the keyed wake through the keyed door (cycle 7)', async () => {
+    const { resumeAgent } = await import('../agents/resume.js');
+    const { sendKeysDedup, completeKeyedSubmit } = await import('../tmux-dedup.js');
+    vi.mocked(resumeAgent).mockClear();
+    vi.mocked(sendKeysDedup).mockClear();
+    vi.mocked(completeKeyedSubmit).mockClear();
+    writeAgentState('agent-pan-2997-stopped', { status: 'stopped' });
+
+    const result = await messageAgent('agent-pan-2997-stopped', 'Linear auth is healthy — recheck', 'linear-mcp-auth-wake', {
+      dedupKey: 'linear-mcp-auth-wake:lifecycle-1',
+    });
+
+    // The wake never rode the resume kickoff prompt…
+    expect(vi.mocked(resumeAgent)).toHaveBeenCalledWith('agent-pan-2997-stopped');
+    // …it was enforced by the keyed door of the new session instead.
+    expect(vi.mocked(sendKeysDedup)).toHaveBeenCalledWith(
+      'agent-pan-2997-stopped',
+      'Linear auth is healthy — recheck',
+      'linear-mcp-auth-wake:lifecycle-1',
+      'messageAgent:linear-mcp-auth-wake',
+    );
+    expect(vi.mocked(completeKeyedSubmit)).toHaveBeenCalledWith('agent-pan-2997-stopped', 'linear-mcp-auth-wake:lifecycle-1');
+    expect(result.delivered).toBe(true);
+    // No keyed mail backup — that file would be a replay channel.
+    expect(existsSync(join(stateDir, 'agent-pan-2997-stopped', 'mail'))).toBe(false);
   });
 });

--- a/src/lib/__tests__/tmux-dedup.test.ts
+++ b/src/lib/__tests__/tmux-dedup.test.ts
@@ -1,0 +1,63 @@
+import { execFileSync } from 'node:child_process';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { sendKeysDedup } from '../tmux-dedup.js';
+
+const socket = `dedup-test-${process.pid}`;
+const session = 'agent-dedup';
+
+const hasTmux = (() => {
+  try {
+    execFileSync('tmux', ['-V'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+function capturePane(): string {
+  return execFileSync('tmux', ['-L', socket, 'capture-pane', '-t', session, '-p'], { encoding: 'utf-8' }).toString();
+}
+
+/**
+ * Real throwaway tmux server — the dedup record is a tmux session option set
+ * atomically with the paste by the tmux SERVER, so only a live server can
+ * prove the check/paste/mark sequence. (PAN-2997)
+ */
+describe.skipIf(!hasTmux)('sendKeysDedup', () => {
+  beforeEach(() => {
+    process.env.OVERDECK_TMUX_SOCKET_NAME = socket;
+    execFileSync('tmux', ['-L', socket, 'new-session', '-d', '-s', session, '-x', '120', '-y', '30', 'cat']);
+  });
+
+  afterEach(() => {
+    try {
+      execFileSync('tmux', ['-L', socket, 'kill-server'], { stdio: 'ignore' });
+    } catch {
+      // Server already gone.
+    }
+    delete process.env.OVERDECK_TMUX_SOCKET_NAME;
+  });
+
+  it('pastes and marks on first delivery, then suppresses a replay of the same key', async () => {
+    const first = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+    expect(first).toBe('delivered');
+    const afterFirst = capturePane();
+    expect(afterFirst).toContain('wake up agent');
+
+    const second = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+    expect(second).toBe('deduplicated');
+    expect(capturePane()).toBe(afterFirst);
+  });
+
+  it('delivers identical content under a different key', async () => {
+    await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+    const third = await sendKeysDedup(session, 'wake up agent', 'test-key-2');
+    expect(third).toBe('delivered');
+    expect(capturePane().match(/wake up agent/g)).toHaveLength(2);
+  });
+
+  it('rejects keys that are unsafe for tmux option names', async () => {
+    await expect(sendKeysDedup(session, 'content', 'bad key with spaces')).rejects.toThrow(/dedupKey/);
+  });
+});

--- a/src/lib/__tests__/tmux-dedup.test.ts
+++ b/src/lib/__tests__/tmux-dedup.test.ts
@@ -31,6 +31,12 @@ function showPaneDead(): string {
   return execFileSync('tmux', ['-L', socket, 'display-message', '-p', '-t', session, '#{pane_dead}'], { encoding: 'utf-8' }).trim();
 }
 
+function readPaneTargetReal(name: string): Promise<{ pid: string; dead: boolean }> {
+  const out = execFileSync('tmux', ['-L', socket, 'display-message', '-p', '-t', name, '#{pane_pid} #{pane_dead}'], { encoding: 'utf-8' }).trim();
+  const [pid = '', dead = ''] = out.split(/\s+/);
+  return Promise.resolve({ pid, dead: dead === '1' });
+}
+
 function occurrences(haystack: string, needle: string): number {
   return haystack.match(new RegExp(needle, 'g'))?.length ?? 0;
 }
@@ -196,6 +202,54 @@ describe.skipIf(!hasTmux)('sendKeysDedup two-phase protocol', () => {
     expect(replay).toBe('pasted');
     await completeKeyedSubmit(session, 'test-key-1');
     expect(occurrences(capturePane(), 'wake up agent')).toBe(2); // input echo + cat output
+    expect(showOption('@overdeck-dedup-test-key-1')).toBe('1');
+  });
+
+  it('repairs a poisoned false-terminal before honoring anything (cycle 11)', async () => {
+    // A prior post-submit check proved this terminal marker FALSE but could
+    // not verify its rollback: terminal sits there next to the poison
+    // breadcrumb.
+    execFileSync('tmux', ['-L', socket, 'set-option', '-t', session, '@overdeck-dedup-test-key-1', '1']);
+    execFileSync('tmux', ['-L', socket, 'set-option', '-t', session, '@overdeck-dedup-poison-test-key-1', '1']);
+
+    const phase = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+
+    // NEVER 'deduplicated' from a false terminal: the repair clears terminal,
+    // restores a pending claim, and lifts the breadcrumb.
+    expect(phase).toBe('submit-pending');
+    expect(showOption('@overdeck-dedup-test-key-1')).toBe('');
+    expect(showOption('@overdeck-dedup-pending-test-key-1')).not.toBe('');
+    expect(showOption('@overdeck-dedup-poison-test-key-1')).toBe('');
+  });
+
+  it('fails CLOSED when the pre-submit target read fails — the Enter lands but the claim rolls back (cycle 11)', async () => {
+    const first = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+    expect(first).toBe('pasted');
+
+    // Transient pre-target read failure: the pane's identity is unprovable,
+    // so even though the Enter lands on the live pane the key must NOT stay
+    // terminal (the pane could have been a contentless replacement).
+    let reads = 0;
+    await expect(
+      completeKeyedSubmit(session, 'test-key-1', {
+        readPaneTarget: (name: string) => {
+          reads += 1;
+          // The production helper converts a failed read into an unprovable
+          // target rather than rejecting — mirror that contract.
+          if (reads === 1) return Promise.resolve({ pid: '', dead: true });
+          return readPaneTargetReal(name);
+        },
+      }),
+    ).rejects.toThrow(KeyedSubmitTargetDeadError);
+    expect(showOption('@overdeck-dedup-test-key-1')).toBe('');
+    expect(showOption('@overdeck-dedup-pending-test-key-1')).not.toBe('');
+    // The rollback was verified, so the poison breadcrumb was lifted.
+    expect(showOption('@overdeck-dedup-poison-test-key-1')).toBe('');
+
+    // Recovery completes the preserved claim.
+    const replay = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+    expect(replay).toBe('submit-pending');
+    await completeKeyedSubmit(session, 'test-key-1');
     expect(showOption('@overdeck-dedup-test-key-1')).toBe('1');
   });
 

--- a/src/lib/__tests__/tmux-dedup.test.ts
+++ b/src/lib/__tests__/tmux-dedup.test.ts
@@ -253,7 +253,7 @@ describe.skipIf(!hasTmux)('sendKeysDedup two-phase protocol', () => {
     expect(await sendKeysDedup(session, 'wake up agent', 'test-key-1')).toBe('deduplicated');
   });
 
-  it('a FAILED poison read aborts without honoring the terminal marker (cycle 12)', async () => {
+  it('a FAILED poison read aborts as a RECOVERABLE marker error without honoring the terminal marker (cycle 12/15)', async () => {
     // A false terminal and its breadcrumb both exist; the poison read fails.
     execFileSync('tmux', ['-L', socket, 'set-option', '-t', session, '@overdeck-dedup-test-key-1', '1']);
     execFileSync('tmux', ['-L', socket, 'set-option', '-t', session, '@overdeck-dedup-poison-test-key-1', '1']);
@@ -262,7 +262,7 @@ describe.skipIf(!hasTmux)('sendKeysDedup two-phase protocol', () => {
       sendKeysDedup(session, 'wake up agent', 'test-key-1', 'test', {
         readMarkerStrict: () => Promise.reject(new Error('transient poison-read failure')),
       }),
-    ).rejects.toThrow(/transient poison-read failure/);
+    ).rejects.toThrow(KeyedMarkerVerificationError);
 
     // Nothing was honored, repaired, or pasted — and the call did NOT return
     // 'deduplicated' from the false terminal.

--- a/src/lib/__tests__/tmux-dedup.test.ts
+++ b/src/lib/__tests__/tmux-dedup.test.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { completeKeyedSubmit, sendKeysDedup } from '../tmux-dedup.js';
+import { completeKeyedSubmit, KeyedSubmitTargetDeadError, sendKeysDedup } from '../tmux-dedup.js';
 
 const socket = `dedup-test-${process.pid}`;
 const session = 'agent-dedup';
@@ -25,6 +25,10 @@ function showOption(name: string): string {
   } catch {
     return '';
   }
+}
+
+function showPaneDead(): string {
+  return execFileSync('tmux', ['-L', socket, 'display-message', '-p', '-t', session, '#{pane_dead}'], { encoding: 'utf-8' }).trim();
 }
 
 function occurrences(haystack: string, needle: string): number {
@@ -132,6 +136,39 @@ describe.skipIf(!hasTmux)('sendKeysDedup two-phase protocol', () => {
 
     expect(occurrences(capturePane(), 'wake up agent')).toBe(2);
     expect(occurrences(capturePane(), 'operator follow-up')).toBe(1);
+  });
+
+  it('refuses to claim the key when the pane dies after the paste — no terminal, no Enter, pending preserved (cycle 9)', async () => {
+    // remain-on-exit keeps the session (and its option markers) alive as a
+    // corpse after the pane process exits.
+    execFileSync('tmux', ['-L', socket, 'set-option', '-t', session, 'remain-on-exit', 'on']);
+    const first = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+    expect(first).toBe('pasted');
+    const pendingBefore = showOption('@overdeck-dedup-pending-test-key-1');
+    expect(pendingBefore).not.toBe('');
+
+    // The harness exits during the settle window: C-c kills the cat.
+    execFileSync('tmux', ['-L', socket, 'send-keys', '-t', session, 'C-c']);
+    const deadline = Date.now() + 3_000;
+    while (showPaneDead() !== '1' && Date.now() < deadline) {
+      execFileSync('sleep', ['0.05']);
+    }
+    expect(showPaneDead()).toBe('1');
+
+    // The submit must NOT flip the key terminal and must NOT send Enter.
+    await expect(completeKeyedSubmit(session, 'test-key-1')).rejects.toThrow(KeyedSubmitTargetDeadError);
+    expect(showOption('@overdeck-dedup-test-key-1')).toBe('');
+    expect(showOption('@overdeck-dedup-pending-test-key-1')).toBe(pendingBefore);
+
+    // Recovery after the agent "resumes" (pane respawned): the preserved
+    // pending claim routes to completion, never to a false dedup. The wake
+    // CONTENT re-delivery belongs to the resume path; the marker protocol's
+    // job here is to prove the key was never falsely claimed.
+    execFileSync('tmux', ['-L', socket, 'respawn-pane', '-k', '-t', session, 'cat']);
+    const replay = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+    expect(replay).toBe('submit-pending');
+    await completeKeyedSubmit(session, 'test-key-1');
+    expect(showOption('@overdeck-dedup-test-key-1')).toBe('1');
   });
 
   it('delivers identical content under a different key', async () => {

--- a/src/lib/__tests__/tmux-dedup.test.ts
+++ b/src/lib/__tests__/tmux-dedup.test.ts
@@ -205,7 +205,7 @@ describe.skipIf(!hasTmux)('sendKeysDedup two-phase protocol', () => {
     expect(showOption('@overdeck-dedup-test-key-1')).toBe('1');
   });
 
-  it('repairs a poisoned false-terminal before honoring anything (cycle 11)', async () => {
+  it('repairs a poisoned false-terminal before honoring anything (cycle 11/12)', async () => {
     // A prior post-submit check proved this terminal marker FALSE but could
     // not verify its rollback: terminal sits there next to the poison
     // breadcrumb.
@@ -215,11 +215,68 @@ describe.skipIf(!hasTmux)('sendKeysDedup two-phase protocol', () => {
     const phase = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
 
     // NEVER 'deduplicated' from a false terminal: the repair clears terminal,
-    // restores a pending claim, and lifts the breadcrumb.
+    // restores a pending claim, and lifts the breadcrumb — verified.
     expect(phase).toBe('submit-pending');
     expect(showOption('@overdeck-dedup-test-key-1')).toBe('');
     expect(showOption('@overdeck-dedup-pending-test-key-1')).not.toBe('');
     expect(showOption('@overdeck-dedup-poison-test-key-1')).toBe('');
+
+    // The repaired completion delivers for real, and the breadcrumb lifecycle
+    // closes: a later replay dedups on the VERIFIED terminal.
+    await completeKeyedSubmit(session, 'test-key-1');
+    expect(showOption('@overdeck-dedup-test-key-1')).toBe('1');
+    expect(showOption('@overdeck-dedup-poison-test-key-1')).toBe('');
+    expect(await sendKeysDedup(session, 'wake up agent', 'test-key-1')).toBe('deduplicated');
+  });
+
+  it('a FAILED poison read aborts without honoring the terminal marker (cycle 12)', async () => {
+    // A false terminal and its breadcrumb both exist; the poison read fails.
+    execFileSync('tmux', ['-L', socket, 'set-option', '-t', session, '@overdeck-dedup-test-key-1', '1']);
+    execFileSync('tmux', ['-L', socket, 'set-option', '-t', session, '@overdeck-dedup-poison-test-key-1', '1']);
+
+    await expect(
+      sendKeysDedup(session, 'wake up agent', 'test-key-1', 'test', {
+        readMarkerStrict: () => Promise.reject(new Error('transient poison-read failure')),
+      }),
+    ).rejects.toThrow(/transient poison-read failure/);
+
+    // Nothing was honored, repaired, or pasted — and the call did NOT return
+    // 'deduplicated' from the false terminal.
+    expect(showOption('@overdeck-dedup-test-key-1')).toBe('1');
+    expect(showOption('@overdeck-dedup-poison-test-key-1')).toBe('1');
+    expect(occurrences(capturePane(), 'wake up agent')).toBe(0);
+
+    // Recovery with a healthy read repairs and completes.
+    const phase = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+    expect(phase).toBe('submit-pending');
+    await completeKeyedSubmit(session, 'test-key-1');
+    expect(showOption('@overdeck-dedup-test-key-1')).toBe('1');
+    expect(showOption('@overdeck-dedup-poison-test-key-1')).toBe('');
+  });
+
+  it('a FAILED poison clear after verified delivery is loud — no success with a stale breadcrumb (cycle 12)', async () => {
+    const first = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+    expect(first).toBe('pasted');
+
+    // The delivery verifies live, but the breadcrumb-clear verification reads
+    // a stale poison — the call must NOT report success.
+    await expect(
+      completeKeyedSubmit(session, 'test-key-1', {
+        readMarker: (name: string, option: string) => {
+          if (option === '@overdeck-dedup-poison-test-key-1') {
+            return Promise.resolve('1');
+          }
+          return Promise.resolve(showOption(option));
+        },
+      }),
+    ).rejects.toThrow(/poison breadcrumb could not be cleared/);
+
+    // The terminal is legitimately set and the REAL breadcrumb was cleared —
+    // only the verification read lied — so a healthy recovery dedups on the
+    // verified terminal instead of invalidating it.
+    expect(showOption('@overdeck-dedup-test-key-1')).toBe('1');
+    expect(showOption('@overdeck-dedup-poison-test-key-1')).toBe('');
+    expect(await sendKeysDedup(session, 'wake up agent', 'test-key-1')).toBe('deduplicated');
   });
 
   it('fails CLOSED when the pre-submit target read fails — the Enter lands but the claim rolls back (cycle 11)', async () => {

--- a/src/lib/__tests__/tmux-dedup.test.ts
+++ b/src/lib/__tests__/tmux-dedup.test.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { sendKeysDedup } from '../tmux-dedup.js';
+import { completeKeyedSubmit, sendKeysDedup } from '../tmux-dedup.js';
 
 const socket = `dedup-test-${process.pid}`;
 const session = 'agent-dedup';
@@ -19,12 +19,25 @@ function capturePane(): string {
   return execFileSync('tmux', ['-L', socket, 'capture-pane', '-t', session, '-p'], { encoding: 'utf-8' }).toString();
 }
 
+function showOption(name: string): string {
+  try {
+    return execFileSync('tmux', ['-L', socket, 'show-option', '-qv', '-t', session, name], { encoding: 'utf-8' }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function occurrences(haystack: string, needle: string): number {
+  return haystack.match(new RegExp(needle, 'g'))?.length ?? 0;
+}
+
 /**
- * Real throwaway tmux server — the dedup record is a tmux session option set
- * atomically with the paste by the tmux SERVER, so only a live server can
- * prove the check/paste/mark sequence. (PAN-2997)
+ * Real throwaway tmux server — the dedup record is a pair of tmux session
+ * options set atomically with the paste by the tmux SERVER, so only a live
+ * server can prove the check/paste/mark sequence and the crash boundaries
+ * around the standalone Enter. (PAN-2997)
  */
-describe.skipIf(!hasTmux)('sendKeysDedup', () => {
+describe.skipIf(!hasTmux)('sendKeysDedup two-phase protocol', () => {
   beforeEach(() => {
     process.env.OVERDECK_TMUX_SOCKET_NAME = socket;
     execFileSync('tmux', ['-L', socket, 'new-session', '-d', '-s', session, '-x', '120', '-y', '30', 'cat']);
@@ -39,25 +52,76 @@ describe.skipIf(!hasTmux)('sendKeysDedup', () => {
     delete process.env.OVERDECK_TMUX_SOCKET_NAME;
   });
 
-  it('pastes and marks on first delivery, then suppresses a replay of the same key', async () => {
+  it('pastes and claims on first delivery, submits once, then suppresses a replay of the same key', async () => {
     const first = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
-    expect(first).toBe('delivered');
-    const afterFirst = capturePane();
-    expect(afterFirst).toContain('wake up agent');
+    expect(first).toBe('pasted');
+    expect(capturePane()).toContain('wake up agent');
+    expect(showOption('@overdeck-dedup-pending-test-key-1')).not.toBe('');
+
+    await completeKeyedSubmit(session, 'test-key-1');
+    expect(showOption('@overdeck-dedup-test-key-1')).toBe('1');
+    expect(showOption('@overdeck-dedup-pending-test-key-1')).toBe('');
+    const afterSubmit = capturePane();
 
     const second = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
     expect(second).toBe('deduplicated');
-    expect(capturePane()).toBe(afterFirst);
+    expect(capturePane()).toBe(afterSubmit);
+  });
+
+  it('completes a crashed attempt from the pending marker WITHOUT pasting a second copy', async () => {
+    // First attempt pastes, then "crashes" before the submit.
+    const first = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+    expect(first).toBe('pasted');
+    const afterPaste = capturePane();
+    expect(occurrences(afterPaste, 'wake up agent')).toBe(1);
+
+    // Recovery replay: the pending marker routes to submit-completion, not a
+    // second paste.
+    const replay = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+    expect(replay).toBe('submit-pending');
+    expect(occurrences(capturePane(), 'wake up agent')).toBe(1);
+
+    await completeKeyedSubmit(session, 'test-key-1');
+    // cat echoes the submitted line once: exactly one input copy plus one
+    // cat output copy — no second paste ever happened.
+    expect(occurrences(capturePane(), 'wake up agent')).toBe(2);
+    expect(showOption('@overdeck-dedup-test-key-1')).toBe('1');
+
+    const settled = capturePane();
+    const afterRecovery = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+    expect(afterRecovery).toBe('deduplicated');
+    expect(capturePane()).toBe(settled);
+  });
+
+  it('sends at most one visible message when the crash lands between Enter and the terminal flip', async () => {
+    const first = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+    expect(first).toBe('pasted');
+
+    // Simulate Enter sent but the terminal flip interrupted: send C-m by hand,
+    // leave the pending marker in place.
+    execFileSync('tmux', ['-L', socket, 'send-keys', '-t', session, 'C-m']);
+    const afterManualEnter = capturePane();
+    expect(occurrences(afterManualEnter, 'wake up agent')).toBe(2); // input echo + cat output
+
+    // Recovery replay: pending is still set, so the replay completes the
+    // transaction — one more Enter lands on the now-EMPTY composer (a no-op),
+    // and the key flips terminal. The message itself is never re-pasted.
+    const replay = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+    expect(replay).toBe('submit-pending');
+    await completeKeyedSubmit(session, 'test-key-1');
+    expect(occurrences(capturePane(), 'wake up agent')).toBe(2);
+    expect(showOption('@overdeck-dedup-test-key-1')).toBe('1');
   });
 
   it('delivers identical content under a different key', async () => {
     await sendKeysDedup(session, 'wake up agent', 'test-key-1');
     const third = await sendKeysDedup(session, 'wake up agent', 'test-key-2');
-    expect(third).toBe('delivered');
-    expect(capturePane().match(/wake up agent/g)).toHaveLength(2);
+    expect(third).toBe('pasted');
+    expect(occurrences(capturePane(), 'wake up agent')).toBe(2);
   });
 
   it('rejects keys that are unsafe for tmux option names', async () => {
     await expect(sendKeysDedup(session, 'content', 'bad key with spaces')).rejects.toThrow(/dedupKey/);
+    await expect(completeKeyedSubmit(session, 'bad key with spaces')).rejects.toThrow(/dedupKey/);
   });
 });

--- a/src/lib/__tests__/tmux-dedup.test.ts
+++ b/src/lib/__tests__/tmux-dedup.test.ts
@@ -171,6 +171,34 @@ describe.skipIf(!hasTmux)('sendKeysDedup two-phase protocol', () => {
     expect(showOption('@overdeck-dedup-test-key-1')).toBe('1');
   });
 
+  it('rolls the key back when the pane dies AROUND the Enter — no false terminal, recovery pastes real content (cycle 10)', async () => {
+    // Replace cat with a shell that exits as soon as it consumes the
+    // submitted line: the if-shell's condition sees a live pane, the Enter
+    // lands, and the harness dies in the same breath — the exact
+    // shell-to-branch handoff window.
+    execFileSync('tmux', ['-L', socket, 'respawn-pane', '-k', '-t', session, 'sh']);
+    execFileSync('tmux', ['-L', socket, 'set-option', '-t', session, 'remain-on-exit', 'on']);
+    const first = await sendKeysDedup(session, 'exit', 'test-key-1');
+    expect(first).toBe('pasted');
+
+    await expect(completeKeyedSubmit(session, 'test-key-1')).rejects.toThrow(KeyedSubmitTargetDeadError);
+    // The terminal marker was rolled back and the pending claim restored —
+    // the key was NOT claimed even though send-keys reported success.
+    expect(showOption('@overdeck-dedup-test-key-1')).toBe('');
+    expect(showOption('@overdeck-dedup-pending-test-key-1')).not.toBe('');
+
+    // Recovery after resume recreates the session (resumeAgent kills the
+    // zombie): fresh markers, and the keyed delivery performs a REAL content
+    // submission into the live session.
+    execFileSync('tmux', ['-L', socket, 'kill-session', '-t', session]);
+    execFileSync('tmux', ['-L', socket, 'new-session', '-d', '-s', session, '-x', '120', '-y', '30', 'cat']);
+    const replay = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+    expect(replay).toBe('pasted');
+    await completeKeyedSubmit(session, 'test-key-1');
+    expect(occurrences(capturePane(), 'wake up agent')).toBe(2); // input echo + cat output
+    expect(showOption('@overdeck-dedup-test-key-1')).toBe('1');
+  });
+
   it('delivers identical content under a different key', async () => {
     await sendKeysDedup(session, 'wake up agent', 'test-key-1');
     const third = await sendKeysDedup(session, 'wake up agent', 'test-key-2');

--- a/src/lib/__tests__/tmux-dedup.test.ts
+++ b/src/lib/__tests__/tmux-dedup.test.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { completeKeyedSubmit, KeyedSubmitTargetDeadError, sendKeysDedup } from '../tmux-dedup.js';
+import { completeKeyedSubmit, KeyedMarkerVerificationError, KeyedSubmitTargetDeadError, sendKeysDedup } from '../tmux-dedup.js';
 
 const socket = `dedup-test-${process.pid}`;
 const session = 'agent-dedup';
@@ -166,15 +166,19 @@ describe.skipIf(!hasTmux)('sendKeysDedup two-phase protocol', () => {
     expect(showOption('@overdeck-dedup-test-key-1')).toBe('');
     expect(showOption('@overdeck-dedup-pending-test-key-1')).toBe(pendingBefore);
 
-    // Recovery after the agent "resumes" (pane respawned): the preserved
-    // pending claim routes to completion, never to a false dedup. The wake
-    // CONTENT re-delivery belongs to the resume path; the marker protocol's
-    // job here is to prove the key was never falsely claimed.
+    // Recovery after the agent "resumes" (pane respawned = a REPLACEMENT
+    // pane): the recorded paste target no longer matches, so the protocol
+    // re-pastes the REAL content instead of completing with a blank Enter
+    // (cycle 13). The marker protocol's job here is to prove the key was
+    // never falsely claimed and the content reaches the replacement.
     execFileSync('tmux', ['-L', socket, 'respawn-pane', '-k', '-t', session, 'cat']);
     const replay = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
-    expect(replay).toBe('submit-pending');
+    expect(replay).toBe('pasted');
+    expect(capturePane()).toContain('wake up agent');
     await completeKeyedSubmit(session, 'test-key-1');
     expect(showOption('@overdeck-dedup-test-key-1')).toBe('1');
+    // Exactly one content submission reached the replacement pane.
+    expect(occurrences(capturePane(), 'wake up agent')).toBe(2);
   });
 
   it('rolls the key back when the pane dies AROUND the Enter — no false terminal, recovery pastes real content (cycle 10)', async () => {
@@ -214,14 +218,18 @@ describe.skipIf(!hasTmux)('sendKeysDedup two-phase protocol', () => {
 
     const phase = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
 
-    // NEVER 'deduplicated' from a false terminal: the repair clears terminal,
-    // restores a pending claim, and lifts the breadcrumb — verified.
-    expect(phase).toBe('submit-pending');
+    // NEVER 'deduplicated' from a false terminal: the repair clears terminal
+    // and restores a pending claim. With no recorded paste target (the seeded
+    // markers predate it), the content is unverifiable — so the protocol
+    // RE-PASTES the real content and records the current pane as target.
+    expect(phase).toBe('pasted');
     expect(showOption('@overdeck-dedup-test-key-1')).toBe('');
     expect(showOption('@overdeck-dedup-pending-test-key-1')).not.toBe('');
     expect(showOption('@overdeck-dedup-poison-test-key-1')).toBe('');
+    expect(showOption('@overdeck-dedup-target-test-key-1')).not.toBe('');
+    expect(capturePane()).toContain('wake up agent');
 
-    // The repaired completion delivers for real, and the breadcrumb lifecycle
+    // The completion delivers for real, and the breadcrumb lifecycle
     // closes: a later replay dedups on the VERIFIED terminal.
     await completeKeyedSubmit(session, 'test-key-1');
     expect(showOption('@overdeck-dedup-test-key-1')).toBe('1');
@@ -246,9 +254,11 @@ describe.skipIf(!hasTmux)('sendKeysDedup two-phase protocol', () => {
     expect(showOption('@overdeck-dedup-poison-test-key-1')).toBe('1');
     expect(occurrences(capturePane(), 'wake up agent')).toBe(0);
 
-    // Recovery with a healthy read repairs and completes.
+    // Recovery with a healthy read repairs and RE-PASTES the real content
+    // (the seeded markers carry no recorded target).
     const phase = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
-    expect(phase).toBe('submit-pending');
+    expect(phase).toBe('pasted');
+    expect(capturePane()).toContain('wake up agent');
     await completeKeyedSubmit(session, 'test-key-1');
     expect(showOption('@overdeck-dedup-test-key-1')).toBe('1');
     expect(showOption('@overdeck-dedup-poison-test-key-1')).toBe('');
@@ -262,7 +272,7 @@ describe.skipIf(!hasTmux)('sendKeysDedup two-phase protocol', () => {
     // a stale poison — the call must NOT report success.
     await expect(
       completeKeyedSubmit(session, 'test-key-1', {
-        readMarker: (name: string, option: string) => {
+        readMarkerStrict: (name: string, option: string) => {
           if (option === '@overdeck-dedup-poison-test-key-1') {
             return Promise.resolve('1');
           }
@@ -308,6 +318,69 @@ describe.skipIf(!hasTmux)('sendKeysDedup two-phase protocol', () => {
     expect(replay).toBe('submit-pending');
     await completeKeyedSubmit(session, 'test-key-1');
     expect(showOption('@overdeck-dedup-test-key-1')).toBe('1');
+  });
+
+  it('crash recovery re-delivers real content to a REPLACED pane exactly once (cycle 13)', async () => {
+    // Paste into pane A; its pid is recorded as the target atomically.
+    const first = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+    expect(first).toBe('pasted');
+    // Simulate the provisional crash state: the server-owned submit wrote
+    // poison+terminal and the dashboard died before any post-submit read.
+    execFileSync('tmux', ['-L', socket, 'set-option', '-t', session, '@overdeck-dedup-poison-test-key-1', '1']);
+    execFileSync('tmux', ['-L', socket, 'set-option', '-t', session, '@overdeck-dedup-test-key-1', '1']);
+    execFileSync('tmux', ['-L', socket, 'set-option', '-u', '-t', session, '@overdeck-dedup-pending-test-key-1']);
+    // Pane A is replaced (respawned harness) while the session options survive.
+    execFileSync('tmux', ['-L', socket, 'respawn-pane', '-k', '-t', session, 'cat']);
+
+    // Recovery: the breadcrumb forces repair, the recorded target no longer
+    // matches, so the REAL content is re-pasted into the replacement —
+    // never 'deduplicated', never a blank-Enter completion.
+    const replay = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+    expect(replay).toBe('pasted');
+    expect(capturePane()).toContain('wake up agent');
+
+    await completeKeyedSubmit(session, 'test-key-1');
+    expect(showOption('@overdeck-dedup-test-key-1')).toBe('1');
+    expect(showOption('@overdeck-dedup-poison-test-key-1')).toBe('');
+    // Exactly one content submission reached the replacement pane.
+    expect(occurrences(capturePane(), 'wake up agent')).toBe(2);
+  });
+
+  it('a rejected REPAIR verification read aborts with the breadcrumb authoritative (cycle 13)', async () => {
+    execFileSync('tmux', ['-L', socket, 'set-option', '-t', session, '@overdeck-dedup-test-key-1', '1']);
+    execFileSync('tmux', ['-L', socket, 'set-option', '-t', session, '@overdeck-dedup-poison-test-key-1', '1']);
+
+    await expect(
+      sendKeysDedup(session, 'wake up agent', 'test-key-1', 'test', {
+        readMarkerStrict: (name: string, option: string) => (
+          option === '@overdeck-dedup-test-key-1'
+            ? Promise.reject(new Error('transient verify-read failure'))
+            : Promise.resolve(showOption(option))
+        ),
+      }),
+    ).rejects.toThrow(KeyedMarkerVerificationError);
+    // The failed read was NOT converted to empty state: the breadcrumb stays
+    // authoritative for the next recovery attempt.
+    expect(showOption('@overdeck-dedup-poison-test-key-1')).toBe('1');
+  });
+
+  it('a rejected ROLLBACK verification read aborts with the breadcrumb authoritative (cycle 13)', async () => {
+    // Pane exits upon consuming the submitted line — targetLost rollback path.
+    execFileSync('tmux', ['-L', socket, 'respawn-pane', '-k', '-t', session, 'sh']);
+    execFileSync('tmux', ['-L', socket, 'set-option', '-t', session, 'remain-on-exit', 'on']);
+    const first = await sendKeysDedup(session, 'exit', 'test-key-1');
+    expect(first).toBe('pasted');
+
+    await expect(
+      completeKeyedSubmit(session, 'test-key-1', {
+        readMarkerStrict: (name: string, option: string) => (
+          option === '@overdeck-dedup-test-key-1'
+            ? Promise.reject(new Error('transient verify-read failure'))
+            : Promise.resolve(showOption(option))
+        ),
+      }),
+    ).rejects.toThrow(KeyedMarkerVerificationError);
+    expect(showOption('@overdeck-dedup-poison-test-key-1')).toBe('1');
   });
 
   it('delivers identical content under a different key', async () => {

--- a/src/lib/__tests__/tmux-dedup.test.ts
+++ b/src/lib/__tests__/tmux-dedup.test.ts
@@ -31,11 +31,16 @@ function occurrences(haystack: string, needle: string): number {
   return haystack.match(new RegExp(needle, 'g'))?.length ?? 0;
 }
 
+/** Type literal text into the pane WITHOUT submitting it (a busy composer). */
+function typeWithoutSubmit(text: string): void {
+  execFileSync('tmux', ['-L', socket, 'send-keys', '-t', session, '-l', text]);
+}
+
 /**
  * Real throwaway tmux server — the dedup record is a pair of tmux session
- * options set atomically with the paste by the tmux SERVER, so only a live
- * server can prove the check/paste/mark sequence and the crash boundaries
- * around the standalone Enter. (PAN-2997)
+ * options and the submission is a single server-executed `if-shell` command
+ * list, so only a live server can prove the claim/Enter ordering and the
+ * crash boundaries around it. (PAN-2997)
  */
 describe.skipIf(!hasTmux)('sendKeysDedup two-phase protocol', () => {
   beforeEach(() => {
@@ -72,8 +77,7 @@ describe.skipIf(!hasTmux)('sendKeysDedup two-phase protocol', () => {
     // First attempt pastes, then "crashes" before the submit.
     const first = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
     expect(first).toBe('pasted');
-    const afterPaste = capturePane();
-    expect(occurrences(afterPaste, 'wake up agent')).toBe(1);
+    expect(occurrences(capturePane(), 'wake up agent')).toBe(1);
 
     // Recovery replay: the pending marker routes to submit-completion, not a
     // second paste.
@@ -93,24 +97,41 @@ describe.skipIf(!hasTmux)('sendKeysDedup two-phase protocol', () => {
     expect(capturePane()).toBe(settled);
   });
 
-  it('sends at most one visible message when the crash lands between Enter and the terminal flip', async () => {
-    const first = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
-    expect(first).toBe('pasted');
+  it('runs the submission exactly once for TWO CONCURRENT completers (cycle 8)', async () => {
+    // Call A pastes and claims; call B observes the pending claim.
+    const a = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+    expect(a).toBe('pasted');
+    const b = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+    expect(b).toBe('submit-pending');
 
-    // Simulate Enter sent but the terminal flip interrupted: send C-m by hand,
-    // leave the pending marker in place.
-    execFileSync('tmux', ['-L', socket, 'send-keys', '-t', session, 'C-m']);
-    const afterManualEnter = capturePane();
-    expect(occurrences(afterManualEnter, 'wake up agent')).toBe(2); // input echo + cat output
+    // Both callers complete — the server-side condition admits exactly one.
+    await Promise.all([
+      completeKeyedSubmit(session, 'test-key-1'),
+      completeKeyedSubmit(session, 'test-key-1'),
+    ]);
 
-    // Recovery replay: pending is still set, so the replay completes the
-    // transaction — one more Enter lands on the now-EMPTY composer (a no-op),
-    // and the key flips terminal. The message itself is never re-pasted.
-    const replay = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
-    expect(replay).toBe('submit-pending');
-    await completeKeyedSubmit(session, 'test-key-1');
+    // The wake was submitted exactly once (input echo + one cat output).
     expect(occurrences(capturePane(), 'wake up agent')).toBe(2);
     expect(showOption('@overdeck-dedup-test-key-1')).toBe('1');
+    expect(showOption('@overdeck-dedup-pending-test-key-1')).toBe('');
+  });
+
+  it('sends no second Enter when a replayed submit races a completed transaction into a busy composer (cycle 8)', async () => {
+    const first = await sendKeysDedup(session, 'wake up agent', 'test-key-1');
+    expect(first).toBe('pasted');
+    await completeKeyedSubmit(session, 'test-key-1');
+    expect(occurrences(capturePane(), 'wake up agent')).toBe(2);
+
+    // The agent reached a new prompt and the operator is typing again.
+    typeWithoutSubmit('operator follow-up');
+
+    // A misguided late completer (e.g. a recovery pass that crashed after the
+    // server claimed the submit but before it read the response) must not
+    // send another Enter into the busy composer.
+    await completeKeyedSubmit(session, 'test-key-1');
+
+    expect(occurrences(capturePane(), 'wake up agent')).toBe(2);
+    expect(occurrences(capturePane(), 'operator follow-up')).toBe(1);
   });
 
   it('delivers identical content under a different key', async () => {

--- a/src/lib/agents/agent-state.ts
+++ b/src/lib/agents/agent-state.ts
@@ -726,6 +726,13 @@ export type ResumeIntent = 'autonomous' | 'operator-start' | 'message-delivery';
  *  a stopped-by-user agent that has a completed handoff. */
 export interface MessageAgentRedriveOptions {
   owesRework?: boolean;
+  /**
+   * Idempotency key threaded to the delivery door (PAN-2997). Keyed live
+   * deliveries are deduplicated by the crash-independent delivery component
+   * (supervisor key set / tmux session option), so a dashboard crash and
+   * recovery can never inject the same keyed message twice.
+   */
+  dedupKey?: string;
 }
 
 export interface ResumeGateContext {

--- a/src/lib/agents/delivery.ts
+++ b/src/lib/agents/delivery.ts
@@ -16,7 +16,7 @@ import {
 } from '../agents.js';
 import { getAgentRuntimeState } from './runtime-state.js';
 import { isPaneDead, sendKeys, sessionExists } from '../tmux.js';
-import { sendEnterKey, sendKeysDedup } from '../tmux-dedup.js';
+import { completeKeyedSubmit, sendKeysDedup } from '../tmux-dedup.js';
 import { BRIDGE_TOKEN_HEADER, readBridgeTokenSync } from '../bridge-token.js';
 import { PTY_TOKEN_HEADER, readPtyToken } from '../pty-token.js';
 import {
@@ -42,40 +42,20 @@ export interface DeliverAgentMessageOptions {
   /**
    * Idempotency key (PAN-2997). Keyed deliveries are deduplicated by the
    * crash-independent delivery component, not by dashboard-side state: the
-   * PTY supervisor keeps the key set (its exit kills the agent with it, so a
-   * replay after that is a legitimate first delivery), and the tmux fallback
-   * marks a per-session user option in the same server-side command that
-   * pastes. A dashboard crash between the side effect and the caller's own
-   * bookkeeping can therefore never deliver the same keyed message twice.
-   * Channels/app-server/ACP tiers receive the key as advisory metadata only.
+   * PTY supervisor reserves the key synchronously before injecting and
+   * completes it only after the content-plus-Enter injection succeeds, and
+   * the tmux fallback keeps a two-phase (pending/terminal) per-session marker
+   * owned by the tmux server across the whole paste-settle-submit
+   * transaction. A dashboard crash anywhere in those flows can therefore
+   * neither lose nor duplicate a keyed message.
+   *
+   * Keyed payloads are ONLY routed through those two tiers. The
+   * app-server/ACP/Channels tiers acknowledge receipt without enforcing the
+   * key, so they are skipped in auto mode and rejected when requested
+   * explicitly — a crash after their visible side effect but before the
+   * caller's acknowledgment would otherwise replay the wake.
    */
   dedupKey?: string;
-}
-
-/**
- * Record a dedup key in the agent's supervisor without injecting anything
- * (PAN-2997). Used when a keyed message reached the agent through a channel
- * the supervisor did not mediate — e.g. a resume kickoff prompt — so a later
- * keyed replay still deduplicates. Best-effort: any failure only reopens the
- * at-least-once window for this key; it never blocks the caller.
- */
-export async function recordDeliveredKeyWithSupervisor(agentId: string, dedupKey: string): Promise<void> {
-  const normalizedId = normalizeAgentId(agentId);
-  const supervisorSocketPath = join(overdeckHomeForSockets(), 'sockets', `pty-${normalizedId}.sock`);
-  if (!existsSync(supervisorSocketPath)) return;
-  const ptyToken = await readPtyToken(normalizedId);
-  if (!ptyToken) return;
-  try {
-    await postUnixSocketJson(
-      supervisorSocketPath,
-      { op: 'record-delivered', dedupKey },
-      3_000,
-      ptyToken,
-      PTY_TOKEN_HEADER,
-    );
-  } catch {
-    // Best-effort per the doc comment.
-  }
 }
 
 /**
@@ -273,20 +253,15 @@ export async function deliverAgentMessage(
     );
   }
 
+  // Keyed deliveries take a dedicated, narrower cascade: only the tiers whose
+  // crash-independent component enforces the key across the complete side
+  // effect. Everything below this branch is the unkeyed cascade.
+  if (dedupKey !== undefined) {
+    return deliverKeyedAgentMessage(normalizedId, message, caller, resolvedMethod ?? 'auto', isAcpTarget, dedupKey);
+  }
+
   if (resolvedMethod === 'tmux') {
     await assertTmuxTargetCanReceive(normalizedId, caller);
-    if (dedupKey !== undefined) {
-      const outcome = await sendKeysDedup(normalizedId, message, dedupKey, caller);
-      if (outcome === 'delivered') {
-        // Paste landed — submit with a standalone Enter after the settle
-        // window, mirroring the supervisor's proven timing. A deduplicated
-        // replay deliberately sends no stray Enter: the composer may hold
-        // unrelated operator text.
-        await new Promise(r => setTimeout(r, 300));
-        await sendEnterKey(normalizedId);
-      }
-      return { ok: true, path: 'tmux', deduplicated: outcome === 'deduplicated' };
-    }
     await Effect.runPromise(sendKeys(normalizedId, message));
     return { ok: true, path: 'tmux' };
   }
@@ -300,7 +275,7 @@ export async function deliverAgentMessage(
         appServerFailure = 'appserver-token-missing';
       } else {
         try {
-          const appServerBody: Record<string, unknown> = { op: 'message', content: message, meta: { caller, ...(dedupKey !== undefined ? { dedupKey } : {}) } };
+          const appServerBody: Record<string, unknown> = { op: 'message', content: message, meta: { caller } };
           if (state?.model) appServerBody.model = state.model;
           await postUnixSocketJson(
             appServerSocketPath,
@@ -335,7 +310,7 @@ export async function deliverAgentMessage(
           // how long the provider may take to finish the queued turn.
           await postUnixSocketJson(
             acpSocketPath,
-            { op: 'message', content: message, meta: { caller, ...(dedupKey !== undefined ? { dedupKey } : {}) } },
+            { op: 'message', content: message, meta: { caller } },
             8_000,
             acpToken,
           );
@@ -377,24 +352,13 @@ export async function deliverAgentMessage(
         // re-create the duplicate-writer race PAN-1769 fixed.
         const supervisorResponse = await postUnixSocketJson(
           supervisorSocketPath,
-          { content: message, meta: { caller }, ...(dedupKey !== undefined ? { dedupKey } : {}) },
+          { content: message, meta: { caller } },
           supervisorInjectionBudgetMs(message.length) + SUPERVISOR_CLIENT_MARGIN_MS,
           ptyToken,
           PTY_TOKEN_HEADER,
         );
         await appendChannelDeliveryLog(normalizedId, { path: 'supervisor', caller });
-        let supervisorDeduplicated = false;
-        try {
-          const parsed = JSON.parse(supervisorResponse.body) as { deduplicated?: boolean };
-          supervisorDeduplicated = parsed.deduplicated === true;
-        } catch {
-          // Legacy supervisor build without dedup support — treat as delivered.
-        }
-        return {
-          ok: true,
-          path: 'supervisor',
-          ...(dedupKey !== undefined ? { deduplicated: supervisorDeduplicated } : {}),
-        };
+        return { ok: true, path: 'supervisor' };
       } catch (err) {
         const reason = err instanceof Error ? err.message : String(err);
         supervisorFailure = `socket-post-failed: ${reason}`;
@@ -421,7 +385,7 @@ export async function deliverAgentMessage(
         try {
           await postUnixSocketJson(
             socketPath,
-            { content: message, meta: { caller, ...(dedupKey !== undefined ? { dedupKey } : {}) } },
+            { content: message, meta: { caller } },
             2000,
             bridgeToken,
           );
@@ -452,29 +416,115 @@ export async function deliverAgentMessage(
       ...(channelFailure ? { channels: channelFailure } : {}),
     });
     await assertTmuxTargetCanReceive(normalizedId, caller);
-    if (dedupKey !== undefined) {
-      const outcome = await sendKeysDedup(normalizedId, message, dedupKey, caller);
-      if (outcome === 'delivered') {
-        await new Promise(r => setTimeout(r, 300));
-        await sendEnterKey(normalizedId);
-      }
-      return { ok: true, path: 'tmux', failure: channelFailure ?? supervisorFailure, deduplicated: outcome === 'deduplicated' };
-    }
     await Effect.runPromise(sendKeys(normalizedId, message));
     return { ok: true, path: 'tmux', failure: channelFailure ?? supervisorFailure };
   }
 
   await assertTmuxTargetCanReceive(normalizedId, caller);
-  if (dedupKey !== undefined) {
-    const outcome = await sendKeysDedup(normalizedId, message, dedupKey, caller);
-    if (outcome === 'delivered') {
-      await new Promise(r => setTimeout(r, 300));
-      await sendEnterKey(normalizedId);
-    }
-    return { ok: true, path: 'tmux', deduplicated: outcome === 'deduplicated' };
-  }
   await Effect.runPromise(sendKeys(normalizedId, message));
   return { ok: true, path: 'tmux' };
+}
+
+/**
+ * Keyed delivery cascade (PAN-2997). Only two tiers may carry a keyed
+ * message, because only their crash-independent components enforce the key
+ * across the COMPLETE visible side effect:
+ *
+ * - the PTY supervisor reserves the key synchronously (closing the concurrent
+ *   same-key race) and completes it only after its single-request
+ *   content-plus-Enter injection succeeds; and
+ * - the tmux fallback keeps two-phase pending/terminal session markers owned
+ *   by the tmux server across paste, settle, and submit.
+ *
+ * App-server, ACP, and Channels acknowledge receipt without enforcing the
+ * key, so they are never used for keyed payloads: a dashboard crash after
+ * their side effect but before the caller's acknowledgment would replay the
+ * wake. Explicitly requesting one of them with a key is a loud error, not a
+ * silent downgrade.
+ */
+async function deliverKeyedAgentMessage(
+  normalizedId: string,
+  message: string,
+  caller: string,
+  resolvedMethod: 'auto' | 'supervisor' | 'channels' | 'tmux',
+  isAcpTarget: boolean,
+  dedupKey: string,
+): Promise<DeliveryResult> {
+  if (isAcpTarget) {
+    throw new Error(
+      `MessageDeliveryFailed: keyed delivery failed for ${normalizedId} (${caller}): the ACP tier cannot enforce a dedup key`,
+    );
+  }
+  if (resolvedMethod === 'channels') {
+    throw new Error(
+      `MessageDeliveryFailed: keyed delivery failed for ${normalizedId} (${caller}): the Channels tier cannot enforce a dedup key`,
+    );
+  }
+  if (resolvedMethod === 'tmux') {
+    return deliverKeyedViaTmux(normalizedId, message, caller, dedupKey);
+  }
+
+  let supervisorFailure: string | undefined;
+  const supervisorSocketPath = join(overdeckHomeForSockets(), 'sockets', `pty-${normalizedId}.sock`);
+  const ptyToken = await readPtyToken(normalizedId);
+  if (!existsSync(supervisorSocketPath)) {
+    supervisorFailure = 'socket-missing';
+  } else if (!ptyToken) {
+    supervisorFailure = 'pty-token-missing';
+  } else {
+    try {
+      // The client deadline must remain above the supervisor's payload-aware
+      // worst-case injection budget. Abandoning the POST mid-injection would
+      // fire the tmux fallback while the supervisor is still writing and
+      // re-create the duplicate-writer race PAN-1769 fixed.
+      const supervisorResponse = await postUnixSocketJson(
+        supervisorSocketPath,
+        { content: message, meta: { caller }, dedupKey },
+        supervisorInjectionBudgetMs(message.length) + SUPERVISOR_CLIENT_MARGIN_MS,
+        ptyToken,
+        PTY_TOKEN_HEADER,
+      );
+      await appendChannelDeliveryLog(normalizedId, { path: 'supervisor', caller });
+      let deduplicated = false;
+      try {
+        deduplicated = (JSON.parse(supervisorResponse.body) as { deduplicated?: boolean }).deduplicated === true;
+      } catch {
+        // Legacy supervisor build without dedup support — treat as delivered.
+      }
+      return { ok: true, path: 'supervisor', deduplicated };
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      supervisorFailure = `socket-post-failed: ${reason}`;
+    }
+  }
+
+  if (resolvedMethod === 'supervisor') {
+    throw new Error(`MessageDeliveryFailed: PTY supervisor delivery failed for ${normalizedId} (${caller}): ${supervisorFailure}`);
+  }
+
+  await appendChannelDeliveryLog(normalizedId, { path: 'tmux', reason: supervisorFailure, caller });
+  const result = await deliverKeyedViaTmux(normalizedId, message, caller, dedupKey);
+  return { ...result, failure: supervisorFailure };
+}
+
+/**
+ * Keyed tmux delivery: paste under the two-phase marker protocol, then
+ * complete the submit. A replay that finds the pending marker completes the
+ * prior attempt's submission WITHOUT re-pasting; a terminal marker suppresses
+ * the replay entirely.
+ */
+async function deliverKeyedViaTmux(
+  normalizedId: string,
+  message: string,
+  caller: string,
+  dedupKey: string,
+): Promise<DeliveryResult> {
+  await assertTmuxTargetCanReceive(normalizedId, caller);
+  const phase = await sendKeysDedup(normalizedId, message, dedupKey, caller);
+  if (phase !== 'deduplicated') {
+    await completeKeyedSubmit(normalizedId, dedupKey);
+  }
+  return { ok: true, path: 'tmux', deduplicated: phase === 'deduplicated' };
 }
 
 /**

--- a/src/lib/agents/delivery.ts
+++ b/src/lib/agents/delivery.ts
@@ -138,6 +138,40 @@ function readAcpTokenSync(agentId: string): string | null {
 }
 
 /**
+ * A non-2xx RESPONSE from a protocol host. The host answered, so the outcome
+ * is definitive: for a keyed supervisor request a 502 means the injection
+ * failed and was purged and the key was never recorded — unlike a lost
+ * response, this is safe to fall back from.
+ */
+export class SocketPostStatusError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'SocketPostStatusError';
+    this.status = status;
+  }
+}
+
+/**
+ * Thrown when a keyed delivery's outcome is UNKNOWN: the keyed supervisor
+ * request was sent but no response came back (timeout, reset, dropped
+ * connection), so the injection may have completed. Crossing to the tmux
+ * tier with the same key would risk a second visible delivery, because the
+ * supervisor and tmux keep INDEPENDENT dedup stores. The caller's recovery
+ * must retry the same key at the same tier — the supervisor's in-flight
+ * reservation and delivered set deduplicate the retry (PAN-2997 cycle 8).
+ */
+export class AmbiguousKeyedDeliveryError extends Error {
+  constructor(agentId: string, caller: string, reason: string) {
+    super(
+      `MessageDeliveryFailed: ambiguous keyed delivery for ${agentId} (${caller}): ${reason} — ` +
+      'the supervisor may have completed the injection; NOT crossing to the tmux tier with the same key',
+    );
+    this.name = 'AmbiguousKeyedDeliveryError';
+  }
+}
+
+/**
  * POST a JSON body to a Unix-domain socket using node:net + a hand-rolled
  * minimal HTTP/1.1 request. Resolves on a 200-class response, rejects on any
  * error including socket-not-found, connection refused, an optional client
@@ -200,7 +234,7 @@ async function postUnixSocketJson(
             finishOk({ status, body: responseBody });
             return;
           }
-          finishErr(new Error(`socket POST: status ${status}: ${responseBody.slice(0, 100)}`));
+          finishErr(new SocketPostStatusError(status, `socket POST: status ${status}: ${responseBody.slice(0, 100)}`));
         });
       },
     );
@@ -494,6 +528,18 @@ async function deliverKeyedAgentMessage(
       return { ok: true, path: 'supervisor', deduplicated };
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
+      if (!(err instanceof SocketPostStatusError)) {
+        // AMBIGUOUS (cycle 8): no response came back, so the supervisor may
+        // have completed the injection. The tmux tier keeps an INDEPENDENT
+        // key store, so crossing to it with the same key could submit a
+        // second visible wake. Stay with the same delivery owner: the
+        // caller's recovery retries the same key at the supervisor, whose
+        // in-flight reservation/delivered set deduplicates the retry.
+        throw new AmbiguousKeyedDeliveryError(normalizedId, caller, reason);
+      }
+      // A received non-2xx (e.g. 502 echo-confirm failure after purge) is a
+      // DEFINITIVE failure: the supervisor answered, recorded no key, and
+      // erased its partial write — safe to fall through to keyed tmux.
       supervisorFailure = `socket-post-failed: ${reason}`;
     }
   }

--- a/src/lib/agents/delivery.ts
+++ b/src/lib/agents/delivery.ts
@@ -16,6 +16,7 @@ import {
 } from '../agents.js';
 import { getAgentRuntimeState } from './runtime-state.js';
 import { isPaneDead, sendKeys, sessionExists } from '../tmux.js';
+import { sendEnterKey, sendKeysDedup } from '../tmux-dedup.js';
 import { BRIDGE_TOKEN_HEADER, readBridgeTokenSync } from '../bridge-token.js';
 import { PTY_TOKEN_HEADER, readPtyToken } from '../pty-token.js';
 import {
@@ -32,7 +33,50 @@ export type DeliveryResult = {
   ok: boolean;
   path: 'app-server' | 'acp' | 'supervisor' | 'channels' | 'tmux' | 'pi' | 'codex';
   failure?: string;
+  /** True when the delivery was suppressed by the keyed dedup record — the
+   * side effect already happened on an earlier call with the same key. */
+  deduplicated?: boolean;
 };
+
+export interface DeliverAgentMessageOptions {
+  /**
+   * Idempotency key (PAN-2997). Keyed deliveries are deduplicated by the
+   * crash-independent delivery component, not by dashboard-side state: the
+   * PTY supervisor keeps the key set (its exit kills the agent with it, so a
+   * replay after that is a legitimate first delivery), and the tmux fallback
+   * marks a per-session user option in the same server-side command that
+   * pastes. A dashboard crash between the side effect and the caller's own
+   * bookkeeping can therefore never deliver the same keyed message twice.
+   * Channels/app-server/ACP tiers receive the key as advisory metadata only.
+   */
+  dedupKey?: string;
+}
+
+/**
+ * Record a dedup key in the agent's supervisor without injecting anything
+ * (PAN-2997). Used when a keyed message reached the agent through a channel
+ * the supervisor did not mediate — e.g. a resume kickoff prompt — so a later
+ * keyed replay still deduplicates. Best-effort: any failure only reopens the
+ * at-least-once window for this key; it never blocks the caller.
+ */
+export async function recordDeliveredKeyWithSupervisor(agentId: string, dedupKey: string): Promise<void> {
+  const normalizedId = normalizeAgentId(agentId);
+  const supervisorSocketPath = join(overdeckHomeForSockets(), 'sockets', `pty-${normalizedId}.sock`);
+  if (!existsSync(supervisorSocketPath)) return;
+  const ptyToken = await readPtyToken(normalizedId);
+  if (!ptyToken) return;
+  try {
+    await postUnixSocketJson(
+      supervisorSocketPath,
+      { op: 'record-delivered', dedupKey },
+      3_000,
+      ptyToken,
+      PTY_TOKEN_HEADER,
+    );
+  } catch {
+    // Best-effort per the doc comment.
+  }
+}
 
 /**
  * PAN-1988: resume / feedback / continue delivery must be RESILIENT. When an agent is pinned to
@@ -206,8 +250,10 @@ export async function deliverAgentMessage(
   message: string,
   caller: string = 'unknown',
   deliveryMethod?: 'auto' | 'supervisor' | 'channels' | 'tmux',
+  opts: DeliverAgentMessageOptions = {},
 ): Promise<DeliveryResult> {
   const normalizedId = normalizeAgentId(agentId);
+  const dedupKey = opts.dedupKey;
 
   let channelsEnabled = false;
   let resolvedMethod = deliveryMethod;
@@ -229,6 +275,18 @@ export async function deliverAgentMessage(
 
   if (resolvedMethod === 'tmux') {
     await assertTmuxTargetCanReceive(normalizedId, caller);
+    if (dedupKey !== undefined) {
+      const outcome = await sendKeysDedup(normalizedId, message, dedupKey, caller);
+      if (outcome === 'delivered') {
+        // Paste landed — submit with a standalone Enter after the settle
+        // window, mirroring the supervisor's proven timing. A deduplicated
+        // replay deliberately sends no stray Enter: the composer may hold
+        // unrelated operator text.
+        await new Promise(r => setTimeout(r, 300));
+        await sendEnterKey(normalizedId);
+      }
+      return { ok: true, path: 'tmux', deduplicated: outcome === 'deduplicated' };
+    }
     await Effect.runPromise(sendKeys(normalizedId, message));
     return { ok: true, path: 'tmux' };
   }
@@ -242,7 +300,7 @@ export async function deliverAgentMessage(
         appServerFailure = 'appserver-token-missing';
       } else {
         try {
-          const appServerBody: Record<string, unknown> = { op: 'message', content: message, meta: { caller } };
+          const appServerBody: Record<string, unknown> = { op: 'message', content: message, meta: { caller, ...(dedupKey !== undefined ? { dedupKey } : {}) } };
           if (state?.model) appServerBody.model = state.model;
           await postUnixSocketJson(
             appServerSocketPath,
@@ -277,7 +335,7 @@ export async function deliverAgentMessage(
           // how long the provider may take to finish the queued turn.
           await postUnixSocketJson(
             acpSocketPath,
-            { op: 'message', content: message, meta: { caller } },
+            { op: 'message', content: message, meta: { caller, ...(dedupKey !== undefined ? { dedupKey } : {}) } },
             8_000,
             acpToken,
           );
@@ -317,15 +375,26 @@ export async function deliverAgentMessage(
         // worst-case injection budget. Abandoning the POST mid-injection would
         // fire the tmux fallback while the supervisor is still writing and
         // re-create the duplicate-writer race PAN-1769 fixed.
-        await postUnixSocketJson(
+        const supervisorResponse = await postUnixSocketJson(
           supervisorSocketPath,
-          { content: message, meta: { caller } },
+          { content: message, meta: { caller }, ...(dedupKey !== undefined ? { dedupKey } : {}) },
           supervisorInjectionBudgetMs(message.length) + SUPERVISOR_CLIENT_MARGIN_MS,
           ptyToken,
           PTY_TOKEN_HEADER,
         );
         await appendChannelDeliveryLog(normalizedId, { path: 'supervisor', caller });
-        return { ok: true, path: 'supervisor' };
+        let supervisorDeduplicated = false;
+        try {
+          const parsed = JSON.parse(supervisorResponse.body) as { deduplicated?: boolean };
+          supervisorDeduplicated = parsed.deduplicated === true;
+        } catch {
+          // Legacy supervisor build without dedup support — treat as delivered.
+        }
+        return {
+          ok: true,
+          path: 'supervisor',
+          ...(dedupKey !== undefined ? { deduplicated: supervisorDeduplicated } : {}),
+        };
       } catch (err) {
         const reason = err instanceof Error ? err.message : String(err);
         supervisorFailure = `socket-post-failed: ${reason}`;
@@ -352,7 +421,7 @@ export async function deliverAgentMessage(
         try {
           await postUnixSocketJson(
             socketPath,
-            { content: message, meta: { caller } },
+            { content: message, meta: { caller, ...(dedupKey !== undefined ? { dedupKey } : {}) } },
             2000,
             bridgeToken,
           );
@@ -383,11 +452,27 @@ export async function deliverAgentMessage(
       ...(channelFailure ? { channels: channelFailure } : {}),
     });
     await assertTmuxTargetCanReceive(normalizedId, caller);
+    if (dedupKey !== undefined) {
+      const outcome = await sendKeysDedup(normalizedId, message, dedupKey, caller);
+      if (outcome === 'delivered') {
+        await new Promise(r => setTimeout(r, 300));
+        await sendEnterKey(normalizedId);
+      }
+      return { ok: true, path: 'tmux', failure: channelFailure ?? supervisorFailure, deduplicated: outcome === 'deduplicated' };
+    }
     await Effect.runPromise(sendKeys(normalizedId, message));
     return { ok: true, path: 'tmux', failure: channelFailure ?? supervisorFailure };
   }
 
   await assertTmuxTargetCanReceive(normalizedId, caller);
+  if (dedupKey !== undefined) {
+    const outcome = await sendKeysDedup(normalizedId, message, dedupKey, caller);
+    if (outcome === 'delivered') {
+      await new Promise(r => setTimeout(r, 300));
+      await sendEnterKey(normalizedId);
+    }
+    return { ok: true, path: 'tmux', deduplicated: outcome === 'deduplicated' };
+  }
   await Effect.runPromise(sendKeys(normalizedId, message));
   return { ok: true, path: 'tmux' };
 }

--- a/src/lib/agents/messaging.ts
+++ b/src/lib/agents/messaging.ts
@@ -60,6 +60,8 @@ export interface MessageDeliveryOutcome {
   reason?: string;
 }
 
+export type MessageAgentOutcome = 'delivered' | 'queued';
+
 function queueAgentMail(agentId: string, message: string, pendingTurnEndDelivery = false, source?: string): void {
   const mailDir = join(getAgentDir(agentId), 'mail');
   mkdirSync(mailDir, { recursive: true });
@@ -461,4 +463,14 @@ export async function messageAgent(
   queueAgentMail(normalizedId, message);
   await appendTellInterventionForUserSource(normalizedId, caller);
   return { delivered: delivery.ok, queuedToMail: true };
+}
+
+export async function messageAgentWithOutcome(
+  agentId: string,
+  message: string,
+  caller = 'internal',
+  opts: MessageAgentRedriveOptions = {},
+): Promise<MessageAgentOutcome> {
+  const outcome = await messageAgent(agentId, message, caller, opts);
+  return outcome.delivered ? 'delivered' : 'queued';
 }

--- a/src/lib/agents/messaging.ts
+++ b/src/lib/agents/messaging.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { Effect } from 'effect';
 import { emitActivityEntrySync } from '../activity-logger.js';
@@ -75,37 +75,6 @@ function queueAgentMail(agentId: string, message: string, pendingTurnEndDelivery
     join(mailDir, `${timestamp}${pendingTurnEndDelivery ? '.pending' : ''}.md`),
     content
   );
-}
-
-/**
- * Durable-delivery check for outbox reconciliation (PAN-2997): every
- * non-throwing path through `messageAgentWithOutcome` backs the message up to
- * the agent's mail queue, so a mail file containing `content` with an mtime
- * at or after `sinceIso` proves an acknowledged send reached the agent's
- * durable outbox. Recovery uses this to complete an interrupted claim without
- * re-sending. Small negative tolerance for filesystem clock granularity.
- */
-export function agentHasMailContentSince(agentId: string, content: string, sinceIso: string): boolean {
-  const mailDir = join(getAgentDir(normalizeAgentId(agentId)), 'mail');
-  let entries: string[];
-  try {
-    entries = readdirSync(mailDir);
-  } catch {
-    return false;
-  }
-  const sinceMs = Date.parse(sinceIso);
-  if (Number.isNaN(sinceMs)) return false;
-  for (const entry of entries) {
-    if (!entry.endsWith('.md')) continue;
-    try {
-      const path = join(mailDir, entry);
-      if (statSync(path).mtimeMs + 1000 < sinceMs) continue;
-      if (readFileSync(path, 'utf-8').includes(content)) return true;
-    } catch {
-      // Unreadable entry — keep scanning.
-    }
-  }
-  return false;
 }
 
 const USER_MESSAGE_INTERVENTION_SOURCES = new Set(['pan-tell', 'dashboard:user-message']);

--- a/src/lib/agents/messaging.ts
+++ b/src/lib/agents/messaging.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { Effect } from 'effect';
 import { emitActivityEntrySync } from '../activity-logger.js';
@@ -75,6 +75,37 @@ function queueAgentMail(agentId: string, message: string, pendingTurnEndDelivery
     join(mailDir, `${timestamp}${pendingTurnEndDelivery ? '.pending' : ''}.md`),
     content
   );
+}
+
+/**
+ * Durable-delivery check for outbox reconciliation (PAN-2997): every
+ * non-throwing path through `messageAgentWithOutcome` backs the message up to
+ * the agent's mail queue, so a mail file containing `content` with an mtime
+ * at or after `sinceIso` proves an acknowledged send reached the agent's
+ * durable outbox. Recovery uses this to complete an interrupted claim without
+ * re-sending. Small negative tolerance for filesystem clock granularity.
+ */
+export function agentHasMailContentSince(agentId: string, content: string, sinceIso: string): boolean {
+  const mailDir = join(getAgentDir(normalizeAgentId(agentId)), 'mail');
+  let entries: string[];
+  try {
+    entries = readdirSync(mailDir);
+  } catch {
+    return false;
+  }
+  const sinceMs = Date.parse(sinceIso);
+  if (Number.isNaN(sinceMs)) return false;
+  for (const entry of entries) {
+    if (!entry.endsWith('.md')) continue;
+    try {
+      const path = join(mailDir, entry);
+      if (statSync(path).mtimeMs + 1000 < sinceMs) continue;
+      if (readFileSync(path, 'utf-8').includes(content)) return true;
+    } catch {
+      // Unreadable entry — keep scanning.
+    }
+  }
+  return false;
 }
 
 const USER_MESSAGE_INTERVENTION_SOURCES = new Set(['pan-tell', 'dashboard:user-message']);

--- a/src/lib/agents/messaging.ts
+++ b/src/lib/agents/messaging.ts
@@ -32,7 +32,6 @@ import { getLatestSessionIdSync } from './activity.js';
 import {
   deliverAgentMessage,
   deliverResumeMessageWithTranscriptConfirmation,
-  recordDeliveredKeyWithSupervisor,
   resilientDeliveryMethod,
 } from './delivery.js';
 import { formatMailFileContent, isMonitorLive } from './monitor-transport.js';
@@ -137,6 +136,40 @@ function deliverWithOptionalKey(
     : deliverAgentMessage(normalizedId, message, caller, deliveryMethod);
 }
 
+/**
+ * Keyed delivery to an agent that must be resumed first (PAN-2997 review
+ * cycle 7). The keyed message NEVER rides the resume kickoff prompt: the
+ * kickoff is delivered by components that cannot enforce the key, so a
+ * dashboard crash after the kickoff but before any post-hoc key bookkeeping
+ * would replay the wake. Instead the agent is resumed with its bare
+ * auto-continue prompt, and the keyed message then goes through the keyed
+ * delivery door, where the crash-independent component — the new session's
+ * supervisor key set or the tmux session's two-phase markers — enforces
+ * at-most-once across the whole replay window.
+ */
+async function resumeThenDeliverKeyed(
+  normalizedId: string,
+  message: string,
+  caller: string,
+  agentState: AgentState | null,
+  dedupKey: string,
+): Promise<MessageDeliveryOutcome> {
+  const { resumeAgent } = await import('../agents.js');
+  const result = await resumeAgent(normalizedId);
+  if (!result.success) {
+    throw new Error(`Failed to auto-resume agent: ${result.error}`);
+  }
+  const delivery = await deliverAgentMessage(
+    normalizedId,
+    message,
+    `messageAgent:${caller}`,
+    resolveAgentDeliveryMethod(agentState),
+    { dedupKey },
+  );
+  await appendTellInterventionForUserSource(normalizedId, caller);
+  return { delivered: delivery.ok, queuedToMail: false };
+}
+
 
 export async function messageAgent(
   agentId: string,
@@ -188,6 +221,9 @@ export async function messageAgent(
       return { delivered: false, queuedToMail: true, reason: gateBlockReason };
     }
     console.log(`[agents] Auto-resuming suspended agent ${normalizedId} to deliver message`);
+    if (opts.dedupKey !== undefined) {
+      return resumeThenDeliverKeyed(normalizedId, message, caller, agentState, opts.dedupKey);
+    }
     const { resumeAgent } = await import('../agents.js');
     const result = await resumeAgent(normalizedId, message);
     if (!result.success) {
@@ -197,11 +233,6 @@ export async function messageAgent(
       throw new Error(`Agent resumed but ready signal did not fire — message not delivered. Feedback is in the mail queue.`);
     }
     // Message already sent during resume
-    if (opts.dedupKey !== undefined) {
-      // The resume kickoff prompt carried the keyed message without the new
-      // supervisor mediating it — record the key so a crash replay dedups.
-      await recordDeliveredKeyWithSupervisor(normalizedId, opts.dedupKey);
-    }
     await appendTellInterventionForUserSource(normalizedId, caller);
     return { delivered: true, queuedToMail: false };
   }
@@ -230,16 +261,21 @@ export async function messageAgent(
     }
     console.log(`[agents] Auto-resuming stopped agent ${normalizedId} to deliver feedback (session exists: ${await Effect.runPromise(sessionExists(normalizedId))})`);
 
+    if (opts.dedupKey !== undefined) {
+      // Keyed deliveries resume bare and then enforce the key at the delivery
+      // door — no kickoff-riding, no post-hoc key recording, and no mail
+      // backup (a keyed mail file is a replay channel: a monitor started
+      // later would drain and print it as a second copy).
+      return resumeThenDeliverKeyed(normalizedId, message, caller, agentState, opts.dedupKey);
+    }
+
     const { resumeAgent } = await import('../agents.js');
     const resumeResult = await resumeAgent(normalizedId, message);
 
     // Save to mail queue regardless so the agent can re-read feedback if needed
-    queueAgentMail(normalizedId, message, false, opts.dedupKey);
+    queueAgentMail(normalizedId, message, false);
 
     if (resumeResult.success && resumeResult.messageDelivered !== false) {
-      if (opts.dedupKey !== undefined) {
-        await recordDeliveredKeyWithSupervisor(normalizedId, opts.dedupKey);
-      }
       await appendTellInterventionForUserSource(normalizedId, caller);
       console.log(`[agents] Resumed ${normalizedId} and delivered feedback`);
       return { delivered: true, queuedToMail: true };
@@ -405,10 +441,23 @@ export async function messageAgent(
   const remoteState = loadRemoteAgentState(normalizedId);
   if (remoteState && remoteState.vmName) {
     console.log(`[agents] Sending message to remote agent ${normalizedId} on ${remoteState.vmName}`);
+    if (opts.dedupKey !== undefined) {
+      // Keyed: the REMOTE tmux server is the crash-independent component and
+      // enforces the key across the complete paste-settle-submit transaction
+      // via the same two-phase marker protocol as the local tmux tier — a
+      // dashboard crash mid-send replays into a dedup, never a second wake.
+      const { sendToRemoteAgentKeyed } = await import('../remote/remote-agents.js');
+      const remoteOutcome = await sendToRemoteAgentKeyed(normalizedId, remoteState.vmName, message, opts.dedupKey);
+      // Durable backup (idempotent keyed filename); the remote agent never
+      // drains the local mail dir, so this cannot replay.
+      queueAgentMail(normalizedId, message, false, opts.dedupKey);
+      await appendTellInterventionForUserSource(normalizedId, caller);
+      return { delivered: true, queuedToMail: true, ...(remoteOutcome === 'deduplicated' ? { reason: 'deduplicated' } : {}) };
+    }
     await sendToRemoteAgent(normalizedId, remoteState.vmName, message);
 
     // Also save to mail queue for persistence
-    queueAgentMail(normalizedId, message, false, opts.dedupKey);
+    queueAgentMail(normalizedId, message, false);
     await appendTellInterventionForUserSource(normalizedId, caller);
     return { delivered: true, queuedToMail: true };
   }
@@ -423,7 +472,14 @@ export async function messageAgent(
   // PAN-1988). Mid-session tells only: kickoff/resume never reach this path
   // (no monitor exists before the session's first turn), and a stale
   // heartbeat or dead pid falls through to the normal cascade.
-  if (expectedHarness === 'claude-code' && isMonitorLive(normalizedId)) {
+  //
+  // KEYED deliveries never take this tier (PAN-2997 review cycle 7): the
+  // monitor claims a mail file by renaming it before emitting, so a monitor
+  // exit between claim and emit loses the wake, and a dashboard crash after
+  // the emit but before the outbox ack replays it — the mail spool cannot
+  // enforce the key across the complete model-visible side effect. Keyed
+  // messages fall through to the supervisor/tmux door, which can.
+  if (expectedHarness === 'claude-code' && opts.dedupKey === undefined && isMonitorLive(normalizedId)) {
     queueAgentMail(normalizedId, message, false, opts.dedupKey, caller);
     logAgentLifecycleSync(normalizedId, `messageAgent delivered via monitor mail (caller: ${caller})`);
     console.log(`[agents] Delivered message to ${normalizedId} via monitor inbox`);
@@ -469,14 +525,14 @@ export async function messageAgent(
   const panePids = await Effect.runPromise(listPaneValues(normalizedId, '#{pane_pid}'));
   if (panePids.length > 0 && !(await hasAgentRuntimeInSubtree(panePids[0], expectedHarness))) {
     console.warn(`[agents] ${normalizedId} tmux session is a zombie (no ${expectedHarness} runtime) — attempting resume`);
+    if (opts.dedupKey !== undefined) {
+      return resumeThenDeliverKeyed(normalizedId, message, caller, agentState, opts.dedupKey);
+    }
     const { resumeAgent } = await import('../agents.js');
     const resumeResult = await resumeAgent(normalizedId, message);
     if (resumeResult.success) {
       const delivered = resumeResult.messageDelivered !== false;
       if (delivered) {
-        if (opts.dedupKey !== undefined) {
-          await recordDeliveredKeyWithSupervisor(normalizedId, opts.dedupKey);
-        }
         await appendTellInterventionForUserSource(normalizedId, caller);
       }
       return { delivered, queuedToMail: false };
@@ -498,9 +554,14 @@ export async function messageAgent(
 
   // Save a durable backup. Unlike `.pending.md` busy-turn mail, the Codex hook
   // does not replay ordinary `.md` backups because they have already landed.
-  queueAgentMail(normalizedId, message, false, opts.dedupKey);
+  // Keyed deliveries skip the backup: the caller's outbox is the durable
+  // receipt, and a keyed mail file is a replay channel — a monitor started
+  // later would drain and print it as a second visible copy (cycle 7).
+  if (opts.dedupKey === undefined) {
+    queueAgentMail(normalizedId, message, false);
+  }
   await appendTellInterventionForUserSource(normalizedId, caller);
-  return { delivered: delivery.ok, queuedToMail: true };
+  return { delivered: delivery.ok, queuedToMail: opts.dedupKey === undefined };
 }
 
 export async function messageAgentWithOutcome(

--- a/src/lib/agents/messaging.ts
+++ b/src/lib/agents/messaging.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { Effect } from 'effect';
@@ -31,6 +32,7 @@ import { getLatestSessionIdSync } from './activity.js';
 import {
   deliverAgentMessage,
   deliverResumeMessageWithTranscriptConfirmation,
+  recordDeliveredKeyWithSupervisor,
   resilientDeliveryMethod,
 } from './delivery.js';
 import { formatMailFileContent, isMonitorLive } from './monitor-transport.js';
@@ -62,18 +64,26 @@ export interface MessageDeliveryOutcome {
 
 export type MessageAgentOutcome = 'delivered' | 'queued';
 
-function queueAgentMail(agentId: string, message: string, pendingTurnEndDelivery = false, source?: string): void {
+function queueAgentMail(
+  agentId: string,
+  message: string,
+  pendingTurnEndDelivery = false,
+  dedupKey?: string,
+  source?: string,
+): void {
   const mailDir = join(getAgentDir(agentId), 'mail');
   mkdirSync(mailDir, { recursive: true });
   const now = new Date();
-  const timestamp = now.toISOString().replace(/[:.]/g, '-');
+  // Keyed messages get a deterministic filename so a crash-replayed send
+  // overwrites the same durable backup instead of stacking a second copy.
+  const filename = dedupKey !== undefined
+    ? `dedup-${createHash('sha256').update(dedupKey).digest('hex').slice(0, 24)}.md`
+    : `${now.toISOString().replace(/[:.]/g, '-')}${pendingTurnEndDelivery ? '.pending' : ''}.md`;
   // The provenance header is only written when a source is known (the monitor
   // tier, PAN-3015). Callers that replay mail verbatim (codex notify hook
   // pastes `.pending.md` content) keep the legacy `# Message\n\n<body>` shape.
   const content = source ? formatMailFileContent(message, source, now) : `# Message\n\n${message}\n`;
-  writeFileSync(
-    join(mailDir, `${timestamp}${pendingTurnEndDelivery ? '.pending' : ''}.md`),
-    content
+  writeFileSync(join(mailDir, filename), content
   );
 }
 
@@ -111,6 +121,23 @@ async function appendTellInterventionForUserSource(normalizedId: string, caller:
   });
 }
 
+type DeliveryMethod = 'auto' | 'supervisor' | 'channels' | 'tmux' | undefined;
+
+/** Call the delivery door with the idempotency key only when one is set, so
+ * unkeyed callers keep their exact pre-key call shape. */
+function deliverWithOptionalKey(
+  normalizedId: string,
+  message: string,
+  caller: string,
+  deliveryMethod: DeliveryMethod,
+  dedupKey: string | undefined,
+) {
+  return dedupKey !== undefined
+    ? deliverAgentMessage(normalizedId, message, caller, deliveryMethod, { dedupKey })
+    : deliverAgentMessage(normalizedId, message, caller, deliveryMethod);
+}
+
+
 export async function messageAgent(
   agentId: string,
   message: string,
@@ -143,7 +170,7 @@ export async function messageAgent(
   };
   if (agentState?.paused === true) {
     const gateBlockReason = getAgentResumeGateBlockReason(agentState)?.reason ?? 'agent is paused';
-    queueAgentMail(normalizedId, message);
+    queueAgentMail(normalizedId, message, false, opts.dedupKey);
     logAgentLifecycleSync(normalizedId, `messageAgent queued mail without resume: ${gateBlockReason}`);
     console.log(`[agents] Queued message for ${normalizedId}; ${gateBlockReason}`);
     return { delivered: false, queuedToMail: true, reason: gateBlockReason };
@@ -155,7 +182,7 @@ export async function messageAgent(
     const suspendedGate = decideMessageGate();
     if (suspendedGate.decision !== 'proceed') {
       const gateBlockReason = suspendedGate.reason ?? 'agent is gated';
-      queueAgentMail(normalizedId, message);
+      queueAgentMail(normalizedId, message, false, opts.dedupKey);
       logAgentLifecycleSync(normalizedId, `messageAgent queued mail without resume: ${gateBlockReason}`);
       console.log(`[agents] Queued message for ${normalizedId}; ${gateBlockReason}`);
       return { delivered: false, queuedToMail: true, reason: gateBlockReason };
@@ -170,6 +197,11 @@ export async function messageAgent(
       throw new Error(`Agent resumed but ready signal did not fire — message not delivered. Feedback is in the mail queue.`);
     }
     // Message already sent during resume
+    if (opts.dedupKey !== undefined) {
+      // The resume kickoff prompt carried the keyed message without the new
+      // supervisor mediating it — record the key so a crash replay dedups.
+      await recordDeliveredKeyWithSupervisor(normalizedId, opts.dedupKey);
+    }
     await appendTellInterventionForUserSource(normalizedId, caller);
     return { delivered: true, queuedToMail: false };
   }
@@ -191,7 +223,7 @@ export async function messageAgent(
     const stoppedGate = decideMessageGate();
     if (stoppedGate.decision !== 'proceed') {
       const gateBlockReason = stoppedGate.reason ?? 'agent is gated';
-      queueAgentMail(normalizedId, message);
+      queueAgentMail(normalizedId, message, false, opts.dedupKey);
       logAgentLifecycleSync(normalizedId, `messageAgent queued mail without resume: ${gateBlockReason}`);
       console.log(`[agents] Queued message for ${normalizedId}; ${gateBlockReason}`);
       return { delivered: false, queuedToMail: true, reason: gateBlockReason };
@@ -202,9 +234,12 @@ export async function messageAgent(
     const resumeResult = await resumeAgent(normalizedId, message);
 
     // Save to mail queue regardless so the agent can re-read feedback if needed
-    queueAgentMail(normalizedId, message);
+    queueAgentMail(normalizedId, message, false, opts.dedupKey);
 
     if (resumeResult.success && resumeResult.messageDelivered !== false) {
+      if (opts.dedupKey !== undefined) {
+        await recordDeliveredKeyWithSupervisor(normalizedId, opts.dedupKey);
+      }
       await appendTellInterventionForUserSource(normalizedId, caller);
       console.log(`[agents] Resumed ${normalizedId} and delivered feedback`);
       return { delivered: true, queuedToMail: true };
@@ -348,7 +383,7 @@ export async function messageAgent(
           console.error(`[agents] Fallback-restarted ${normalizedId} but no session id was recorded — feedback in mail queue`);
         }
       } else {
-        const delivery = await deliverAgentMessage(normalizedId, resumeMessage.message, 'resumeAgent:resume-prompt', resolveAgentDeliveryMethod(agentState));
+        const delivery = await deliverWithOptionalKey(normalizedId, resumeMessage.message, 'resumeAgent:resume-prompt', resolveAgentDeliveryMethod(agentState), opts.dedupKey);
         delivered = delivery.ok;
         if (!delivery.ok) reason = 'resume prompt delivery failed';
       }
@@ -373,7 +408,7 @@ export async function messageAgent(
     await sendToRemoteAgent(normalizedId, remoteState.vmName, message);
 
     // Also save to mail queue for persistence
-    queueAgentMail(normalizedId, message);
+    queueAgentMail(normalizedId, message, false, opts.dedupKey);
     await appendTellInterventionForUserSource(normalizedId, caller);
     return { delivered: true, queuedToMail: true };
   }
@@ -389,7 +424,7 @@ export async function messageAgent(
   // (no monitor exists before the session's first turn), and a stale
   // heartbeat or dead pid falls through to the normal cascade.
   if (expectedHarness === 'claude-code' && isMonitorLive(normalizedId)) {
-    queueAgentMail(normalizedId, message, false, caller);
+    queueAgentMail(normalizedId, message, false, opts.dedupKey, caller);
     logAgentLifecycleSync(normalizedId, `messageAgent delivered via monitor mail (caller: ${caller})`);
     console.log(`[agents] Delivered message to ${normalizedId} via monitor inbox`);
     await appendTellInterventionForUserSource(normalizedId, caller);
@@ -406,7 +441,7 @@ export async function messageAgent(
   if (appServerState && appServerState !== 'closed' && appServerState !== 'error') {
     const promptReady = claimCodexIdleTurn(normalizedId);
     if (!promptReady) {
-      queueAgentMail(normalizedId, message, true);
+      queueAgentMail(normalizedId, message, true, opts.dedupKey);
       logAgentLifecycleSync(normalizedId, 'messageAgent queued mail for codex turn-end delivery: agent busy');
       console.log(`[agents] Queued message for ${normalizedId}; codex agent is mid-turn`);
       await appendTellInterventionForUserSource(normalizedId, caller);
@@ -414,8 +449,8 @@ export async function messageAgent(
     }
 
     const deliveryMethod = resolveAgentDeliveryMethod(agentState);
-    const delivery = await deliverAgentMessage(normalizedId, message, `messageAgent:${caller}`, deliveryMethod);
-    queueAgentMail(normalizedId, message);
+    const delivery = await deliverWithOptionalKey(normalizedId, message, `messageAgent:${caller}`, deliveryMethod, opts.dedupKey);
+    queueAgentMail(normalizedId, message, false, opts.dedupKey);
     await appendTellInterventionForUserSource(normalizedId, caller);
     return { delivered: delivery.ok, queuedToMail: true };
   }
@@ -439,6 +474,9 @@ export async function messageAgent(
     if (resumeResult.success) {
       const delivered = resumeResult.messageDelivered !== false;
       if (delivered) {
+        if (opts.dedupKey !== undefined) {
+          await recordDeliveredKeyWithSupervisor(normalizedId, opts.dedupKey);
+        }
         await appendTellInterventionForUserSource(normalizedId, caller);
       }
       return { delivered, queuedToMail: false };
@@ -456,11 +494,11 @@ export async function messageAgent(
   }
 
   const deliveryMethod = resolveAgentDeliveryMethod(agentState);
-  const delivery = await deliverAgentMessage(normalizedId, message, `messageAgent:${caller}`, deliveryMethod);
+  const delivery = await deliverWithOptionalKey(normalizedId, message, `messageAgent:${caller}`, deliveryMethod, opts.dedupKey);
 
   // Save a durable backup. Unlike `.pending.md` busy-turn mail, the Codex hook
   // does not replay ordinary `.md` backups because they have already landed.
-  queueAgentMail(normalizedId, message);
+  queueAgentMail(normalizedId, message, false, opts.dedupKey);
   await appendTellInterventionForUserSource(normalizedId, caller);
   return { delivered: delivery.ok, queuedToMail: true };
 }

--- a/src/lib/channels/__tests__/pty-supervisor.test.ts
+++ b/src/lib/channels/__tests__/pty-supervisor.test.ts
@@ -492,4 +492,42 @@ describe.skipIf(isBun)('pty-supervisor subprocess', () => {
 
     expect(statSync(socketPath).mode & 0o777).toBe(0o600);
   });
+
+  it('deduplicates a repeated dedupKey without a second PTY write (PAN-2997)', async () => {
+    const agentId = 'agent-dedup-key';
+    const content = 'dedup-wake-content';
+    const { token, socketPath } = await readySupervisor(agentId, 'cat');
+
+    const first = await postToUnixSocket(socketPath, token, { content, echo: false, dedupKey: 'wake-seq-1' });
+    expect(first.status).toBe(200);
+    await waitForProcessOutput(() => stdout.includes(content), 'supervisor did not echo posted content');
+    // Plain cat echoes both the tty input and its output, so let the first
+    // delivery's output fully settle, then require the replay adds nothing.
+    await new Promise(r => setTimeout(r, 500));
+    const occurrencesAfterFirst = stdout.match(new RegExp(content, 'g'))?.length ?? 0;
+    expect(occurrencesAfterFirst).toBeGreaterThan(0);
+
+    // The dashboard-crash replay: same key, same content. The supervisor
+    // survived the "crash", so it answers with a dedup, not a second write.
+    const second = await postToUnixSocket(socketPath, token, { content, echo: false, dedupKey: 'wake-seq-1' });
+    expect(second.status).toBe(200);
+    expect(second.body).toContain('deduplicated');
+    await new Promise(r => setTimeout(r, 300));
+    expect(stdout.match(new RegExp(content, 'g'))).toHaveLength(occurrencesAfterFirst);
+  });
+
+  it('record-delivered suppresses a later keyed injection without writing (PAN-2997)', async () => {
+    const agentId = 'agent-dedup-record';
+    const content = 'dedup-recorded-content';
+    const { token, socketPath } = await readySupervisor(agentId, 'cat');
+
+    const record = await postToUnixSocket(socketPath, token, { op: 'record-delivered', dedupKey: 'wake-seq-2' });
+    expect(record.status).toBe(200);
+
+    const replay = await postToUnixSocket(socketPath, token, { content, echo: false, dedupKey: 'wake-seq-2' });
+    expect(replay.status).toBe(200);
+    expect(replay.body).toContain('deduplicated');
+    await new Promise(r => setTimeout(r, 300));
+    expect(stdout).not.toContain(content);
+  });
 });

--- a/src/lib/channels/__tests__/pty-supervisor.test.ts
+++ b/src/lib/channels/__tests__/pty-supervisor.test.ts
@@ -516,18 +516,56 @@ describe.skipIf(isBun)('pty-supervisor subprocess', () => {
     expect(stdout.match(new RegExp(content, 'g'))).toHaveLength(occurrencesAfterFirst);
   });
 
-  it('record-delivered suppresses a later keyed injection without writing (PAN-2997)', async () => {
-    const agentId = 'agent-dedup-record';
-    const content = 'dedup-recorded-content';
-    const { token, socketPath } = await readySupervisor(agentId, 'cat');
+  it('coalesces two CONCURRENT same-key injections into a single PTY write (PAN-2997 cycle 7)', async () => {
+    const agentId = 'agent-dedup-race';
+    const content = 'dedup-race-content';
+    // The child echoes its input only after a delay, so the first injection is
+    // still awaiting echo confirmation when the second request arrives — the
+    // exact interleaving that used to let both pass the dedup check.
+    const { token, socketPath } = await readySupervisor(agentId, 'bash', [
+      '-lc',
+      'stty raw -echo; printf READY; sleep 1; cat',
+    ]);
+    await waitForProcessOutput(() => stdout.includes('READY'), 'child did not start');
+    stdout = '';
 
-    const record = await postToUnixSocket(socketPath, token, { op: 'record-delivered', dedupKey: 'wake-seq-2' });
-    expect(record.status).toBe(200);
+    const [first, second] = await Promise.all([
+      postToUnixSocket(socketPath, token, { content, echo: false, dedupKey: 'wake-race-1' }),
+      postToUnixSocket(socketPath, token, { content, echo: false, dedupKey: 'wake-race-1' }),
+    ]);
 
-    const replay = await postToUnixSocket(socketPath, token, { content, echo: false, dedupKey: 'wake-seq-2' });
-    expect(replay.status).toBe(200);
-    expect(replay.body).toContain('deduplicated');
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    // Exactly one request injected; the other coalesced onto it and answered dedup.
+    const dedupAnswers = [first.body, second.body].filter(body => body.includes('deduplicated'));
+    expect(dedupAnswers).toHaveLength(1);
+
+    // With tty echo disabled and supervisor stdout echo off, ONE injection
+    // produces exactly one occurrence of the content (cat's output); a racing
+    // second injection would add another.
+    await waitForProcessOutput(() => stdout.includes(content), 'injected content did not echo through cat');
     await new Promise(r => setTimeout(r, 300));
-    expect(stdout).not.toContain(content);
-  });
+    expect(stdout.match(new RegExp(content, 'g'))).toHaveLength(1);
+  }, 15_000);
+
+  it('releases the key reservation when the injection fails so a retry can succeed (PAN-2997 cycle 7)', async () => {
+    const agentId = 'agent-dedup-release';
+    const content = `release-${'y'.repeat(32)}`;
+    // The child never echoes — echo confirmation fails after the retry budget
+    // and the supervisor answers 502. The reservation must be released: a
+    // later same-key request is a fresh attempt, not a false dedup.
+    const byteCount = Buffer.byteLength(content, 'utf8') * 4 + 16;
+    const { token, socketPath } = await readySupervisor(agentId, 'bash', [
+      '-lc',
+      `stty raw -echo; printf READY; dd bs=1 count=${byteCount} of=/dev/null 2>/dev/null; sleep 30`,
+    ]);
+    await waitForProcessOutput(() => stdout.includes('READY'), 'child did not enter raw no-echo mode');
+
+    const first = await postToUnixSocket(socketPath, token, { content, echo: true, dedupKey: 'wake-release-1' });
+    expect(first.status).toBe(502);
+
+    const retry = await postToUnixSocket(socketPath, token, { content, echo: true, dedupKey: 'wake-release-1' });
+    expect(retry.status).toBe(502);
+    expect(retry.body).not.toContain('deduplicated');
+  }, 30_000);
 });

--- a/src/lib/channels/pty-supervisor.ts
+++ b/src/lib/channels/pty-supervisor.ts
@@ -49,7 +49,29 @@ export interface PtySupervisorPayload {
   echo?: boolean;
   caller?: string;
   meta?: Record<string, string>;
+  /**
+   * Optional idempotency key (PAN-2997). When present, the supervisor
+   * remembers injected keys and silently deduplicates repeat deliveries of
+   * the same key. The set is in-memory by design: the supervisor owns the
+   * agent's PTY, so a supervisor exit means the agent died too (H1) — a
+   * replayed delivery to a resumed session is a legitimate first delivery,
+   * not a duplicate. What this closes is the dashboard-crash window: the
+   * dashboard may die between the supervisor's injection and its own
+   * bookkeeping, but the supervisor survives and answers the replay with a
+   * dedup instead of a second PTY write.
+   */
+  dedupKey?: string;
+  /**
+   * When 'record-delivered', no content is injected — the key is simply added
+   * to the dedup set. Used when the message reached the agent through a
+   * channel the supervisor did not mediate (e.g. a resume kickoff prompt),
+   * so a later keyed replay still deduplicates.
+   */
+  op?: 'record-delivered';
 }
+
+/** Max accepted dedup key length; keys are free-form caller namespaces. */
+const DEDUP_KEY_MAX_CHARS = 200;
 
 export function getPtySupervisorSocketPath(agentId: string): string {
   return join(getOverdeckHome(), 'sockets', `pty-${agentId}.sock`);
@@ -112,10 +134,19 @@ async function readJsonBody(req: IncomingMessage): Promise<unknown> {
 function parsePayload(value: unknown): PtySupervisorPayload | null {
   if (value === null || typeof value !== 'object') return null;
   const payload = value as Partial<PtySupervisorPayload>;
+  if (payload.op === 'record-delivered') {
+    // Key-only operation: no content required.
+    return typeof payload.dedupKey === 'string' && payload.dedupKey.length > 0
+      && payload.dedupKey.length <= DEDUP_KEY_MAX_CHARS
+      ? payload as PtySupervisorPayload
+      : null;
+  }
   if (typeof payload.content !== 'string' || payload.content.length === 0) return null;
   if (payload.content.length > INPUT_PURGE_MAX_CHARS) return null;
   if (payload.echo !== undefined && typeof payload.echo !== 'boolean') return null;
   if (payload.caller !== undefined && typeof payload.caller !== 'string') return null;
+  if (payload.dedupKey !== undefined
+    && (typeof payload.dedupKey !== 'string' || payload.dedupKey.length === 0 || payload.dedupKey.length > DEDUP_KEY_MAX_CHARS)) return null;
   if (payload.meta !== undefined) {
     if (payload.meta === null || typeof payload.meta !== 'object' || Array.isArray(payload.meta)) return null;
     for (const [key, metaValue] of Object.entries(payload.meta)) {
@@ -373,6 +404,12 @@ export async function injectPtyMessage(
 }
 
 export function createPtySupervisorServer(agentId: string, child: pty.IPty): Server {
+  // Per-server dedup memory. A supervisor exit kills the agent with it (H1),
+  // so this never needs to survive the supervisor itself — only the
+  // dashboard, whose crash between the supervisor's injection and the
+  // dashboard's own ack bookkeeping is exactly the replay this suppresses.
+  const deliveredDedupKeys = new Set<string>();
+
   return createServer(async (req, res) => {
     if (req.method !== 'POST') {
       writeJson(res, 405, { error: 'method not allowed' });
@@ -397,8 +434,32 @@ export function createPtySupervisorServer(agentId: string, child: pty.IPty): Ser
       return;
     }
 
+    if (payload.dedupKey !== undefined && deliveredDedupKeys.has(payload.dedupKey)) {
+      // Already injected (or recorded) — suppress the replay. This is what
+      // keeps a dashboard crash-and-recovery from delivering the same keyed
+      // message twice.
+      writeJson(res, 200, { ok: true, deduplicated: true });
+      return;
+    }
+
+    if (payload.op === 'record-delivered') {
+      const key = payload.dedupKey;
+      if (key === undefined) {
+        writeJson(res, 400, { error: 'dedupKey is required for record-delivered' });
+        return;
+      }
+      deliveredDedupKeys.add(key);
+      writeJson(res, 200, { ok: true, recorded: true });
+      return;
+    }
+
     try {
       await injectPtyMessage(child, agentId, payload);
+      if (payload.dedupKey !== undefined) {
+        // Recorded only after a confirmed injection, inside the supervisor's
+        // own crash boundary — the dashboard cannot interrupt this ordering.
+        deliveredDedupKeys.add(payload.dedupKey);
+      }
       writeJson(res, 200, 'ok');
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/src/lib/channels/pty-supervisor.ts
+++ b/src/lib/channels/pty-supervisor.ts
@@ -61,13 +61,6 @@ export interface PtySupervisorPayload {
    * dedup instead of a second PTY write.
    */
   dedupKey?: string;
-  /**
-   * When 'record-delivered', no content is injected — the key is simply added
-   * to the dedup set. Used when the message reached the agent through a
-   * channel the supervisor did not mediate (e.g. a resume kickoff prompt),
-   * so a later keyed replay still deduplicates.
-   */
-  op?: 'record-delivered';
 }
 
 /** Max accepted dedup key length; keys are free-form caller namespaces. */
@@ -134,13 +127,6 @@ async function readJsonBody(req: IncomingMessage): Promise<unknown> {
 function parsePayload(value: unknown): PtySupervisorPayload | null {
   if (value === null || typeof value !== 'object') return null;
   const payload = value as Partial<PtySupervisorPayload>;
-  if (payload.op === 'record-delivered') {
-    // Key-only operation: no content required.
-    return typeof payload.dedupKey === 'string' && payload.dedupKey.length > 0
-      && payload.dedupKey.length <= DEDUP_KEY_MAX_CHARS
-      ? payload as PtySupervisorPayload
-      : null;
-  }
   if (typeof payload.content !== 'string' || payload.content.length === 0) return null;
   if (payload.content.length > INPUT_PURGE_MAX_CHARS) return null;
   if (payload.echo !== undefined && typeof payload.echo !== 'boolean') return null;
@@ -409,6 +395,12 @@ export function createPtySupervisorServer(agentId: string, child: pty.IPty): Ser
   // dashboard, whose crash between the supervisor's injection and the
   // dashboard's own ack bookkeeping is exactly the replay this suppresses.
   const deliveredDedupKeys = new Set<string>();
+  // In-flight keyed injections. The reservation is made SYNCHRONOUSLY before
+  // the first await of the injection, so two concurrent same-key requests can
+  // never both pass the dedup check and inject twice (review cycle 7): the
+  // second coalesces onto the first attempt's promise and answers dedup if it
+  // succeeded, or becomes the next attempt if it failed.
+  const inFlightDedupKeys = new Map<string, { promise: Promise<void>; settle: (error?: unknown) => void }>();
 
   return createServer(async (req, res) => {
     if (req.method !== 'POST') {
@@ -434,32 +426,62 @@ export function createPtySupervisorServer(agentId: string, child: pty.IPty): Ser
       return;
     }
 
-    if (payload.dedupKey !== undefined && deliveredDedupKeys.has(payload.dedupKey)) {
-      // Already injected (or recorded) — suppress the replay. This is what
-      // keeps a dashboard crash-and-recovery from delivering the same keyed
-      // message twice.
-      writeJson(res, 200, { ok: true, deduplicated: true });
-      return;
-    }
-
-    if (payload.op === 'record-delivered') {
+    if (payload.dedupKey !== undefined) {
       const key = payload.dedupKey;
-      if (key === undefined) {
-        writeJson(res, 400, { error: 'dedupKey is required for record-delivered' });
-        return;
+      // Coalesce concurrent same-key deliveries. The loop re-checks after
+      // each await: a waiter that watched a FAILED attempt re-enters and may
+      // find another waiter already holding the fresh reservation.
+      for (;;) {
+        if (deliveredDedupKeys.has(key)) {
+          // Already injected — suppress the replay. This is what keeps a
+          // dashboard crash-and-recovery from delivering the same keyed
+          // message twice.
+          writeJson(res, 200, { ok: true, deduplicated: true });
+          return;
+        }
+        const inFlight = inFlightDedupKeys.get(key);
+        if (inFlight === undefined) break;
+        try {
+          await inFlight.promise;
+        } catch {
+          // The first attempt failed — loop to re-check and retry.
+        }
       }
-      deliveredDedupKeys.add(key);
-      writeJson(res, 200, { ok: true, recorded: true });
+
+      // Reserve the key synchronously, before any injection await.
+      let settle!: (error?: unknown) => void;
+      const promise = new Promise<void>((resolve, reject) => {
+        settle = (error?: unknown) => {
+          if (error === undefined) resolve();
+          else reject(error);
+        };
+      });
+      // A rejected reservation with no coalesced waiter must not surface as
+      // an unhandled rejection.
+      promise.catch(() => {});
+      inFlightDedupKeys.set(key, { promise, settle });
+
+      try {
+        await injectPtyMessage(child, agentId, payload);
+        // Completed only after a confirmed injection, inside the
+        // supervisor's own crash boundary — the dashboard cannot interrupt
+        // this ordering.
+        deliveredDedupKeys.add(key);
+        inFlightDedupKeys.delete(key);
+        settle();
+        writeJson(res, 200, 'ok');
+      } catch (error) {
+        // Release the reservation so a later retry can attempt the injection.
+        inFlightDedupKeys.delete(key);
+        settle(error);
+        const message = error instanceof Error ? error.message : String(error);
+        writeJson(res, 502, { error: message });
+      }
       return;
     }
 
     try {
       await injectPtyMessage(child, agentId, payload);
-      if (payload.dedupKey !== undefined) {
-        // Recorded only after a confirmed injection, inside the supervisor's
-        // own crash boundary — the dashboard cannot interrupt this ordering.
-        deliveredDedupKeys.add(payload.dedupKey);
-      }
       writeJson(res, 200, 'ok');
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/src/lib/claude-hooks-registration.ts
+++ b/src/lib/claude-hooks-registration.ts
@@ -57,6 +57,7 @@ export const HOOK_SCRIPT_NAMES: readonly string[] = [
   'pan-hook-lib.sh',        // PAN-800: shared library sourced by all hooks
   'pre-tool-hook',
   'ask-user-question-hook',
+  'linear-mcp-auth-hook',
   'auto-approve-hook',
   'heartbeat-hook',
   'stop-hook',
@@ -97,6 +98,7 @@ export const OVERDECK_HOOK_REGISTRATIONS: readonly HookRegistration[] = [
   { hookType: 'PreToolUse', scriptName: 'tmux-send-keys-guard', matcher: 'Bash' },
   { hookType: 'PreToolUse', scriptName: 'ask-user-question-hook', matcher: 'AskUserQuestion' },
   { hookType: 'PostToolUse', scriptName: 'heartbeat-hook' },
+  { hookType: 'PostToolUse', scriptName: 'linear-mcp-auth-hook', matcher: 'mcp__linear__.*' },
   { hookType: 'PostToolUse', scriptName: 'permission-event-hook' },
   { hookType: 'Stop', scriptName: 'stop-hook' },
   { hookType: 'Stop', scriptName: 'permission-event-hook' },

--- a/src/lib/claude-hooks-registration.ts
+++ b/src/lib/claude-hooks-registration.ts
@@ -33,6 +33,7 @@ export interface ClaudeSettings {
   hooks?: {
     PreToolUse?: HookConfig[];
     PostToolUse?: HookConfig[];
+    PostToolUseFailure?: HookConfig[];
     Stop?: HookConfig[];
     SessionStart?: HookConfig[];
     Notification?: HookConfig[];
@@ -99,6 +100,10 @@ export const OVERDECK_HOOK_REGISTRATIONS: readonly HookRegistration[] = [
   { hookType: 'PreToolUse', scriptName: 'ask-user-question-hook', matcher: 'AskUserQuestion' },
   { hookType: 'PostToolUse', scriptName: 'heartbeat-hook' },
   { hookType: 'PostToolUse', scriptName: 'linear-mcp-auth-hook', matcher: 'mcp__linear__.*' },
+  // PostToolUse only fires on successful tool calls; a failed MCP call (the
+  // motivating Linear OAuth-expired case) fires PostToolUseFailure with a
+  // top-level `error` field instead (PAN-2997 review cycle 2).
+  { hookType: 'PostToolUseFailure', scriptName: 'linear-mcp-auth-hook', matcher: 'mcp__linear__.*' },
   { hookType: 'PostToolUse', scriptName: 'permission-event-hook' },
   { hookType: 'Stop', scriptName: 'stop-hook' },
   { hookType: 'Stop', scriptName: 'permission-event-hook' },

--- a/src/lib/cloister/service-reactive.ts
+++ b/src/lib/cloister/service-reactive.ts
@@ -386,6 +386,12 @@ export function issueStateChangeFromDomainEvent(event: CloisterDomainEventLike):
 }
 
 async function handleCloisterDomainEventPromise(event: CloisterDomainEventLike): Promise<void> {
+  if (event.type === 'linear_mcp_auth.healthy') {
+    const { processLinearMcpAuthWake } = await import('../linear-mcp-auth.js');
+    await processLinearMcpAuthWake();
+    return;
+  }
+
   // PAN-1908: reactive agent liveness — deacon handles agent.stopped and
   // agent.heartbeat_dead events instead of scanning agent directories.
   if (event.type === 'agent.stopped') {

--- a/src/lib/cloister/service.ts
+++ b/src/lib/cloister/service.ts
@@ -504,6 +504,14 @@ export class CloisterService {
 
     await this.subscribeToDomainEvents();
 
+    try {
+      const { processLinearMcpAuthWake } = await import('../linear-mcp-auth.js');
+      await processLinearMcpAuthWake();
+      console.log('  ✓ Reconciled pending Linear MCP auth wakes');
+    } catch (error) {
+      console.error('  ✗ Failed to recover pending Linear MCP auth wakes:', error);
+    }
+
     // Start monitoring loop
     this.startMonitoringLoop();
   }

--- a/src/lib/linear-mcp-auth.ts
+++ b/src/lib/linear-mcp-auth.ts
@@ -20,6 +20,9 @@ export interface LinearMcpAuthBlockedAgent {
   declaredAt: string;
   expiresAt: string;
   notifiedAt: string | null;
+  /** Projection-only enrichment attached by the GET route from the issues
+   * resolver; never persisted in lifecycle events. */
+  issueUrl?: string | null;
 }
 
 export interface LinearMcpAuthIntervention {
@@ -32,6 +35,10 @@ export interface LinearMcpAuthIntervention {
 }
 
 interface LinearMcpAuthLifecycle {
+  /** Durable correlation id: the sequence of the required event that opened
+   * this lifecycle. `notified` events carry it so a delayed delivery record
+   * can only be applied to the lifecycle whose wake attempt produced it. */
+  id: string;
   declaredAt: string;
   authUrl: string | null;
   authUrlAgentId: string | null;
@@ -61,6 +68,9 @@ export interface NotifiedPayload {
   agentId: string;
   issueId: string | null;
   outcome: LinearMcpAuthNotificationOutcome;
+  /** Correlates this record to the lifecycle whose wake attempt produced it.
+   * Absent only in events written before PAN-2997 review cycle 2. */
+  lifecycleId?: string;
 }
 
 export interface CallbackRelayedPayload {
@@ -94,6 +104,7 @@ function foldLinearMcpAuthEvents(events: StoredEvent[]): LinearMcpAuthFold {
       case 'linear_mcp_auth.required': {
         const payload = event.payload as RequiredPayload;
         open ??= {
+          id: `seq-${event.sequence}`,
           declaredAt: event.timestamp,
           authUrl: null,
           authUrlAgentId: null,
@@ -123,7 +134,15 @@ function foldLinearMcpAuthEvents(events: StoredEvent[]): LinearMcpAuthFold {
         break;
       case 'linear_mcp_auth.notified': {
         const payload = event.payload as NotifiedPayload;
-        const lifecycle = open ?? lastCompleted;
+        // A notification record belongs to exactly one lifecycle: the one
+        // whose wake pass produced it. Without this correlation a delayed
+        // delivery from lifecycle A could be stamped onto lifecycle B,
+        // permanently suppressing B's wake.
+        const lifecycle = payload.lifecycleId !== undefined
+          ? (open?.id === payload.lifecycleId ? open
+            : lastCompleted?.id === payload.lifecycleId ? lastCompleted
+            : null)
+          : (open ?? lastCompleted);
         const agent = lifecycle?.agents.get(payload.agentId);
         if (agent !== undefined) {
           lifecycle?.agents.set(payload.agentId, {
@@ -141,12 +160,40 @@ function foldLinearMcpAuthEvents(events: StoredEvent[]): LinearMcpAuthFold {
   return { open, lastCompleted };
 }
 
+const HEALTHY_BOUNDARY_CANDIDATES = 50;
+
 async function readLinearMcpAuthFold(): Promise<LinearMcpAuthFold> {
   const store = await initEventStore();
-  const events = LINEAR_MCP_AUTH_EVENT_TYPES
-    .flatMap(type => store.queryByType(type))
-    .sort((a, b) => a.sequence - b.sequence);
-  return foldLinearMcpAuthEvents(events);
+  // The fold needs the currently-open lifecycle plus the last completed one
+  // (for wake bookkeeping). queryByType's per-type cap (default 100) silently
+  // drops blocked agents once one type overflows, so read with a sequence
+  // predicate instead, anchored just before the last completed lifecycle.
+  //
+  // The anchor is a healthy event, but healthy events are only lifecycle
+  // boundaries when a lifecycle was open — a duplicate healthy is a no-op.
+  // So walk candidate boundaries from the second-most-recent healthy
+  // backwards: if the window contains a healthy event yet reconstructs no
+  // completed lifecycle, that healthy closed a lifecycle whose opening
+  // required events were cut off — expand to the next older candidate.
+  const healthyEvents = store.queryByType('linear_mcp_auth.healthy', HEALTHY_BOUNDARY_CANDIDATES);
+  const candidates = [
+    ...healthyEvents.slice(0, -1).map(candidate => candidate.sequence).reverse(),
+    0,
+  ];
+
+  let fold: LinearMcpAuthFold = { open: null, lastCompleted: null };
+  for (const boundary of candidates) {
+    const events = store.readFrom(boundary)
+      .filter(candidate =>
+        (LINEAR_MCP_AUTH_EVENT_TYPES as readonly string[]).includes(candidate.type))
+      .sort((a, b) => a.sequence - b.sequence);
+    fold = foldLinearMcpAuthEvents(events);
+    const windowHasHealthy = events.some(candidate => candidate.type === 'linear_mcp_auth.healthy');
+    if (fold.lastCompleted !== null || !windowHasHealthy || boundary === 0) {
+      break;
+    }
+  }
+  return fold;
 }
 
 function projectLifecycle(
@@ -227,31 +274,49 @@ export async function resolveLinearMcpAuthIntervention(
   return projectLifecycle(open, nowIso);
 }
 
-export async function computeLinearMcpAuthWakeSet(): Promise<LinearMcpAuthBlockedAgent[]> {
-  const { lastCompleted } = await readLinearMcpAuthFold();
-  if (lastCompleted === null) return [];
-  return [...lastCompleted.agents.values()].filter(agent => agent.notifiedAt === null);
+export interface LinearMcpAuthWakeSet {
+  lifecycleId: string;
+  agents: LinearMcpAuthBlockedAgent[];
 }
+
+export async function computeLinearMcpAuthWakeSet(): Promise<LinearMcpAuthWakeSet | null> {
+  const { lastCompleted } = await readLinearMcpAuthFold();
+  if (lastCompleted === null) return null;
+  const agents = [...lastCompleted.agents.values()].filter(agent => agent.notifiedAt === null);
+  return { lifecycleId: lastCompleted.id, agents };
+}
+
+const MAX_WAKE_PASSES = 10;
 
 export function processLinearMcpAuthWake(): Promise<void> {
   return linearMcpAuthWakeCoalescer.run('global', async () => {
-    const blockedAgents = await computeLinearMcpAuthWakeSet();
-    for (const blockedAgent of blockedAgents) {
-      let outcome: LinearMcpAuthNotificationOutcome;
-      try {
-        outcome = await messageAgentWithOutcome(
-          blockedAgent.agentId,
-          LINEAR_MCP_AUTH_WAKE_COPY,
-          'linear-mcp-auth-wake',
-        );
-      } catch {
-        outcome = 'failed';
+    // Drain-until-stable: a healthy event that lands while this pass is
+    // delivering wakes would otherwise be swallowed by the coalescer (its
+    // trigger gets this in-flight promise back). Re-reading the fold after
+    // each pass surfaces the newly completed lifecycle, so it gets its own
+    // wake round inside the same coalesced run.
+    for (let pass = 0; pass < MAX_WAKE_PASSES; pass++) {
+      const wakeSet = await computeLinearMcpAuthWakeSet();
+      if (wakeSet === null || wakeSet.agents.length === 0) return;
+      for (const blockedAgent of wakeSet.agents) {
+        let outcome: LinearMcpAuthNotificationOutcome;
+        try {
+          outcome = await messageAgentWithOutcome(
+            blockedAgent.agentId,
+            LINEAR_MCP_AUTH_WAKE_COPY,
+            'linear-mcp-auth-wake',
+          );
+        } catch {
+          outcome = 'failed';
+        }
+        await appendLinearMcpAuthNotifiedEvent({
+          agentId: blockedAgent.agentId,
+          issueId: blockedAgent.issueId,
+          outcome,
+          lifecycleId: wakeSet.lifecycleId,
+        });
       }
-      await appendLinearMcpAuthNotifiedEvent({
-        agentId: blockedAgent.agentId,
-        issueId: blockedAgent.issueId,
-        outcome,
-      });
     }
+    console.error(`[linear-mcp-auth] wake pass did not stabilize after ${MAX_WAKE_PASSES} passes — remaining wakes deferred to the next trigger or boot recovery`);
   });
 }

--- a/src/lib/linear-mcp-auth.ts
+++ b/src/lib/linear-mcp-auth.ts
@@ -12,7 +12,7 @@ export const LINEAR_MCP_AUTH_WAKE_COPY = 'Linear MCP authentication has been res
 const linearMcpAuthWakeCoalescer = createPromiseCoalescer<void>();
 
 export type LinearMcpAuthStatus = 'none' | 'active' | 'expired';
-export type LinearMcpAuthNotificationOutcome = 'delivered' | 'queued' | 'failed';
+export type LinearMcpAuthNotificationOutcome = 'delivering' | 'delivered' | 'queued' | 'failed';
 
 export interface LinearMcpAuthBlockedAgent {
   agentId: string;
@@ -95,9 +95,12 @@ function defaultExpiresAt(declaredAt: string): string {
   return new Date(Date.parse(declaredAt) + LINEAR_MCP_AUTH_URL_TTL_MS).toISOString();
 }
 
-function foldLinearMcpAuthEvents(events: StoredEvent[]): LinearMcpAuthFold {
-  let open: LinearMcpAuthLifecycle | null = null;
-  let lastCompleted: LinearMcpAuthLifecycle | null = null;
+function foldLinearMcpAuthEvents(
+  events: StoredEvent[],
+  initial: LinearMcpAuthFold = { open: null, lastCompleted: null },
+): LinearMcpAuthFold {
+  let open = initial.open;
+  let lastCompleted = initial.lastCompleted;
 
   for (const event of events) {
     switch (event.type) {
@@ -160,39 +163,45 @@ function foldLinearMcpAuthEvents(events: StoredEvent[]): LinearMcpAuthFold {
   return { open, lastCompleted };
 }
 
-const HEALTHY_BOUNDARY_CANDIDATES = 50;
+interface LinearMcpAuthProjectionCache {
+  fold: LinearMcpAuthFold;
+  coveredSequence: number;
+}
 
+let projectionCache: LinearMcpAuthProjectionCache | null = null;
+
+export function _resetLinearMcpAuthProjectionCacheForTests(): void {
+  projectionCache = null;
+}
+
+/**
+ * Read the lifecycle fold from a maintained projection rather than rebuilding
+ * it per poll. The projection advances incrementally: each read fetches only
+ * auth-typed events newer than the covered sequence via an indexed SQL query
+ * (`queryByTypesSince`), so unrelated retained history is never materialized
+ * — a full `readFrom(0)` on the seven-day event table has blown the heap in
+ * smoke testing, and the banner calls this path every 5–30 seconds per
+ * connected client.
+ */
 async function readLinearMcpAuthFold(): Promise<LinearMcpAuthFold> {
   const store = await initEventStore();
-  // The fold needs the currently-open lifecycle plus the last completed one
-  // (for wake bookkeeping). queryByType's per-type cap (default 100) silently
-  // drops blocked agents once one type overflows, so read with a sequence
-  // predicate instead, anchored just before the last completed lifecycle.
-  //
-  // The anchor is a healthy event, but healthy events are only lifecycle
-  // boundaries when a lifecycle was open — a duplicate healthy is a no-op.
-  // So walk candidate boundaries from the second-most-recent healthy
-  // backwards: if the window contains a healthy event yet reconstructs no
-  // completed lifecycle, that healthy closed a lifecycle whose opening
-  // required events were cut off — expand to the next older candidate.
-  const healthyEvents = store.queryByType('linear_mcp_auth.healthy', HEALTHY_BOUNDARY_CANDIDATES);
-  const candidates = [
-    ...healthyEvents.slice(0, -1).map(candidate => candidate.sequence).reverse(),
-    0,
-  ];
-
-  let fold: LinearMcpAuthFold = { open: null, lastCompleted: null };
-  for (const boundary of candidates) {
-    const events = store.readFrom(boundary)
-      .filter(candidate =>
-        (LINEAR_MCP_AUTH_EVENT_TYPES as readonly string[]).includes(candidate.type))
-      .sort((a, b) => a.sequence - b.sequence);
-    fold = foldLinearMcpAuthEvents(events);
-    const windowHasHealthy = events.some(candidate => candidate.type === 'linear_mcp_auth.healthy');
-    if (fold.lastCompleted !== null || !windowHasHealthy || boundary === 0) {
-      break;
-    }
+  // The events table is a disposable cache — rebuilt, compacted, or purged
+  // underneath us. If it now ends before the covered sequence, the cached
+  // prefix is stale and the projection must restart from scratch.
+  if (projectionCache !== null && store.getLatestSequence() < projectionCache.coveredSequence) {
+    projectionCache = null;
   }
+  const afterSequence = projectionCache?.coveredSequence ?? 0;
+  const delta = store.queryByTypesSince([...LINEAR_MCP_AUTH_EVENT_TYPES], afterSequence);
+  if (delta.length === 0 && projectionCache !== null) {
+    return projectionCache.fold;
+  }
+  const fold = foldLinearMcpAuthEvents(delta, projectionCache?.fold);
+  const lastEvent = delta[delta.length - 1];
+  projectionCache = {
+    fold,
+    coveredSequence: lastEvent !== undefined ? lastEvent.sequence : afterSequence,
+  };
   return fold;
 }
 
@@ -295,10 +304,36 @@ export function processLinearMcpAuthWake(): Promise<void> {
     // trigger gets this in-flight promise back). Re-reading the fold after
     // each pass surfaces the newly completed lifecycle, so it gets its own
     // wake round inside the same coalesced run.
+    let stabilized = false;
     for (let pass = 0; pass < MAX_WAKE_PASSES; pass++) {
       const wakeSet = await computeLinearMcpAuthWakeSet();
-      if (wakeSet === null || wakeSet.agents.length === 0) return;
+      if (wakeSet === null || wakeSet.agents.length === 0) {
+        stabilized = true;
+        break;
+      }
       for (const blockedAgent of wakeSet.agents) {
+        // Durable claim BEFORE delivery: the (lifecycleId, agentId) claim row
+        // is the deterministic delivery key that makes the wake
+        // crash-idempotent. A crash after the claim is visible to boot
+        // recovery (notifiedAt is set), so the delivery is never replayed; a
+        // crash before it delivers exactly once on the next pass. This is
+        // at-most-once by design — the residual lost-wake window self-heals
+        // when the still-blocked agent's next failed Linear call opens a
+        // fresh lifecycle.
+        try {
+          await appendLinearMcpAuthNotifiedEvent({
+            agentId: blockedAgent.agentId,
+            issueId: blockedAgent.issueId,
+            outcome: 'delivering',
+            lifecycleId: wakeSet.lifecycleId,
+          });
+        } catch (claimError) {
+          // Without the durable claim a crash could replay the delivery —
+          // skip this agent rather than risk a duplicate wake.
+          console.error(`[linear-mcp-auth] failed to record wake claim for ${blockedAgent.agentId}; skipping delivery this pass:`, claimError);
+          continue;
+        }
+
         let outcome: LinearMcpAuthNotificationOutcome;
         try {
           outcome = await messageAgentWithOutcome(
@@ -309,14 +344,27 @@ export function processLinearMcpAuthWake(): Promise<void> {
         } catch {
           outcome = 'failed';
         }
-        await appendLinearMcpAuthNotifiedEvent({
-          agentId: blockedAgent.agentId,
-          issueId: blockedAgent.issueId,
-          outcome,
-          lifecycleId: wakeSet.lifecycleId,
-        });
+        try {
+          await appendLinearMcpAuthNotifiedEvent({
+            agentId: blockedAgent.agentId,
+            issueId: blockedAgent.issueId,
+            outcome,
+            lifecycleId: wakeSet.lifecycleId,
+          });
+        } catch (completionError) {
+          // The claim already guarantees at-most-once; a lost completion
+          // record leaves the log showing 'delivering' for this agent.
+          console.error(`[linear-mcp-auth] failed to record wake outcome for ${blockedAgent.agentId}:`, completionError);
+        }
       }
     }
-    console.error(`[linear-mcp-auth] wake pass did not stabilize after ${MAX_WAKE_PASSES} passes — remaining wakes deferred to the next trigger or boot recovery`);
+    if (!stabilized) {
+      console.error(`[linear-mcp-auth] wake pass did not stabilize after ${MAX_WAKE_PASSES} passes — scheduling a follow-up run`);
+      // Every healthy trigger that arrived during this run received the same
+      // coalesced promise, so no external retry is guaranteed. Schedule one
+      // ourselves, after the coalescer entry for this run clears.
+      const timer = setTimeout(() => { void processLinearMcpAuthWake(); }, 1000);
+      timer.unref();
+    }
   });
 }

--- a/src/lib/linear-mcp-auth.ts
+++ b/src/lib/linear-mcp-auth.ts
@@ -8,6 +8,7 @@ import {
 import { getAgentDir } from './agents/agent-state.js';
 import { AmbiguousKeyedDeliveryError } from './agents/delivery.js';
 import { messageAgentWithOutcome } from './agents/messaging.js';
+import { KeyedSubmitTargetDeadError } from './tmux-dedup.js';
 import { createPromiseCoalescer } from './cloister/in-flight-guard.js';
 
 export const LINEAR_MCP_AUTH_URL_TTL_MS = 30 * 60 * 1000;
@@ -404,7 +405,13 @@ async function deliverWakeWithOutbox(agentId: string, lifecycleId: string): Prom
     // in-flight reservation/delivered set deduplicates it. At-most-once is
     // preserved by the door; a terminal record would either lose a wake that
     // never landed or misreport one that did.
-    if (error instanceof AmbiguousKeyedDeliveryError) {
+    //
+    // DEAD TARGET (cycle 9): the tmux submit found the pane dead and sent NO
+    // Enter, deliberately preserving the pending claim and leaving the key
+    // non-terminal. Same handling: the entry stays pending so a later pass
+    // re-drives the wake — by then messageAgent's zombie/stopped detection
+    // resumes the agent and the keyed door of the new session delivers.
+    if (error instanceof AmbiguousKeyedDeliveryError || error instanceof KeyedSubmitTargetDeadError) {
       throw error;
     }
     outcome = 'failed';

--- a/src/lib/linear-mcp-auth.ts
+++ b/src/lib/linear-mcp-auth.ts
@@ -3,8 +3,13 @@ import {
   initEventStore,
   type StoredEvent,
 } from '../dashboard/server/event-store.js';
+import { messageAgentWithOutcome } from './agents/messaging.js';
+import { createPromiseCoalescer } from './cloister/in-flight-guard.js';
 
 export const LINEAR_MCP_AUTH_URL_TTL_MS = 30 * 60 * 1000;
+export const LINEAR_MCP_AUTH_WAKE_COPY = 'Linear MCP authentication has been restored — the operator completed OAuth. Re-check access now with one lightweight read (e.g. mcp__linear__list_issues). If it succeeds, resume your canonical task. If it still returns an authentication error, call mcp__linear__authenticate once and wait; do not retry in a loop.';
+
+const linearMcpAuthWakeCoalescer = createPromiseCoalescer<void>();
 
 export type LinearMcpAuthStatus = 'none' | 'active' | 'expired';
 export type LinearMcpAuthNotificationOutcome = 'delivered' | 'queued' | 'failed';
@@ -226,4 +231,27 @@ export async function computeLinearMcpAuthWakeSet(): Promise<LinearMcpAuthBlocke
   const { lastCompleted } = await readLinearMcpAuthFold();
   if (lastCompleted === null) return [];
   return [...lastCompleted.agents.values()].filter(agent => agent.notifiedAt === null);
+}
+
+export function processLinearMcpAuthWake(): Promise<void> {
+  return linearMcpAuthWakeCoalescer.run('global', async () => {
+    const blockedAgents = await computeLinearMcpAuthWakeSet();
+    for (const blockedAgent of blockedAgents) {
+      let outcome: LinearMcpAuthNotificationOutcome;
+      try {
+        outcome = await messageAgentWithOutcome(
+          blockedAgent.agentId,
+          LINEAR_MCP_AUTH_WAKE_COPY,
+          'linear-mcp-auth-wake',
+        );
+      } catch {
+        outcome = 'failed';
+      }
+      await appendLinearMcpAuthNotifiedEvent({
+        agentId: blockedAgent.agentId,
+        issueId: blockedAgent.issueId,
+        outcome,
+      });
+    }
+  });
 }

--- a/src/lib/linear-mcp-auth.ts
+++ b/src/lib/linear-mcp-auth.ts
@@ -6,6 +6,7 @@ import {
   type StoredEvent,
 } from '../dashboard/server/event-store.js';
 import { getAgentDir } from './agents/agent-state.js';
+import { AmbiguousKeyedDeliveryError } from './agents/delivery.js';
 import { messageAgentWithOutcome } from './agents/messaging.js';
 import { createPromiseCoalescer } from './cloister/in-flight-guard.js';
 
@@ -395,7 +396,17 @@ async function deliverWakeWithOutbox(agentId: string, lifecycleId: string): Prom
       'linear-mcp-auth-wake',
       { dedupKey: `linear-mcp-auth-wake:${lifecycleId}` },
     );
-  } catch {
+  } catch (error) {
+    // AMBIGUOUS keyed delivery (cycle 8): the supervisor may have completed
+    // the injection but its answer never arrived. Do NOT record a terminal
+    // 'failed' — leave the entry pending so the next wake pass (or boot
+    // recovery) retries the SAME key at the SAME tier, where the supervisor's
+    // in-flight reservation/delivered set deduplicates it. At-most-once is
+    // preserved by the door; a terminal record would either lose a wake that
+    // never landed or misreport one that did.
+    if (error instanceof AmbiguousKeyedDeliveryError) {
+      throw error;
+    }
     outcome = 'failed';
   }
   await writeWakeOutbox({

--- a/src/lib/linear-mcp-auth.ts
+++ b/src/lib/linear-mcp-auth.ts
@@ -1,9 +1,12 @@
 import type { DomainEvent } from '@overdeck/contracts';
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import {
   initEventStore,
   type StoredEvent,
 } from '../dashboard/server/event-store.js';
-import { messageAgentWithOutcome, agentHasMailContentSince } from './agents/messaging.js';
+import { getAgentDir } from './agents/agent-state.js';
+import { messageAgentWithOutcome } from './agents/messaging.js';
 import { createPromiseCoalescer } from './cloister/in-flight-guard.js';
 
 export const LINEAR_MCP_AUTH_URL_TTL_MS = 30 * 60 * 1000;
@@ -22,11 +25,6 @@ export interface LinearMcpAuthBlockedAgent {
   /** Set by a completion record (delivered/queued/failed). Terminal: the
    * agent never re-enters the wake set for this lifecycle. */
   notifiedAt: string | null;
-  /** Set by a pre-delivery 'delivering' claim. NOT terminal: an agent with a
-   * claim but no completion stays in the wake set, and recovery reconciles
-   * the claim against the durable mail outbox before deciding whether the
-   * send must be replayed. */
-  claimedAt?: string | null;
   /** Projection-only enrichment attached by the GET route from the issues
    * resolver; never persisted in lifecycle events. */
   issueUrl?: string | null;
@@ -154,20 +152,14 @@ function foldLinearMcpAuthEvents(
             : null)
           : (open ?? lastCompleted);
         const agent = lifecycle?.agents.get(payload.agentId);
-        if (agent !== undefined) {
-          if (payload.outcome === 'delivering') {
-            // A claim is not a completion: it marks where an interrupted
-            // delivery resumes from, never that the wake happened.
-            lifecycle?.agents.set(payload.agentId, {
-              ...agent,
-              claimedAt: event.timestamp,
-            });
-          } else {
-            lifecycle?.agents.set(payload.agentId, {
-              ...agent,
-              notifiedAt: event.timestamp,
-            });
-          }
+        // 'delivering' rows from earlier iterations are not completions and
+        // are ignored: interrupted deliveries are resumed through the keyed
+        // outbox (see deliverWakeWithOutbox), not the event log.
+        if (agent !== undefined && payload.outcome !== 'delivering') {
+          lifecycle?.agents.set(payload.agentId, {
+            ...agent,
+            notifiedAt: event.timestamp,
+          });
         }
         break;
       }
@@ -318,9 +310,101 @@ const WAKE_FOLLOW_UP_MAX_DELAY_MS = 60_000;
 
 let wakeFollowUpDelayMs = WAKE_FOLLOW_UP_MIN_DELAY_MS;
 
+// ── Keyed wake outbox ────────────────────────────────────────────────────────
+//
+// The durable delivery receipt for one (lifecycleId, agentId) wake. Unlike a
+// claim flag in the event log, the entry is lifecycle-keyed, carries the
+// intended message and the delivery state/outcome, and is updated by the
+// delivery wrapper itself on every path — so every acknowledged send has a
+// receipt, recovery resumes only unacknowledged entries, and no cross-
+// lifecycle content or timestamp matching is involved. Writes are temp-file +
+// rename (atomic on POSIX) and all I/O is async (NFR-1).
+
+export interface LinearMcpWakeOutboxEntry {
+  lifecycleId: string;
+  agentId: string;
+  message: string;
+  state: 'pending' | 'acknowledged';
+  outcome?: LinearMcpAuthNotificationOutcome;
+  createdAt: string;
+  acknowledgedAt?: string;
+}
+
+function wakeOutboxPath(agentId: string, lifecycleId: string): string {
+  return join(getAgentDir(agentId), 'linear-mcp-wake', `${lifecycleId}.json`);
+}
+
+async function readWakeOutbox(agentId: string, lifecycleId: string): Promise<LinearMcpWakeOutboxEntry | null> {
+  try {
+    const raw = await readFile(wakeOutboxPath(agentId, lifecycleId), 'utf-8');
+    return JSON.parse(raw) as LinearMcpWakeOutboxEntry;
+  } catch {
+    return null;
+  }
+}
+
+async function writeWakeOutbox(entry: LinearMcpWakeOutboxEntry): Promise<void> {
+  const path = wakeOutboxPath(entry.agentId, entry.lifecycleId);
+  await mkdir(join(getAgentDir(entry.agentId), 'linear-mcp-wake'), { recursive: true });
+  const tmpPath = `${path}.${process.pid}.tmp`;
+  await writeFile(tmpPath, JSON.stringify(entry, null, 2), 'utf-8');
+  await rename(tmpPath, path);
+}
+
+interface WakeDelivery {
+  /** True when this call actually invoked the delivery door. */
+  sent: boolean;
+  outcome: LinearMcpAuthNotificationOutcome;
+}
+
 /**
- * Record the completion of a delivery attempt. Kept tiny so both the normal
- * send path and the mail-reconciled recovery path share it.
+ * Deliver one lifecycle's wake through the keyed outbox. An acknowledged
+ * entry suppresses the replay and replays only its recorded outcome — a
+ * crash after the ack write never produces a second send, and the recorded
+ * outcome stays faithful ('queued' is never upgraded to 'delivered'). A
+ * pending or missing entry is (re)driven: a crash before the ack write
+ * replays the send, which is correct because that send was never
+ * acknowledged.
+ */
+async function deliverWakeWithOutbox(agentId: string, lifecycleId: string): Promise<WakeDelivery> {
+  const existing = await readWakeOutbox(agentId, lifecycleId);
+  if (existing?.state === 'acknowledged' && existing.outcome !== undefined) {
+    return { sent: false, outcome: existing.outcome };
+  }
+  if (existing === null) {
+    await writeWakeOutbox({
+      lifecycleId,
+      agentId,
+      message: LINEAR_MCP_AUTH_WAKE_COPY,
+      state: 'pending',
+      createdAt: new Date().toISOString(),
+    });
+  }
+
+  let outcome: LinearMcpAuthNotificationOutcome;
+  try {
+    outcome = await messageAgentWithOutcome(agentId, LINEAR_MCP_AUTH_WAKE_COPY, 'linear-mcp-auth-wake');
+  } catch {
+    outcome = 'failed';
+  }
+  await writeWakeOutbox({
+    lifecycleId,
+    agentId,
+    message: LINEAR_MCP_AUTH_WAKE_COPY,
+    state: 'acknowledged',
+    outcome,
+    createdAt: existing?.createdAt ?? new Date().toISOString(),
+    acknowledgedAt: new Date().toISOString(),
+  });
+  return { sent: true, outcome };
+}
+
+/**
+ * Record the completion of a delivery attempt in the lifecycle event log —
+ * this, not the outbox receipt, is what removes the agent from the wake set.
+ * If the append fails, the agent stays in the wake set but the acknowledged
+ * outbox entry suppresses any replay: the next pass only retries this
+ * completion record.
  */
 async function recordWakeCompletion(
   blockedAgent: LinearMcpAuthBlockedAgent,
@@ -335,9 +419,6 @@ async function recordWakeCompletion(
       lifecycleId,
     });
   } catch (completionError) {
-    // The claim already bounds replay; a lost completion record leaves the
-    // agent in the wake set with a claim, and the next pass reconciles
-    // against the mail outbox instead of re-sending.
     console.error(`[linear-mcp-auth] failed to record wake outcome for ${blockedAgent.agentId}:`, completionError);
   }
 }
@@ -358,61 +439,22 @@ export function processLinearMcpAuthWake(): Promise<void> {
         break;
       }
       for (const blockedAgent of wakeSet.agents) {
-        if (blockedAgent.claimedAt !== null && blockedAgent.claimedAt !== undefined) {
-          // Resume an interrupted claim. Every non-throwing path through
-          // messageAgentWithOutcome backs the message up to the agent's
-          // durable mail queue, so mail containing the wake copy at or after
-          // the claim timestamp proves the acknowledged send reached the
-          // outbox — complete the ledger WITHOUT re-sending. Mail absent
-          // means the send never durably happened, so fall through and send.
-          const alreadyDelivered = agentHasMailContentSince(
-            blockedAgent.agentId,
-            LINEAR_MCP_AUTH_WAKE_COPY,
-            blockedAgent.claimedAt,
-          );
-          if (alreadyDelivered) {
-            await recordWakeCompletion(blockedAgent, wakeSet.lifecycleId, 'delivered');
-            continue;
-          }
-        } else {
-          // Durable claim BEFORE delivery: the (lifecycleId, agentId) claim
-          // marks the deterministic delivery key an interrupted attempt
-          // resumes from. It is NOT terminal — the agent stays in the wake
-          // set until a completion lands — so a crash after the claim still
-          // produces exactly one eventual delivery, never zero and never two.
-          try {
-            await appendLinearMcpAuthNotifiedEvent({
-              agentId: blockedAgent.agentId,
-              issueId: blockedAgent.issueId,
-              outcome: 'delivering',
-              lifecycleId: wakeSet.lifecycleId,
-            });
-          } catch (claimError) {
-            // Without the durable claim, an interrupted attempt cannot be
-            // reconciled — skip this agent rather than risk a duplicate wake.
-            console.error(`[linear-mcp-auth] failed to record wake claim for ${blockedAgent.agentId}; skipping delivery this pass:`, claimError);
-            continue;
-          }
-        }
-
-        let outcome: LinearMcpAuthNotificationOutcome;
         try {
-          outcome = await messageAgentWithOutcome(
-            blockedAgent.agentId,
-            LINEAR_MCP_AUTH_WAKE_COPY,
-            'linear-mcp-auth-wake',
-          );
-        } catch {
-          outcome = 'failed';
+          const delivery = await deliverWakeWithOutbox(blockedAgent.agentId, wakeSet.lifecycleId);
+          await recordWakeCompletion(blockedAgent, wakeSet.lifecycleId, delivery.outcome);
+        } catch (deliveryError) {
+          // The outbox itself is unreadable/unwritable — without a durable
+          // receipt an interrupted attempt cannot be reconciled, so skip this
+          // agent rather than risk an unreconciled replay.
+          console.error(`[linear-mcp-auth] wake outbox failure for ${blockedAgent.agentId}; skipping this pass:`, deliveryError);
         }
-        await recordWakeCompletion(blockedAgent, wakeSet.lifecycleId, outcome);
       }
     }
     if (!stabilized) {
       // Every healthy trigger that arrived during this run received the same
       // coalesced promise, so no external retry is guaranteed. Schedule one
-      // ourselves with bounded exponential backoff — a persistent EventStore
-      // failure must not turn into a hot retry/log loop.
+      // ourselves with bounded exponential backoff — a persistent outbox or
+      // EventStore failure must not turn into a hot retry/log loop.
       console.error(`[linear-mcp-auth] wake pass did not stabilize after ${MAX_WAKE_PASSES} passes — scheduling a follow-up run in ${wakeFollowUpDelayMs}ms`);
       const timer = setTimeout(() => { void processLinearMcpAuthWake(); }, wakeFollowUpDelayMs);
       timer.unref();

--- a/src/lib/linear-mcp-auth.ts
+++ b/src/lib/linear-mcp-auth.ts
@@ -1,0 +1,229 @@
+import type { DomainEvent } from '@overdeck/contracts';
+import {
+  initEventStore,
+  type StoredEvent,
+} from '../dashboard/server/event-store.js';
+
+export const LINEAR_MCP_AUTH_URL_TTL_MS = 30 * 60 * 1000;
+
+export type LinearMcpAuthStatus = 'none' | 'active' | 'expired';
+export type LinearMcpAuthNotificationOutcome = 'delivered' | 'queued' | 'failed';
+
+export interface LinearMcpAuthBlockedAgent {
+  agentId: string;
+  issueId: string | null;
+  declaredAt: string;
+  expiresAt: string;
+  notifiedAt: string | null;
+}
+
+export interface LinearMcpAuthIntervention {
+  status: LinearMcpAuthStatus;
+  authUrl: string | null;
+  authUrlAgentId: string | null;
+  authUrlExpiresAt: string | null;
+  declaredAt: string | null;
+  blockedAgents: LinearMcpAuthBlockedAgent[];
+}
+
+interface LinearMcpAuthLifecycle {
+  declaredAt: string;
+  authUrl: string | null;
+  authUrlAgentId: string | null;
+  authUrlExpiresAt: string | null;
+  agents: Map<string, LinearMcpAuthBlockedAgent>;
+}
+
+interface LinearMcpAuthFold {
+  open: LinearMcpAuthLifecycle | null;
+  lastCompleted: LinearMcpAuthLifecycle | null;
+}
+
+export interface RequiredPayload {
+  agentId: string;
+  issueId: string | null;
+  authUrl: string | null;
+  expiresAt: string | null;
+}
+
+export interface HealthyPayload {
+  agentId: string;
+  issueId: string | null;
+  source: 'hook' | 'operator';
+}
+
+export interface NotifiedPayload {
+  agentId: string;
+  issueId: string | null;
+  outcome: LinearMcpAuthNotificationOutcome;
+}
+
+export interface CallbackRelayedPayload {
+  agentId: string;
+  issueId: string | null;
+}
+
+export type LinearMcpAuthEventInput =
+  | { type: 'linear_mcp_auth.required'; timestamp?: string; payload: RequiredPayload }
+  | { type: 'linear_mcp_auth.healthy'; timestamp?: string; payload: HealthyPayload }
+  | { type: 'linear_mcp_auth.notified'; timestamp?: string; payload: NotifiedPayload }
+  | { type: 'linear_mcp_auth.callback_relayed'; timestamp?: string; payload: CallbackRelayedPayload };
+
+const LINEAR_MCP_AUTH_EVENT_TYPES = [
+  'linear_mcp_auth.required',
+  'linear_mcp_auth.healthy',
+  'linear_mcp_auth.notified',
+  'linear_mcp_auth.callback_relayed',
+] as const;
+
+function defaultExpiresAt(declaredAt: string): string {
+  return new Date(Date.parse(declaredAt) + LINEAR_MCP_AUTH_URL_TTL_MS).toISOString();
+}
+
+function foldLinearMcpAuthEvents(events: StoredEvent[]): LinearMcpAuthFold {
+  let open: LinearMcpAuthLifecycle | null = null;
+  let lastCompleted: LinearMcpAuthLifecycle | null = null;
+
+  for (const event of events) {
+    switch (event.type) {
+      case 'linear_mcp_auth.required': {
+        const payload = event.payload as RequiredPayload;
+        open ??= {
+          declaredAt: event.timestamp,
+          authUrl: null,
+          authUrlAgentId: null,
+          authUrlExpiresAt: null,
+          agents: new Map(),
+        };
+        const expiresAt = payload.expiresAt ?? defaultExpiresAt(event.timestamp);
+        open.agents.set(payload.agentId, {
+          agentId: payload.agentId,
+          issueId: payload.issueId,
+          declaredAt: event.timestamp,
+          expiresAt,
+          notifiedAt: null,
+        });
+        if (payload.authUrl !== null) {
+          open.authUrl = payload.authUrl;
+          open.authUrlAgentId = payload.agentId;
+          open.authUrlExpiresAt = expiresAt;
+        }
+        break;
+      }
+      case 'linear_mcp_auth.healthy':
+        if (open !== null) {
+          lastCompleted = open;
+          open = null;
+        }
+        break;
+      case 'linear_mcp_auth.notified': {
+        const payload = event.payload as NotifiedPayload;
+        const lifecycle = open ?? lastCompleted;
+        const agent = lifecycle?.agents.get(payload.agentId);
+        if (agent !== undefined) {
+          lifecycle?.agents.set(payload.agentId, {
+            ...agent,
+            notifiedAt: event.timestamp,
+          });
+        }
+        break;
+      }
+      case 'linear_mcp_auth.callback_relayed':
+        break;
+    }
+  }
+
+  return { open, lastCompleted };
+}
+
+async function readLinearMcpAuthFold(): Promise<LinearMcpAuthFold> {
+  const store = await initEventStore();
+  const events = LINEAR_MCP_AUTH_EVENT_TYPES
+    .flatMap(type => store.queryByType(type))
+    .sort((a, b) => a.sequence - b.sequence);
+  return foldLinearMcpAuthEvents(events);
+}
+
+function projectLifecycle(
+  lifecycle: LinearMcpAuthLifecycle | null,
+  nowIso: string,
+): LinearMcpAuthIntervention {
+  if (lifecycle === null) {
+    return {
+      status: 'none',
+      authUrl: null,
+      authUrlAgentId: null,
+      authUrlExpiresAt: null,
+      declaredAt: null,
+      blockedAgents: [],
+    };
+  }
+
+  const status = lifecycle.authUrlExpiresAt !== null
+    && lifecycle.authUrlExpiresAt < nowIso
+    ? 'expired'
+    : 'active';
+
+  return {
+    status,
+    authUrl: lifecycle.authUrl,
+    authUrlAgentId: lifecycle.authUrlAgentId,
+    authUrlExpiresAt: lifecycle.authUrlExpiresAt,
+    declaredAt: lifecycle.declaredAt,
+    blockedAgents: [...lifecycle.agents.values()],
+  };
+}
+
+export function linearMcpAuthEvent(input: LinearMcpAuthEventInput): Omit<DomainEvent, 'sequence'> {
+  return {
+    type: input.type,
+    timestamp: input.timestamp ?? new Date().toISOString(),
+    payload: input.payload,
+  } as Omit<DomainEvent, 'sequence'>;
+}
+
+export async function appendLinearMcpAuthEvent(input: LinearMcpAuthEventInput): Promise<number> {
+  const store = await initEventStore();
+  return store.appendAsync(linearMcpAuthEvent(input));
+}
+
+export function appendLinearMcpAuthRequiredEvent(
+  payload: RequiredPayload,
+  timestamp?: string,
+): Promise<number> {
+  return appendLinearMcpAuthEvent({ type: 'linear_mcp_auth.required', payload, timestamp });
+}
+
+export function appendLinearMcpAuthHealthyEvent(
+  payload: HealthyPayload,
+  timestamp?: string,
+): Promise<number> {
+  return appendLinearMcpAuthEvent({ type: 'linear_mcp_auth.healthy', payload, timestamp });
+}
+
+export function appendLinearMcpAuthNotifiedEvent(
+  payload: NotifiedPayload,
+  timestamp?: string,
+): Promise<number> {
+  return appendLinearMcpAuthEvent({ type: 'linear_mcp_auth.notified', payload, timestamp });
+}
+
+export function appendLinearMcpAuthCallbackRelayedEvent(
+  payload: CallbackRelayedPayload,
+  timestamp?: string,
+): Promise<number> {
+  return appendLinearMcpAuthEvent({ type: 'linear_mcp_auth.callback_relayed', payload, timestamp });
+}
+
+export async function resolveLinearMcpAuthIntervention(
+  nowIso = new Date().toISOString(),
+): Promise<LinearMcpAuthIntervention> {
+  const { open } = await readLinearMcpAuthFold();
+  return projectLifecycle(open, nowIso);
+}
+
+export async function computeLinearMcpAuthWakeSet(): Promise<LinearMcpAuthBlockedAgent[]> {
+  const { lastCompleted } = await readLinearMcpAuthFold();
+  if (lastCompleted === null) return [];
+  return [...lastCompleted.agents.values()].filter(agent => agent.notifiedAt === null);
+}

--- a/src/lib/linear-mcp-auth.ts
+++ b/src/lib/linear-mcp-auth.ts
@@ -8,7 +8,7 @@ import {
 import { getAgentDir } from './agents/agent-state.js';
 import { AmbiguousKeyedDeliveryError } from './agents/delivery.js';
 import { messageAgentWithOutcome } from './agents/messaging.js';
-import { KeyedSubmitTargetDeadError } from './tmux-dedup.js';
+import { KeyedMarkerVerificationError, KeyedSubmitTargetDeadError } from './tmux-dedup.js';
 import { createPromiseCoalescer } from './cloister/in-flight-guard.js';
 
 export const LINEAR_MCP_AUTH_URL_TTL_MS = 30 * 60 * 1000;
@@ -411,7 +411,11 @@ async function deliverWakeWithOutbox(agentId: string, lifecycleId: string): Prom
     // non-terminal. Same handling: the entry stays pending so a later pass
     // re-drives the wake — by then messageAgent's zombie/stopped detection
     // resumes the agent and the keyed door of the new session delivers.
-    if (error instanceof AmbiguousKeyedDeliveryError || error instanceof KeyedSubmitTargetDeadError) {
+    //
+    // UNVERIFIED MARKERS (cycle 13): a safety-critical marker read failed
+    // mid-repair/rollback, so the marker state is unproven and the poison
+    // breadcrumb stays authoritative. Same handling: pending, retried later.
+    if (error instanceof AmbiguousKeyedDeliveryError || error instanceof KeyedSubmitTargetDeadError || error instanceof KeyedMarkerVerificationError) {
       throw error;
     }
     outcome = 'failed';

--- a/src/lib/linear-mcp-auth.ts
+++ b/src/lib/linear-mcp-auth.ts
@@ -383,7 +383,18 @@ async function deliverWakeWithOutbox(agentId: string, lifecycleId: string): Prom
 
   let outcome: LinearMcpAuthNotificationOutcome;
   try {
-    outcome = await messageAgentWithOutcome(agentId, LINEAR_MCP_AUTH_WAKE_COPY, 'linear-mcp-auth-wake');
+    // The key is threaded to the delivery door, where the crash-independent
+    // component (supervisor key set / tmux session option) deduplicates the
+    // side effect itself. A dashboard crash after a completed delivery can
+    // still replay THIS call (the outbox ack may not have landed), but the
+    // replayed delivery deduplicates at the door — the agent never sees the
+    // same keyed wake twice.
+    outcome = await messageAgentWithOutcome(
+      agentId,
+      LINEAR_MCP_AUTH_WAKE_COPY,
+      'linear-mcp-auth-wake',
+      { dedupKey: `linear-mcp-auth-wake:${lifecycleId}` },
+    );
   } catch {
     outcome = 'failed';
   }

--- a/src/lib/linear-mcp-auth.ts
+++ b/src/lib/linear-mcp-auth.ts
@@ -3,7 +3,7 @@ import {
   initEventStore,
   type StoredEvent,
 } from '../dashboard/server/event-store.js';
-import { messageAgentWithOutcome } from './agents/messaging.js';
+import { messageAgentWithOutcome, agentHasMailContentSince } from './agents/messaging.js';
 import { createPromiseCoalescer } from './cloister/in-flight-guard.js';
 
 export const LINEAR_MCP_AUTH_URL_TTL_MS = 30 * 60 * 1000;
@@ -19,7 +19,14 @@ export interface LinearMcpAuthBlockedAgent {
   issueId: string | null;
   declaredAt: string;
   expiresAt: string;
+  /** Set by a completion record (delivered/queued/failed). Terminal: the
+   * agent never re-enters the wake set for this lifecycle. */
   notifiedAt: string | null;
+  /** Set by a pre-delivery 'delivering' claim. NOT terminal: an agent with a
+   * claim but no completion stays in the wake set, and recovery reconciles
+   * the claim against the durable mail outbox before deciding whether the
+   * send must be replayed. */
+  claimedAt?: string | null;
   /** Projection-only enrichment attached by the GET route from the issues
    * resolver; never persisted in lifecycle events. */
   issueUrl?: string | null;
@@ -148,10 +155,19 @@ function foldLinearMcpAuthEvents(
           : (open ?? lastCompleted);
         const agent = lifecycle?.agents.get(payload.agentId);
         if (agent !== undefined) {
-          lifecycle?.agents.set(payload.agentId, {
-            ...agent,
-            notifiedAt: event.timestamp,
-          });
+          if (payload.outcome === 'delivering') {
+            // A claim is not a completion: it marks where an interrupted
+            // delivery resumes from, never that the wake happened.
+            lifecycle?.agents.set(payload.agentId, {
+              ...agent,
+              claimedAt: event.timestamp,
+            });
+          } else {
+            lifecycle?.agents.set(payload.agentId, {
+              ...agent,
+              notifiedAt: event.timestamp,
+            });
+          }
         }
         break;
       }
@@ -172,6 +188,7 @@ let projectionCache: LinearMcpAuthProjectionCache | null = null;
 
 export function _resetLinearMcpAuthProjectionCacheForTests(): void {
   projectionCache = null;
+  wakeFollowUpDelayMs = WAKE_FOLLOW_UP_MIN_DELAY_MS;
 }
 
 /**
@@ -296,6 +313,34 @@ export async function computeLinearMcpAuthWakeSet(): Promise<LinearMcpAuthWakeSe
 }
 
 const MAX_WAKE_PASSES = 10;
+const WAKE_FOLLOW_UP_MIN_DELAY_MS = 1000;
+const WAKE_FOLLOW_UP_MAX_DELAY_MS = 60_000;
+
+let wakeFollowUpDelayMs = WAKE_FOLLOW_UP_MIN_DELAY_MS;
+
+/**
+ * Record the completion of a delivery attempt. Kept tiny so both the normal
+ * send path and the mail-reconciled recovery path share it.
+ */
+async function recordWakeCompletion(
+  blockedAgent: LinearMcpAuthBlockedAgent,
+  lifecycleId: string,
+  outcome: LinearMcpAuthNotificationOutcome,
+): Promise<void> {
+  try {
+    await appendLinearMcpAuthNotifiedEvent({
+      agentId: blockedAgent.agentId,
+      issueId: blockedAgent.issueId,
+      outcome,
+      lifecycleId,
+    });
+  } catch (completionError) {
+    // The claim already bounds replay; a lost completion record leaves the
+    // agent in the wake set with a claim, and the next pass reconciles
+    // against the mail outbox instead of re-sending.
+    console.error(`[linear-mcp-auth] failed to record wake outcome for ${blockedAgent.agentId}:`, completionError);
+  }
+}
 
 export function processLinearMcpAuthWake(): Promise<void> {
   return linearMcpAuthWakeCoalescer.run('global', async () => {
@@ -309,29 +354,45 @@ export function processLinearMcpAuthWake(): Promise<void> {
       const wakeSet = await computeLinearMcpAuthWakeSet();
       if (wakeSet === null || wakeSet.agents.length === 0) {
         stabilized = true;
+        wakeFollowUpDelayMs = WAKE_FOLLOW_UP_MIN_DELAY_MS;
         break;
       }
       for (const blockedAgent of wakeSet.agents) {
-        // Durable claim BEFORE delivery: the (lifecycleId, agentId) claim row
-        // is the deterministic delivery key that makes the wake
-        // crash-idempotent. A crash after the claim is visible to boot
-        // recovery (notifiedAt is set), so the delivery is never replayed; a
-        // crash before it delivers exactly once on the next pass. This is
-        // at-most-once by design — the residual lost-wake window self-heals
-        // when the still-blocked agent's next failed Linear call opens a
-        // fresh lifecycle.
-        try {
-          await appendLinearMcpAuthNotifiedEvent({
-            agentId: blockedAgent.agentId,
-            issueId: blockedAgent.issueId,
-            outcome: 'delivering',
-            lifecycleId: wakeSet.lifecycleId,
-          });
-        } catch (claimError) {
-          // Without the durable claim a crash could replay the delivery —
-          // skip this agent rather than risk a duplicate wake.
-          console.error(`[linear-mcp-auth] failed to record wake claim for ${blockedAgent.agentId}; skipping delivery this pass:`, claimError);
-          continue;
+        if (blockedAgent.claimedAt !== null && blockedAgent.claimedAt !== undefined) {
+          // Resume an interrupted claim. Every non-throwing path through
+          // messageAgentWithOutcome backs the message up to the agent's
+          // durable mail queue, so mail containing the wake copy at or after
+          // the claim timestamp proves the acknowledged send reached the
+          // outbox — complete the ledger WITHOUT re-sending. Mail absent
+          // means the send never durably happened, so fall through and send.
+          const alreadyDelivered = agentHasMailContentSince(
+            blockedAgent.agentId,
+            LINEAR_MCP_AUTH_WAKE_COPY,
+            blockedAgent.claimedAt,
+          );
+          if (alreadyDelivered) {
+            await recordWakeCompletion(blockedAgent, wakeSet.lifecycleId, 'delivered');
+            continue;
+          }
+        } else {
+          // Durable claim BEFORE delivery: the (lifecycleId, agentId) claim
+          // marks the deterministic delivery key an interrupted attempt
+          // resumes from. It is NOT terminal — the agent stays in the wake
+          // set until a completion lands — so a crash after the claim still
+          // produces exactly one eventual delivery, never zero and never two.
+          try {
+            await appendLinearMcpAuthNotifiedEvent({
+              agentId: blockedAgent.agentId,
+              issueId: blockedAgent.issueId,
+              outcome: 'delivering',
+              lifecycleId: wakeSet.lifecycleId,
+            });
+          } catch (claimError) {
+            // Without the durable claim, an interrupted attempt cannot be
+            // reconciled — skip this agent rather than risk a duplicate wake.
+            console.error(`[linear-mcp-auth] failed to record wake claim for ${blockedAgent.agentId}; skipping delivery this pass:`, claimError);
+            continue;
+          }
         }
 
         let outcome: LinearMcpAuthNotificationOutcome;
@@ -344,27 +405,18 @@ export function processLinearMcpAuthWake(): Promise<void> {
         } catch {
           outcome = 'failed';
         }
-        try {
-          await appendLinearMcpAuthNotifiedEvent({
-            agentId: blockedAgent.agentId,
-            issueId: blockedAgent.issueId,
-            outcome,
-            lifecycleId: wakeSet.lifecycleId,
-          });
-        } catch (completionError) {
-          // The claim already guarantees at-most-once; a lost completion
-          // record leaves the log showing 'delivering' for this agent.
-          console.error(`[linear-mcp-auth] failed to record wake outcome for ${blockedAgent.agentId}:`, completionError);
-        }
+        await recordWakeCompletion(blockedAgent, wakeSet.lifecycleId, outcome);
       }
     }
     if (!stabilized) {
-      console.error(`[linear-mcp-auth] wake pass did not stabilize after ${MAX_WAKE_PASSES} passes — scheduling a follow-up run`);
       // Every healthy trigger that arrived during this run received the same
       // coalesced promise, so no external retry is guaranteed. Schedule one
-      // ourselves, after the coalescer entry for this run clears.
-      const timer = setTimeout(() => { void processLinearMcpAuthWake(); }, 1000);
+      // ourselves with bounded exponential backoff — a persistent EventStore
+      // failure must not turn into a hot retry/log loop.
+      console.error(`[linear-mcp-auth] wake pass did not stabilize after ${MAX_WAKE_PASSES} passes — scheduling a follow-up run in ${wakeFollowUpDelayMs}ms`);
+      const timer = setTimeout(() => { void processLinearMcpAuthWake(); }, wakeFollowUpDelayMs);
       timer.unref();
+      wakeFollowUpDelayMs = Math.min(wakeFollowUpDelayMs * 2, WAKE_FOLLOW_UP_MAX_DELAY_MS);
     }
   });
 }

--- a/src/lib/remote/__tests__/remote-keyed-delivery.test.ts
+++ b/src/lib/remote/__tests__/remote-keyed-delivery.test.ts
@@ -1,18 +1,27 @@
-import { describe, expect, it } from 'vitest';
+import { Effect } from 'effect';
+import { describe, expect, it, vi } from 'vitest';
 
 import { sendToRemoteAgentKeyed } from '../remote-agents.js';
 import { dedupPendingOptionName, dedupTerminalOptionName } from '../../tmux-dedup.js';
 
 /**
  * Fake remote tmux server for the keyed remote-delivery protocol (PAN-2997
- * cycle 7). Implements just enough of the marker/paste semantics to prove the
+ * cycle 8). Implements just enough of the marker/paste semantics to prove the
  * command sequencing: option state per marker, a paste log, and an Enter log.
+ * The submit phase is the atomic if-shell (claim terminal + clear pending +
+ * Enter in one server-owned command list).
  */
-function createFakeRemoteTmux(seed: { pending?: string; terminal?: string; failPaste?: boolean } = {}) {
+function createFakeRemoteTmux(seed: {
+  pending?: string;
+  terminal?: string;
+  failPaste?: boolean;
+  failSubmit?: boolean;
+} = {}) {
   const state = {
     pending: seed.pending ?? '',
     terminal: seed.terminal ?? '',
     failPaste: seed.failPaste ?? false,
+    failSubmit: seed.failSubmit ?? false,
     pastes: 0,
     enters: 0,
     writes: [] as string[],
@@ -25,8 +34,10 @@ function createFakeRemoteTmux(seed: { pending?: string; terminal?: string; failP
       state.writes.push(command);
       return '';
     }
-    if (command.includes('if-shell')) {
-      if (!state.failPaste && state.pending === '' && state.terminal === '') {
+    if (command.includes('if-shell') && command.includes('paste-buffer')) {
+      // Phase 1: atomic check + paste + pending claim.
+      if (state.failPaste) throw new Error('exit 1: simulated paste failure');
+      if (state.pending === '' && state.terminal === '') {
         state.pastes += 1;
         // The onTrue command string ends with `set-option -t <agent> <pendingOption> <sendId>`.
         const sendId = command.trim().replace(/'/g, '').split(/\s+/).at(-1) ?? '';
@@ -34,21 +45,20 @@ function createFakeRemoteTmux(seed: { pending?: string; terminal?: string; failP
       }
       return '';
     }
+    if (command.includes('if-shell') && command.includes('send-keys')) {
+      // Phase 2: atomic submit — claim terminal, clear pending, then Enter.
+      if (state.failSubmit) throw new Error('exit 1: simulated submit failure');
+      if (state.pending !== '' && state.terminal === '') {
+        state.terminal = '1';
+        state.pending = '';
+        state.enters += 1;
+      }
+      return '';
+    }
     if (command.includes('show-option')) {
       const option = command.trim().split(/\s+/).at(-1)?.replace(/'/g, '') ?? '';
       if (option.includes('-pending-')) return `${state.pending}\n`;
       return `${state.terminal}\n`;
-    }
-    if (command.includes('send-keys')) {
-      state.enters += 1;
-      return '';
-    }
-    if (command.includes('set-option')) {
-      // The finalize step sets the terminal marker and unsets pending in one
-      // command; both option names appear in the string.
-      if (command.includes(dedupTerminalOptionName(KEY))) state.terminal = '1';
-      if (command.includes(`'-u'`) && command.includes(dedupPendingOptionName(KEY))) state.pending = '';
-      return '';
     }
     return '';
   };
@@ -61,7 +71,7 @@ const VM = 'vm-test-1';
 const KEY = 'linear-mcp-auth-wake:lifecycle-1';
 
 describe('sendToRemoteAgentKeyed', () => {
-  it('pastes once, submits, and flips the key terminal on a fresh delivery', async () => {
+  it('pastes once, submits atomically, and flips the key terminal on a fresh delivery', async () => {
     const { exec, state } = createFakeRemoteTmux();
 
     const outcome = await sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec);
@@ -77,7 +87,7 @@ describe('sendToRemoteAgentKeyed', () => {
 
   it('completes a crashed attempt from the pending marker WITHOUT a second paste', async () => {
     // A prior attempt pasted and set its pending claim, then the dashboard died
-    // before the Enter.
+    // before the submit.
     const { exec, state } = createFakeRemoteTmux({ pending: 'earlier-send-id' });
 
     const outcome = await sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec);
@@ -87,6 +97,22 @@ describe('sendToRemoteAgentKeyed', () => {
     expect(state.enters).toBe(1);
     expect(state.terminal).toBe('1');
     expect(state.pending).toBe('');
+  });
+
+  it('admits exactly one completer when the submit races (cycle 8)', async () => {
+    // Both a prior paste claim and a racing completer hit the atomic submit:
+    // the first claims terminal; the second loses the server-side condition.
+    const { exec, state } = createFakeRemoteTmux({ pending: 'earlier-send-id' });
+
+    const [first, second] = await Promise.all([
+      sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec),
+      sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec),
+    ]);
+
+    expect(first).toBe('delivered');
+    expect(second).toBe('delivered');
+    expect(state.pastes).toBe(0);
+    expect(state.enters).toBe(1);
   });
 
   it('suppresses the replay entirely once the key is terminal', async () => {
@@ -103,7 +129,16 @@ describe('sendToRemoteAgentKeyed', () => {
     const { exec } = createFakeRemoteTmux({ failPaste: true });
 
     await expect(sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec))
-      .rejects.toThrow(/did not land/);
+      .rejects.toThrow(/simulated paste failure/);
+  });
+
+  it('a FAILED Enter-submit can never return delivered or create a terminal marker (cycle 8)', async () => {
+    const { exec, state } = createFakeRemoteTmux({ failSubmit: true });
+
+    await expect(sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec))
+      .rejects.toThrow(/simulated submit failure/);
+    expect(state.enters).toBe(0);
+    expect(state.terminal).toBe('');
   });
 
   it('rejects keys that are unsafe for tmux option names', async () => {
@@ -111,5 +146,28 @@ describe('sendToRemoteAgentKeyed', () => {
 
     await expect(sendToRemoteAgentKeyed(AGENT, VM, 'wake', 'bad key with spaces', exec))
       .rejects.toThrow(/dedupKey/);
+  });
+});
+
+describe('sendToRemoteAgentKeyed production adapter (cycle 8)', () => {
+  it('throws on any non-zero SSH exit instead of acknowledging the command', async () => {
+    vi.resetModules();
+    vi.doMock('../fly-provider.js', () => ({
+      createFlyProvider: () => ({
+        ssh: (_vm: string, command: string) => {
+          // The tmux-context bootstrap succeeds; the first protocol command fails.
+          if (command.includes('overdeck.tmux.conf')) {
+            return Effect.succeed({ stdout: '', stderr: '', exitCode: 0 });
+          }
+          return Effect.succeed({ stdout: '', stderr: 'simulated remote failure', exitCode: 1 });
+        },
+      }),
+    }));
+    const { sendToRemoteAgentKeyed: keyedWithRealAdapter } = await import('../remote-agents.js');
+
+    await expect(keyedWithRealAdapter(AGENT, VM, 'wake up remote', KEY))
+      .rejects.toThrow(/exit 1.*simulated remote failure/);
+    vi.doUnmock('../fly-provider.js');
+    vi.resetModules();
   });
 });

--- a/src/lib/remote/__tests__/remote-keyed-delivery.test.ts
+++ b/src/lib/remote/__tests__/remote-keyed-delivery.test.ts
@@ -20,6 +20,8 @@ function createFakeRemoteTmux(seed: {
   failSubmit?: boolean;
   failMarkerSetOption?: boolean;
   failNextTargetRead?: boolean;
+  failNextPoisonRead?: boolean;
+  failPoisonClear?: boolean;
   paneDead?: boolean;
   dieOnEnter?: boolean;
 } = {}) {
@@ -31,6 +33,8 @@ function createFakeRemoteTmux(seed: {
     failSubmit: seed.failSubmit ?? false,
     failMarkerSetOption: seed.failMarkerSetOption ?? false,
     failNextTargetRead: seed.failNextTargetRead ?? false,
+    failNextPoisonRead: seed.failNextPoisonRead ?? false,
+    failPoisonClear: seed.failPoisonClear ?? false,
     paneDead: seed.paneDead ?? false,
     dieOnEnter: seed.dieOnEnter ?? false,
     pid: '4242',
@@ -58,10 +62,12 @@ function createFakeRemoteTmux(seed: {
       return '';
     }
     if (command.includes('if-shell') && command.includes('send-keys')) {
-      // Phase 2: atomic submit — liveness gate, Enter, then terminal claim.
+      // Phase 2: atomic submit — liveness gate, Enter, then PROVISIONAL
+      // poison + terminal claim in the same server-owned list.
       if (state.failSubmit) throw new Error('exit 1: simulated submit failure');
       if (state.pending !== '' && state.terminal === '' && !state.paneDead) {
         state.enters += 1;
+        state.poison = '1';
         state.terminal = '1';
         state.pending = '';
         // The pane dies in the shell-to-branch handoff window: send-keys
@@ -72,7 +78,13 @@ function createFakeRemoteTmux(seed: {
     }
     if (command.includes('show-option')) {
       const option = command.trim().split(/\s+/).at(-1)?.replace(/'/g, '') ?? '';
-      if (option.includes('-poison-')) return `${state.poison}\n`;
+      if (option.includes('-poison-')) {
+        if (state.failNextPoisonRead) {
+          state.failNextPoisonRead = false;
+          throw new Error('exit 1: simulated transient poison-read failure');
+        }
+        return `${state.poison}\n`;
+      }
       if (option.includes('-pending-')) return `${state.pending}\n`;
       return `${state.terminal}\n`;
     }
@@ -84,9 +96,12 @@ function createFakeRemoteTmux(seed: {
       return `${state.pid} ${state.paneDead ? '1' : '0'}\n`;
     }
     if (command.includes('set-option')) {
-      // Direct marker mutations (rollback, poison, repair): each subcommand
-      // is quoted as `';'`-separated argv.
+      // Direct marker mutations (rollback, poison clear, repair): each
+      // subcommand is quoted as `';'`-separated argv.
       for (const sub of command.split(`';'`)) {
+        if (sub.includes(dedupPoisonOptionName(KEY)) && sub.includes(`'-u'`) && state.failPoisonClear) {
+          throw new Error('exit 1: simulated poison-clear failure');
+        }
         const touchesMarker =
           sub.includes(dedupTerminalOptionName(KEY)) || sub.includes(dedupPendingOptionName(KEY));
         if (state.failMarkerSetOption && touchesMarker) {
@@ -125,6 +140,8 @@ describe('sendToRemoteAgentKeyed', () => {
     expect(state.enters).toBe(1);
     expect(state.terminal).toBe('1');
     expect(state.pending).toBe('');
+    // Verified delivery lifted the provisional breadcrumb.
+    expect(state.poison).toBe('');
     // The message travels base64-encoded in the prompt-file write.
     expect(state.writes[0]).toContain(Buffer.from('wake up remote').toString('base64'));
   });
@@ -213,9 +230,12 @@ describe('sendToRemoteAgentKeyed', () => {
 
     await expect(sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec))
       .rejects.toThrow(KeyedSubmitTargetDeadError);
-    // The terminal marker was rolled back and the pending claim restored.
+    // The terminal marker was rolled back and the pending claim restored —
+    // the key was NOT claimed even though send-keys reported success, and the
+    // verified rollback lifted the breadcrumb.
     expect(state.terminal).toBe('');
     expect(state.pending).toBe('earlier-send-id');
+    expect(state.poison).toBe('');
 
     // Recovery after the pane is alive again: real submission, never a false dedup.
     state.paneDead = false;
@@ -280,6 +300,54 @@ describe('sendToRemoteAgentKeyed', () => {
     const outcome = await sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec);
     expect(outcome).toBe('delivered');
     expect(state.terminal).toBe('1');
+  });
+
+  it('a PROVISIONAL terminal (crash before post-submit verification) is repaired, never honored as a dedup (cycle 12)', async () => {
+    // The server-owned submit set poison+terminal and the dashboard died
+    // before any post-submit read. The breadcrumb forces repair-first
+    // handling: roll back to pending and re-drive — NEVER 'deduplicated'
+    // from the provisional marker.
+    const { exec, state } = createFakeRemoteTmux({ terminal: '1', poison: '1' });
+
+    const outcome = await sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec);
+
+    expect(outcome).toBe('delivered');
+    expect(state.pastes).toBe(0); // repair continues as a completion, not a fresh paste
+    expect(state.terminal).toBe('1');
+    expect(state.poison).toBe('');
+  });
+
+  it('a FAILED poison read aborts without honoring the terminal marker (cycle 12)', async () => {
+    // A false terminal and its breadcrumb both exist; the poison read fails
+    // transiently. Fail-closed: the call must abort, never interpret the
+    // failed read as "no poison", and never return 'deduplicated'.
+    const { exec, state } = createFakeRemoteTmux({ terminal: '1', poison: '1', failNextPoisonRead: true });
+
+    await expect(sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec))
+      .rejects.toThrow(/transient poison-read failure/);
+    expect(state.terminal).toBe('1'); // untouched — nothing honored or repaired
+    expect(state.poison).toBe('1');
+    expect(state.pastes).toBe(0);
+    expect(state.enters).toBe(0);
+  });
+
+  it('a FAILED poison clear after verified delivery is loud — no success with a stale breadcrumb (cycle 12)', async () => {
+    const { exec, state } = createFakeRemoteTmux({ pending: 'earlier-send-id', failPoisonClear: true });
+
+    await expect(sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec))
+      .rejects.toThrow(/poison/i);
+    // The submission happened and is terminal, but success was NOT reported
+    // while the breadcrumb survived.
+    expect(state.terminal).toBe('1');
+    expect(state.poison).toBe('1');
+
+    // Recovery: the breadcrumb forces repair-first handling, the clear works
+    // now, and the delivery completes with the breadcrumb verifiably gone.
+    state.failPoisonClear = false;
+    const outcome = await sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec);
+    expect(outcome).toBe('delivered');
+    expect(state.terminal).toBe('1');
+    expect(state.poison).toBe('');
   });
 
   it('rejects keys that are unsafe for tmux option names', async () => {

--- a/src/lib/remote/__tests__/remote-keyed-delivery.test.ts
+++ b/src/lib/remote/__tests__/remote-keyed-delivery.test.ts
@@ -2,28 +2,35 @@ import { Effect } from 'effect';
 import { describe, expect, it, vi } from 'vitest';
 
 import { sendToRemoteAgentKeyed } from '../remote-agents.js';
-import { dedupPendingOptionName, dedupTerminalOptionName, KeyedSubmitTargetDeadError } from '../../tmux-dedup.js';
+import { dedupPendingOptionName, dedupPoisonOptionName, dedupTerminalOptionName, KeyedSubmitTargetDeadError } from '../../tmux-dedup.js';
 
 /**
  * Fake remote tmux server for the keyed remote-delivery protocol (PAN-2997
- * cycle 9). Implements just enough of the marker/paste/liveness semantics to
- * prove the command sequencing: option state per marker, pane liveness, a
- * paste log, and an Enter log. The submit phase is the atomic if-shell
- * (liveness check, Enter, then terminal claim — in one server-owned list).
+ * cycle 11). Implements just enough of the marker/paste/liveness semantics to
+ * prove the command sequencing: option state per marker (pending, terminal,
+ * poison breadcrumb), pane liveness, a paste log, and an Enter log. The
+ * submit phase is the atomic if-shell (liveness gate, Enter, then terminal
+ * claim — in one server-owned list) plus the verified rollback.
  */
 function createFakeRemoteTmux(seed: {
   pending?: string;
   terminal?: string;
+  poison?: string;
   failPaste?: boolean;
   failSubmit?: boolean;
+  failMarkerSetOption?: boolean;
+  failNextTargetRead?: boolean;
   paneDead?: boolean;
   dieOnEnter?: boolean;
 } = {}) {
   const state = {
     pending: seed.pending ?? '',
     terminal: seed.terminal ?? '',
+    poison: seed.poison ?? '',
     failPaste: seed.failPaste ?? false,
     failSubmit: seed.failSubmit ?? false,
+    failMarkerSetOption: seed.failMarkerSetOption ?? false,
+    failNextTargetRead: seed.failNextTargetRead ?? false,
     paneDead: seed.paneDead ?? false,
     dieOnEnter: seed.dieOnEnter ?? false,
     pid: '4242',
@@ -65,22 +72,34 @@ function createFakeRemoteTmux(seed: {
     }
     if (command.includes('show-option')) {
       const option = command.trim().split(/\s+/).at(-1)?.replace(/'/g, '') ?? '';
+      if (option.includes('-poison-')) return `${state.poison}\n`;
       if (option.includes('-pending-')) return `${state.pending}\n`;
       return `${state.terminal}\n`;
     }
     if (command.includes('display-message')) {
+      if (state.failNextTargetRead) {
+        state.failNextTargetRead = false;
+        throw new Error('exit 1: simulated transient target-read failure');
+      }
       return `${state.pid} ${state.paneDead ? '1' : '0'}\n`;
     }
     if (command.includes('set-option')) {
-      // Marker rollback: each subcommand is quoted as `';'`-separated argv.
+      // Direct marker mutations (rollback, poison, repair): each subcommand
+      // is quoted as `';'`-separated argv.
       for (const sub of command.split(`';'`)) {
-        if (sub.includes(dedupTerminalOptionName(KEY))) {
-          state.terminal = sub.includes(`'-u'`) ? '' : '1';
+        const touchesMarker =
+          sub.includes(dedupTerminalOptionName(KEY)) || sub.includes(dedupPendingOptionName(KEY));
+        if (state.failMarkerSetOption && touchesMarker) {
+          throw new Error('exit 1: simulated rollback failure');
         }
-        if (sub.includes(dedupPendingOptionName(KEY))) {
+        if (sub.includes(dedupPoisonOptionName(KEY))) {
+          state.poison = sub.includes(`'-u'`) ? '' : '1';
+        } else if (sub.includes(dedupPendingOptionName(KEY))) {
           state.pending = sub.includes(`'-u'`)
             ? ''
             : (sub.trim().replace(/'/g, '').split(/\s+/).at(-1) ?? '');
+        } else if (sub.includes(dedupTerminalOptionName(KEY))) {
+          state.terminal = sub.includes(`'-u'`) ? '' : '1';
         }
       }
       return '';
@@ -205,6 +224,61 @@ describe('sendToRemoteAgentKeyed', () => {
     expect(outcome).toBe('delivered');
     // Two Enters in total: the one lost to the dying pane, and the recovery's.
     expect(state.enters).toBe(2);
+    expect(state.terminal).toBe('1');
+  });
+
+  it('a FAILED rollback leaves a poison breadcrumb — recovery repairs the false terminal instead of honoring it (cycle 11)', async () => {
+    // The Enter sets TERMINAL, the pane dies in the handoff, the poison
+    // breadcrumb lands — and the rollback itself fails.
+    const { exec, state } = createFakeRemoteTmux({
+      pending: 'earlier-send-id',
+      dieOnEnter: true,
+      failMarkerSetOption: true,
+    });
+
+    await expect(sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec))
+      .rejects.toThrow(KeyedSubmitTargetDeadError);
+    // The false terminal marker survived the failed rollback, but the poison
+    // breadcrumb marks it as rollback-required.
+    expect(state.terminal).toBe('1');
+    expect(state.poison).toBe('1');
+    expect(state.pending).toBe('');
+
+    // Next attempt (transport healthy again): the breadcrumb forces a repair
+    // BEFORE anything is honored — never a 'deduplicated' from the false
+    // terminal, even though it is still sitting there.
+    state.failMarkerSetOption = false;
+    await expect(sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec))
+      .rejects.toThrow(KeyedSubmitTargetDeadError); // pane still dead
+    expect(state.terminal).toBe('');
+    expect(state.pending).not.toBe('');
+    expect(state.poison).toBe('');
+
+    // Recovery after the pane is alive again: real submission completes.
+    state.paneDead = false;
+    state.dieOnEnter = false;
+    const outcome = await sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec);
+    expect(outcome).toBe('delivered');
+    expect(state.terminal).toBe('1');
+  });
+
+  it('fails CLOSED when the pre-submit target is unreadable and a live pane appears (cycle 11)', async () => {
+    // The pre-submit target read fails transiently; the submit then "succeeds"
+    // against a pane whose identity cannot be proven — the Enter may have
+    // landed on a replacement with no pasted content.
+    const { exec, state } = createFakeRemoteTmux({ pending: 'earlier-send-id', failNextTargetRead: true });
+
+    await expect(sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec))
+      .rejects.toThrow(KeyedSubmitTargetDeadError);
+    // The terminal claim was rolled back and verified, so the breadcrumb is
+    // cleared and the pending claim restored.
+    expect(state.terminal).toBe('');
+    expect(state.pending).not.toBe('');
+    expect(state.poison).toBe('');
+
+    // Recovery re-drives the delivery and claims the key for real.
+    const outcome = await sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec);
+    expect(outcome).toBe('delivered');
     expect(state.terminal).toBe('1');
   });
 

--- a/src/lib/remote/__tests__/remote-keyed-delivery.test.ts
+++ b/src/lib/remote/__tests__/remote-keyed-delivery.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import { sendToRemoteAgentKeyed } from '../remote-agents.js';
+import { dedupPendingOptionName, dedupTerminalOptionName } from '../../tmux-dedup.js';
+
+/**
+ * Fake remote tmux server for the keyed remote-delivery protocol (PAN-2997
+ * cycle 7). Implements just enough of the marker/paste semantics to prove the
+ * command sequencing: option state per marker, a paste log, and an Enter log.
+ */
+function createFakeRemoteTmux(seed: { pending?: string; terminal?: string; failPaste?: boolean } = {}) {
+  const state = {
+    pending: seed.pending ?? '',
+    terminal: seed.terminal ?? '',
+    failPaste: seed.failPaste ?? false,
+    pastes: 0,
+    enters: 0,
+    writes: [] as string[],
+    commands: [] as string[],
+  };
+
+  const exec = async (command: string): Promise<string> => {
+    state.commands.push(command);
+    if (command.includes('base64 -d >')) {
+      state.writes.push(command);
+      return '';
+    }
+    if (command.includes('if-shell')) {
+      if (!state.failPaste && state.pending === '' && state.terminal === '') {
+        state.pastes += 1;
+        // The onTrue command string ends with `set-option -t <agent> <pendingOption> <sendId>`.
+        const sendId = command.trim().replace(/'/g, '').split(/\s+/).at(-1) ?? '';
+        state.pending = sendId;
+      }
+      return '';
+    }
+    if (command.includes('show-option')) {
+      const option = command.trim().split(/\s+/).at(-1)?.replace(/'/g, '') ?? '';
+      if (option.includes('-pending-')) return `${state.pending}\n`;
+      return `${state.terminal}\n`;
+    }
+    if (command.includes('send-keys')) {
+      state.enters += 1;
+      return '';
+    }
+    if (command.includes('set-option')) {
+      // The finalize step sets the terminal marker and unsets pending in one
+      // command; both option names appear in the string.
+      if (command.includes(dedupTerminalOptionName(KEY))) state.terminal = '1';
+      if (command.includes(`'-u'`) && command.includes(dedupPendingOptionName(KEY))) state.pending = '';
+      return '';
+    }
+    return '';
+  };
+
+  return { exec, state };
+}
+
+const AGENT = 'agent-remote-1';
+const VM = 'vm-test-1';
+const KEY = 'linear-mcp-auth-wake:lifecycle-1';
+
+describe('sendToRemoteAgentKeyed', () => {
+  it('pastes once, submits, and flips the key terminal on a fresh delivery', async () => {
+    const { exec, state } = createFakeRemoteTmux();
+
+    const outcome = await sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec);
+
+    expect(outcome).toBe('delivered');
+    expect(state.pastes).toBe(1);
+    expect(state.enters).toBe(1);
+    expect(state.terminal).toBe('1');
+    expect(state.pending).toBe('');
+    // The message travels base64-encoded in the prompt-file write.
+    expect(state.writes[0]).toContain(Buffer.from('wake up remote').toString('base64'));
+  });
+
+  it('completes a crashed attempt from the pending marker WITHOUT a second paste', async () => {
+    // A prior attempt pasted and set its pending claim, then the dashboard died
+    // before the Enter.
+    const { exec, state } = createFakeRemoteTmux({ pending: 'earlier-send-id' });
+
+    const outcome = await sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec);
+
+    expect(outcome).toBe('delivered');
+    expect(state.pastes).toBe(0);
+    expect(state.enters).toBe(1);
+    expect(state.terminal).toBe('1');
+    expect(state.pending).toBe('');
+  });
+
+  it('suppresses the replay entirely once the key is terminal', async () => {
+    const { exec, state } = createFakeRemoteTmux({ terminal: '1' });
+
+    const outcome = await sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec);
+
+    expect(outcome).toBe('deduplicated');
+    expect(state.pastes).toBe(0);
+    expect(state.enters).toBe(0);
+  });
+
+  it('fails loudly when the paste did not land and no marker explains why', async () => {
+    const { exec } = createFakeRemoteTmux({ failPaste: true });
+
+    await expect(sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec))
+      .rejects.toThrow(/did not land/);
+  });
+
+  it('rejects keys that are unsafe for tmux option names', async () => {
+    const { exec } = createFakeRemoteTmux();
+
+    await expect(sendToRemoteAgentKeyed(AGENT, VM, 'wake', 'bad key with spaces', exec))
+      .rejects.toThrow(/dedupKey/);
+  });
+});

--- a/src/lib/remote/__tests__/remote-keyed-delivery.test.ts
+++ b/src/lib/remote/__tests__/remote-keyed-delivery.test.ts
@@ -402,14 +402,15 @@ describe('sendToRemoteAgentKeyed', () => {
     expect(state.poison).toBe('1');
   });
 
-  it('a FAILED poison read aborts without honoring the terminal marker (cycle 12)', async () => {
+  it('a FAILED poison read aborts as a RECOVERABLE marker error without honoring the terminal marker (cycle 12/15)', async () => {
     // A false terminal and its breadcrumb both exist; the poison read fails
-    // transiently. Fail-closed: the call must abort, never interpret the
-    // failed read as "no poison", and never return 'deduplicated'.
+    // transiently. Fail-closed AND recoverable: the call aborts as
+    // KeyedMarkerVerificationError (outbox stays pending), never interprets
+    // the failed read as "no poison", and never returns 'deduplicated'.
     const { exec, state } = createFakeRemoteTmux({ terminal: '1', poison: '1', failNextPoisonRead: true });
 
     await expect(sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec))
-      .rejects.toThrow(/transient poison-read failure/);
+      .rejects.toThrow(KeyedMarkerVerificationError);
     expect(state.terminal).toBe('1'); // untouched — nothing honored or repaired
     expect(state.poison).toBe('1');
     expect(state.pastes).toBe(0);

--- a/src/lib/remote/__tests__/remote-keyed-delivery.test.ts
+++ b/src/lib/remote/__tests__/remote-keyed-delivery.test.ts
@@ -17,6 +17,7 @@ function createFakeRemoteTmux(seed: {
   failPaste?: boolean;
   failSubmit?: boolean;
   paneDead?: boolean;
+  dieOnEnter?: boolean;
 } = {}) {
   const state = {
     pending: seed.pending ?? '',
@@ -24,6 +25,8 @@ function createFakeRemoteTmux(seed: {
     failPaste: seed.failPaste ?? false,
     failSubmit: seed.failSubmit ?? false,
     paneDead: seed.paneDead ?? false,
+    dieOnEnter: seed.dieOnEnter ?? false,
+    pid: '4242',
     pastes: 0,
     enters: 0,
     writes: [] as string[],
@@ -54,6 +57,9 @@ function createFakeRemoteTmux(seed: {
         state.enters += 1;
         state.terminal = '1';
         state.pending = '';
+        // The pane dies in the shell-to-branch handoff window: send-keys
+        // already "succeeded", the markers already flipped.
+        if (state.dieOnEnter) state.paneDead = true;
       }
       return '';
     }
@@ -63,7 +69,21 @@ function createFakeRemoteTmux(seed: {
       return `${state.terminal}\n`;
     }
     if (command.includes('display-message')) {
-      return `${state.paneDead ? '1' : '0'}\n`;
+      return `${state.pid} ${state.paneDead ? '1' : '0'}\n`;
+    }
+    if (command.includes('set-option')) {
+      // Marker rollback: each subcommand is quoted as `';'`-separated argv.
+      for (const sub of command.split(`';'`)) {
+        if (sub.includes(dedupTerminalOptionName(KEY))) {
+          state.terminal = sub.includes(`'-u'`) ? '' : '1';
+        }
+        if (sub.includes(dedupPendingOptionName(KEY))) {
+          state.pending = sub.includes(`'-u'`)
+            ? ''
+            : (sub.trim().replace(/'/g, '').split(/\s+/).at(-1) ?? '');
+        }
+      }
+      return '';
     }
     return '';
   };
@@ -163,6 +183,28 @@ describe('sendToRemoteAgentKeyed', () => {
     const outcome = await sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec);
     expect(outcome).toBe('delivered');
     expect(state.enters).toBe(1);
+    expect(state.terminal).toBe('1');
+  });
+
+  it('rolls the key back when the pane dies AROUND the Enter — send-keys "succeeded" but the harness is gone (cycle 10)', async () => {
+    // The if-shell condition sees a live pane, the Enter lands, the markers
+    // flip — and the pane dies in the same breath, inside the shell-to-branch
+    // handoff window. tmux reported success throughout.
+    const { exec, state } = createFakeRemoteTmux({ pending: 'earlier-send-id', dieOnEnter: true });
+
+    await expect(sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec))
+      .rejects.toThrow(KeyedSubmitTargetDeadError);
+    // The terminal marker was rolled back and the pending claim restored.
+    expect(state.terminal).toBe('');
+    expect(state.pending).toBe('earlier-send-id');
+
+    // Recovery after the pane is alive again: real submission, never a false dedup.
+    state.paneDead = false;
+    state.dieOnEnter = false;
+    const outcome = await sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec);
+    expect(outcome).toBe('delivered');
+    // Two Enters in total: the one lost to the dying pane, and the recovery's.
+    expect(state.enters).toBe(2);
     expect(state.terminal).toBe('1');
   });
 

--- a/src/lib/remote/__tests__/remote-keyed-delivery.test.ts
+++ b/src/lib/remote/__tests__/remote-keyed-delivery.test.ts
@@ -2,26 +2,28 @@ import { Effect } from 'effect';
 import { describe, expect, it, vi } from 'vitest';
 
 import { sendToRemoteAgentKeyed } from '../remote-agents.js';
-import { dedupPendingOptionName, dedupTerminalOptionName } from '../../tmux-dedup.js';
+import { dedupPendingOptionName, dedupTerminalOptionName, KeyedSubmitTargetDeadError } from '../../tmux-dedup.js';
 
 /**
  * Fake remote tmux server for the keyed remote-delivery protocol (PAN-2997
- * cycle 8). Implements just enough of the marker/paste semantics to prove the
- * command sequencing: option state per marker, a paste log, and an Enter log.
- * The submit phase is the atomic if-shell (claim terminal + clear pending +
- * Enter in one server-owned command list).
+ * cycle 9). Implements just enough of the marker/paste/liveness semantics to
+ * prove the command sequencing: option state per marker, pane liveness, a
+ * paste log, and an Enter log. The submit phase is the atomic if-shell
+ * (liveness check, Enter, then terminal claim — in one server-owned list).
  */
 function createFakeRemoteTmux(seed: {
   pending?: string;
   terminal?: string;
   failPaste?: boolean;
   failSubmit?: boolean;
+  paneDead?: boolean;
 } = {}) {
   const state = {
     pending: seed.pending ?? '',
     terminal: seed.terminal ?? '',
     failPaste: seed.failPaste ?? false,
     failSubmit: seed.failSubmit ?? false,
+    paneDead: seed.paneDead ?? false,
     pastes: 0,
     enters: 0,
     writes: [] as string[],
@@ -46,12 +48,12 @@ function createFakeRemoteTmux(seed: {
       return '';
     }
     if (command.includes('if-shell') && command.includes('send-keys')) {
-      // Phase 2: atomic submit — claim terminal, clear pending, then Enter.
+      // Phase 2: atomic submit — liveness gate, Enter, then terminal claim.
       if (state.failSubmit) throw new Error('exit 1: simulated submit failure');
-      if (state.pending !== '' && state.terminal === '') {
+      if (state.pending !== '' && state.terminal === '' && !state.paneDead) {
+        state.enters += 1;
         state.terminal = '1';
         state.pending = '';
-        state.enters += 1;
       }
       return '';
     }
@@ -59,6 +61,9 @@ function createFakeRemoteTmux(seed: {
       const option = command.trim().split(/\s+/).at(-1)?.replace(/'/g, '') ?? '';
       if (option.includes('-pending-')) return `${state.pending}\n`;
       return `${state.terminal}\n`;
+    }
+    if (command.includes('display-message')) {
+      return `${state.paneDead ? '1' : '0'}\n`;
     }
     return '';
   };
@@ -139,6 +144,26 @@ describe('sendToRemoteAgentKeyed', () => {
       .rejects.toThrow(/simulated submit failure/);
     expect(state.enters).toBe(0);
     expect(state.terminal).toBe('');
+  });
+
+  it('a pane that dies after the paste keeps the key NON-terminal and recoverable (cycle 9)', async () => {
+    // The harness exited during the settle window: pending claim exists, pane dead.
+    const { exec, state } = createFakeRemoteTmux({ pending: 'earlier-send-id', paneDead: true });
+
+    await expect(sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec))
+      .rejects.toThrow(KeyedSubmitTargetDeadError);
+    // No Enter was attempted, no terminal marker was written, and the pending
+    // claim survived so recovery can retry after the agent resumes.
+    expect(state.enters).toBe(0);
+    expect(state.terminal).toBe('');
+    expect(state.pending).toBe('earlier-send-id');
+
+    // Recovery once the pane is alive again: never a false dedup.
+    state.paneDead = false;
+    const outcome = await sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec);
+    expect(outcome).toBe('delivered');
+    expect(state.enters).toBe(1);
+    expect(state.terminal).toBe('1');
   });
 
   it('rejects keys that are unsafe for tmux option names', async () => {

--- a/src/lib/remote/__tests__/remote-keyed-delivery.test.ts
+++ b/src/lib/remote/__tests__/remote-keyed-delivery.test.ts
@@ -2,7 +2,7 @@ import { Effect } from 'effect';
 import { describe, expect, it, vi } from 'vitest';
 
 import { sendToRemoteAgentKeyed } from '../remote-agents.js';
-import { dedupPendingOptionName, dedupPoisonOptionName, dedupTerminalOptionName, KeyedSubmitTargetDeadError } from '../../tmux-dedup.js';
+import { dedupPendingOptionName, dedupPoisonOptionName, dedupTerminalOptionName, KeyedMarkerVerificationError, KeyedSubmitTargetDeadError } from '../../tmux-dedup.js';
 
 /**
  * Fake remote tmux server for the keyed remote-delivery protocol (PAN-2997
@@ -16,11 +16,13 @@ function createFakeRemoteTmux(seed: {
   pending?: string;
   terminal?: string;
   poison?: string;
+  targetPid?: string;
   failPaste?: boolean;
   failSubmit?: boolean;
   failMarkerSetOption?: boolean;
-  failNextTargetRead?: boolean;
+  failTargetReadOnCall?: number;
   failNextPoisonRead?: boolean;
+  failTerminalReadOnCall?: number;
   failPoisonClear?: boolean;
   paneDead?: boolean;
   dieOnEnter?: boolean;
@@ -29,11 +31,13 @@ function createFakeRemoteTmux(seed: {
     pending: seed.pending ?? '',
     terminal: seed.terminal ?? '',
     poison: seed.poison ?? '',
+    targetPid: seed.targetPid ?? '',
     failPaste: seed.failPaste ?? false,
     failSubmit: seed.failSubmit ?? false,
     failMarkerSetOption: seed.failMarkerSetOption ?? false,
-    failNextTargetRead: seed.failNextTargetRead ?? false,
+    failTargetReadOnCall: seed.failTargetReadOnCall ?? 0,
     failNextPoisonRead: seed.failNextPoisonRead ?? false,
+    failTerminalReadOnCall: seed.failTerminalReadOnCall ?? 0,
     failPoisonClear: seed.failPoisonClear ?? false,
     paneDead: seed.paneDead ?? false,
     dieOnEnter: seed.dieOnEnter ?? false,
@@ -44,6 +48,17 @@ function createFakeRemoteTmux(seed: {
     commands: [] as string[],
   };
 
+  // The sendId follows the LAST occurrence of the pending option name in an
+  // if-shell onTrue (a UUID: hex + dashes).
+  const sendIdRe = new RegExp(
+    dedupPendingOptionName(KEY).replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s+([A-Za-z0-9-]+)(?!.*' +
+    dedupPendingOptionName(KEY).replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + ')',
+  );
+  const extractSendId = (command: string): string => sendIdRe.exec(command)?.[1] ?? '';
+
+  let targetReadCalls = 0;
+  let terminalReadCalls = 0;
+
   const exec = async (command: string): Promise<string> => {
     state.commands.push(command);
     if (command.includes('base64 -d >')) {
@@ -51,21 +66,29 @@ function createFakeRemoteTmux(seed: {
       return '';
     }
     if (command.includes('if-shell') && command.includes('paste-buffer')) {
-      // Phase 1: atomic check + paste + pending claim.
+      // Paste steps (fresh or re-paste after a target mismatch).
       if (state.failPaste) throw new Error('exit 1: simulated paste failure');
+      const isRepaste = command.includes('! test');
+      if (isRepaste) {
+        if (state.pending !== '' && state.terminal === '' && state.targetPid !== state.pid) {
+          state.pastes += 1;
+          state.pending = extractSendId(command);
+          state.targetPid = state.pid;
+        }
+        return '';
+      }
       if (state.pending === '' && state.terminal === '') {
         state.pastes += 1;
-        // The onTrue command string ends with `set-option -t <agent> <pendingOption> <sendId>`.
-        const sendId = command.trim().replace(/'/g, '').split(/\s+/).at(-1) ?? '';
-        state.pending = sendId;
+        state.pending = extractSendId(command);
+        state.targetPid = state.pid;
       }
       return '';
     }
     if (command.includes('if-shell') && command.includes('send-keys')) {
-      // Phase 2: atomic submit — liveness gate, Enter, then PROVISIONAL
-      // poison + terminal claim in the same server-owned list.
+      // Phase 2: atomic submit — liveness gate, target-identity match,
+      // Enter, then PROVISIONAL poison + terminal claim in one list.
       if (state.failSubmit) throw new Error('exit 1: simulated submit failure');
-      if (state.pending !== '' && state.terminal === '' && !state.paneDead) {
+      if (state.pending !== '' && state.terminal === '' && !state.paneDead && state.targetPid === state.pid) {
         state.enters += 1;
         state.poison = '1';
         state.terminal = '1';
@@ -86,11 +109,16 @@ function createFakeRemoteTmux(seed: {
         return `${state.poison}\n`;
       }
       if (option.includes('-pending-')) return `${state.pending}\n`;
+      if (option.includes('-target-')) return `${state.targetPid}\n`;
+      terminalReadCalls += 1;
+      if (state.failTerminalReadOnCall === terminalReadCalls) {
+        throw new Error('exit 1: simulated transient verify-read failure');
+      }
       return `${state.terminal}\n`;
     }
     if (command.includes('display-message')) {
-      if (state.failNextTargetRead) {
-        state.failNextTargetRead = false;
+      targetReadCalls += 1;
+      if (state.failTargetReadOnCall === targetReadCalls) {
         throw new Error('exit 1: simulated transient target-read failure');
       }
       return `${state.pid} ${state.paneDead ? '1' : '0'}\n`;
@@ -149,7 +177,7 @@ describe('sendToRemoteAgentKeyed', () => {
   it('completes a crashed attempt from the pending marker WITHOUT a second paste', async () => {
     // A prior attempt pasted and set its pending claim, then the dashboard died
     // before the submit.
-    const { exec, state } = createFakeRemoteTmux({ pending: 'earlier-send-id' });
+    const { exec, state } = createFakeRemoteTmux({ pending: 'earlier-send-id', targetPid: '4242' });
 
     const outcome = await sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec);
 
@@ -163,7 +191,7 @@ describe('sendToRemoteAgentKeyed', () => {
   it('admits exactly one completer when the submit races (cycle 8)', async () => {
     // Both a prior paste claim and a racing completer hit the atomic submit:
     // the first claims terminal; the second loses the server-side condition.
-    const { exec, state } = createFakeRemoteTmux({ pending: 'earlier-send-id' });
+    const { exec, state } = createFakeRemoteTmux({ pending: 'earlier-send-id', targetPid: '4242' });
 
     const [first, second] = await Promise.all([
       sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec),
@@ -204,7 +232,7 @@ describe('sendToRemoteAgentKeyed', () => {
 
   it('a pane that dies after the paste keeps the key NON-terminal and recoverable (cycle 9)', async () => {
     // The harness exited during the settle window: pending claim exists, pane dead.
-    const { exec, state } = createFakeRemoteTmux({ pending: 'earlier-send-id', paneDead: true });
+    const { exec, state } = createFakeRemoteTmux({ pending: 'earlier-send-id', targetPid: '4242', paneDead: true });
 
     await expect(sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec))
       .rejects.toThrow(KeyedSubmitTargetDeadError);
@@ -226,7 +254,7 @@ describe('sendToRemoteAgentKeyed', () => {
     // The if-shell condition sees a live pane, the Enter lands, the markers
     // flip — and the pane dies in the same breath, inside the shell-to-branch
     // handoff window. tmux reported success throughout.
-    const { exec, state } = createFakeRemoteTmux({ pending: 'earlier-send-id', dieOnEnter: true });
+    const { exec, state } = createFakeRemoteTmux({ pending: 'earlier-send-id', targetPid: '4242', dieOnEnter: true });
 
     await expect(sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec))
       .rejects.toThrow(KeyedSubmitTargetDeadError);
@@ -252,6 +280,7 @@ describe('sendToRemoteAgentKeyed', () => {
     // breadcrumb lands — and the rollback itself fails.
     const { exec, state } = createFakeRemoteTmux({
       pending: 'earlier-send-id',
+      targetPid: '4242',
       dieOnEnter: true,
       failMarkerSetOption: true,
     });
@@ -286,7 +315,7 @@ describe('sendToRemoteAgentKeyed', () => {
     // The pre-submit target read fails transiently; the submit then "succeeds"
     // against a pane whose identity cannot be proven — the Enter may have
     // landed on a replacement with no pasted content.
-    const { exec, state } = createFakeRemoteTmux({ pending: 'earlier-send-id', failNextTargetRead: true });
+    const { exec, state } = createFakeRemoteTmux({ pending: 'earlier-send-id', targetPid: '4242', failTargetReadOnCall: 2 });
 
     await expect(sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec))
       .rejects.toThrow(KeyedSubmitTargetDeadError);
@@ -312,9 +341,65 @@ describe('sendToRemoteAgentKeyed', () => {
     const outcome = await sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec);
 
     expect(outcome).toBe('delivered');
-    expect(state.pastes).toBe(0); // repair continues as a completion, not a fresh paste
+    // With no recorded paste target the content is unverifiable (cycle 13):
+    // the repair RE-PASTES the real content rather than completing blind.
+    expect(state.pastes).toBe(1);
     expect(state.terminal).toBe('1');
     expect(state.poison).toBe('');
+  });
+
+  it('crash recovery re-delivers real content to a REPLACED pane exactly once (cycle 13)', async () => {
+    // The provisional crash state (poison+terminal) survives, but the pane
+    // that held the pasted message was replaced: the recorded target pid no
+    // longer matches the current pane.
+    const { exec, state } = createFakeRemoteTmux({ terminal: '1', poison: '1', targetPid: '4242' });
+    state.pid = '9999'; // replacement pane, session options survive
+
+    const outcome = await sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec);
+
+    expect(outcome).toBe('delivered');
+    // The repair rolled back, the target mismatch forced a REAL re-paste into
+    // the replacement, and the submit completed against the new target.
+    expect(state.pastes).toBe(1);
+    expect(state.enters).toBe(1);
+    expect(state.targetPid).toBe('9999');
+    expect(state.terminal).toBe('1');
+    expect(state.poison).toBe('');
+  });
+
+  it('a provisional claim with the SAME pane completes without a re-paste (cycle 13)', async () => {
+    const { exec, state } = createFakeRemoteTmux({ terminal: '1', poison: '1', targetPid: '4242' });
+
+    const outcome = await sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec);
+
+    expect(outcome).toBe('delivered');
+    expect(state.pastes).toBe(0);
+    expect(state.enters).toBe(1);
+    expect(state.terminal).toBe('1');
+    expect(state.poison).toBe('');
+  });
+
+  it('a rejected REPAIR verification read aborts with the breadcrumb authoritative (cycle 13)', async () => {
+    const { exec, state } = createFakeRemoteTmux({ terminal: '1', poison: '1', failTerminalReadOnCall: 1 });
+
+    await expect(sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec))
+      .rejects.toThrow(KeyedMarkerVerificationError);
+    // The failed read was NOT converted to empty state: the breadcrumb stays
+    // authoritative for the next recovery attempt.
+    expect(state.poison).toBe('1');
+  });
+
+  it('a rejected ROLLBACK verification read aborts with the breadcrumb authoritative (cycle 13)', async () => {
+    const { exec, state } = createFakeRemoteTmux({
+      pending: 'earlier-send-id',
+      targetPid: '4242',
+      dieOnEnter: true,
+      failTerminalReadOnCall: 3,
+    });
+
+    await expect(sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec))
+      .rejects.toThrow(KeyedMarkerVerificationError);
+    expect(state.poison).toBe('1');
   });
 
   it('a FAILED poison read aborts without honoring the terminal marker (cycle 12)', async () => {
@@ -332,7 +417,7 @@ describe('sendToRemoteAgentKeyed', () => {
   });
 
   it('a FAILED poison clear after verified delivery is loud — no success with a stale breadcrumb (cycle 12)', async () => {
-    const { exec, state } = createFakeRemoteTmux({ pending: 'earlier-send-id', failPoisonClear: true });
+    const { exec, state } = createFakeRemoteTmux({ pending: 'earlier-send-id', targetPid: '4242', failPoisonClear: true });
 
     await expect(sendToRemoteAgentKeyed(AGENT, VM, 'wake up remote', KEY, exec))
       .rejects.toThrow(/poison/i);

--- a/src/lib/remote/remote-agents.ts
+++ b/src/lib/remote/remote-agents.ts
@@ -755,7 +755,21 @@ export async function sendToRemoteAgentKeyed(
   } else {
     const fly = createFlyProvider();
     await ensureRemoteTmuxContext(fly, vmName);
-    run = async (command: string) => (await runSsh(fly, vmName, command)).stdout;
+    // Every protocol command must fail loudly (cycle 8): a non-zero exit on
+    // a write, buffer load, marker transition, or the Enter-submit must never
+    // be acknowledged as delivery. The marker READS are the only tolerant
+    // calls — an unset user option is a legitimate empty state, and a failed
+    // read collapses into the loud "did not land" path rather than a false
+    // success.
+    run = async (command: string) => {
+      const result = await runSsh(fly, vmName, command);
+      if (result.exitCode !== 0) {
+        throw new Error(
+          `remote keyed-delivery command failed (exit ${result.exitCode}): ${result.stderr.slice(0, 200)}`,
+        );
+      }
+      return result.stdout;
+    };
   }
 
   const pendingOption = dedupPendingOptionName(dedupKey);
@@ -800,16 +814,28 @@ export async function sendToRemoteAgentKeyed(
     }
 
     // 'pasted' (our sendId) and 'submit-pending' (a prior crashed attempt's
-    // sendId) both complete the same transaction WITHOUT re-pasting: settle,
-    // Enter, then flip the key terminal and clear the pending claim in one
-    // server-side command.
+    // sendId) both complete the same transaction WITHOUT re-pasting. The
+    // SUBMISSION is one server-owned command (cycle 8): a single if-shell
+    // whose condition requires the pending claim and no terminal marker, and
+    // whose command list flips the key terminal and clears pending BEFORE
+    // sending the Enter. The remote tmux server executes the whole sequence,
+    // so exactly one caller can complete — a concurrent or post-crash caller
+    // loses the condition and sends no stray Enter.
     await new Promise(resolve => setTimeout(resolve, 300));
-    await run(buildRemoteTmuxCommand(['send-keys', '-t', agentId, 'C-m']));
-    await run(buildRemoteTmuxCommand([
-      'set-option', '-t', agentId, terminalOption, '1',
-      ';',
-      'set-option', '-u', '-t', agentId, pendingOption,
-    ]));
+    const submitCondition =
+      `test -z "$(${innerTmux} show-option -qv -t ${agentId} ${terminalOption})" && ` +
+      `test -n "$(${innerTmux} show-option -qv -t ${agentId} ${pendingOption})"`;
+    const submitOnTrue =
+      `set-option -t ${agentId} ${terminalOption} 1 \; ` +
+      `set-option -u -t ${agentId} ${pendingOption} \; ` +
+      `send-keys -t ${agentId} C-m`;
+    await run(buildRemoteTmuxCommand(['if-shell', '-t', agentId, submitCondition, submitOnTrue]));
+
+    const terminalAfter = await readMarker(terminalOption);
+    const pendingAfter = await readMarker(pendingOption);
+    if (terminalAfter === '' && pendingAfter === '') {
+      throw new Error(`Keyed remote submit for ${agentId} found neither a pending claim nor a terminal marker — the paste vanished without submission`);
+    }
     return 'delivered';
   } finally {
     await cleanup();

--- a/src/lib/remote/remote-agents.ts
+++ b/src/lib/remote/remote-agents.ts
@@ -815,13 +815,23 @@ export async function sendToRemoteAgentKeyed(
 
     // 'pasted' (our sendId) and 'submit-pending' (a prior crashed attempt's
     // sendId) both complete the same transaction WITHOUT re-pasting. The
-    // SUBMISSION is one server-owned command (cycle 9): a single if-shell
-    // whose condition requires the pending claim, no terminal marker, AND a
-    // LIVE pane, and whose command list sends the Enter FIRST and only then
-    // flips terminal and clears pending. A pane that died during the settle
-    // window fails the liveness condition — no marker changes, no Enter — so
-    // a wake that never landed is never recorded as delivered; exactly one
-    // caller becomes the completer.
+    // SUBMISSION is one server-owned command: a single if-shell whose
+    // condition requires the pending claim, no terminal marker, AND a LIVE
+    // pane, and whose command list sends the Enter FIRST and only then flips
+    // terminal and clears pending. The pre-branch liveness check is only an
+    // optimization (cycle 10): the pane can die in the shell-to-branch
+    // handoff and remote tmux reports send-keys into a corpse as success, so
+    // acceptance is proven by the post-submit target re-read below.
+    const readPaneTarget = async (): Promise<{ pid: string; dead: boolean }> =>
+      run(buildRemoteTmuxCommand(['display-message', '-p', '-t', agentId, '#{pane_pid} #{pane_dead}']))
+        .then(stdout => {
+          const [pid = '', dead = ''] = stdout.trim().split(/\s+/);
+          return { pid, dead: dead === '1' };
+        })
+        .catch(() => ({ pid: '', dead: true }));
+
+    const preTarget = await readPaneTarget();
+    const pendingBefore = pendingMarker;
     await new Promise(resolve => setTimeout(resolve, 300));
     const submitCondition =
       `test -z "$(${innerTmux} show-option -qv -t ${agentId} ${terminalOption})" && ` +
@@ -833,17 +843,30 @@ export async function sendToRemoteAgentKeyed(
       `set-option -u -t ${agentId} ${pendingOption}`;
     await run(buildRemoteTmuxCommand(['if-shell', '-t', agentId, submitCondition, submitOnTrue]));
 
-    const terminalAfter = await readMarker(terminalOption);
-    const pendingAfter = await readMarker(pendingOption);
+    const [terminalAfter, pendingAfter, postTarget] = await Promise.all([
+      readMarker(terminalOption),
+      readMarker(pendingOption),
+      readPaneTarget(),
+    ]);
+    const targetLost = postTarget.dead || (preTarget.pid !== '' && postTarget.pid !== preTarget.pid);
+
     if (terminalAfter === '' && pendingAfter === '') {
       throw new Error(`Keyed remote submit for ${agentId} found neither a pending claim nor a terminal marker — the paste vanished without submission`);
     }
+    if (targetLost) {
+      // The pane died or was replaced around the Enter: acceptance is
+      // unprovable and the receiving harness is gone. ROLL THE KEY BACK —
+      // clear terminal, restore the pending claim — so recovery re-drives
+      // the wake after resume instead of suppressing it as delivered.
+      if (terminalAfter !== '') {
+        const rollbackArgs = pendingBefore === ''
+          ? ['set-option', '-u', '-t', agentId, terminalOption, ';', 'set-option', '-u', '-t', agentId, pendingOption]
+          : ['set-option', '-u', '-t', agentId, terminalOption, ';', 'set-option', '-t', agentId, pendingOption, pendingBefore];
+        await run(buildRemoteTmuxCommand(rollbackArgs)).catch(() => '');
+      }
+      throw new KeyedSubmitTargetDeadError(agentId, dedupKey);
+    }
     if (terminalAfter === '') {
-      // The condition rejected the submit. A dead pane is recoverable — the
-      // pending claim is preserved so recovery can retry after resume.
-      const paneDead = await run(buildRemoteTmuxCommand(['display-message', '-p', '-t', agentId, '#{pane_dead}']))
-        .then(stdout => stdout.trim() === '1', () => false);
-      if (paneDead) throw new KeyedSubmitTargetDeadError(agentId, dedupKey);
       throw new Error(`Keyed remote submit for ${agentId} was rejected with the pending claim intact on a live pane`);
     }
     return 'delivered';

--- a/src/lib/remote/remote-agents.ts
+++ b/src/lib/remote/remote-agents.ts
@@ -11,6 +11,7 @@
  */
 
 import { Effect } from 'effect';
+import { randomUUID } from 'node:crypto';
 import { createFlyProvider } from './fly-provider.js';
 import type { FlyProvider } from './fly-provider.js';
 import type { RemoteWorkspaceMetadata, ExecResult } from './interface.js';
@@ -18,6 +19,7 @@ import { join } from 'path';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from 'fs';
 import { homedir } from 'os';
 import { getManagedTmuxSocketName } from '../tmux.js';
+import { assertValidDedupKey, dedupPendingOptionName, dedupTerminalOptionName } from '../tmux-dedup.js';
 import { generateLauncherScriptSync } from '../launcher-generator.js';
 import { getClaudePermissionFlagsSync, getClaudePermissionFlagsStringSync } from '../claude-permissions.js';
 import { resolveProjectForIssue } from '../pan-dir/record.js';
@@ -721,6 +723,97 @@ export async function sendToRemoteAgent(
   await new Promise(resolve => setTimeout(resolve, 300));
   await runSsh(fly, vmName, buildRemoteTmuxCommand(['send-keys', '-t', agentId, 'C-m']));
   await runSsh(fly, vmName, `rm -f ${shellQuote(promptFile)}`);
+}
+
+export type RemoteKeyedDeliveryOutcome = 'delivered' | 'deduplicated';
+
+/** Injectable command runner for tests — resolves with the command's stdout. */
+export type RemoteKeyedExec = (command: string) => Promise<string>;
+
+/**
+ * Keyed remote delivery (PAN-2997 review cycle 7). The REMOTE tmux server is
+ * the crash-independent component: it survives both the local dashboard and
+ * the remote agent shell, so the same two-phase pending/terminal marker
+ * protocol as the local tmux tier (src/lib/tmux-dedup.ts) enforces the dedup
+ * key across the complete paste-settle-submit transaction. A local dashboard
+ * crash anywhere in the sequence replays into either a completed pending
+ * submission (no second paste) or a terminal-marker dedup — never a lost or
+ * duplicated wake.
+ */
+export async function sendToRemoteAgentKeyed(
+  agentId: string,
+  vmName: string,
+  message: string,
+  dedupKey: string,
+  exec?: RemoteKeyedExec,
+): Promise<RemoteKeyedDeliveryOutcome> {
+  assertValidDedupKey(dedupKey);
+
+  let run: RemoteKeyedExec;
+  if (exec) {
+    run = exec;
+  } else {
+    const fly = createFlyProvider();
+    await ensureRemoteTmuxContext(fly, vmName);
+    run = async (command: string) => (await runSsh(fly, vmName, command)).stdout;
+  }
+
+  const pendingOption = dedupPendingOptionName(dedupKey);
+  const terminalOption = dedupTerminalOptionName(dedupKey);
+  const sendId = randomUUID();
+  const bufferName = `pan-keyed-${sendId}`;
+  const promptFile = `${REMOTE_PAN_DIR}/prompts/${agentId}-keyed-${sendId}.txt`;
+  // Inner marker reads must target the managed remote server explicitly —
+  // the if-shell condition cannot rely on a TMUX env the remote server may
+  // not have inherited.
+  const innerTmux = ['tmux', ...getRemoteTmuxBaseArgs()].map(shellQuote).join(' ');
+
+  const cleanup = async (): Promise<void> => {
+    await run(buildRemoteTmuxCommand(['delete-buffer', '-b', bufferName])).catch(() => '');
+    await run(`rm -f ${shellQuote(promptFile)}`).catch(() => '');
+  };
+
+  try {
+    const messageBase64 = Buffer.from(message).toString('base64');
+    await run(
+      `mkdir -p ${shellQuote(`${REMOTE_PAN_DIR}/prompts`)} && echo ${shellQuote(messageBase64)} | base64 -d > ${shellQuote(promptFile)}`,
+    );
+    await run(buildRemoteTmuxCommand(['load-buffer', '-b', bufferName, promptFile]));
+
+    // One server-side command: paste only when NEITHER marker is set, and
+    // record OUR sendId in the pending option in the same breath.
+    const condition =
+      `test -z "$(${innerTmux} show-option -qv -t ${agentId} ${pendingOption})" && ` +
+      `test -z "$(${innerTmux} show-option -qv -t ${agentId} ${terminalOption})"`;
+    const onTrue = `paste-buffer -b ${bufferName} -p -t ${agentId} \; set-option -t ${agentId} ${pendingOption} ${sendId}`;
+    await run(buildRemoteTmuxCommand(['if-shell', '-t', agentId, condition, onTrue]));
+
+    const readMarker = async (option: string): Promise<string> =>
+      run(buildRemoteTmuxCommand(['show-option', '-qv', '-t', agentId, option]))
+        .then(stdout => stdout.trim(), () => '');
+    const pendingMarker = await readMarker(pendingOption);
+    const terminalMarker = await readMarker(terminalOption);
+
+    if (terminalMarker !== '') return 'deduplicated';
+    if (pendingMarker === '') {
+      throw new Error(`Keyed remote paste for ${agentId} did not land and no dedup marker was recorded`);
+    }
+
+    // 'pasted' (our sendId) and 'submit-pending' (a prior crashed attempt's
+    // sendId) both complete the same transaction WITHOUT re-pasting: settle,
+    // Enter, then flip the key terminal and clear the pending claim in one
+    // server-side command.
+    await new Promise(resolve => setTimeout(resolve, 300));
+    await run(buildRemoteTmuxCommand(['send-keys', '-t', agentId, 'C-m']));
+    await run(buildRemoteTmuxCommand([
+      'set-option', '-t', agentId, terminalOption, '1',
+      ';',
+      'set-option', '-u', '-t', agentId, pendingOption,
+    ]));
+    return 'delivered';
+  } finally {
+    await cleanup();
+  }
 }
 
 /**

--- a/src/lib/remote/remote-agents.ts
+++ b/src/lib/remote/remote-agents.ts
@@ -19,7 +19,7 @@ import { join } from 'path';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from 'fs';
 import { homedir } from 'os';
 import { getManagedTmuxSocketName } from '../tmux.js';
-import { assertValidDedupKey, dedupPendingOptionName, dedupTerminalOptionName } from '../tmux-dedup.js';
+import { assertValidDedupKey, dedupPendingOptionName, dedupTerminalOptionName, KeyedSubmitTargetDeadError } from '../tmux-dedup.js';
 import { generateLauncherScriptSync } from '../launcher-generator.js';
 import { getClaudePermissionFlagsSync, getClaudePermissionFlagsStringSync } from '../claude-permissions.js';
 import { resolveProjectForIssue } from '../pan-dir/record.js';
@@ -815,26 +815,36 @@ export async function sendToRemoteAgentKeyed(
 
     // 'pasted' (our sendId) and 'submit-pending' (a prior crashed attempt's
     // sendId) both complete the same transaction WITHOUT re-pasting. The
-    // SUBMISSION is one server-owned command (cycle 8): a single if-shell
-    // whose condition requires the pending claim and no terminal marker, and
-    // whose command list flips the key terminal and clears pending BEFORE
-    // sending the Enter. The remote tmux server executes the whole sequence,
-    // so exactly one caller can complete — a concurrent or post-crash caller
-    // loses the condition and sends no stray Enter.
+    // SUBMISSION is one server-owned command (cycle 9): a single if-shell
+    // whose condition requires the pending claim, no terminal marker, AND a
+    // LIVE pane, and whose command list sends the Enter FIRST and only then
+    // flips terminal and clears pending. A pane that died during the settle
+    // window fails the liveness condition — no marker changes, no Enter — so
+    // a wake that never landed is never recorded as delivered; exactly one
+    // caller becomes the completer.
     await new Promise(resolve => setTimeout(resolve, 300));
     const submitCondition =
       `test -z "$(${innerTmux} show-option -qv -t ${agentId} ${terminalOption})" && ` +
-      `test -n "$(${innerTmux} show-option -qv -t ${agentId} ${pendingOption})"`;
+      `test -n "$(${innerTmux} show-option -qv -t ${agentId} ${pendingOption})" && ` +
+      `test "$(${innerTmux} display-message -p -t ${agentId} '#{pane_dead}')" = "0"`;
     const submitOnTrue =
+      `send-keys -t ${agentId} C-m \; ` +
       `set-option -t ${agentId} ${terminalOption} 1 \; ` +
-      `set-option -u -t ${agentId} ${pendingOption} \; ` +
-      `send-keys -t ${agentId} C-m`;
+      `set-option -u -t ${agentId} ${pendingOption}`;
     await run(buildRemoteTmuxCommand(['if-shell', '-t', agentId, submitCondition, submitOnTrue]));
 
     const terminalAfter = await readMarker(terminalOption);
     const pendingAfter = await readMarker(pendingOption);
     if (terminalAfter === '' && pendingAfter === '') {
       throw new Error(`Keyed remote submit for ${agentId} found neither a pending claim nor a terminal marker — the paste vanished without submission`);
+    }
+    if (terminalAfter === '') {
+      // The condition rejected the submit. A dead pane is recoverable — the
+      // pending claim is preserved so recovery can retry after resume.
+      const paneDead = await run(buildRemoteTmuxCommand(['display-message', '-p', '-t', agentId, '#{pane_dead}']))
+        .then(stdout => stdout.trim() === '1', () => false);
+      if (paneDead) throw new KeyedSubmitTargetDeadError(agentId, dedupKey);
+      throw new Error(`Keyed remote submit for ${agentId} was rejected with the pending claim intact on a live pane`);
     }
     return 'delivered';
   } finally {

--- a/src/lib/remote/remote-agents.ts
+++ b/src/lib/remote/remote-agents.ts
@@ -11,31 +11,29 @@
  */
 
 import { Effect } from 'effect';
-import { randomUUID } from 'node:crypto';
 import { createFlyProvider } from './fly-provider.js';
 import type { FlyProvider } from './fly-provider.js';
 import type { RemoteWorkspaceMetadata, ExecResult } from './interface.js';
 import { join } from 'path';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from 'fs';
 import { homedir } from 'os';
-import { getManagedTmuxSocketName } from '../tmux.js';
-import { assertValidDedupKey, dedupPendingOptionName, dedupTerminalOptionName, KeyedSubmitTargetDeadError } from '../tmux-dedup.js';
+import {
+  buildRemoteTmuxCommand,
+  ensureRemoteTmuxContext,
+  REMOTE_PAN_DIR,
+  runSsh,
+  shellQuote,
+} from './remote-tmux.js';
 import { generateLauncherScriptSync } from '../launcher-generator.js';
 import { getClaudePermissionFlagsSync, getClaudePermissionFlagsStringSync } from '../claude-permissions.js';
 import { resolveProjectForIssue } from '../pan-dir/record.js';
 import { isStateMigrated } from '../state-home.js';
 
+export { sendToRemoteAgentKeyed } from './remote-keyed-delivery.js';
+export type { RemoteKeyedDeliveryOutcome, RemoteKeyedExec } from './remote-keyed-delivery.js';
+
 const AGENTS_DIR = join(homedir(), '.overdeck', 'agents');
-const REMOTE_PAN_DIR = '/workspace/.pan';
-const REMOTE_TMUX_DIR = `${REMOTE_PAN_DIR}/tmux`;
-const REMOTE_TMUX_CONFIG_PATH = `${REMOTE_TMUX_DIR}/overdeck.tmux.conf`;
 const REMOTE_HOST_HEARTBEAT_PATH = `${REMOTE_PAN_DIR}/host-heartbeat`;
-const REMOTE_TMUX_CONFIG_CONTENT = [
-  '# Overdeck-managed tmux config',
-  '# Keep this minimal and include only behavior Overdeck intentionally depends on.',
-  'set -g mouse on',
-  '',
-].join('\n');
 
 const PUSH_DAEMON_INTERVAL_SECONDS = 300;
 const EPHEMERAL_WATCHDOG_INTERVAL_SECONDS = 60;
@@ -335,15 +333,6 @@ export function listActiveRemoteAgentStates(): RemoteAgentState[] {
       state?.location === 'remote' && (state.status === 'running' || state.status === 'starting'));
 }
 
-/** Run a FlyProvider Effect at the async/Promise boundary. */
-function runSsh(
-  provider: FlyProvider,
-  vmName: string,
-  command: string,
-): Promise<ExecResult> {
-  return Effect.runPromise(provider.ssh(vmName, command));
-}
-
 export interface RefreshHostHeartbeatDeps {
   listActiveRemoteAgentStates?: typeof listActiveRemoteAgentStates;
   createFlyProvider?: typeof createFlyProvider;
@@ -505,27 +494,6 @@ export function assertFlyRemoteStateSupported(issueId: string, migrated: boolean
       `Fly remote spawn blocked for ${issueId.toUpperCase()}: PAN-2541 D14 forbids remote work on migrated projects until PAN-2549 implements overdeck-state synchronization.`,
     );
   }
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, `'\\''`)}'`;
-}
-
-function getRemoteTmuxBaseArgs(): string[] {
-  return ['-L', getManagedTmuxSocketName(), '-f', REMOTE_TMUX_CONFIG_PATH];
-}
-
-function buildRemoteTmuxCommand(args: string[]): string {
-  return ['tmux', ...getRemoteTmuxBaseArgs(), ...args].map(shellQuote).join(' ');
-}
-
-async function ensureRemoteTmuxContext(provider: FlyProvider, vmName: string): Promise<void> {
-  const configBase64 = Buffer.from(REMOTE_TMUX_CONFIG_CONTENT).toString('base64');
-  await runSsh(
-    provider,
-    vmName,
-    `mkdir -p ${shellQuote(REMOTE_TMUX_DIR)} && echo ${shellQuote(configBase64)} | base64 -d > ${shellQuote(REMOTE_TMUX_CONFIG_PATH)}`,
-  );
 }
 
 /**
@@ -725,155 +693,6 @@ export async function sendToRemoteAgent(
   await runSsh(fly, vmName, `rm -f ${shellQuote(promptFile)}`);
 }
 
-export type RemoteKeyedDeliveryOutcome = 'delivered' | 'deduplicated';
-
-/** Injectable command runner for tests — resolves with the command's stdout. */
-export type RemoteKeyedExec = (command: string) => Promise<string>;
-
-/**
- * Keyed remote delivery (PAN-2997 review cycle 7). The REMOTE tmux server is
- * the crash-independent component: it survives both the local dashboard and
- * the remote agent shell, so the same two-phase pending/terminal marker
- * protocol as the local tmux tier (src/lib/tmux-dedup.ts) enforces the dedup
- * key across the complete paste-settle-submit transaction. A local dashboard
- * crash anywhere in the sequence replays into either a completed pending
- * submission (no second paste) or a terminal-marker dedup — never a lost or
- * duplicated wake.
- */
-export async function sendToRemoteAgentKeyed(
-  agentId: string,
-  vmName: string,
-  message: string,
-  dedupKey: string,
-  exec?: RemoteKeyedExec,
-): Promise<RemoteKeyedDeliveryOutcome> {
-  assertValidDedupKey(dedupKey);
-
-  let run: RemoteKeyedExec;
-  if (exec) {
-    run = exec;
-  } else {
-    const fly = createFlyProvider();
-    await ensureRemoteTmuxContext(fly, vmName);
-    // Every protocol command must fail loudly (cycle 8): a non-zero exit on
-    // a write, buffer load, marker transition, or the Enter-submit must never
-    // be acknowledged as delivery. The marker READS are the only tolerant
-    // calls — an unset user option is a legitimate empty state, and a failed
-    // read collapses into the loud "did not land" path rather than a false
-    // success.
-    run = async (command: string) => {
-      const result = await runSsh(fly, vmName, command);
-      if (result.exitCode !== 0) {
-        throw new Error(
-          `remote keyed-delivery command failed (exit ${result.exitCode}): ${result.stderr.slice(0, 200)}`,
-        );
-      }
-      return result.stdout;
-    };
-  }
-
-  const pendingOption = dedupPendingOptionName(dedupKey);
-  const terminalOption = dedupTerminalOptionName(dedupKey);
-  const sendId = randomUUID();
-  const bufferName = `pan-keyed-${sendId}`;
-  const promptFile = `${REMOTE_PAN_DIR}/prompts/${agentId}-keyed-${sendId}.txt`;
-  // Inner marker reads must target the managed remote server explicitly —
-  // the if-shell condition cannot rely on a TMUX env the remote server may
-  // not have inherited.
-  const innerTmux = ['tmux', ...getRemoteTmuxBaseArgs()].map(shellQuote).join(' ');
-
-  const cleanup = async (): Promise<void> => {
-    await run(buildRemoteTmuxCommand(['delete-buffer', '-b', bufferName])).catch(() => '');
-    await run(`rm -f ${shellQuote(promptFile)}`).catch(() => '');
-  };
-
-  try {
-    const messageBase64 = Buffer.from(message).toString('base64');
-    await run(
-      `mkdir -p ${shellQuote(`${REMOTE_PAN_DIR}/prompts`)} && echo ${shellQuote(messageBase64)} | base64 -d > ${shellQuote(promptFile)}`,
-    );
-    await run(buildRemoteTmuxCommand(['load-buffer', '-b', bufferName, promptFile]));
-
-    // One server-side command: paste only when NEITHER marker is set, and
-    // record OUR sendId in the pending option in the same breath.
-    const condition =
-      `test -z "$(${innerTmux} show-option -qv -t ${agentId} ${pendingOption})" && ` +
-      `test -z "$(${innerTmux} show-option -qv -t ${agentId} ${terminalOption})"`;
-    const onTrue = `paste-buffer -b ${bufferName} -p -t ${agentId} \; set-option -t ${agentId} ${pendingOption} ${sendId}`;
-    await run(buildRemoteTmuxCommand(['if-shell', '-t', agentId, condition, onTrue]));
-
-    const readMarker = async (option: string): Promise<string> =>
-      run(buildRemoteTmuxCommand(['show-option', '-qv', '-t', agentId, option]))
-        .then(stdout => stdout.trim(), () => '');
-    const pendingMarker = await readMarker(pendingOption);
-    const terminalMarker = await readMarker(terminalOption);
-
-    if (terminalMarker !== '') return 'deduplicated';
-    if (pendingMarker === '') {
-      throw new Error(`Keyed remote paste for ${agentId} did not land and no dedup marker was recorded`);
-    }
-
-    // 'pasted' (our sendId) and 'submit-pending' (a prior crashed attempt's
-    // sendId) both complete the same transaction WITHOUT re-pasting. The
-    // SUBMISSION is one server-owned command: a single if-shell whose
-    // condition requires the pending claim, no terminal marker, AND a LIVE
-    // pane, and whose command list sends the Enter FIRST and only then flips
-    // terminal and clears pending. The pre-branch liveness check is only an
-    // optimization (cycle 10): the pane can die in the shell-to-branch
-    // handoff and remote tmux reports send-keys into a corpse as success, so
-    // acceptance is proven by the post-submit target re-read below.
-    const readPaneTarget = async (): Promise<{ pid: string; dead: boolean }> =>
-      run(buildRemoteTmuxCommand(['display-message', '-p', '-t', agentId, '#{pane_pid} #{pane_dead}']))
-        .then(stdout => {
-          const [pid = '', dead = ''] = stdout.trim().split(/\s+/);
-          return { pid, dead: dead === '1' };
-        })
-        .catch(() => ({ pid: '', dead: true }));
-
-    const preTarget = await readPaneTarget();
-    const pendingBefore = pendingMarker;
-    await new Promise(resolve => setTimeout(resolve, 300));
-    const submitCondition =
-      `test -z "$(${innerTmux} show-option -qv -t ${agentId} ${terminalOption})" && ` +
-      `test -n "$(${innerTmux} show-option -qv -t ${agentId} ${pendingOption})" && ` +
-      `test "$(${innerTmux} display-message -p -t ${agentId} '#{pane_dead}')" = "0"`;
-    const submitOnTrue =
-      `send-keys -t ${agentId} C-m \; ` +
-      `set-option -t ${agentId} ${terminalOption} 1 \; ` +
-      `set-option -u -t ${agentId} ${pendingOption}`;
-    await run(buildRemoteTmuxCommand(['if-shell', '-t', agentId, submitCondition, submitOnTrue]));
-
-    const [terminalAfter, pendingAfter, postTarget] = await Promise.all([
-      readMarker(terminalOption),
-      readMarker(pendingOption),
-      readPaneTarget(),
-    ]);
-    const targetLost = postTarget.dead || (preTarget.pid !== '' && postTarget.pid !== preTarget.pid);
-
-    if (terminalAfter === '' && pendingAfter === '') {
-      throw new Error(`Keyed remote submit for ${agentId} found neither a pending claim nor a terminal marker — the paste vanished without submission`);
-    }
-    if (targetLost) {
-      // The pane died or was replaced around the Enter: acceptance is
-      // unprovable and the receiving harness is gone. ROLL THE KEY BACK —
-      // clear terminal, restore the pending claim — so recovery re-drives
-      // the wake after resume instead of suppressing it as delivered.
-      if (terminalAfter !== '') {
-        const rollbackArgs = pendingBefore === ''
-          ? ['set-option', '-u', '-t', agentId, terminalOption, ';', 'set-option', '-u', '-t', agentId, pendingOption]
-          : ['set-option', '-u', '-t', agentId, terminalOption, ';', 'set-option', '-t', agentId, pendingOption, pendingBefore];
-        await run(buildRemoteTmuxCommand(rollbackArgs)).catch(() => '');
-      }
-      throw new KeyedSubmitTargetDeadError(agentId, dedupKey);
-    }
-    if (terminalAfter === '') {
-      throw new Error(`Keyed remote submit for ${agentId} was rejected with the pending claim intact on a live pane`);
-    }
-    return 'delivered';
-  } finally {
-    await cleanup();
-  }
-}
 
 /**
  * Check if remote agent is still running

--- a/src/lib/remote/remote-keyed-delivery.ts
+++ b/src/lib/remote/remote-keyed-delivery.ts
@@ -17,7 +17,9 @@ import {
   assertValidDedupKey,
   dedupPendingOptionName,
   dedupPoisonOptionName,
+  dedupTargetOptionName,
   dedupTerminalOptionName,
+  KeyedMarkerVerificationError,
   KeyedSubmitTargetDeadError,
 } from '../tmux-dedup.js';
 import { createFlyProvider } from './fly-provider.js';
@@ -87,22 +89,31 @@ export async function sendToRemoteAgentKeyed(
     run(buildRemoteTmuxCommand(['show-option', '-qv', '-t', agentId, option]))
       .then(stdout => stdout.trim(), () => '');
 
-  // Fail-CLOSED marker read (cycle 12): `-q` makes an unset user option a
-  // clean empty read, so a rejection is always a REAL failure. The poison
-  // breadcrumb must be read this way — interpreting a failed read as
-  // "absent" could honor a false terminal marker.
+  // Fail-CLOSED marker read (cycle 12/13): `-q` makes an unset user option a
+  // clean empty read, so a rejection is always a REAL failure. Safety-critical
+  // markers (the poison breadcrumb, every verification read) must be read
+  // this way — interpreting a failed read as "absent" could honor a false
+  // terminal marker or bypass a rollback-required state.
   const readMarkerStrict = async (option: string): Promise<string> =>
     run(buildRemoteTmuxCommand(['show-option', '-qv', '-t', agentId, option]))
       .then(stdout => stdout.trim());
 
-  // Clear the poison breadcrumb and VERIFY it is gone (cycle 12).
+  // Clear the poison breadcrumb and VERIFY it is gone with a strict read (cycle 13).
   const clearPoisonVerified = async (context: string): Promise<void> => {
     await run(buildRemoteTmuxCommand(['set-option', '-u', '-t', agentId, poisonOption]));
-    const remaining = await readMarker(poisonOption);
+    const remaining = await readMarkerStrict(poisonOption);
     if (remaining !== '') {
       throw new Error(`Keyed remote markers for ${agentId}: poison breadcrumb could not be cleared (${context})`);
     }
   };
+
+  const readPaneTarget = async (): Promise<{ pid: string; dead: boolean }> =>
+    run(buildRemoteTmuxCommand(['display-message', '-p', '-t', agentId, '#{pane_pid} #{pane_dead}']))
+      .then(stdout => {
+        const [pid = '', dead = ''] = stdout.trim().split(/\s+/);
+        return { pid, dead: dead === '1' };
+      })
+      .catch(() => ({ pid: '', dead: true }));
 
   try {
     // The poison breadcrumb invalidates any terminal marker (cycle 11/12):
@@ -111,44 +122,59 @@ export async function sendToRemoteAgentKeyed(
     // The read is fail-CLOSED — a failed poison read must never be
     // interpreted as "no poison" while a false terminal sits next to it.
     const poisonMarker = await readMarkerStrict(poisonOption);
-    let skipPaste = false;
-    if (poisonMarker !== '') {
+    // A repaired pending claim still has to prove its pane identity below —
+    // the original paste's target may be stale or missing (cycle 13).
+    const repaired = poisonMarker !== '';
+    if (repaired) {
       // Repair (cycle 12): a poisoned terminal may be false or
       // delivered-but-unverified, and the tmux tier cannot distinguish —
-      // always roll back to pending and let normal recovery re-drive. The
-      // breadcrumb must be verifiably gone before any submission.
+      // always roll back to pending and let normal recovery re-drive. STRICT
+      // verification reads (cycle 13): a failed read aborts with the
+      // breadcrumb authoritative, never converted to empty state.
       await run(buildRemoteTmuxCommand([
         'set-option', '-u', '-t', agentId, terminalOption,
         ';',
         'set-option', '-t', agentId, pendingOption, sendId,
       ]));
-      const [repairedTerminal, repairedPending] = await Promise.all([
-        readMarker(terminalOption),
-        readMarker(pendingOption),
-      ]);
+      let repairedTerminal: string;
+      let repairedPending: string;
+      try {
+        [repairedTerminal, repairedPending] = await Promise.all([
+          readMarkerStrict(terminalOption),
+          readMarkerStrict(pendingOption),
+        ]);
+      } catch {
+        throw new KeyedMarkerVerificationError(agentId, `repair verification of key "${dedupKey}"`);
+      }
       if (repairedTerminal !== '' || repairedPending === '') {
         throw new Error(`Keyed remote markers for ${agentId} are poisoned and could not be repaired (key "${dedupKey}")`);
       }
       await clearPoisonVerified(`repair of key "${dedupKey}"`);
-      skipPaste = true;
     }
 
+    const targetOption = dedupTargetOptionName(dedupKey);
+    // The buffer is needed for a fresh paste AND for a re-paste after a
+    // repair or a target mismatch.
+    const messageBase64 = Buffer.from(message).toString('base64');
+    await run(
+      `mkdir -p ${shellQuote(`${REMOTE_PAN_DIR}/prompts`)} && echo ${shellQuote(messageBase64)} | base64 -d > ${shellQuote(promptFile)}`,
+    );
+    await run(buildRemoteTmuxCommand(['load-buffer', '-b', bufferName, promptFile]));
+
     let pendingMarker: string;
-    if (skipPaste) {
+    if (repaired) {
       pendingMarker = sendId;
     } else {
-      const messageBase64 = Buffer.from(message).toString('base64');
-      await run(
-        `mkdir -p ${shellQuote(`${REMOTE_PAN_DIR}/prompts`)} && echo ${shellQuote(messageBase64)} | base64 -d > ${shellQuote(promptFile)}`,
-      );
-      await run(buildRemoteTmuxCommand(['load-buffer', '-b', bufferName, promptFile]));
-
       // One server-side command: paste only when NEITHER marker is set, and
-      // record OUR sendId in the pending option in the same breath.
+      // record OUR sendId in the pending option AND the receiving pane's pid
+      // in the target option in the same breath (cycle 13).
       const condition =
         `test -z "$(${innerTmux} show-option -qv -t ${agentId} ${pendingOption})" && ` +
         `test -z "$(${innerTmux} show-option -qv -t ${agentId} ${terminalOption})"`;
-      const onTrue = `paste-buffer -b ${bufferName} -p -t ${agentId} \; set-option -t ${agentId} ${pendingOption} ${sendId}`;
+      const onTrue =
+        `paste-buffer -b ${bufferName} -p -t ${agentId} \; ` +
+        `set-option -t ${agentId} ${pendingOption} ${sendId} \; ` +
+        `set-option -F -t ${agentId} ${targetOption} '#{pane_pid}'`;
       await run(buildRemoteTmuxCommand(['if-shell', '-t', agentId, condition, onTrue]));
 
       const terminalMarker = await readMarker(terminalOption);
@@ -159,23 +185,43 @@ export async function sendToRemoteAgentKeyed(
       }
     }
 
-    // 'pasted' (our sendId) and 'submit-pending' (a prior crashed attempt's
-    // sendId) both complete the same transaction WITHOUT re-pasting. The
-    // SUBMISSION is one server-owned command: a single if-shell whose
-    // condition requires the pending claim, no terminal marker, AND a LIVE
-    // pane, and whose command list sends the Enter FIRST and only then flips
-    // terminal and clears pending. The pre-branch liveness check is only an
-    // optimization (cycle 10): the pane can die in the shell-to-branch
-    // handoff and remote tmux reports send-keys into a corpse as success, so
-    // acceptance is proven by the post-submit target re-read below.
-    const readPaneTarget = async (): Promise<{ pid: string; dead: boolean }> =>
-      run(buildRemoteTmuxCommand(['display-message', '-p', '-t', agentId, '#{pane_pid} #{pane_dead}']))
-        .then(stdout => {
-          const [pid = '', dead = ''] = stdout.trim().split(/\s+/);
-          return { pid, dead: dead === '1' };
-        })
-        .catch(() => ({ pid: '', dead: true }));
+    // A pending claim (fresh, prior, or repaired) is only completable with
+    // Enter alone when the current pane IS the pane that received the paste
+    // (cycle 13): a replaced pane has an empty composer, so Enter alone
+    // would be a blank submission. Re-paste the real content instead.
+    const recordedTarget = await readMarker(targetOption);
+    const currentPid = (await readPaneTarget()).pid;
+    if (!(recordedTarget !== '' && currentPid !== '' && recordedTarget === currentPid)) {
+      // One server-side command: re-paste only when the pending claim still
+      // stands, no terminal exists, and the recorded target does NOT match
+      // the current pane — and record the NEW target in the same breath.
+      const repasteCondition =
+        `test -n "$(${innerTmux} show-option -qv -t ${agentId} ${pendingOption})" && ` +
+        `test -z "$(${innerTmux} show-option -qv -t ${agentId} ${terminalOption})" && ` +
+        `! test "$(${innerTmux} display-message -p -t ${agentId} '#{pane_pid}')" = "$(${innerTmux} show-option -qv -t ${agentId} ${targetOption})"`;
+      const repasteOnTrue =
+        `paste-buffer -b ${bufferName} -p -t ${agentId} \; ` +
+        `set-option -t ${agentId} ${pendingOption} ${sendId} \; ` +
+        `set-option -F -t ${agentId} ${targetOption} '#{pane_pid}'`;
+      await run(buildRemoteTmuxCommand(['if-shell', '-t', agentId, repasteCondition, repasteOnTrue]));
+      const [repastedPending, repastedTerminal] = await Promise.all([
+        readMarker(pendingOption),
+        readMarker(terminalOption),
+      ]);
+      if (repastedTerminal !== '') return 'deduplicated';
+      if (repastedPending === '') {
+        throw new Error(`Keyed remote paste for ${agentId} did not land and no dedup marker was recorded`);
+      }
+      pendingMarker = repastedPending;
+    }
 
+    // The SUBMISSION is one server-owned command: a single if-shell whose
+    // condition requires the pending claim, no terminal marker, a LIVE pane,
+    // AND the current pane matching the recorded paste target (cycle 13).
+    // The pre-branch liveness check is only an optimization (cycle 10): the
+    // pane can die in the shell-to-branch handoff and remote tmux reports
+    // send-keys into a corpse as success, so acceptance is proven by the
+    // post-submit target re-read below.
     const preTarget = await readPaneTarget();
     const pendingBefore = pendingMarker;
     await new Promise(resolve => setTimeout(resolve, 300));
@@ -187,7 +233,8 @@ export async function sendToRemoteAgentKeyed(
     const submitCondition =
       `test -z "$(${innerTmux} show-option -qv -t ${agentId} ${terminalOption})" && ` +
       `test -n "$(${innerTmux} show-option -qv -t ${agentId} ${pendingOption})" && ` +
-      `test "$(${innerTmux} display-message -p -t ${agentId} '#{pane_dead}')" = "0"`;
+      `test "$(${innerTmux} display-message -p -t ${agentId} '#{pane_dead}')" = "0" && ` +
+      `test "$(${innerTmux} display-message -p -t ${agentId} '#{pane_pid}')" = "$(${innerTmux} show-option -qv -t ${agentId} ${targetOption})"`;
     const submitOnTrue =
       `send-keys -t ${agentId} C-m \; ` +
       `set-option -t ${agentId} ${poisonOption} 1 \; ` +
@@ -195,10 +242,11 @@ export async function sendToRemoteAgentKeyed(
       `set-option -u -t ${agentId} ${pendingOption}`;
     await run(buildRemoteTmuxCommand(['if-shell', '-t', agentId, submitCondition, submitOnTrue]));
 
-    const [terminalAfter, pendingAfter, postTarget] = await Promise.all([
+    const [terminalAfter, pendingAfter, postTarget, recordedTargetAfter] = await Promise.all([
       readMarker(terminalOption),
       readMarker(pendingOption),
       readPaneTarget(),
+      readMarker(targetOption),
     ]);
     // FAIL CLOSED (cycle 11): the key may only become terminal when BOTH
     // target reads succeeded, BOTH report a live pane, and the pid identity
@@ -213,21 +261,33 @@ export async function sendToRemoteAgentKeyed(
     if (terminalAfter === '' && pendingAfter === '') {
       throw new Error(`Keyed remote submit for ${agentId} found neither a pending claim nor a terminal marker — the paste vanished without submission`);
     }
+    if (terminalAfter === '' && (targetLost || recordedTargetAfter === '' || recordedTargetAfter !== postTarget.pid)) {
+      // The condition rejected the submit: a dead/replaced/unprovable pane
+      // is the recoverable case — recovery re-pastes the real content via
+      // the target-mismatch path above.
+      throw new KeyedSubmitTargetDeadError(agentId, dedupKey);
+    }
     if (targetLost) {
       // The pane died, was replaced, or cannot be identified around the
       // Enter: acceptance is unprovable and the receiving harness is gone.
-      // ROLL THE KEY BACK and verify; the breadcrumb set by the submit list
-      // already marks the terminal provisional, so a failed rollback can
-      // never leave it honorable.
+      // ROLL THE KEY BACK and verify with STRICT reads (cycle 13): the
+      // breadcrumb set by the submit list already marks the terminal
+      // provisional, so a failed rollback can never leave it honorable.
       if (terminalAfter !== '') {
         const rollbackArgs = pendingBefore === ''
           ? ['set-option', '-u', '-t', agentId, terminalOption, ';', 'set-option', '-u', '-t', agentId, pendingOption]
           : ['set-option', '-u', '-t', agentId, terminalOption, ';', 'set-option', '-t', agentId, pendingOption, pendingBefore];
         await run(buildRemoteTmuxCommand(rollbackArgs)).catch(() => '');
-        const [rolledTerminal, restoredPending] = await Promise.all([
-          readMarker(terminalOption),
-          readMarker(pendingOption),
-        ]);
+        let rolledTerminal: string;
+        let restoredPending: string;
+        try {
+          [rolledTerminal, restoredPending] = await Promise.all([
+            readMarkerStrict(terminalOption),
+            readMarkerStrict(pendingOption),
+          ]);
+        } catch {
+          throw new KeyedMarkerVerificationError(agentId, `rollback verification of key "${dedupKey}"`);
+        }
         if (rolledTerminal === '' && restoredPending !== '') {
           // Verified rollback — lift the breadcrumb. A failed clear is
           // idempotent-safe here (terminal is already clear).

--- a/src/lib/remote/remote-keyed-delivery.ts
+++ b/src/lib/remote/remote-keyed-delivery.ts
@@ -87,15 +87,36 @@ export async function sendToRemoteAgentKeyed(
     run(buildRemoteTmuxCommand(['show-option', '-qv', '-t', agentId, option]))
       .then(stdout => stdout.trim(), () => '');
 
+  // Fail-CLOSED marker read (cycle 12): `-q` makes an unset user option a
+  // clean empty read, so a rejection is always a REAL failure. The poison
+  // breadcrumb must be read this way — interpreting a failed read as
+  // "absent" could honor a false terminal marker.
+  const readMarkerStrict = async (option: string): Promise<string> =>
+    run(buildRemoteTmuxCommand(['show-option', '-qv', '-t', agentId, option]))
+      .then(stdout => stdout.trim());
+
+  // Clear the poison breadcrumb and VERIFY it is gone (cycle 12).
+  const clearPoisonVerified = async (context: string): Promise<void> => {
+    await run(buildRemoteTmuxCommand(['set-option', '-u', '-t', agentId, poisonOption]));
+    const remaining = await readMarker(poisonOption);
+    if (remaining !== '') {
+      throw new Error(`Keyed remote markers for ${agentId}: poison breadcrumb could not be cleared (${context})`);
+    }
+  };
+
   try {
-    // The poison breadcrumb invalidates any terminal marker (cycle 11): a
-    // previous post-submit check proved the terminal marker FALSE but its
-    // rollback could not be verified. Repair the markers FIRST — a false
-    // terminal must never be honored as a dedup — then continue as a pending
-    // completion, never as a fresh paste.
-    const poisonMarker = await readMarker(poisonOption);
+    // The poison breadcrumb invalidates any terminal marker (cycle 11/12):
+    // it marks either a FALSE terminal whose rollback was interrupted or a
+    // PROVISIONAL terminal whose post-submit verification never completed.
+    // The read is fail-CLOSED — a failed poison read must never be
+    // interpreted as "no poison" while a false terminal sits next to it.
+    const poisonMarker = await readMarkerStrict(poisonOption);
     let skipPaste = false;
     if (poisonMarker !== '') {
+      // Repair (cycle 12): a poisoned terminal may be false or
+      // delivered-but-unverified, and the tmux tier cannot distinguish —
+      // always roll back to pending and let normal recovery re-drive. The
+      // breadcrumb must be verifiably gone before any submission.
       await run(buildRemoteTmuxCommand([
         'set-option', '-u', '-t', agentId, terminalOption,
         ';',
@@ -108,7 +129,7 @@ export async function sendToRemoteAgentKeyed(
       if (repairedTerminal !== '' || repairedPending === '') {
         throw new Error(`Keyed remote markers for ${agentId} are poisoned and could not be repaired (key "${dedupKey}")`);
       }
-      await run(buildRemoteTmuxCommand(['set-option', '-u', '-t', agentId, poisonOption])).catch(() => '');
+      await clearPoisonVerified(`repair of key "${dedupKey}"`);
       skipPaste = true;
     }
 
@@ -158,12 +179,18 @@ export async function sendToRemoteAgentKeyed(
     const preTarget = await readPaneTarget();
     const pendingBefore = pendingMarker;
     await new Promise(resolve => setTimeout(resolve, 300));
+    // PROVISIONAL from birth (cycle 12): the Enter, the POISON breadcrumb,
+    // the TERMINAL marker, and the pending clear are ONE server-owned command
+    // list, so a dashboard crash anywhere after this command leaves
+    // poison+terminal together — recovery can never find an
+    // honorable-but-unverified terminal.
     const submitCondition =
       `test -z "$(${innerTmux} show-option -qv -t ${agentId} ${terminalOption})" && ` +
       `test -n "$(${innerTmux} show-option -qv -t ${agentId} ${pendingOption})" && ` +
       `test "$(${innerTmux} display-message -p -t ${agentId} '#{pane_dead}')" = "0"`;
     const submitOnTrue =
       `send-keys -t ${agentId} C-m \; ` +
+      `set-option -t ${agentId} ${poisonOption} 1 \; ` +
       `set-option -t ${agentId} ${terminalOption} 1 \; ` +
       `set-option -u -t ${agentId} ${pendingOption}`;
     await run(buildRemoteTmuxCommand(['if-shell', '-t', agentId, submitCondition, submitOnTrue]));
@@ -189,11 +216,10 @@ export async function sendToRemoteAgentKeyed(
     if (targetLost) {
       // The pane died, was replaced, or cannot be identified around the
       // Enter: acceptance is unprovable and the receiving harness is gone.
-      // ROLL THE KEY BACK as a VERIFIED protocol transition (cycle 11):
-      // breadcrumb first so a failed rollback can never leave a false
-      // terminal marker honorable, then rollback, then verify.
+      // ROLL THE KEY BACK and verify; the breadcrumb set by the submit list
+      // already marks the terminal provisional, so a failed rollback can
+      // never leave it honorable.
       if (terminalAfter !== '') {
-        await run(buildRemoteTmuxCommand(['set-option', '-t', agentId, poisonOption, '1']));
         const rollbackArgs = pendingBefore === ''
           ? ['set-option', '-u', '-t', agentId, terminalOption, ';', 'set-option', '-u', '-t', agentId, pendingOption]
           : ['set-option', '-u', '-t', agentId, terminalOption, ';', 'set-option', '-t', agentId, pendingOption, pendingBefore];
@@ -203,8 +229,9 @@ export async function sendToRemoteAgentKeyed(
           readMarker(pendingOption),
         ]);
         if (rolledTerminal === '' && restoredPending !== '') {
-          // Verified — the breadcrumb is no longer needed.
-          await run(buildRemoteTmuxCommand(['set-option', '-u', '-t', agentId, poisonOption])).catch(() => '');
+          // Verified rollback — lift the breadcrumb. A failed clear is
+          // idempotent-safe here (terminal is already clear).
+          await clearPoisonVerified(`verified rollback of key "${dedupKey}"`).catch(() => '');
         }
       }
       throw new KeyedSubmitTargetDeadError(agentId, dedupKey);
@@ -212,6 +239,10 @@ export async function sendToRemoteAgentKeyed(
     if (terminalAfter === '') {
       throw new Error(`Keyed remote submit for ${agentId} was rejected with the pending claim intact on a live pane`);
     }
+    // Verified delivery — lift the provisional breadcrumb, fail-closed
+    // (cycle 12): a stale breadcrumb would let a later replay invalidate
+    // this legitimate terminal and re-submit.
+    await clearPoisonVerified(`verified delivery of key "${dedupKey}"`);
     return 'delivered';
   } finally {
     await cleanup();

--- a/src/lib/remote/remote-keyed-delivery.ts
+++ b/src/lib/remote/remote-keyed-delivery.ts
@@ -1,0 +1,219 @@
+/**
+ * Keyed remote delivery (PAN-2997). The REMOTE tmux server is the
+ * crash-independent component for a remote session: it survives both the
+ * local dashboard and the remote agent shell, so the same two-phase
+ * pending/terminal marker protocol as the local tmux tier
+ * (src/lib/tmux-dedup.ts) enforces the dedup key across the complete
+ * paste-settle-submit transaction — paste under an atomic pending claim, a
+ * liveness-gated Enter-first submit, post-submit target verification with a
+ * verified rollback under a poison breadcrumb. A local dashboard crash
+ * anywhere in the sequence replays into either a completed pending
+ * submission (no second paste) or a terminal-marker dedup — never a lost or
+ * duplicated wake.
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  assertValidDedupKey,
+  dedupPendingOptionName,
+  dedupPoisonOptionName,
+  dedupTerminalOptionName,
+  KeyedSubmitTargetDeadError,
+} from '../tmux-dedup.js';
+import { createFlyProvider } from './fly-provider.js';
+import {
+  buildRemoteTmuxCommand,
+  ensureRemoteTmuxContext,
+  getRemoteTmuxBaseArgs,
+  REMOTE_PAN_DIR,
+  runSsh,
+  shellQuote,
+} from './remote-tmux.js';
+
+export type RemoteKeyedDeliveryOutcome = 'delivered' | 'deduplicated';
+
+/** Injectable command runner for tests — resolves with the command's stdout. */
+export type RemoteKeyedExec = (command: string) => Promise<string>;
+
+export async function sendToRemoteAgentKeyed(
+  agentId: string,
+  vmName: string,
+  message: string,
+  dedupKey: string,
+  exec?: RemoteKeyedExec,
+): Promise<RemoteKeyedDeliveryOutcome> {
+  assertValidDedupKey(dedupKey);
+
+  let run: RemoteKeyedExec;
+  if (exec) {
+    run = exec;
+  } else {
+    const fly = createFlyProvider();
+    await ensureRemoteTmuxContext(fly, vmName);
+    // Every protocol command must fail loudly (cycle 8): a non-zero exit on
+    // a write, buffer load, marker transition, or the Enter-submit must never
+    // be acknowledged as delivery. The marker READS are the only tolerant
+    // calls — an unset user option is a legitimate empty state, and a failed
+    // read collapses into the loud "did not land" path rather than a false
+    // success.
+    run = async (command: string) => {
+      const result = await runSsh(fly, vmName, command);
+      if (result.exitCode !== 0) {
+        throw new Error(
+          `remote keyed-delivery command failed (exit ${result.exitCode}): ${result.stderr.slice(0, 200)}`,
+        );
+      }
+      return result.stdout;
+    };
+  }
+
+  const pendingOption = dedupPendingOptionName(dedupKey);
+  const terminalOption = dedupTerminalOptionName(dedupKey);
+  const poisonOption = dedupPoisonOptionName(dedupKey);
+  const sendId = randomUUID();
+  const bufferName = `pan-keyed-${sendId}`;
+  const promptFile = `${REMOTE_PAN_DIR}/prompts/${agentId}-keyed-${sendId}.txt`;
+  // Inner marker reads must target the managed remote server explicitly —
+  // the if-shell condition cannot rely on a TMUX env the remote server may
+  // not have inherited.
+  const innerTmux = ['tmux', ...getRemoteTmuxBaseArgs()].map(shellQuote).join(' ');
+
+  const cleanup = async (): Promise<void> => {
+    await run(buildRemoteTmuxCommand(['delete-buffer', '-b', bufferName])).catch(() => '');
+    await run(`rm -f ${shellQuote(promptFile)}`).catch(() => '');
+  };
+
+  const readMarker = async (option: string): Promise<string> =>
+    run(buildRemoteTmuxCommand(['show-option', '-qv', '-t', agentId, option]))
+      .then(stdout => stdout.trim(), () => '');
+
+  try {
+    // The poison breadcrumb invalidates any terminal marker (cycle 11): a
+    // previous post-submit check proved the terminal marker FALSE but its
+    // rollback could not be verified. Repair the markers FIRST — a false
+    // terminal must never be honored as a dedup — then continue as a pending
+    // completion, never as a fresh paste.
+    const poisonMarker = await readMarker(poisonOption);
+    let skipPaste = false;
+    if (poisonMarker !== '') {
+      await run(buildRemoteTmuxCommand([
+        'set-option', '-u', '-t', agentId, terminalOption,
+        ';',
+        'set-option', '-t', agentId, pendingOption, sendId,
+      ]));
+      const [repairedTerminal, repairedPending] = await Promise.all([
+        readMarker(terminalOption),
+        readMarker(pendingOption),
+      ]);
+      if (repairedTerminal !== '' || repairedPending === '') {
+        throw new Error(`Keyed remote markers for ${agentId} are poisoned and could not be repaired (key "${dedupKey}")`);
+      }
+      await run(buildRemoteTmuxCommand(['set-option', '-u', '-t', agentId, poisonOption])).catch(() => '');
+      skipPaste = true;
+    }
+
+    let pendingMarker: string;
+    if (skipPaste) {
+      pendingMarker = sendId;
+    } else {
+      const messageBase64 = Buffer.from(message).toString('base64');
+      await run(
+        `mkdir -p ${shellQuote(`${REMOTE_PAN_DIR}/prompts`)} && echo ${shellQuote(messageBase64)} | base64 -d > ${shellQuote(promptFile)}`,
+      );
+      await run(buildRemoteTmuxCommand(['load-buffer', '-b', bufferName, promptFile]));
+
+      // One server-side command: paste only when NEITHER marker is set, and
+      // record OUR sendId in the pending option in the same breath.
+      const condition =
+        `test -z "$(${innerTmux} show-option -qv -t ${agentId} ${pendingOption})" && ` +
+        `test -z "$(${innerTmux} show-option -qv -t ${agentId} ${terminalOption})"`;
+      const onTrue = `paste-buffer -b ${bufferName} -p -t ${agentId} \; set-option -t ${agentId} ${pendingOption} ${sendId}`;
+      await run(buildRemoteTmuxCommand(['if-shell', '-t', agentId, condition, onTrue]));
+
+      const terminalMarker = await readMarker(terminalOption);
+      pendingMarker = await readMarker(pendingOption);
+      if (terminalMarker !== '') return 'deduplicated';
+      if (pendingMarker === '') {
+        throw new Error(`Keyed remote paste for ${agentId} did not land and no dedup marker was recorded`);
+      }
+    }
+
+    // 'pasted' (our sendId) and 'submit-pending' (a prior crashed attempt's
+    // sendId) both complete the same transaction WITHOUT re-pasting. The
+    // SUBMISSION is one server-owned command: a single if-shell whose
+    // condition requires the pending claim, no terminal marker, AND a LIVE
+    // pane, and whose command list sends the Enter FIRST and only then flips
+    // terminal and clears pending. The pre-branch liveness check is only an
+    // optimization (cycle 10): the pane can die in the shell-to-branch
+    // handoff and remote tmux reports send-keys into a corpse as success, so
+    // acceptance is proven by the post-submit target re-read below.
+    const readPaneTarget = async (): Promise<{ pid: string; dead: boolean }> =>
+      run(buildRemoteTmuxCommand(['display-message', '-p', '-t', agentId, '#{pane_pid} #{pane_dead}']))
+        .then(stdout => {
+          const [pid = '', dead = ''] = stdout.trim().split(/\s+/);
+          return { pid, dead: dead === '1' };
+        })
+        .catch(() => ({ pid: '', dead: true }));
+
+    const preTarget = await readPaneTarget();
+    const pendingBefore = pendingMarker;
+    await new Promise(resolve => setTimeout(resolve, 300));
+    const submitCondition =
+      `test -z "$(${innerTmux} show-option -qv -t ${agentId} ${terminalOption})" && ` +
+      `test -n "$(${innerTmux} show-option -qv -t ${agentId} ${pendingOption})" && ` +
+      `test "$(${innerTmux} display-message -p -t ${agentId} '#{pane_dead}')" = "0"`;
+    const submitOnTrue =
+      `send-keys -t ${agentId} C-m \; ` +
+      `set-option -t ${agentId} ${terminalOption} 1 \; ` +
+      `set-option -u -t ${agentId} ${pendingOption}`;
+    await run(buildRemoteTmuxCommand(['if-shell', '-t', agentId, submitCondition, submitOnTrue]));
+
+    const [terminalAfter, pendingAfter, postTarget] = await Promise.all([
+      readMarker(terminalOption),
+      readMarker(pendingOption),
+      readPaneTarget(),
+    ]);
+    // FAIL CLOSED (cycle 11): the key may only become terminal when BOTH
+    // target reads succeeded, BOTH report a live pane, and the pid identity
+    // matches. An unreadable pre-target cannot prove the pane wasn't
+    // replaced (with the pasted content lost), so it counts as lost.
+    const targetLost =
+      preTarget.dead ||
+      preTarget.pid === '' ||
+      postTarget.dead ||
+      postTarget.pid !== preTarget.pid;
+
+    if (terminalAfter === '' && pendingAfter === '') {
+      throw new Error(`Keyed remote submit for ${agentId} found neither a pending claim nor a terminal marker — the paste vanished without submission`);
+    }
+    if (targetLost) {
+      // The pane died, was replaced, or cannot be identified around the
+      // Enter: acceptance is unprovable and the receiving harness is gone.
+      // ROLL THE KEY BACK as a VERIFIED protocol transition (cycle 11):
+      // breadcrumb first so a failed rollback can never leave a false
+      // terminal marker honorable, then rollback, then verify.
+      if (terminalAfter !== '') {
+        await run(buildRemoteTmuxCommand(['set-option', '-t', agentId, poisonOption, '1']));
+        const rollbackArgs = pendingBefore === ''
+          ? ['set-option', '-u', '-t', agentId, terminalOption, ';', 'set-option', '-u', '-t', agentId, pendingOption]
+          : ['set-option', '-u', '-t', agentId, terminalOption, ';', 'set-option', '-t', agentId, pendingOption, pendingBefore];
+        await run(buildRemoteTmuxCommand(rollbackArgs)).catch(() => '');
+        const [rolledTerminal, restoredPending] = await Promise.all([
+          readMarker(terminalOption),
+          readMarker(pendingOption),
+        ]);
+        if (rolledTerminal === '' && restoredPending !== '') {
+          // Verified — the breadcrumb is no longer needed.
+          await run(buildRemoteTmuxCommand(['set-option', '-u', '-t', agentId, poisonOption])).catch(() => '');
+        }
+      }
+      throw new KeyedSubmitTargetDeadError(agentId, dedupKey);
+    }
+    if (terminalAfter === '') {
+      throw new Error(`Keyed remote submit for ${agentId} was rejected with the pending claim intact on a live pane`);
+    }
+    return 'delivered';
+  } finally {
+    await cleanup();
+  }
+}

--- a/src/lib/remote/remote-keyed-delivery.ts
+++ b/src/lib/remote/remote-keyed-delivery.ts
@@ -132,9 +132,16 @@ export async function sendToRemoteAgentKeyed(
     // The poison breadcrumb invalidates any terminal marker (cycle 11/12):
     // it marks either a FALSE terminal whose rollback was interrupted or a
     // PROVISIONAL terminal whose post-submit verification never completed.
-    // The read is fail-CLOSED — a failed poison read must never be
-    // interpreted as "no poison" while a false terminal sits next to it.
-    const poisonMarker = await readMarkerStrict(poisonOption);
+    // The read is fail-CLOSED — and a REJECTED read is unproven protocol
+    // state, so it becomes the recoverable marker-error class (cycle 15): a
+    // transient failure before any side effect must never close the wake as
+    // terminal 'failed'.
+    let poisonMarker: string;
+    try {
+      poisonMarker = await readMarkerStrict(poisonOption);
+    } catch (error) {
+      throw new KeyedMarkerVerificationError(agentId, `initial poison read (key "${dedupKey}")`, { cause: error });
+    }
     // A repaired pending claim still has to prove its pane identity below —
     // the original paste's target may be stale or missing (cycle 13).
     const repaired = poisonMarker !== '';

--- a/src/lib/remote/remote-tmux.ts
+++ b/src/lib/remote/remote-tmux.ts
@@ -1,0 +1,52 @@
+/**
+ * Remote tmux/SSH plumbing for Fly-hosted agents.
+ *
+ * Extracted from remote-agents.ts (file-size ceiling) — the remote tmux
+ * server is the crash-independent component for remote sessions, and both
+ * remote-agents.ts and remote-keyed-delivery.ts build on these primitives.
+ */
+
+import { Effect } from 'effect';
+import type { FlyProvider } from './fly-provider.js';
+import type { ExecResult } from './interface.js';
+import { getManagedTmuxSocketName } from '../tmux.js';
+
+export const REMOTE_PAN_DIR = '/workspace/.pan';
+const REMOTE_TMUX_DIR = `${REMOTE_PAN_DIR}/tmux`;
+const REMOTE_TMUX_CONFIG_PATH = `${REMOTE_TMUX_DIR}/overdeck.tmux.conf`;
+const REMOTE_TMUX_CONFIG_CONTENT = [
+  '# Overdeck-managed tmux config',
+  '# Keep this minimal and include only behavior Overdeck intentionally depends on.',
+  'set -g mouse on',
+  '',
+].join('\n');
+
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function getRemoteTmuxBaseArgs(): string[] {
+  return ['-L', getManagedTmuxSocketName(), '-f', REMOTE_TMUX_CONFIG_PATH];
+}
+
+export function buildRemoteTmuxCommand(args: string[]): string {
+  return ['tmux', ...getRemoteTmuxBaseArgs(), ...args].map(shellQuote).join(' ');
+}
+
+/** Run a FlyProvider Effect at the async/Promise boundary. */
+export function runSsh(
+  provider: FlyProvider,
+  vmName: string,
+  command: string,
+): Promise<ExecResult> {
+  return Effect.runPromise(provider.ssh(vmName, command));
+}
+
+export async function ensureRemoteTmuxContext(provider: FlyProvider, vmName: string): Promise<void> {
+  const configBase64 = Buffer.from(REMOTE_TMUX_CONFIG_CONTENT).toString('base64');
+  await runSsh(
+    provider,
+    vmName,
+    `mkdir -p ${shellQuote(REMOTE_TMUX_DIR)} && echo ${shellQuote(configBase64)} | base64 -d > ${shellQuote(REMOTE_TMUX_CONFIG_PATH)}`,
+  );
+}

--- a/src/lib/tmux-dedup.ts
+++ b/src/lib/tmux-dedup.ts
@@ -1,0 +1,76 @@
+/**
+ * Keyed, crash-safe tmux delivery (PAN-2997).
+ *
+ * The dashboard cannot dedupe a tmux paste from its own state — a crash
+ * between the paste and the dashboard's acknowledgment bookkeeping would make
+ * recovery re-paste. The dedup record therefore lives in the
+ * crash-independent component: a per-session tmux user option. The check,
+ * the paste, and the option set are issued as ONE `if-shell` command list,
+ * which the tmux SERVER executes — a dashboard exit cannot interrupt it, and
+ * a tmux-server exit kills the agent session itself, so a replay after
+ * either crash is correct.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { unlink, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { tmuxExecAsync, validateSessionName } from './tmux.js';
+
+const DEDUP_KEY_RE = /^[A-Za-z0-9:_-]+$/;
+
+/** Standalone Enter keystroke (no paste), used to submit after a dedup-checked paste. */
+export async function sendEnterKey(sessionName: string): Promise<void> {
+  validateSessionName(sessionName);
+  await tmuxExecAsync(['send-keys', '-t', sessionName, 'C-m'], { encoding: 'utf-8' });
+}
+
+/**
+ * Deduplicated message delivery for the tmux fallback path.
+ *
+ * Returns 'delivered' when this call pasted, 'deduplicated' when the key was
+ * already recorded (no paste, no Enter). Submission (C-m) is only sent by the
+ * caller on a 'delivered' result; a deduplicated replay deliberately sends no
+ * stray Enter, because the composer may hold unrelated operator text.
+ */
+export async function sendKeysDedup(
+  sessionName: string,
+  keys: string,
+  dedupKey: string,
+  caller?: string,
+): Promise<'delivered' | 'deduplicated'> {
+  validateSessionName(sessionName);
+  if (!DEDUP_KEY_RE.test(dedupKey)) {
+    throw new Error(`dedupKey must match [A-Za-z0-9:_-]+, got: ${dedupKey.slice(0, 40)}`);
+  }
+  const optionName = `@overdeck-dedup-${dedupKey}`;
+
+  const sendId = randomUUID();
+  const tmpFile = join(tmpdir(), `pan-sendkeys-${sendId}.txt`);
+  const bufferName = `pan-${sendId}`;
+
+  try {
+    await writeFile(tmpFile, keys, 'utf-8');
+    await tmuxExecAsync(['load-buffer', '-b', bufferName, tmpFile], { encoding: 'utf-8' });
+
+    // One server-side command: paste only when the option is unset, and set
+    // the option to OUR sendId in the same breath. Reading the value back
+    // distinguishes "we just pasted" from "a prior delivery already marked
+    // this key".
+    await tmuxExecAsync([
+      'if-shell', '-t', sessionName,
+      `test -z "$(tmux show-option -qv -t ${sessionName} ${optionName})"`,
+      `paste-buffer -b ${bufferName} -p -t ${sessionName} \; set-option -t ${sessionName} ${optionName} ${sendId}`,
+    ], { encoding: 'utf-8' });
+
+    const marker = await tmuxExecAsync(
+      ['show-option', '-qv', '-t', sessionName, optionName],
+      { encoding: 'utf-8' },
+    ).then(result => String(result.stdout).trim(), () => '');
+
+    return marker === sendId ? 'delivered' : 'deduplicated';
+  } finally {
+    await unlink(tmpFile).catch(() => {});
+    await tmuxExecAsync(['delete-buffer', '-b', bufferName], { encoding: 'utf-8' }).catch(() => {});
+  }
+}

--- a/src/lib/tmux-dedup.ts
+++ b/src/lib/tmux-dedup.ts
@@ -19,12 +19,18 @@
  * - `sendKeysDedup` atomically pastes and sets the PENDING option only when
  *   neither option is set. A replay that finds PENDING (a prior attempt
  *   crashed before submitting) returns 'submit-pending' WITHOUT re-pasting.
- * - `completeKeyedSubmit` issues ONE `if-shell`: only when PENDING is present
- *   and TERMINAL absent does the tmux server flip TERMINAL, clear PENDING,
- *   and send the Enter — in that order, in a single server-executed command
- *   list. Exactly one caller can become the completer; every other concurrent
- *   or post-crash caller loses the server-side condition and sends nothing,
- *   so no stray Enter can ever land in a composer holding unrelated text.
+ *   A POISON breadcrumb (a terminal marker that proved false but could not be
+ *   rolled back) is repaired first and never honored as a dedup.
+ * - `completeKeyedSubmit` issues ONE `if-shell`: only when PENDING is
+ *   present, TERMINAL absent, and the pane alive does the tmux server send
+ *   the Enter and then flip TERMINAL and clear PENDING — in that order, in a
+ *   single server-executed command list. After the command the target is
+ *   re-read: if the pane died, was replaced, or cannot be identified around
+ *   the Enter, the terminal marker is rolled back under a poison breadcrumb
+ *   and the pending claim restored. Exactly one caller can become the
+ *   completer; every other concurrent or post-crash caller loses the
+ *   server-side condition and sends nothing, so no stray Enter can ever land
+ *   in a composer holding unrelated text.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -43,6 +49,16 @@ export function dedupTerminalOptionName(dedupKey: string): string {
 /** Set atomically with the paste; cleared when the terminal marker lands. */
 export function dedupPendingOptionName(dedupKey: string): string {
   return `@overdeck-dedup-pending-${dedupKey}`;
+}
+
+/**
+ * Rollback-required breadcrumb (cycle 11). Set when a post-submit check
+ * proves a terminal marker FALSE but the rollback could not be verified.
+ * While this marker exists the terminal marker must never be honored — the
+ * next keyed call repairs the markers before anything else.
+ */
+export function dedupPoisonOptionName(dedupKey: string): string {
+  return `@overdeck-dedup-poison-${dedupKey}`;
 }
 
 export function assertValidDedupKey(dedupKey: string): void {
@@ -80,7 +96,7 @@ export class KeyedSubmitTargetDeadError extends Error {
   }
 }
 
-interface PaneTarget {
+export interface PaneTarget {
   pid: string;
   dead: boolean;
 }
@@ -124,8 +140,33 @@ export async function sendKeysDedup(
   assertValidDedupKey(dedupKey);
   const terminalOption = dedupTerminalOptionName(dedupKey);
   const pendingOption = dedupPendingOptionName(dedupKey);
+  const poisonOption = dedupPoisonOptionName(dedupKey);
 
   const sendId = randomUUID();
+
+  // The poison breadcrumb invalidates any terminal marker (cycle 11): a
+  // previous post-submit check proved the terminal marker FALSE but could
+  // not verify its rollback. Repair the markers FIRST — the terminal marker
+  // must never be honored while the breadcrumb exists — then continue as a
+  // pending completion, never as a dedup and never as a fresh paste.
+  const poisonMarker = await readMarker(sessionName, poisonOption);
+  if (poisonMarker !== '') {
+    await tmuxExecAsync([
+      'set-option', '-u', '-t', sessionName, terminalOption,
+      ';',
+      'set-option', '-t', sessionName, pendingOption, sendId,
+    ], { encoding: 'utf-8' });
+    const [repairedTerminal, repairedPending] = await Promise.all([
+      readMarker(sessionName, terminalOption),
+      readMarker(sessionName, pendingOption),
+    ]);
+    if (repairedTerminal !== '' || repairedPending === '') {
+      throw new Error(`Keyed tmux markers for ${sessionName} are poisoned and could not be repaired (key "${dedupKey}")`);
+    }
+    await tmuxExecAsync(['set-option', '-u', '-t', sessionName, poisonOption], { encoding: 'utf-8' }).catch(() => {});
+    return 'submit-pending';
+  }
+
   const tmpFile = join(tmpdir(), `pan-sendkeys-${sendId}.txt`);
   const bufferName = `pan-${sendId}`;
 
@@ -194,11 +235,22 @@ export async function sendKeysDedup(
  * the pane is dead (pending claim preserved), and a generic error when both
  * markers vanished without a submission.
  */
-export async function completeKeyedSubmit(sessionName: string, dedupKey: string): Promise<void> {
+export interface KeyedSubmitDeps {
+  /** Test seam for target-read failures; production uses the real tmux read. */
+  readPaneTarget?: (sessionName: string) => Promise<PaneTarget>;
+}
+
+export async function completeKeyedSubmit(
+  sessionName: string,
+  dedupKey: string,
+  deps: KeyedSubmitDeps = {},
+): Promise<void> {
   validateSessionName(sessionName);
   assertValidDedupKey(dedupKey);
+  const readTarget = deps.readPaneTarget ?? readPaneTarget;
   const terminalOption = dedupTerminalOptionName(dedupKey);
   const pendingOption = dedupPendingOptionName(dedupKey);
+  const poisonOption = dedupPoisonOptionName(dedupKey);
 
   await new Promise(resolve => setTimeout(resolve, PASTE_SETTLE_MS));
 
@@ -207,7 +259,7 @@ export async function completeKeyedSubmit(sessionName: string, dedupKey: string)
   // in the shell-to-branch handoff, and tmux reports send-keys into a
   // remain-on-exit corpse as SUCCESS. What proves acceptance is the
   // post-submit check below (cycle 10).
-  const preTarget = await readPaneTarget(sessionName);
+  const preTarget = await readTarget(sessionName);
   const pendingBefore = await readMarker(sessionName, pendingOption);
 
   await tmuxExecAsync([
@@ -221,29 +273,46 @@ export async function completeKeyedSubmit(sessionName: string, dedupKey: string)
   const [terminalAfter, pendingAfter, postTarget] = await Promise.all([
     readMarker(sessionName, terminalOption),
     readMarker(sessionName, pendingOption),
-    readPaneTarget(sessionName),
+    readTarget(sessionName),
   ]);
 
-  const targetLost = postTarget.dead || (preTarget.pid !== '' && postTarget.pid !== preTarget.pid);
+  // FAIL CLOSED (cycle 11): the key may only become terminal when BOTH target
+  // reads succeeded, BOTH report a live pane, and the pid identity matches.
+  // An unreadable pre-target cannot prove the pane wasn't replaced (with the
+  // pasted content lost), so it counts as lost.
+  const targetLost =
+    preTarget.dead ||
+    preTarget.pid === '' ||
+    postTarget.dead ||
+    postTarget.pid !== preTarget.pid;
 
   if (terminalAfter !== '') {
-    if (!targetLost) return; // Submitted to a live pane — by this call or a concurrent completer.
-    // The pane died or was replaced around the Enter: tmux may have reported
-    // send-keys as successful while the input landed nowhere, and even an
-    // accepted Enter is worthless once the receiving harness is gone. ROLL
-    // THE KEY BACK — clear the terminal marker and restore the pending claim
-    // — so recovery re-drives the wake after resume instead of suppressing
-    // it as delivered (cycle 10).
+    if (!targetLost) return; // Submitted to a proven-live pane — by this call or a concurrent completer.
+    // The pane died, was replaced, or cannot be identified around the Enter:
+    // tmux may have reported send-keys as successful while the input landed
+    // nowhere, and even an accepted Enter is worthless once the receiving
+    // harness is gone. ROLL THE KEY BACK as a VERIFIED protocol transition
+    // (cycle 11): breadcrumb first so a failed rollback can never leave a
+    // false terminal marker honorable, then rollback, then verify.
+    await tmuxExecAsync(['set-option', '-t', sessionName, poisonOption, '1'], { encoding: 'utf-8' });
     const rollbackArgs = pendingBefore === ''
       ? ['set-option', '-u', '-t', sessionName, terminalOption, ';', 'set-option', '-u', '-t', sessionName, pendingOption]
       : ['set-option', '-u', '-t', sessionName, terminalOption, ';', 'set-option', '-t', sessionName, pendingOption, pendingBefore];
     await tmuxExecAsync(rollbackArgs, { encoding: 'utf-8' }).catch(() => {});
+    const [rolledTerminal, restoredPending] = await Promise.all([
+      readMarker(sessionName, terminalOption),
+      readMarker(sessionName, pendingOption),
+    ]);
+    if (rolledTerminal === '' && restoredPending !== '') {
+      // Verified — the breadcrumb is no longer needed.
+      await tmuxExecAsync(['set-option', '-u', '-t', sessionName, poisonOption], { encoding: 'utf-8' }).catch(() => {});
+    }
     throw new KeyedSubmitTargetDeadError(sessionName, dedupKey);
   }
   if (pendingAfter !== '') {
-    // The condition rejected the submit. A dead/replaced pane is the
-    // recoverable case (the pending claim is preserved so recovery can retry
-    // after resume); anything else is a definitive delivery failure.
+    // The condition rejected the submit. A dead/replaced/unprovable pane is
+    // the recoverable case (the pending claim is preserved so recovery can
+    // retry after resume); anything else is a definitive delivery failure.
     if (targetLost) throw new KeyedSubmitTargetDeadError(sessionName, dedupKey);
     throw new Error(`Keyed tmux submit for ${sessionName} was rejected with the pending claim intact on a live pane`);
   }

--- a/src/lib/tmux-dedup.ts
+++ b/src/lib/tmux-dedup.ts
@@ -64,19 +64,42 @@ export type KeyedTmuxPhase =
 
 /**
  * Thrown when a keyed submit found the target pane DEAD (the harness exited
- * between the paste and the submission). The pending claim is deliberately
- * preserved and the key is NOT terminal, so no recovery ever suppresses the
- * wake as delivered: the caller's recovery leaves its receipt pending and
- * re-drives the delivery after the agent resumes (PAN-2997 cycle 9).
+ * between the paste and the submission) or dying around the Enter. The
+ * pending claim is deliberately preserved/restored and the key is NOT
+ * terminal, so no recovery ever suppresses the wake as delivered: the
+ * caller's recovery leaves its receipt pending and re-drives the delivery
+ * after the agent resumes (PAN-2997 cycle 9/10).
  */
 export class KeyedSubmitTargetDeadError extends Error {
   constructor(sessionName: string, dedupKey: string) {
     super(
-      `Keyed tmux submit for ${sessionName} found a dead pane — the Enter was NOT sent, ` +
+      `Keyed tmux submit for ${sessionName} found a dead pane — the Enter was NOT accepted by a live harness, ` +
       `the pending claim for key "${dedupKey}" is preserved, and the key is not terminal`,
     );
     this.name = 'KeyedSubmitTargetDeadError';
   }
+}
+
+interface PaneTarget {
+  pid: string;
+  dead: boolean;
+}
+
+/** pane_pid + pane_dead in one read — the identity of the Enter's target. */
+async function readPaneTarget(sessionName: string): Promise<PaneTarget> {
+  return tmuxExecAsync(['display-message', '-p', '-t', sessionName, '#{pane_pid} #{pane_dead}'], { encoding: 'utf-8' })
+    .then(result => {
+      const [pid = '', dead = ''] = String(result.stdout).trim().split(/\s+/);
+      return { pid, dead: dead === '1' };
+    })
+    // An unreadable target cannot be proven alive — treat it as dead so the
+    // key is never claimed on guesswork.
+    .catch(() => ({ pid: '', dead: true }));
+}
+
+async function readMarker(sessionName: string, option: string): Promise<string> {
+  return tmuxExecAsync(['show-option', '-qv', '-t', sessionName, option], { encoding: 'utf-8' })
+    .then(result => String(result.stdout).trim(), () => '');
 }
 
 /**
@@ -153,6 +176,12 @@ export async function sendKeysDedup(
  *   NO marker changes and NO Enter is sent, so the wake is never recorded as
  *   delivered when it never landed. The preserved pending claim lets
  *   recovery retry after the agent resumes.
+ * - The pre-branch liveness condition is NOT proof of acceptance (cycle 10):
+ *   the pane can die in the shell-to-branch handoff, and tmux reports
+ *   send-keys into a remain-on-exit corpse as success. So after the command
+ *   the target is re-read — if the pane died or its pid changed around the
+ *   Enter, the terminal marker is ROLLED BACK, the pending claim restored,
+ *   and KeyedSubmitTargetDeadError is thrown.
  * - The Enter precedes the terminal transition inside the transaction, so a
  *   failed Enter (which aborts the command list) can never leave the key
  *   terminal.
@@ -172,6 +201,15 @@ export async function completeKeyedSubmit(sessionName: string, dedupKey: string)
   const pendingOption = dedupPendingOptionName(dedupKey);
 
   await new Promise(resolve => setTimeout(resolve, PASTE_SETTLE_MS));
+
+  // Snapshot the Enter target's identity BEFORE the submit. The if-shell's
+  // pre-branch liveness condition is only an optimization: the pane can die
+  // in the shell-to-branch handoff, and tmux reports send-keys into a
+  // remain-on-exit corpse as SUCCESS. What proves acceptance is the
+  // post-submit check below (cycle 10).
+  const preTarget = await readPaneTarget(sessionName);
+  const pendingBefore = await readMarker(sessionName, pendingOption);
+
   await tmuxExecAsync([
     'if-shell', '-t', sessionName,
     `test -z "$(tmux show-option -qv -t ${sessionName} ${terminalOption})" && ` +
@@ -180,20 +218,33 @@ export async function completeKeyedSubmit(sessionName: string, dedupKey: string)
     `send-keys -t ${sessionName} C-m \; set-option -t ${sessionName} ${terminalOption} 1 \; set-option -u -t ${sessionName} ${pendingOption}`,
   ], { encoding: 'utf-8' });
 
-  const [terminalMarker, pendingMarker] = await Promise.all([
-    tmuxExecAsync(['show-option', '-qv', '-t', sessionName, terminalOption], { encoding: 'utf-8' })
-      .then(result => String(result.stdout).trim(), () => ''),
-    tmuxExecAsync(['show-option', '-qv', '-t', sessionName, pendingOption], { encoding: 'utf-8' })
-      .then(result => String(result.stdout).trim(), () => ''),
+  const [terminalAfter, pendingAfter, postTarget] = await Promise.all([
+    readMarker(sessionName, terminalOption),
+    readMarker(sessionName, pendingOption),
+    readPaneTarget(sessionName),
   ]);
-  if (terminalMarker !== '') return; // Submitted — by this call or a concurrent completer.
-  if (pendingMarker !== '') {
-    // The condition rejected the submit. A dead pane is the recoverable case
-    // (the pending claim is preserved so recovery can retry after resume);
-    // anything else is a definitive delivery failure.
-    const paneDead = await tmuxExecAsync(['display-message', '-p', '-t', sessionName, '#{pane_dead}'], { encoding: 'utf-8' })
-      .then(result => String(result.stdout).trim() === '1', () => false);
-    if (paneDead) throw new KeyedSubmitTargetDeadError(sessionName, dedupKey);
+
+  const targetLost = postTarget.dead || (preTarget.pid !== '' && postTarget.pid !== preTarget.pid);
+
+  if (terminalAfter !== '') {
+    if (!targetLost) return; // Submitted to a live pane — by this call or a concurrent completer.
+    // The pane died or was replaced around the Enter: tmux may have reported
+    // send-keys as successful while the input landed nowhere, and even an
+    // accepted Enter is worthless once the receiving harness is gone. ROLL
+    // THE KEY BACK — clear the terminal marker and restore the pending claim
+    // — so recovery re-drives the wake after resume instead of suppressing
+    // it as delivered (cycle 10).
+    const rollbackArgs = pendingBefore === ''
+      ? ['set-option', '-u', '-t', sessionName, terminalOption, ';', 'set-option', '-u', '-t', sessionName, pendingOption]
+      : ['set-option', '-u', '-t', sessionName, terminalOption, ';', 'set-option', '-t', sessionName, pendingOption, pendingBefore];
+    await tmuxExecAsync(rollbackArgs, { encoding: 'utf-8' }).catch(() => {});
+    throw new KeyedSubmitTargetDeadError(sessionName, dedupKey);
+  }
+  if (pendingAfter !== '') {
+    // The condition rejected the submit. A dead/replaced pane is the
+    // recoverable case (the pending claim is preserved so recovery can retry
+    // after resume); anything else is a definitive delivery failure.
+    if (targetLost) throw new KeyedSubmitTargetDeadError(sessionName, dedupKey);
     throw new Error(`Keyed tmux submit for ${sessionName} was rejected with the pending claim intact on a live pane`);
   }
   throw new Error(`Keyed tmux submit for ${sessionName} found neither a pending claim nor a terminal marker — the paste vanished without submission`);

--- a/src/lib/tmux-dedup.ts
+++ b/src/lib/tmux-dedup.ts
@@ -63,6 +63,23 @@ export type KeyedTmuxPhase =
   | 'deduplicated';
 
 /**
+ * Thrown when a keyed submit found the target pane DEAD (the harness exited
+ * between the paste and the submission). The pending claim is deliberately
+ * preserved and the key is NOT terminal, so no recovery ever suppresses the
+ * wake as delivered: the caller's recovery leaves its receipt pending and
+ * re-drives the delivery after the agent resumes (PAN-2997 cycle 9).
+ */
+export class KeyedSubmitTargetDeadError extends Error {
+  constructor(sessionName: string, dedupKey: string) {
+    super(
+      `Keyed tmux submit for ${sessionName} found a dead pane — the Enter was NOT sent, ` +
+      `the pending claim for key "${dedupKey}" is preserved, and the key is not terminal`,
+    );
+    this.name = 'KeyedSubmitTargetDeadError';
+  }
+}
+
+/**
  * Deduplicated message paste for the tmux fallback path.
  *
  * Returns 'pasted' when this call pasted (caller must complete the submit),
@@ -127,20 +144,26 @@ export async function sendKeysDedup(
  * Complete the paste-settle-submit transaction for a keyed tmux delivery.
  *
  * After the settle window, the SUBMISSION is one server-owned command: a
- * single `if-shell` whose condition requires the pending claim present and
- * the terminal marker absent, and whose command list flips the key TERMINAL
- * and clears pending BEFORE sending the Enter. The tmux server executes the
- * whole sequence, so exactly one caller can ever become the completer —
- * concurrent same-key completers lose the condition and send nothing, and a
- * dashboard that retries after a crash never has to decide whether a prior
- * standalone Enter landed: the server-side condition answers that. No code
- * path sends a stray Enter into a composer that may hold unrelated operator
- * text (review cycle 8).
+ * single `if-shell` whose condition requires the pending claim present, the
+ * terminal marker absent, AND the pane alive, and whose command list sends
+ * the Enter FIRST and only then flips the key TERMINAL and clears pending.
+ * The tmux server executes the whole sequence (cycle 9 ordering):
+ *
+ * - A pane that died during the settle window fails the liveness condition —
+ *   NO marker changes and NO Enter is sent, so the wake is never recorded as
+ *   delivered when it never landed. The preserved pending claim lets
+ *   recovery retry after the agent resumes.
+ * - The Enter precedes the terminal transition inside the transaction, so a
+ *   failed Enter (which aborts the command list) can never leave the key
+ *   terminal.
+ * - Exactly one caller becomes the completer; concurrent or post-crash
+ *   callers lose the server-side condition and send no stray Enter into a
+ *   composer that may hold unrelated operator text.
  *
  * Safe to call for both 'pasted' and 'submit-pending' phases; a call whose
- * key is already terminal is a no-op. Throws when neither marker is present
- * after the command — the pending claim vanished without a submission, which
- * must surface as a delivery failure rather than silent loss.
+ * key is already terminal is a no-op. Throws KeyedSubmitTargetDeadError when
+ * the pane is dead (pending claim preserved), and a generic error when both
+ * markers vanished without a submission.
  */
 export async function completeKeyedSubmit(sessionName: string, dedupKey: string): Promise<void> {
   validateSessionName(sessionName);
@@ -151,8 +174,10 @@ export async function completeKeyedSubmit(sessionName: string, dedupKey: string)
   await new Promise(resolve => setTimeout(resolve, PASTE_SETTLE_MS));
   await tmuxExecAsync([
     'if-shell', '-t', sessionName,
-    `test -z "$(tmux show-option -qv -t ${sessionName} ${terminalOption})" && test -n "$(tmux show-option -qv -t ${sessionName} ${pendingOption})"`,
-    `set-option -t ${sessionName} ${terminalOption} 1 \; set-option -u -t ${sessionName} ${pendingOption} \; send-keys -t ${sessionName} C-m`,
+    `test -z "$(tmux show-option -qv -t ${sessionName} ${terminalOption})" && ` +
+    `test -n "$(tmux show-option -qv -t ${sessionName} ${pendingOption})" && ` +
+    `test "$(tmux display-message -p -t ${sessionName} '#{pane_dead}')" = "0"`,
+    `send-keys -t ${sessionName} C-m \; set-option -t ${sessionName} ${terminalOption} 1 \; set-option -u -t ${sessionName} ${pendingOption}`,
   ], { encoding: 'utf-8' });
 
   const [terminalMarker, pendingMarker] = await Promise.all([
@@ -161,7 +186,15 @@ export async function completeKeyedSubmit(sessionName: string, dedupKey: string)
     tmuxExecAsync(['show-option', '-qv', '-t', sessionName, pendingOption], { encoding: 'utf-8' })
       .then(result => String(result.stdout).trim(), () => ''),
   ]);
-  if (terminalMarker === '' && pendingMarker === '') {
-    throw new Error(`Keyed tmux submit for ${sessionName} found neither a pending claim nor a terminal marker — the paste vanished without submission`);
+  if (terminalMarker !== '') return; // Submitted — by this call or a concurrent completer.
+  if (pendingMarker !== '') {
+    // The condition rejected the submit. A dead pane is the recoverable case
+    // (the pending claim is preserved so recovery can retry after resume);
+    // anything else is a definitive delivery failure.
+    const paneDead = await tmuxExecAsync(['display-message', '-p', '-t', sessionName, '#{pane_dead}'], { encoding: 'utf-8' })
+      .then(result => String(result.stdout).trim() === '1', () => false);
+    if (paneDead) throw new KeyedSubmitTargetDeadError(sessionName, dedupKey);
+    throw new Error(`Keyed tmux submit for ${sessionName} was rejected with the pending claim intact on a live pane`);
   }
+  throw new Error(`Keyed tmux submit for ${sessionName} found neither a pending claim nor a terminal marker — the paste vanished without submission`);
 }

--- a/src/lib/tmux-dedup.ts
+++ b/src/lib/tmux-dedup.ts
@@ -4,11 +4,28 @@
  * The dashboard cannot dedupe a tmux paste from its own state — a crash
  * between the paste and the dashboard's acknowledgment bookkeeping would make
  * recovery re-paste. The dedup record therefore lives in the
- * crash-independent component: a per-session tmux user option. The check,
- * the paste, and the option set are issued as ONE `if-shell` command list,
- * which the tmux SERVER executes — a dashboard exit cannot interrupt it, and
- * a tmux-server exit kills the agent session itself, so a replay after
- * either crash is correct.
+ * crash-independent component: per-session tmux user options. All
+ * check/paste/mark sequences that must not be interrupted are issued as ONE
+ * `if-shell` command list, which the tmux SERVER executes — a dashboard exit
+ * cannot interrupt it, and a tmux-server exit kills the agent session itself,
+ * so a replay after either crash is correct.
+ *
+ * The protocol is two-phase so the complete paste-settle-submit transaction
+ * survives a dashboard crash (review cycle 7): the key becomes terminal only
+ * after submission is complete.
+ *
+ *   (none) ──paste──► PENDING ──Enter──► TERMINAL
+ *
+ * - `sendKeysDedup` atomically pastes and sets the PENDING option only when
+ *   neither option is set. A replay that finds PENDING (a prior attempt
+ *   crashed between paste and submit) returns 'submit-pending' WITHOUT
+ *   re-pasting; the caller completes the pending submission instead.
+ * - `completeKeyedSubmit` waits out the settle window, sends the standalone
+ *   Enter, and only then flips the key to TERMINAL and clears PENDING. A
+ *   crash between Enter and the terminal flip leaves PENDING set, so the
+ *   next replay sends one more Enter — a no-op on the already-submitted,
+ *   now-empty composer — and then marks the key terminal. No replay ever
+ *   re-pastes the message.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -17,33 +34,57 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { tmuxExecAsync, validateSessionName } from './tmux.js';
 
-const DEDUP_KEY_RE = /^[A-Za-z0-9:_-]+$/;
+export const DEDUP_KEY_RE = /^[A-Za-z0-9:_-]+$/;
 
-/** Standalone Enter keystroke (no paste), used to submit after a dedup-checked paste. */
-export async function sendEnterKey(sessionName: string): Promise<void> {
-  validateSessionName(sessionName);
-  await tmuxExecAsync(['send-keys', '-t', sessionName, 'C-m'], { encoding: 'utf-8' });
+/** Set once the keyed message has been SUBMITTED (Enter sent). */
+export function dedupTerminalOptionName(dedupKey: string): string {
+  return `@overdeck-dedup-${dedupKey}`;
 }
 
+/** Set atomically with the paste; cleared when the terminal marker lands. */
+export function dedupPendingOptionName(dedupKey: string): string {
+  return `@overdeck-dedup-pending-${dedupKey}`;
+}
+
+export function assertValidDedupKey(dedupKey: string): void {
+  if (!DEDUP_KEY_RE.test(dedupKey)) {
+    throw new Error(`dedupKey must match [A-Za-z0-9:_-]+, got: ${dedupKey.slice(0, 40)}`);
+  }
+}
+
+/** Settle window between paste and Enter — mirrors the supervisor's proven timing. */
+const PASTE_SETTLE_MS = 300;
+
+export type KeyedTmuxPhase =
+  /** This call pasted the message and owns the pending claim — caller must submit. */
+  | 'pasted'
+  /** A prior attempt pasted but crashed before/around submit — caller must complete the submit WITHOUT pasting. */
+  | 'submit-pending'
+  /** The key is terminal: the message was already submitted. No paste, no Enter. */
+  | 'deduplicated';
+
 /**
- * Deduplicated message delivery for the tmux fallback path.
+ * Deduplicated message paste for the tmux fallback path.
  *
- * Returns 'delivered' when this call pasted, 'deduplicated' when the key was
- * already recorded (no paste, no Enter). Submission (C-m) is only sent by the
- * caller on a 'delivered' result; a deduplicated replay deliberately sends no
- * stray Enter, because the composer may hold unrelated operator text.
+ * Returns 'pasted' when this call pasted (caller must complete the submit),
+ * 'submit-pending' when a prior attempt's paste is still awaiting submission
+ * (caller must complete the submit — crucially WITHOUT pasting again), and
+ * 'deduplicated' when the key is already terminal (caller does nothing; no
+ * stray Enter, because the composer may hold unrelated operator text).
+ *
+ * Throws when the keyed paste did not land and no marker explains why —
+ * silent loss must surface as a delivery failure, not as a false dedup.
  */
 export async function sendKeysDedup(
   sessionName: string,
   keys: string,
   dedupKey: string,
   caller?: string,
-): Promise<'delivered' | 'deduplicated'> {
+): Promise<KeyedTmuxPhase> {
   validateSessionName(sessionName);
-  if (!DEDUP_KEY_RE.test(dedupKey)) {
-    throw new Error(`dedupKey must match [A-Za-z0-9:_-]+, got: ${dedupKey.slice(0, 40)}`);
-  }
-  const optionName = `@overdeck-dedup-${dedupKey}`;
+  assertValidDedupKey(dedupKey);
+  const terminalOption = dedupTerminalOptionName(dedupKey);
+  const pendingOption = dedupPendingOptionName(dedupKey);
 
   const sendId = randomUUID();
   const tmpFile = join(tmpdir(), `pan-sendkeys-${sendId}.txt`);
@@ -53,24 +94,58 @@ export async function sendKeysDedup(
     await writeFile(tmpFile, keys, 'utf-8');
     await tmuxExecAsync(['load-buffer', '-b', bufferName, tmpFile], { encoding: 'utf-8' });
 
-    // One server-side command: paste only when the option is unset, and set
-    // the option to OUR sendId in the same breath. Reading the value back
-    // distinguishes "we just pasted" from "a prior delivery already marked
-    // this key".
+    // One server-side command: paste only when NEITHER marker is set, and
+    // record OUR sendId in the pending option in the same breath. Reading the
+    // markers back distinguishes "we just pasted" from "a prior attempt is
+    // mid-transaction" from "already submitted".
     await tmuxExecAsync([
       'if-shell', '-t', sessionName,
-      `test -z "$(tmux show-option -qv -t ${sessionName} ${optionName})"`,
-      `paste-buffer -b ${bufferName} -p -t ${sessionName} \; set-option -t ${sessionName} ${optionName} ${sendId}`,
+      `test -z "$(tmux show-option -qv -t ${sessionName} ${pendingOption})" && test -z "$(tmux show-option -qv -t ${sessionName} ${terminalOption})"`,
+      `paste-buffer -b ${bufferName} -p -t ${sessionName} \; set-option -t ${sessionName} ${pendingOption} ${sendId}`,
     ], { encoding: 'utf-8' });
 
-    const marker = await tmuxExecAsync(
-      ['show-option', '-qv', '-t', sessionName, optionName],
-      { encoding: 'utf-8' },
-    ).then(result => String(result.stdout).trim(), () => '');
+    const [pendingMarker, terminalMarker] = await Promise.all([
+      tmuxExecAsync(['show-option', '-qv', '-t', sessionName, pendingOption], { encoding: 'utf-8' })
+        .then(result => String(result.stdout).trim(), () => ''),
+      tmuxExecAsync(['show-option', '-qv', '-t', sessionName, terminalOption], { encoding: 'utf-8' })
+        .then(result => String(result.stdout).trim(), () => ''),
+    ]);
 
-    return marker === sendId ? 'delivered' : 'deduplicated';
+    if (terminalMarker !== '') return 'deduplicated';
+    if (pendingMarker === sendId) return 'pasted';
+    if (pendingMarker !== '') return 'submit-pending';
+    throw new Error(
+      `Keyed tmux paste for ${sessionName} did not land and no dedup marker was recorded` +
+      (caller ? ` (caller: ${caller})` : ''),
+    );
   } finally {
     await unlink(tmpFile).catch(() => {});
     await tmuxExecAsync(['delete-buffer', '-b', bufferName], { encoding: 'utf-8' }).catch(() => {});
   }
+}
+
+/**
+ * Complete the paste-settle-submit transaction for a keyed tmux delivery.
+ * Sends the standalone Enter after the settle window, then makes the key
+ * TERMINAL and clears the pending claim in one server-side command. Safe to
+ * call for both 'pasted' and 'submit-pending' phases; a replayed call after a
+ * crash lands at worst one extra Enter on an already-empty composer.
+ */
+export async function completeKeyedSubmit(sessionName: string, dedupKey: string): Promise<void> {
+  validateSessionName(sessionName);
+  assertValidDedupKey(dedupKey);
+  const terminalOption = dedupTerminalOptionName(dedupKey);
+  const pendingOption = dedupPendingOptionName(dedupKey);
+
+  await new Promise(resolve => setTimeout(resolve, PASTE_SETTLE_MS));
+  await tmuxExecAsync(['send-keys', '-t', sessionName, 'C-m'], { encoding: 'utf-8' });
+  // Submission is done — only now may the key become terminal. One
+  // server-side command so a dashboard exit cannot leave the markers
+  // half-flipped; if it fires anyway, the pending marker drives the harmless
+  // replay-Enter described above.
+  await tmuxExecAsync([
+    'set-option', '-t', sessionName, terminalOption, '1',
+    ';',
+    'set-option', '-u', '-t', sessionName, pendingOption,
+  ], { encoding: 'utf-8' });
 }

--- a/src/lib/tmux-dedup.ts
+++ b/src/lib/tmux-dedup.ts
@@ -270,9 +270,17 @@ export async function sendKeysDedup(
   // The poison breadcrumb invalidates any terminal marker (cycle 11/12): it
   // marks either a FALSE terminal whose rollback was interrupted or a
   // PROVISIONAL terminal whose post-submit verification never completed. The
-  // read is fail-CLOSED — a failed poison read must never be interpreted as
-  // "no poison" while a false terminal sits next to it.
-  const poisonMarker = await readStrict(sessionName, poisonOption);
+  // read is fail-CLOSED — and a REJECTED read is unproven protocol state, so
+  // it becomes the recoverable marker-error class (cycle 15): a transient
+  // failure before any side effect must never close the wake as terminal
+  // 'failed'. (A genuinely missing target is classified upstream at the
+  // messageAgent stopped/zombie layer, which resumes and re-delivers.)
+  let poisonMarker: string;
+  try {
+    poisonMarker = await readStrict(sessionName, poisonOption);
+  } catch (error) {
+    throw new KeyedMarkerVerificationError(sessionName, `initial poison read (key "${dedupKey}")`, { cause: error });
+  }
   // A repaired pending claim still has to prove its pane identity below —
   // the original paste's target may be stale or missing (cycle 13).
   const repaired = poisonMarker !== '';

--- a/src/lib/tmux-dedup.ts
+++ b/src/lib/tmux-dedup.ts
@@ -61,6 +61,17 @@ export function dedupPoisonOptionName(dedupKey: string): string {
   return `@overdeck-dedup-poison-${dedupKey}`;
 }
 
+/**
+ * The pane_pid of the pane that received the keyed paste (cycle 13). Set
+ * atomically with the paste (`set-option -F ... '#{pane_pid}'`) and required
+ * by the submit condition: recovery may complete an old pending claim with
+ * Enter alone ONLY when the current pane IS the pane that holds the pasted
+ * content. A replaced pane gets a real re-paste instead.
+ */
+export function dedupTargetOptionName(dedupKey: string): string {
+  return `@overdeck-dedup-target-${dedupKey}`;
+}
+
 export function assertValidDedupKey(dedupKey: string): void {
   if (!DEDUP_KEY_RE.test(dedupKey)) {
     throw new Error(`dedupKey must match [A-Za-z0-9:_-]+, got: ${dedupKey.slice(0, 40)}`);
@@ -93,6 +104,19 @@ export class KeyedSubmitTargetDeadError extends Error {
       `the pending claim for key "${dedupKey}" is preserved, and the key is not terminal`,
     );
     this.name = 'KeyedSubmitTargetDeadError';
+  }
+}
+
+/**
+ * A safety-critical marker read/verification failed (cycle 13) — the marker
+ * state is UNPROVEN, neither delivered nor lost. Recoverable: the caller's
+ * recovery retries; the poison breadcrumb (if set) stays authoritative in
+ * the meantime and is never bypassed by a failed read.
+ */
+export class KeyedMarkerVerificationError extends Error {
+  constructor(sessionName: string, context: string) {
+    super(`Keyed tmux markers for ${sessionName} could not be verified (${context})`);
+    this.name = 'KeyedMarkerVerificationError';
   }
 }
 
@@ -130,15 +154,15 @@ async function readMarkerStrict(sessionName: string, option: string): Promise<st
   return String(result.stdout).trim();
 }
 
-/** Clear the poison breadcrumb and VERIFY it is gone (cycle 12). */
+/** Clear the poison breadcrumb and VERIFY it is gone with a strict read (cycle 13). */
 async function clearPoisonVerified(
   sessionName: string,
   poisonOption: string,
   context: string,
-  read: (sessionName: string, option: string) => Promise<string> = readMarker,
+  readStrict: (sessionName: string, option: string) => Promise<string> = readMarkerStrict,
 ): Promise<void> {
   await tmuxExecAsync(['set-option', '-u', '-t', sessionName, poisonOption], { encoding: 'utf-8' });
-  const remaining = await read(sessionName, poisonOption);
+  const remaining = await readStrict(sessionName, poisonOption);
   if (remaining !== '') {
     throw new Error(`Keyed tmux markers for ${sessionName}: poison breadcrumb could not be cleared (${context})`);
   }
@@ -169,7 +193,7 @@ async function repairPoisonedMarkers(
   sessionName: string,
   dedupKey: string,
   sendId: string,
-  read: (sessionName: string, option: string) => Promise<string>,
+  readStrict: (sessionName: string, option: string) => Promise<string>,
 ): Promise<void> {
   const terminalOption = dedupTerminalOptionName(dedupKey);
   const pendingOption = dedupPendingOptionName(dedupKey);
@@ -179,14 +203,22 @@ async function repairPoisonedMarkers(
     ';',
     'set-option', '-t', sessionName, pendingOption, sendId,
   ], { encoding: 'utf-8' });
-  const [repairedTerminal, repairedPending] = await Promise.all([
-    read(sessionName, terminalOption),
-    read(sessionName, pendingOption),
-  ]);
+  let repairedTerminal: string;
+  let repairedPending: string;
+  try {
+    // STRICT reads (cycle 13): a failed verification read must abort while
+    // the breadcrumb stays authoritative — never convert it to empty state.
+    [repairedTerminal, repairedPending] = await Promise.all([
+      readStrict(sessionName, terminalOption),
+      readStrict(sessionName, pendingOption),
+    ]);
+  } catch {
+    throw new KeyedMarkerVerificationError(sessionName, `repair verification of key "${dedupKey}"`);
+  }
   if (repairedTerminal !== '' || repairedPending === '') {
     throw new Error(`Keyed tmux markers for ${sessionName} are poisoned and could not be repaired (key "${dedupKey}")`);
   }
-  await clearPoisonVerified(sessionName, poisonOption, `repair of key "${dedupKey}"`, read);
+  await clearPoisonVerified(sessionName, poisonOption, `repair of key "${dedupKey}"`, readStrict);
 }
 
 /**
@@ -224,11 +256,14 @@ export async function sendKeysDedup(
   // read is fail-CLOSED — a failed poison read must never be interpreted as
   // "no poison" while a false terminal sits next to it.
   const poisonMarker = await readStrict(sessionName, poisonOption);
-  if (poisonMarker !== '') {
-    await repairPoisonedMarkers(sessionName, dedupKey, sendId, read);
-    return 'submit-pending';
+  // A repaired pending claim still has to prove its pane identity below —
+  // the original paste's target may be stale or missing (cycle 13).
+  const repaired = poisonMarker !== '';
+  if (repaired) {
+    await repairPoisonedMarkers(sessionName, dedupKey, sendId, readStrict);
   }
 
+  const targetOption = dedupTargetOptionName(dedupKey);
   const tmpFile = join(tmpdir(), `pan-sendkeys-${sendId}.txt`);
   const bufferName = `pan-${sendId}`;
 
@@ -236,26 +271,62 @@ export async function sendKeysDedup(
     await writeFile(tmpFile, keys, 'utf-8');
     await tmuxExecAsync(['load-buffer', '-b', bufferName, tmpFile], { encoding: 'utf-8' });
 
-    // One server-side command: paste only when NEITHER marker is set, and
-    // record OUR sendId in the pending option in the same breath. Reading the
-    // markers back distinguishes "we just pasted" from "a prior attempt is
-    // mid-transaction" from "already submitted".
-    await tmuxExecAsync([
-      'if-shell', '-t', sessionName,
-      `test -z "$(tmux show-option -qv -t ${sessionName} ${pendingOption})" && test -z "$(tmux show-option -qv -t ${sessionName} ${terminalOption})"`,
-      `paste-buffer -b ${bufferName} -p -t ${sessionName} \; set-option -t ${sessionName} ${pendingOption} ${sendId}`,
-    ], { encoding: 'utf-8' });
+    if (!repaired) {
+      // One server-side command: paste only when NEITHER marker is set, and
+      // record OUR sendId in the pending option AND the receiving pane's pid
+      // in the target option in the same breath (cycle 13 — the target
+      // identity is what lets recovery decide whether the pasted content is
+      // still there).
+      await tmuxExecAsync([
+        'if-shell', '-t', sessionName,
+        `test -z "$(tmux show-option -qv -t ${sessionName} ${pendingOption})" && test -z "$(tmux show-option -qv -t ${sessionName} ${terminalOption})"`,
+        `paste-buffer -b ${bufferName} -p -t ${sessionName} \; set-option -t ${sessionName} ${pendingOption} ${sendId} \; set-option -F -t ${sessionName} ${targetOption} '#{pane_pid}'`,
+      ], { encoding: 'utf-8' });
+    }
 
     const [pendingMarker, terminalMarker] = await Promise.all([
-      tmuxExecAsync(['show-option', '-qv', '-t', sessionName, pendingOption], { encoding: 'utf-8' })
-        .then(result => String(result.stdout).trim(), () => ''),
-      tmuxExecAsync(['show-option', '-qv', '-t', sessionName, terminalOption], { encoding: 'utf-8' })
-        .then(result => String(result.stdout).trim(), () => ''),
+      read(sessionName, pendingOption),
+      read(sessionName, terminalOption),
     ]);
 
     if (terminalMarker !== '') return 'deduplicated';
-    if (pendingMarker === sendId) return 'pasted';
-    if (pendingMarker !== '') return 'submit-pending';
+    if (!repaired && pendingMarker === sendId) return 'pasted';
+    if (pendingMarker !== '') {
+      // A prior attempt's claim (or a repaired one) is still pending. The
+      // pasted content is only reusable when the current pane IS the pane
+      // that received it (cycle 13): a replaced pane (respawned harness,
+      // crashed session that kept its options) has an empty composer, so
+      // completing with Enter alone would acknowledge a blank submission.
+      // Re-paste the real content instead.
+      const recordedTarget = await read(sessionName, targetOption);
+      const currentPid = (await (deps.readPaneTarget ?? readPaneTarget)(sessionName)).pid;
+      if (recordedTarget !== '' && currentPid !== '' && recordedTarget === currentPid) {
+        return 'submit-pending';
+      }
+      // One server-side command: re-paste only when the pending claim still
+      // stands, no terminal exists, and the recorded target does NOT match
+      // the current pane — and record the NEW target in the same breath.
+      await tmuxExecAsync([
+        'if-shell', '-t', sessionName,
+        `test -n "$(tmux show-option -qv -t ${sessionName} ${pendingOption})" && ` +
+        `test -z "$(tmux show-option -qv -t ${sessionName} ${terminalOption})" && ` +
+        `! test "$(tmux display-message -p -t ${sessionName} '#{pane_pid}')" = "$(tmux show-option -qv -t ${sessionName} ${targetOption})"`,
+        `paste-buffer -b ${bufferName} -p -t ${sessionName} \; set-option -t ${sessionName} ${pendingOption} ${sendId} \; set-option -F -t ${sessionName} ${targetOption} '#{pane_pid}'`,
+      ], { encoding: 'utf-8' });
+      const [repastedPending, repastedTerminal, repastedTarget] = await Promise.all([
+        read(sessionName, pendingOption),
+        read(sessionName, terminalOption),
+        read(sessionName, targetOption),
+      ]);
+      if (repastedTerminal !== '') return 'deduplicated';
+      if (repastedPending === sendId) return 'pasted';
+      if (repastedPending !== '') {
+        // A concurrent attempt owns the claim; honor it only if its target
+        // matches the current pane.
+        const nowPid = (await (deps.readPaneTarget ?? readPaneTarget)(sessionName)).pid;
+        if (repastedTarget !== '' && nowPid !== '' && repastedTarget === nowPid) return 'submit-pending';
+      }
+    }
     throw new Error(
       `Keyed tmux paste for ${sessionName} did not land and no dedup marker was recorded` +
       (caller ? ` (caller: ${caller})` : ''),
@@ -310,10 +381,12 @@ export async function completeKeyedSubmit(
   validateSessionName(sessionName);
   assertValidDedupKey(dedupKey);
   const read = deps.readMarker ?? readMarker;
+  const readStrict = deps.readMarkerStrict ?? readMarkerStrict;
   const readTarget = deps.readPaneTarget ?? readPaneTarget;
   const terminalOption = dedupTerminalOptionName(dedupKey);
   const pendingOption = dedupPendingOptionName(dedupKey);
   const poisonOption = dedupPoisonOptionName(dedupKey);
+  const targetOption = dedupTargetOptionName(dedupKey);
 
   await new Promise(resolve => setTimeout(resolve, PASTE_SETTLE_MS));
 
@@ -329,18 +402,23 @@ export async function completeKeyedSubmit(
   // TERMINAL marker, and the pending clear are ONE server-owned command list,
   // so a dashboard crash anywhere after this command leaves poison+terminal
   // together — recovery can never find an honorable-but-unverified terminal.
+  // The condition also requires the current pane to BE the pane that received
+  // the paste (cycle 13): a replaced pane has an empty composer, so Enter
+  // alone would be a blank submission.
   await tmuxExecAsync([
     'if-shell', '-t', sessionName,
     `test -z "$(tmux show-option -qv -t ${sessionName} ${terminalOption})" && ` +
     `test -n "$(tmux show-option -qv -t ${sessionName} ${pendingOption})" && ` +
-    `test "$(tmux display-message -p -t ${sessionName} '#{pane_dead}')" = "0"`,
+    `test "$(tmux display-message -p -t ${sessionName} '#{pane_dead}')" = "0" && ` +
+    `test "$(tmux display-message -p -t ${sessionName} '#{pane_pid}')" = "$(tmux show-option -qv -t ${sessionName} ${targetOption})"`,
     `send-keys -t ${sessionName} C-m \; set-option -t ${sessionName} ${poisonOption} 1 \; set-option -t ${sessionName} ${terminalOption} 1 \; set-option -u -t ${sessionName} ${pendingOption}`,
   ], { encoding: 'utf-8' });
 
-  const [terminalAfter, pendingAfter, postTarget] = await Promise.all([
+  const [terminalAfter, pendingAfter, postTarget, recordedTarget] = await Promise.all([
     read(sessionName, terminalOption),
     read(sessionName, pendingOption),
     readTarget(sessionName),
+    read(sessionName, targetOption),
   ]);
 
   // FAIL CLOSED (cycle 11): the key may only become terminal when BOTH target
@@ -356,39 +434,49 @@ export async function completeKeyedSubmit(
   if (terminalAfter !== '') {
     if (!targetLost) {
       // Verified delivery — lift the provisional breadcrumb, fail-closed
-      // (cycle 12): a stale breadcrumb would let a later replay invalidate
-      // this legitimate terminal and re-submit.
-      await clearPoisonVerified(sessionName, poisonOption, `verified delivery of key "${dedupKey}"`, read);
+      // (cycle 12/13): a stale breadcrumb would let a later replay
+      // invalidate this legitimate terminal and re-submit.
+      await clearPoisonVerified(sessionName, poisonOption, `verified delivery of key "${dedupKey}"`, readStrict);
       return;
     }
     // The pane died, was replaced, or cannot be identified around the Enter:
     // tmux may have reported send-keys as successful while the input landed
     // nowhere, and even an accepted Enter is worthless once the receiving
-    // harness is gone. ROLL THE KEY BACK and verify; the breadcrumb set by
-    // the submit list already marks the terminal provisional, so a failed
-    // rollback can never leave it honorable.
+    // harness is gone. ROLL THE KEY BACK and verify with STRICT reads (cycle
+    // 13): the breadcrumb set by the submit list already marks the terminal
+    // provisional, so a failed rollback can never leave it honorable.
     const rollbackArgs = pendingBefore === ''
       ? ['set-option', '-u', '-t', sessionName, terminalOption, ';', 'set-option', '-u', '-t', sessionName, pendingOption]
       : ['set-option', '-u', '-t', sessionName, terminalOption, ';', 'set-option', '-t', sessionName, pendingOption, pendingBefore];
     await tmuxExecAsync(rollbackArgs, { encoding: 'utf-8' }).catch(() => {});
-    const [rolledTerminal, restoredPending] = await Promise.all([
-      read(sessionName, terminalOption),
-      read(sessionName, pendingOption),
-    ]);
+    let rolledTerminal: string;
+    let restoredPending: string;
+    try {
+      [rolledTerminal, restoredPending] = await Promise.all([
+        readStrict(sessionName, terminalOption),
+        readStrict(sessionName, pendingOption),
+      ]);
+    } catch {
+      // Verification read failed — rollback state unproven; the breadcrumb
+      // stays authoritative and recovery retries.
+      throw new KeyedMarkerVerificationError(sessionName, `rollback verification of key "${dedupKey}"`);
+    }
     if (rolledTerminal === '' && restoredPending !== '') {
       // Verified rollback — lift the breadcrumb. If the clear fails the
       // surviving poison is idempotent-safe here (terminal is already clear,
       // so a later repair restores the same pending state and retries).
-      await clearPoisonVerified(sessionName, poisonOption, `verified rollback of key "${dedupKey}"`, read)
+      await clearPoisonVerified(sessionName, poisonOption, `verified rollback of key "${dedupKey}"`, readStrict)
         .catch(() => {});
     }
     throw new KeyedSubmitTargetDeadError(sessionName, dedupKey);
   }
   if (pendingAfter !== '') {
     // The condition rejected the submit. A dead/replaced/unprovable pane is
-    // the recoverable case (the pending claim is preserved so recovery can
-    // retry after resume); anything else is a definitive delivery failure.
-    if (targetLost) throw new KeyedSubmitTargetDeadError(sessionName, dedupKey);
+    // the recoverable case: a pane whose pid no longer matches the recorded
+    // paste target has an empty composer (cycle 13) — recovery must re-paste
+    // the real content, which phase 1's target-mismatch path does.
+    const replaced = recordedTarget === '' || postTarget.pid === '' || recordedTarget !== postTarget.pid;
+    if (targetLost || replaced) throw new KeyedSubmitTargetDeadError(sessionName, dedupKey);
     throw new Error(`Keyed tmux submit for ${sessionName} was rejected with the pending claim intact on a live pane`);
   }
   throw new Error(`Keyed tmux submit for ${sessionName} found neither a pending claim nor a terminal marker — the paste vanished without submission`);

--- a/src/lib/tmux-dedup.ts
+++ b/src/lib/tmux-dedup.ts
@@ -11,21 +11,20 @@
  * so a replay after either crash is correct.
  *
  * The protocol is two-phase so the complete paste-settle-submit transaction
- * survives a dashboard crash (review cycle 7): the key becomes terminal only
- * after submission is complete.
+ * survives a dashboard crash: the key becomes terminal only as part of the
+ * server-owned submission itself.
  *
- *   (none) ──paste──► PENDING ──Enter──► TERMINAL
+ *   (none) ──paste──► PENDING ──atomic claim+Enter──► TERMINAL
  *
  * - `sendKeysDedup` atomically pastes and sets the PENDING option only when
  *   neither option is set. A replay that finds PENDING (a prior attempt
- *   crashed between paste and submit) returns 'submit-pending' WITHOUT
- *   re-pasting; the caller completes the pending submission instead.
- * - `completeKeyedSubmit` waits out the settle window, sends the standalone
- *   Enter, and only then flips the key to TERMINAL and clears PENDING. A
- *   crash between Enter and the terminal flip leaves PENDING set, so the
- *   next replay sends one more Enter — a no-op on the already-submitted,
- *   now-empty composer — and then marks the key terminal. No replay ever
- *   re-pastes the message.
+ *   crashed before submitting) returns 'submit-pending' WITHOUT re-pasting.
+ * - `completeKeyedSubmit` issues ONE `if-shell`: only when PENDING is present
+ *   and TERMINAL absent does the tmux server flip TERMINAL, clear PENDING,
+ *   and send the Enter — in that order, in a single server-executed command
+ *   list. Exactly one caller can become the completer; every other concurrent
+ *   or post-crash caller loses the server-side condition and sends nothing,
+ *   so no stray Enter can ever land in a composer holding unrelated text.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -126,10 +125,22 @@ export async function sendKeysDedup(
 
 /**
  * Complete the paste-settle-submit transaction for a keyed tmux delivery.
- * Sends the standalone Enter after the settle window, then makes the key
- * TERMINAL and clears the pending claim in one server-side command. Safe to
- * call for both 'pasted' and 'submit-pending' phases; a replayed call after a
- * crash lands at worst one extra Enter on an already-empty composer.
+ *
+ * After the settle window, the SUBMISSION is one server-owned command: a
+ * single `if-shell` whose condition requires the pending claim present and
+ * the terminal marker absent, and whose command list flips the key TERMINAL
+ * and clears pending BEFORE sending the Enter. The tmux server executes the
+ * whole sequence, so exactly one caller can ever become the completer —
+ * concurrent same-key completers lose the condition and send nothing, and a
+ * dashboard that retries after a crash never has to decide whether a prior
+ * standalone Enter landed: the server-side condition answers that. No code
+ * path sends a stray Enter into a composer that may hold unrelated operator
+ * text (review cycle 8).
+ *
+ * Safe to call for both 'pasted' and 'submit-pending' phases; a call whose
+ * key is already terminal is a no-op. Throws when neither marker is present
+ * after the command — the pending claim vanished without a submission, which
+ * must surface as a delivery failure rather than silent loss.
  */
 export async function completeKeyedSubmit(sessionName: string, dedupKey: string): Promise<void> {
   validateSessionName(sessionName);
@@ -138,14 +149,19 @@ export async function completeKeyedSubmit(sessionName: string, dedupKey: string)
   const pendingOption = dedupPendingOptionName(dedupKey);
 
   await new Promise(resolve => setTimeout(resolve, PASTE_SETTLE_MS));
-  await tmuxExecAsync(['send-keys', '-t', sessionName, 'C-m'], { encoding: 'utf-8' });
-  // Submission is done — only now may the key become terminal. One
-  // server-side command so a dashboard exit cannot leave the markers
-  // half-flipped; if it fires anyway, the pending marker drives the harmless
-  // replay-Enter described above.
   await tmuxExecAsync([
-    'set-option', '-t', sessionName, terminalOption, '1',
-    ';',
-    'set-option', '-u', '-t', sessionName, pendingOption,
+    'if-shell', '-t', sessionName,
+    `test -z "$(tmux show-option -qv -t ${sessionName} ${terminalOption})" && test -n "$(tmux show-option -qv -t ${sessionName} ${pendingOption})"`,
+    `set-option -t ${sessionName} ${terminalOption} 1 \; set-option -u -t ${sessionName} ${pendingOption} \; send-keys -t ${sessionName} C-m`,
   ], { encoding: 'utf-8' });
+
+  const [terminalMarker, pendingMarker] = await Promise.all([
+    tmuxExecAsync(['show-option', '-qv', '-t', sessionName, terminalOption], { encoding: 'utf-8' })
+      .then(result => String(result.stdout).trim(), () => ''),
+    tmuxExecAsync(['show-option', '-qv', '-t', sessionName, pendingOption], { encoding: 'utf-8' })
+      .then(result => String(result.stdout).trim(), () => ''),
+  ]);
+  if (terminalMarker === '' && pendingMarker === '') {
+    throw new Error(`Keyed tmux submit for ${sessionName} found neither a pending claim nor a terminal marker — the paste vanished without submission`);
+  }
 }

--- a/src/lib/tmux-dedup.ts
+++ b/src/lib/tmux-dedup.ts
@@ -119,6 +119,77 @@ async function readMarker(sessionName: string, option: string): Promise<string> 
 }
 
 /**
+ * Fail-CLOSED marker read (cycle 12): `-q` makes an unset user option a clean
+ * empty read, so a rejection is always a REAL failure (missing session,
+ * unreachable server). Safety-critical markers (the poison breadcrumb) must
+ * be read this way — interpreting a failed read as "absent" could honor a
+ * false terminal marker or bypass a rollback-required state.
+ */
+async function readMarkerStrict(sessionName: string, option: string): Promise<string> {
+  const result = await tmuxExecAsync(['show-option', '-qv', '-t', sessionName, option], { encoding: 'utf-8' });
+  return String(result.stdout).trim();
+}
+
+/** Clear the poison breadcrumb and VERIFY it is gone (cycle 12). */
+async function clearPoisonVerified(
+  sessionName: string,
+  poisonOption: string,
+  context: string,
+  read: (sessionName: string, option: string) => Promise<string> = readMarker,
+): Promise<void> {
+  await tmuxExecAsync(['set-option', '-u', '-t', sessionName, poisonOption], { encoding: 'utf-8' });
+  const remaining = await read(sessionName, poisonOption);
+  if (remaining !== '') {
+    throw new Error(`Keyed tmux markers for ${sessionName}: poison breadcrumb could not be cleared (${context})`);
+  }
+}
+
+export interface KeyedTmuxDeps {
+  /** Test seam for marker-read failures; production uses the real tmux reads. */
+  readMarker?: (sessionName: string, option: string) => Promise<string>;
+  readMarkerStrict?: (sessionName: string, option: string) => Promise<string>;
+  /** Test seam for target-read failures; production uses the real tmux read. */
+  readPaneTarget?: (sessionName: string) => Promise<PaneTarget>;
+}
+
+/**
+ * Repair a poisoned marker set (cycle 11/12): clear the terminal marker,
+ * restore a pending claim, verify both, then clear the breadcrumb — verified.
+ * A poisoned terminal is PROVISIONAL: it may be a false claim (rollback was
+ * interrupted) or a delivered-but-unverified one, and the tmux tier cannot
+ * distinguish them — so repair always rolls back to pending and lets the
+ * normal recovery re-drive. An empty Enter on the (already-submitted, live)
+ * composer is the worst case; a suppressed wake is never acceptable.
+ *
+ * Returns normally only when the breadcrumb is verifiably gone; throws
+ * otherwise (the caller must NOT submit while a stale breadcrumb survives —
+ * a later replay would invalidate a legitimate terminal and re-submit).
+ */
+async function repairPoisonedMarkers(
+  sessionName: string,
+  dedupKey: string,
+  sendId: string,
+  read: (sessionName: string, option: string) => Promise<string>,
+): Promise<void> {
+  const terminalOption = dedupTerminalOptionName(dedupKey);
+  const pendingOption = dedupPendingOptionName(dedupKey);
+  const poisonOption = dedupPoisonOptionName(dedupKey);
+  await tmuxExecAsync([
+    'set-option', '-u', '-t', sessionName, terminalOption,
+    ';',
+    'set-option', '-t', sessionName, pendingOption, sendId,
+  ], { encoding: 'utf-8' });
+  const [repairedTerminal, repairedPending] = await Promise.all([
+    read(sessionName, terminalOption),
+    read(sessionName, pendingOption),
+  ]);
+  if (repairedTerminal !== '' || repairedPending === '') {
+    throw new Error(`Keyed tmux markers for ${sessionName} are poisoned and could not be repaired (key "${dedupKey}")`);
+  }
+  await clearPoisonVerified(sessionName, poisonOption, `repair of key "${dedupKey}"`, read);
+}
+
+/**
  * Deduplicated message paste for the tmux fallback path.
  *
  * Returns 'pasted' when this call pasted (caller must complete the submit),
@@ -135,35 +206,26 @@ export async function sendKeysDedup(
   keys: string,
   dedupKey: string,
   caller?: string,
+  deps: KeyedTmuxDeps = {},
 ): Promise<KeyedTmuxPhase> {
   validateSessionName(sessionName);
   assertValidDedupKey(dedupKey);
+  const read = deps.readMarker ?? readMarker;
+  const readStrict = deps.readMarkerStrict ?? readMarkerStrict;
   const terminalOption = dedupTerminalOptionName(dedupKey);
   const pendingOption = dedupPendingOptionName(dedupKey);
   const poisonOption = dedupPoisonOptionName(dedupKey);
 
   const sendId = randomUUID();
 
-  // The poison breadcrumb invalidates any terminal marker (cycle 11): a
-  // previous post-submit check proved the terminal marker FALSE but could
-  // not verify its rollback. Repair the markers FIRST — the terminal marker
-  // must never be honored while the breadcrumb exists — then continue as a
-  // pending completion, never as a dedup and never as a fresh paste.
-  const poisonMarker = await readMarker(sessionName, poisonOption);
+  // The poison breadcrumb invalidates any terminal marker (cycle 11/12): it
+  // marks either a FALSE terminal whose rollback was interrupted or a
+  // PROVISIONAL terminal whose post-submit verification never completed. The
+  // read is fail-CLOSED — a failed poison read must never be interpreted as
+  // "no poison" while a false terminal sits next to it.
+  const poisonMarker = await readStrict(sessionName, poisonOption);
   if (poisonMarker !== '') {
-    await tmuxExecAsync([
-      'set-option', '-u', '-t', sessionName, terminalOption,
-      ';',
-      'set-option', '-t', sessionName, pendingOption, sendId,
-    ], { encoding: 'utf-8' });
-    const [repairedTerminal, repairedPending] = await Promise.all([
-      readMarker(sessionName, terminalOption),
-      readMarker(sessionName, pendingOption),
-    ]);
-    if (repairedTerminal !== '' || repairedPending === '') {
-      throw new Error(`Keyed tmux markers for ${sessionName} are poisoned and could not be repaired (key "${dedupKey}")`);
-    }
-    await tmuxExecAsync(['set-option', '-u', '-t', sessionName, poisonOption], { encoding: 'utf-8' }).catch(() => {});
+    await repairPoisonedMarkers(sessionName, dedupKey, sendId, read);
     return 'submit-pending';
   }
 
@@ -210,8 +272,10 @@ export async function sendKeysDedup(
  * After the settle window, the SUBMISSION is one server-owned command: a
  * single `if-shell` whose condition requires the pending claim present, the
  * terminal marker absent, AND the pane alive, and whose command list sends
- * the Enter FIRST and only then flips the key TERMINAL and clears pending.
- * The tmux server executes the whole sequence (cycle 9 ordering):
+ * the Enter FIRST and then sets the POISON breadcrumb and the TERMINAL
+ * marker and clears pending — the terminal is PROVISIONAL from the moment it
+ * exists, so a dashboard crash can never strand an honorable-but-unverified
+ * terminal (cycle 12). The tmux server executes the whole sequence:
  *
  * - A pane that died during the settle window fails the liveness condition —
  *   NO marker changes and NO Enter is sent, so the wake is never recorded as
@@ -220,9 +284,12 @@ export async function sendKeysDedup(
  * - The pre-branch liveness condition is NOT proof of acceptance (cycle 10):
  *   the pane can die in the shell-to-branch handoff, and tmux reports
  *   send-keys into a remain-on-exit corpse as success. So after the command
- *   the target is re-read — if the pane died or its pid changed around the
- *   Enter, the terminal marker is ROLLED BACK, the pending claim restored,
- *   and KeyedSubmitTargetDeadError is thrown.
+ *   the target is re-read — if the pane died, was replaced, or cannot be
+ *   identified around the Enter, the terminal marker is ROLLED BACK and the
+ *   pending claim restored, and KeyedSubmitTargetDeadError is thrown. The
+ *   breadcrumb is lifted only after verification, and clearing it is itself
+ *   verified (cycle 12): a stale breadcrumb would let a later replay
+ *   invalidate a legitimate terminal and re-submit.
  * - The Enter precedes the terminal transition inside the transaction, so a
  *   failed Enter (which aborts the command list) can never leave the key
  *   terminal.
@@ -235,18 +302,14 @@ export async function sendKeysDedup(
  * the pane is dead (pending claim preserved), and a generic error when both
  * markers vanished without a submission.
  */
-export interface KeyedSubmitDeps {
-  /** Test seam for target-read failures; production uses the real tmux read. */
-  readPaneTarget?: (sessionName: string) => Promise<PaneTarget>;
-}
-
 export async function completeKeyedSubmit(
   sessionName: string,
   dedupKey: string,
-  deps: KeyedSubmitDeps = {},
+  deps: KeyedTmuxDeps = {},
 ): Promise<void> {
   validateSessionName(sessionName);
   assertValidDedupKey(dedupKey);
+  const read = deps.readMarker ?? readMarker;
   const readTarget = deps.readPaneTarget ?? readPaneTarget;
   const terminalOption = dedupTerminalOptionName(dedupKey);
   const pendingOption = dedupPendingOptionName(dedupKey);
@@ -260,19 +323,23 @@ export async function completeKeyedSubmit(
   // remain-on-exit corpse as SUCCESS. What proves acceptance is the
   // post-submit check below (cycle 10).
   const preTarget = await readTarget(sessionName);
-  const pendingBefore = await readMarker(sessionName, pendingOption);
+  const pendingBefore = await read(sessionName, pendingOption);
 
+  // PROVISIONAL from birth (cycle 12): the Enter, the POISON breadcrumb, the
+  // TERMINAL marker, and the pending clear are ONE server-owned command list,
+  // so a dashboard crash anywhere after this command leaves poison+terminal
+  // together — recovery can never find an honorable-but-unverified terminal.
   await tmuxExecAsync([
     'if-shell', '-t', sessionName,
     `test -z "$(tmux show-option -qv -t ${sessionName} ${terminalOption})" && ` +
     `test -n "$(tmux show-option -qv -t ${sessionName} ${pendingOption})" && ` +
     `test "$(tmux display-message -p -t ${sessionName} '#{pane_dead}')" = "0"`,
-    `send-keys -t ${sessionName} C-m \; set-option -t ${sessionName} ${terminalOption} 1 \; set-option -u -t ${sessionName} ${pendingOption}`,
+    `send-keys -t ${sessionName} C-m \; set-option -t ${sessionName} ${poisonOption} 1 \; set-option -t ${sessionName} ${terminalOption} 1 \; set-option -u -t ${sessionName} ${pendingOption}`,
   ], { encoding: 'utf-8' });
 
   const [terminalAfter, pendingAfter, postTarget] = await Promise.all([
-    readMarker(sessionName, terminalOption),
-    readMarker(sessionName, pendingOption),
+    read(sessionName, terminalOption),
+    read(sessionName, pendingOption),
     readTarget(sessionName),
   ]);
 
@@ -287,25 +354,33 @@ export async function completeKeyedSubmit(
     postTarget.pid !== preTarget.pid;
 
   if (terminalAfter !== '') {
-    if (!targetLost) return; // Submitted to a proven-live pane — by this call or a concurrent completer.
+    if (!targetLost) {
+      // Verified delivery — lift the provisional breadcrumb, fail-closed
+      // (cycle 12): a stale breadcrumb would let a later replay invalidate
+      // this legitimate terminal and re-submit.
+      await clearPoisonVerified(sessionName, poisonOption, `verified delivery of key "${dedupKey}"`, read);
+      return;
+    }
     // The pane died, was replaced, or cannot be identified around the Enter:
     // tmux may have reported send-keys as successful while the input landed
     // nowhere, and even an accepted Enter is worthless once the receiving
-    // harness is gone. ROLL THE KEY BACK as a VERIFIED protocol transition
-    // (cycle 11): breadcrumb first so a failed rollback can never leave a
-    // false terminal marker honorable, then rollback, then verify.
-    await tmuxExecAsync(['set-option', '-t', sessionName, poisonOption, '1'], { encoding: 'utf-8' });
+    // harness is gone. ROLL THE KEY BACK and verify; the breadcrumb set by
+    // the submit list already marks the terminal provisional, so a failed
+    // rollback can never leave it honorable.
     const rollbackArgs = pendingBefore === ''
       ? ['set-option', '-u', '-t', sessionName, terminalOption, ';', 'set-option', '-u', '-t', sessionName, pendingOption]
       : ['set-option', '-u', '-t', sessionName, terminalOption, ';', 'set-option', '-t', sessionName, pendingOption, pendingBefore];
     await tmuxExecAsync(rollbackArgs, { encoding: 'utf-8' }).catch(() => {});
     const [rolledTerminal, restoredPending] = await Promise.all([
-      readMarker(sessionName, terminalOption),
-      readMarker(sessionName, pendingOption),
+      read(sessionName, terminalOption),
+      read(sessionName, pendingOption),
     ]);
     if (rolledTerminal === '' && restoredPending !== '') {
-      // Verified — the breadcrumb is no longer needed.
-      await tmuxExecAsync(['set-option', '-u', '-t', sessionName, poisonOption], { encoding: 'utf-8' }).catch(() => {});
+      // Verified rollback — lift the breadcrumb. If the clear fails the
+      // surviving poison is idempotent-safe here (terminal is already clear,
+      // so a later repair restores the same pending state and retries).
+      await clearPoisonVerified(sessionName, poisonOption, `verified rollback of key "${dedupKey}"`, read)
+        .catch(() => {});
     }
     throw new KeyedSubmitTargetDeadError(sessionName, dedupKey);
   }

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -21,7 +21,7 @@ const VALID_SESSION_NAME_RE = /^[a-zA-Z0-9._-]+$/;
 const DEFAULT_TMUX_WINDOW_COLS = 200;
 const DEFAULT_TMUX_WINDOW_ROWS = 50;
 
-function validateSessionName(name: string): void {
+export function validateSessionName(name: string): void {
   if (!VALID_SESSION_NAME_RE.test(name)) {
     throw new Error(`Invalid tmux session name: ${name}`);
   }
@@ -466,7 +466,7 @@ export function buildTmuxCommandString(args: string[]): string {
   return [command, ...commandArgs.map(shellQuote)].join(' ');
 }
 
-async function tmuxExecAsync(args: string[], options?: Parameters<typeof execFileAsync>[2]) {
+export async function tmuxExecAsync(args: string[], options?: Parameters<typeof execFileAsync>[2]) {
   const mode = getTmuxConfigMode();
   await ensureTmuxContextPreparedAsync(mode);
   return execFileAsync('tmux', [...getTmuxContextArgsForMode(mode), ...args], options);

--- a/sync-sources/hooks/linear-mcp-auth-hook
+++ b/sync-sources/hooks/linear-mcp-auth-hook
@@ -1,5 +1,10 @@
 #!/bin/bash
-# PostToolUse hook for structured Linear MCP OAuth intervention events (PAN-2997).
+# PostToolUse + PostToolUseFailure hook for structured Linear MCP OAuth
+# intervention events (PAN-2997). Registered with matcher mcp__linear__.* for
+# both hook events: PostToolUse fires after a tool call SUCCEEDS, while a
+# failed MCP call — the motivating OAuth-expired case — fires
+# PostToolUseFailure with a top-level `error` field and no tool_response.
+#
 # Never breaks Claude Code: every failure exits 0 silently.
 
 set +e
@@ -10,6 +15,8 @@ command -v jq >/dev/null 2>&1 || exit 0
 TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)
 [[ "$TOOL_NAME" == mcp__linear__* ]] || exit 0
 
+EVENT_NAME=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // "PostToolUse"' 2>/dev/null)
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=pan-hook-lib.sh
 . "$SCRIPT_DIR/pan-hook-lib.sh" 2>/dev/null || exit 0
@@ -17,14 +24,15 @@ declare -f pan_resolve_agent_id >/dev/null 2>&1 || exit 0
 pan_resolve_agent_id || exit 0
 declare -f pan_emit_event >/dev/null 2>&1 || exit 0
 
-RESPONSE=$(printf '%s' "$INPUT" | jq -r '
-  (.tool_response // .tool_result // "")
-  | if type == "string" then . else tojson end
-' 2>/dev/null)
-[ -n "$RESPONSE" ] || RESPONSE=''
-
 MARKER_DIR="${OVERDECK_HOME:-$HOME/.overdeck}/agents/$AGENT_ID"
 MARKER="$MARKER_DIR/linear-mcp-auth-pending"
+
+# Auth-failure classifier. The 401 alternative requires a non-identifier
+# boundary on both sides so ordinary Linear data (MIN-401, "AUR-4015") can
+# never match; prose phrases are matched as words.
+is_auth_error_text() {
+  printf '%s' "$1" | grep -Eiq 'requires authentication|not authenticated|unauthorized|(^|[^0-9A-Za-z-])401([^0-9]|$)'
+}
 
 emit_required() {
   local auth_url="$1"
@@ -46,6 +54,22 @@ emit_healthy_if_pending() {
   rm -f "$MARKER" 2>/dev/null || true
 }
 
+if [ "$EVENT_NAME" = "PostToolUseFailure" ]; then
+  # Documented failure-event shape: top-level `error`, no tool_response.
+  ERROR_TEXT=$(printf '%s' "$INPUT" | jq -r '.error // ""' 2>/dev/null)
+  if is_auth_error_text "$ERROR_TEXT"; then
+    emit_required ''
+  fi
+  exit 0
+fi
+
+# PostToolUse — successful tool call.
+RESPONSE=$(printf '%s' "$INPUT" | jq -r '
+  (.tool_response // .tool_result // "")
+  | if type == "string" then . else tojson end
+' 2>/dev/null)
+[ -n "$RESPONSE" ] || RESPONSE=''
+
 if [ "$TOOL_NAME" = 'mcp__linear__authenticate' ]; then
   AUTH_URL=$(printf '%s\n' "$RESPONSE" \
     | grep -Eo 'https://linear\.app/oauth/authorize[^"[:space:]<>]*' 2>/dev/null \
@@ -54,7 +78,17 @@ if [ "$TOOL_NAME" = 'mcp__linear__authenticate' ]; then
   exit 0
 fi
 
-if printf '%s' "$RESPONSE" | grep -Eiq 'requires authentication|not authenticated|unauthorized|401'; then
+# An MCP server can report a failure inside a successful hook event as an
+# error-shaped payload (isError: true, or an `error` member). Only those
+# payloads are auth-classified — ordinary successful result data (issue
+# identifiers like MIN-401, titles mentioning 401s or "unauthorized") never
+# reaches this check and simply clears any pending intervention below.
+ERROR_SHAPED=$(printf '%s' "$INPUT" | jq -r '
+  (.tool_response // .tool_result // {})
+  | if type == "object" and ((.isError == true) or (.error != null)) then "yes" else "" end
+' 2>/dev/null)
+
+if [ -n "$ERROR_SHAPED" ] && is_auth_error_text "$RESPONSE"; then
   emit_required ''
   exit 0
 fi

--- a/sync-sources/hooks/linear-mcp-auth-hook
+++ b/sync-sources/hooks/linear-mcp-auth-hook
@@ -1,0 +1,63 @@
+#!/bin/bash
+# PostToolUse hook for structured Linear MCP OAuth intervention events (PAN-2997).
+# Never breaks Claude Code: every failure exits 0 silently.
+
+set +e
+
+INPUT=$(cat 2>/dev/null || echo '{}')
+command -v jq >/dev/null 2>&1 || exit 0
+
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)
+[[ "$TOOL_NAME" == mcp__linear__* ]] || exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=pan-hook-lib.sh
+. "$SCRIPT_DIR/pan-hook-lib.sh" 2>/dev/null || exit 0
+declare -f pan_resolve_agent_id >/dev/null 2>&1 || exit 0
+pan_resolve_agent_id || exit 0
+declare -f pan_emit_event >/dev/null 2>&1 || exit 0
+
+RESPONSE=$(printf '%s' "$INPUT" | jq -r '
+  (.tool_response // .tool_result // "")
+  | if type == "string" then . else tojson end
+' 2>/dev/null)
+[ -n "$RESPONSE" ] || RESPONSE=''
+
+MARKER_DIR="${OVERDECK_HOME:-$HOME/.overdeck}/agents/$AGENT_ID"
+MARKER="$MARKER_DIR/linear-mcp-auth-pending"
+
+emit_required() {
+  local auth_url="$1"
+  local body
+  body=$(jq -n --arg authUrl "$auth_url" '{
+    kind: "linear_mcp_auth_required",
+    authUrl: (if $authUrl == "" then null else $authUrl end)
+  }' 2>/dev/null) || return 0
+  pan_emit_event "$AGENT_ID" "$body" >/dev/null 2>&1 || true
+  mkdir -p "$MARKER_DIR" 2>/dev/null || true
+  : > "$MARKER" 2>/dev/null || true
+}
+
+emit_healthy_if_pending() {
+  [ -f "$MARKER" ] || return 0
+  local body
+  body=$(jq -n '{kind: "linear_mcp_auth_healthy"}' 2>/dev/null) || return 0
+  pan_emit_event "$AGENT_ID" "$body" >/dev/null 2>&1 || true
+  rm -f "$MARKER" 2>/dev/null || true
+}
+
+if [ "$TOOL_NAME" = 'mcp__linear__authenticate' ]; then
+  AUTH_URL=$(printf '%s\n' "$RESPONSE" \
+    | grep -Eo 'https://linear\.app/oauth/authorize[^"[:space:]<>]*' 2>/dev/null \
+    | sed -n '1p')
+  emit_required "$AUTH_URL"
+  exit 0
+fi
+
+if printf '%s' "$RESPONSE" | grep -Eiq 'requires authentication|not authenticated|unauthorized|401'; then
+  emit_required ''
+  exit 0
+fi
+
+emit_healthy_if_pending
+exit 0

--- a/tests/contracts/heartbeat-ingestion.test.ts
+++ b/tests/contracts/heartbeat-ingestion.test.ts
@@ -8,9 +8,14 @@
  * accepts a bad enum value).
  */
 
-import { Schema } from 'effect'
+import { Effect, Schema, Stream } from 'effect'
 import { describe, expect, it } from 'vitest'
 import { DomainEvent } from '@overdeck/contracts'
+import { emitAgentRuntimeEvent } from '../../src/dashboard/server/routes/agents/runtime-events'
+import {
+  AgentStateService,
+  type AgentStateServiceShape,
+} from '../../src/dashboard/server/services/agent-state-service'
 import { bodyToEvent } from '../../src/dashboard/server/services/agent-event-utils'
 
 const AGENT = 'agent-800'
@@ -20,6 +25,34 @@ const decode = Schema.decodeUnknownResult(DomainEvent)
 function decodeCandidate(raw: Record<string, unknown> | null) {
   if (!raw) return null
   return decode({ ...raw, sequence: 0 })
+}
+
+function makeAgentStateService(emitted: Array<Omit<DomainEvent, 'sequence'>>): AgentStateServiceShape {
+  const snapshot = {
+    id: AGENT,
+    activity: 'idle' as const,
+    lastActivity: TS,
+    currentIssue: 'PAN-2997',
+    updatedAtSequence: 1,
+  }
+  return {
+    get: () => Effect.succeed(snapshot),
+    getAll: Effect.succeed({ [AGENT]: snapshot }),
+    changes: Stream.empty,
+    emit: event => Effect.sync(() => {
+      emitted.push(event)
+    }),
+  }
+}
+
+async function runHeartbeat(body: Record<string, unknown>) {
+  const emitted: Array<Omit<DomainEvent, 'sequence'>> = []
+  const result = await Effect.runPromise(
+    emitAgentRuntimeEvent(AGENT, body, TS).pipe(
+      Effect.provideService(AgentStateService, makeAgentStateService(emitted)),
+    ),
+  )
+  return { emitted, result }
 }
 
 describe('PAN-800 bodyToEvent + DomainEvent decode', () => {
@@ -60,6 +93,55 @@ describe('PAN-800 bodyToEvent + DomainEvent decode', () => {
       sessionModel: 'claude-opus-4-7',
       sessionHarness: 'claude-code',
     })
+  })
+
+  it('linear_mcp_auth_required → Schema-valid event with resolved issue attribution', async () => {
+    const { emitted, result } = await runHeartbeat({
+      kind: 'linear_mcp_auth_required',
+      authUrl: 'https://linear.app/oauth/authorize?state=test',
+      expiresAt: '2026-04-22T06:30:00.000Z',
+    })
+
+    expect(result).toEqual({ ok: true, emitted: true })
+    expect(emitted).toEqual([{
+      sequence: 0,
+      type: 'linear_mcp_auth.required',
+      timestamp: TS,
+      payload: {
+        agentId: AGENT,
+        issueId: 'PAN-2997',
+        authUrl: 'https://linear.app/oauth/authorize?state=test',
+        expiresAt: '2026-04-22T06:30:00.000Z',
+      },
+    }])
+  })
+
+  it('linear_mcp_auth_healthy → Schema-valid hook event with resolved issue attribution', async () => {
+    const { emitted, result } = await runHeartbeat({ kind: 'linear_mcp_auth_healthy' })
+
+    expect(result).toEqual({ ok: true, emitted: true })
+    expect(emitted).toEqual([{
+      sequence: 0,
+      type: 'linear_mcp_auth.healthy',
+      timestamp: TS,
+      payload: {
+        agentId: AGENT,
+        issueId: 'PAN-2997',
+        source: 'hook',
+      },
+    }])
+  })
+
+  it('rejects a malformed Linear MCP auth heartbeat with 400 and emits nothing', async () => {
+    const { emitted, result } = await runHeartbeat({
+      kind: 'linear_mcp_auth_required',
+      authUrl: 42,
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected malformed heartbeat to be rejected')
+    expect(result.response.status).toBe(400)
+    expect(emitted).toEqual([])
   })
 
   it('unknown kind → null (no emit)', () => {

--- a/tests/scripts/linear-mcp-auth-hook.test.ts
+++ b/tests/scripts/linear-mcp-auth-hook.test.ts
@@ -1,0 +1,181 @@
+import { spawn } from 'node:child_process'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+const SCRIPT_PATH = join(process.cwd(), 'sync-sources', 'hooks', 'linear-mcp-auth-hook')
+
+function writeStubHookLib(dir: string, eventLog: string): void {
+  const lib = `#!/bin/bash
+set +e
+pan_resolve_agent_id() {
+  AGENT_ID="\${OVERDECK_AGENT_ID:-}"
+  [ -n "$AGENT_ID" ]
+}
+pan_emit_event() {
+  printf '%s\\t%s\\n' "$1" "$(printf '%s' "$2" | jq -c .)" >> "${eventLog}"
+}
+`
+  writeFileSync(join(dir, 'pan-hook-lib.sh'), lib, 'utf-8')
+  chmodSync(join(dir, 'pan-hook-lib.sh'), 0o755)
+}
+
+function runHook(
+  scriptDir: string,
+  stdin: string,
+  env: Record<string, string> = {},
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((resolve) => {
+    const child = spawn(join(scriptDir, 'linear-mcp-auth-hook'), [], {
+      env: { ...process.env, ...env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf-8') })
+    child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf-8') })
+    child.on('close', code => resolve({ stdout, stderr, code: code ?? 0 }))
+    child.on('error', () => resolve({ stdout, stderr, code: 1 }))
+    if (stdin) child.stdin.write(stdin)
+    child.stdin.end()
+  })
+}
+
+function eventBodies(eventLog: string): Array<Record<string, unknown>> {
+  if (!existsSync(eventLog)) return []
+  return readFileSync(eventLog, 'utf-8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line.split('\t')[1] ?? '{}') as Record<string, unknown>)
+}
+
+describe('linear-mcp-auth-hook', () => {
+  let tempDir: string
+  let eventLog: string
+  let overdeckHome: string
+  const agentId = 'agent-min-852'
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'overdeck-linear-mcp-hook-'))
+    eventLog = join(tempDir, 'events.log')
+    overdeckHome = join(tempDir, 'home')
+    mkdirSync(tempDir, { recursive: true })
+    writeFileSync(join(tempDir, 'linear-mcp-auth-hook'), readFileSync(SCRIPT_PATH, 'utf-8'), 'utf-8')
+    chmodSync(join(tempDir, 'linear-mcp-auth-hook'), 0o755)
+    writeStubHookLib(tempDir, eventLog)
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  function markerPath(): string {
+    return join(overdeckHome, 'agents', agentId, 'linear-mcp-auth-pending')
+  }
+
+  function input(toolName: string, toolResponse: unknown): string {
+    return JSON.stringify({ tool_name: toolName, tool_response: toolResponse })
+  }
+
+  function environment(extra: Record<string, string> = {}): Record<string, string> {
+    return {
+      OVERDECK_AGENT_ID: agentId,
+      OVERDECK_HOME: overdeckHome,
+      PATH: process.env.PATH ?? '',
+      ...extra,
+    }
+  }
+
+  it('extracts the authorization URL from authenticate and emits required', async () => {
+    const authUrl = 'https://linear.app/oauth/authorize?client_id=test&state=abc'
+
+    const result = await runHook(
+      tempDir,
+      input('mcp__linear__authenticate', `Authorize Linear by opening ${authUrl}`),
+      environment(),
+    )
+
+    expect(result).toMatchObject({ code: 0, stdout: '', stderr: '' })
+    expect(eventBodies(eventLog)).toEqual([{
+      kind: 'linear_mcp_auth_required',
+      authUrl,
+    }])
+    expect(existsSync(markerPath())).toBe(true)
+  })
+
+  it('emits required with a null URL for an auth error from any Linear tool', async () => {
+    await runHook(
+      tempDir,
+      input('mcp__linear__list_issues', { error: '401 Unauthorized: not authenticated' }),
+      environment(),
+    )
+
+    expect(eventBodies(eventLog)).toEqual([{
+      kind: 'linear_mcp_auth_required',
+      authUrl: null,
+    }])
+    expect(existsSync(markerPath())).toBe(true)
+  })
+
+  it('emits healthy and deletes the marker after complete_authentication succeeds', async () => {
+    mkdirSync(join(overdeckHome, 'agents', agentId), { recursive: true })
+    writeFileSync(markerPath(), '')
+
+    await runHook(
+      tempDir,
+      input('mcp__linear__complete_authentication', { success: true }),
+      environment(),
+    )
+
+    expect(eventBodies(eventLog)).toEqual([{ kind: 'linear_mcp_auth_healthy' }])
+    expect(existsSync(markerPath())).toBe(false)
+  })
+
+  it('emits healthy after any successful Linear call only when the marker exists', async () => {
+    await runHook(
+      tempDir,
+      input('mcp__linear__list_issues', { issues: [] }),
+      environment(),
+    )
+    expect(eventBodies(eventLog)).toEqual([])
+
+    mkdirSync(join(overdeckHome, 'agents', agentId), { recursive: true })
+    writeFileSync(markerPath(), '')
+    await runHook(
+      tempDir,
+      input('mcp__linear__list_issues', { issues: [] }),
+      environment(),
+    )
+
+    expect(eventBodies(eventLog)).toEqual([{ kind: 'linear_mcp_auth_healthy' }])
+    expect(existsSync(markerPath())).toBe(false)
+  })
+
+  it('exits 0 silently for malformed stdin', async () => {
+    const result = await runHook(tempDir, 'not-json-{', environment())
+
+    expect(result).toMatchObject({ code: 0, stdout: '', stderr: '' })
+    expect(eventBodies(eventLog)).toEqual([])
+  })
+
+  it('exits 0 silently when jq is unavailable', async () => {
+    const result = await runHook(
+      tempDir,
+      input('mcp__linear__authenticate', 'response'),
+      environment({ PATH: '' }),
+    )
+
+    expect(result).toMatchObject({ code: 0, stdout: '', stderr: '' })
+    expect(eventBodies(eventLog)).toEqual([])
+  })
+})

--- a/tests/scripts/linear-mcp-auth-hook.test.ts
+++ b/tests/scripts/linear-mcp-auth-hook.test.ts
@@ -113,10 +113,30 @@ describe('linear-mcp-auth-hook', () => {
     expect(existsSync(markerPath())).toBe(true)
   })
 
-  it('emits required with a null URL for an auth error from any Linear tool', async () => {
+  it('emits required with a null URL for a real PostToolUseFailure auth error', async () => {
+    // The documented failure-event shape: top-level `error` + `is_interrupt`,
+    // no tool_response. PostToolUse does not fire for failed MCP calls at all.
+    const failureInput = JSON.stringify({
+      hook_event_name: 'PostToolUseFailure',
+      tool_name: 'mcp__linear__list_issues',
+      tool_input: {},
+      error: 'MCP error 401: Unauthorized — Linear session requires authentication',
+      is_interrupt: false,
+    })
+
+    await runHook(tempDir, failureInput, environment())
+
+    expect(eventBodies(eventLog)).toEqual([{
+      kind: 'linear_mcp_auth_required',
+      authUrl: null,
+    }])
+    expect(existsSync(markerPath())).toBe(true)
+  })
+
+  it('emits required for an error-shaped success payload carrying an auth error', async () => {
     await runHook(
       tempDir,
-      input('mcp__linear__list_issues', { error: '401 Unauthorized: not authenticated' }),
+      input('mcp__linear__list_issues', { isError: true, error: '401 Unauthorized: not authenticated' }),
       environment(),
     )
 
@@ -125,6 +145,45 @@ describe('linear-mcp-auth-hook', () => {
       authUrl: null,
     }])
     expect(existsSync(markerPath())).toBe(true)
+  })
+
+  it('stays silent for a PostToolUseFailure that is not an auth error', async () => {
+    const failureInput = JSON.stringify({
+      hook_event_name: 'PostToolUseFailure',
+      tool_name: 'mcp__linear__get_issue',
+      tool_input: {},
+      error: 'MCP error -40: issue MIN-401 not found',
+      is_interrupt: false,
+    })
+
+    const result = await runHook(tempDir, failureInput, environment())
+
+    expect(result.code).toBe(0)
+    expect(eventBodies(eventLog)).toEqual([])
+    expect(existsSync(markerPath())).toBe(false)
+  })
+
+  it('never auth-classifies successful issue data containing 401s or "unauthorized"', async () => {
+    // Regression: ordinary Linear payloads legitimately contain identifiers
+    // like MIN-401 and prose about 401/unauthorized behavior — none of that is
+    // MCP authentication state, and a successful call must clear a pending
+    // intervention instead of raising a false one.
+    mkdirSync(join(overdeckHome, 'agents', agentId), { recursive: true })
+    writeFileSync(markerPath(), '')
+
+    await runHook(
+      tempDir,
+      input('mcp__linear__list_issues', {
+        issues: [
+          { identifier: 'MIN-401', title: 'Retry after a 401 response' },
+          { identifier: 'MIN-402', title: 'Mark legacy tokens unauthorized in docs' },
+        ],
+      }),
+      environment(),
+    )
+
+    expect(eventBodies(eventLog)).toEqual([{ kind: 'linear_mcp_auth_healthy' }])
+    expect(existsSync(markerPath())).toBe(false)
   })
 
   it('emits healthy and deletes the marker after complete_authentication succeeds', async () => {

--- a/tests/unit/dashboard/server/routes/conversations-no-loss.test.ts
+++ b/tests/unit/dashboard/server/routes/conversations-no-loss.test.ts
@@ -39,6 +39,7 @@ const EXPECTED_CONVERSATION_ROUTES = [
   'POST /api/conversations/:name/delete-image',
   'POST /api/conversations/:name/message',
   'POST /api/conversations/:id/codex-approval',
+  'POST /api/conversations/:id/pane-choice',
   'POST /api/conversations/:name/delivery-method',
   'POST /api/conversations/:name/control-ack',
   'PATCH /api/conversations/:name',
@@ -100,6 +101,6 @@ describe('PAN-2145 conversations route no-loss audit', () => {
       ...unexpected.map((route) => `  unexpected: ${route}`),
     ].join('\n')).toEqual([]);
 
-    expect(liveRoutes.size).toBe(34);
+    expect(liveRoutes.size).toBe(35);
   });
 });

--- a/tests/unit/lib/overdeck/no-loss-matrix.ts
+++ b/tests/unit/lib/overdeck/no-loss-matrix.ts
@@ -173,6 +173,7 @@ export const NO_LOSS_MATRIX: MatrixEntry[] = [
   { surface: 'POST /api/conversations/:name/delete-image',               kind: 'http', disposition: 'RELOCATE',    door: 'ConversationRuntime.removeAttachment' },
   { surface: 'POST /api/conversations/:name/message',                    kind: 'http', disposition: 'RELOCATE',    door: 'ConversationRuntime.deliver' },
   { surface: 'POST /api/conversations/:id/codex-approval',               kind: 'http', disposition: 'RELOCATE',    door: 'ConversationRuntime.approve' },
+  { surface: 'POST /api/conversations/:id/pane-choice',                  kind: 'http', disposition: 'RELOCATE',    door: 'handleConversationPaneChoiceAnswer (lib/overdeck/conversation-pane-choice)' },
   { surface: 'POST /api/conversations/:name/delivery-method',            kind: 'http', disposition: 'RELOCATE',    door: 'ConversationRuntime.setDeliveryMethod' },
   { surface: 'POST /api/conversations/:name/thinking-level',             kind: 'http', disposition: 'WRITE',       door: 'ConversationWriter.setEffort + ConversationRuntime.controlChannel' },
   { surface: 'POST /api/conversations/:name/compact',                    kind: 'http', disposition: 'RELOCATE',    door: 'ConversationRuntime.controlChannel.compact' },

--- a/tests/unit/lib/overdeck/no-loss-matrix.ts
+++ b/tests/unit/lib/overdeck/no-loss-matrix.ts
@@ -137,6 +137,11 @@ export const NO_LOSS_MATRIX: MatrixEntry[] = [
   // ── commands.ts ───────────────────────────────────────────────────────────
   { surface: 'GET /api/commands',                                      kind: 'http', disposition: 'OUT_OF_SCOPE', door: 'Composer command catalog from generated module state; no canonical state store' },
 
+  // ── linear-mcp-auth.ts (PAN-2997) ─────────────────────────────────────────
+  { surface: 'GET /api/linear-mcp-auth',                  kind: 'http', disposition: 'READ',        door: 'linear-mcp-auth event fold (resolveLinearMcpAuthIntervention)' },
+  { surface: 'POST /api/linear-mcp-auth/callback',        kind: 'http', disposition: 'WRITE',       door: 'linear-mcp-auth events + messageAgent delivery door' },
+  { surface: 'POST /api/linear-mcp-auth/complete',        kind: 'http', disposition: 'WRITE',       door: 'linear-mcp-auth events (appendLinearMcpAuthHealthyEvent)' },
+
   // ── command-deck.ts ───────────────────────────────────────────────────────
   { surface: 'GET /api/command-deck/activity/:issueId',                  kind: 'http', disposition: 'AGGREGATE',   door: 'Issues + Agents + events' },
   { surface: 'GET /api/command-deck/planning/:issueId',                  kind: 'http', disposition: 'AGGREGATE',   door: 'Issues + Agents planning detail' },


### PR DESCRIPTION
**Issue:** #2997

## Acceptance Criteria

- [ ] Add four linear_mcp_auth.* DomainEvent schemas to @overdeck/contracts
- [ ] Create src/lib/linear-mcp-auth.ts read/write door with lifecycle fold and projection
- [ ] Add linear_mcp_auth_required/healthy heartbeat kinds to bodyToEvent with issueId enrichment
- [ ] Wake blocked agents on healthy via messageAgent, with reactive trigger and boot recovery
- [ ] Add operator routes: GET projection, POST callback relay, POST mark-completed
- [ ] Add linear-mcp-auth-hook PostToolUse script, registration, and contract test
- [ ] Add LinearMcpAuthBanner with status hook and AppChrome mount
- [ ] Document the Linear MCP auth contract in roles/work.md and roles/plan.md
- [ ] Write docs/LINEAR-MCP-AUTH.md and link it from docs/CODEX-AUTH.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Linear MCP authentication banner in the dashboard with blocked-agent context and OAuth re-auth actions (“relay callback” and “mark completed”).
  * Introduced Linear MCP auth API endpoints, new auth-related domain events, and automated wake/recovery of blocked work.
  * Added crash-safe, keyed idempotent delivery to reduce duplicate operator/work messages on retries.
* **Documentation**
  * Documented the Linear MCP OAuth dashboard intervention and global re-auth workflow.
* **Tests**
  * Expanded end-to-end coverage for banner UI, routes, heartbeat ingestion, hook/projection logic, wake/recovery, and keyed delivery idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->