### PR TITLE
PAN-2838

### DIFF
--- a/configuration/auto-merge.mdx
+++ b/configuration/auto-merge.mdx
@@ -42,6 +42,17 @@ The default is `true` (auto-merge OFF — operator UAT required before merge).
 When the toggle is `false`, the Flywheel orchestrator may schedule auto-merge
 for any issue that satisfies the eligibility predicate.
 
+## Per-project default
+
+Every registered project's HOME tab includes a **Project settings** panel, even
+when the project has no in-flight pipeline issues. Its auto-merge control offers
+**⚡ Auto**, **🔒 Hold for UAT**, and **Global default**, and the collapsed row
+shows the current auto-merge and swarming values at a glance. The project default
+applies only to issues without an explicit per-issue auto-merge setting.
+
+Changes are saved through `POST /api/projects/:key/auto-merge-default` and stored
+in `~/.overdeck/projects.yaml`.
+
 <Note>
 **Auto-merge vs. UAT batch trains.** This toggle controls *per-issue* scheduled
 auto-merge — Overdeck merging one eligible PR at a time without a human click.

--- a/docs/SWARM-POLICY.md
+++ b/docs/SWARM-POLICY.md
@@ -5,7 +5,7 @@ Automatic swarming is off by default. An explicit `pan swarm <issue>` remains an
 The policy resolves each field independently in this order: one-run CLI override, issue record override, project override, global configuration, then the built-in default. The fields are `mode` (`off`, `auto`, or `always`), `maxSlots`, and `autoAdvance`.
 
 - Global values are edited under **Settings → Swarming** and stored in `~/.overdeck/config.yaml`.
-- Project values are edited in the project's overview settings and stored in `~/.overdeck/projects.yaml`.
+- Project values are edited in the **Project settings** panel on the project's HOME tab, which is available for every registered project, including projects with no in-flight pipeline issues, and stored in `~/.overdeck/projects.yaml`.
 - Issue values are edited in Issue Detail and stored in the issue's canonical record on `overdeck-state`.
 
 `off` selects a single work agent for future automatic dispatch. `auto` permits a swarm only when xBRIEF readiness proves the work can be partitioned safely. `always` requires swarm readiness rather than silently falling back. Policy changes never stop or resize an already-running swarm; use the existing freeze, stop, resume, recover, and reset controls for runtime operations.

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectOverview.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectOverview.tsx
@@ -14,6 +14,7 @@ import {
   isBlockedFeature,
 } from './pipeline-helpers';
 import { PipelineSection } from './PipelineSection';
+import { ProjectSettingsDisclosure } from './ProjectSettingsDisclosure';
 
 export type { IssueCostBreakdown };
 
@@ -218,78 +219,6 @@ export function projectTotalCost(
   return sum;
 }
 
