### PR TITLE
fix(cli): unswallow promotion errors, exempt pipeline-owned .pan/ paths from the spawn dirty gate, drop the gh/git-cwd assumption (PAN-3042)

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,7 +7,6 @@
 1002 src/dashboard/frontend/src/components/KanbanBoard.tsx
 1106 src/dashboard/frontend/src/components/PlanDialog.tsx
 1541 src/dashboard/frontend/src/components/chat/ConversationPanel.tsx
-1006 src/dashboard/server/routes/agents/spawn.ts
 1443 src/dashboard/server/routes/command-deck.ts
 1005 src/dashboard/server/routes/flywheel.ts
 1064 src/dashboard/server/routes/projects.ts

--- a/src/dashboard/server/routes/__tests__/agents-spawn-dirty-workspace.test.ts
+++ b/src/dashboard/server/routes/__tests__/agents-spawn-dirty-workspace.test.ts
@@ -18,6 +18,12 @@ describe('isOnlyOverdeckRuntimeWorkspaceChanges', () => {
     ['a canonical continue file', ' M .overdeck/continue.json'],
     ['a legacy workspace spec', '?? .pan/spec.vbrief.json'],
     ['a legacy continue file', '?? .pan/continue.json'],
+    // PAN-3042: the gate runs with --untracked-files=all, so it never sees the
+    // collapsed `?? .pan/` form — it sees expanded paths like this
+    // pipeline-authored PRD draft, which used to read as operator dirt and 409
+    // the planning→work auto-handoff.
+    ['an expanded pipeline-authored PRD draft', '?? .pan/drafts/MIN-898.md'],
+    ['any other Overdeck-owned .pan/ path', '?? .pan/user-notes.md'],
   ])('allows %s', (_label, porcelain) => {
     expect(isOnlyOverdeckRuntimeWorkspaceChanges(porcelain)).toBe(true);
   });
