### PR TITLE
fix(dashboard): surface tool-permission prompts as decisions without Channels (PAN-3051)

### DIFF
--- a/src/dashboard/frontend/src/App/hooks/usePendingInputDialogs.ts
+++ b/src/dashboard/frontend/src/App/hooks/usePendingInputDialogs.ts
@@ -5,7 +5,7 @@ import type { ClaudeChannelPermissionBehavior } from '@overdeck/contracts';
 import type { ConfirmationRequest } from '../../components/ConfirmationDialog';
 import type { AskUserQuestionSubject } from '../../components/AskUserQuestionDialog';
 import type { PlanApprovalSubject } from '../../components/PlanApprovalDialog';
-import { useDashboardStore, selectAgentsWithPendingAskUserQuestion, selectAgentsWithPendingProposedPlan, selectChannelPermissionRequests } from '../../lib/store';
+import { useDashboardStore, hasDetectedToolPermission, selectAgentsWithPendingAskUserQuestion, selectAgentsWithPendingProposedPlan, selectChannelPermissionRequests } from '../../lib/store';
 import { useAskUserQuestionUiStore } from '../../lib/askUserQuestionUiStore';
 import { refreshDashboardState } from '../../lib/refresh-dashboard-state';
 import { fetchWithTimeout } from '../../lib/apiFetch';
