### PR TITLE
fix(dod): verification row passes on the verdict, not the commit anchor (PAN-3067)

### DIFF
--- a/docs/DEFINITION-OF-DONE.md
+++ b/docs/DEFINITION-OF-DONE.md
@@ -12,7 +12,7 @@ this table and that module from drifting silently.
 | --- | --- | --- | --- | --- |
 | 1 | `review` | Review passed (mode per issue policy; full = convoy + synthesis) | review role → `pan admin specialists done review` → review-status write door | `reviewStatus: passed` |
 | 2 | `tests` | Tests passed (incl. browser UAT when required) | test role → `pan admin specialists done test` | `testStatus: passed` |
-| 3 | `verification` | Verification green on the branch (typecheck, lint, suite, build) | supervised verification worker (`verification-runner.ts` / `verification-worker.ts`) | `verificationStatus: passed`, `lastVerifiedCommit` |
+| 3 | `verification` | Verification green on the branch (typecheck, lint, suite, build) | supervised verification worker (`verification-runner.ts` / `verification-worker.ts`) | `verificationStatus: passed` (or `skipped` per issue policy) |
 | 4 | `merged` | Merged to main (squash PR, revertible history) | merge door: `triggerMerge` → merge specialist (`merge-agent.ts`) | PR `MERGED`, `mergeStatus: merged` |
 | 5 | `post-merge` | Post-merge handoff: work/planning agents paused, workspace Docker stack + networks stopped, `verifying-on-main` label | `postMergeLifecycle()` (`merge-agent.ts`) — at-most-once per merge (PAN-328 in-flight guard) | issue labels, agent states |
 | 6 | `main-verify` | Verified on main (post-merge verification of the merged commit) | deacon verify-on-main flow | `verifying_on_main` → verified |
@@ -37,6 +37,12 @@ this table and that module from drifting silently.
   the operator's behalf; `flywheel-*` callers are mechanically barred from `--accept-*`.
 - **Branch absence is not merge evidence.** The `merged` row requires positive evidence from
   the forge or the durable close-out merge record; deleting an unmerged branch remains a miss.
+- **The verification verdict is the row; `lastVerifiedCommit` is not required** (PAN-3067). The
+  runner writes that anchor best-effort — it snapshots HEAD inside a `try/catch` for the
+  test-skip drift check, and a policy `skipped` verdict never has one — so its absence proves
+  nothing about whether verification ran, while requiring it made merged, green, deployed
+  issues permanently un-closable. The row still reports the anchor's presence or absence, so
+  a reader never has to guess which condition a miss came from.
 
 ## Related
 

