### PR TITLE
PAN-3180

### DIFF
--- a/docs/DEFINITION-OF-DONE.md
+++ b/docs/DEFINITION-OF-DONE.md
@@ -10,11 +10,11 @@ this table and that module from drifting silently.
 
 | # | Gate ID | Step | Mechanical owner | Visible at |
 | --- | --- | --- | --- | --- |
-| 1 | `review` | Review passed (mode per issue policy; full = convoy + synthesis) | review role → `pan admin specialists done review` → review-status write door | `reviewStatus: passed` |
-| 2 | `tests` | Tests passed (incl. browser UAT when required) | test role → `pan admin specialists done test` | `testStatus: passed` |
+| 1 | `review` | Review passed (mode per issue policy; full = convoy + synthesis); a strike-landed issue records the row skipped-by-strike because no review specialist is dispatched for a strike (PAN-3180) | review role → `pan admin specialists done review` → review-status write door | `reviewStatus: passed`, or `skip` naming `strikeLandingState: landed` |
+| 2 | `tests` | Tests passed (incl. browser UAT when required); a strike-landed issue records the row skipped-by-strike because no test specialist is dispatched for a strike (PAN-3180) | test role → `pan admin specialists done test` | `testStatus: passed`, or `skip` naming `strikeLandingState: landed` |
 | 3 | `verification` | Verification green on the branch (typecheck, lint, suite, build) | supervised verification worker (`verification-runner.ts` / `verification-worker.ts`); uat-promotion (recorded at batch promotion, PAN-3114) | `verificationStatus: passed` (or `skipped` per issue policy) |
 | 4 | `merged` | Merged to main: forge/durable merge evidence resolved through either convention head (`feature/<id>` or `strike/<id>`), including forge squash-merge detection; or a non-PR landing where the shared L2-work lens finds at least one convention-branch ref contained in its repository's default branch with the tip off the first-parent line and zero unmerged refs across all configured repositories | merge door: `triggerMerge` → merge specialist (`merge-agent.ts`); fallback: `gatherIssueBranchContainment()` | PR `MERGED`, `mergeStatus: merged`, or branch-containment evidence |
-| 5 | `post-merge` | Post-merge handoff: work/planning agents paused, workspace Docker stack + networks stopped, `verifying-on-main` label; for a containment-evidenced non-PR landing, passes when no work/planning agents are running because no observed merge event could trigger the lifecycle | `postMergeLifecycle()` (`merge-agent.ts`) — at-most-once per merge (PAN-328 in-flight guard); DoD containment fallback | issue labels, agent states |
+| 5 | `post-merge` | Post-merge handoff: work/planning agents paused, workspace Docker stack + networks stopped, `verifying-on-main` label; for a containment-evidenced non-PR landing, passes when no work/planning agents are running because no observed merge event could trigger the lifecycle; for a strike landing, skips on the same quiescence test because the strike path never runs the work-agent handoff (PAN-3180) | `postMergeLifecycle()` (`merge-agent.ts`) — at-most-once per merge (PAN-328 in-flight guard); DoD containment and strike fallbacks | issue labels, agent states |
 | 6 | `main-verify` | Verified on main (post-merge verification of the merged commit) | deacon verify-on-main flow | `verifying_on_main` → verified |
 | 7 | `deploy` | **Deployed: the live dashboard runs a canonical build that includes the merge.** When the `merged` row misses without resolving a merge commit, this row skips and reports its row-4 dependency instead of recording a second miss. | staleness-gated Step 0 (`merge-agent.ts`) + Deacon deploy patrol (`deploy-patrol.ts`) + deploy intent queue (`pending-deploy.json`), guarded by `getDeployBlockReason()` | `/api/health` `buildCommit`, `buildDirty`, and `buildBranch` + stale-build chip; the row misses when the build is dirty or `buildCommit` is not an ancestor of `origin/main` |
 | 8 | `teardown` | Close-out: worktree removed, branches per `close_out` config, xBRIEF `plan.status: completed`, planning artifacts archived, tracker issue CLOSED + `closed-out` label, review status cleared, Docker `_devnet` teardown verified | `pan close <id>` / dashboard Close Out (`closeOut`); closed-issue reaper (`reapIssueResidue`) as backstop | issue state, `workspaces/` dir |
