### PR TITLE
fix(tests): restore main-green gates for boot-reconciliation extend route (PAN-3056)

### DIFF
--- a/src/dashboard/server/routes/__tests__/boot-reconciliation.test.ts
+++ b/src/dashboard/server/routes/__tests__/boot-reconciliation.test.ts
@@ -91,6 +91,14 @@ const mocks = vi.hoisted(() => {
 vi.mock('../../../../lib/cloister/boot-reconciliation.js', () => ({
   isBootReconciliationCandidate: vi.fn((agent: { id: string }) => agent.id === 'agent-candidate'),
   listBootReconciliationCandidates: vi.fn(() => mocks.candidates),
+  MAX_BOOT_RECONCILIATION_GRACE_EXTENSIONS: 3,
+  extendBootReconciliationGrace: vi.fn(() => ({
+    extended: true,
+    graceDeadline: '2026-06-29T15:01:00.000Z',
+    graceExtensions: 1,
+    maxGraceExtensions: 3,
+    reason: 'extended',
+  })),
 }));
 
 vi.mock('../../../../lib/cloister/deacon.js', () => ({
@@ -144,16 +152,19 @@ async function requestRoute(path: string, init?: RequestInit): Promise<{ status:
 }
 
 describe('boot reconciliation route', () => {
-  it('omits stale stopped non-candidates while retaining read-only context rows', async () => {
+  it('puts only decision candidates in set, read-only rows in context, and omits stale stopped non-candidates', async () => {
     const response = await requestRoute('/api/boot-reconciliation');
 
     expect(response.status).toBe(200);
-    const ids = response.body.set.map((agent: { id: string }) => agent.id);
-    expect(ids).toEqual(['agent-candidate', 'agent-paused', 'agent-troubled', 'agent-remote']);
-    expect(ids).not.toContain('agent-stale');
+    const setIds = response.body.set.map((agent: { id: string }) => agent.id);
+    const contextIds = response.body.context.map((agent: { id: string }) => agent.id);
+    expect(setIds).toEqual(['agent-candidate']);
+    expect(contextIds).toEqual(['agent-paused', 'agent-troubled', 'agent-remote']);
+    expect([...setIds, ...contextIds]).not.toContain('agent-stale');
+    expect(response.body.maxGraceExtensions).toBe(3);
     expect(response.body.set.find((agent: { id: string }) => agent.id === 'agent-candidate').readOnly).toBe(false);
     for (const id of ['agent-paused', 'agent-troubled', 'agent-remote']) {
-      expect(response.body.set.find((agent: { id: string }) => agent.id === id).readOnly).toBe(true);
+      expect(response.body.context.find((agent: { id: string }) => agent.id === id).readOnly).toBe(true);
     }
   });
 

--- a/tests/unit/lib/overdeck/no-loss-matrix.ts
+++ b/tests/unit/lib/overdeck/no-loss-matrix.ts
@@ -127,6 +127,7 @@ export const NO_LOSS_MATRIX: MatrixEntry[] = [
   { surface: 'GET /api/cloister/agents/health',           kind: 'http', disposition: 'RELOCATE',    door: 'AgentsResolver.getHealthHistory ×N' },
   { surface: 'GET /api/boot-reconciliation',              kind: 'http', disposition: 'AGGREGATE',   door: 'BootReconciliationRuntime.getState + AgentsResolver.list' },
   { surface: 'POST /api/boot-reconciliation/decision',    kind: 'http', disposition: 'WRITE',       door: 'SettingsWriter.bootReconciliationDecision + CloisterRuntime.apply' },
+  { surface: 'POST /api/boot-reconciliation/extend',      kind: 'http', disposition: 'WRITE',       door: 'BootReconciliationRuntime.extendGrace → SettingsWriter.bootReconciliationGrace' },
 
   // ── codex-auth.ts ─────────────────────────────────────────────────────────
   { surface: 'GET /api/settings/codex-auth',              kind: 'http', disposition: 'RELOCATE',    door: 'provider-auth' },


### PR DESCRIPTION
Fixes #3056. Restores `main` to green.

`cb39b20958` (PAN-3052) added the `POST /api/boot-reconciliation/extend` route and the `MAX_BOOT_RECONCILIATION_GRACE_EXTENSIONS` export usage without updating the two gates that exist to catch exactly that, leaving `main` red since 07:41 -0400. Every feature PR inherited the failing `test` check.

**Changes (+17/-5, tests only):**

- The route test's `vi.mock` of `lib/cloister/boot-reconciliation.js` now supplies `MAX_BOOT_RECONCILIATION_GRACE_EXTENSIONS` and `extendBootReconciliationGrace`, matching the surface the route imports. The mocked value `3` matches the real export at `boot-reconciliation.ts:30`.
- With the mock fixed, the route test's stale assertions surfaced. `cb39b20958` deliberately moved paused/troubled/remote rows out of `set` into `context`; the assertions now check that intended contract rather than the pre-change behavior — `set` holds only decision candidates, `context` holds the read-only rows, the stale stopped non-candidate appears in neither.
- `NO_LOSS_MATRIX` gains the `POST /api/boot-reconciliation/extend` entry with a `WRITE` disposition naming the grace write door.

**Gates run on this branch:**

- `npx vitest run src/dashboard/server/routes/__tests__/boot-reconciliation.test.ts tests/unit/lib/overdeck/no-loss-matrix.test.ts` — 2 files, 7 tests passed (both previously failing)
- `npm run typecheck` — passed
- `npm run lint` — passed

Filed and driven by the Flywheel (RUN-70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmAFhdqW76Z5bnmkLRXkMH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for extending the boot reconciliation grace period through a dedicated endpoint.
  * Responses now distinguish writable decision candidates from read-only contextual agents.
  * Added visibility into the grace deadline and current and maximum extension counts.

* **Tests**
  * Updated reconciliation coverage to validate agent filtering, read-only states, and grace extension details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->