--- a/src/lib/lifecycle/dod-gate.ts
+++ b/src/lib/lifecycle/dod-gate.ts
@@ -213,15 +213,24 @@ export async function checkVerificationRow(issueId: string, deps: DodStatusRowDe
   const loaded = await loadStatus(issueId, deps);
   if (!loaded) return result('verification', 'miss', 'no review status or journal record found');
 
+  // PAN-3067: the verdict alone decides this row, exactly like rows 1 and 2.
+  // `lastVerifiedCommit` is a best-effort optimization anchor — verification-runner.ts
+  // snapshots it inside a try/catch and spreads the field conditionally, and a
+  // `skipped` verdict never has one at all — so its absence says nothing about
+  // whether verification ran. Requiring it made every issue whose anchor was
+  // never written un-closable. The observed string always names the anchor's
+  // presence or absence so a reader can never mistake it for a hidden condition.
   const value = loaded.status.verificationStatus;
   const commit = loaded.status.lastVerifiedCommit;
-  const source = loaded.source === 'journal' ? ' from pipeline journal' : '';
-  const policy = value === 'skipped' ? ' (skipped per issue policy)' : '';
-  const commitNote = commit ? ` at ${commit}` : '';
-  const observed = `verificationStatus: ${value ?? 'missing'}${commitNote}${source}${policy}`;
-  const acceptedStatus = value === 'passed' || value === 'skipped';
-  const hasRequiredCommit = Boolean(commit);
-  return result('verification', acceptedStatus && hasRequiredCommit ? 'pass' : 'miss', observed);
+  const accepted = value === 'passed' || value === 'skipped';
+  const notes: string[] = [];
+  if (loaded.source === 'journal') notes.push('from pipeline journal');
+  if (value === 'skipped') notes.push('skipped per issue policy');
+  if (accepted && !commit) notes.push('no lastVerifiedCommit recorded');
+  const observed = `verificationStatus: ${value ?? 'missing'}${commit ? ` at ${commit}` : ''}${
+    notes.length > 0 ? ` (${notes.join('; ')})` : ''
+  }`;
+  return result('verification', accepted ? 'pass' : 'miss', observed);
 }
 
 export async function checkMergedRow(

--- a/src/lib/lifecycle/dod.ts
+++ b/src/lib/lifecycle/dod.ts
@@ -25,7 +25,7 @@ export const DOD_ROWS: readonly DodRowDef[] = [
     id: 'verification',
     num: 3,
     title: 'Verification green on the branch',
-    expected: 'verificationStatus: passed at lastVerifiedCommit',
+    expected: 'verificationStatus: passed',
     overridable: true,
   },
   { id: 'merged', num: 4, title: 'Merged to main', expected: 'PR merged on the forge', overridable: true },

--- a/sync-sources/skills/pan-close/SKILL.md
+++ b/sync-sources/skills/pan-close/SKILL.md
@@ -35,7 +35,7 @@ Each overridable row has one explicit acceptance flag:
 ```text
 --accept-review       Row 1: review passed
 --accept-tests        Row 2: tests passed
---accept-verification Row 3: branch verification passed at lastVerifiedCommit
+--accept-verification Row 3: branch verification passed
 --accept-merged       Row 4: PR merged on the forge
 --accept-post-merge   Row 5: post-merge lifecycle completed
 --accept-main-verify  Row 6: merge commit verified on main

--- a/tests/unit/lib/lifecycle/dod-gate.test.ts
+++ b/tests/unit/lib/lifecycle/dod-gate.test.ts
@@ -70,10 +70,25 @@ describe('Definition-of-Done status rows', () => {
     expect(await checkVerificationRow(issueId, source)).toMatchObject({ status: 'miss', observed: 'verificationStatus: failed at abc123' });
   });
 
-  it('requires a commit for a passed live verification verdict', async () => {
+  it('passes a verified verdict whose best-effort commit anchor was never recorded, and names the gap', async () => {
+    // PAN-3067: lastVerifiedCommit is written best-effort by the verification runner,
+    // so its absence must neither block the row nor hide itself from the observed string.
     expect(await checkVerificationRow(issueId, deps(live({ lastVerifiedCommit: undefined })))).toMatchObject({
+      status: 'pass',
+      observed: 'verificationStatus: passed (no lastVerifiedCommit recorded)',
+    });
+    expect(
+      await checkVerificationRow(issueId, deps(live({ verificationStatus: 'skipped', lastVerifiedCommit: undefined }))),
+    ).toMatchObject({
+      status: 'pass',
+      observed: 'verificationStatus: skipped (skipped per issue policy; no lastVerifiedCommit recorded)',
+    });
+  });
+
+  it('never claims a missing anchor for a verdict that already fails on its own', async () => {
+    expect(await checkVerificationRow(issueId, deps(live({ verificationStatus: undefined, lastVerifiedCommit: undefined })))).toMatchObject({
       status: 'miss',
-      observed: 'verificationStatus: passed',
+      observed: 'verificationStatus: missing',
     });
   });
 
@@ -85,9 +100,12 @@ describe('Definition-of-Done status rows', () => {
     }
   });
 
-  it('requires a verified commit from the durable pipeline journal', async () => {
+  it('passes a durable journal verdict without a commit anchor and still reports both facts', async () => {
     const row = await checkVerificationRow(issueId, deps(null, journal({ lastVerifiedCommit: undefined })));
-    expect(row).toMatchObject({ status: 'miss', observed: expect.stringContaining('from pipeline journal') });
+    expect(row).toMatchObject({
+      status: 'pass',
+      observed: 'verificationStatus: passed (from pipeline journal; no lastVerifiedCommit recorded)',
+    });
   });
 
   it('returns misses instead of throwing when both sources are empty or a door fails', async () => {


### PR DESCRIPTION
Fixes #3067.

DoD row 3 required both an accepted `verificationStatus` **and** a `lastVerifiedCommit`, and the observed string dropped the commit clause entirely when the commit was absent. A blocked issue therefore rendered as `verificationStatus: passed` — a MISS whose stated evidence reads like a pass, naming nothing that would unblock it. I filed the wrong root cause directly from that string.

**The judgement call, stated explicitly (as the strike scope required):** `lastVerifiedCommit` is a **best-effort optimization anchor**, not evidence that verification ran. `verification-runner` snapshots HEAD inside a try/catch marked *"non-fatal — skip optimization if we can't get HEAD"* and spreads the field conditionally, and a policy `skipped` verdict never carries one at all. Its absence proves nothing — while requiring it left merged, CI-green, deployed issues permanently un-closable: **PAN-3021, PAN-3029, PAN-3051, PAN-3053, PAN-3056, PAN-3068**. So the verdict alone decides the row, matching rows 1 and 2.

The observed string now **always** reports the anchor's presence or absence, so no miss can hide the condition that produced it.

**Why this matters beyond the six issues:** close-out is what tears down workspaces and Docker stacks. A gate that blocks every close-out feeds the resource leaks tracked in PAN-3049/PAN-3050 — this run hit Docker's 31-network pool ceiling and silently halted the pipeline.

**Gates:** `tests/unit/lib/lifecycle/dod-gate.test.ts` 30 passed (including the regression case for an absent anchor); `npm run typecheck` passed.

Filed, diagnosed, self-corrected and driven by the Flywheel (RUN-70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmAFhdqW76Z5bnmkLRXkMH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Verification now passes when the status is `passed` or policy-skipped, even if no commit reference is recorded.
  * Verification results clearly indicate when a commit reference is unavailable.

* **Documentation**
  * Clarified verification acceptance criteria and the best-effort nature of commit references.
  * Updated close-out guidance to reflect the revised verification behavior.

* **Tests**
  * Added coverage for passed and skipped verification results without commit references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->