### PR TITLE
PAN-3083

### DIFF
--- a/docs/REVIEW-AGENT-ARCHITECTURE.md
+++ b/docs/REVIEW-AGENT-ARCHITECTURE.md
@@ -64,7 +64,14 @@ The full round trip between the work agent and review:
    which rebases + pushes, records the durable `reviewRequestedAt` intent in the
    journal, and triggers review dispatch. If the reactive trigger is dropped, the
    host auto-dispatches from the journal intent on the next status read
-   (PAN-1988) — no deacon required.
+   (PAN-1988) — no deacon required. The intent lifecycle has four stages: `pan
+   done` **writes** it before HTTP progression; dispatch **services** it by
+   stamping `reviewSpawnedAt`; a terminal verdict **consumes** it by clearing a
+   serviced request from status and the journal; and `needsReviewDispatch`
+   **guards** passed, skipped, and `readyForMerge` states from dispatch. Genuine
+   re-review paths reset `reviewStatus` to `pending` first. PAN-3083 added the
+   consumption and guards after an unconsumed intent repeatedly re-dispatched
+   passed-and-ready issues and invalidated their UAT generations.
 2. **Review runs** in the resolved mode (above). Sessions are **warm by
    default** (PAN-2579): recording a verdict never kills the session; re-review
    resumes reviewers with their prior-cycle context.

--- a/src/lib/__tests__/review-dispatch-decision.test.ts
+++ b/src/lib/__tests__/review-dispatch-decision.test.ts
@@ -21,11 +21,11 @@ describe('needsReviewDispatch (PAN-1988 — auto-heal from durable journal inten
       })).toBe(true);
     });
 
-    it('re-request after a passed verdict with new commits', () => {
+    it('re-request after new commits reset review to pending', () => {
       expect(needsReviewDispatch({
         reviewRequestedAt: '2026-06-20T12:00:00Z',
         reviewSpawnedAt: '2026-06-20T10:00:00Z',
-        reviewStatus: 'passed',
+        reviewStatus: 'pending',
       })).toBe(true);
     });
   });

