### PR TITLE
fix(test): pin forwarded inspect notes arg in itemId attribution test (PAN-3088)

### DIFF
--- a/tests/unit/dashboard/server/routes/specialists-inspect-item.test.ts
+++ b/tests/unit/dashboard/server/routes/specialists-inspect-item.test.ts
@@ -107,12 +107,16 @@ describe('POST /api/specialists/done inspect item attribution', () => {
     });
 
     expect(result.status).toBe(200);
+    // The itemId argument is the structured `itemId` field verbatim. The notes
+    // ride along as their own argument (PAN-3078 forwards them into the verdict
+    // message delivered to the work agent) and must never leak into attribution.
     expect(mocks.onInspectComplete).toHaveBeenCalledWith(
       'overdeck',
       'PAN-2724',
       'issue-view-model',
       'passed',
       join(projectPath, 'workspaces', 'feature-pan-2724'),
+      'This predates this bead and is correct',
     );
   });
 });


### PR DESCRIPTION
Fixes #3088. Restores `main` to green.

`main` went red on `tests/unit/dashboard/server/routes/specialists-inspect-item.test.ts` > "checkpoints the exact structured itemId regardless of notes wording" after `1302ccf6d2` (PAN-3077/PAN-3078).

**No production behaviour regressed.** `onInspectComplete` gained a sixth `notes` parameter so the verdict message delivered to the work agent can carry the blocking finding. `toHaveBeenCalledWith` requires an exact argument match, so the *added* argument failed the assertion. The structured itemId is still passed in its own position.

**The assertion is extended, not loosened.** It now pins both invariants: attribution comes from the structured field, and the prose travels as its own argument rather than leaking into the itemId. That is strictly stronger than the original test.

Note: the issue body's original root cause (written by me) claimed itemId attribution had regressed and warned of silent wrong-item checkpointing. That was a misdiagnosis — I read vitest's `+` line as a substituted value when it was an added argument. Corrected in a comment on the issue.

**Gate:** `npx vitest run tests/unit/dashboard/server/routes/specialists-inspect-item.test.ts` — 3 passed.

Filed, misdiagnosed, corrected and driven by the Flywheel (RUN-70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmAFhdqW76Z5bnmkLRXkMH