@@ -49,6 +49,16 @@ this table and that module from drifting silently.
   non-terminal member at promote time, and close-out heals members of batches promoted before
   that write path existed (PAN-3114). The row still reports the anchor's presence or absence,
   so a reader never has to guess which condition a miss came from.
+- **A strike skips rows 1, 2 and 5; it never passes them** (PAN-3180). Bypassing review and
+  test is the entire point of the strike path, so "never ran" and "still outstanding" are
+  different facts and the gate now tells them apart. The waiver keys on
+  `strikeLandingState: landed` — the merge door's own durable statement that the work reached
+  main through `strike/<id>`, mirrored into the per-issue record's `pipeline` block. Every
+  earlier landing state is a strike still in flight and earns nothing; a specialist that ran
+  and returned `failed`/`blocked`/`dispatch_failed` still blocks, because a rejection is not
+  an absence; and a live work or planning agent still misses row 5. The rows land in the
+  close-out record as `skip` with an observed string naming the strike path, so a reader can
+  always tell a strike-landed issue from a fully-reviewed one.
 
 ## Related
 

--- a/src/lib/lifecycle/dod-gate.ts
+++ b/src/lib/lifecycle/dod-gate.ts
@@ -9,6 +9,7 @@ import { Effect } from 'effect';
 import { listRunningAgents, type AgentState } from '../agents.js';
 import { getDashboardApiUrlSync } from '../config.js';
 import { getReviewStatus, type ReviewStatus } from '../review-status.js';
+import type { StrikeLandingStatus } from '../strike-landing.js';
 import {
   getProjectConfigFromWorkspacePath,
   readIssueRecord,
@@ -92,9 +93,11 @@ interface PostMergeRowDeps {
   readCanonicalState: (ctx: LifecycleContext) => Promise<CanonicalState | null>;
   readMergeStatus: (issueId: string) => Awaitable<string | undefined>;
   listAgents: () => Awaitable<Array<Pick<AgentState, 'id' | 'issueId' | 'role' | 'status'>>>;
+  readStrikeLanded?: (issueId: string) => Awaitable<boolean>;
 }
 
 const defaultPostMergeRowDeps: PostMergeRowDeps = {
+  readStrikeLanded: async issueId => strikeLanded((await loadStatus(issueId, defaultDeps))?.status),
   readCanonicalState: async ctx => {
     return getAutoCloseOutCanonicalState(ctx.issueId) as Promise<CanonicalState | null>;
   },
@@ -200,6 +203,37 @@ async function loadStatus(issueId: string, deps: DodStatusRowDeps): Promise<Stat
   }
 }
 