--- a/src/lib/overdeck/review-status-record-sync.ts
+++ b/src/lib/overdeck/review-status-record-sync.ts
@@ -94,6 +94,7 @@ type DurableStatusFields = Partial<ReviewStatus> & { closedOut?: boolean; closed
 const FALLBACK_CLEARABLE_FIELDS = [
   'strikeTransportRetryCount',
   'strikeNextAttemptAt',
+  'reviewRequestedAt',
 ] as const;
 type FallbackClearableField = typeof FALLBACK_CLEARABLE_FIELDS[number];
 

--- a/src/lib/review-dispatch-decision.ts
+++ b/src/lib/review-dispatch-decision.ts
@@ -13,17 +13,23 @@
  *  - a request exists (`reviewRequestedAt` set), AND
  *  - it is newer than the last spawn (or there was never a spawn) — i.e. a genuinely un-serviced
  *    request, not the request that produced the current review, AND
- *  - a review is not already in progress (`reviewing`), AND
- *  - the issue is not already merged.
+ *  - review is pending rather than already reviewing or terminal, AND
+ *  - the issue is not already ready to merge or merged.
+ *
+ * Genuine re-review paths reset `reviewStatus` to `pending` before recording a fresh request: `pan
+ * done` does this for a new commit, and the operator force-review route does it explicitly.
  */
 export function needsReviewDispatch(params: {
   reviewRequestedAt?: string;
   reviewSpawnedAt?: string | number;
   reviewStatus?: string;
   mergeStatus?: string;
+  readyForMerge?: boolean;
 }): boolean {
   if (!params.reviewRequestedAt) return false;
   if (params.reviewStatus === 'reviewing') return false;
+  if (params.reviewStatus === 'passed' || params.reviewStatus === 'skipped') return false;
+  if (params.readyForMerge) return false;
   if (params.mergeStatus === 'merged') return false;
   return !params.reviewSpawnedAt || Date.parse(params.reviewRequestedAt) > new Date(params.reviewSpawnedAt).getTime();
 }

--- a/src/lib/review-status.ts
+++ b/src/lib/review-status.ts
@@ -233,6 +233,24 @@ export function setReviewStatusSync(
     merged.reviewerVerdicts = { ...status.reviewerVerdicts, ...update.reviewerVerdicts };
   }
 
+  // A terminal verdict consumes the durable request that produced this review. Preserve only a
+  // request newer than the current spawn, which represents an explicit re-review requested while
+  // this review was still running.
+  const terminalReviewVerdict =
+    update.reviewStatus !== status.reviewStatus &&
+    (update.reviewStatus === 'passed' ||
+      update.reviewStatus === 'blocked' ||
+      update.reviewStatus === 'failed' ||
+      update.reviewStatus === 'skipped');
+  if (
+    terminalReviewVerdict &&
+    merged.reviewRequestedAt &&
+    (!merged.reviewSpawnedAt ||
+      Date.parse(merged.reviewRequestedAt) <= new Date(merged.reviewSpawnedAt).getTime())
+  ) {
+    merged.reviewRequestedAt = undefined;
+  }
+
   // Track status transitions in history (last 10 entries)
   const history = [...(status.history || [])];
   const now = new Date().toISOString();

--- a/src/lib/review-status.ts
+++ b/src/lib/review-status.ts
@@ -233,21 +233,12 @@ export function setReviewStatusSync(
     merged.reviewerVerdicts = { ...status.reviewerVerdicts, ...update.reviewerVerdicts };
   }
 
-  // A terminal verdict consumes the durable request that produced this review. Preserve only a
-  // request newer than the current spawn, which represents an explicit re-review requested while
-  // this review was still running.
-  const terminalReviewVerdict =
-    update.reviewStatus !== status.reviewStatus &&
-    (update.reviewStatus === 'passed' ||
-      update.reviewStatus === 'blocked' ||
-      update.reviewStatus === 'failed' ||
-      update.reviewStatus === 'skipped');
-  if (
-    terminalReviewVerdict &&
-    merged.reviewRequestedAt &&
-    (!merged.reviewSpawnedAt ||
-      Date.parse(merged.reviewRequestedAt) <= new Date(merged.reviewSpawnedAt).getTime())
-  ) {
+  // Terminal verdicts consume the request that spawned this review. Preserve a newer request
+  // because it represents an explicit re-review requested while the current review was running.
+  const terminalReviewVerdict = update.reviewStatus !== status.reviewStatus &&
+    ['passed', 'blocked', 'failed', 'skipped'].includes(update.reviewStatus ?? '');
+  if (terminalReviewVerdict && merged.reviewRequestedAt &&
+      (!merged.reviewSpawnedAt || Date.parse(merged.reviewRequestedAt) <= new Date(merged.reviewSpawnedAt).getTime())) {
     merged.reviewRequestedAt = undefined;
   }
 

--- a/src/lib/review-status.ts
+++ b/src/lib/review-status.ts
@@ -512,6 +512,7 @@ function maybeAutoDispatchReviewHostSide(issueId: string, status: ReviewStatus):
     reviewSpawnedAt: status.reviewSpawnedAt,
     reviewStatus: status.reviewStatus,
     mergeStatus: status.mergeStatus,
+    readyForMerge: status.readyForMerge,
   })) return;
   const last = reviewDispatchAttemptAt.get(issueId) ?? 0;
   if (Date.now() - last < REVIEW_AUTO_DISPATCH_THROTTLE_MS) return;

--- a/tests/unit/dashboard/server/routes/specialists-inspect-item.test.ts
+++ b/tests/unit/dashboard/server/routes/specialists-inspect-item.test.ts
@@ -113,6 +113,7 @@ describe('POST /api/specialists/done inspect item attribution', () => {
       'issue-view-model',
       'passed',
       join(projectPath, 'workspaces', 'feature-pan-2724'),
+      'This predates this bead and is correct',
     );
   });
 });

--- a/tests/unit/lib/cloister/uat-reconciler.test.ts
+++ b/tests/unit/lib/cloister/uat-reconciler.test.ts
@@ -11,6 +11,7 @@ import {
   type UatReconcilerDeps,
 } from '../../../../src/lib/cloister/uat-reconciler.js';
 import type { ReadyFeature } from '../../../../src/lib/cloister/uat-generation-engine.js';
+import { needsReviewDispatch } from '../../../../src/lib/review-dispatch-decision.js';
 import type { UatGeneration, UatGenerationStatus } from '../../../../src/lib/database/uat-generations-db.js';
 
 const MAIN = 'main-sha-1';
