### PR TITLE
PAN-3020

### DIFF
--- a/src/dashboard/server/routes/command-deck.ts
+++ b/src/dashboard/server/routes/command-deck.ts
@@ -604,6 +604,9 @@ export async function fetchActivityDataWithContext(
       const specialistSessionId = isShipStage
         ? `agent-${issueLower}-ship`
         : `agent-${issueLower}-test`;
+      const specialistIsLive = tmuxSessionNames.has(specialistSessionId);
+      const specialistState = getAgentStateSync(specialistSessionId);
+      if (isShipStage && !specialistIsLive && !specialistState) continue;
 
       if (includeTranscripts && ss.status === 'running') {
         try {
@@ -616,15 +619,12 @@ export async function fetchActivityDataWithContext(
         } catch { /* specialist may not be running */ }
       }
 
-      const specialistIsLive = tmuxSessionNames.has(specialistSessionId);
       const specialistIsZombie = specialistIsLive && (ss.status === 'completed' || ss.status === 'failed');
       const specialistPresence: SessionNodePresence = specialistIsLive && !specialistIsZombie
         ? (ss.status === 'running' ? 'active' : 'idle')
         : specialistIsZombie ? 'idle' : 'ended';
       const specialistJsonlPath = await resolveJsonlPath(specialistSessionId, workspacePath);
-      // PAN-1832: surface the actual test/ship agent model + harness rather than
-      // a hardcoded 'specialist' label the frontend back-fills with role defaults.
-      const specialistState = getAgentStateSync(specialistSessionId);
+      if (isShipStage && !specialistIsLive && !specialistJsonlPath) continue;
 
       sections.push({
         type: nodeType,

--- a/src/dashboard/server/routes/projects.ts
+++ b/src/dashboard/server/routes/projects.ts
@@ -467,30 +467,30 @@ async function collectSessionTreeNodes(
       });
     }
 
-    // Merge/ship history — server-side shipping now prepares the branch, while
-    // historical `merge` entries still surface under the `ship` node identity.
     const mergeEntries = centralStatus.history.filter((entry) => entry.type === 'merge');
     const latestMerge = mergeEntries[mergeEntries.length - 1];
     if (latestMerge) {
       const shipSessionName = `agent-${issueLower}-ship`;
       const shipIsLive = context.tmuxSessionNames.has(shipSessionName);
-      const shipJsonlPath = await resolveJsonlPath(shipSessionName, workspacePath);
-      sections.push({
-        type: 'ship',
-        sessionId: shipSessionName,
-        model: 'specialist',
-        startedAt: latestMerge.timestamp,
-        endedAt: undefined,
-        duration: 0,
-        status: normalizeAgentStatus(latestMerge.status === 'merging' ? 'running' : latestMerge.status),
-        presence: shipIsLive ? (latestMerge.status === 'merging' ? 'active' : 'idle') : 'ended',
-        hasJsonl: !!shipJsonlPath,
-        tmuxSession: shipIsLive ? shipSessionName : undefined,
-        ...await readSessionGateFields(shipSessionName),
-      });
+      const shipState = getAgentStateSync(shipSessionName);
+      const shipJsonlPath = shipIsLive || shipState ? await resolveJsonlPath(shipSessionName, workspacePath) : null;
+      if (shipIsLive || shipJsonlPath) {
+        sections.push({
+          type: 'ship',
+          sessionId: shipSessionName,
+          model: 'specialist',
+          startedAt: latestMerge.timestamp,
+          endedAt: undefined,
+          duration: 0,
+          status: normalizeAgentStatus(latestMerge.status === 'merging' ? 'running' : latestMerge.status),
+          presence: shipIsLive ? (latestMerge.status === 'merging' ? 'active' : 'idle') : 'ended',
+          hasJsonl: !!shipJsonlPath,
+          tmuxSession: shipIsLive ? shipSessionName : undefined,
+          ...await readSessionGateFields(shipSessionName),
+        });
+      }
     }
   }
-
   // PAN-2053: attach read-only model-origin so the right-click MODEL inspector works
   // in the project tree, not just the activity cockpit. Shared helper with command-deck.
   enrichSessionsWithModelOrigin(sections, issueId);

--- a/tests/unit/dashboard/server/routes/command-deck.test.ts
+++ b/tests/unit/dashboard/server/routes/command-deck.test.ts
@@ -76,6 +76,8 @@ vi.mock('node:fs/promises', async () => {
 });
 
 import { extractReviewerRole, fetchActivityDataWithContext } from '../../../../../src/dashboard/server/routes/command-deck.ts';
+import { getReviewStatusSync } from '../../../../../src/dashboard/server/review-status.js';
+import { resolveJsonlPath } from '../../../../../src/dashboard/server/routes/jsonl-resolver.js';
 
 const mockAgentStates = vi.hoisted(() => new Map<string, any>());
 const mockRuntimeStates = vi.hoisted(() => new Map<string, any>());
@@ -138,6 +140,8 @@ describe('fetchActivityDataWithContext', () => {
     mockAgentStates.clear();
     mockRuntimeStates.clear();
     mockIsPlanningComplete.mockReturnValue(Effect.succeed(false));
+    vi.mocked(getReviewStatusSync).mockReturnValue(null);
+    vi.mocked(resolveJsonlPath).mockResolvedValue(null);
   });
 
   it('leaves endedAt undefined for a live work session', async () => {
@@ -267,5 +271,46 @@ describe('fetchActivityDataWithContext', () => {
     expect(planning).toBeDefined();
     expect(planning?.type).toBe('planning');
     expect(planning?.planningComplete).toBe(false);
+  });
+
+  it('uses merge-door history without probing a synthetic ship conversation', async () => {
+    const issueId = 'PAN-3020';
+    const shipId = 'agent-pan-3020-ship';
+    vi.mocked(getReviewStatusSync).mockReturnValue({
+      history: [{ type: 'merge', status: 'merging', timestamp: '2026-07-24T12:00:00Z' }],
+    } as ReturnType<typeof getReviewStatusSync>);
+
+    const result = await fetchActivityDataWithContext(issueId, { tmuxSessionNames: new Set() });
+    const sections = (result as { sections: Array<{ sessionId: string; type: string }> }).sections;
+
+    expect(sections.some((section) => section.sessionId === shipId)).toBe(false);
+    expect(resolveJsonlPath).not.toHaveBeenCalledWith(shipId, expect.any(String));
+  });
+
+  it('retains a historical ship conversation when its transcript resolves', async () => {
+    const issueId = 'PAN-3020';
+    const shipId = 'agent-pan-3020-ship';
+    mockAgentStates.set(shipId, {
+      id: shipId,
+      issueId,
+      role: 'ship',
+      model: 'claude-sonnet-5',
+      status: 'stopped',
+      startedAt: '2026-07-24T12:00:00Z',
+    });
+    vi.mocked(getReviewStatusSync).mockReturnValue({
+      history: [{ type: 'merge', status: 'passed', timestamp: '2026-07-24T12:00:00Z' }],
+    } as ReturnType<typeof getReviewStatusSync>);
+    vi.mocked(resolveJsonlPath).mockImplementation(async (agentId) => (
+      agentId === shipId ? '/tmp/ship.jsonl' : null
+    ));
+
+    const result = await fetchActivityDataWithContext(issueId, { tmuxSessionNames: new Set() });
+    const sections = (result as { sections: Array<{ sessionId: string; type: string; hasJsonl?: boolean }> }).sections;
+
+    expect(sections.find((section) => section.sessionId === shipId)).toMatchObject({
+      type: 'ship',
+      hasJsonl: true,
+    });
   });
 });

--- a/tests/unit/dashboard/server/routes/projects.test.ts
+++ b/tests/unit/dashboard/server/routes/projects.test.ts
@@ -92,6 +92,7 @@ import { listProjectsSync } from '../../../../../src/lib/projects.js';
 import { listSessionNames } from '../../../../../src/lib/tmux.js';
 import { getAgentRuntimeState } from '../../../../../src/lib/agents.js';
 import { getReviewStatusSync } from '../../../../../src/dashboard/server/review-status.js';
+import { resolveJsonlPath } from '../../../../../src/dashboard/server/routes/jsonl-resolver.js';
 import { access, readdir, readFile, stat } from 'node:fs/promises';
 
 const RECENT_PLANNING_MTIME = new Date(Date.now() - 60_000);
@@ -139,6 +140,7 @@ describe('fetchProjectSessionTree', () => {
     (stat as any).mockResolvedValue({ mtime: RECENT_PLANNING_MTIME });
     mockFindSpecByIssue.mockReturnValue(Effect.succeed(null));
     (getReviewStatusSync as any).mockReturnValue(null);
+    (resolveJsonlPath as any).mockResolvedValue(null);
     (getAgentRuntimeState as any).mockReturnValue(Effect.succeed(null));
   });
 
@@ -462,6 +464,67 @@ describe('fetchProjectSessionTree', () => {
       troubledAt: '2026-02-03T04:05:06Z',
       consecutiveFailures: 1,
       queuedMailCount: 1,
+    });
+  });
+
+  it('uses merge-door history without probing a synthetic ship conversation', async () => {
+    (listProjectsSync as any).mockReturnValue([
+      {
+        key: 'overdeck',
+        config: { name: 'overdeck', path: '/tmp/overdeck', workspace: { workspaces_dir: 'workspaces' } },
+      },
+    ]);
+    (listSessionNames as any).mockReturnValue(Effect.succeed([]));
+    (getReviewStatusSync as any).mockReturnValue({
+      history: [{ type: 'merge', status: 'merging', timestamp: '2026-07-24T12:00:00Z' }],
+    });
+    mockAccess(new Set([
+      '/tmp/overdeck/workspaces',
+      '/tmp/overdeck/workspaces/feature-pan-3020/.overdeck',
+    ]));
+    mockWorkspaceReaddir([{ name: 'feature-pan-3020', isDirectory: () => true, isFile: () => false }]);
+
+    const result = await fetchProjectSessionTree('overdeck');
+
+    const tree = result as { features: Array<{ sessions: Array<{ sessionId: string }> }> };
+    expect(tree.features[0]?.sessions.some((session) => session.sessionId === 'agent-pan-3020-ship')).toBe(false);
+    expect(resolveJsonlPath).not.toHaveBeenCalledWith('agent-pan-3020-ship', expect.any(String));
+  });
+
+  it('retains a historical ship conversation when its transcript resolves', async () => {
+    (listProjectsSync as any).mockReturnValue([
+      {
+        key: 'overdeck',
+        config: { name: 'overdeck', path: '/tmp/overdeck', workspace: { workspaces_dir: 'workspaces' } },
+      },
+    ]);
+    (listSessionNames as any).mockReturnValue(Effect.succeed([]));
+    (getReviewStatusSync as any).mockReturnValue({
+      history: [{ type: 'merge', status: 'passed', timestamp: '2026-07-24T12:00:00Z' }],
+    });
+    mockAgentStates.set('agent-pan-3020-ship', agentState({
+      id: 'agent-pan-3020-ship',
+      issueId: 'PAN-3020',
+      role: 'ship',
+      model: 'claude-sonnet-5',
+      status: 'stopped',
+      workspace: '/tmp/overdeck/workspaces/feature-pan-3020',
+    }));
+    (resolveJsonlPath as any).mockImplementation(async (agentId: string) => (
+      agentId === 'agent-pan-3020-ship' ? '/tmp/ship.jsonl' : null
+    ));
+    mockAccess(new Set([
+      '/tmp/overdeck/workspaces',
+      '/tmp/overdeck/workspaces/feature-pan-3020/.overdeck',
+    ]));
+    mockWorkspaceReaddir([{ name: 'feature-pan-3020', isDirectory: () => true, isFile: () => false }]);
+
+    const result = await fetchProjectSessionTree('overdeck');
+
+    const tree = result as { features: Array<{ sessions: Array<{ sessionId: string; type: string; hasJsonl?: boolean }> }> };
+    expect(tree.features[0]?.sessions.find((session) => session.sessionId === 'agent-pan-3020-ship')).toMatchObject({
+      type: 'ship',
+      hasJsonl: true,
     });
   });
 


### PR DESCRIPTION
**Issue:** #3020


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ship-stage activity and session visibility.
  * Prevented inactive or unavailable ship sessions from appearing as empty entries.
  * Preserved historical ship conversations when a completed merge has transcript data.
  * Avoided probing for ship transcripts while merges are still in progress.

* **Tests**
  * Added coverage for ship-session visibility across merging and completed merge states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->