### PR TITLE
PAN-3055

### DIFF
--- a/docs/ASKUSERQUESTION-DASHBOARD.md
+++ b/docs/ASKUSERQUESTION-DASHBOARD.md
@@ -274,6 +274,33 @@ own in that dir (codex and omp keep history elsewhere). Freshest-wins alone
 attributes whichever session wrote last to whoever asks: the live flywheel was
 observed reporting an operator conversation's open question as its own.
 
+## Liveness is part of pendingness (PAN-3055)
+
+A question is actionable only while its asking agent has a live tmux pane. Before
+PAN-3055, a missing tmux server during dashboard boot produced
+`tmuxAvailable:false`, but `listRunningAgents` deliberately failed open and marked
+every registered agent `tmuxActive:true`. The enrichment poller then scanned
+long-stopped agents, projected them as running, and announced their weeks-old
+questions with TTS.
+
+The poller now checks the runtime census before each cycle. When the census cannot
+see tmux, `pollOnce` returns before it scans agents, emits domain or activity
+events, speaks TTS, or mutates its enrichment caches. The fail-open remains in
+`listRunningAgents` because one-off CLI processes may not see the dashboard-owned
+tmux socket; those callers must not declare every registered agent dead from
+missing local evidence.
+
+Once the census is available, the poller treats removal from the census-verified
+active set as a falling edge. If the removed agent had pending input, it emits a
+clearing `agent.enrichment_changed` event and one info-level activity entry. It
+emits no TTS because the operator cannot answer the question in place. PAN-2633's
+idle-alive case remains intact: a live pane is never reaped, even when the agent
+registry still carries a stop-shaped status.
+
+Reaping removes the question from the Decisions list, but it does not erase
+history. The original question and its options remain in the agent's JSONL
+transcript, and the agent's terminal status records why the question expired.
+
 ## Gotchas for future debugging
 
 - Dashboard runs under `pan dev`: the **frontend is Vite HMR** (source changes

--- a/src/dashboard/server/__tests__/read-model-pending-input.test.ts
+++ b/src/dashboard/server/__tests__/read-model-pending-input.test.ts
@@ -1,6 +1,78 @@
 import { describe, expect, it } from 'vitest';
-import type { AgentStatus } from '@overdeck/contracts';
+import {
+  applyEvent,
+  INITIAL_READ_MODEL_STATE,
+  type AgentSnapshot,
+  type AgentStatus,
+  type DomainEvent,
+} from '@overdeck/contracts';
 import { projectPendingInput } from '../read-model.js';
+
+const pendingAskUserQuestion = {
+  toolUseId: 'toolu-pan-3055',
+  askedAt: '2026-06-29T09:02:55.023Z',
+  questions: [{
+    question: 'Which scope should this issue use?',
+    header: 'Scope',
+    multiSelect: false,
+    options: [
+      { label: 'Residual only', description: 'Keep only the remaining Kimi-native work.' },
+      { label: 'Original scope', description: 'Retain the original issue scope.' },
+    ],
+  }],
+};
+
+describe('pending-input event projection', () => {
+  it('clears a planted AskUserQuestion when the reap event is applied', () => {
+    const agentId = 'agent-pan-3055';
+    const agent: AgentSnapshot = { id: agentId, issueId: 'PAN-3055', status: 'running' };
+    const initialState = {
+      ...INITIAL_READ_MODEL_STATE,
+      agentsById: { [agentId]: agent },
+    };
+
+    const planted = applyEvent(initialState, {
+      type: 'agent.enrichment_changed',
+      sequence: 1,
+      timestamp: '2026-06-29T09:02:55.023Z',
+      payload: {
+        agentId,
+        hasPendingQuestion: true,
+        pendingQuestionCount: 1,
+        pendingInputCount: 1,
+        pendingInputKinds: ['askUserQuestion'],
+        pendingAskUserQuestion,
+      },
+    } as DomainEvent);
+    expect(planted.agentsById[agentId].pendingAskUserQuestion).toEqual(pendingAskUserQuestion);
+
+    const reaped = applyEvent(planted, {
+      type: 'agent.enrichment_changed',
+      sequence: 2,
+      timestamp: '2026-07-25T12:20:00.000Z',
+      payload: {
+        agentId,
+        hasPendingQuestion: false,
+        pendingQuestionCount: 0,
+        pendingQuestionPrompt: undefined,
+        pendingQuestionReason: undefined,
+        pendingInputCount: 0,
+        pendingInputKinds: [],
+        pendingAskUserQuestion: undefined,
+        pendingProposedPlan: undefined,
+      },
+    } as DomainEvent);
+
+    expect(reaped.agentsById[agentId]).toMatchObject({
+      hasPendingQuestion: false,
+      pendingQuestionCount: 0,
+      pendingInputCount: 0,
+      pendingInputKinds: [],
+    });
+    expect(reaped.agentsById[agentId].pendingAskUserQuestion).toBeUndefined();
+    expect(reaped.agentsById[agentId].pendingProposedPlan).toBeUndefined();
+  });
+});
 
 // PAN-1591 — a non-running agent cannot be awaiting interactive input. The
 // bootstrap projection must strip a stale cached hasPendingQuestion so a stopped
@@ -42,9 +114,31 @@ describe('projectPendingInput', () => {
       pendingQuestionCount: 1,
       pendingInputCount: 1,
       pendingInputKinds: ['askUserQuestion'] as readonly string[],
-      pendingAskUserQuestion: { toolUseId: 't1', askedAt: '2026-06-02T00:00:00Z', questions: [] },
+      pendingAskUserQuestion,
     };
     expect(projectPendingInput('running', withQuestion)).toEqual(withQuestion);
     expect(projectPendingInput('stopped', withQuestion).pendingAskUserQuestion).toBeUndefined();
+  });
+
+  it('surfaces no pending fields when bootstrapping a long-stopped agent with stale question data', () => {
+    const stalePending = {
+      hasPendingQuestion: true,
+      pendingQuestionCount: 1,
+      pendingQuestionPrompt: 'Which scope should this issue use?',
+      pendingQuestionReason: 'Planning is blocked',
+      pendingInputCount: 1,
+      pendingInputKinds: ['askUserQuestion'] as readonly string[],
+      pendingAskUserQuestion,
+    };
+
+    expect(projectPendingInput('stopped', stalePending)).toEqual({
+      hasPendingQuestion: undefined,
+      pendingQuestionCount: undefined,
+      pendingQuestionPrompt: undefined,
+      pendingQuestionReason: undefined,
+      pendingInputCount: undefined,
+      pendingInputKinds: undefined,
+      pendingAskUserQuestion: undefined,
+    });
   });
 });