@@ -224,6 +225,48 @@ describe('growth and invalidation', () => {
     expect(result.invalidated).toEqual([]);
     expect(deps.rows.get('uat/pan-held-0610')!.status).toBe('ready');
     expect(result.action).toBe('assembled'); // retry chance for PAN-2 in a fresh generation
+  });
+});
+
+describe('PAN-3083 passed and ready review intents', () => {
+  const stalePassedStatus = {
+    reviewStatus: 'passed',
+    testStatus: 'passed',
+    readyForMerge: true,
+    reviewRequestedAt: '2026-07-25T10:01:00.000Z',
+    reviewSpawnedAt: '2026-07-25T10:00:00.000Z',
+  };
+
+  it('keeps the generation live when the stale intent does not redispatch review', async () => {
+    expect(needsReviewDispatch(stalePassedStatus)).toBe(false);
+
+    const proj = freshProject();
+    const current = gen(proj, 'uat/pan-stable-0725', 'ready', {
+      members: [{ issueId: 'PAN-1', title: 'First', branch: 'feature/pan-1', headSha: 'h1', mergeOrder: 1 }],
+    });
+    const deps = makeDeps(proj, { rows: [current], readySet: [READY[0]!] });
+
+    const result = await reconcileUatGenerations(proj, deps);
+
+    expect(result.action).toBe('idle');
+    expect(result.invalidated).toEqual([]);
+    expect(deps.rows.get(current.name)?.status).toBe('ready');
+  });
+
+  it('invalidates the generation when the member genuinely leaves the ready queue', async () => {
+    const proj = freshProject();
+    const current = gen(proj, 'uat/pan-left-0725', 'ready', {
+      members: [{ issueId: 'PAN-1', title: 'First', branch: 'feature/pan-1', headSha: 'h1', mergeOrder: 1 }],
+    });
+    const deps = makeDeps(proj, { rows: [current], readySet: [] });
+    const log = vi.fn();
+    deps.log = log;
+
+    const result = await reconcileUatGenerations(proj, deps);
+
+    expect(result.invalidated).toEqual([current.name]);
+    expect(deps.rows.get(current.name)?.status).toBe('invalidated');
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('PAN-1 left the ready queue'));
   });
 });
 

--- a/tests/unit/lib/overdeck/review-status-record-sync-drain.test.ts
+++ b/tests/unit/lib/overdeck/review-status-record-sync-drain.test.ts
@@ -137,6 +137,54 @@ describe('workspace verdict fallback drain (PAN-2989)', () => {
     expect(status.strikeNextAttemptAt).toBeUndefined();
   });
 