@@ -25,7 +31,7 @@ describe('isOnlyOverdeckRuntimeWorkspaceChanges', () => {
   it.each([
     ['a source file', ' M src/index.ts'],
     ['runtime files mixed with a source file', '?? .pan/spec.vbrief.json\n M src/index.ts'],
-    ['an unknown legacy path', '?? .pan/user-notes.md'],
+    ['a runtime-lookalike path outside the runtime dirs', '?? pan/drafts/MIN-898.md'],
   ])('rejects %s', (_label, porcelain) => {
     expect(isOnlyOverdeckRuntimeWorkspaceChanges(porcelain)).toBe(false);
   });

--- a/src/dashboard/server/routes/agents/spawn.ts
+++ b/src/dashboard/server/routes/agents/spawn.ts
@@ -102,24 +102,17 @@ export function emitDirtyWorkspaceRefusalActivity(issueId: string, porcelain: st
   } catch { /* non-fatal — activity emit should not block the response */ }
 }
 
-const LEGACY_WORKSPACE_RUNTIME_FILES = new Set([
-  '.pan/continue.json',
-  '.pan/spec.vbrief.json',
-  '.pan/kickoff.md',
-  '.pan/sessions.jsonl',
-  '.pan/pipeline-verdict.json',
-  '.pan/verification-latest.json',
-  '.pan/agent-mcp.json',
-]);
-
+/**
+ * Both workspace runtime directories are Overdeck-owned in full, so both get a
+ * blanket prefix match. The legacy `.pan/` allowlist only matched the collapsed
+ * `?? .pan/` porcelain form plus a closed set of files — but this gate always
+ * runs with `--untracked-files=all`, which expands untracked directories into
+ * individual paths. A pipeline-authored `.pan/drafts/<ISSUE>.md` therefore read
+ * as operator dirt and 409'd the planning→work auto-handoff (PAN-3042).
+ */
 function isOverdeckWorkspaceRuntimePath(path: string): boolean {
   if (path === '.overdeck' || path.startsWith('.overdeck/')) return true;
-  if (path === '.pan' || path === '.pan/') return true;
-  if (LEGACY_WORKSPACE_RUNTIME_FILES.has(path)) return true;
-  return path.startsWith('.pan/feedback/')
-    || path.startsWith('.pan/review/')
-    || path.startsWith('.pan/test/')
-    || path.startsWith('.pan/handoff-');
+  return path === '.pan' || path === '.pan/' || path.startsWith('.pan/');
 }
 
 /** True when git porcelain contains only Overdeck-owned workspace runtime files. */

--- a/src/lib/__tests__/errors.test.ts
+++ b/src/lib/__tests__/errors.test.ts
@@ -98,6 +98,23 @@ describe('FsError', () => {
     const eff = Effect.fail(new FsError({ path: '/tmp/foo', operation: 'write' }));
     expect(catchTag(eff, 'FsError')).toBe('caught:FsError');
   });
+
+  // PAN-3042: operator-facing surfaces render `error.message`, and a payload
+  // without a `message` field left it empty ("PRD draft promotion failed: ").
+  it('renders a non-empty message carrying operation, path, and cause', () => {
+    const err = new FsError({ path: '/state/drafts/MIN-902.md', operation: 'pushDraft', cause: new Error('push rejected') });
+    expect(err.message).toBe('pushDraft failed for /state/drafts/MIN-902.md: push rejected');
+  });
+
+  it('renders a message when no cause is attached', () => {
+    const err = new FsError({ path: '/tmp/foo', operation: 'writeFileString' });
+    expect(err.message).toBe('writeFileString failed for /tmp/foo');
+  });
+
+  it('surfaces the message when rejected through Effect.runPromise', async () => {
+    const eff = Effect.fail(new FsError({ path: '/tmp/foo', operation: 'readFileString', cause: 'EACCES' }));
+    await expect(Effect.runPromise(eff)).rejects.toThrow('readFileString failed for /tmp/foo: EACCES');
+  });
 });
 
 describe('FsNotFoundError', () => {

--- a/src/lib/cloister/__tests__/orphan-proposed-reconciler.test.ts
+++ b/src/lib/cloister/__tests__/orphan-proposed-reconciler.test.ts
@@ -55,7 +55,8 @@ vi.mock('../../github-app.js', () => ({
   listPullRequestsForHead: githubAppMocks.listPullRequestsForHead,
 }));
 
-vi.mock('../../tracker-utils.js', () => ({
+vi.mock('../../tracker-utils.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../../tracker-utils.js')>(),
   resolveGitHubIssueSync: trackerUtilsMocks.resolveGitHubIssueSync,
 }));
 
@@ -449,9 +450,37 @@ describe('orphan proposed spec reconciler', () => {
     expect(spawnWorkAgent).not.toHaveBeenCalled();
     expect(childProcessMocks.exec).toHaveBeenCalledTimes(1);
     const [command, options] = childProcessMocks.exec.mock.calls[0];
-    expect(command).toBe('gh pr list --head feature/pan-3603 --state open --json number --limit 1');
+    // PAN-3042: --repo keeps the probe working when the project path is not a
+    // git repo (polyrepo wrapper) or has no origin remote.
+    expect(command).toBe('gh pr list --repo eltmon/overdeck --head feature/pan-3603 --state open --json number --limit 1');
     expect(options).toMatchObject({ cwd: projectPath });
     expect(activityLogger.emitActivityEntrySync).not.toHaveBeenCalled();
+  });
+
+  it('skips the gh open-PR probe for a non-GitHub tracker and still spawns', async () => {
+    // PAN-3042: MYN is Linear-tracked and its project path is not a git repo,
+    // so `gh pr list` failed with "fatal: not a git repository" every scan. The
+    // probe keys off the tracker resolver, not the issue prefix — this fixture
+    // uses an unconfigured prefix so no tracker client is constructed.
+    const projectPath = join(testDir, 'project');
+    mkdirSync(projectPath, { recursive: true });
+    writeSpec(projectPath, 'ZZZ-9042', 'proposed');
+    writeTasks(projectPath, 'ZZZ-9042');
+    trackerUtilsMocks.resolveGitHubIssueSync.mockReturnValue({ isGitHub: false } as never);
+    const spawnWorkAgent = vi.fn(async () => ({ spawned: true, agentId: 'agent-zzz-9042' }));
+
+    await expect(reconcileOrphanProposedSpecs({
+      projects: [{ key: 'other', config: { name: 'Non-GitHub Project', path: projectPath } }],
+      tmuxSessionNames: [],
+      getAgentStateForIssue: async () => null,
+      closedIssueIds: new Set(),
+      now: new Date('2026-05-25T20:00:00.000Z'),
+      config: { enabled: true, minAttemptIntervalMs: 5 * 60 * 1000 },
+      spawnWorkAgent,
+    })).resolves.toEqual(['Spawned work agent for orphan proposed spec ZZZ-9042']);
+
+    expect(childProcessMocks.exec).not.toHaveBeenCalled();
+    expect(spawnWorkAgent).toHaveBeenCalledWith('ZZZ-9042');
   });
 
   it('checks open PRs with GitHub App REST when configured', async () => {

--- a/src/lib/cloister/orphan-proposed-reconciler.ts
+++ b/src/lib/cloister/orphan-proposed-reconciler.ts
@@ -161,11 +161,21 @@ async function defaultHasOpenPrForBranch(projectPath: string, issueId: string): 
 
   try {
     const resolved = resolveGitHubIssueSync(issueId);
-    if (isGitHubAppConfigured() && resolved.isGitHub) {
+    if (!resolved.isGitHub) {
+      // Linear/GitLab-tracked issue: there is no GitHub PR to probe, and `gh`
+      // would fail anyway — a polyrepo wrapper projectPath is not a git repo
+      // ("fatal: not a git repository", PAN-3042).
+      logReconcilerDiagnostic('open-pr-check-skipped', { projectPath, issueId, branch, reason: 'non-github-tracker' });
+      return false;
+    }
+    if (isGitHubAppConfigured()) {
       return (await Effect.runPromise(listPullRequestsForHead(resolved.owner, resolved.repo, branch, 'open'))).length > 0;
     }
 
-    const result = await execAsync(`gh pr list --head ${branch} --state open --json number --limit 1`, { cwd: projectPath }) as { stdout?: string } | string;
+    // `--repo` keeps the probe independent of cwd: gh otherwise resolves the
+    // repo from git remotes, which fails when projectPath has no git repo or no
+    // origin (the polyrepo wrapper case).
+    const result = await execAsync(`gh pr list --repo ${resolved.owner}/${resolved.repo} --head ${branch} --state open --json number --limit 1`, { cwd: projectPath }) as { stdout?: string } | string;
     const stdout = typeof result === 'string' ? result : result.stdout;
     const prs = JSON.parse(stdout ?? '[]') as unknown;
     return Array.isArray(prs) && prs.length > 0;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -29,7 +29,23 @@ export class FsError extends Data.TaggedError('FsError')<{
   readonly path: string;
   readonly operation: string;
   readonly cause?: unknown;
-}> {}
+}> {
+  /**
+   * `Data.TaggedError` only populates `message` when the payload declares one,
+   * and this payload does not — so every operator-facing surface that renders
+   * `error.message` printed an empty string (PAN-3042: "PRD draft promotion
+   * failed for MIN-902: " with nothing after the colon). Derive the message
+   * from the fields the payload does carry.
+   */
+  override get message(): string {
+    const detail = this.cause instanceof Error
+      ? this.cause.message
+      : this.cause === undefined || this.cause === null ? '' : String(this.cause);
+    return detail
+      ? `${this.operation} failed for ${this.path}: ${detail}`
+      : `${this.operation} failed for ${this.path}`;
+  }
+}
 
 /** The requested path does not exist. */
 export class FsNotFoundError extends Data.TaggedError('FsNotFoundError')<{

--- a/src/lib/overdeck/planning-promotion.ts
+++ b/src/lib/overdeck/planning-promotion.ts
@@ -577,7 +577,8 @@ export async function completePlanningForIssue(options: {
           promoteWorkspacePrdDraft({ projectRoot: projectPath, workspacePath, issueId: id }),
         );
         if (draftPromotion.promoted) {
-          emitCompletePlanningPhase(id, 'prdPromote', 'success', `promoted ${draftPromotion.source} -> ${draftPromotion.path}`);
+          const removalNote = draftPromotion.sourceRemoved ? '' : ' (workspace copy left in place)';
+          emitCompletePlanningPhase(id, 'prdPromote', 'success', `promoted ${draftPromotion.source} -> ${draftPromotion.path}${removalNote}`);
         } else {
           emitCompletePlanningPhase(id, 'prdPromote', 'skipped', draftPromotion.reason);
         }

--- a/src/lib/pan-dir/__tests__/drafts-promote.test.ts
+++ b/src/lib/pan-dir/__tests__/drafts-promote.test.ts
@@ -50,6 +50,41 @@ describe('promoteWorkspacePrdDraft', () => {
     expect(readFileSync(canonical, 'utf-8')).toBe('# PRD for PAN-2858\n\nbody\n');
   });
 
+  it('removes the promoted workspace copy so the workspace stays clean', async () => {
+    // PAN-3042: the leftover untracked `.pan/drafts/<ISSUE>.md` tripped the
+    // spawn-time dirty-workspace gate and stranded the planning→work handoff.
+    const wsDrafts = join(workspaceRoot, '.pan', 'drafts');
+    mkdirSync(wsDrafts, { recursive: true });
+    const source = join(wsDrafts, 'PAN-3042.md');
+    writeFileSync(source, '# PRD for PAN-3042\n', 'utf-8');
+
+    const result = await Effect.runPromise(
+      promoteWorkspacePrdDraft({ projectRoot, workspacePath: workspaceRoot, issueId: 'PAN-3042' }),
+    );
+
+    expect(result.promoted).toBe(true);
+    expect(result.sourceRemoved).toBe(true);
+    expect(existsSync(source)).toBe(false);
+    expect(readFileSync(getIssueDraftPath(projectRoot, 'PAN-3042'), 'utf-8')).toBe('# PRD for PAN-3042\n');
+  });
+
+  it('keeps the workspace copy when promotion is skipped for an existing canonical draft', async () => {
+    const draftsDir = getDraftsDir(projectRoot);
+    mkdirSync(draftsDir, { recursive: true });
+    writeFileSync(join(draftsDir, 'PAN-3042.md'), 'canonical\n', 'utf-8');
+    const wsDrafts = join(workspaceRoot, '.pan', 'drafts');
+    mkdirSync(wsDrafts, { recursive: true });
+    const source = join(wsDrafts, 'PAN-3042.md');
+    writeFileSync(source, 'workspace copy\n', 'utf-8');
+
+    const result = await Effect.runPromise(
+      promoteWorkspacePrdDraft({ projectRoot, workspacePath: workspaceRoot, issueId: 'PAN-3042' }),
+    );
+
+    expect(result.promoted).toBe(false);
+    expect(existsSync(source)).toBe(true);
+  });
+
   it('promotes a lowercase-named workspace draft', async () => {
     const wsDrafts = join(workspaceRoot, '.pan', 'drafts');
     mkdirSync(wsDrafts, { recursive: true });

--- a/src/lib/pan-dir/drafts.ts
+++ b/src/lib/pan-dir/drafts.ts
@@ -1,5 +1,5 @@
 import { join, basename } from 'path'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, rmSync } from 'node:fs'
 import { Effect, FileSystem, Option } from 'effect'
 import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem'
 import { FsError } from '../errors.js'
@@ -225,6 +225,8 @@ export interface PromoteWorkspacePrdDraftResult {
   path?: string
   /** Workspace file the content was promoted from. */
   source?: string
+  /** True when the now-redundant workspace copy was removed after promotion. */
+  sourceRemoved?: boolean
 }
 
 /**
@@ -237,6 +239,12 @@ export interface PromoteWorkspacePrdDraftResult {
  *
  * No-loss rule: an existing canonical draft is never overwritten — the
  * canonical copy may carry operator edits the workspace copy predates.
+ *
+ * A successful promotion also removes the workspace copy: the identical content
+ * is committed and pushed on the state plane, and the leftover untracked file
+ * tripped the spawn-time dirty-workspace gate, stranding the planning→work
+ * auto-handoff with `planning_auto_handoff_failed` (PAN-3042). Removal is
+ * best-effort — the spawn gate exempts Overdeck-owned `.pan/` paths anyway.
  */
 export function promoteWorkspacePrdDraft(args: {
   projectRoot: string
@@ -272,7 +280,17 @@ export function promoteWorkspacePrdDraft(args: {
       return Effect.fail(new FsError({ path: source, operation: 'readFileString', cause }))
     }
     return writeIssueDraft(projectRoot, issueId, content).pipe(
-      Effect.map((path): PromoteWorkspacePrdDraftResult => ({ promoted: true, reason: 'promoted', path, source })),
+      Effect.map((path): PromoteWorkspacePrdDraftResult => {
+        let sourceRemoved = false
+        try {
+          rmSync(source)
+          sourceRemoved = true
+        } catch {
+          // Best effort: the canonical copy is already committed and pushed, so
+          // a failed unlink must not fail promotion.
+        }
+        return { promoted: true, reason: 'promoted', path, source, sourceRemoved }
+      }),
     )
   })
 }


### PR DESCRIPTION
Fixes #3042.

Strike fix for the planning→work auto-handoff failure that stranded MIN-902 and five more MIN issues (MIN-898, MIN-901, MIN-858, MIN-891, MIN-896) this morning, each with a finished plan and no work agent.

### 1. Promotion errors were empty strings

`FsError` extends `Data.TaggedError` with a payload that declares no `message`, so `Data.TaggedError` never populated one and every operator-facing surface rendering `error.message` printed nothing — the observed `PRD draft promotion failed for MIN-902: ` with nothing after the colon. Adds a derived `message` getter built from the `operation`, `path`, and `cause` the payload does carry.

### 2. The spawn dirty-workspace gate rejected pipeline-owned `.pan/` paths

The gate runs `git status --porcelain --untracked-files=all`, which expands untracked directories into individual paths, so it sees `?? .pan/drafts/MIN-898.md` and never the collapsed `?? .pan/`. `isOverdeckWorkspaceRuntimePath` gave `.overdeck/` a blanket prefix match but `.pan/` only that collapsed form plus a closed 7-file allowlist and four prefixes — none covering `.pan/drafts/`, which is exactly where the planning agent writes the PRD workspace-side. The pipeline's own planning step therefore produced a file its own spawn gate classified as operator dirt, 409'd the handoff, and marked the issue `planning_auto_handoff_failed`.

Two changes, deliberately belt-and-braces:
- `.pan/` now gets the same blanket prefix treatment as `.overdeck/` (both directories are Overdeck-owned in full), retiring the dead collapsed-form branch and the allowlist.
- `promoteWorkspacePrdDraft` removes the workspace copy after a successful promotion, so the workspace is genuinely clean rather than merely exempt. Best-effort — the canonical copy is already committed and pushed on the state plane, so a failed unlink must not fail the promotion.

Test coverage pins the expanded porcelain form specifically; a test asserting on `?? .pan/` would have passed while the bug was live. The reject case is re-pointed at `?? pan/drafts/...` (no leading dot) so the broadened prefix cannot drift too loose.

### 3. The handoff PR probe assumed GitHub and a git cwd

`defaultHasOpenPrForBranch` shelled out to `gh pr list` with `cwd: projectPath`, which fails on MYN — a GitLab-tracked polyrepo whose wrapper root is not a git repo (`fatal: not a git repository`). Now returns early for non-GitHub trackers, and passes `--repo <owner>/<repo>` so `gh` no longer resolves the repo from cwd git remotes.

### Not covered here

Landing this stops new stranding but does not recover issues already stuck: `planning_auto_handoff_failed` clears only on the next successful start (`spawn.ts:661`) and nothing retries. MIN-898, MIN-901, MIN-858, MIN-891 and MIN-896 still need a re-kick. Noted on #3042.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dirty-workspace checks to recognize all runtime files and avoid blocking agent startup unnecessarily.
  - Improved filesystem error messages with clearer operation, path, and cause details.
  - Prevented irrelevant pull-request checks for non-GitHub-tracked work.
  - Made pull-request checks more reliable when run outside a Git repository.

- **Improvements**
  - Promoted workspace drafts are now cleaned up automatically when appropriate, while existing canonical drafts remain protected.
  - Promotion activity now indicates whether the original draft was removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->