### PR TITLE
PAN-3076

### DIFF
--- a/docs/REVIEW-AGENT-ARCHITECTURE.md
+++ b/docs/REVIEW-AGENT-ARCHITECTURE.md
@@ -104,8 +104,9 @@ workspace path:
   and an additive `repos: [{repoKey, branch, headSha, diffBase, fileCount}]`
   manifest field. Top-level `headSha`/`branch` come from the first sub-repo
   with changes.
-- **runId head suffix** (`review-agent.ts`): resolved from the primary sub-repo
-  so re-review runs get distinct directories.
+- **runId head suffix** (`review-agent.ts`): monorepos keep their short HEAD;
+  polyrepos use the first eight hex characters of a SHA-1 over the full composite
+  snapshot, so a commit in any sub-repo creates a distinct review directory.
 - **Dispatch pushes** (`review-pipeline.ts`): one shared helper pushes each
   sub-repo's `feature/<issue>` where the branch exists locally; the wrapper is
   never pushed.
@@ -124,6 +125,39 @@ workspace path:
   repo satisfies the guard; a failed repo diff skips the guard conservatively.
   When a container gate reports infrastructure unavailable, verification waits
   for the triggered stack rebuild to settle before another cycle can start.
+
+### Verdict anchors (`HeadAnchor`)
+
+`snapshotWorkspaceHeadsPromise()` is the only producer of `HeadAnchor`: one full
+SHA for a monorepo, or a space-separated `repoKey@sha` token for every polyrepo
+code root. `parseCompositeSnapshot()` is the one lenient parser for inspecting
+that composite shape; `parseWorkspaceHeadAnchor()` remains the strict validator
+used before passing an anchor to Git.
+
+The TypeScript brand prevents a plain string from entering the review-status
+write door. A value read from SQLite, a durable issue record, or another wire
+boundary may regain the brand only through `rehydrateHeadAnchor()`, with a
+comment naming that storage boundary. The pairing rule is: **a compare site may only compare against what the producer stamped**.
+
+The five converted stamp/compare sites are:
+
+1. `checkPostReviewCommits()` in `cloister/deacon.ts` compares
+   `reviewedAtCommit` through the composite-aware drift evaluator.
+2. Role-run liveness stamps in `agents/spawn.ts` and compares in
+   `cloister/service-reactive.ts` using the same full `roleRunHead` anchor.
+3. `POST /api/review/:issueId/status` in `routes/workspaces.ts` stamps
+   `reviewedAtCommit` from the producer.
+4. The legacy specialists-done route stamps `reviewedAtCommit` from the
+   producer.
+5. The verification/review contradiction bypass in `cloister/deacon.ts` stamps
+   `reviewedAtCommit` from the producer.
+
+A legacy wrapper SHA compared with a current composite anchor is intentionally
+reported as drift once. That conservative reset writes the new producer shape,
+so subsequent patrols stabilize instead of repeating. The historical failure
+signature was MIN-901 logging 56 resets like `(fe@52d65 → 7492ae82)`: the first
+value was a composite truncated with `substring(0, 8)`, while the second was the
+wrapper SHA. Logs now render every token as `repoKey@<8-char sha>`.
 
 ---
 

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -17,7 +17,7 @@
 1520 src/dashboard/server/services/issue-data-service.ts
 1306 src/dashboard/server/ws-rpc.ts
 1148 src/lib/cloister/deacon-swarm.ts
-3634 src/lib/cloister/deacon.ts
+3605 src/lib/cloister/deacon.ts
 1407 src/lib/cloister/merge-agent.ts
 1195 src/lib/conversations/smart-compaction.ts
 1726 src/lib/database/schema.ts

--- a/src/cli/commands/specialists/done.ts
+++ b/src/cli/commands/specialists/done.ts
@@ -18,7 +18,9 @@ import {
   setReviewStatusSync,
   getReviewStatusSync,
   type ReviewStatus,
+  type ReviewStatusUpdate,
 } from '../../../lib/review-status.js';