--- a/src/dashboard/server/services/__tests__/agent-enrichment-service.test.ts
+++ b/src/dashboard/server/services/__tests__/agent-enrichment-service.test.ts
@@ -3,6 +3,7 @@ import {
   buildAwaitingInputActivityMessage,
   isAwaitingInputRisingEdge,
   shouldForceReemitPendingInput,
+  shouldSkipEnrichmentCycle,
 } from '../agent-enrichment-service.js'
 import type { AgentEnrichment } from '../../../../lib/agent-enrichment.js'
 
@@ -22,6 +23,16 @@ function makeEnrichment(
     ...overrides,
   }
 }
+
+describe('shouldSkipEnrichmentCycle', () => {
+  it('returns true when tmux census evidence is unavailable', () => {
+    expect(shouldSkipEnrichmentCycle({ tmuxAvailable: false })).toBe(true)
+  })
+
+  it('returns false when tmux census evidence is available', () => {
+    expect(shouldSkipEnrichmentCycle({ tmuxAvailable: true })).toBe(false)
+  })
+})
 
 describe('isAwaitingInputRisingEdge', () => {
   it('returns true when pendingInputCount rises from 0 to greater than 0', () => {

--- a/src/dashboard/server/services/__tests__/agent-enrichment-service.test.ts
+++ b/src/dashboard/server/services/__tests__/agent-enrichment-service.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildAwaitingInputActivityMessage,
+  buildExpiredQuestionActivityMessage,
+  buildPendingReapEvent,
+  hasReapablePendingInput,
   isAwaitingInputRisingEdge,
   shouldForceReemitPendingInput,
   shouldSkipEnrichmentCycle,
@@ -31,6 +34,73 @@ describe('shouldSkipEnrichmentCycle', () => {
 
   it('returns false when tmux census evidence is available', () => {
     expect(shouldSkipEnrichmentCycle({ tmuxAvailable: true })).toBe(false)
+  })
+})
+
+describe('hasReapablePendingInput', () => {
+  it('returns true when pendingInputCount is greater than zero', () => {
+    expect(hasReapablePendingInput(makeEnrichment(1, ['askUserQuestion']))).toBe(true)
+  })
+
+  it('returns true when only an AskUserQuestion payload remains', () => {
+    expect(hasReapablePendingInput(makeEnrichment(0, [], {
+      pendingAskUserQuestion: { toolUseId: 't1' } as any,
+    }))).toBe(true)
+  })
+
+  it('returns true when only a proposed-plan payload remains', () => {
+    expect(hasReapablePendingInput(makeEnrichment(0, [], {
+      pendingProposedPlan: { toolUseId: 't2' } as any,
+    }))).toBe(true)
+  })
+
+  it('returns false when no pending input remains', () => {
+    expect(hasReapablePendingInput(makeEnrichment(0))).toBe(false)
+  })
+})
+
+describe('buildPendingReapEvent', () => {
+  it('clears every pending field and preserves role and resolution fields', () => {
+    const previous = makeEnrichment(2, ['askUserQuestion', 'plan'], {
+      role: 'plan',
+      hasPendingQuestion: true,
+      pendingQuestionCount: 1,
+      pendingQuestionPrompt: 'Choose a scope',
+      pendingQuestionReason: 'Planning is blocked',
+      pendingAskUserQuestion: { toolUseId: 't1' } as any,
+      pendingProposedPlan: { toolUseId: 't2' } as any,
+      resolution: 'awaiting_input',
+      resolutionCount: 3,
+    })
+
+    expect(buildPendingReapEvent('agent-pan-123', previous).payload).toEqual({
+      agentId: 'agent-pan-123',
+      role: 'plan',
+      hasPendingQuestion: false,
+      pendingQuestionCount: 0,
+      pendingQuestionPrompt: undefined,
+      pendingQuestionReason: undefined,
+      pendingInputCount: 0,
+      pendingInputKinds: [],
+      pendingAskUserQuestion: undefined,
+      pendingProposedPlan: undefined,
+      resolution: 'awaiting_input',
+      resolutionCount: 3,
+    })
+  })
+})
+
+describe('buildExpiredQuestionActivityMessage', () => {
+  it('includes the agent and issue identifiers', () => {
+    expect(buildExpiredQuestionActivityMessage('agent-pan-123', 'PAN-123')).toBe(
+      'agent-pan-123 on PAN-123 stopped with its question unanswered — the question has expired and is no longer actionable',
+    )
+  })
+
+  it('omits the issue clause when no issue is known', () => {
+    expect(buildExpiredQuestionActivityMessage('agent-pan-123', undefined)).toBe(
+      'agent-pan-123 stopped with its question unanswered — the question has expired and is no longer actionable',
+    )
   })
 })
 

--- a/src/dashboard/server/services/agent-enrichment-service.ts
+++ b/src/dashboard/server/services/agent-enrichment-service.ts
@@ -17,6 +17,7 @@ import { listRunningAgents, type AgentState } from '../../../lib/agents.js'
 import { computeAgentEnrichment, getAgentJsonlMtime, type AgentEnrichment, type PendingInputsScan } from '../../../lib/agent-enrichment.js'
 import { getReviewStatusSync } from '../../../lib/review-status.js'
 import { withConcurrencyLimit } from '../../../lib/concurrency.js'
+import { getRuntimeCensus, type RuntimeCensus } from '../../../lib/runtime-census.js'
 import { getEventStore } from '../event-store.js'
 import { saveAgentStateAndEmitEvent } from './agent-projection.js'
 import { emitActivityEntrySync, emitActivityTtsSync } from '../../../lib/activity-logger.js'
@@ -102,9 +103,23 @@ export function buildAwaitingInputActivityMessage(
     : `${agentId} is waiting for ${kindList}`
 }
 
+// PAN-3055 — no census evidence means no liveness claims: the listRunningAgents
+// fail-open would mark every stopped agent tmuxActive at boot and resurrect dead questions with TTS.
+export function shouldSkipEnrichmentCycle(census: Pick<RuntimeCensus, 'tmuxAvailable'>): boolean {
+  return !census.tmuxAvailable
+}
+
 // ─── Poller ───────────────────────────────────────────────────────────────────
 
 async function pollOnce(state: EnrichmentServiceState): Promise<void> {
+  let census: RuntimeCensus
+  try {
+    census = await getRuntimeCensus()
+  } catch {
+    return
+  }
+  if (shouldSkipEnrichmentCycle(census)) return
+
   let runningAgents: RunningAgent[]
   try {
     runningAgents = await Effect.runPromise(listRunningAgents())

--- a/src/dashboard/server/services/agent-enrichment-service.ts
+++ b/src/dashboard/server/services/agent-enrichment-service.ts
@@ -135,7 +135,7 @@ export function buildPendingReapEvent(
       pendingInputKinds: [],
       pendingAskUserQuestion: undefined,
       pendingProposedPlan: undefined,
-      resolution: previous.resolution,
+      resolution: previous.resolution as AgentEnrichmentChangedEvent['payload']['resolution'],
       resolutionCount: previous.resolutionCount,
     },
   }

--- a/src/dashboard/server/services/agent-enrichment-service.ts
+++ b/src/dashboard/server/services/agent-enrichment-service.ts
@@ -109,6 +109,43 @@ export function shouldSkipEnrichmentCycle(census: Pick<RuntimeCensus, 'tmuxAvail
   return !census.tmuxAvailable
 }
 
+export function hasReapablePendingInput(enrichment: AgentEnrichment): boolean {
+  return (
+    enrichment.pendingInputCount > 0 ||
+    enrichment.pendingAskUserQuestion != null ||
+    enrichment.pendingProposedPlan != null
+  )
+}
+
+export function buildPendingReapEvent(
+  agentId: string,
+  previous: AgentEnrichment,
+): Omit<AgentEnrichmentChangedEvent, 'sequence'> {
+  return {
+    type: 'agent.enrichment_changed',
+    timestamp: new Date().toISOString(),
+    payload: {
+      agentId,
+      role: previous.role,
+      hasPendingQuestion: false,
+      pendingQuestionCount: 0,
+      pendingQuestionPrompt: undefined,
+      pendingQuestionReason: undefined,
+      pendingInputCount: 0,
+      pendingInputKinds: [],
+      pendingAskUserQuestion: undefined,
+      pendingProposedPlan: undefined,
+      resolution: previous.resolution,
+      resolutionCount: previous.resolutionCount,
+    },
+  }
+}
+
+export function buildExpiredQuestionActivityMessage(agentId: string, issueId: string | undefined): string {
+  const subject = issueId ? `${agentId} on ${issueId}` : agentId
+  return `${subject} stopped with its question unanswered — the question has expired and is no longer actionable`
+}
+
 // ─── Poller ───────────────────────────────────────────────────────────────────
 
 async function pollOnce(state: EnrichmentServiceState): Promise<void> {
@@ -290,8 +327,25 @@ async function pollOnce(state: EnrichmentServiceState): Promise<void> {
 
   // Clean up stale entries for agents that have stopped
   const activeIds = new Set(activeAgents.map(a => a.id))
-  for (const id of state.lastEnrichment.keys()) {
+  for (const [id, previousEnrichment] of state.lastEnrichment) {
     if (!activeIds.has(id)) {
+      if (hasReapablePendingInput(previousEnrichment)) {
+        try {
+          await eventStore.appendAsync(buildPendingReapEvent(id, previousEnrichment) as never)
+        } catch {
+          // Non-fatal — event store may not be initialized yet at startup
+        }
+
+        const agentRecord = runningAgents.find(agent => agent.id === id)
+        const issueId = agentRecord?.issueId
+        emitActivityEntrySync({
+          source: toRole(agentRecord?.role) ?? 'work',
+          level: 'info',
+          message: buildExpiredQuestionActivityMessage(id, issueId),
+          issueId,
+        })
+      }
+
       state.lastEnrichment.delete(id)
       state.lastScan.delete(id)
     }


### PR DESCRIPTION
**Issue:** #3055

## Acceptance Criteria

- [ ] Gate pollOnce on runtime-census tmux availability
- [ ] Reap dead agents' pending input on the falling edge
- [ ] Regression test: zombie AUQ sequence resolves and boot re-hydration surfaces nothing
- [ ] Document liveness-is-part-of-pendingness in the AUQ field guide