-/** PAN-1693/1695: per-project settings in the cockpit — currently the auto-merge default. */
-function ProjectSettingsSection({ projectKey }: { projectKey: string }) {
-  const queryClient = useQueryClient();
-  const { data } = useQuery({
-    queryKey: ['project-auto-merge-default', projectKey],
-    queryFn: async (): Promise<{ value: 'auto' | 'hold' | null }> => {
-      const res = await fetch(`/api/projects/${encodeURIComponent(projectKey)}/auto-merge-default`);
-      if (!res.ok) return { value: null };
-      return res.json();
-    },
-    enabled: !!projectKey,
-  });
-  const value = data?.value ?? null;
-  const { data: swarmData } = useQuery({ queryKey: ['project-swarm-policy', projectKey], queryFn: async () => (await fetch(`/api/projects/${encodeURIComponent(projectKey)}/swarm-policy`)).json() as Promise<{ configured: { mode?: 'off' | 'auto' | 'always' } | null }> });
-  const swarmMutation = useMutation({ mutationFn: async (mode: 'off' | 'auto' | 'always' | null) => { const res = await fetch(`/api/projects/${encodeURIComponent(projectKey)}/swarm-policy`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ value: mode ? { mode } : null }) }); if (!res.ok) throw new Error('Failed to save swarm policy'); }, onSuccess: () => queryClient.invalidateQueries({ queryKey: ['project-swarm-policy', projectKey] }) });
-  const mutation = useMutation({
-    mutationFn: async (next: 'auto' | 'hold' | null) => {
-      const res = await fetch(`/api/projects/${encodeURIComponent(projectKey)}/auto-merge-default`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ value: next }),
-      });
-      if (!res.ok) throw new Error('Failed to save project setting');
-      return res.json();
-    },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['project-auto-merge-default', projectKey] }),
-  });
-  const options: Array<{ v: 'auto' | 'hold' | null; label: string; color: string }> = [
-    { v: 'auto', label: '⚡ Auto', color: 'var(--success)' },
-    { v: 'hold', label: '🔒 Hold for UAT', color: 'var(--warning)' },
-    { v: null, label: 'Global default', color: 'var(--muted-foreground)' },
-  ];
-  return (
-    <div style={{ border: '1px solid var(--border)', borderRadius: 10, padding: 14, display: 'flex', flexDirection: 'column', gap: 8 }}>
-      <div style={{ fontSize: 11, fontWeight: 650, textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--muted-foreground)' }}>Project settings</div>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
-        <span style={{ fontSize: 13, color: 'var(--foreground)' }}>Auto-merge default</span>
-        <div style={{ display: 'inline-flex', border: '1px solid var(--border)', borderRadius: 8, overflow: 'hidden' }}>
-          {options.map((o, i) => {
-            const active = value === o.v;
-            return (
-              <button
-                key={String(o.v)}
-                type="button"
-                disabled={mutation.isPending}
-                onClick={() => mutation.mutate(o.v)}
-                style={{
-                  appearance: 'none',
-                  border: 0,
-                  borderLeft: i === 0 ? 0 : '1px solid var(--border)',
-                  padding: '6px 12px',
-                  fontSize: 12,
-                  fontWeight: 600,
-                  cursor: 'pointer',
-                  background: active ? `color-mix(in srgb, ${o.color} 16%, transparent)` : 'transparent',
-                  color: active ? o.color : 'var(--muted-foreground)',
-                }}
-              >
-                {o.label}
-              </button>
-            );
-          })}
-        </div>
-      </div>
-      <div style={{ fontSize: 11, color: 'var(--muted-foreground)' }}>
-        Applies to this project's issues that have no explicit per-issue auto-merge setting.
-      </div>
-      <div className="mt-2 flex flex-wrap items-center gap-3 border-t border-border pt-3"><span className="text-[13px] text-foreground">Automatic swarming</span><select aria-label="Project swarm policy" className="rounded-md border border-input bg-background px-2 py-1.5 text-xs" value={swarmData?.configured?.mode ?? ''} onChange={e => { const value = e.target.value; swarmMutation.mutate(value === 'off' || value === 'auto' || value === 'always' ? value : null); }}><option value="">Inherit global</option><option value="off">Off</option><option value="auto">Auto</option><option value="always">Always</option></select><span className="text-[11px] text-muted-foreground">Future dispatches only</span></div>
-    </div>
-  );
-}
-
 export function ProjectOverview({
   projectName,
   projectKey,
@@ -395,15 +324,7 @@ export function ProjectOverview({
 
       <ProjectCiHealthSection health={ciHealth} />
 
-      {projectKey && (
-        <ProjectDisclosure
-          title="Project settings"
-          summary="Auto-merge default and project-level merge policy"
-          badges={['collapsed']}
-        >
-          <ProjectSettingsSection projectKey={projectKey} />
-        </ProjectDisclosure>
-      )}
+      {projectKey && <ProjectSettingsDisclosure projectKey={projectKey} />}
 
       <div ref={pipelineRef} style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
         <PipelineSection
@@ -538,73 +459,6 @@ function HealthTile({ label, value, tone }: { label: string; value: string; tone
       <div style={{ fontSize: 10, color: 'var(--muted-foreground)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{label}</div>
       <div style={{ marginTop: 3, fontSize: 12, fontWeight: 700, color }}>{value}</div>
     </div>
-  );
-}
-
-function ProjectDisclosure({
-  title,
-  summary,
-  badges,
-  defaultOpen = false,
-  children,
-}: {
-  title: string;
-  summary: string;
-  badges?: string[];
-  defaultOpen?: boolean;
-  children: ReactNode;
-}) {
-  return (
-    <details
-      open={defaultOpen}
-      style={{
-        border: '1px solid var(--border)',
-        borderRadius: 10,
-        background: 'var(--card)',
-        overflow: 'hidden',
-      }}
-    >
-      <summary
-        style={{
-          cursor: 'pointer',
-          display: 'grid',
-          gridTemplateColumns: '1fr auto',
-          alignItems: 'center',
-          gap: 10,
-          padding: '11px 12px',
-          listStyle: 'none',
-        }}
-      >
-        <span style={{ minWidth: 0, display: 'flex', alignItems: 'baseline', gap: 8 }}>
-          <span style={{ fontSize: 13, fontWeight: 700, color: 'var(--foreground)' }}>{title}</span>
-          <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 12, color: 'var(--muted-foreground)' }}>{summary}</span>
-        </span>
-        {badges && badges.length > 0 && (
-          <span style={{ display: 'flex', gap: 6, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
-            {badges.map((badge) => (
-              <span
-                key={badge}
-                style={{
-                  border: '1px solid var(--border)',
-                  borderRadius: 999,
-                  padding: '2px 7px',
-                  background: 'var(--secondary)',
-                  color: 'var(--foreground)',
-                  fontSize: 11,
-                  fontWeight: 650,
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {badge}
-              </span>
-            ))}
-          </span>
-        )}
-      </summary>
-      <div style={{ borderTop: '1px solid var(--border)', padding: 12, background: 'var(--background)' }}>
-        {children}
-      </div>
-    </details>
   );
 }
 

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectSettingsDisclosure.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectSettingsDisclosure.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ChevronRight } from 'lucide-react';
 
 /** PAN-1693/1695: per-project settings in the cockpit — currently the auto-merge default. */
 function ProjectSettingsSection({ projectKey }: { projectKey: string }) {
@@ -76,19 +77,18 @@ function ProjectSettingsSection({ projectKey }: { projectKey: string }) {
 function ProjectDisclosure({
   title,
   summary,
-  badges,
   defaultOpen = false,
   children,
 }: {
   title: string;
   summary: string;
-  badges?: string[];
   defaultOpen?: boolean;
   children: ReactNode;
 }) {
   return (
     <details
       open={defaultOpen}
+      className="group"
       style={{
         border: '1px solid var(--border)',
         borderRadius: 10,
@@ -108,30 +108,10 @@ function ProjectDisclosure({
         }}
       >
         <span style={{ minWidth: 0, display: 'flex', alignItems: 'baseline', gap: 8 }}>
+          <ChevronRight size={14} className="shrink-0 text-muted-foreground transition-transform group-open:rotate-90" aria-hidden="true" />
           <span style={{ fontSize: 13, fontWeight: 700, color: 'var(--foreground)' }}>{title}</span>
           <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 12, color: 'var(--muted-foreground)' }}>{summary}</span>
         </span>
-        {badges && badges.length > 0 && (
-          <span style={{ display: 'flex', gap: 6, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
-            {badges.map((badge) => (
-              <span
-                key={badge}
-                style={{
-                  border: '1px solid var(--border)',
-                  borderRadius: 999,
-                  padding: '2px 7px',
-                  background: 'var(--secondary)',
-                  color: 'var(--foreground)',
-                  fontSize: 11,
-                  fontWeight: 650,
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {badge}
-              </span>
-            ))}
-          </span>
-        )}
       </summary>
       <div style={{ borderTop: '1px solid var(--border)', padding: 12, background: 'var(--background)' }}>
         {children}
@@ -145,7 +125,6 @@ export function ProjectSettingsDisclosure({ projectKey }: { projectKey: string }
     <ProjectDisclosure
       title="Project settings"
       summary="Auto-merge default and project-level merge policy"
-      badges={['collapsed']}
     >
       <ProjectSettingsSection projectKey={projectKey} />
     </ProjectDisclosure>

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectSettingsDisclosure.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectSettingsDisclosure.tsx
@@ -1,0 +1,153 @@
+import type { ReactNode } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+/** PAN-1693/1695: per-project settings in the cockpit — currently the auto-merge default. */
+function ProjectSettingsSection({ projectKey }: { projectKey: string }) {
+  const queryClient = useQueryClient();
+  const { data } = useQuery({
+    queryKey: ['project-auto-merge-default', projectKey],
+    queryFn: async (): Promise<{ value: 'auto' | 'hold' | null }> => {
+      const res = await fetch(`/api/projects/${encodeURIComponent(projectKey)}/auto-merge-default`);
+      if (!res.ok) return { value: null };
+      return res.json();
+    },
+    enabled: !!projectKey,
+  });
+  const value = data?.value ?? null;
+  const { data: swarmData } = useQuery({ queryKey: ['project-swarm-policy', projectKey], queryFn: async () => (await fetch(`/api/projects/${encodeURIComponent(projectKey)}/swarm-policy`)).json() as Promise<{ configured: { mode?: 'off' | 'auto' | 'always' } | null }> });
+  const swarmMutation = useMutation({ mutationFn: async (mode: 'off' | 'auto' | 'always' | null) => { const res = await fetch(`/api/projects/${encodeURIComponent(projectKey)}/swarm-policy`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ value: mode ? { mode } : null }) }); if (!res.ok) throw new Error('Failed to save swarm policy'); }, onSuccess: () => queryClient.invalidateQueries({ queryKey: ['project-swarm-policy', projectKey] }) });
+  const mutation = useMutation({
+    mutationFn: async (next: 'auto' | 'hold' | null) => {
+      const res = await fetch(`/api/projects/${encodeURIComponent(projectKey)}/auto-merge-default`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value: next }),
+      });
+      if (!res.ok) throw new Error('Failed to save project setting');
+      return res.json();
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['project-auto-merge-default', projectKey] }),
+  });
+  const options: Array<{ v: 'auto' | 'hold' | null; label: string; color: string }> = [
+    { v: 'auto', label: '⚡ Auto', color: 'var(--success)' },
+    { v: 'hold', label: '🔒 Hold for UAT', color: 'var(--warning)' },
+    { v: null, label: 'Global default', color: 'var(--muted-foreground)' },
+  ];
+  return (
+    <div style={{ border: '1px solid var(--border)', borderRadius: 10, padding: 14, display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <div style={{ fontSize: 11, fontWeight: 650, textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--muted-foreground)' }}>Project settings</div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+        <span style={{ fontSize: 13, color: 'var(--foreground)' }}>Auto-merge default</span>
+        <div style={{ display: 'inline-flex', border: '1px solid var(--border)', borderRadius: 8, overflow: 'hidden' }}>
+          {options.map((o, i) => {
+            const active = value === o.v;
+            return (
+              <button
+                key={String(o.v)}
+                type="button"
+                disabled={mutation.isPending}
+                onClick={() => mutation.mutate(o.v)}
+                style={{
+                  appearance: 'none',
+                  border: 0,
+                  borderLeft: i === 0 ? 0 : '1px solid var(--border)',
+                  padding: '6px 12px',
+                  fontSize: 12,
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                  background: active ? `color-mix(in srgb, ${o.color} 16%, transparent)` : 'transparent',
+                  color: active ? o.color : 'var(--muted-foreground)',
+                }}
+              >
+                {o.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <div style={{ fontSize: 11, color: 'var(--muted-foreground)' }}>
+        Applies to this project's issues that have no explicit per-issue auto-merge setting.
+      </div>
+      <div className="mt-2 flex flex-wrap items-center gap-3 border-t border-border pt-3"><span className="text-[13px] text-foreground">Automatic swarming</span><select aria-label="Project swarm policy" className="rounded-md border border-input bg-background px-2 py-1.5 text-xs" value={swarmData?.configured?.mode ?? ''} onChange={e => { const value = e.target.value; swarmMutation.mutate(value === 'off' || value === 'auto' || value === 'always' ? value : null); }}><option value="">Inherit global</option><option value="off">Off</option><option value="auto">Auto</option><option value="always">Always</option></select><span className="text-[11px] text-muted-foreground">Future dispatches only</span></div>
+    </div>
+  );
+}
+
+function ProjectDisclosure({
+  title,
+  summary,
+  badges,
+  defaultOpen = false,
+  children,
+}: {
+  title: string;
+  summary: string;
+  badges?: string[];
+  defaultOpen?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <details
+      open={defaultOpen}
+      style={{
+        border: '1px solid var(--border)',
+        borderRadius: 10,
+        background: 'var(--card)',
+        overflow: 'hidden',
+      }}
+    >
+      <summary
+        style={{
+          cursor: 'pointer',
+          display: 'grid',
+          gridTemplateColumns: '1fr auto',
+          alignItems: 'center',
+          gap: 10,
+          padding: '11px 12px',
+          listStyle: 'none',
+        }}
+      >
+        <span style={{ minWidth: 0, display: 'flex', alignItems: 'baseline', gap: 8 }}>
+          <span style={{ fontSize: 13, fontWeight: 700, color: 'var(--foreground)' }}>{title}</span>
+          <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 12, color: 'var(--muted-foreground)' }}>{summary}</span>
+        </span>
+        {badges && badges.length > 0 && (
+          <span style={{ display: 'flex', gap: 6, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+            {badges.map((badge) => (
+              <span
+                key={badge}
+                style={{
+                  border: '1px solid var(--border)',
+                  borderRadius: 999,
+                  padding: '2px 7px',
+                  background: 'var(--secondary)',
+                  color: 'var(--foreground)',
+                  fontSize: 11,
+                  fontWeight: 650,
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {badge}
+              </span>
+            ))}
+          </span>
+        )}
+      </summary>
+      <div style={{ borderTop: '1px solid var(--border)', padding: 12, background: 'var(--background)' }}>
+        {children}
+      </div>
+    </details>
+  );
+}
+
+export function ProjectSettingsDisclosure({ projectKey }: { projectKey: string }) {
+  return (
+    <ProjectDisclosure
+      title="Project settings"
+      summary="Auto-merge default and project-level merge policy"
+      badges={['collapsed']}
+    >
+      <ProjectSettingsSection projectKey={projectKey} />
+    </ProjectDisclosure>
+  );
+}

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectSettingsDisclosure.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectSettingsDisclosure.tsx
@@ -74,6 +74,40 @@ function ProjectSettingsSection({ projectKey }: { projectKey: string }) {
   );
 }
 
+function ProjectSettingsSummary({ projectKey }: { projectKey: string }) {
+  const { data } = useQuery({
+    queryKey: ['project-auto-merge-default', projectKey],
+    queryFn: async (): Promise<{ value: 'auto' | 'hold' | null }> => {
+      const res = await fetch(`/api/projects/${encodeURIComponent(projectKey)}/auto-merge-default`);
+      if (!res.ok) return { value: null };
+      return res.json();
+    },
+    enabled: !!projectKey,
+  });
+  const { data: swarmData } = useQuery({ queryKey: ['project-swarm-policy', projectKey], queryFn: async () => (await fetch(`/api/projects/${encodeURIComponent(projectKey)}/swarm-policy`)).json() as Promise<{ configured: { mode?: 'off' | 'auto' | 'always' } | null }> });
+
+  if (!data || !swarmData) return null;
+
+  const autoMergeLabel = data.value === 'auto'
+    ? '⚡ Auto'
+    : data.value === 'hold'
+      ? '🔒 Hold for UAT'
+      : 'Global default';
+  const swarmLabel = swarmData.configured?.mode === 'off'
+    ? 'Swarm off'
+    : swarmData.configured?.mode === 'auto'
+      ? 'Swarm auto'
+      : swarmData.configured?.mode === 'always'
+        ? 'Swarm always'
+        : 'Swarm inherit';
+
+  return (
+    <span style={{ fontSize: 12, fontWeight: 500, color: 'var(--muted-foreground)' }}>
+      {autoMergeLabel} · {swarmLabel}
+    </span>
+  );
+}
+
 function ProjectDisclosure({
   title,
   summary,
@@ -81,7 +115,7 @@ function ProjectDisclosure({
   children,
 }: {
   title: string;
-  summary: string;
+  summary: ReactNode;
   defaultOpen?: boolean;
   children: ReactNode;
 }) {
@@ -124,7 +158,7 @@ export function ProjectSettingsDisclosure({ projectKey }: { projectKey: string }
   return (
     <ProjectDisclosure
       title="Project settings"
-      summary="Auto-merge default and project-level merge policy"
+      summary={<ProjectSettingsSummary projectKey={projectKey} />}
     >
       <ProjectSettingsSection projectKey={projectKey} />
     </ProjectDisclosure>

--- a/src/dashboard/frontend/src/components/CommandDeck/__tests__/ProjectSettingsDisclosure.test.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/__tests__/ProjectSettingsDisclosure.test.tsx
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ProjectSettingsDisclosure } from '../ProjectSettingsDisclosure';
+import { installStrictFetchMock } from '../../../test-utils/strictFetchMock';
+
+let fetchControl: ReturnType<typeof installStrictFetchMock>;
+let autoMergeValue: 'auto' | 'hold' | null;
+let swarmMode: 'off' | 'auto' | 'always' | null;
+
+function renderDisclosure() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return rtlRender(<ProjectSettingsDisclosure projectKey="overdeck" />, {
+    wrapper: ({ children }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>,
+  });
+}
+
+describe('ProjectSettingsDisclosure', () => {
+  beforeEach(() => {
+    autoMergeValue = null;
+    swarmMode = null;
+    fetchControl = installStrictFetchMock(({ method, url, init }) => {
+      if (method === 'GET' && url === '/api/projects/overdeck/auto-merge-default') {
+        return Response.json({ value: autoMergeValue });
+      }
+      if (method === 'POST' && url === '/api/projects/overdeck/auto-merge-default') {
+        autoMergeValue = (JSON.parse(String(init?.body)) as { value: 'auto' | 'hold' | null }).value;
+        return Response.json({ value: autoMergeValue });
+      }
+      if (method === 'GET' && url === '/api/projects/overdeck/swarm-policy') {
+        return Response.json({ configured: swarmMode ? { mode: swarmMode } : null });
+      }
+      if (method === 'POST' && url === '/api/projects/overdeck/swarm-policy') {
+        const value = (JSON.parse(String(init?.body)) as { value: { mode: 'off' | 'auto' | 'always' } | null }).value;
+        swarmMode = value?.mode ?? null;
+        return Response.json({ configured: value });
+      }
+      return undefined;
+    });
+  });
+
+  afterEach(async () => {
+    cleanup();
+    await fetchControl.assertNoUnexpectedRequests();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders no stale collapsed label', () => {
+    renderDisclosure();
+
+    expect(screen.queryByText(/collapsed/i)).toBeNull();
+  });
+
+  it('renders a CSS-driven rotating chevron under a group details element', () => {
+    const { container } = renderDisclosure();
+    const details = container.querySelector('details');
+    const chevron = container.querySelector('svg');
+
+    expect(details).toHaveClass('group');
+    expect(chevron).toHaveClass('transition-transform', 'group-open:rotate-90');
+    details?.setAttribute('open', '');
+    expect(details).toHaveAttribute('open');
+  });
+
+  it('shows configured values in the collapsed summary', async () => {
+    autoMergeValue = 'hold';
+    swarmMode = 'auto';
+    renderDisclosure();
+
+    expect(await screen.findByText('🔒 Hold for UAT · Swarm auto')).toBeInTheDocument();
+  });
+
+  it('shows inherited labels when neither setting is configured', async () => {
+    renderDisclosure();
+
+    expect(await screen.findByText('Global default · Swarm inherit')).toBeInTheDocument();
+  });
+
+  it('preserves the complete expanded settings panel', async () => {
+    const { container } = renderDisclosure();
+    await screen.findByText('Global default · Swarm inherit');
+    container.querySelector('details')?.setAttribute('open', '');
+
+    expect(screen.getByRole('button', { name: '⚡ Auto' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '🔒 Hold for UAT' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Global default' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Project swarm policy' })).toBeInTheDocument();
+    expect(screen.getByText("Applies to this project's issues that have no explicit per-issue auto-merge setting.")).toBeInTheDocument();
+    expect(screen.getByText('Future dispatches only')).toBeInTheDocument();
+  });
+
+  it('posts the selected auto-merge value', async () => {
+    renderDisclosure();
+    await screen.findByText('Global default · Swarm inherit');
+
+    fireEvent.click(screen.getByRole('button', { name: '⚡ Auto' }));
+
+    await waitFor(() => {
+      expect(fetchControl.fetchMock).toHaveBeenCalledWith(
+        '/api/projects/overdeck/auto-merge-default',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ value: 'auto' }),
+        }),
+      );
+    });
+  });
+});

--- a/src/dashboard/frontend/src/components/Stage/ProjectHome.test.tsx
+++ b/src/dashboard/frontend/src/components/Stage/ProjectHome.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ProjectHome } from './ProjectHome'
 import type { StageApi } from './types'
 
@@ -24,6 +25,10 @@ function deferred<T>() {
 }
 
 describe('ProjectHome', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it('passes the launcher query into the created agent conversation', async () => {
     const openOrFocusAgentPane = vi.fn()
     const onCreateConversation = vi.fn().mockResolvedValue({ name: 'conv-123' })
@@ -123,5 +128,48 @@ describe('ProjectHome', () => {
       await retry.promise
     })
     expect(openOrFocusAgentPane).toHaveBeenCalledWith('conv-456', 'Agent')
+  })
+
+  it('renders project settings in the sparse layout for a registered project', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === '/api/projects/myn/auto-merge-default') {
+        return Response.json({ value: null })
+      }
+      if (url === '/api/projects/myn/swarm-policy') {
+        return Response.json({ configured: null })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    render(
+      <QueryClientProvider client={client}>
+        <ProjectHome
+          projectName="Mind Your Now"
+          projectKey="myn"
+          api={api()}
+        />
+      </QueryClientProvider>,
+    )
+
+    expect(await screen.findAllByText('Project settings')).not.toHaveLength(0)
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+  })
+
+  it('omits project settings and settings requests without a project key', () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <ProjectHome
+        projectName="No project"
+        api={api()}
+      />,
+    )
+
+    expect(screen.queryByText('Project settings')).toBeNull()
+    expect(fetchMock.mock.calls.some(([input]) => String(input).startsWith('/api/projects/'))).toBe(false)
   })
 })

--- a/src/dashboard/frontend/src/components/Stage/ProjectHome.tsx
+++ b/src/dashboard/frontend/src/components/Stage/ProjectHome.tsx
@@ -14,6 +14,7 @@ import type { TimelineConversation } from './HomePane/timeline-utils'
 import type { StageApi } from './types'
 import { ProjectReleasePanel } from './HomePane/ProjectReleasePanel'
 import { ProjectOverview, projectTotalCost, type IssueCostBreakdown } from '../CommandDeck/ProjectOverview'
+import { ProjectSettingsDisclosure } from '../CommandDeck/ProjectSettingsDisclosure'
 import type { ProjectFeature } from '../CommandDeck/ProjectTree/ProjectNode'
 import styles from './stage.module.css'
 
@@ -225,6 +226,7 @@ export function ProjectHome({
           }
         />
       }
+      detail={projectKey ? <ProjectSettingsDisclosure projectKey={projectKey} /> : undefined}
       timeline={
         <Timeline
           conversations={timelineConversations}


### PR DESCRIPTION
**Issue:** #2838

## Acceptance Criteria

- [ ] Extract ProjectSettingsSection + ProjectDisclosure into shared ProjectSettingsDisclosure.tsx
- [ ] Replace static 'collapsed' badge with a pure-CSS rotating chevron
- [ ] Show current auto-merge default and swarm mode in the collapsed summary row
- [ ] Render Project settings in ProjectHome's sparse fallback for registered projects
- [ ] Component tests for the disclosure affordance, summary values, and no-loss panel content
- [ ] ProjectHome tests for the sparse-fallback settings path
- [ ] Document the always-available project settings surface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Project settings panel to project HOME tabs.
  * Configure per-project auto-merge defaults, including Auto, Hold for UAT, and Global default.
  * Configure project-level swarming policies.
  * Settings are available for all registered projects, including those without active pipeline issues.

* **Documentation**
  * Documented project-level auto-merge and swarming settings, including their available options and storage behavior.

* **Tests**
  * Added coverage for displaying, expanding, updating, and inheriting project settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->