### PR TITLE
fix(tests): register POST /api/conversations/:id/pane-choice in both no-loss inventories (PAN-3119)

### DIFF
--- a/tests/unit/dashboard/server/routes/conversations-no-loss.test.ts
+++ b/tests/unit/dashboard/server/routes/conversations-no-loss.test.ts
@@ -39,6 +39,7 @@ const EXPECTED_CONVERSATION_ROUTES = [
   'POST /api/conversations/:name/delete-image',
   'POST /api/conversations/:name/message',
   'POST /api/conversations/:id/codex-approval',
+  'POST /api/conversations/:id/pane-choice',
   'POST /api/conversations/:name/delivery-method',
   'POST /api/conversations/:name/control-ack',
   'PATCH /api/conversations/:name',
@@ -77,7 +78,7 @@ describe('PAN-2145 conversations route no-loss audit', () => {
     expect(conversationsRouteLayer).toBeDefined();
   });
 
-  it('keeps all 34 conversationsRouteLayer method/path registrations', () => {
+  it('keeps all 35 conversationsRouteLayer method/path registrations', () => {
     const liveRoutes = enumerateConversationRoutes();
     const expectedRoutes = new Set(EXPECTED_CONVERSATION_ROUTES);
 
@@ -100,6 +101,6 @@ describe('PAN-2145 conversations route no-loss audit', () => {
       ...unexpected.map((route) => `  unexpected: ${route}`),
     ].join('\n')).toEqual([]);
 
-    expect(liveRoutes.size).toBe(34);
+    expect(liveRoutes.size).toBe(35);
   });
 });

--- a/tests/unit/lib/overdeck/no-loss-matrix.ts
+++ b/tests/unit/lib/overdeck/no-loss-matrix.ts
@@ -168,6 +168,7 @@ export const NO_LOSS_MATRIX: MatrixEntry[] = [
   { surface: 'POST /api/conversations/:name/delete-image',               kind: 'http', disposition: 'RELOCATE',    door: 'ConversationRuntime.removeAttachment' },
   { surface: 'POST /api/conversations/:name/message',                    kind: 'http', disposition: 'RELOCATE',    door: 'ConversationRuntime.deliver' },
   { surface: 'POST /api/conversations/:id/codex-approval',               kind: 'http', disposition: 'RELOCATE',    door: 'ConversationRuntime.approve' },
+  { surface: 'POST /api/conversations/:id/pane-choice',                  kind: 'http', disposition: 'RELOCATE',    door: 'ConversationRuntime.answerPaneChoice (pane keystrokes; no durable state)' },
   { surface: 'POST /api/conversations/:name/delivery-method',            kind: 'http', disposition: 'RELOCATE',    door: 'ConversationRuntime.setDeliveryMethod' },
   { surface: 'POST /api/conversations/:name/thinking-level',             kind: 'http', disposition: 'WRITE',       door: 'ConversationWriter.setEffort + ConversationRuntime.controlChannel' },
   { surface: 'POST /api/conversations/:name/compact',                    kind: 'http', disposition: 'RELOCATE',    door: 'ConversationRuntime.controlChannel.compact' },


### PR DESCRIPTION
Fixes #3119. Unblocks red main at `e10c9cf79b`.

PAN-3113 added `POST /api/conversations/:id/pane-choice` (`conversations.ts:629`) without registering it in either no-loss inventory, failing 2 of 10,828 tests and blocking every feature PR at the merge gate.

Registration only — no production code changes:
- `tests/unit/lib/overdeck/no-loss-matrix.ts`: entry beside `codex-approval`, `RELOCATE` → `ConversationRuntime.answerPaneChoice`
- `tests/unit/dashboard/server/routes/conversations-no-loss.test.ts`: added to the locked surface, count 34 → 35

Verified against the specific failing gates:
```
npx vitest run tests/unit/lib/overdeck/no-loss-matrix.test.ts \
               tests/unit/dashboard/server/routes/conversations-no-loss.test.ts
Test Files  2 passed (2)   Tests  7 passed (7)
```
typecheck and lint both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rtpxbxCA85zk9FfXgyFLj