### PR TITLE
PAN-3029: regenerate slash-command registry to unblock red main

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,7 +7,7 @@
 1002 src/dashboard/frontend/src/components/KanbanBoard.tsx
 1106 src/dashboard/frontend/src/components/PlanDialog.tsx
 1547 src/dashboard/frontend/src/components/chat/ConversationPanel.tsx
-1792 src/dashboard/frontend/src/components/chat/slashCommands.generated.ts
+1806 src/dashboard/frontend/src/components/chat/slashCommands.generated.ts
 1006 src/dashboard/server/routes/agents/spawn.ts
 1443 src/dashboard/server/routes/command-deck.ts
 1005 src/dashboard/server/routes/flywheel.ts

--- a/src/dashboard/frontend/src/components/chat/slashCommands.generated.ts
+++ b/src/dashboard/frontend/src/components/chat/slashCommands.generated.ts
@@ -131,6 +131,13 @@ export const GENERATED_SLASH_COMMANDS: SlashCommand[] = [
     category: 'Review',
   },
   {
+    id: 'pan-review-resync',
+    label: 'pan review resync',
+    description: 'Re-emit canonical review status (heal a lost pipeline event)',
+    insert: 'pan review resync ',
+    category: 'Review',
+  },
+  {
     id: 'pan-review-abort',
     label: 'pan review abort',
     description: 'Kill all running reviewer sessions and leave the worker idle',
@@ -695,6 +702,13 @@ export const GENERATED_SLASH_COMMANDS: SlashCommand[] = [
     label: 'pan release canary',
     description: 'Create a canary release commit and tag',
     insert: 'pan release canary',
+    category: 'Flywheel',
+  },
+  {
+    id: 'pan-release-sourcemaps',
+    label: 'pan release sourcemaps',
+    description: 'Upload the built dashboard sourcemaps to PostHog',
+    insert: 'pan release sourcemaps',
     category: 'Flywheel',
   },
   {


### PR DESCRIPTION
Strike fix for red main on promote 6c79528428. Regenerates slashCommands.generated.ts + file-size baseline. Passed typecheck+lint+test. Closes PAN-3029.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the recorded file-size baseline for an internal generated asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->