+/**
+ * PAN-3180: `landed` is the strike path's own durable statement that this issue's
+ * work reached main through `strike/<id>`. It is written by the server merge door
+ * (`mergeCompletionStatus` in `merge-strike.ts`) and mirrored into the per-issue
+ * record's `pipeline` block, so it outlives review-status clearing. Every earlier
+ * landing state (`ready`/`landing`/`recovering`/`needs_you`) is a strike still in
+ * flight and earns no waiver.
+ */
+function strikeLanded(status: StrikeLandingStatus | null | undefined): boolean {
+  return status?.strikeLandingState === 'landed';
+}
+
+/**
+ * PAN-3180: a strike dispatches neither a review nor a test specialist — that
+ * bypass is the whole point of the path. So for a strike-landed issue these rows
+ * are `skip` (deliberately not run), never `pass` (ran and succeeded) and never
+ * `miss` (outstanding). A reader of the close-out record still sees the real
+ * verdict and the reason it was never produced.
+ */
+const STRIKE_BYPASS_NOTE: Record<'review' | 'tests', string> = {
+  review: 'no review specialist is dispatched for a strike',
+  tests: 'no test specialist is dispatched for a strike',
+};
+
+/**
+ * A specialist that ran and returned a negative verdict is a different fact from
+ * one that was never dispatched, so the strike waiver never covers it — those
+ * still block until an operator records an explicit `--accept-<row>` override.
+ */
+const NEGATIVE_VERDICTS = new Set(['failed', 'blocked', 'dispatch_failed']);
+
 async function checkVerdict(
   issueId: string,
   id: 'review' | 'tests',
@@ -213,7 +247,15 @@ async function checkVerdict(
   const source = loaded.source === 'journal' ? ' from pipeline journal' : '';
   const policy = value === 'skipped' ? ' (skipped per issue policy)' : '';
   const observed = `${field}: ${value ?? 'missing'}${source}${policy}`;
-  return result(id, value === 'passed' || value === 'skipped' ? 'pass' : 'miss', observed);
+  if (value === 'passed' || value === 'skipped') return result(id, 'pass', observed);
+  if (strikeLanded(loaded.status) && !NEGATIVE_VERDICTS.has(value ?? '')) {
+    return result(
+      id,
+      'skip',
+      `${observed}; skipped by the strike path (strikeLandingState: landed) — ${STRIKE_BYPASS_NOTE[id]}`,
+    );
+  }
+  return result(id, 'miss', observed);
 }
 
 export function checkReviewRow(issueId: string, deps: DodStatusRowDeps = defaultDeps): Promise<DodRowResult> {
@@ -343,6 +385,19 @@ export async function checkPostMergeRow(
       ? `running agents: ${runningAgents.map(agent => agent.id).join(', ')}`
       : 'no running work/planning agents';
     const lifecycleObserved = canonicalState === 'verifying_on_main' || mergeStatus === 'merged';
+    // PAN-3180: `postMergeLifecycle()` is the work-agent handoff — it pauses the
+    // work/planning agents, stops the workspace stack, and applies
+    // `verifying-on-main`. A strike has no work agent to pause and its landing is
+    // owned by the Deacon's merge door, so the marker this row looks for is never
+    // written and its absence proves nothing. What a strike does still owe is
+    // quiescence, so a live work/planning agent remains a real miss.
+    if (!lifecycleObserved && await (deps.readStrikeLanded ?? defaultPostMergeRowDeps.readStrikeLanded!)(ctx.issueId)) {
+      return result(
+        'post-merge',
+        runningAgents.length === 0 ? 'skip' : 'miss',
+        `strike landing (strikeLandingState: landed) — the work-agent post-merge handoff is not the strike path's lifecycle; ${stateObserved}; ${agentsObserved}`,
+      );
+    }
     if (!lifecycleObserved && merged?.evidence === 'branch-containment') {
       return result(
         'post-merge',

--- a/tests/unit/lib/lifecycle/dod-gate.test.ts
+++ b/tests/unit/lib/lifecycle/dod-gate.test.ts
@@ -120,6 +120,59 @@ describe('Definition-of-Done status rows', () => {
       }
     }
   });
+
+  it('marks review and tests skipped-by-strike for a strike-landed issue, never passed', async () => {
+    // PAN-3180: a strike dispatches neither specialist by design, so "never ran"
+    // must resolve as a deliberate skip while still reporting the real verdict.
+    const source = deps(live({ reviewStatus: 'pending', testStatus: 'pending', strikeLandingState: 'landed' }));
+    const [review, tests] = await Promise.all([checkReviewRow(issueId, source), checkTestsRow(issueId, source)]);
+
+    expect(review).toMatchObject({ status: 'skip' });
+    expect(review.observed).toContain('reviewStatus: pending');
+    expect(review.observed).toContain('skipped by the strike path (strikeLandingState: landed)');
+    expect(review.observed).toContain('no review specialist is dispatched for a strike');
+
+    expect(tests).toMatchObject({ status: 'skip' });
+    expect(tests.observed).toContain('testStatus: pending');
+    expect(tests.observed).toContain('no test specialist is dispatched for a strike');
+  });
+
+  it('reads the strike waiver from the durable pipeline journal after live status is cleared', async () => {
+    const source = deps(null, journal({ reviewStatus: 'pending', testStatus: 'pending', strikeLandingState: 'landed' }));
+    for (const row of await Promise.all([checkReviewRow(issueId, source), checkTestsRow(issueId, source)])) {
+      expect(row.status).toBe('skip');
+      expect(row.observed).toContain('from pipeline journal');
+      expect(row.observed).toContain('skipped by the strike path');
+    }
+  });
+
+  it('keeps review and tests blocking for a normal work-agent issue and for an in-flight strike', async () => {
+    const normal = deps(live({ reviewStatus: 'pending', testStatus: 'pending' }));
+    for (const row of await Promise.all([checkReviewRow(issueId, normal), checkTestsRow(issueId, normal)])) {
+      expect(row.status).toBe('miss');
+      expect(row.observed).not.toContain('strike');
+    }
+
+    // Only `landed` is the strike path's statement that the work reached main.
+    for (const state of ['ready', 'landing', 'recovering', 'needs_you'] as const) {
+      const inFlight = deps(live({ reviewStatus: 'pending', testStatus: 'failed', strikeLandingState: state }));
+      for (const row of await Promise.all([checkReviewRow(issueId, inFlight), checkTestsRow(issueId, inFlight)])) {
+        expect(row.status).toBe('miss');
+      }
+    }
+  });
+
+  it('never lets the strike waiver overwrite a verdict a specialist actually produced', async () => {
+    const passed = deps(live({ reviewStatus: 'passed', testStatus: 'passed', strikeLandingState: 'landed' }));
+    expect(await checkReviewRow(issueId, passed)).toMatchObject({ status: 'pass', observed: 'reviewStatus: passed' });
+    expect(await checkTestsRow(issueId, passed)).toMatchObject({ status: 'pass', observed: 'testStatus: passed' });
+
+    // A specialist that ran and rejected the work is a different fact from one
+    // that was never dispatched — those keep blocking until an operator accepts.
+    const negative = deps(live({ reviewStatus: 'blocked', testStatus: 'failed', strikeLandingState: 'landed' }));
+    expect(await checkReviewRow(issueId, negative)).toMatchObject({ status: 'miss', observed: 'reviewStatus: blocked' });
+    expect(await checkTestsRow(issueId, negative)).toMatchObject({ status: 'miss', observed: 'testStatus: failed' });
+  });
 });
 
 describe('Definition-of-Done merged row', () => {
@@ -363,6 +416,47 @@ describe('Definition-of-Done post-merge row', () => {
 
     expect(row).toMatchObject({ status: 'miss' });
     expect(row.observed).toContain('agent-pan-2715');
+  });
+
+  it('marks the work-agent handoff skipped-by-strike for a quiescent strike landing', async () => {
+    // PAN-3180: `postMergeLifecycle()` is the work-agent handoff. A strike has no
+    // work agent to pause and the Deacon owns its landing, so the marker this row
+    // looks for is never written and its absence is not evidence of a gap.
+    const row = await checkPostMergeRow(ctx, undefined, {
+      readCanonicalState: async () => 'in_review',
+      readMergeStatus: () => 'verifying',
+      listAgents: clearAgents,
+      readStrikeLanded: () => true,
+    });
+
+    expect(row).toMatchObject({ status: 'skip' });
+    expect(row.observed).toContain('strikeLandingState: landed');
+    expect(row.observed).toContain('not the strike path');
+    expect(row.observed).toContain('no running work/planning agents');
+  });
+
+  it('keeps a strike landing blocked while an issue work agent is still running', async () => {
+    const row = await checkPostMergeRow(ctx, undefined, {
+      readCanonicalState: async () => 'in_review',
+      readMergeStatus: () => 'verifying',
+      listAgents: () => [{ id: 'agent-pan-2715', issueId, role: 'work', status: 'running' }],
+      readStrikeLanded: () => true,
+    });
+
+    expect(row).toMatchObject({ status: 'miss' });
+    expect(row.observed).toContain('agent-pan-2715');
+  });
+
+  it('prefers the observed work-agent lifecycle over the strike waiver when both are present', async () => {
+    const row = await checkPostMergeRow(ctx, undefined, {
+      readCanonicalState: async () => 'verifying_on_main',
+      readMergeStatus: () => 'merged',
+      listAgents: clearAgents,
+      readStrikeLanded: () => true,
+    });
+
+    expect(row).toMatchObject({ status: 'pass' });
+    expect(row.observed).not.toContain('strikeLandingState');
   });
 });
 
@@ -630,6 +724,46 @@ describe('assembled Definition-of-Done gate', () => {
     expect(gate.misses).toEqual(['review', 'tests', 'verification']);
     expect(gate.rows.find(row => row.id === 'merged')).toMatchObject({ status: 'pass' });
     expect(gate.rows.find(row => row.id === 'post-merge')).toMatchObject({ status: 'pass' });
+  });
+
+  it('resolves every row for a strike-landed close-out without a single --accept-<row> override', async () => {
+    // PAN-3180 regression: rows 1, 2 and 5 resolve from the strike lens (PAN-3155
+    // already covered row 4), so a strike that merged cleanly closes out on its own.
+    const strikeCtx = { issueId: 'PAN-3165', projectPath: '/repo/overdeck' };
+    const strikeStatus: DodStatusRowDeps = {
+      getReviewStatus: () => live({
+        issueId: strikeCtx.issueId,
+        reviewStatus: 'pending',
+        testStatus: 'pending',
+        verificationStatus: 'passed',
+        strikeLandingState: 'landed',
+      }),
+      getJournalStatus: () => null,
+    };
+    const gate = await evaluateDodGate(strikeCtx, {}, {
+      review: rowIssueId => checkReviewRow(rowIssueId, strikeStatus),
+      tests: rowIssueId => checkTestsRow(rowIssueId, strikeStatus),
+      verification: rowIssueId => checkVerificationRow(rowIssueId, strikeStatus),
+      merged: async () => ({ ...makeRow('merged'), mergeCommit: 'strike123' }),
+      postMerge: (postMergeCtx, mergedRow) => checkPostMergeRow(postMergeCtx, mergedRow, {
+        readCanonicalState: async () => 'in_review',
+        readMergeStatus: () => 'failed',
+        listAgents: () => [],
+        readStrikeLanded: () => true,
+      }),
+      mainVerify: async () => makeRow('main-verify'),
+      deploy: async () => makeRow('deploy'),
+      now: () => '2026-07-26T23:00:00Z',
+    });
+
+    expect(gate).toMatchObject({ passed: true, misses: [], accepted: [] });
+    // Row 8 is appended by the close-out workflow once teardown succeeds; the gate
+    // itself owns rows 1–7, and none of them may be a silent pass for a strike.
+    expect(gate.rows).toHaveLength(DOD_ROWS.length - 1);
+    expect(gate.rows.filter(row => row.status === 'skip').map(row => row.id)).toEqual(['review', 'tests', 'post-merge']);
+    for (const id of ['review', 'tests', 'post-merge'] as const) {
+      expect(gate.rows.find(row => row.id === id)?.observed).toContain('strike');
+    }
   });
 
   it('rejects Definition-of-Done overrides issued by the autonomous flywheel', async () => {


### PR DESCRIPTION
**Issue:** #3180


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strike-aware Definition-of-Done evaluation.
  * Review and test gates now show intentional skips when no specialist is dispatched.
  * Post-merge checks now recognize completed, quiescent strike paths while still flagging active work.

* **Documentation**
  * Clarified strike-specific pass, skip, and outstanding-work rules in the Definition of Done.

* **Bug Fixes**
  * Prevented strike waivers from overriding failed or blocked specialist results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->