### PR TITLE
PAN-3172

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -46,6 +46,21 @@ Node 22, owns Claude's PTY master fd, and binds
 supervisor owns the PTY, a supervisor crash also terminates Claude; resume the
 session through the normal dashboard/Deacon flow.
 
+`resolvePtySupervisorScriptPath()` only accepts a built supervisor whose own
+bare imports resolve from where it sits — `unresolvedSupervisorImports()`
+checks them against that copy's `node_modules`. Existence is not enough: `pan
+reload` runs the dashboard out of
+`~/.overdeck/deployments/dashboard/.pan-reload-generation-{a,b}`, and a
+generation that cannot resolve `@lydell/node-pty` yields a supervisor that dies
+on `ERR_MODULE_NOT_FOUND` before binding its socket, so every conversation
+created afterwards ends on a spawn timeout (PAN-3172). Resolution therefore
+falls through to the primary checkout recorded in
+`active-dashboard-bundle.json`, whose `node_modules` is complete;
+`pan reload` runs `supervisorDeploymentFailure()` on the freshly built
+generation and fails the deploy rather than reporting "healthy"; and a spawn
+that still times out reports the supervisor's own pane output alongside the
+socket timeout.
+
 `deliverAgentMessage()` uses a three-tier router: PTY supervisor first, legacy
 Claude Code Channels MCP second, and tmux paste-buffer last. Docker workspaces
 are still excluded from supervisor wiring until host/container socket sharing is

--- a/src/cli/commands/__tests__/reload-health-timeout.integration.test.ts
+++ b/src/cli/commands/__tests__/reload-health-timeout.integration.test.ts
@@ -133,6 +133,13 @@ describe('reloadCommand health-timeout recovery', () => {
     await fs.mkdir(join(deployRoot, 'dist', 'dashboard'), { recursive: true });
     await fs.mkdir(join(deployRoot, 'node_modules'), { recursive: true });
     await fs.writeFile(serverPath, 'canonical bundle');
+    // PAN-3172: reload now refuses a generation whose PTY supervisor cannot
+    // start there. This stand-in imports nothing the deployment lacks, so the
+    // gate passes and the health-timeout path under test still runs.
+    await fs.writeFile(
+      join(deployRoot, 'dist', 'pty-supervisor.js'),
+      'import { join } from "node:path";\nexport { join };\n',
+    );
 
     mocks.readPlatformConfigSync.mockReturnValue({
       dashboardPort,

--- a/src/cli/commands/__tests__/reload.test.ts
+++ b/src/cli/commands/__tests__/reload.test.ts
@@ -29,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   readActiveDashboardBundle: vi.fn(),
   writeActiveDashboardBundle: vi.fn(),
   fsMkdir: vi.fn(),
+  supervisorDeploymentFailure: vi.fn(),
 }));
 
 // reloadCommand refuses to run when a `pan dev` supervisor marker is present.
@@ -47,6 +48,10 @@ vi.mock('../../../lib/restart-lock.js', () => ({
 
 vi.mock('../../../lib/deploy/agent-restart-gate.js', () => ({
   agentRestartBlockReason: mocks.agentRestartBlockReason,
+}));
+
+vi.mock('../../../lib/channels/pty-supervisor-locate.js', () => ({
+  supervisorDeploymentFailure: mocks.supervisorDeploymentFailure,
 }));
 
 vi.mock('../../../lib/deploy/active-dashboard-bundle.js', () => ({
@@ -197,6 +202,7 @@ describe('reloadCommand', () => {
     mocks.agentRestartBlockReason.mockResolvedValue(null);
     mocks.readActiveDashboardBundle.mockReturnValue(null);
     mocks.writeActiveDashboardBundle.mockResolvedValue(undefined);
+    mocks.supervisorDeploymentFailure.mockReturnValue(null);
     mocks.fsAccess.mockImplementation(async (path: string) => {
       if (path === '/usr/bin/bun') return;
       throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' });
@@ -360,6 +366,30 @@ describe('reloadCommand', () => {
     expect(installOrder).toBeLessThan(buildOrder);
     expect(mocks.restartDashboard).toHaveBeenCalledTimes(1);
     expect(process.exitCode).toBeUndefined();
+  });
+
+  // PAN-3172: the HTTP health check stays green when a generation's
+  // node_modules cannot resolve @lydell/node-pty, so the reload printed
+  // "healthy" while every new conversation died on a supervisor socket timeout.
+  it('fails the reload when the built deployment cannot run the PTY supervisor', async () => {
+    mocks.statSync.mockReturnValue({ mtimeMs: 2000 });
+    mocks.supervisorDeploymentFailure.mockReturnValue(
+      'Deployment cannot resolve @lydell/node-pty from /dist/pty-supervisor.js',
+    );
+    mockSpawnExits();
+
+    await reloadCommand({});
+
+    expect(mocks.supervisorDeploymentFailure).toHaveBeenCalledWith(DEFAULT_BUILD_WORKTREE);
+    expect(mocks.restartDashboard).not.toHaveBeenCalled();
+    expect(mocks.exec).toHaveBeenCalledWith(
+      `git 'worktree' 'remove' '--force' '${DEFAULT_BUILD_WORKTREE}'`,
+      expect.objectContaining({ cwd: DEFAULT_REPO_ROOT }),
+    );
+    expect(mocks.writeRestartStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false, error: expect.stringContaining('@lydell/node-pty') }),
+    );
+    expect(process.exitCode).toBe(1);
   });
 
   it('keeps a successful restart green when previous deployment cleanup fails', async () => {

--- a/src/cli/commands/reload.ts
+++ b/src/cli/commands/reload.ts
@@ -17,6 +17,7 @@ import {
   readActiveDashboardBundleSync,
   writeActiveDashboardBundle,
 } from '../../lib/deploy/active-dashboard-bundle.js';
+import { supervisorDeploymentFailure } from '../../lib/channels/pty-supervisor-locate.js';
 import { acquireRestartLock, readRestartLockHolder } from '../../lib/restart-lock.js';
 import {
   leavesDashboardRunning,
@@ -177,6 +178,12 @@ export async function reloadCommand(options: ReloadOptions): Promise<void> {
         if (deployedMtime <= 0) {
           throw new Error(`Build did not create ${deployment.serverPath}`);
         }
+        // A deployment that cannot run the PTY supervisor cannot spawn a
+        // conversation or a Claude Code agent, yet it serves HTTP happily — so
+        // the ordinary health check stays green while a core operator surface
+        // is dead (PAN-3172). Fail before any traffic moves onto it.
+        const supervisorFailure = supervisorDeploymentFailure(deployment.deployRoot);
+        if (supervisorFailure) throw new Error(supervisorFailure);
         await writeActiveDashboardBundle({ repoRoot, ...deployment });
         try {
           activation = await activateDashboardDeployment(repoRoot, deployment);

--- a/src/lib/channels/__tests__/pty-supervisor-locate.test.ts
+++ b/src/lib/channels/__tests__/pty-supervisor-locate.test.ts
@@ -3,7 +3,12 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { materializePtySupervisorRuntime, resolvePtySupervisorScriptPath } from '../pty-supervisor-locate.js';
+import {
+  materializePtySupervisorRuntime,
+  resolvePtySupervisorScriptPath,
+  supervisorDeploymentFailure,
+  unresolvedSupervisorImports,
+} from '../pty-supervisor-locate.js';
 
 // PAN-2592: desktop packaging stages the supervisor chunk closure plus a
 // vendored node-pty next to the server bundle; the runtime copies it onto
@@ -71,5 +76,89 @@ describe('resolvePtySupervisorScriptPath', () => {
     const resolved = resolvePtySupervisorScriptPath();
     expect(resolved.endsWith(join('dist', 'pty-supervisor.js'))).toBe(true);
     expect(existsSync(resolved)).toBe(true);
+  });
+});
+
+// PAN-3172: a `pan reload` deployment generation whose node_modules could not
+// resolve @lydell/node-pty produced a supervisor that died on
+// ERR_MODULE_NOT_FOUND before binding its socket, so every conversation created
+// afterwards timed out. Existence of the artifact is not evidence it can run.
+describe('unresolvedSupervisorImports', () => {
+  function writeScript(dir: string, body: string): string {
+    mkdirSync(dir, { recursive: true });
+    const scriptPath = join(dir, 'pty-supervisor.js');
+    writeFileSync(scriptPath, body);
+    return scriptPath;
+  }
+
+  it('reports a bare import that does not resolve from the script location', () => {
+    const scriptPath = writeScript(
+      join(tmpRoot, 'generation-b', 'dist'),
+      'import * as pty from "@lydell/node-pty";\nimport { join } from "node:path";\n',
+    );
+
+    expect(unresolvedSupervisorImports(scriptPath)).toEqual(['@lydell/node-pty']);
+  });
+
+  it('ignores relative chunks and node: builtins', () => {
+    const scriptPath = writeScript(
+      join(tmpRoot, 'builtins-only', 'dist'),
+      'import { x } from "./paths-K3noE4N_.js";\nimport { createServer } from "node:http";\nexport { y } from "../chunk.js";\n',
+    );
+
+    expect(unresolvedSupervisorImports(scriptPath)).toEqual([]);
+  });
+
+  it('accepts a bare import whose package is installed beside the script', () => {
+    const generationRoot = join(tmpRoot, 'generation-a');
+    const packageDir = join(generationRoot, 'node_modules', '@lydell', 'node-pty');
+    mkdirSync(packageDir, { recursive: true });
+    writeFileSync(join(packageDir, 'package.json'), '{"name":"@lydell/node-pty","main":"index.js"}\n');
+    writeFileSync(join(packageDir, 'index.js'), 'module.exports = {};\n');
+    const scriptPath = writeScript(join(generationRoot, 'dist'), 'import * as pty from "@lydell/node-pty";\n');
+
+    expect(unresolvedSupervisorImports(scriptPath)).toEqual([]);
+  });
+
+  it('finds every import of the real built supervisor unresolvable from a bare deployment tree', () => {
+    // The regression itself: take the artifact this repo actually ships and
+    // drop it into a generation whose node_modules is missing.
+    const built = resolvePtySupervisorScriptPath();
+    const bareDist = join(tmpRoot, 'bare-generation', 'dist');
+    mkdirSync(bareDist, { recursive: true });
+    const copied = join(bareDist, 'pty-supervisor.js');
+    writeFileSync(copied, readFileSync(built, 'utf-8'));
+
+    expect(unresolvedSupervisorImports(built)).toEqual([]);
+    expect(unresolvedSupervisorImports(copied)).toContain('@lydell/node-pty');
+  });
+});
+
+describe('supervisorDeploymentFailure', () => {
+  it('passes a deployment whose supervisor resolves its imports', () => {
+    const deployRoot = join(tmpRoot, 'good-deploy');
+    const packageDir = join(deployRoot, 'node_modules', '@lydell', 'node-pty');
+    mkdirSync(packageDir, { recursive: true });
+    writeFileSync(join(packageDir, 'package.json'), '{"name":"@lydell/node-pty","main":"index.js"}\n');
+    writeFileSync(join(packageDir, 'index.js'), 'module.exports = {};\n');
+    mkdirSync(join(deployRoot, 'dist'), { recursive: true });
+    writeFileSync(join(deployRoot, 'dist', 'pty-supervisor.js'), 'import * as pty from "@lydell/node-pty";\n');
+
+    expect(supervisorDeploymentFailure(deployRoot)).toBeNull();
+  });
+
+  it('names the missing package when the deployment cannot resolve it', () => {
+    const deployRoot = join(tmpRoot, 'bad-deploy');
+    mkdirSync(join(deployRoot, 'dist'), { recursive: true });
+    writeFileSync(join(deployRoot, 'dist', 'pty-supervisor.js'), 'import * as pty from "@lydell/node-pty";\n');
+
+    expect(supervisorDeploymentFailure(deployRoot)).toContain('@lydell/node-pty');
+  });
+
+  it('reports a deployment that never built the supervisor at all', () => {
+    const deployRoot = join(tmpRoot, 'unbuilt-deploy');
+    mkdirSync(deployRoot, { recursive: true });
+
+    expect(supervisorDeploymentFailure(deployRoot)).toContain('Build did not create');
   });
 });

--- a/src/lib/channels/pty-supervisor-locate.ts
+++ b/src/lib/channels/pty-supervisor-locate.ts
@@ -23,31 +23,112 @@
  *      (content-hash keyed over the whole staged tree, so an app upgrade
  *      refreshes it even when only non-entry files changed) and the vendored
  *      packages land under node_modules/ there for normal Node resolution.
+ *   3. <activeBundle.repoRoot>/dist/pty-supervisor.js — the primary checkout a
+ *      `pan reload` deployment was built from (PAN-3172).
  *
- * Missing everywhere is a build/packaging defect and throws — never silently
- * degrade a spawn that the caller expects to be supervised.
+ * A candidate is only accepted when its own bare imports actually resolve from
+ * where it sits. Existence alone is not enough: `pan reload` runs the dashboard
+ * out of ~/.overdeck/deployments/dashboard/.pan-reload-generation-{a,b}, and a
+ * generation whose node_modules cannot resolve @lydell/node-pty produces a
+ * supervisor that dies on ERR_MODULE_NOT_FOUND before it ever binds its socket
+ * — every conversation spawned afterwards then died on a socket timeout with no
+ * hint of the real cause (PAN-3172). Falling through to the primary checkout,
+ * whose node_modules is complete, keeps spawns alive; that copy is the same
+ * build, since activateDashboardDeployment() copies the generation's dist/ into
+ * the primary checkout.
+ *
+ * Missing (or unresolvable) everywhere is a build/packaging defect and throws —
+ * never silently degrade a spawn that the caller expects to be supervised.
  */
 
 import { createHash } from 'node:crypto';
 import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { readActiveDashboardBundleSync } from '../deploy/active-dashboard-bundle.js';
 import { getOverdeckHome, packageRoot } from '../paths.js';
 
 const moduleDir = dirname(fileURLToPath(import.meta.url));
 
-export function resolvePtySupervisorScriptPath(): string {
-  const built = join(packageRoot, 'dist', 'pty-supervisor.js');
-  if (existsSync(built)) return built;
+/** `from "x"`, `import "x"`, and `import("x")` in the bundled ESM output. */
+const IMPORT_SOURCE_PATTERN = /\b(?:from|import)\s*\(?\s*(["'])([^"'\n]+)\1/g;
+/** Bare package specifiers — relative, absolute, and `node:` are always fine. */
+const PACKAGE_SPECIFIER_PATTERN = /^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*(?:\/[^\s]*)?$/;
 
-  // Desktop layouts: all server chunks (this module included) sit in one
-  // bundle directory with the staged supervisor tree beside them.
-  const staged = join(moduleDir, 'supervisor');
-  if (existsSync(join(staged, 'pty-supervisor.js'))) {
-    return materializePtySupervisorRuntime(staged);
+/**
+ * Bare package specifiers the built supervisor imports but cannot resolve from
+ * its own location. Empty means the artifact can start where it sits.
+ *
+ * Only a genuine module-not-found counts. A package that is present but whose
+ * exports refuse the `require` condition still resolves under `import`, so it
+ * must not be reported as missing.
+ */
+export function unresolvedSupervisorImports(scriptPath: string): string[] {
+  const source = readFileSync(scriptPath, 'utf8');
+  const requireFrom = createRequire(scriptPath);
+  const missing = new Set<string>();
+
+  for (const match of source.matchAll(IMPORT_SOURCE_PATTERN)) {
+    const specifier = match[2];
+    if (!specifier || !PACKAGE_SPECIFIER_PATTERN.test(specifier)) continue;
+    try {
+      requireFrom.resolve(specifier);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'MODULE_NOT_FOUND' || code === 'ERR_MODULE_NOT_FOUND') missing.add(specifier);
+    }
   }
 
+  return [...missing];
+}
+
+/**
+ * Why a freshly built deployment cannot run the supervisor, or null if it can.
+ *
+ * `pan reload`'s health check only exercises the dashboard's HTTP surface, which
+ * stays green even when the generation's node_modules is incomplete — so the
+ * reload reported "healthy" while every new conversation died on a supervisor
+ * socket timeout (PAN-3172). Callers use this to fail the deploy instead.
+ */
+export function supervisorDeploymentFailure(deployRoot: string): string | null {
+  const supervisorPath = join(deployRoot, 'dist', 'pty-supervisor.js');
+  if (!existsSync(supervisorPath)) return `Build did not create ${supervisorPath}`;
+
+  const missing = unresolvedSupervisorImports(supervisorPath);
+  if (missing.length === 0) return null;
+  return `Deployment cannot resolve ${missing.join(', ')} from ${supervisorPath} — `
+    + 'the PTY supervisor would die on startup and every new conversation would time out. '
+    + 'Run `bun install` in the deployment root, then reload again';
+}
+
+export function resolvePtySupervisorScriptPath(): string {
+  const activeBundle = readActiveDashboardBundleSync();
+  const candidates = [
+    join(packageRoot, 'dist', 'pty-supervisor.js'),
+    // Desktop layouts: all server chunks (this module included) sit in one
+    // bundle directory with the staged supervisor tree beside them.
+    join(moduleDir, 'supervisor', 'pty-supervisor.js'),
+    ...(activeBundle ? [join(activeBundle.repoRoot, 'dist', 'pty-supervisor.js')] : []),
+  ];
+
+  const rejected: string[] = [];
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) continue;
+    const staged = dirname(candidate) === join(moduleDir, 'supervisor');
+    const entry = staged ? materializePtySupervisorRuntime(dirname(candidate)) : candidate;
+    const missing = unresolvedSupervisorImports(entry);
+    if (missing.length === 0) return entry;
+    rejected.push(`${entry} cannot resolve ${missing.join(', ')}`);
+  }
+
+  if (rejected.length > 0) {
+    throw new Error(
+      `pty-supervisor cannot start — its dependencies are missing from every built copy: ${rejected.join('; ')}. `
+      + 'Reinstall dependencies where the dashboard is running from (`bun install`), then rebuild.',
+    );
+  }
   throw new Error('pty-supervisor build artifact missing — run `npm run build`.');
 }
 

--- a/src/lib/overdeck/__tests__/conversation-supervisor-failure.test.ts
+++ b/src/lib/overdeck/__tests__/conversation-supervisor-failure.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// PAN-3172: when the PTY supervisor dies before binding its socket, the spawn
+// path only saw the socket timeout. Four conversations across four models died
+// identically and the recorded spawn_error said nothing about the real cause —
+// an ERR_MODULE_NOT_FOUND for @lydell/node-pty sitting in the tmux pane — which
+// sent the operator hunting the memory governor instead.
+
+vi.setConfig({ testTimeout: 15_000 });
+
+const { extractSupervisorFailure } = await import('../conversation-runtime.js');
+
+const MODULE_NOT_FOUND_PANE = [
+  'node:internal/modules/esm/resolve:275',
+  '  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);',
+  '        ^',
+  '',
+  "Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@lydell/node-pty' imported from "
+  + '/home/u/.overdeck/deployments/dashboard/.pan-reload-generation-b/dist/pty-supervisor.js',
+  '    at packageResolve (node:internal/modules/esm/resolve:275:9)',
+].join('\n');
+
+describe('extractSupervisorFailure', () => {
+  it('surfaces the module resolution error from the pane', () => {
+    const failure = extractSupervisorFailure(MODULE_NOT_FOUND_PANE);
+
+    expect(failure).toContain('ERR_MODULE_NOT_FOUND');
+    expect(failure).toContain('@lydell/node-pty');
+  });
+
+  it('falls back to the pane tail when no line looks like an error', () => {
+    const failure = extractSupervisorFailure('starting\n\nwaiting for pty\n');
+
+    expect(failure).toBe('starting | waiting for pty');
+  });
+
+  it('returns null for an empty pane so the timeout message stands alone', () => {
+    expect(extractSupervisorFailure('')).toBeNull();
+    expect(extractSupervisorFailure('   \n\n  ')).toBeNull();
+  });
+
+  it('caps the extracted detail so a noisy pane cannot flood spawn_error', () => {
+    const noisy = Array.from({ length: 20 }, (_, i) => `Error: line ${i} ${'x'.repeat(200)}`).join('\n');
+
+    expect(extractSupervisorFailure(noisy)!.length).toBeLessThanOrEqual(500);
+  });
+});

--- a/src/lib/overdeck/conversation-runtime.ts
+++ b/src/lib/overdeck/conversation-runtime.ts
@@ -30,6 +30,7 @@ import {
 } from './conversations.js';
 import {
   capturePane,
+  capturePaneText,
   sessionExists,
   isHarnessProcessAlive,
   killSession,
@@ -391,6 +392,22 @@ export async function handleConversationSwitchModel(
 function getPtySupervisorSocketPath(agentId: string): string {
   return join(getOverdeckHome(), 'sockets', `pty-${agentId}.sock`);
 }
+/**
+ * Pull the supervisor's own failure out of the tmux pane it died in.
+ *
+ * A supervisor that cannot load its native node-pty exits instantly with an
+ * ERR_MODULE_NOT_FOUND on stderr; all the spawn path sees is the socket that
+ * never appeared. Reporting only the timeout hides the actual cause and sent
+ * an operator hunting the memory governor instead (PAN-3172).
+ */
+export function extractSupervisorFailure(paneText: string): string | null {
+  const lines = paneText.split('\n').map((line) => line.trim()).filter(Boolean);
+  const errors = lines.filter((line) => /error|cannot find|ERR_[A-Z_]+|pty-supervisor:/i.test(line));
+  const chosen = (errors.length > 0 ? errors : lines).slice(-3);
+  if (chosen.length === 0) return null;
+  return chosen.join(' | ').slice(0, 500);
+}
+
 async function waitForPtySupervisorSocket(agentId: string, timeoutMs = PTY_SUPERVISOR_SOCKET_WAIT_MS): Promise<void> {
   const socketPath = getPtySupervisorSocketPath(agentId);
   const start = Date.now();
@@ -402,7 +419,11 @@ async function waitForPtySupervisorSocket(agentId: string, timeoutMs = PTY_SUPER
     }
     await new Promise(r => setTimeout(r, 250));
   }
-  throw new Error(`Timed out waiting for PTY supervisor socket ${socketPath}`);
+  const failure = extractSupervisorFailure(await capturePaneText(agentId, 40));
+  throw new Error(
+    `Timed out waiting for PTY supervisor socket ${socketPath}`
+    + (failure ? ` — supervisor output: ${failure}` : ''),
+  );
 }
 async function extractModelFromSessionFile(sessionFile: string): Promise<string | null> {
   try {


### PR DESCRIPTION
**Issue:** #3172


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reloads now fail safely when the PTY supervisor cannot start, preventing unhealthy deployments from being activated.
  - Conversation startup timeouts now include relevant supervisor error details when available.
  - Improved recovery handling for reload health-timeout scenarios.

- **Improvements**
  - PTY supervisor resolution now verifies required dependencies before use and reports missing modules more clearly.

- **Documentation**
  - Clarified PTY supervisor resolution, reload failure behavior, and troubleshooting details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->