+  it('removes reviewRequestedAt from the record when the drained fallback clears it', async () => {
+    state.pipeline = {
+      reviewStatus: 'reviewing',
+      testStatus: 'pending',
+      reviewRequestedAt: '2026-07-22T09:00:00.000Z',
+      updatedAt: '2026-07-22T09:00:00.000Z',
+    };
+    writeFallback(
+      '2026-07-22T10:00:00.000Z',
+      { reviewStatus: 'passed', testStatus: 'pending' },
+      ['reviewRequestedAt'],
+    );
+    mockUpdateIssueRecordForIssue.mockImplementation(async (_issueId, status: ReviewStatus) => {
+      state.pipeline = JSON.parse(JSON.stringify(status));
+      return true;
+    });
+
+    await expect(drainWorkspaceVerdictFallback(ISSUE)).resolves.toBe(true);
+
+    expect(state.pipeline).not.toHaveProperty('reviewRequestedAt');
+    const [, status] = mockUpdateIssueRecordForIssue.mock.calls[0] as [string, ReviewStatus];
+    expect(status.reviewRequestedAt).toBeUndefined();
+  });
+
+  it('preserves reviewRequestedAt when the drained fallback still carries it', async () => {
+    state.pipeline = {
+      reviewStatus: 'reviewing',
+      testStatus: 'pending',
+      reviewRequestedAt: '2026-07-22T09:00:00.000Z',
+      updatedAt: '2026-07-22T09:00:00.000Z',
+    };
+    writeFallback('2026-07-22T10:00:00.000Z', {
+      reviewStatus: 'failed',
+      testStatus: 'pending',
+      reviewRequestedAt: '2026-07-22T10:30:00.000Z',
+    });
+    mockUpdateIssueRecordForIssue.mockImplementation(async (_issueId, status: ReviewStatus) => {
+      state.pipeline = JSON.parse(JSON.stringify(status));
+      return true;
+    });
+
+    await expect(drainWorkspaceVerdictFallback(ISSUE)).resolves.toBe(true);
+
+    expect(state.pipeline?.reviewRequestedAt).toBe('2026-07-22T10:30:00.000Z');
+    const [, status] = mockUpdateIssueRecordForIssue.mock.calls[0] as [string, ReviewStatus];
+    expect(status.reviewRequestedAt).toBe('2026-07-22T10:30:00.000Z');
+  });
+
   it('keeps the fallback when the record write does not land', async () => {
     writeFallback('2026-07-22T10:00:00.000Z', { reviewStatus: 'blocked' });
     mockUpdateIssueRecordForIssue.mockResolvedValue(false);

--- a/tests/unit/lib/overdeck/review-status-record-sync-fallback.test.ts
+++ b/tests/unit/lib/overdeck/review-status-record-sync-fallback.test.ts
@@ -198,7 +198,7 @@ describe('workspace verdict fallback (PAN-2583)', () => {
     expect(result?.durable.reviewStatus).toBe('blocked');
   });
 
-  it('writes the fallback when the journal write does not land', async () => {
+  it('writes the fallback with reviewRequestedAt marked clear when the journal write does not land', async () => {
     state.recordLanded = false;
     updateIssueRecordForReviewStatusSync(ISSUE, {
       issueId: ISSUE,
@@ -217,6 +217,7 @@ describe('workspace verdict fallback (PAN-2583)', () => {
     expect(written.clearedFields).toEqual([
       'strikeTransportRetryCount',
       'strikeNextAttemptAt',
+      'reviewRequestedAt',
     ]);
     expect(written.updatedAt).toBe('2026-07-11T13:00:00.000Z');
   });

--- a/tests/unit/lib/review-dispatch-decision.test.ts
+++ b/tests/unit/lib/review-dispatch-decision.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { needsReviewDispatch } from '../../../src/lib/review-dispatch-decision.js';
+
+const olderSpawn = '2026-07-25T10:00:00.000Z';
+const newerRequest = '2026-07-25T10:01:00.000Z';
+
+describe('needsReviewDispatch', () => {
+  it('does not dispatch the PAN-3037 passed and ready snapshot', () => {
+    expect(needsReviewDispatch({
+      reviewStatus: 'passed',
+      readyForMerge: true,
+      reviewRequestedAt: newerRequest,
+      reviewSpawnedAt: olderSpawn,
+    })).toBe(false);
+  });
+
+  it('does not dispatch a skipped review with an unserviced request', () => {
+    expect(needsReviewDispatch({
+      reviewStatus: 'skipped',
+      reviewRequestedAt: newerRequest,
+      reviewSpawnedAt: olderSpawn,
+    })).toBe(false);
+  });
+
+  it('does not dispatch a ready issue even when review is pending', () => {
+    expect(needsReviewDispatch({
+      reviewStatus: 'pending',
+      readyForMerge: true,
+      reviewRequestedAt: newerRequest,
+      reviewSpawnedAt: olderSpawn,
+    })).toBe(false);
+  });
+
+  it('dispatches a newer pending review request', () => {
+    expect(needsReviewDispatch({
+      reviewStatus: 'pending',
+      reviewRequestedAt: newerRequest,
+      reviewSpawnedAt: olderSpawn,
+    })).toBe(true);
+  });
+
+  it('dispatches a pending request that has never spawned', () => {
+    expect(needsReviewDispatch({
+      reviewStatus: 'pending',
+      reviewRequestedAt: newerRequest,
+    })).toBe(true);
+  });
+
+  it('does not dispatch while reviewing or after merge', () => {
+    expect(needsReviewDispatch({
+      reviewStatus: 'reviewing',
+      reviewRequestedAt: newerRequest,
+    })).toBe(false);
+    expect(needsReviewDispatch({
+      reviewStatus: 'pending',
+      mergeStatus: 'merged',
+      reviewRequestedAt: newerRequest,
+    })).toBe(false);
+  });
+
+  it('does not dispatch without a durable request', () => {
+    expect(needsReviewDispatch({
+      reviewStatus: 'pending',
+    })).toBe(false);
+  });
+});

--- a/tests/unit/lib/review-status.test.ts
+++ b/tests/unit/lib/review-status.test.ts
@@ -34,7 +34,7 @@ vi.mock('../../../src/lib/telemetry/pipeline.js', () => ({
 
 import { getReviewStatusSync, setReviewStatusSync } from '../../../src/lib/review-status.js';
 
-describe('review status scope drift', () => {
+describe('review status', () => {
   beforeEach(() => {
     testDb = openDatabase(':memory:');
     testDb.pragma('foreign_keys = ON');
@@ -89,5 +89,66 @@ describe('review status scope drift', () => {
     });
     expect(capturePipelineStageForIssueMock).toHaveBeenCalledTimes(1);
     expect(capturePipelineStageForIssueMock).toHaveBeenCalledWith('PAN-2200', 'review_passed');
+  });
+
+  it('consumes a serviced review request when review passes', () => {
+    const initial = setReviewStatusSync('PAN-3083', {
+      reviewStatus: 'pending',
+      reviewRequestedAt: '2026-07-25T10:00:00.000Z',
+      reviewSpawnedAt: '2026-07-25T10:01:00.000Z',
+    });
+    mockUpdateIssueRecordForIssue.mockClear();
+
+    const status = setReviewStatusSync('PAN-3083', { reviewStatus: 'passed' }, initial);
+
+    expect(status.reviewRequestedAt).toBeUndefined();
+    const [, journalStatus] = mockUpdateIssueRecordForIssue.mock.calls.at(-1)!;
+    const journalPipeline = JSON.parse(JSON.stringify(journalStatus));
+    expect(journalPipeline).not.toHaveProperty('reviewRequestedAt');
+  });
+
+  it('preserves a review request newer than the current spawn', () => {
+    const initial = setReviewStatusSync('PAN-3084', {
+      reviewStatus: 'pending',
+      reviewRequestedAt: '2026-07-25T10:02:00.000Z',
+      reviewSpawnedAt: '2026-07-25T10:01:00.000Z',
+    });
+    mockUpdateIssueRecordForIssue.mockClear();
+
+    const status = setReviewStatusSync('PAN-3084', { reviewStatus: 'failed' }, initial);
+
+    expect(status.reviewRequestedAt).toBe('2026-07-25T10:02:00.000Z');
+    const [, journalStatus] = mockUpdateIssueRecordForIssue.mock.calls.at(-1)!;
+    expect(journalStatus.reviewRequestedAt).toBe('2026-07-25T10:02:00.000Z');
+  });
+
+  it('consumes a review request without a spawn timestamp when review blocks', () => {
+    const initial = setReviewStatusSync('PAN-3085', {
+      reviewStatus: 'pending',
+      reviewRequestedAt: '2026-07-25T10:00:00.000Z',
+    });
+    mockUpdateIssueRecordForIssue.mockClear();
+
+    const status = setReviewStatusSync('PAN-3085', { reviewStatus: 'blocked' }, initial);
+
+    expect(status.reviewRequestedAt).toBeUndefined();
+    const [, journalStatus] = mockUpdateIssueRecordForIssue.mock.calls.at(-1)!;
+    const journalPipeline = JSON.parse(JSON.stringify(journalStatus));
+    expect(journalPipeline).not.toHaveProperty('reviewRequestedAt');
+  });
+
+  it('preserves a pending review request during non-verdict updates', () => {
+    const initial = setReviewStatusSync('PAN-3086', {
+      reviewStatus: 'pending',
+      reviewRequestedAt: '2026-07-25T10:00:00.000Z',
+      reviewSpawnedAt: '2026-07-25T10:01:00.000Z',
+    });
+    mockUpdateIssueRecordForIssue.mockClear();
+
+    const status = setReviewStatusSync('PAN-3086', { testStatus: 'running' }, initial);
+
+    expect(status.reviewRequestedAt).toBe('2026-07-25T10:00:00.000Z');
+    const [, journalStatus] = mockUpdateIssueRecordForIssue.mock.calls.at(-1)!;
+    expect(journalStatus.reviewRequestedAt).toBe('2026-07-25T10:00:00.000Z');
   });
 });


### PR DESCRIPTION
**Issue:** #3083

## Acceptance Criteria

- [ ] Guard needsReviewDispatch against passed/skipped verdicts and readyForMerge
- [ ] Terminal review verdict consumes a serviced reviewRequestedAt in setReviewStatusSync
- [ ] Add reviewRequestedAt to FALLBACK_CLEARABLE_FIELDS so sandboxed verdict writes propagate the clear
- [ ] Regression test: a passed+ready issue with a stale intent does not invalidate its UAT generation
- [ ] Document the reviewRequestedAt lifecycle and dispatch guards in REVIEW-AGENT-ARCHITECTURE.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unnecessary review re-dispatches for passed, skipped, merged, actively reviewing, or ready-to-merge items.
  - Review requests are now correctly consumed after terminal verdicts while newer requests remain available for re-review.
  - Improved handling of stale passed reviews and UAT generation invalidation.

- **Tests**
  - Added coverage for review dispatch decisions, verdict lifecycle behavior, and fallback record synchronization.

- **Documentation**
  - Expanded documentation of review intent lifecycle and re-dispatch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->