+import type { HeadAnchor } from '../../../lib/git-utils.js';
 
 interface DoneOptions {
   status: 'passed' | 'failed' | 'blocked';
@@ -94,7 +96,7 @@ export async function doneCommand(
   // computed readyForMerge, and JSON persistence in one call.
   // This eliminates the read-modify-write race that caused duplicate
   // specialist runs to overwrite each other's results.
-  const update: Partial<ReviewStatus> = {};
+  const update: ReviewStatusUpdate = {};
 
   switch (specialist) {
     case 'review':
@@ -128,7 +130,7 @@ export async function doneCommand(
       // A bare blocked verdict (no --reviewers) skips the git probe so the durable
       // write stays synchronous ahead of feedback delivery (PAN-2524).
       if (options.status === 'passed' || update.reviewerVerdicts) {
-        let workspaceHead: string | undefined;
+        let workspaceHead: HeadAnchor | undefined;
         try {
           const { resolveProjectFromIssueSync } = await import('../../../lib/projects.js');
           const { existsSync } = await import('node:fs');

--- a/src/dashboard/server/routes/__tests__/effect-patterns.test.ts
+++ b/src/dashboard/server/routes/__tests__/effect-patterns.test.ts
@@ -128,12 +128,14 @@ describe('EventStoreServiceLive + ReadModelServiceLive end-to-end', () => {
   }, 30000);
 });
 
-describe('Effect-returning helper composition', () => {
-  it('does not wrap workspace git info Effect in Effect.promise', () => {
+describe('Effect helper composition', () => {
+  it('wraps the promise-based workspace head snapshot in Effect.promise', () => {
     const source = readFileSync(resolve(process.cwd(), 'src/dashboard/server/routes/workspaces.ts'), 'utf8');
 
-    expect(source).not.toMatch(/Effect\.promise\(\(\) => getWorkspaceGitInfo\(/);
-    expect(source).toMatch(/yield\* getWorkspaceGitInfo\((?:workspacePath|localPath)\)/);
+    expect(source).not.toContain('getWorkspaceGitInfo(localPath)');
+    expect(source).toContain(
+      'yield* Effect.promise(() => snapshotWorkspaceHeadsPromise(issueId, localPath))',
+    );
   });
 });
 

--- a/src/dashboard/server/routes/specialists/legacy-routes.ts
+++ b/src/dashboard/server/routes/specialists/legacy-routes.ts
@@ -9,7 +9,7 @@ import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
 import { getAgentState, getAgentRuntimeState, messageAgent, saveAgentRuntimeState, transitionIssueToInProgress } from '../../../../lib/agents.js';
 import { getUnblockedItemsSync } from '../../../../lib/cloister/task-readiness.js';
 import { resolveProjectFromIssueSync } from '../../../../lib/projects.js';
-import { getReviewStatusSync, loadReviewStatuses, setReviewStatusSync as setReviewStatusBase, type ReviewStatus } from '../../../../lib/review-status.js';
+import { getReviewStatusSync, loadReviewStatuses, setReviewStatusSync as setReviewStatusBase, type ReviewStatus, type ReviewStatusUpdate } from '../../../../lib/review-status.js';
 import { readWorkspacePlanSync } from '../../../../lib/xbrief/io.js';
 import { jsonResponse } from '../../http-helpers.js';
 import { EventStoreService } from '../../services/domain-services.js';
@@ -190,7 +190,7 @@ const postSpecialistsDoneRoute = HttpRouter.add(
     }
 
     // Build the update based on specialist type
-    const update: Partial<ReviewStatus> = {};
+    const update: ReviewStatusUpdate = {};
 
     switch (specialist) {
       case 'review':

--- a/src/dashboard/server/routes/specialists/legacy-routes.ts
+++ b/src/dashboard/server/routes/specialists/legacy-routes.ts
@@ -323,10 +323,12 @@ const postSpecialistsDoneRoute = HttpRouter.add(
               `feature-${normalizedIssueId.toLowerCase()}`,
             );
             if (existsSync(workspacePath)) {
-              const { getWorkspaceGitInfo } = await import('../../../../lib/git-utils.js');
-              const { HEAD } = await Effect.runPromise(getWorkspaceGitInfo(workspacePath));
-              setReviewStatusBase(normalizedIssueId, { reviewedAtCommit: HEAD });
-              console.log(`[specialists/done] Snapshotted reviewedAtCommit=${HEAD.substring(0, 8)} for ${normalizedIssueId}`);
+              const { formatAnchorShort, snapshotWorkspaceHeadsPromise } = await import('../../../../lib/git-utils.js');
+              const headAnchor = await snapshotWorkspaceHeadsPromise(normalizedIssueId, workspacePath);
+              if (headAnchor) {
+                setReviewStatusBase(normalizedIssueId, { reviewedAtCommit: headAnchor });
+                console.log(`[specialists/done] Snapshotted reviewedAtCommit=${formatAnchorShort(headAnchor)} for ${normalizedIssueId}`);
+              }
             }
           }
         } catch (err) {

--- a/src/dashboard/server/routes/workspaces.ts
+++ b/src/dashboard/server/routes/workspaces.ts
@@ -76,6 +76,7 @@ import {
   setDeaconIgnored,
   setAutoMerge,
   type ReviewStatus,
+  type ReviewStatusUpdate,
 } from '../../../lib/review-status.js';
 import {
   getCachedConflictGateMergeability,
@@ -926,7 +927,7 @@ export async function repairFlywayIfNeeded(
 // setReviewStatus wrapper (mirrors the index.ts version; side-effects are
 // intentionally omitted here — the server-side side-effects (auto-PR, auto-merge)
 // live in the Express server until full migration is complete).
-export function setReviewStatus(issueId: string, update: Partial<ReviewStatus>): ReviewStatus {
+export function setReviewStatus(issueId: string, update: ReviewStatusUpdate): ReviewStatus {
   return setReviewStatusBase(issueId, update);
 }
 
@@ -1454,7 +1455,7 @@ const postWorkspaceReviewStatusRoute = HttpRouter.add(
     // Snapshot reviewedAtCommit BEFORE the first setReviewStatus call so canSkipTests
     // fires correctly in that same call — setting it afterward is too late (the
     // async test-agent dispatch is already scheduled).
-    const update: Partial<ReviewStatus> = {};
+    const update: ReviewStatusUpdate = {};
     if (reviewStatus === 'passed') {
       const workspaceInfo = getWorkspaceInfoForIssue(issueId);
       if (workspaceInfo.exists && workspaceInfo.localPath) {

--- a/src/dashboard/server/routes/workspaces.ts
+++ b/src/dashboard/server/routes/workspaces.ts
@@ -75,8 +75,7 @@ import {
   markWorkspaceStuck,
   setDeaconIgnored,
   setAutoMerge,
-  type ReviewStatus,
-  type ReviewStatusUpdate,
+  type ReviewStatus, type ReviewStatusUpdate,
 } from '../../../lib/review-status.js';
 import {
   getCachedConflictGateMergeability,

--- a/src/dashboard/server/routes/workspaces.ts
+++ b/src/dashboard/server/routes/workspaces.ts
@@ -1459,11 +1459,11 @@ const postWorkspaceReviewStatusRoute = HttpRouter.add(
       const workspaceInfo = getWorkspaceInfoForIssue(issueId);
       if (workspaceInfo.exists && workspaceInfo.localPath) {
         const localPath = workspaceInfo.localPath;
-        const { getWorkspaceGitInfo } = yield* Effect.promise(() => import('../../../lib/git-utils.js'));
+        const { snapshotWorkspaceHeadsPromise } = yield* Effect.promise(() => import('../../../lib/git-utils.js'));
         try {
-          const gitInfo = yield* getWorkspaceGitInfo(localPath);
-          if (gitInfo.HEAD) {
-            update.reviewedAtCommit = gitInfo.HEAD;
+          const headAnchor = yield* Effect.promise(() => snapshotWorkspaceHeadsPromise(issueId, localPath));
+          if (headAnchor) {
+            update.reviewedAtCommit = headAnchor;
           }
         } catch { /* non-fatal */ }
       }

--- a/src/lib/agents/spawn.ts
+++ b/src/lib/agents/spawn.ts
@@ -459,15 +459,15 @@ export async function spawnRun(issueId: string, role: Role, options: SpawnRunOpt
 
   markAgentRunning(state);
 
-  // Stamp the workspace HEAD this role run was launched against. The reactive
-  // scheduler uses this to tell a still-relevant run from a zombie session
-  // left behind by an agent that finished work but never exited (the ship/test
-  // stall class of bug). A non-fatal git probe — if it fails the marker is
-  // simply absent and activeRoleRunExists falls back to status-only checks.
+  // Stamp the producer-issued workspace anchor this role run was launched
+  // against. The reactive scheduler uses it to distinguish a still-relevant
+  // run from a zombie session after any monorepo or polyrepo HEAD advances.
+  // A non-fatal probe failure leaves the marker absent and preserves the
+  // status-only fallback.
   try {
-    const { stdout } = await execAsync('git rev-parse --short=8 HEAD', { cwd: workspace });
-    const head = stdout.trim();
-    if (head) state.roleRunHead = head;
+    const { snapshotWorkspaceHeadsPromise } = await import('../git-utils.js');
+    const headAnchor = await snapshotWorkspaceHeadsPromise(issueId, workspace);
+    if (headAnchor) state.roleRunHead = headAnchor;
   } catch { /* non-fatal — marker stays absent */ }
 
   await Effect.runPromise(saveAgentState(state));

--- a/src/lib/cloister/conflict-gate.ts
+++ b/src/lib/cloister/conflict-gate.ts
@@ -2,7 +2,7 @@ import { exec, type ExecOptions } from 'node:child_process';
 import { promisify } from 'node:util';
 import { emitActivityEntrySync } from '../activity-logger.js';
 import { messageAgent, spawnRun } from '../agents.js';
-import { getReviewStatusSync, setReviewStatusSync, type BlockerReason, type ReviewStatus } from '../review-status.js';
+import { getReviewStatusSync, setReviewStatusSync, type BlockerReason, type ReviewStatus, type ReviewStatusUpdate } from '../review-status.js';
 
 const execAsync = promisify(exec);
 const GIT_TIMEOUT_MS = 30_000;
@@ -45,7 +45,7 @@ export interface ResolveConflictGateDeps {
   getReviewStatus: (issueId: string) => ReviewStatus | null | Promise<ReviewStatus | null>;
   setReviewStatus: (
     issueId: string,
-    update: Partial<ReviewStatus>,
+    update: ReviewStatusUpdate,
     existing?: ReviewStatus,
   ) => ReviewStatus | Promise<ReviewStatus>;
   probeMergeability?: (workspacePath: string, targetBranch: string) => BranchMergeability | Promise<BranchMergeability>;

--- a/src/lib/cloister/deacon-review-status.ts
+++ b/src/lib/cloister/deacon-review-status.ts
@@ -9,7 +9,7 @@ import { listAllAgentsSync as listAllAgents } from '../overdeck/agents.js';
 import { markWorkspaceStuck } from '../overdeck/review-status-sync.js';
 import { AGENTS_DIR } from '../paths.js';
 import { resolveProjectFromIssueSync } from '../projects.js';
-import { getReviewStatusSync, loadReviewStatuses, setReviewStatusSync, type ReviewStatus } from '../review-status.js';
+import { getReviewStatusSync, loadReviewStatuses, setReviewStatusSync, type ReviewStatus, type ReviewStatusUpdate } from '../review-status.js';
 import { logDeaconEventSync } from '../persistent-logger.js';
 import { recordDeaconNudge } from './deacon-nudge-log.js';
 import { REVIEW_SUB_ROLES } from './review-monitor.js';
@@ -245,7 +245,7 @@ function latestHistoryByType(
 
 export function completedReviewSnapshotAfterCoordinatorExit(
   status: Pick<ReviewStatus, 'history'>,
-): Partial<ReviewStatus> | null {
+): ReviewStatusUpdate | null {
   const review = latestHistoryEntry(status.history, 'review', ['passed', 'failed', 'blocked']);
   if (review?.status !== 'passed') return null;
   const test = latestHistoryEntry(status.history, 'test', ['passed', 'failed', 'skipped']);

--- a/src/lib/cloister/deacon.ts
+++ b/src/lib/cloister/deacon.ts
@@ -49,7 +49,6 @@ import { createInFlightGuard } from './in-flight-guard.js';
 // }
 import { listAllAgentsSync as listAllAgents } from '../overdeck/agents.js';
 import { isContextOverflowTail } from '../context-overflow.js';
-import type { HeadAnchor } from '../git-utils.js';
 import { REVIEW_SUB_ROLES, type ReviewSubRole } from './review-monitor.js';
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -1511,7 +1510,7 @@ export async function checkVerificationReviewContradiction(): Promise<string[]> 
         // it, checkPostReviewCommits can never confirm the review is current and
         // the canSkipTests fast-path in setReviewStatus never fires, leaving the
         // issue jammed at passed-but-stuck forever (PAN-977).
-        let reviewedAtCommit: HeadAnchor | undefined;
+        let reviewedAtCommit;
         try {
           const project = resolveProjectFromIssueSync(issueId);
           if (project) {
@@ -1599,8 +1598,7 @@ export async function checkPostReviewCommits(): Promise<string[]> {
       const verdict = await evaluateWorkspaceAnchorDrift(
         issueId,
         workspacePath,
-        // ReviewStatus deserializes anchors as strings; re-brand at the evaluator boundary.
-        rehydrateHeadAnchor(status.reviewedAtCommit),
+        rehydrateHeadAnchor(status.reviewedAtCommit), // Stored anchors re-brand at the evaluator boundary.
       );
       if (verdict.kind === 'unreadable' || verdict.kind === 'current') continue;
 

--- a/src/lib/cloister/deacon.ts
+++ b/src/lib/cloister/deacon.ts
@@ -49,6 +49,7 @@ import { createInFlightGuard } from './in-flight-guard.js';
 // }
 import { listAllAgentsSync as listAllAgents } from '../overdeck/agents.js';
 import { isContextOverflowTail } from '../context-overflow.js';
+import type { HeadAnchor } from '../git-utils.js';
 import { REVIEW_SUB_ROLES, type ReviewSubRole } from './review-monitor.js';
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -1510,7 +1511,7 @@ export async function checkVerificationReviewContradiction(): Promise<string[]> 
         // it, checkPostReviewCommits can never confirm the review is current and
         // the canSkipTests fast-path in setReviewStatus never fires, leaving the
         // issue jammed at passed-but-stuck forever (PAN-977).
-        let reviewedAtCommit: string | undefined;
+        let reviewedAtCommit: HeadAnchor | undefined;
         try {
           const project = resolveProjectFromIssueSync(issueId);
           if (project) {
@@ -1598,6 +1599,7 @@ export async function checkPostReviewCommits(): Promise<string[]> {
       const verdict = await evaluateWorkspaceAnchorDrift(
         issueId,
         workspacePath,
+        // ReviewStatus deserializes anchors as strings; re-brand at the evaluator boundary.
         rehydrateHeadAnchor(status.reviewedAtCommit),
       );
       if (verdict.kind === 'unreadable' || verdict.kind === 'current') continue;

--- a/src/lib/cloister/deacon.ts
+++ b/src/lib/cloister/deacon.ts
@@ -1521,8 +1521,8 @@ export async function checkVerificationReviewContradiction(): Promise<string[]> 
               `feature-${issueId.toLowerCase()}`,
             );
             if (existsSync(workspacePath)) {
-              const { stdout } = await execAsync('git rev-parse HEAD', { cwd: workspacePath });
-              reviewedAtCommit = stdout.trim();
+              const { snapshotWorkspaceHeadsPromise } = await import('../git-utils.js');
+              reviewedAtCommit = await snapshotWorkspaceHeadsPromise(issueId, workspacePath);
             }
           }
         } catch { /* non-fatal — leave reviewedAtCommit undefined */ }

--- a/src/lib/cloister/deacon.ts
+++ b/src/lib/cloister/deacon.ts
@@ -50,7 +50,6 @@ import { createInFlightGuard } from './in-flight-guard.js';
 import { listAllAgentsSync as listAllAgents } from '../overdeck/agents.js';
 import { isContextOverflowTail } from '../context-overflow.js';
 import { REVIEW_SUB_ROLES, type ReviewSubRole } from './review-monitor.js';
-import { haveSameEffectiveCodeCommit, haveSameCodeContribution } from '../pipeline-state-paths.js';
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 // ---------------------------------------------------------------------------
@@ -1594,55 +1593,27 @@ export async function checkPostReviewCommits(): Promise<string[]> {
       );
       if (!existsSync(workspacePath)) continue;
 
-      // Get current HEAD
-      let currentHead: string;
-      try {
-        const { stdout } = await execAsync('git rev-parse HEAD', { cwd: workspacePath });
-        currentHead = stdout.trim();
-      } catch {
-        continue; // not a git repo or git unavailable
+      const { formatAnchorShort, rehydrateHeadAnchor } = await import('../git-utils.js');
+      const { evaluateWorkspaceAnchorDrift } = await import('../workspace-anchor-drift.js');
+      const verdict = await evaluateWorkspaceAnchorDrift(
+        issueId,
+        workspacePath,
+        rehydrateHeadAnchor(status.reviewedAtCommit),
+      );
+      if (verdict.kind === 'unreadable' || verdict.kind === 'current') continue;
+
+      if (verdict.kind === 'benign') {
+        setReviewStatusSync(issueId, { reviewedAtCommit: verdict.currentAnchor });
+        console.log(`[deacon] Benign post-review HEAD move for ${issueId}: ${formatAnchorShort(status.reviewedAtCommit)} → ${formatAnchorShort(verdict.currentAnchor)} — review/test preserved`);
+        continue;
       }
 
-      if (currentHead === status.reviewedAtCommit) continue;
-
-      // Tree-identical rebases and state-plane-only commits move HEAD without
-      // invalidating review/test verdicts. Preserve the gates and advance the
-      // snapshot so this patrol does not repeatedly compare against old HEAD.
-      try {
-        const [oldTree, newTree] = await Promise.all([
-          execAsync(`git rev-parse ${status.reviewedAtCommit}^{tree}`, { cwd: workspacePath }),
-          execAsync(`git rev-parse ${currentHead}^{tree}`, { cwd: workspacePath }),
-        ]);
-        if (oldTree.stdout.trim() === newTree.stdout.trim()) {
-          setReviewStatusSync(issueId, { reviewedAtCommit: currentHead });
-          console.log(`[deacon] Tree-identical rebase for ${issueId}: ${status.reviewedAtCommit.substring(0, 8)} → ${currentHead.substring(0, 8)} (same tree) — review/test preserved`);
-          continue;
-        }
-      } catch {
-        // Fall through to reset if we can't read tree SHAs — safer than skipping
-      }
-
-      // State-plane-only commits (same effective code commit) and rebases onto a
-      // newer main (same non-state contribution by patch-id, despite rewritten
-      // SHAs — PAN-2468) move HEAD without changing the branch's own work.
-      // Preserve the verdicts and advance the snapshot rather than re-reviewing.
-      try {
-        const sameContribution =
-          (await haveSameEffectiveCodeCommit(workspacePath, status.reviewedAtCommit, currentHead)) ||
-          (await haveSameCodeContribution(workspacePath, status.reviewedAtCommit, currentHead));
-        if (sameContribution) {
-          setReviewStatusSync(issueId, { reviewedAtCommit: currentHead });
-          console.log(`[deacon] Benign post-review HEAD move for ${issueId}: ${status.reviewedAtCommit.substring(0, 8)} → ${currentHead.substring(0, 8)} — review/test preserved`);
-          continue;
-        }
-      } catch {
-        // Fall through to reset if the move cannot be inspected.
-      }
+      const currentHead = verdict.currentAnchor;
 
       // HEAD moved with a real tree change — new commits since review. Reset review pipeline.
       console.log(
         `[deacon] Post-review commit detected for ${issueId}: ` +
-        `was ${status.reviewedAtCommit.substring(0, 8)}, now ${currentHead.substring(0, 8)} — resetting review`,
+        `was ${formatAnchorShort(status.reviewedAtCommit)}, now ${formatAnchorShort(currentHead)} — resetting review`,
       );
       setReviewStatusSync(issueId, {
         reviewStatus: 'pending',
@@ -1663,7 +1634,7 @@ export async function checkPostReviewCommits(): Promise<string[]> {
       // starts fresh. Without this, ciRetryMap retains count=6 from the previous
       // CI failure cycle, permanently blocking transient retries for this issue.
       ciRetryMap.delete(issueId);
-      actions.push(`Reset review for ${issueId}: new commits after review passed (${status.reviewedAtCommit.substring(0, 8)} → ${currentHead.substring(0, 8)})`);
+      actions.push(`Reset review for ${issueId}: new commits after review passed (${formatAnchorShort(status.reviewedAtCommit)} → ${formatAnchorShort(currentHead)})`);
 
       // Redispatch a fresh review convoy. Re-read status to guard against races
       // with other dispatch paths (HTTP request-review, manual CLI) that may have

--- a/src/lib/cloister/inspect-checkpoints.ts
+++ b/src/lib/cloister/inspect-checkpoints.ts
@@ -12,7 +12,7 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 import { Effect } from 'effect';
 import { resolveWorkspaceRepoRootsSync, type WorkspaceRepoRoot } from '../project-repos.js';
-import { snapshotWorkspaceHeadsPromise } from '../git-utils.js';
+import { parseCompositeSnapshot, snapshotWorkspaceHeadsPromise } from '../git-utils.js';
 
 const execAsync = promisify(exec);
 
@@ -114,17 +114,6 @@ export interface InspectDiffContext {
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'"'"'`)}'`;
-}
-
-function parseCompositeSnapshot(snapshot: string | undefined): Map<string, string> {
-  const heads = new Map<string, string>();
-  if (!snapshot) return heads;
-  for (const token of snapshot.split(/\s+/)) {
-    const separator = token.lastIndexOf('@');
-    if (separator <= 0 || separator === token.length - 1) continue;
-    heads.set(token.slice(0, separator), token.slice(separator + 1));
-  }
-  return heads;
 }
 
 async function readHead(root: WorkspaceRepoRoot): Promise<string | null> {

--- a/src/lib/cloister/review-agent.ts
+++ b/src/lib/cloister/review-agent.ts
@@ -37,6 +37,7 @@
  */
 
 import { exec } from 'child_process';
+import { createHash } from 'node:crypto';
 import { existsSync } from 'fs';
 import { mkdir, readFile, rm, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
@@ -80,6 +81,30 @@ export const PARENT_REVIEW_TIMEOUT_MS = 45 * 60 * 1000;
 
 const reviewSynthesisPath = (reviewDir: string): string => join(reviewDir, 'synthesis.md');
 const selfReviewReportPath = (reviewDir: string): string => join(reviewDir, 'review.md');
+
+async function deriveReviewRunHead8(issueId: string, workspace: string): Promise<string> {
+  try {
+    const { resolveWorkspaceRepoRootsSync } = await import('../project-repos.js');
+    const roots = resolveWorkspaceRepoRootsSync(issueId, workspace);
+    if (roots.some(root => root.isPolyrepo)) {
+      const { snapshotWorkspaceHeadsPromise } = await import('../git-utils.js');
+      const anchor = await snapshotWorkspaceHeadsPromise(issueId, workspace);
+      return anchor
+        ? createHash('sha1').update(anchor).digest('hex').substring(0, 8)
+        : 'unknown';
+    }
+
+    const probeDir = roots[0]?.dir ?? workspace;
+    const { stdout } = await execAsync(['git', 'rev-parse', '--short=8', 'HEAD'].join(' '), {
+      cwd: probeDir,
+      encoding: 'utf-8',
+      timeout: 10_000,
+    });
+    return stdout.trim() || 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
 
 function buildReviewRolePrompt(opts: {
   issueId: string;
@@ -359,17 +384,9 @@ async function spawnReviewRoleForIssuePromise(
       let currentRunId: string | undefined;
       if (!paneDead && !opts.force) {
         try {
-          // PAN-2948: probe the primary code repo — the polyrepo wrapper's HEAD
-          // never moves, so a wrapper-derived runId would mismatch every live
-          // run and kill a healthy convoy on each dispatch.
-          const { resolveWorkspaceRepoRootsSync } = await import('../project-repos.js');
-          const probeDir = resolveWorkspaceRepoRootsSync(opts.issueId, opts.workspace)[0]?.dir ?? opts.workspace;
-          const { stdout } = await execAsync('git rev-parse --short=8 HEAD', {
-            cwd: probeDir,
-            encoding: 'utf-8',
-            timeout: 10_000,
-          });
-          currentRunId = `agent-${opts.issueId.toLowerCase()}-review-${stdout.trim()}`;
+          const head8 = await deriveReviewRunHead8(opts.issueId, opts.workspace);
+          if (head8 === 'unknown') throw new Error('workspace HEAD unavailable');
+          currentRunId = `agent-${opts.issueId.toLowerCase()}-review-${head8}`;
           const synthReviewRunId = getAgentStateSync(reviewSessionName)?.reviewRunId;
           // A missing identity cannot prove that the live pane covers the
           // current obligation, so legacy/unknown sessions are stale too.
@@ -538,20 +555,12 @@ async function spawnReviewRoleForIssuePromise(
     // read one pre-built diff+AC object instead of each running git diff
     // independently (PAN-1059).
     //
-    // Include HEAD SHA in runId so re-reviews of the same issue get their own
-    // directory and don't overwrite round-1 files (collision prevention).
-    // PAN-2948: resolve the head from the primary code repo — in a polyrepo
-    // workspace the root is an immutable one-commit wrapper, so its SHA would
-    // pin every re-review to the same run directory.
-    let headSha = 'unknown';
-    try {
-      const { resolveWorkspaceRepoRootsSync } = await import('../project-repos.js');
-      const primaryRepoDir = resolveWorkspaceRepoRootsSync(opts.issueId, opts.workspace)[0]?.dir ?? opts.workspace;
-      const { stdout } = await execAsync('git rev-parse --short=8 HEAD', { cwd: primaryRepoDir, encoding: 'utf-8', timeout: 10_000 });
-      headSha = stdout.trim();
-    } catch { /* non-fatal — fall back to static runId */ }
-    const runId = headSha !== 'unknown'
-      ? `agent-${opts.issueId.toLowerCase()}-review-${headSha}`
+    // Include the shared workspace-head digest in runId so re-reviews of the
+    // same issue get separate directories. Monorepos retain their short HEAD;
+    // polyrepos hash the full composite anchor so any sub-repo move changes it.
+    const head8 = await deriveReviewRunHead8(opts.issueId, opts.workspace);
+    const runId = head8 !== 'unknown'
+      ? `agent-${opts.issueId.toLowerCase()}-review-${head8}`
       : `agent-${opts.issueId.toLowerCase()}-review`;
     const reviewDir = join(opts.workspace, PAN_DIRNAME, 'review', runId);
     let contextManifestPath: string | undefined;

--- a/src/lib/cloister/service-crash.ts
+++ b/src/lib/cloister/service-crash.ts
@@ -108,8 +108,13 @@ export async function progressFingerprint(_host: CrashHost, agentId: string): Pr
   let head = '';
   if (state?.workspace) {
     try {
-      const { stdout } = await execAsync('git rev-parse HEAD', { cwd: state.workspace, encoding: 'utf-8' });
-      head = stdout.trim();
+      if (state.issueId) {
+        const { snapshotWorkspaceHeadsPromise } = await import('../git-utils.js');
+        head = await snapshotWorkspaceHeadsPromise(state.issueId, state.workspace) ?? '';
+      } else {
+        const { stdout } = await execAsync('git rev-parse HEAD', { cwd: state.workspace, encoding: 'utf-8' });
+        head = stdout.trim();
+      }
     } catch { /* workspace may be gone; pane still fingerprints */ }
   }
   let pane = '';

--- a/src/lib/cloister/service-reactive.ts
+++ b/src/lib/cloister/service-reactive.ts
@@ -1,6 +1,4 @@
 /** Cloister reactive lifecycle scheduler. */
-import { exec } from 'node:child_process';
-import { promisify } from 'node:util';
 import { Effect } from 'effect';
 import { getAgentState } from '../agents.js';
 import type { Role } from '../agents.js';
@@ -14,8 +12,6 @@ import {
 import { recordDeadEndNeedsYou } from './dead-end-trip.js';
 import { isIssueClosed } from './issue-closed.js';
 import { shouldSkipDispatchAsMerged } from './merge-verification.js';
-
-const execAsync = promisify(exec);
 
 /** Return issues orphaned in reviewStatus='reviewing' with no active reviewer. */
 export function identifyOrphanedReviewingIssues(
@@ -163,18 +159,17 @@ async function activeRoleRunExists(issueId: string, role: Role, workspacePath?: 
 
   // Zombie detection: an agent that finished its work but never exited keeps
   // status:'running' forever, which would block every future re-dispatch for
-  // this role (the ship/test stall bug). When we know the workspace and the
-  // run stamped a roleRunHead, compare it against the current workspace HEAD —
-  // a HEAD that has advanced past the marker means this session ran against
-  // stale code and must not be treated as the active run for the new HEAD.
+  // this role (the ship/test stall bug). Producer-issued anchors cover every
+  // code root in monorepo and polyrepo workspaces. Persisted pre-fix short SHAs
+  // intentionally compare stale once, then the next run receives a full anchor.
   if (workspacePath && state.roleRunHead) {
     try {
-      const { stdout } = await execAsync('git rev-parse --short=8 HEAD', { cwd: workspacePath });
-      const currentHead = stdout.trim();
+      const { formatAnchorShort, snapshotWorkspaceHeadsPromise } = await import('../git-utils.js');
+      const currentHead = await snapshotWorkspaceHeadsPromise(issueId, workspacePath);
       if (currentHead && currentHead !== state.roleRunHead) {
         console.log(
           `[cloister] ${issueId}: ${role} session ${candidateId} is stale `
-          + `(ran against ${state.roleRunHead}, HEAD is now ${currentHead}) — not active`,
+          + `(ran against ${formatAnchorShort(state.roleRunHead)}, HEAD is now ${formatAnchorShort(currentHead)}) — not active`,
         );
         return false;
       }

--- a/src/lib/cloister/verification-runner.ts
+++ b/src/lib/cloister/verification-runner.ts
@@ -39,6 +39,7 @@ import { isXBriefFilename } from '../xbrief/lifecycle.js';
 import { checkIncompletePlanItemsPromise } from '../work/done-preflight.js';
 import { capturePipelineStageForIssue } from '../telemetry/pipeline.js';
 import type { TemplatePlaceholders } from '../workspace-config.js';
+import type { HeadAnchor } from '../git-utils.js';
 
 const execAsync = promisify(exec);
 
@@ -876,7 +877,7 @@ async function runVerificationForIssuePromise(
     // after review to skip redundant test-agent when no code changed.
     // PAN-2948: polyrepo-aware — the wrapper repo's HEAD never changes, so
     // snapshotting it would make this comparison report "no drift" forever.
-    let lastVerifiedCommit: string | undefined;
+    let lastVerifiedCommit: HeadAnchor | undefined;
     try {
       const { snapshotWorkspaceHeadsPromise } = await import('../git-utils.js');
       lastVerifiedCommit = await snapshotWorkspaceHeadsPromise(issueId, workspacePath);

--- a/src/lib/git-utils.ts
+++ b/src/lib/git-utils.ts
@@ -367,6 +367,14 @@ export function parseCompositeSnapshot(snapshot: string | undefined): Map<string
   return heads;
 }
 
+export function formatAnchorShort(anchor: string): string {
+  return anchor.split(/\s+/).map((token) => {
+    const separator = token.lastIndexOf('@');
+    if (separator <= 0 || separator === token.length - 1) return token.substring(0, 8);
+    return `${token.slice(0, separator)}@${token.slice(separator + 1, separator + 9)}`;
+  }).join(' ');
+}
+
 /**
  * Snapshot the code HEAD(s) of a workspace for drift comparison (PAN-2948).
  *

--- a/src/lib/git-utils.ts
+++ b/src/lib/git-utils.ts
@@ -346,6 +346,27 @@ async function getWorkspaceGitInfoPromise(workspacePath: string): Promise<Worksp
   }
 }
 
+declare const headAnchorBrand: unique symbol;
+
+/** A producer-issued snapshot of every code HEAD in a workspace. */
+export type HeadAnchor = string & { readonly [headAnchorBrand]: true };
+
+/** Rehydrate a persisted anchor after it crosses an unbranded storage boundary. */
+export function rehydrateHeadAnchor(anchor: string): HeadAnchor {
+  return anchor as HeadAnchor;
+}
+
+export function parseCompositeSnapshot(snapshot: string | undefined): Map<string, string> {
+  const heads = new Map<string, string>();
+  if (!snapshot) return heads;
+  for (const token of snapshot.split(/\s+/)) {
+    const separator = token.lastIndexOf('@');
+    if (separator <= 0 || separator === token.length - 1) continue;
+    heads.set(token.slice(0, separator), token.slice(separator + 1));
+  }
+  return heads;
+}
+
 /**
  * Snapshot the code HEAD(s) of a workspace for drift comparison (PAN-2948).
  *
@@ -358,7 +379,7 @@ async function getWorkspaceGitInfoPromise(workspacePath: string): Promise<Worksp
  * head is unchanged; consumers that try to use the anchor as a git ref fail
  * the ref lookup and fall back to their conservative full-rerun path.
  */
-export async function snapshotWorkspaceHeadsPromise(issueId: string, workspacePath: string): Promise<string | undefined> {
+export async function snapshotWorkspaceHeadsPromise(issueId: string, workspacePath: string): Promise<HeadAnchor | undefined> {
   // Dynamic import: project-repos → projects sits above this low-level module
   // in the layering; a static edge here would risk a require cycle.
   const { resolveWorkspaceRepoRootsSync } = await import('./project-repos.js');
@@ -372,7 +393,7 @@ export async function snapshotWorkspaceHeadsPromise(issueId: string, workspacePa
       if (sha) heads.push(isPolyrepo ? `${root.repoKey}@${sha}` : sha);
     } catch { /* unreadable root — omit from the snapshot */ }
   }
-  return heads.length > 0 ? heads.join(' ') : undefined;
+  return heads.length > 0 ? heads.join(' ') as HeadAnchor : undefined;
 }
 
 async function hasStaleLocksPromise(repoPath: string): Promise<boolean> {

--- a/src/lib/git-utils.ts
+++ b/src/lib/git-utils.ts
@@ -386,6 +386,10 @@ export function formatAnchorShort(anchor: string): string {
  * "no drift" forever. Composite snapshots compare equal iff every sub-repo
  * head is unchanged; consumers that try to use the anchor as a git ref fail
  * the ref lookup and fall back to their conservative full-rerun path.
+ *
+ * Its branded return value is the only legitimate source for reviewedAtCommit,
+ * lastVerifiedCommit, and roleRunHead. Persisted values regain that brand only
+ * through rehydrateHeadAnchor at an explicitly documented storage boundary.
  */
 export async function snapshotWorkspaceHeadsPromise(issueId: string, workspacePath: string): Promise<HeadAnchor | undefined> {
   // Dynamic import: project-repos → projects sits above this low-level module

--- a/src/lib/pan-dir/verdict-restore.ts
+++ b/src/lib/pan-dir/verdict-restore.ts
@@ -14,7 +14,8 @@ import {
   resolveProjectFromIssueSync,
   type ProjectConfig,
 } from '../projects.js';
-import { setReviewStatusSync, type ReviewStatus } from '../review-status.js';
+import { setReviewStatusSync, type ReviewStatus, type ReviewStatusUpdate } from '../review-status.js';
+import { rehydrateHeadAnchor } from '../git-utils.js';
 import { collectInFlightIssueIds } from './records-backfill.js';
 import { readIssueRecord, type PanIssuePipelineRecord } from './records.js';
 
@@ -44,7 +45,7 @@ function parseRepoFromPrUrl(prUrl: string): string | null {
  * to a Partial<ReviewStatus> update. Derived/live columns (blockerReasons,
  * readyForMerge) are intentionally omitted.
  */
-function pipelineToDurableUpdate(pipeline: PanIssuePipelineRecord): Partial<ReviewStatus> {
+function pipelineToDurableUpdate(pipeline: PanIssuePipelineRecord): ReviewStatusUpdate {
   return {
     reviewStatus: pipeline.reviewStatus as ReviewStatus['reviewStatus'],
     testStatus: pipeline.testStatus as ReviewStatus['testStatus'],
@@ -59,8 +60,14 @@ function pipelineToDurableUpdate(pipeline: PanIssuePipelineRecord): Partial<Revi
     prUrl: pipeline.prUrl,
     prNumber: pipeline.prNumber,
     prHeadSha: pipeline.prHeadSha,
-    reviewedAtCommit: pipeline.reviewedAtCommit,
-    lastVerifiedCommit: pipeline.lastVerifiedCommit,
+    // Durable records deserialize anchors as strings; re-brand only at the write door.
+    reviewedAtCommit: pipeline.reviewedAtCommit
+      ? rehydrateHeadAnchor(pipeline.reviewedAtCommit)
+      : undefined,
+    // Durable records deserialize anchors as strings; re-brand only at the write door.
+    lastVerifiedCommit: pipeline.lastVerifiedCommit
+      ? rehydrateHeadAnchor(pipeline.lastVerifiedCommit)
+      : undefined,
     autoMerge: pipeline.autoMerge,
     deaconIgnored: pipeline.deaconIgnored,
     deaconIgnoredAt: pipeline.deaconIgnoredAt,

--- a/src/lib/review-status.ts
+++ b/src/lib/review-status.ts
@@ -19,21 +19,15 @@ import {
   reconcileJournalIntoCacheSync,
   reviewGatesPassedSync,
   verificationSatisfied,
-  type BlockerReason,
-  type ReviewStatus,
-  type StatusHistoryEntry,
+  type BlockerReason, type ReviewStatus, type StatusHistoryEntry,
 } from './review-status-reconcile.js';
 import { needsReviewDispatch } from './review-dispatch-decision.js';
 import { capturePipelineStageForIssue } from './telemetry/pipeline.js';
-import type { HeadAnchor } from './git-utils.js';
+import type { ReviewStatusUpdate } from './workspace-anchor-drift.js';
 
 export { reviewGatesPassedSync, verificationSatisfied } from './review-status-reconcile.js';
 export type { BlockerReason, ReviewStatus, StatusHistoryEntry } from './review-status-reconcile.js';
-
-export type ReviewStatusUpdate = Omit<Partial<ReviewStatus>, 'reviewedAtCommit' | 'lastVerifiedCommit'> & {
-  reviewedAtCommit?: HeadAnchor;
-  lastVerifiedCommit?: HeadAnchor;
-};
+export type { ReviewStatusUpdate } from './workspace-anchor-drift.js';
 
 export interface MergeGateEligibility {
   eligible: boolean;

--- a/src/lib/review-status.ts
+++ b/src/lib/review-status.ts
@@ -25,9 +25,15 @@ import {
 } from './review-status-reconcile.js';
 import { needsReviewDispatch } from './review-dispatch-decision.js';
 import { capturePipelineStageForIssue } from './telemetry/pipeline.js';
+import type { HeadAnchor } from './git-utils.js';
 
 export { reviewGatesPassedSync, verificationSatisfied } from './review-status-reconcile.js';
 export type { BlockerReason, ReviewStatus, StatusHistoryEntry } from './review-status-reconcile.js';
+
+export type ReviewStatusUpdate = Omit<Partial<ReviewStatus>, 'reviewedAtCommit' | 'lastVerifiedCommit'> & {
+  reviewedAtCommit?: HeadAnchor;
+  lastVerifiedCommit?: HeadAnchor;
+};
 
 export interface MergeGateEligibility {
   eligible: boolean;
@@ -146,7 +152,7 @@ export function saveReviewStatuses(statuses: Record<string, ReviewStatus>, fileP
 
 export function setReviewStatusSync(
   issueId: string,
-  update: Partial<ReviewStatus>,
+  update: ReviewStatusUpdate,
   existing?: ReviewStatus,
 ): ReviewStatus {
   // Guard: bare numeric IDs (no alphabetic prefix) must never reach the DB.
@@ -963,7 +969,7 @@ export class ReviewStatusError extends Data.TaggedError('ReviewStatusError')<{
 
 export const setReviewStatus = (
   issueId: string,
-  update: Partial<ReviewStatus>,
+  update: ReviewStatusUpdate,
   existing?: ReviewStatus,
 ): Effect.Effect<ReviewStatus, ReviewStatusError> =>
   Effect.tryPromise({

--- a/src/lib/webhook-handlers.ts
+++ b/src/lib/webhook-handlers.ts
@@ -7,7 +7,7 @@
  */
 
 import { Effect } from 'effect';
-import { setReviewStatus, getReviewStatus, loadReviewStatuses, type BlockerReason, type ReviewStatus } from './review-status.js';
+import { setReviewStatus, getReviewStatus, loadReviewStatuses, type BlockerReason, type ReviewStatus, type ReviewStatusUpdate } from './review-status.js';
 import { getGitHubConfig } from '../dashboard/server/services/tracker-config.js';
 import { GitHubApiError } from './errors.js';
 import { relayCiFailureFeedback } from './cloister/ci-failure-feedback.js';
@@ -349,7 +349,7 @@ export async function refreshMergeStateFromGitHub(issueId: string, repo: string,
       }
     }
 
-    const update: Partial<ReviewStatus> = {};
+    const update: ReviewStatusUpdate = {};
     if (blockers.length > 0) update.blockerReasons = blockers;
     else if (status.blockerReasons && status.blockerReasons.length > 0) update.blockerReasons = undefined;
 
@@ -396,7 +396,7 @@ export async function refreshMergeStateFromGitHub(issueId: string, repo: string,
       }
     }
 
-    const update: Partial<ReviewStatus> = {};
+    const update: ReviewStatusUpdate = {};
     if (blockers.length > 0) update.blockerReasons = blockers;
     else if (status.blockerReasons && status.blockerReasons.length > 0) update.blockerReasons = undefined;
 
@@ -443,7 +443,7 @@ export async function refreshMergeStateFromGitHub(issueId: string, repo: string,
   const status = await loadAndValidateStatus(issueId, repo, pr.number, headMayHaveMoved ? undefined : pr.head.sha);
   if (!status) return;
 
-  const update: Partial<ReviewStatus> = {};
+  const update: ReviewStatusUpdate = {};
   let blockers = [...(status.blockerReasons ?? [])];
 
   // Populate missing PR identity and keep head SHA in sync on synchronize
@@ -532,7 +532,7 @@ export async function refreshMergeStateFromGitHub(issueId: string, repo: string,
     blockers = blockers.filter((b) => b.type !== 'changes_requested');
   }
 
-  const update: Partial<ReviewStatus> = {};
+  const update: ReviewStatusUpdate = {};
   if (blockers.length > 0) update.blockerReasons = blockers;
   else if (status.blockerReasons && status.blockerReasons.length > 0) update.blockerReasons = undefined;
 
@@ -622,7 +622,7 @@ async function handlePullRequestReviewThreadPromise(payload: WebhookPayload): Pr
     }
   }
 
-  const update: Partial<ReviewStatus> = {};
+  const update: ReviewStatusUpdate = {};
   if (blockers.length > 0) update.blockerReasons = blockers;
   else if (status.blockerReasons && status.blockerReasons.length > 0) update.blockerReasons = undefined;
 
@@ -671,7 +671,7 @@ async function handlePullRequestReviewThreadPromise(payload: WebhookPayload): Pr
         }
       }
 
-      const update: Partial<ReviewStatus> = {};
+      const update: ReviewStatusUpdate = {};
       if (blockers.length > 0) update.blockerReasons = blockers;
       else if (status.blockerReasons && status.blockerReasons.length > 0) update.blockerReasons = undefined;
 

--- a/src/lib/workspace-anchor-drift.ts
+++ b/src/lib/workspace-anchor-drift.ts
@@ -9,8 +9,14 @@ import {
   haveSameCodeContribution,
   haveSameEffectiveCodeCommit,
 } from './pipeline-state-paths.js';
+import type { ReviewStatus } from './review-status-reconcile.js';
 
 const execFileAsync = promisify(execFile);
+
+export type ReviewStatusUpdate = Omit<Partial<ReviewStatus>, 'reviewedAtCommit' | 'lastVerifiedCommit'> & {
+  reviewedAtCommit?: HeadAnchor;
+  lastVerifiedCommit?: HeadAnchor;
+};
 
 export type WorkspaceAnchorDriftVerdict =
   | { kind: 'current'; currentAnchor: HeadAnchor }

--- a/src/lib/workspace-anchor-drift.ts
+++ b/src/lib/workspace-anchor-drift.ts
@@ -16,7 +16,18 @@ export type WorkspaceAnchorDriftVerdict =
   | { kind: 'current'; currentAnchor: HeadAnchor }
   | { kind: 'benign'; currentAnchor: HeadAnchor; changedRepos?: string[] }
   | { kind: 'drifted'; currentAnchor: HeadAnchor; changedRepos?: string[] }
-  | { kind: 'unreadable'; currentAnchor?: HeadAnchor };
+  | { kind: 'unreadable' };
+
+export interface WorkspaceAnchorDriftChecks {
+  sameTree(repoPath: string, leftCommit: string, rightCommit: string): Promise<boolean>;
+  sameEffectiveCode(repoPath: string, leftCommit: string, rightCommit: string): Promise<boolean>;
+  sameCodeContribution(
+    repoPath: string,
+    leftCommit: string,
+    rightCommit: string,
+    baseRef: string,
+  ): Promise<boolean>;
+}
 
 async function haveSameTree(repoPath: string, leftCommit: string, rightCommit: string): Promise<boolean> {
   const [left, right] = await Promise.all([
@@ -26,15 +37,30 @@ async function haveSameTree(repoPath: string, leftCommit: string, rightCommit: s
   return left.stdout.trim() === right.stdout.trim();
 }
 
+const DEFAULT_CHECKS: WorkspaceAnchorDriftChecks = {
+  sameTree: haveSameTree,
+  sameEffectiveCode: haveSameEffectiveCodeCommit,
+  sameCodeContribution: haveSameCodeContribution,
+};
+
 async function isBenignMove(
   repoPath: string,
   leftCommit: string,
   rightCommit: string,
   baseRef: string,
+  checks: WorkspaceAnchorDriftChecks,
 ): Promise<boolean> {
-  if (await haveSameTree(repoPath, leftCommit, rightCommit)) return true;
-  if (await haveSameEffectiveCodeCommit(repoPath, leftCommit, rightCommit)) return true;
-  return haveSameCodeContribution(repoPath, leftCommit, rightCommit, baseRef);
+  try {
+    if (await checks.sameTree(repoPath, leftCommit, rightCommit)) return true;
+  } catch { /* a failed proof falls through to the next independent check */ }
+  try {
+    if (await checks.sameEffectiveCode(repoPath, leftCommit, rightCommit)) return true;
+  } catch { /* a failed proof falls through to the next independent check */ }
+  try {
+    return await checks.sameCodeContribution(repoPath, leftCommit, rightCommit, baseRef);
+  } catch {
+    return false;
+  }
 }
 
 /** Compare a persisted workspace anchor with a fresh producer-issued snapshot. */
@@ -42,6 +68,7 @@ export async function evaluateWorkspaceAnchorDrift(
   issueId: string,
   workspacePath: string,
   storedAnchor: HeadAnchor,
+  checks: WorkspaceAnchorDriftChecks = DEFAULT_CHECKS,
 ): Promise<WorkspaceAnchorDriftVerdict> {
   const currentAnchor = await snapshotWorkspaceHeadsPromise(issueId, workspacePath);
   if (!currentAnchor) return { kind: 'unreadable' };
@@ -62,12 +89,13 @@ export async function evaluateWorkspaceAnchorDrift(
 
     if (!storedIsComposite) {
       const root = roots[0];
-      if (!root) return { kind: 'unreadable', currentAnchor };
+      if (!root) return { kind: 'drifted', currentAnchor };
       const benign = await isBenignMove(
         root.dir,
         storedAnchor,
         currentAnchor,
         `origin/${root.targetBranch}`,
+        checks,
       );
       return benign
         ? { kind: 'benign', currentAnchor }
@@ -92,13 +120,14 @@ export async function evaluateWorkspaceAnchorDrift(
       const storedHead = storedHeads.get(repoKey);
       const currentHead = currentHeads.get(repoKey);
       if (!root || !storedHead || !currentHead) {
-        return { kind: 'unreadable', currentAnchor };
+        return { kind: 'drifted', currentAnchor, changedRepos };
       }
       if (!await isBenignMove(
         root.dir,
         storedHead,
         currentHead,
         `origin/${root.targetBranch}`,
+        checks,
       )) {
         return { kind: 'drifted', currentAnchor, changedRepos };
       }
@@ -106,6 +135,6 @@ export async function evaluateWorkspaceAnchorDrift(
 
     return { kind: 'benign', currentAnchor, changedRepos };
   } catch {
-    return { kind: 'unreadable', currentAnchor };
+    return { kind: 'drifted', currentAnchor };
   }
 }

--- a/src/lib/workspace-anchor-drift.ts
+++ b/src/lib/workspace-anchor-drift.ts
@@ -1,0 +1,111 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import {
+  type HeadAnchor,
+  parseCompositeSnapshot,
+  snapshotWorkspaceHeadsPromise,
+} from './git-utils.js';
+import {
+  haveSameCodeContribution,
+  haveSameEffectiveCodeCommit,
+} from './pipeline-state-paths.js';
+
+const execFileAsync = promisify(execFile);
+
+export type WorkspaceAnchorDriftVerdict =
+  | { kind: 'current'; currentAnchor: HeadAnchor }
+  | { kind: 'benign'; currentAnchor: HeadAnchor; changedRepos?: string[] }
+  | { kind: 'drifted'; currentAnchor: HeadAnchor; changedRepos?: string[] }
+  | { kind: 'unreadable'; currentAnchor?: HeadAnchor };
+
+async function haveSameTree(repoPath: string, leftCommit: string, rightCommit: string): Promise<boolean> {
+  const [left, right] = await Promise.all([
+    execFileAsync('git', ['rev-parse', `${leftCommit}^{tree}`], { cwd: repoPath, encoding: 'utf-8' }),
+    execFileAsync('git', ['rev-parse', `${rightCommit}^{tree}`], { cwd: repoPath, encoding: 'utf-8' }),
+  ]);
+  return left.stdout.trim() === right.stdout.trim();
+}
+
+async function isBenignMove(
+  repoPath: string,
+  leftCommit: string,
+  rightCommit: string,
+  baseRef: string,
+): Promise<boolean> {
+  if (await haveSameTree(repoPath, leftCommit, rightCommit)) return true;
+  if (await haveSameEffectiveCodeCommit(repoPath, leftCommit, rightCommit)) return true;
+  return haveSameCodeContribution(repoPath, leftCommit, rightCommit, baseRef);
+}
+
+/** Compare a persisted workspace anchor with a fresh producer-issued snapshot. */
+export async function evaluateWorkspaceAnchorDrift(
+  issueId: string,
+  workspacePath: string,
+  storedAnchor: HeadAnchor,
+): Promise<WorkspaceAnchorDriftVerdict> {
+  const currentAnchor = await snapshotWorkspaceHeadsPromise(issueId, workspacePath);
+  if (!currentAnchor) return { kind: 'unreadable' };
+  if (storedAnchor === currentAnchor) return { kind: 'current', currentAnchor };
+
+  const storedHeads = parseCompositeSnapshot(storedAnchor);
+  const currentHeads = parseCompositeSnapshot(currentAnchor);
+  const storedIsComposite = storedHeads.size > 0;
+  const currentIsComposite = currentHeads.size > 0;
+
+  if (storedIsComposite !== currentIsComposite) {
+    return { kind: 'drifted', currentAnchor };
+  }
+
+  try {
+    const { resolveWorkspaceRepoRootsSync } = await import('./project-repos.js');
+    const roots = resolveWorkspaceRepoRootsSync(issueId, workspacePath);
+
+    if (!storedIsComposite) {
+      const root = roots[0];
+      if (!root) return { kind: 'unreadable', currentAnchor };
+      const benign = await isBenignMove(
+        root.dir,
+        storedAnchor,
+        currentAnchor,
+        `origin/${root.targetBranch}`,
+      );
+      return benign
+        ? { kind: 'benign', currentAnchor }
+        : { kind: 'drifted', currentAnchor };
+    }
+
+    const allRepoKeys = new Set([...storedHeads.keys(), ...currentHeads.keys()]);
+    if (
+      storedHeads.size !== currentHeads.size ||
+      [...allRepoKeys].some(repoKey => !storedHeads.has(repoKey) || !currentHeads.has(repoKey))
+    ) {
+      return { kind: 'drifted', currentAnchor, changedRepos: [...allRepoKeys].sort() };
+    }
+
+    const changedRepos = [...allRepoKeys]
+      .filter(repoKey => storedHeads.get(repoKey) !== currentHeads.get(repoKey))
+      .sort();
+    const rootsByKey = new Map(roots.map(root => [root.repoKey, root]));
+
+    for (const repoKey of changedRepos) {
+      const root = rootsByKey.get(repoKey);
+      const storedHead = storedHeads.get(repoKey);
+      const currentHead = currentHeads.get(repoKey);
+      if (!root || !storedHead || !currentHead) {
+        return { kind: 'unreadable', currentAnchor };
+      }
+      if (!await isBenignMove(
+        root.dir,
+        storedHead,
+        currentHead,
+        `origin/${root.targetBranch}`,
+      )) {
+        return { kind: 'drifted', currentAnchor, changedRepos };
+      }
+    }
+
+    return { kind: 'benign', currentAnchor, changedRepos };
+  } catch {
+    return { kind: 'unreadable', currentAnchor };
+  }
+}

--- a/tests/integration/post-review-rebase-scenario.test.ts
+++ b/tests/integration/post-review-rebase-scenario.test.ts
@@ -101,6 +101,12 @@ vi.mock('child_process', async (importOriginal) => {
   };
 });
 
+vi.mock('../../src/lib/workspace-anchor-drift.js', () => ({
+  evaluateWorkspaceAnchorDrift: vi.fn(async () => mockOldTreeSha === mockNewTreeSha
+    ? { kind: 'benign', currentAnchor: mockExecHeadSha }
+    : { kind: 'drifted', currentAnchor: mockExecHeadSha }),
+}));
+
 // ─── Stub modules that deacon and done.ts import ──────────────────────────────
 
 const mockResolveProject = vi.fn();

--- a/tests/lib/cloister/deacon-ci-retry.test.ts
+++ b/tests/lib/cloister/deacon-ci-retry.test.ts
@@ -36,6 +36,11 @@ const mockSaveAgentStateSync = vi.fn();
 const mockClearAgentTroubledSync = vi.fn();
 const mockSpawnWorkAgentThroughAgentsEndpoint = vi.fn();
 const mockRecordDeadEndNeedsYou = vi.fn();
+const mockEvaluateWorkspaceAnchorDrift = vi.fn();
+
+vi.mock('../../../src/lib/workspace-anchor-drift.js', () => ({
+  evaluateWorkspaceAnchorDrift: (...args: unknown[]) => mockEvaluateWorkspaceAnchorDrift(...args),
+}));
 
 vi.mock('../../../src/lib/cloister/dead-end-trip.js', () => ({
   recordDeadEndNeedsYou: (...args: unknown[]) => mockRecordDeadEndNeedsYou(...args),
@@ -177,6 +182,10 @@ describe('checkFailedMergeRetry — CI transient retry state machine', () => {
     mockResolveProjectFromIssue.mockReset().mockReturnValue(null);
     mockSpawnReviewRoleForIssue.mockReset().mockResolvedValue({ success: true, message: 'dispatched' });
     mockIsIssueClosed.mockReset().mockResolvedValue(false);
+    mockEvaluateWorkspaceAnchorDrift.mockReset().mockResolvedValue({
+      kind: 'drifted',
+      currentAnchor: 'feedface00000000000000000000000000000000',
+    });
     // Default: read the real review-status.json so tests that write to it work
     mockLoadReviewStatuses.mockReset().mockImplementation(() => {
       try {

--- a/tests/lib/cloister/review-agent.test.ts
+++ b/tests/lib/cloister/review-agent.test.ts
@@ -697,9 +697,9 @@ describe('stale synthesis session detection (PAN-1131)', () => {
 
     // The guard must consult the existing session's reviewRunId …
     expect(guardBlock).toContain('reviewRunId');
-    // … derived from a HEAD probe, and use it to decide staleness.
+    // … derived from the same composite-aware helper as runId construction.
     expect(guardBlock).toMatch(/staleRunId/);
-    expect(guardBlock).toContain('git rev-parse --short=8 HEAD');
+    expect(guardBlock).toContain('deriveReviewRunHead8(opts.issueId, opts.workspace)');
     // … and the "skip" path must require NOT-stale, not just pane-alive.
     expect(guardBlock).toMatch(/!paneDead && !opts\.force && !staleRunId/);
   });

--- a/tests/unit/dashboard/server/routes/specialists-reviewed-at-commit.test.ts
+++ b/tests/unit/dashboard/server/routes/specialists-reviewed-at-commit.test.ts
@@ -58,6 +58,11 @@ vi.mock('child_process', async (importActual) => {
       const callback = args[args.length - 1] as (err: Error | null, result: { stdout: string; stderr: string }) => void;
       if (gitArgs[0] === 'rev-parse') {
         const ref = gitArgs[1]!;
+        if (ref.endsWith('^{tree}')) {
+          const commit = ref.slice(0, -7);
+          callback(null, { stdout: `${mockTreeShaByCommit.get(commit) ?? `${commit}-tree`}\n`, stderr: '' });
+          return {} as ReturnType<typeof actual.execFile>;
+        }
         if (ref.endsWith('^')) {
           const commit = ref.slice(0, -1);
           const parent = mockParentShaByCommit.get(commit);

--- a/tests/unit/lib/git-utils-polyrepo-anchor.test.ts
+++ b/tests/unit/lib/git-utils-polyrepo-anchor.test.ts
@@ -13,16 +13,33 @@ vi.mock('../../../src/lib/project-repos.js', async () => {
 });
 
 import {
+  type HeadAnchor,
   parseWorkspaceHeadAnchor,
   renderWorkspaceGitShowPromise,
+  snapshotWorkspaceHeadsPromise,
 } from '../../../src/lib/git-utils.js';
 
 const FE_SHA = 'a'.repeat(40);
 const API_SHA = 'b'.repeat(40);
 
+type ProducedHeadAnchor = Exclude<
+  Awaited<ReturnType<typeof snapshotWorkspaceHeadsPromise>>,
+  undefined
+>;
+
+function acceptsHeadAnchor(_anchor: HeadAnchor): void {}
+
 describe('polyrepo workspace head anchors', () => {
   beforeEach(() => {
     repoRootsMock.resolveWorkspaceRepoRootsSync.mockReset();
+  });
+
+  it('only accepts producer-issued values as head anchors', () => {
+    const producedAnchor = '' as ProducedHeadAnchor;
+    acceptsHeadAnchor(producedAnchor);
+
+    // @ts-expect-error Plain strings must not satisfy the branded write-door type.
+    acceptsHeadAnchor('plain-string');
   });
 
   it('keeps a plain sha on the single workspace git-show path', async () => {

--- a/tests/unit/lib/head-anchor-write-sites.test.ts
+++ b/tests/unit/lib/head-anchor-write-sites.test.ts
@@ -8,7 +8,6 @@ type AnchorField = 'reviewedAtCommit' | 'lastVerifiedCommit' | 'roleRunHead';
 interface AnchorWrite {
   file: string;
   field: AnchorField;
-  line: number;
   expression: string;
 }
 
@@ -25,53 +24,54 @@ const ANCHOR_FIELDS = new Set<AnchorField>([
 function allow(
   file: string,
   field: AnchorField,
-  line: number,
   expression: string,
   reason: string,
 ): AllowedWriteSite {
-  return { file, field, line, expression, reason };
+  return { file, field, expression, reason };
 }
 
+// Stable audit identity: file + field + normalized AST expression. Source lines
+// are deliberately excluded, while the full-array comparison preserves counts.
 const ALLOWED_WRITE_SITES: AllowedWriteSite[] = [
-  allow('src/cli/commands/specialists/done.ts', 'reviewedAtCommit', 159, 'update.reviewedAtCommit = workspaceHead', 'Producer-fed review verdict CLI stamp.'),
-  allow('src/dashboard/server/read-model.ts', 'reviewedAtCommit', 336, 'reviewedAtCommit: status.reviewedAtCommit || undefined', 'Read-model projection of persisted status.'),
-  allow('src/dashboard/server/routes/specialists/legacy-routes.ts', 'reviewedAtCommit', 304, 'reviewedAtCommit: headAnchor', 'Producer-fed legacy review verdict stamp.'),
-  allow('src/dashboard/server/routes/workspaces/review-control.ts', 'reviewedAtCommit', 283, 'reviewedAtCommit: undefined', 'Explicit review-reset clear.'),
-  allow('src/dashboard/server/routes/workspaces.ts', 'reviewedAtCommit', 1466, 'update.reviewedAtCommit = headAnchor', 'Producer-fed review status route stamp.'),
-  allow('src/lib/agents/agent-state.ts', 'roleRunHead', 246, 'roleRunHead: raw.roleRunHead', 'Agent-state storage deserialization.'),
-  allow('src/lib/agents/spawn.ts', 'roleRunHead', 470, 'state.roleRunHead = headAnchor', 'Producer-fed role-run stamp.'),
-  allow('src/lib/cloister/deacon-review-status.ts', 'reviewedAtCommit', 544, "reviewUpdate['reviewedAtCommit'] = await snapshotWorkspaceHeadsPromise(issueId, workspacePath)", 'Producer-fed review recovery stamp.'),
-  allow('src/lib/cloister/deacon.ts', 'reviewedAtCommit', 1336, 'reviewedAtCommit: status.reviewedAtCommit', 'Diagnostic nudge payload mirrors persisted status.'),
-  allow('src/lib/cloister/deacon.ts', 'lastVerifiedCommit', 1337, 'lastVerifiedCommit: status.lastVerifiedCommit', 'Diagnostic nudge payload mirrors persisted status.'),
-  allow('src/lib/cloister/deacon.ts', 'reviewedAtCommit', 1535, 'reviewedAtCommit', 'Producer-fed verification-bypass stamp.'),
-  allow('src/lib/cloister/deacon.ts', 'reviewedAtCommit', 1606, 'reviewedAtCommit: verdict.currentAnchor', 'Drift evaluator advances a proven-benign anchor.'),
-  allow('src/lib/cloister/deacon.ts', 'reviewedAtCommit', 1622, 'reviewedAtCommit: undefined', 'Explicit stale-review clear.'),
-  allow('src/lib/cloister/verification-runner.ts', 'lastVerifiedCommit', 892, 'lastVerifiedCommit', 'Producer-fed verification stamp.'),
-  allow('src/lib/database/agent-backfill.ts', 'roleRunHead', 73, "roleRunHead: 'role_run_head'", 'Database backfill column mapping.'),
-  allow('src/lib/database/agent-mappers.ts', 'roleRunHead', 49, 'roleRunHead: state.roleRunHead ?? null', 'Agent runtime serialization.'),
-  allow('src/lib/database/agents-db.ts', 'roleRunHead', 104, "roleRunHead: (row['role_run_head'] as string | null) ?? null", 'Agent runtime deserialization.'),
-  allow('src/lib/database/review-status-db.ts', 'reviewedAtCommit', 479, 'reviewedAtCommit: row.reviewed_at_commit ?? undefined', 'Review cache deserialization.'),
-  allow('src/lib/database/review-status-db.ts', 'lastVerifiedCommit', 489, 'lastVerifiedCommit: row.last_verified_commit ?? undefined', 'Review cache deserialization.'),
-  allow('src/lib/overdeck/agent-state-sync.ts', 'roleRunHead', 171, 'roleRunHead: row.role_run_head ?? undefined', 'Agent cache reconciliation.'),
-  allow('src/lib/overdeck/agents.ts', 'roleRunHead', 1099, "roleRunHead: (row['role_run_head'] as string | null) ?? null", 'Agent cache deserialization.'),
-  allow('src/lib/overdeck/review-status-record-sync.ts', 'reviewedAtCommit', 121, 'reviewedAtCommit: p.reviewedAtCommit', 'Durable record mirror of validated status.'),
-  allow('src/lib/overdeck/review-status-record-sync.ts', 'lastVerifiedCommit', 122, 'lastVerifiedCommit: p.lastVerifiedCommit', 'Durable record mirror of validated status.'),
-  allow('src/lib/overdeck/review-status-sync.ts', 'reviewedAtCommit', 115, 'reviewedAtCommit: row.reviewed_at_commit ?? undefined', 'Review cache deserialization.'),
-  allow('src/lib/overdeck/review-status-sync.ts', 'lastVerifiedCommit', 127, 'lastVerifiedCommit: row.last_verified_commit ?? undefined', 'Review cache deserialization.'),
-  allow('src/lib/pan-dir/records.ts', 'reviewedAtCommit', 124, 'reviewedAtCommit: status.reviewedAtCommit', 'Durable record serialization of validated status.'),
-  allow('src/lib/pan-dir/records.ts', 'lastVerifiedCommit', 125, 'lastVerifiedCommit: status.lastVerifiedCommit', 'Durable record serialization of validated status.'),
-  allow('src/lib/pan-dir/verdict-restore.ts', 'reviewedAtCommit', 64, 'reviewedAtCommit: pipeline.reviewedAtCommit ? rehydrateHeadAnchor(pipeline.reviewedAtCommit) : undefined', 'Explicit durable-record rehydration.'),
-  allow('src/lib/pan-dir/verdict-restore.ts', 'lastVerifiedCommit', 68, 'lastVerifiedCommit: pipeline.lastVerifiedCommit ? rehydrateHeadAnchor(pipeline.lastVerifiedCommit) : undefined', 'Explicit durable-record rehydration.'),
-  allow('src/lib/reconstruct/reconstruct-cache.ts', 'roleRunHead', 88, 'roleRunHead: state.roleRunHead || undefined', 'Cache reconstruction from durable state.'),
-  allow('src/lib/reconstruct/reconstruct-cache.ts', 'reviewedAtCommit', 200, 'reviewedAtCommit: pipeline.reviewedAtCommit', 'Cache reconstruction from durable state.'),
-  allow('src/lib/reconstruct/reconstruct-cache.ts', 'lastVerifiedCommit', 201, 'lastVerifiedCommit: pipeline.lastVerifiedCommit', 'Cache reconstruction from durable state.'),
-  allow('src/lib/reconstruct/reconstruct-cache.ts', 'roleRunHead', 330, 'roleRunHead: agent.roleRunHead ?? undefined', 'Cache reconstruction from agent storage.'),
-  allow('src/lib/reopen.ts', 'reviewedAtCommit', 78, 'reviewedAtCommit: undefined', 'Explicit reopen clear.'),
-  allow('src/lib/review-status.ts', 'reviewedAtCommit', 640, 'reviewedAtCommit: undefined', 'Explicit work-start clear.'),
-  allow('src/lib/review-status.ts', 'lastVerifiedCommit', 641, 'lastVerifiedCommit: undefined', 'Explicit work-start clear.'),
-  allow('packages/contracts/src/types.ts', 'roleRunHead', 304, 'roleRunHead: Schema.optional(Schema.String)', 'Unbranded wire schema boundary.'),
-  allow('packages/contracts/src/types.ts', 'reviewedAtCommit', 381, 'reviewedAtCommit: Schema.optional(Schema.String)', 'Unbranded wire schema boundary.'),
-  allow('packages/contracts/src/types.ts', 'lastVerifiedCommit', 383, 'lastVerifiedCommit: Schema.optional(Schema.String)', 'Unbranded wire schema boundary.'),
+  allow('src/cli/commands/specialists/done.ts', 'reviewedAtCommit', 'update.reviewedAtCommit = workspaceHead', 'Producer-fed review verdict CLI stamp.'),
+  allow('src/dashboard/server/read-model.ts', 'reviewedAtCommit', 'reviewedAtCommit: status.reviewedAtCommit || undefined', 'Read-model projection of persisted status.'),
+  allow('src/dashboard/server/routes/specialists/legacy-routes.ts', 'reviewedAtCommit', 'reviewedAtCommit: headAnchor', 'Producer-fed legacy review verdict stamp.'),
+  allow('src/dashboard/server/routes/workspaces/review-control.ts', 'reviewedAtCommit', 'reviewedAtCommit: undefined', 'Explicit review-reset clear.'),
+  allow('src/dashboard/server/routes/workspaces.ts', 'reviewedAtCommit', 'update.reviewedAtCommit = headAnchor', 'Producer-fed review status route stamp.'),
+  allow('src/lib/agents/agent-state.ts', 'roleRunHead', 'roleRunHead: raw.roleRunHead', 'Agent-state storage deserialization.'),
+  allow('src/lib/agents/spawn.ts', 'roleRunHead', 'state.roleRunHead = headAnchor', 'Producer-fed role-run stamp.'),
+  allow('src/lib/cloister/deacon-review-status.ts', 'reviewedAtCommit', "reviewUpdate['reviewedAtCommit'] = await snapshotWorkspaceHeadsPromise(issueId, workspacePath)", 'Producer-fed review recovery stamp.'),
+  allow('src/lib/cloister/deacon.ts', 'reviewedAtCommit', 'reviewedAtCommit: status.reviewedAtCommit', 'Diagnostic nudge payload mirrors persisted status.'),
+  allow('src/lib/cloister/deacon.ts', 'lastVerifiedCommit', 'lastVerifiedCommit: status.lastVerifiedCommit', 'Diagnostic nudge payload mirrors persisted status.'),
+  allow('src/lib/cloister/deacon.ts', 'reviewedAtCommit', 'reviewedAtCommit', 'Producer-fed verification-bypass stamp.'),
+  allow('src/lib/cloister/deacon.ts', 'reviewedAtCommit', 'reviewedAtCommit: verdict.currentAnchor', 'Drift evaluator advances a proven-benign anchor.'),
+  allow('src/lib/cloister/deacon.ts', 'reviewedAtCommit', 'reviewedAtCommit: undefined', 'Explicit stale-review clear.'),
+  allow('src/lib/cloister/verification-runner.ts', 'lastVerifiedCommit', 'lastVerifiedCommit', 'Producer-fed verification stamp.'),
+  allow('src/lib/database/agent-backfill.ts', 'roleRunHead', "roleRunHead: 'role_run_head'", 'Database backfill column mapping.'),
+  allow('src/lib/database/agent-mappers.ts', 'roleRunHead', 'roleRunHead: state.roleRunHead ?? null', 'Agent runtime serialization.'),
+  allow('src/lib/database/agents-db.ts', 'roleRunHead', "roleRunHead: (row['role_run_head'] as string | null) ?? null", 'Agent runtime deserialization.'),
+  allow('src/lib/database/review-status-db.ts', 'reviewedAtCommit', 'reviewedAtCommit: row.reviewed_at_commit ?? undefined', 'Review cache deserialization.'),
+  allow('src/lib/database/review-status-db.ts', 'lastVerifiedCommit', 'lastVerifiedCommit: row.last_verified_commit ?? undefined', 'Review cache deserialization.'),
+  allow('src/lib/overdeck/agent-state-sync.ts', 'roleRunHead', 'roleRunHead: row.role_run_head ?? undefined', 'Agent cache reconciliation.'),
+  allow('src/lib/overdeck/agents.ts', 'roleRunHead', "roleRunHead: (row['role_run_head'] as string | null) ?? null", 'Agent cache deserialization.'),
+  allow('src/lib/overdeck/review-status-record-sync.ts', 'reviewedAtCommit', 'reviewedAtCommit: p.reviewedAtCommit', 'Durable record mirror of validated status.'),
+  allow('src/lib/overdeck/review-status-record-sync.ts', 'lastVerifiedCommit', 'lastVerifiedCommit: p.lastVerifiedCommit', 'Durable record mirror of validated status.'),
+  allow('src/lib/overdeck/review-status-sync.ts', 'reviewedAtCommit', 'reviewedAtCommit: row.reviewed_at_commit ?? undefined', 'Review cache deserialization.'),
+  allow('src/lib/overdeck/review-status-sync.ts', 'lastVerifiedCommit', 'lastVerifiedCommit: row.last_verified_commit ?? undefined', 'Review cache deserialization.'),
+  allow('src/lib/pan-dir/records.ts', 'reviewedAtCommit', 'reviewedAtCommit: status.reviewedAtCommit', 'Durable record serialization of validated status.'),
+  allow('src/lib/pan-dir/records.ts', 'lastVerifiedCommit', 'lastVerifiedCommit: status.lastVerifiedCommit', 'Durable record serialization of validated status.'),
+  allow('src/lib/pan-dir/verdict-restore.ts', 'reviewedAtCommit', 'reviewedAtCommit: pipeline.reviewedAtCommit ? rehydrateHeadAnchor(pipeline.reviewedAtCommit) : undefined', 'Explicit durable-record rehydration.'),
+  allow('src/lib/pan-dir/verdict-restore.ts', 'lastVerifiedCommit', 'lastVerifiedCommit: pipeline.lastVerifiedCommit ? rehydrateHeadAnchor(pipeline.lastVerifiedCommit) : undefined', 'Explicit durable-record rehydration.'),
+  allow('src/lib/reconstruct/reconstruct-cache.ts', 'roleRunHead', 'roleRunHead: state.roleRunHead || undefined', 'Cache reconstruction from durable state.'),
+  allow('src/lib/reconstruct/reconstruct-cache.ts', 'reviewedAtCommit', 'reviewedAtCommit: pipeline.reviewedAtCommit', 'Cache reconstruction from durable state.'),
+  allow('src/lib/reconstruct/reconstruct-cache.ts', 'lastVerifiedCommit', 'lastVerifiedCommit: pipeline.lastVerifiedCommit', 'Cache reconstruction from durable state.'),
+  allow('src/lib/reconstruct/reconstruct-cache.ts', 'roleRunHead', 'roleRunHead: agent.roleRunHead ?? undefined', 'Cache reconstruction from agent storage.'),
+  allow('src/lib/reopen.ts', 'reviewedAtCommit', 'reviewedAtCommit: undefined', 'Explicit reopen clear.'),
+  allow('src/lib/review-status.ts', 'reviewedAtCommit', 'reviewedAtCommit: undefined', 'Explicit work-start clear.'),
+  allow('src/lib/review-status.ts', 'lastVerifiedCommit', 'lastVerifiedCommit: undefined', 'Explicit work-start clear.'),
+  allow('packages/contracts/src/types.ts', 'roleRunHead', 'roleRunHead: Schema.optional(Schema.String)', 'Unbranded wire schema boundary.'),
+  allow('packages/contracts/src/types.ts', 'reviewedAtCommit', 'reviewedAtCommit: Schema.optional(Schema.String)', 'Unbranded wire schema boundary.'),
+  allow('packages/contracts/src/types.ts', 'lastVerifiedCommit', 'lastVerifiedCommit: Schema.optional(Schema.String)', 'Unbranded wire schema boundary.'),
 ];
 
 function propertyName(node: ts.PropertyName): string | undefined {
@@ -88,7 +88,6 @@ function scanSource(file: string, source: string): AnchorWrite[] {
     writes.push({
       file,
       field: field as AnchorField,
-      line: sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1,
       expression: node.getText(sourceFile).replace(/\s+/g, ' '),
     });
   }
@@ -133,7 +132,6 @@ function scanRepository(): AnchorWrite[] {
 function sameWrite(left: AnchorWrite, right: AnchorWrite): boolean {
   return left.file === right.file
     && left.field === right.field
-    && left.line === right.line
     && left.expression === right.expression;
 }
 
@@ -150,28 +148,29 @@ function withoutReasons(sites: readonly AllowedWriteSite[]): AnchorWrite[] {
 
 function sortWrites(writes: AnchorWrite[]): AnchorWrite[] {
   return [...writes].sort((left, right) =>
-    `${left.file}:${left.line}:${left.field}`.localeCompare(`${right.file}:${right.line}:${right.field}`),
+    `${left.file}:${left.field}:${left.expression}`.localeCompare(
+      `${right.file}:${right.field}:${right.expression}`,
+    ),
   );
 }
 
 describe('HeadAnchor write-site inventory', () => {
-  it('locks every documented write occurrence, source expression, and location', () => {
+  it('locks every documented write occurrence and source expression', () => {
     const writes = scanRepository();
     expect(violations(writes)).toEqual([]);
     expect(sortWrites(writes)).toEqual(sortWrites(withoutReasons(ALLOWED_WRITE_SITES)));
     for (const site of ALLOWED_WRITE_SITES) expect(site.reason.length).toBeGreaterThan(15);
   });
 
-  it('flags a raw write added beside a legitimate write in an allowlisted file', () => {
+  it('flags a raw write without coupling the legitimate allowance to source lines', () => {
     const file = 'src/lib/agents/spawn.ts';
     const writes = scanSource(
       file,
-      "const headAnchor = producer();\nstate.roleRunHead = headAnchor;\nstate.roleRunHead = 'raw-string';\n",
+      "// unrelated edit shifts the write\n\nconst headAnchor = producer();\nstate.roleRunHead = headAnchor;\nstate.roleRunHead = 'raw-string';\n",
     );
     const allowed = [allow(
       file,
       'roleRunHead',
-      2,
       'state.roleRunHead = headAnchor',
       'Fixture producer-fed write.',
     )];
@@ -179,7 +178,6 @@ describe('HeadAnchor write-site inventory', () => {
     expect(violations(writes, allowed)).toEqual([{
       file,
       field: 'roleRunHead',
-      line: 3,
       expression: "state.roleRunHead = 'raw-string'",
     }]);
   });

--- a/tests/unit/lib/head-anchor-write-sites.test.ts
+++ b/tests/unit/lib/head-anchor-write-sites.test.ts
@@ -9,10 +9,10 @@ interface AnchorWrite {
   file: string;
   field: AnchorField;
   line: number;
+  expression: string;
 }
 
-interface AllowedWriteSite {
-  fields: readonly AnchorField[];
+interface AllowedWriteSite extends AnchorWrite {
   reason: string;
 }
 
@@ -22,104 +22,57 @@ const ANCHOR_FIELDS = new Set<AnchorField>([
   'roleRunHead',
 ]);
 
-const ALLOWED_WRITE_SITES: Record<string, AllowedWriteSite> = {
-  'packages/contracts/src/types.ts': {
-    fields: ['reviewedAtCommit', 'lastVerifiedCommit', 'roleRunHead'],
-    reason: 'Wire schemas intentionally remain unbranded strings at serialization boundaries.',
-  },
-  'src/cli/commands/specialists/done.ts': {
-    fields: ['reviewedAtCommit'],
-    reason: 'The review verdict CLI stamps the producer-issued workspace snapshot.',
-  },
-  'src/dashboard/server/read-model.ts': {
-    fields: ['reviewedAtCommit'],
-    reason: 'The dashboard read model projects persisted status without fabricating an anchor.',
-  },
-  'src/dashboard/server/routes/specialists/legacy-routes.ts': {
-    fields: ['reviewedAtCommit'],
-    reason: 'The legacy review verdict route stamps snapshotWorkspaceHeadsPromise output.',
-  },
-  'src/dashboard/server/routes/workspaces/review-control.ts': {
-    fields: ['reviewedAtCommit'],
-    reason: 'Review reset explicitly clears the prior anchor with undefined.',
-  },
-  'src/dashboard/server/routes/workspaces.ts': {
-    fields: ['reviewedAtCommit'],
-    reason: 'The review status route stamps snapshotWorkspaceHeadsPromise output.',
-  },
-  'src/lib/agents/agent-state.ts': {
-    fields: ['roleRunHead'],
-    reason: 'Agent-state deserialization copies the persisted storage value.',
-  },
-  'src/lib/agents/spawn.ts': {
-    fields: ['roleRunHead'],
-    reason: 'Role spawn stamps snapshotWorkspaceHeadsPromise output.',
-  },
-  'src/lib/cloister/deacon-review-status.ts': {
-    fields: ['reviewedAtCommit'],
-    reason: 'Review recovery stamps snapshotWorkspaceHeadsPromise output.',
-  },
-  'src/lib/cloister/deacon.ts': {
-    fields: ['reviewedAtCommit', 'lastVerifiedCommit'],
-    reason: 'The deacon logs stored anchors, stamps producer/evaluator output, and clears stale verdicts.',
-  },
-  'src/lib/cloister/verification-runner.ts': {
-    fields: ['lastVerifiedCommit'],
-    reason: 'Verification stamps snapshotWorkspaceHeadsPromise output.',
-  },
-  'src/lib/database/agent-backfill.ts': {
-    fields: ['roleRunHead'],
-    reason: 'The database backfill maps the storage column name.',
-  },
-  'src/lib/database/agent-mappers.ts': {
-    fields: ['roleRunHead'],
-    reason: 'The database mapper serializes the already-stamped runtime value.',
-  },
-  'src/lib/database/agents-db.ts': {
-    fields: ['roleRunHead'],
-    reason: 'The database mapper deserializes the persisted runtime value.',
-  },
-  'src/lib/database/review-status-db.ts': {
-    fields: ['reviewedAtCommit', 'lastVerifiedCommit'],
-    reason: 'The database mapper deserializes persisted review anchors.',
-  },
-  'src/lib/overdeck/agent-state-sync.ts': {
-    fields: ['roleRunHead'],
-    reason: 'Agent cache reconciliation copies the persisted runtime value.',
-  },
-  'src/lib/overdeck/agents.ts': {
-    fields: ['roleRunHead'],
-    reason: 'Agent cache mapping deserializes the persisted runtime value.',
-  },
-  'src/lib/overdeck/review-status-record-sync.ts': {
-    fields: ['reviewedAtCommit', 'lastVerifiedCommit'],
-    reason: 'The durable record mirror copies already-validated review anchors.',
-  },
-  'src/lib/overdeck/review-status-sync.ts': {
-    fields: ['reviewedAtCommit', 'lastVerifiedCommit'],
-    reason: 'Review cache mapping deserializes persisted review anchors.',
-  },
-  'src/lib/pan-dir/records.ts': {
-    fields: ['reviewedAtCommit', 'lastVerifiedCommit'],
-    reason: 'The durable record writer mirrors already-validated review anchors.',
-  },
-  'src/lib/pan-dir/verdict-restore.ts': {
-    fields: ['reviewedAtCommit', 'lastVerifiedCommit'],
-    reason: 'Verdict restoration explicitly rehydrates stored strings at the write door.',
-  },
-  'src/lib/reconstruct/reconstruct-cache.ts': {
-    fields: ['reviewedAtCommit', 'lastVerifiedCommit', 'roleRunHead'],
-    reason: 'Cache reconstruction copies values from durable storage into cache models.',
-  },
-  'src/lib/reopen.ts': {
-    fields: ['reviewedAtCommit'],
-    reason: 'Reopening an issue explicitly clears the prior review anchor.',
-  },
-  'src/lib/review-status.ts': {
-    fields: ['reviewedAtCommit', 'lastVerifiedCommit'],
-    reason: 'Starting fresh work explicitly clears both review anchors.',
-  },
-};
+function allow(
+  file: string,
+  field: AnchorField,
+  line: number,
+  expression: string,
+  reason: string,
+): AllowedWriteSite {
+  return { file, field, line, expression, reason };
+}
+
+const ALLOWED_WRITE_SITES: AllowedWriteSite[] = [
+  allow('src/cli/commands/specialists/done.ts', 'reviewedAtCommit', 159, 'update.reviewedAtCommit = workspaceHead', 'Producer-fed review verdict CLI stamp.'),
+  allow('src/dashboard/server/read-model.ts', 'reviewedAtCommit', 336, 'reviewedAtCommit: status.reviewedAtCommit || undefined', 'Read-model projection of persisted status.'),
+  allow('src/dashboard/server/routes/specialists/legacy-routes.ts', 'reviewedAtCommit', 304, 'reviewedAtCommit: headAnchor', 'Producer-fed legacy review verdict stamp.'),
+  allow('src/dashboard/server/routes/workspaces/review-control.ts', 'reviewedAtCommit', 283, 'reviewedAtCommit: undefined', 'Explicit review-reset clear.'),
+  allow('src/dashboard/server/routes/workspaces.ts', 'reviewedAtCommit', 1466, 'update.reviewedAtCommit = headAnchor', 'Producer-fed review status route stamp.'),
+  allow('src/lib/agents/agent-state.ts', 'roleRunHead', 246, 'roleRunHead: raw.roleRunHead', 'Agent-state storage deserialization.'),
+  allow('src/lib/agents/spawn.ts', 'roleRunHead', 470, 'state.roleRunHead = headAnchor', 'Producer-fed role-run stamp.'),
+  allow('src/lib/cloister/deacon-review-status.ts', 'reviewedAtCommit', 544, "reviewUpdate['reviewedAtCommit'] = await snapshotWorkspaceHeadsPromise(issueId, workspacePath)", 'Producer-fed review recovery stamp.'),
+  allow('src/lib/cloister/deacon.ts', 'reviewedAtCommit', 1336, 'reviewedAtCommit: status.reviewedAtCommit', 'Diagnostic nudge payload mirrors persisted status.'),
+  allow('src/lib/cloister/deacon.ts', 'lastVerifiedCommit', 1337, 'lastVerifiedCommit: status.lastVerifiedCommit', 'Diagnostic nudge payload mirrors persisted status.'),
+  allow('src/lib/cloister/deacon.ts', 'reviewedAtCommit', 1535, 'reviewedAtCommit', 'Producer-fed verification-bypass stamp.'),
+  allow('src/lib/cloister/deacon.ts', 'reviewedAtCommit', 1606, 'reviewedAtCommit: verdict.currentAnchor', 'Drift evaluator advances a proven-benign anchor.'),
+  allow('src/lib/cloister/deacon.ts', 'reviewedAtCommit', 1622, 'reviewedAtCommit: undefined', 'Explicit stale-review clear.'),
+  allow('src/lib/cloister/verification-runner.ts', 'lastVerifiedCommit', 892, 'lastVerifiedCommit', 'Producer-fed verification stamp.'),
+  allow('src/lib/database/agent-backfill.ts', 'roleRunHead', 73, "roleRunHead: 'role_run_head'", 'Database backfill column mapping.'),
+  allow('src/lib/database/agent-mappers.ts', 'roleRunHead', 49, 'roleRunHead: state.roleRunHead ?? null', 'Agent runtime serialization.'),
+  allow('src/lib/database/agents-db.ts', 'roleRunHead', 104, "roleRunHead: (row['role_run_head'] as string | null) ?? null", 'Agent runtime deserialization.'),
+  allow('src/lib/database/review-status-db.ts', 'reviewedAtCommit', 479, 'reviewedAtCommit: row.reviewed_at_commit ?? undefined', 'Review cache deserialization.'),
+  allow('src/lib/database/review-status-db.ts', 'lastVerifiedCommit', 489, 'lastVerifiedCommit: row.last_verified_commit ?? undefined', 'Review cache deserialization.'),
+  allow('src/lib/overdeck/agent-state-sync.ts', 'roleRunHead', 171, 'roleRunHead: row.role_run_head ?? undefined', 'Agent cache reconciliation.'),
+  allow('src/lib/overdeck/agents.ts', 'roleRunHead', 1099, "roleRunHead: (row['role_run_head'] as string | null) ?? null", 'Agent cache deserialization.'),
+  allow('src/lib/overdeck/review-status-record-sync.ts', 'reviewedAtCommit', 121, 'reviewedAtCommit: p.reviewedAtCommit', 'Durable record mirror of validated status.'),
+  allow('src/lib/overdeck/review-status-record-sync.ts', 'lastVerifiedCommit', 122, 'lastVerifiedCommit: p.lastVerifiedCommit', 'Durable record mirror of validated status.'),
+  allow('src/lib/overdeck/review-status-sync.ts', 'reviewedAtCommit', 115, 'reviewedAtCommit: row.reviewed_at_commit ?? undefined', 'Review cache deserialization.'),
+  allow('src/lib/overdeck/review-status-sync.ts', 'lastVerifiedCommit', 127, 'lastVerifiedCommit: row.last_verified_commit ?? undefined', 'Review cache deserialization.'),
+  allow('src/lib/pan-dir/records.ts', 'reviewedAtCommit', 124, 'reviewedAtCommit: status.reviewedAtCommit', 'Durable record serialization of validated status.'),
+  allow('src/lib/pan-dir/records.ts', 'lastVerifiedCommit', 125, 'lastVerifiedCommit: status.lastVerifiedCommit', 'Durable record serialization of validated status.'),
+  allow('src/lib/pan-dir/verdict-restore.ts', 'reviewedAtCommit', 64, 'reviewedAtCommit: pipeline.reviewedAtCommit ? rehydrateHeadAnchor(pipeline.reviewedAtCommit) : undefined', 'Explicit durable-record rehydration.'),
+  allow('src/lib/pan-dir/verdict-restore.ts', 'lastVerifiedCommit', 68, 'lastVerifiedCommit: pipeline.lastVerifiedCommit ? rehydrateHeadAnchor(pipeline.lastVerifiedCommit) : undefined', 'Explicit durable-record rehydration.'),
+  allow('src/lib/reconstruct/reconstruct-cache.ts', 'roleRunHead', 88, 'roleRunHead: state.roleRunHead || undefined', 'Cache reconstruction from durable state.'),
+  allow('src/lib/reconstruct/reconstruct-cache.ts', 'reviewedAtCommit', 200, 'reviewedAtCommit: pipeline.reviewedAtCommit', 'Cache reconstruction from durable state.'),
+  allow('src/lib/reconstruct/reconstruct-cache.ts', 'lastVerifiedCommit', 201, 'lastVerifiedCommit: pipeline.lastVerifiedCommit', 'Cache reconstruction from durable state.'),
+  allow('src/lib/reconstruct/reconstruct-cache.ts', 'roleRunHead', 330, 'roleRunHead: agent.roleRunHead ?? undefined', 'Cache reconstruction from agent storage.'),
+  allow('src/lib/reopen.ts', 'reviewedAtCommit', 78, 'reviewedAtCommit: undefined', 'Explicit reopen clear.'),
+  allow('src/lib/review-status.ts', 'reviewedAtCommit', 640, 'reviewedAtCommit: undefined', 'Explicit work-start clear.'),
+  allow('src/lib/review-status.ts', 'lastVerifiedCommit', 641, 'lastVerifiedCommit: undefined', 'Explicit work-start clear.'),
+  allow('packages/contracts/src/types.ts', 'roleRunHead', 304, 'roleRunHead: Schema.optional(Schema.String)', 'Unbranded wire schema boundary.'),
+  allow('packages/contracts/src/types.ts', 'reviewedAtCommit', 381, 'reviewedAtCommit: Schema.optional(Schema.String)', 'Unbranded wire schema boundary.'),
+  allow('packages/contracts/src/types.ts', 'lastVerifiedCommit', 383, 'lastVerifiedCommit: Schema.optional(Schema.String)', 'Unbranded wire schema boundary.'),
+];
 
 function propertyName(node: ts.PropertyName): string | undefined {
   if (ts.isIdentifier(node) || ts.isStringLiteral(node)) return node.text;
@@ -136,6 +89,7 @@ function scanSource(file: string, source: string): AnchorWrite[] {
       file,
       field: field as AnchorField,
       line: sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1,
+      expression: node.getText(sourceFile).replace(/\s+/g, ' '),
     });
   }
 
@@ -176,34 +130,57 @@ function scanRepository(): AnchorWrite[] {
   ));
 }
 
-function violations(writes: AnchorWrite[]): AnchorWrite[] {
-  return writes.filter((write) => {
-    const allowed = ALLOWED_WRITE_SITES[write.file];
-    return !allowed || !allowed.fields.includes(write.field);
-  });
+function sameWrite(left: AnchorWrite, right: AnchorWrite): boolean {
+  return left.file === right.file
+    && left.field === right.field
+    && left.line === right.line
+    && left.expression === right.expression;
+}
+
+function violations(
+  writes: AnchorWrite[],
+  allowed: readonly AllowedWriteSite[] = ALLOWED_WRITE_SITES,
+): AnchorWrite[] {
+  return writes.filter(write => !allowed.some(site => sameWrite(write, site)));
+}
+
+function withoutReasons(sites: readonly AllowedWriteSite[]): AnchorWrite[] {
+  return sites.map(({ reason: _reason, ...write }) => write);
+}
+
+function sortWrites(writes: AnchorWrite[]): AnchorWrite[] {
+  return [...writes].sort((left, right) =>
+    `${left.file}:${left.line}:${left.field}`.localeCompare(`${right.file}:${right.line}:${right.field}`),
+  );
 }
 
 describe('HeadAnchor write-site inventory', () => {
-  it('allows only documented producer, clear, mirror, and deserializer sites', () => {
+  it('locks every documented write occurrence, source expression, and location', () => {
     const writes = scanRepository();
     expect(violations(writes)).toEqual([]);
-
-    const observed = new Set(writes.map(write => `${write.file}:${write.field}`));
-    const allowed = Object.entries(ALLOWED_WRITE_SITES).flatMap(([file, site]) => {
-      expect(site.reason.length).toBeGreaterThan(20);
-      return site.fields.map(field => `${file}:${field}`);
-    });
-    expect([...observed].sort()).toEqual(allowed.sort());
+    expect(sortWrites(writes)).toEqual(sortWrites(withoutReasons(ALLOWED_WRITE_SITES)));
+    for (const site of ALLOWED_WRITE_SITES) expect(site.reason.length).toBeGreaterThan(15);
   });
 
-  it('flags an unlisted raw-string write with its file and line', () => {
+  it('flags a raw write added beside a legitimate write in an allowlisted file', () => {
+    const file = 'src/lib/agents/spawn.ts';
     const writes = scanSource(
-      'src/lib/unlisted-anchor-writer.ts',
-      "const update = { reviewedAtCommit: 'raw-string' };\n",
+      file,
+      "const headAnchor = producer();\nstate.roleRunHead = headAnchor;\nstate.roleRunHead = 'raw-string';\n",
     );
+    const allowed = [allow(
+      file,
+      'roleRunHead',
+      2,
+      'state.roleRunHead = headAnchor',
+      'Fixture producer-fed write.',
+    )];
 
-    expect(violations(writes)).toEqual([
-      { file: 'src/lib/unlisted-anchor-writer.ts', field: 'reviewedAtCommit', line: 1 },
-    ]);
+    expect(violations(writes, allowed)).toEqual([{
+      file,
+      field: 'roleRunHead',
+      line: 3,
+      expression: "state.roleRunHead = 'raw-string'",
+    }]);
   });
 });

--- a/tests/unit/lib/head-anchor-write-sites.test.ts
+++ b/tests/unit/lib/head-anchor-write-sites.test.ts
@@ -1,0 +1,209 @@
+import { readdirSync, readFileSync } from 'fs';
+import { join, relative } from 'path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+type AnchorField = 'reviewedAtCommit' | 'lastVerifiedCommit' | 'roleRunHead';
+
+interface AnchorWrite {
+  file: string;
+  field: AnchorField;
+  line: number;
+}
+
+interface AllowedWriteSite {
+  fields: readonly AnchorField[];
+  reason: string;
+}
+
+const ANCHOR_FIELDS = new Set<AnchorField>([
+  'reviewedAtCommit',
+  'lastVerifiedCommit',
+  'roleRunHead',
+]);
+
+const ALLOWED_WRITE_SITES: Record<string, AllowedWriteSite> = {
+  'packages/contracts/src/types.ts': {
+    fields: ['reviewedAtCommit', 'lastVerifiedCommit', 'roleRunHead'],
+    reason: 'Wire schemas intentionally remain unbranded strings at serialization boundaries.',
+  },
+  'src/cli/commands/specialists/done.ts': {
+    fields: ['reviewedAtCommit'],
+    reason: 'The review verdict CLI stamps the producer-issued workspace snapshot.',
+  },
+  'src/dashboard/server/read-model.ts': {
+    fields: ['reviewedAtCommit'],
+    reason: 'The dashboard read model projects persisted status without fabricating an anchor.',
+  },
+  'src/dashboard/server/routes/specialists/legacy-routes.ts': {
+    fields: ['reviewedAtCommit'],
+    reason: 'The legacy review verdict route stamps snapshotWorkspaceHeadsPromise output.',
+  },
+  'src/dashboard/server/routes/workspaces/review-control.ts': {
+    fields: ['reviewedAtCommit'],
+    reason: 'Review reset explicitly clears the prior anchor with undefined.',
+  },
+  'src/dashboard/server/routes/workspaces.ts': {
+    fields: ['reviewedAtCommit'],
+    reason: 'The review status route stamps snapshotWorkspaceHeadsPromise output.',
+  },
+  'src/lib/agents/agent-state.ts': {
+    fields: ['roleRunHead'],
+    reason: 'Agent-state deserialization copies the persisted storage value.',
+  },
+  'src/lib/agents/spawn.ts': {
+    fields: ['roleRunHead'],
+    reason: 'Role spawn stamps snapshotWorkspaceHeadsPromise output.',
+  },
+  'src/lib/cloister/deacon-review-status.ts': {
+    fields: ['reviewedAtCommit'],
+    reason: 'Review recovery stamps snapshotWorkspaceHeadsPromise output.',
+  },
+  'src/lib/cloister/deacon.ts': {
+    fields: ['reviewedAtCommit', 'lastVerifiedCommit'],
+    reason: 'The deacon logs stored anchors, stamps producer/evaluator output, and clears stale verdicts.',
+  },
+  'src/lib/cloister/verification-runner.ts': {
+    fields: ['lastVerifiedCommit'],
+    reason: 'Verification stamps snapshotWorkspaceHeadsPromise output.',
+  },
+  'src/lib/database/agent-backfill.ts': {
+    fields: ['roleRunHead'],
+    reason: 'The database backfill maps the storage column name.',
+  },
+  'src/lib/database/agent-mappers.ts': {
+    fields: ['roleRunHead'],
+    reason: 'The database mapper serializes the already-stamped runtime value.',
+  },
+  'src/lib/database/agents-db.ts': {
+    fields: ['roleRunHead'],
+    reason: 'The database mapper deserializes the persisted runtime value.',
+  },
+  'src/lib/database/review-status-db.ts': {
+    fields: ['reviewedAtCommit', 'lastVerifiedCommit'],
+    reason: 'The database mapper deserializes persisted review anchors.',
+  },
+  'src/lib/overdeck/agent-state-sync.ts': {
+    fields: ['roleRunHead'],
+    reason: 'Agent cache reconciliation copies the persisted runtime value.',
+  },
+  'src/lib/overdeck/agents.ts': {
+    fields: ['roleRunHead'],
+    reason: 'Agent cache mapping deserializes the persisted runtime value.',
+  },
+  'src/lib/overdeck/review-status-record-sync.ts': {
+    fields: ['reviewedAtCommit', 'lastVerifiedCommit'],
+    reason: 'The durable record mirror copies already-validated review anchors.',
+  },
+  'src/lib/overdeck/review-status-sync.ts': {
+    fields: ['reviewedAtCommit', 'lastVerifiedCommit'],
+    reason: 'Review cache mapping deserializes persisted review anchors.',
+  },
+  'src/lib/pan-dir/records.ts': {
+    fields: ['reviewedAtCommit', 'lastVerifiedCommit'],
+    reason: 'The durable record writer mirrors already-validated review anchors.',
+  },
+  'src/lib/pan-dir/verdict-restore.ts': {
+    fields: ['reviewedAtCommit', 'lastVerifiedCommit'],
+    reason: 'Verdict restoration explicitly rehydrates stored strings at the write door.',
+  },
+  'src/lib/reconstruct/reconstruct-cache.ts': {
+    fields: ['reviewedAtCommit', 'lastVerifiedCommit', 'roleRunHead'],
+    reason: 'Cache reconstruction copies values from durable storage into cache models.',
+  },
+  'src/lib/reopen.ts': {
+    fields: ['reviewedAtCommit'],
+    reason: 'Reopening an issue explicitly clears the prior review anchor.',
+  },
+  'src/lib/review-status.ts': {
+    fields: ['reviewedAtCommit', 'lastVerifiedCommit'],
+    reason: 'Starting fresh work explicitly clears both review anchors.',
+  },
+};
+
+function propertyName(node: ts.PropertyName): string | undefined {
+  if (ts.isIdentifier(node) || ts.isStringLiteral(node)) return node.text;
+  return undefined;
+}
+
+function scanSource(file: string, source: string): AnchorWrite[] {
+  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true);
+  const writes: AnchorWrite[] = [];
+
+  function record(node: ts.Node, field: string | undefined): void {
+    if (!field || !ANCHOR_FIELDS.has(field as AnchorField)) return;
+    writes.push({
+      file,
+      field: field as AnchorField,
+      line: sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1,
+    });
+  }
+
+  function visit(node: ts.Node): void {
+    if (ts.isPropertyAssignment(node) || ts.isShorthandPropertyAssignment(node)) {
+      record(node, propertyName(node.name));
+    } else if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      if (ts.isPropertyAccessExpression(node.left)) {
+        record(node, node.left.name.text);
+      } else if (ts.isElementAccessExpression(node.left) && ts.isStringLiteral(node.left.argumentExpression)) {
+        record(node, node.left.argumentExpression.text);
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return writes;
+}
+
+function sourceFiles(root: string): string[] {
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) return entry.name === '__tests__' ? [] : sourceFiles(path);
+    return entry.isFile() && path.endsWith('.ts') ? [path] : [];
+  });
+}
+
+function scanRepository(): AnchorWrite[] {
+  const root = process.cwd();
+  const files = [
+    ...sourceFiles(join(root, 'src')),
+    join(root, 'packages', 'contracts', 'src', 'types.ts'),
+  ];
+  return files.flatMap((file) => scanSource(
+    relative(root, file).replaceAll('\\', '/'),
+    readFileSync(file, 'utf-8'),
+  ));
+}
+
+function violations(writes: AnchorWrite[]): AnchorWrite[] {
+  return writes.filter((write) => {
+    const allowed = ALLOWED_WRITE_SITES[write.file];
+    return !allowed || !allowed.fields.includes(write.field);
+  });
+}
+
+describe('HeadAnchor write-site inventory', () => {
+  it('allows only documented producer, clear, mirror, and deserializer sites', () => {
+    const writes = scanRepository();
+    expect(violations(writes)).toEqual([]);
+
+    const observed = new Set(writes.map(write => `${write.file}:${write.field}`));
+    const allowed = Object.entries(ALLOWED_WRITE_SITES).flatMap(([file, site]) => {
+      expect(site.reason.length).toBeGreaterThan(20);
+      return site.fields.map(field => `${file}:${field}`);
+    });
+    expect([...observed].sort()).toEqual(allowed.sort());
+  });
+
+  it('flags an unlisted raw-string write with its file and line', () => {
+    const writes = scanSource(
+      'src/lib/unlisted-anchor-writer.ts',
+      "const update = { reviewedAtCommit: 'raw-string' };\n",
+    );
+
+    expect(violations(writes)).toEqual([
+      { file: 'src/lib/unlisted-anchor-writer.ts', field: 'reviewedAtCommit', line: 1 },
+    ]);
+  });
+});

--- a/tests/unit/lib/review-status.test.ts
+++ b/tests/unit/lib/review-status.test.ts
@@ -33,6 +33,7 @@ vi.mock('../../../src/lib/telemetry/pipeline.js', () => ({
 }));
 
 import { getReviewStatusSync, setReviewStatusSync } from '../../../src/lib/review-status.js';
+import { rehydrateHeadAnchor } from '../../../src/lib/git-utils.js';
 
 describe('review status', () => {
   beforeEach(() => {
@@ -45,6 +46,15 @@ describe('review status', () => {
 
   afterEach(() => {
     testDb.close();
+  });
+
+  it('rejects raw strings at the review anchor write door', () => {
+    const invalidWrite = () => {
+      // @ts-expect-error reviewedAtCommit must be producer-issued or explicitly rehydrated.
+      setReviewStatusSync('PAN-3076', { reviewedAtCommit: 'raw-string' });
+    };
+
+    expect(invalidWrite).toBeTypeOf('function');
   });
 
   it('persists scope drift through the review status journal update', () => {
@@ -69,7 +79,8 @@ describe('review status', () => {
   });
 
   it('finalizes verification when no-code-drift skips the post-review test role', () => {
-    const head = 'abc123abc123abc123abc123abc123abc123abcd';
+    // This fixture simulates an anchor read back from unbranded storage.
+    const head = rehydrateHeadAnchor('abc123abc123abc123abc123abc123abc123abcd');
     setReviewStatusSync('PAN-2200', {
       reviewStatus: 'pending',
       testStatus: 'pending',

--- a/tests/unit/lib/workspace-anchor-drift.test.ts
+++ b/tests/unit/lib/workspace-anchor-drift.test.ts
@@ -123,6 +123,7 @@ describe('evaluateWorkspaceAnchorDrift', () => {
     await expect(evaluateWorkspaceAnchorDrift(
       'PAN-3076',
       workspace,
+      // The fixture simulates a legacy anchor read back from unbranded storage.
       rehydrateHeadAnchor('a'.repeat(40)),
     )).resolves.toMatchObject({ kind: 'drifted' });
   });
@@ -160,6 +161,7 @@ describe('evaluateWorkspaceAnchorDrift', () => {
     await expect(evaluateWorkspaceAnchorDrift(
       'PAN-3076',
       workspace,
+      // The fixture simulates a legacy anchor read back from unbranded storage.
       rehydrateHeadAnchor('a'.repeat(40)),
     )).resolves.toEqual({ kind: 'unreadable' });
   });

--- a/tests/unit/lib/workspace-anchor-drift.test.ts
+++ b/tests/unit/lib/workspace-anchor-drift.test.ts
@@ -1,0 +1,166 @@
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const repoRootsMock = vi.hoisted(() => ({
+  resolveWorkspaceRepoRootsSync: vi.fn(),
+}));
+
+vi.mock('../../../src/lib/project-repos.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/lib/project-repos.js')>(
+    '../../../src/lib/project-repos.js',
+  );
+  return {
+    ...actual,
+    resolveWorkspaceRepoRootsSync: repoRootsMock.resolveWorkspaceRepoRootsSync,
+  };
+});
+
+import {
+  rehydrateHeadAnchor,
+  snapshotWorkspaceHeadsPromise,
+} from '../../../src/lib/git-utils.js';
+import { evaluateWorkspaceAnchorDrift } from '../../../src/lib/workspace-anchor-drift.js';
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8' }).trim();
+}
+
+function initializeRepo(parent: string, name: string): string {
+  const repo = join(parent, name);
+  mkdirSync(repo, { recursive: true });
+  git(repo, 'init', '-b', 'main');
+  git(repo, 'config', 'user.email', 'test@test.com');
+  git(repo, 'config', 'user.name', 'Test');
+  writeFileSync(join(repo, 'app.ts'), `export const name = '${name}';\n`);
+  git(repo, 'add', '.');
+  git(repo, 'commit', '-m', 'base');
+  git(repo, 'update-ref', 'refs/remotes/origin/main', git(repo, 'rev-parse', 'HEAD'));
+  return repo;
+}
+
+function root(repoKey: string, dir: string, isPolyrepo: boolean) {
+  return {
+    repoKey,
+    dir,
+    sourceBranch: 'feature/pan-3076',
+    targetBranch: 'main',
+    isPolyrepo,
+  };
+}
+
+describe('evaluateWorkspaceAnchorDrift', () => {
+  let workspace: string;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'pan-3076-anchor-'));
+    repoRootsMock.resolveWorkspaceRepoRootsSync.mockReset();
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  it('reports current anchors and real changes in any polyrepo root', async () => {
+    const fe = initializeRepo(workspace, 'fe');
+    const api = initializeRepo(workspace, 'api');
+    repoRootsMock.resolveWorkspaceRepoRootsSync.mockReturnValue([
+      root('fe', fe, true),
+      root('api', api, true),
+    ]);
+    const storedAnchor = await snapshotWorkspaceHeadsPromise('PAN-3076', workspace);
+    expect(storedAnchor).toBeDefined();
+
+    await expect(evaluateWorkspaceAnchorDrift(
+      'PAN-3076',
+      workspace,
+      storedAnchor!,
+    )).resolves.toEqual({ kind: 'current', currentAnchor: storedAnchor });
+
+    writeFileSync(join(api, 'app.ts'), "export const name = 'changed';\n");
+    git(api, 'add', 'app.ts');
+    git(api, 'commit', '-m', 'change api');
+
+    const verdict = await evaluateWorkspaceAnchorDrift('PAN-3076', workspace, storedAnchor!);
+    expect(verdict.kind).toBe('drifted');
+    expect(verdict.changedRepos).toEqual(['api']);
+  });
+
+  it('reports a tree-identical rewritten sub-repo head as benign', async () => {
+    const fe = initializeRepo(workspace, 'fe');
+    const api = initializeRepo(workspace, 'api');
+    repoRootsMock.resolveWorkspaceRepoRootsSync.mockReturnValue([
+      root('fe', fe, true),
+      root('api', api, true),
+    ]);
+    const storedAnchor = await snapshotWorkspaceHeadsPromise('PAN-3076', workspace);
+    const tree = git(api, 'rev-parse', 'HEAD^{tree}');
+    const rewrittenHead = execFileSync(
+      'git',
+      ['commit-tree', tree],
+      { cwd: api, encoding: 'utf-8', input: 'rewritten base\n' },
+    ).trim();
+    git(api, 'update-ref', 'HEAD', rewrittenHead);
+
+    const verdict = await evaluateWorkspaceAnchorDrift('PAN-3076', workspace, storedAnchor!);
+    expect(verdict).toEqual({
+      kind: 'benign',
+      currentAnchor: await snapshotWorkspaceHeadsPromise('PAN-3076', workspace),
+      changedRepos: ['api'],
+    });
+  });
+
+  it('treats a legacy plain anchor against a composite snapshot as drifted', async () => {
+    const fe = initializeRepo(workspace, 'fe');
+    const api = initializeRepo(workspace, 'api');
+    repoRootsMock.resolveWorkspaceRepoRootsSync.mockReturnValue([
+      root('fe', fe, true),
+      root('api', api, true),
+    ]);
+
+    await expect(evaluateWorkspaceAnchorDrift(
+      'PAN-3076',
+      workspace,
+      rehydrateHeadAnchor('a'.repeat(40)),
+    )).resolves.toMatchObject({ kind: 'drifted' });
+  });
+
+  it('preserves monorepo benign semantics and detects real code drift', async () => {
+    const repo = initializeRepo(workspace, 'repo');
+    repoRootsMock.resolveWorkspaceRepoRootsSync.mockReturnValue([root('overdeck', repo, false)]);
+    const storedAnchor = await snapshotWorkspaceHeadsPromise('PAN-3076', repo);
+
+    mkdirSync(join(repo, '.pan', 'specs'), { recursive: true });
+    writeFileSync(join(repo, '.pan', 'specs', 'plan.json'), '{}\n');
+    git(repo, 'add', '.pan');
+    git(repo, 'commit', '-m', 'state only');
+    await expect(evaluateWorkspaceAnchorDrift(
+      'PAN-3076',
+      repo,
+      storedAnchor!,
+    )).resolves.toMatchObject({ kind: 'benign' });
+
+    writeFileSync(join(repo, 'app.ts'), "export const name = 'changed';\n");
+    git(repo, 'add', 'app.ts');
+    git(repo, 'commit', '-m', 'real code change');
+    await expect(evaluateWorkspaceAnchorDrift(
+      'PAN-3076',
+      repo,
+      storedAnchor!,
+    )).resolves.toMatchObject({ kind: 'drifted' });
+  });
+
+  it('reports unreadable when no current workspace head can be produced', async () => {
+    repoRootsMock.resolveWorkspaceRepoRootsSync.mockReturnValue([
+      root('missing', join(workspace, 'missing'), false),
+    ]);
+
+    await expect(evaluateWorkspaceAnchorDrift(
+      'PAN-3076',
+      workspace,
+      rehydrateHeadAnchor('a'.repeat(40)),
+    )).resolves.toEqual({ kind: 'unreadable' });
+  });
+});

--- a/tests/unit/lib/workspace-anchor-drift.test.ts
+++ b/tests/unit/lib/workspace-anchor-drift.test.ts
@@ -22,7 +22,10 @@ import {
   rehydrateHeadAnchor,
   snapshotWorkspaceHeadsPromise,
 } from '../../../src/lib/git-utils.js';
-import { evaluateWorkspaceAnchorDrift } from '../../../src/lib/workspace-anchor-drift.js';
+import {
+  evaluateWorkspaceAnchorDrift,
+  type WorkspaceAnchorDriftChecks,
+} from '../../../src/lib/workspace-anchor-drift.js';
 
 function git(cwd: string, ...args: string[]): string {
   return execFileSync('git', args, { cwd, encoding: 'utf-8' }).trim();
@@ -48,6 +51,17 @@ function root(repoKey: string, dir: string, isPolyrepo: boolean) {
     sourceBranch: 'feature/pan-3076',
     targetBranch: 'main',
     isPolyrepo,
+  };
+}
+
+function checks(
+  overrides: Partial<WorkspaceAnchorDriftChecks> = {},
+): WorkspaceAnchorDriftChecks {
+  return {
+    sameTree: vi.fn().mockResolvedValue(false),
+    sameEffectiveCode: vi.fn().mockResolvedValue(false),
+    sameCodeContribution: vi.fn().mockResolvedValue(false),
+    ...overrides,
   };
 }
 
@@ -151,6 +165,80 @@ describe('evaluateWorkspaceAnchorDrift', () => {
       repo,
       storedAnchor!,
     )).resolves.toMatchObject({ kind: 'drifted' });
+  });
+
+  it('continues to later benign checks when the tree lookup fails', async () => {
+    const repo = initializeRepo(workspace, 'repo');
+    repoRootsMock.resolveWorkspaceRepoRootsSync.mockReturnValue([root('overdeck', repo, false)]);
+    const storedAnchor = await snapshotWorkspaceHeadsPromise('PAN-3076', repo);
+    writeFileSync(join(repo, 'app.ts'), "export const name = 'changed';\n");
+    git(repo, 'add', 'app.ts');
+    git(repo, 'commit', '-m', 'rewrite code');
+    const sameCodeContribution = vi.fn().mockResolvedValue(false);
+    const probeChecks = checks({
+      sameTree: vi.fn().mockRejectedValue(new Error('tree unavailable')),
+      sameEffectiveCode: vi.fn().mockResolvedValue(true),
+      sameCodeContribution,
+    });
+
+    await expect(evaluateWorkspaceAnchorDrift(
+      'PAN-3076',
+      repo,
+      storedAnchor!,
+      probeChecks,
+    )).resolves.toMatchObject({ kind: 'benign' });
+    expect(probeChecks.sameEffectiveCode).toHaveBeenCalledOnce();
+    expect(sameCodeContribution).not.toHaveBeenCalled();
+  });
+
+  it('returns drifted when every benign comparison fails', async () => {
+    const repo = initializeRepo(workspace, 'repo');
+    repoRootsMock.resolveWorkspaceRepoRootsSync.mockReturnValue([root('overdeck', repo, false)]);
+    const storedAnchor = await snapshotWorkspaceHeadsPromise('PAN-3076', repo);
+    writeFileSync(join(repo, 'app.ts'), "export const name = 'changed';\n");
+    git(repo, 'add', 'app.ts');
+    git(repo, 'commit', '-m', 'uninspectable code move');
+    const probeChecks = checks({
+      sameTree: vi.fn().mockRejectedValue(new Error('tree unavailable')),
+      sameEffectiveCode: vi.fn().mockRejectedValue(new Error('history unavailable')),
+      sameCodeContribution: vi.fn().mockRejectedValue(new Error('patch unavailable')),
+    });
+
+    await expect(evaluateWorkspaceAnchorDrift(
+      'PAN-3076',
+      repo,
+      storedAnchor!,
+      probeChecks,
+    )).resolves.toMatchObject({ kind: 'drifted' });
+    expect(probeChecks.sameTree).toHaveBeenCalledOnce();
+    expect(probeChecks.sameEffectiveCode).toHaveBeenCalledOnce();
+    expect(probeChecks.sameCodeContribution).toHaveBeenCalledOnce();
+  });
+
+  it('returns drifted when a changed composite repo has no resolved root', async () => {
+    const fe = initializeRepo(workspace, 'fe');
+    const api = initializeRepo(workspace, 'api');
+    const bothRoots = [root('fe', fe, true), root('api', api, true)];
+    repoRootsMock.resolveWorkspaceRepoRootsSync.mockReturnValue(bothRoots);
+    const storedAnchor = await snapshotWorkspaceHeadsPromise('PAN-3076', workspace);
+    writeFileSync(join(api, 'app.ts'), "export const name = 'changed';\n");
+    git(api, 'add', 'app.ts');
+    git(api, 'commit', '-m', 'change api');
+    const currentAnchor = await snapshotWorkspaceHeadsPromise('PAN-3076', workspace);
+    repoRootsMock.resolveWorkspaceRepoRootsSync
+      .mockReset()
+      .mockReturnValueOnce(bothRoots)
+      .mockReturnValueOnce([root('fe', fe, true)]);
+
+    await expect(evaluateWorkspaceAnchorDrift(
+      'PAN-3076',
+      workspace,
+      storedAnchor!,
+    )).resolves.toEqual({
+      kind: 'drifted',
+      currentAnchor,
+      changedRepos: ['api'],
+    });
   });
 
   it('reports unreadable when no current workspace head can be produced', async () => {


### PR DESCRIPTION
**Issue:** #3076

## Acceptance Criteria

- [ ] Branded HeadAnchor type, producer return type, and canonical parseCompositeSnapshot export in git-utils
- [ ] Composite-aware workspace anchor drift evaluator with per-repo benign-move checks
- [ ] checkPostReviewCommits compares via the drift evaluator and renders composite anchors in logs
- [ ] POST /api/review/:issueId/status stamps reviewedAtCommit via the producer
- [ ] Legacy specialists-done route stamps reviewedAtCommit via the producer
- [ ] Deacon verification-bypass path stamps reviewedAtCommit via the producer
- [ ] roleRunHead stamp (spawn) and staleness compare (service-reactive) both use the producer
- [ ] Review runId derivation and staleness probe share one composite-aware head8 helper
- [ ] progressFingerprint uses the producer; write-site scan test locks the anchor-field inventory
- [ ] Narrow the review-status write-door update types to HeadAnchor with rehydration casts for plane copies
- [ ] Document the HeadAnchor contract in REVIEW-AGENT-ARCHITECTURE.md and the producer doc comment