@@ -90,18 +90,23 @@ export function usePendingInputDialogs({ agents, issues }: UsePendingInputDialog
     // sessionResume) has no AUQ payload, so the old check told the operator
     // "no longer waiting" while the agent was still modal-blocked — and the
     // needs-you entry (correctly) refused to clear.
-    const stillPending =
-      agentEntry?.pendingAskUserQuestion != null ||
-      (agentEntry?.pendingInputKinds?.length ?? 0) > 0;
+    // PAN-3051 — a tool-permission prompt under the supervisor transport adds no
+    // kind to `pendingInputKinds` and (with Channels off) no permission request,
+    // so judging by those alone told the operator the question was "no longer
+    // waiting" about an agent parked on the modal. Read the same detection the
+    // needs-you selector reads.
+    const terminalDialogPending =
+      (agentEntry?.pendingInputKinds?.length ?? 0) > 0 || hasDetectedToolPermission(agentEntry);
+    const stillPending = agentEntry?.pendingAskUserQuestion != null || terminalDialogPending;
     undismissAskUserQuestion(askUserQuestionReopenId);
     setFocusedAskUserQuestionId(askUserQuestionReopenId);
     if (knownAgent && !stillPending) {
       toast.info('That question is no longer waiting', {
         description: 'The agent stopped or already received an answer.',
       });
-    } else if (knownAgent && agentEntry?.pendingAskUserQuestion == null && (agentEntry?.pendingInputKinds?.length ?? 0) > 0) {
+    } else if (knownAgent && agentEntry?.pendingAskUserQuestion == null && terminalDialogPending) {
       toast.info('This agent is blocked on a terminal dialog', {
-        description: 'Open its terminal to answer (e.g. a harness rate-limit or session-resume prompt) — it cannot be answered from here yet.',
+        description: 'Open its terminal to answer (e.g. a tool-permission, rate-limit, or session-resume prompt) — it cannot be answered from here yet.',
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/dashboard/frontend/src/__tests__/store.test.ts
+++ b/src/dashboard/frontend/src/__tests__/store.test.ts
@@ -19,6 +19,7 @@ import {
   selectIssuesByCycle,
   selectMemoryObservations,
   selectMemoryStatus,
+  selectPendingInputSubjects,
   selectResetMarkersByScope,
   useDashboardStore,
   type DashboardState,
@@ -558,6 +559,89 @@ describe('selectors', () => {
       'perm-1',
       'perm-2',
     ])
+  })
+})
+
+// ─── selectPendingInputSubjects (PAN-3051) ────────────────────────────────────
+
+describe('selectPendingInputSubjects', () => {
+  /**
+   * The live defect: with `experimental.claudeCodeChannelsMcp: false` no Channels
+   * bridge runs, so `channelPermissionRequestsById` stays empty and the only
+   * evidence of the prompt is the pane detection's `tool_permission` reason.
+   * Agents froze on `❯ Do you want to proceed?` and produced no decision.
+   */
+  it('surfaces a tool-permission prompt with the Channels map empty', () => {
+    const state: DashboardState = {
+      ...emptyState,
+      agentsById: {
+        'agent-min-896': {
+          ...baseAgent,
+          id: 'agent-min-896',
+          issueId: 'MIN-896',
+          hasPendingQuestion: true,
+          pendingQuestionReason: 'tool_permission',
+          pendingQuestionPrompt: 'Claude needs your permission',
+          pendingInputKinds: [],
+        },
+      },
+      channelPermissionRequestsById: {},
+    }
+
+    const subjects = selectPendingInputSubjects(state)
+    expect(subjects).toHaveLength(1)
+    expect(subjects[0]!.agentId).toBe('agent-min-896')
+    expect(subjects[0]!.kinds).toContain('permissionRequest')
+  })
+
+  it('does not duplicate the kind when the Channels map also has the request', () => {
+    const state: DashboardState = {
+      ...emptyState,
+      agentsById: {
+        'agent-1': {
+          ...baseAgent,
+          hasPendingQuestion: true,
+          pendingQuestionReason: 'tool_permission',
+        },
+      },
+      channelPermissionRequestsById: {
+        'perm-1': {
+          requestId: 'perm-1',
+          agentId: 'agent-1',
+          issueId: 'PAN-1',
+          toolName: 'Bash',
+          description: 'Run npm test',
+          inputPreview: '{"command":"npm test"}',
+          createdAt: '2026-05-07T18:30:00.000Z',
+        },
+      },
+    }
+
+    const subjects = selectPendingInputSubjects(state)
+    expect(subjects).toHaveLength(1)
+    expect(subjects[0]!.kinds).toEqual(['permissionRequest'])
+    expect(subjects[0]!.permissionRequestIds).toEqual(['perm-1'])
+  })
+
+  /**
+   * PAN-1591 must keep holding: the fuzzy `hasPendingQuestion` bool on its own —
+   * the generic 'other' pane/runtime fallbacks — names no answerable prompt and
+   * must not put a phantom row on the operator's list.
+   */
+  it('ignores a pending question whose reason is not a tool permission', () => {
+    const state: DashboardState = {
+      ...emptyState,
+      agentsById: {
+        'agent-1': {
+          ...baseAgent,
+          hasPendingQuestion: true,
+          pendingQuestionReason: 'other',
+        },
+      },
+      channelPermissionRequestsById: {},
+    }
+
+    expect(selectPendingInputSubjects(state)).toEqual([])
   })
 })
 

--- a/src/dashboard/frontend/src/lib/__tests__/useDecisions.test.ts
+++ b/src/dashboard/frontend/src/lib/__tests__/useDecisions.test.ts
@@ -22,8 +22,13 @@ describe('isBlockingDecision', () => {
     expect(isBlockingDecision(['exitPlanMode'])).toBe(false);
   });
 
-  it('does not treat a permission request as blocking on its own', () => {
-    expect(isBlockingDecision(['permissionRequest'])).toBe(false);
+  /**
+   * PAN-3051 — reversed. Under the PTY supervisor the agent is parked on the
+   * permission modal in its own pane and cannot run another tool until someone
+   * answers it, so it belongs at the top of the list with the other hard stops.
+   */
+  it('treats a permission request as blocking — the supervisor pane is parked on the modal', () => {
+    expect(isBlockingDecision(['permissionRequest'])).toBe(true);
   });
 
   it('is blocking when any kind blocks', () => {

--- a/src/dashboard/frontend/src/lib/store.ts
+++ b/src/dashboard/frontend/src/lib/store.ts
@@ -368,6 +368,9 @@ export const selectPendingPermissionAgentIds = memoizeArraySelector<
  * channel-permission event stream — they live in different store slices and the
  * enrichment event overwrites `pendingInputKinds` each poll, so the merge must
  * happen here at read time rather than being baked into one field server-side.
+ * PAN-3051 adds the supervisor-era source for that same kind: the pane/runtime
+ * detection's `hasPendingQuestion` + `pendingQuestionReason === 'tool_permission'`,
+ * which is the only one that fires when the Channels bridge is off.
  */
 export interface PendingInputSubject {
   agentId: string
@@ -402,6 +405,24 @@ function deriveMemo<S, A, B, R>(
   }
 }
 
+/**
+ * PAN-3051 — the supervisor-era evidence of an outstanding tool-permission
+ * prompt. `channelPermissionRequestsById` is fed by the Claude Code Channels
+ * bridge, which does not run when `experimental.claudeCodeChannelsMcp` is false
+ * (the default now that the PTY supervisor is the primary transport). With
+ * Channels off, that map is always empty and a permission prompt reached no
+ * operator surface at all — agents sat frozen at `❯ Do you want to proceed?`
+ * while the dashboard reported them healthy. The pane/runtime detection does see
+ * the prompt and reports it as `pendingQuestionReason: 'tool_permission'`.
+ *
+ * Exported so the selector and the reopen router judge "still waiting" from the
+ * same evidence; when they disagreed the operator was told the question was no
+ * longer waiting while the agent was still parked on it.
+ */
+export function hasDetectedToolPermission(agent: AgentSnapshot | undefined): boolean {
+  return agent?.hasPendingQuestion === true && agent.pendingQuestionReason === 'tool_permission'
+}
+
 export const selectPendingInputSubjects = deriveMemo<
   DashboardState,
   DashboardState['agentsById'],
@@ -424,7 +445,10 @@ export const selectPendingInputSubjects = deriveMemo<
       const jsonlKinds = a.pendingInputKinds ? [...a.pendingInputKinds] : []
       const agentPerms = permByAgent.get(a.id) ?? []
       const kinds = [...jsonlKinds]
-      if (agentPerms.length > 0 && !kinds.includes('permissionRequest')) {
+      // PAN-3051 — the Channels map is one of TWO sources for this kind now; see
+      // hasDetectedToolPermission above for why the supervisor-era detection has
+      // to be read here as well.
+      if ((agentPerms.length > 0 || hasDetectedToolPermission(a)) && !kinds.includes('permissionRequest')) {
         kinds.push('permissionRequest')
       }
       // PAN-1591 — "Needs you" must be ACTIONABLE. Require a concrete pending
@@ -436,6 +460,10 @@ export const selectPendingInputSubjects = deriveMemo<
       // false-positive. Those surfaced phantom "Waiting on your input" rows that
       // said "no longer waiting" the moment you clicked them. An actionable wait
       // always carries a kind, so `kinds.length > 0` is the precise signal.
+      // The PAN-3051 read above is not a walk-back of that: it consults the bool
+      // only in conjunction with the specific `tool_permission` reason, which
+      // names a concrete answerable prompt, never the generic 'other' fallbacks
+      // PAN-1591 was about.
       const waiting = kinds.length > 0
       if (!waiting) continue
       const since =

--- a/src/dashboard/frontend/src/lib/useDecisions.ts
+++ b/src/dashboard/frontend/src/lib/useDecisions.ts
@@ -46,14 +46,30 @@ export interface Decision {
   /**
    * True when an agent has stopped until this is answered, as opposed to work
    * continuing around it. This is what the operator triages on, so it groups the
-   * list. A rate-limit modal or a question halts the turn outright; a permission
-   * request or a plan review does not necessarily.
+   * list. A rate-limit modal, a question, or a permission prompt halts the turn
+   * outright; a plan review does not necessarily.
    */
   blocking: boolean;
 }
 
-/** Kinds that mean the agent has actually stopped and cannot proceed. */
-const BLOCKING_KINDS = new Set(['askUserQuestion', 'rateLimit', 'sessionResume', 'agentTurnEnded']);
+/**
+ * Kinds that mean the agent has actually stopped and cannot proceed.
+ *
+ * PAN-3051 added `permissionRequest`. It was excluded on the reasoning that a
+ * permission request "does not necessarily" halt the turn, which held while the
+ * Channels bridge could answer one out-of-band. Under the PTY supervisor the
+ * agent is parked on the `❯ Do you want to proceed?` modal in its own pane and
+ * cannot advance a single tool call until a human picks an option — that is the
+ * definition of blocking, and treating it as non-blocking sorted five frozen
+ * agents below work that was still moving.
+ */
+const BLOCKING_KINDS = new Set([
+  'askUserQuestion',
+  'rateLimit',
+  'sessionResume',
+  'agentTurnEnded',
+  'permissionRequest',
+]);
 
 export function isBlockingDecision(kinds: ReadonlyArray<string>): boolean {
   return kinds.some((k) => BLOCKING_KINDS.has(k));


### PR DESCRIPTION
Fixes #3051.

Tool-permission prompts reached no operator surface at all. Agents sat frozen at `❯ Do you want to proceed?` while the dashboard reported them `status: healthy, resolution: working`.

**Root cause:** `selectPendingInputSubjects` built its `kinds` from `pendingInputKinds` plus `channelPermissionRequestsById` — a map fed by the Claude Code Channels bridge. With `experimental.claudeCodeChannelsMcp: false` (the default now that the PTY supervisor is the primary transport) no bridge runs, so that map is always empty and `permissionRequest` could never enter `kinds`. The pane/runtime detection *did* see the prompt and reported `hasPendingQuestion: true` / `pendingQuestionReason: 'tool_permission'`; nothing read it.

**Changes (frontend read-model only):**

- New exported `hasDetectedToolPermission()` in `store.ts`, requiring **both** `hasPendingQuestion === true` and `pendingQuestionReason === 'tool_permission'`.
- `selectPendingInputSubjects` now treats that as a second source for the `permissionRequest` kind, **additively** — the Channels map is still read, so already-wired sessions are unaffected.
- `permissionRequest` added to `BLOCKING_KINDS` in `useDecisions.ts`. It was excluded on the reasoning that a permission request "does not necessarily" halt the turn, which held while Channels could answer one out-of-band. Under the supervisor the agent cannot advance a single tool call until a human picks an option.
- `usePendingInputDialogs` judges "still waiting" from the same exported predicate, so the selector and the reopen router cannot disagree.

Because every decision surface reads through `useDecisions.ts`, this fixes the Decisions list, the modal, and the needs-you trip together.

**On PAN-1591:** that change required a concrete kind so phantom "Waiting on your input" rows could not appear. This is not a walk-back — the new read consults the boolean only in conjunction with the specific `tool_permission` reason, which names a concrete answerable prompt, never the generic `other` fallback PAN-1591 was about.

**Scope contract honored.** Detection-to-surface wiring only. No deacon, review/merge route, or agents-runtime changes — TENET-10 keeps those on supervised handoff. Diff is 5 files, all frontend.

**Gates verified independently before merge:**

- `npx vitest run src/__tests__/store.test.ts src/lib/__tests__/useDecisions.test.ts` — 2 files, 55 tests passed
- `npm run typecheck` — passed
- `npm run lint` — passed

Live repro driving this: `agent-min-896` has been frozen on a `.devcontainer` sensitive-file permission prompt for over an hour across two host states.

Filed and driven by the Flywheel (RUN-70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmAFhdqW76Z5bnmkLRXkMH