### PR TITLE
PAN-3183

### DIFF
--- a/docs/AGENT-STATE-PLANES.md
+++ b/docs/AGENT-STATE-PLANES.md
@@ -69,6 +69,20 @@ status, lifecycle events, and conversations. It is a disposable cache rebuilt
 from Git state, JSONL transcripts, tracker data, and tmux through the canonical
 domain resolvers.
 
+### Agents-table event invariant
+
+The agents table is the authoritative runtime registry, but event-derived
+projections consume the event log independently. Every agents-table status
+transition, including boot backfill reconciliation, must persist a matching
+`agent.status_changed` or `agent.stopped` event during the same boot; otherwise
+stale events can produce phantom running agents (PAN-3183). The agents-table
+rule in `scripts/lint-state-writes.sh` enforces the boundary around
+`src/lib/overdeck/{agents,agent-state-sync,agent-record-sync,reconstruction}.ts`,
+`src/lib/database/{agents-db,agent-backfill,schema}.ts`, and
+`src/dashboard/server/services/agent-projection.ts`. During bootstrap/seed, a
+table row that is stopped with no live tmux session overrides a newer
+running/starting event projection; a live tmux session still wins.
+
 ## Liveness oracle — tmux
 
 A session on the `overdeck` tmux socket is the physical liveness authority.

--- a/scripts/lint-state-writes.sh
+++ b/scripts/lint-state-writes.sh
@@ -170,4 +170,42 @@ if [[ -n "$orders_violations" ]]; then
   exit 1
 fi
 
+# ── Rule 6: agents-table mutations stay inside audited write doors (PAN-3183) ──
+AGENTS_TABLE_APPROVED=(
+  # AgentWriter verbs, boot backfill, and canonical removal live here.
+  ':!src/lib/overdeck/agents.ts'
+  # Legacy sync agent-state writes used by lifecycle callers live here.
+  ':!src/lib/overdeck/agent-state-sync.ts'
+  # Durable harness/model identity mirroring is part of the agent write surface.
+  ':!src/lib/overdeck/agent-record-sync.ts'
+  # The dormant sources-only reconstruction service owns its audited rebuild upsert.
+  ':!src/lib/overdeck/reconstruction.ts'
+  # Legacy generic agents-table writers remain for migration and tests.
+  ':!src/lib/database/agents-db.ts'
+  # The one-time state.json migration backfill owns its full-row upsert.
+  ':!src/lib/database/agent-backfill.ts'
+  # Schema migrations own agents DDL and invoke the one-time backfill.
+  ':!src/lib/database/schema.ts'
+  # Dashboard lifecycle projection atomically persists the row and domain event.
+  ':!src/dashboard/server/services/agent-projection.ts'
+)
+
+agents_table_candidates=$(
+  { git grep -nEi \
+      -e 'INSERT( OR REPLACE)? INTO agents' \
+      -e 'UPDATE agents' \
+      -e 'DELETE FROM agents' \
+      -e '\.(insert|update|delete)\((overdeckAgents|agentsTable)\)' \
+      -- 'src/**' 'packages/**' "${AGENTS_TABLE_APPROVED[@]}" \
+      ':!src/**/__tests__/**' ':!src/**/*.test.ts' \
+      ':!packages/**/__tests__/**' ':!packages/**/*.test.ts'; } || true
+)
+agents_table_violations=$(printf '%s\n' "$agents_table_candidates" | comment_filter)
+if [[ -n "$agents_table_violations" ]]; then
+  echo "✗ direct agents-table mutation outside the audited agent write doors:" >&2
+  echo "$agents_table_violations" >&2
+  echo "Route status writes through AgentWriter or agent-projection; audit rebuild exceptions here." >&2
+  exit 1
+fi
+
 echo "✓ state-write lint passed (single write surface intact)"

--- a/src/dashboard/server/read-model.ts
+++ b/src/dashboard/server/read-model.ts
@@ -24,6 +24,7 @@ import type { ReviewStatus } from '../../lib/review-status.js';
 import { listOverdeckAgentStatesSync } from '../../lib/overdeck/agent-state-sync.js';
 import { computeQueuePositionFromStatusSync } from '../../lib/queue-position.js'
 import { AgentsResolver, type Agent as OverdeckAgent } from '../../lib/overdeck/agents.js';
+import { emitBootReconciledStopEvents } from './services/boot-reconciled-stop-events.js';
 
 // ─── Exported async helpers (used by bootstrap Effect + tests) ───────────────
 
@@ -539,10 +540,7 @@ export const ReadModelServiceLive = Layer.effect(
     // ── Bootstrap inline during layer construction ───────────────────────────
     const agentsResolver = yield* AgentsResolver;
     yield* Effect.gen(function* () {
-      // PAN-1938 source-swap: agents now come from overdeck.db via AgentsResolver.
-      // reconstructCache still runs for reviewStatusByIssueId (which reads
-      // git-backed per-issue records, NOT panopticon.db SQLite cache tables)
-      // and for its side effects (agent-backfill sync, checkpoint cleanup).
+      // Agents come from AgentsResolver; reconstructCache supplies git-backed review status and boot side effects.
       const { reconstructCacheAuto } = yield* Effect.promise(() =>
         import('../../lib/reconstruct/reconstruct-cache.js'),
       );
@@ -564,12 +562,13 @@ export const ReadModelServiceLive = Layer.effect(
           () => import('./event-store.js'),
         );
         const eventStore = getEventStore();
+        yield* Effect.promise(() => emitBootReconciledStopEvents(eventStore, result.markedStoppedIds, result.agentsById, '[ReadModel] Failed to emit boot-reconciled stop events:'));
         sequence = eventStore.getLatestSequence();
         recentActivity = activityEntriesFromStoredEvents(
           eventStore.queryByType('activity.entry', MAX_SNAPSHOT_ACTIVITY_ENTRIES),
         );
-      } catch {
-        // Event store may not be initialized yet
+      } catch (err) {
+        console.error('[ReadModel] Failed to emit boot-reconciled stop events:', err);
       }
 
       state = {

--- a/src/dashboard/server/read-model.ts
+++ b/src/dashboard/server/read-model.ts
@@ -545,10 +545,8 @@ export const ReadModelServiceLive = Layer.effect(
         import('../../lib/reconstruct/reconstruct-cache.js'),
       );
 
-      const [overdeckAgents, result] = yield* Effect.all([
-        agentsResolver.list({}),
-        Effect.promise(() => reconstructCacheAuto()),
-      ]);
+      const result = yield* Effect.promise(() => reconstructCacheAuto());
+      const overdeckAgents = yield* agentsResolver.list({});
 
       const agentsById: Record<string, AgentSnapshot> = Object.fromEntries(
         overdeckAgents.map((a) => [a.id, agentSnapshotFromOverdeck(a)]),

--- a/src/dashboard/server/services/agent-state-service.ts
+++ b/src/dashboard/server/services/agent-state-service.ts
@@ -28,6 +28,7 @@ import {
 } from '@overdeck/contracts';
 import type {
   AgentRuntimeSnapshot,
+  AgentSnapshot,
   DomainEvent,
 } from '@overdeck/contracts';
 import { initEventStore } from '../event-store.js';
@@ -114,7 +115,7 @@ export const AgentStateServiceLive = Layer.effect(
       const seeded = result.agentRuntimeById;
       if (Object.keys(seeded).length > 0) {
         yield* SubscriptionRef.update(ref, (current) =>
-          mergeRuntimeBySequence(current, seeded),
+          mergeRuntimeBySequence(current, seeded, result.agentsById),
         );
         yield* setAgentRuntimeMirror(yield* SubscriptionRef.get(ref));
         console.log(
@@ -157,15 +158,20 @@ export const AgentStateServiceLive = Layer.effect(
 
 // ─── Internals ────────────────────────────────────────────────────────────────
 
-function mergeRuntimeBySequence(
+export function mergeRuntimeBySequence(
   current: Record<string, AgentRuntimeSnapshot>,
   reconstructed: Record<string, AgentRuntimeSnapshot>,
+  reconstructedAgents: Record<string, AgentSnapshot>,
 ): Record<string, AgentRuntimeSnapshot> {
   const merged: Record<string, AgentRuntimeSnapshot> = { ...reconstructed };
   for (const [id, snap] of Object.entries(current)) {
     const recon = reconstructed[id];
     if (!recon) {
       merged[id] = snap;
+      continue;
+    }
+    const sourceAgent = reconstructedAgents[id];
+    if (recon.activity === 'stopped' && sourceAgent?.hasLiveTmuxSession === false) {
       continue;
     }
     const currentSeq = snap.updatedAtSequence ?? -1;

--- a/src/dashboard/server/services/agent-state-service.ts
+++ b/src/dashboard/server/services/agent-state-service.ts
@@ -35,6 +35,7 @@ import { initEventStore } from '../event-store.js';
 import type { StoredEvent } from '../event-store.js';
 import { setAgentRuntimeMirror, getRuntimeSnapshot as getMirrorSnapshot, markAgentStateServiceInProcess } from '../../../lib/agent-runtime-mirror.js';
 import { appendSessionIdToHistory } from '../../../lib/session-history.js';
+import { emitBootReconciledStopEvents } from './boot-reconciled-stop-events.js';
 
 // ─── Event filtering ──────────────────────────────────────────────────────────
 
@@ -113,6 +114,7 @@ export const AgentStateServiceLive = Layer.effect(
       );
       const result = yield* Effect.promise(() => reconstructCacheAuto());
       const seeded = result.agentRuntimeById;
+      yield* Effect.promise(() => emitBootReconciledStopEvents(store, result.markedStoppedIds, seeded, '[AgentStateService] Failed to emit boot-reconciled stop event:'));
       if (Object.keys(seeded).length > 0) {
         yield* SubscriptionRef.update(ref, (current) =>
           mergeRuntimeBySequence(current, seeded, result.agentsById),

--- a/src/dashboard/server/services/boot-reconciled-stop-events.ts
+++ b/src/dashboard/server/services/boot-reconciled-stop-events.ts
@@ -6,27 +6,50 @@ export interface BootReconciledStop {
   previousStatus: string;
 }
 
+const appendByStore = new WeakMap<object, Map<string, Promise<boolean>>>();
+
+async function appendStopOnce(
+  store: Pick<EventStore, 'appendAsync'>,
+  stop: BootReconciledStop,
+  errorMessage: string,
+): Promise<void> {
+  const pendingByKey = appendByStore.get(store) ?? new Map<string, Promise<boolean>>();
+  appendByStore.set(store, pendingByKey);
+  const key = `${stop.id}:${stop.previousStatus}`;
+  const existing = pendingByKey.get(key);
+  if (existing && await existing) return;
+
+  const pending = (async () => {
+    try {
+      const sequence = await store.appendAsync({
+        type: 'agent.status_changed',
+        timestamp: new Date().toISOString(),
+        payload: {
+          agentId: stop.id,
+          status: 'stopped',
+          previousStatus: stop.previousStatus,
+          hasLiveTmuxSession: false,
+        },
+      } as Omit<DomainEvent, 'sequence'>);
+      if (sequence <= 0) throw new Error(`Event append returned invalid sequence ${sequence}`);
+      return true;
+    } catch (err) {
+      console.error(errorMessage, err);
+      return false;
+    }
+  })();
+  pendingByKey.set(key, pending);
+  if (!await pending && pendingByKey.get(key) === pending) pendingByKey.delete(key);
+}
+
 export async function emitBootReconciledStopEvents(
   store: Pick<EventStore, 'appendAsync'>,
   stopped: ReadonlyArray<BootReconciledStop>,
   presentAgents: Readonly<Record<string, unknown>>,
   errorMessage: string,
 ): Promise<void> {
-  for (const { id, previousStatus } of stopped) {
-    if (!presentAgents[id]) continue;
-    try {
-      await store.appendAsync({
-        type: 'agent.status_changed',
-        timestamp: new Date().toISOString(),
-        payload: {
-          agentId: id,
-          status: 'stopped',
-          previousStatus,
-          hasLiveTmuxSession: false,
-        },
-      } as Omit<DomainEvent, 'sequence'>);
-    } catch (err) {
-      console.error(errorMessage, err);
-    }
+  for (const stop of stopped) {
+    if (!presentAgents[stop.id]) continue;
+    await appendStopOnce(store, stop, errorMessage);
   }
 }

--- a/src/dashboard/server/services/boot-reconciled-stop-events.ts
+++ b/src/dashboard/server/services/boot-reconciled-stop-events.ts
@@ -1,0 +1,32 @@
+import type { DomainEvent } from '@overdeck/contracts';
+import type { EventStore } from '../event-store.js';
+
+export interface BootReconciledStop {
+  id: string;
+  previousStatus: string;
+}
+
+export async function emitBootReconciledStopEvents(
+  store: Pick<EventStore, 'appendAsync'>,
+  stopped: ReadonlyArray<BootReconciledStop>,
+  presentAgents: Readonly<Record<string, unknown>>,
+  errorMessage: string,
+): Promise<void> {
+  for (const { id, previousStatus } of stopped) {
+    if (!presentAgents[id]) continue;
+    try {
+      await store.appendAsync({
+        type: 'agent.status_changed',
+        timestamp: new Date().toISOString(),
+        payload: {
+          agentId: id,
+          status: 'stopped',
+          previousStatus,
+          hasLiveTmuxSession: false,
+        },
+      } as Omit<DomainEvent, 'sequence'>);
+    } catch (err) {
+      console.error(errorMessage, err);
+    }
+  }
+}

--- a/src/lib/database/agent-backfill.ts
+++ b/src/lib/database/agent-backfill.ts
@@ -186,14 +186,13 @@ export function backfillAgentsFromStateJsonSync(
   const readHarnessModel = options?.readHarnessModel ?? readAgentHarnessModelRecordSync;
   let processed = 0;
   let skipped = 0;
-  let markedStopped = 0;
   const markedStoppedIds: Array<{ id: string; previousStatus: string }> = [];
 
   let entries: string[] = [];
   try {
     entries = readdirSync(agentsDir);
   } catch {
-    return { processed, skipped, markedStopped, markedStoppedIds };
+    return { processed, skipped, markedStopped: 0, markedStoppedIds };
   }
 
   const columns = Object.values(COLUMN_MAP);
@@ -228,12 +227,9 @@ export function backfillAgentsFromStateJsonSync(
       }
 
       const reconciled = reconcileAgentStatus(state, liveSessions);
-      if (reconciled.status === 'stopped' && state.status !== 'stopped') {
-        const previousStatus = state.status;
-        logAgentLifecycleSync(state.id, `status changed: ${previousStatus} → stopped (boot backfill reconcile: no live tmux session)`);
-        markedStoppedIds.push({ id: state.id, previousStatus });
-        markedStopped++;
-      }
+      const reconciledStop = reconciled.status === 'stopped' && state.status !== 'stopped'
+        ? { id: state.id, previousStatus: state.status }
+        : undefined;
 
       // PAN-1919: prefer harness/model from the per-issue git-tracked record so
       // rebuild-agents sources from the travelling record, not machine-local state.
@@ -249,6 +245,7 @@ export function backfillAgentsFromStateJsonSync(
 
       const row = agentStateToDbAgent(effective);
       upsert.run(buildNamedParams(row));
+      if (reconciledStop) markedStoppedIds.push(reconciledStop);
       processed++;
 
       if (options?.verbose) {
@@ -258,8 +255,10 @@ export function backfillAgentsFromStateJsonSync(
   });
 
   tx();
-
-  return { processed, skipped, markedStopped, markedStoppedIds };
+  for (const { id, previousStatus } of markedStoppedIds) {
+    logAgentLifecycleSync(id, `status changed: ${previousStatus} → stopped (boot backfill reconcile: no live tmux session)`);
+  }
+  return { processed, skipped, markedStopped: markedStoppedIds.length, markedStoppedIds };
 }
 
 function reconcileAgentStatus(

--- a/src/lib/database/agent-backfill.ts
+++ b/src/lib/database/agent-backfill.ts
@@ -22,6 +22,7 @@ import { agentStateToDbAgent } from './agent-mappers.js';
 import type { AgentState } from '../agents.js';
 import type { Agent as DbAgent } from './agents-db.js';
 import { readAgentHarnessModelRecordSync } from '../overdeck/agent-record-sync.js';
+import { logAgentLifecycleSync } from '../persistent-logger.js';
 import type { RuntimeName } from '../runtimes/types.js';
 
 const VALID_ROLES = new Set<AgentState['role']>([
@@ -166,6 +167,7 @@ export interface BackfillAgentsResult {
   processed: number;
   skipped: number;
   markedStopped: number;
+  markedStoppedIds: Array<{ id: string; previousStatus: string }>;
 }
 
 /**
@@ -185,12 +187,13 @@ export function backfillAgentsFromStateJsonSync(
   let processed = 0;
   let skipped = 0;
   let markedStopped = 0;
+  const markedStoppedIds: Array<{ id: string; previousStatus: string }> = [];
 
   let entries: string[] = [];
   try {
     entries = readdirSync(agentsDir);
   } catch {
-    return { processed, skipped, markedStopped };
+    return { processed, skipped, markedStopped, markedStoppedIds };
   }
 
   const columns = Object.values(COLUMN_MAP);
@@ -226,6 +229,9 @@ export function backfillAgentsFromStateJsonSync(
 
       const reconciled = reconcileAgentStatus(state, liveSessions);
       if (reconciled.status === 'stopped' && state.status !== 'stopped') {
+        const previousStatus = state.status;
+        logAgentLifecycleSync(state.id, `status changed: ${previousStatus} → stopped (boot backfill reconcile: no live tmux session)`);
+        markedStoppedIds.push({ id: state.id, previousStatus });
         markedStopped++;
       }
 
@@ -253,7 +259,7 @@ export function backfillAgentsFromStateJsonSync(
 
   tx();
 
-  return { processed, skipped, markedStopped };
+  return { processed, skipped, markedStopped, markedStoppedIds };
 }
 
 function reconcileAgentStatus(

--- a/src/lib/overdeck/agents.ts
+++ b/src/lib/overdeck/agents.ts
@@ -833,13 +833,7 @@ export interface BackfillAgentsSyncResult {
   markedStoppedIds: Array<{ id: string; previousStatus: string }>;
 }
 
-/**
- * Read each agent's state.json from ~/.overdeck/agents/ and upsert rows into
- * the overdeck agents table. Reconciles running/starting agents against live
- * tmux sessions.
- *
- * Replaces database/agent-backfill.ts backfillAgentsAutoSync for the overdeck layer.
- */
+/** Rebuild the agents table from state.json and reconcile statuses against live tmux. */
 /**
  * All agent ids matching a prefix — unions the overdeck.db rows and the on-disk state
  * dirs, so it catches both row-only and dir-only orphans (the two can drift apart).
@@ -939,10 +933,7 @@ export function backfillAgentsSync(options?: BackfillAgentsSyncOptions): Backfil
       // Reconcile: mark stopped if no live tmux session
       if ((state.status === 'running' || state.status === 'starting') && !liveSessions.has(state.id)) {
         const previousStatus = state.status;
-        logAgentLifecycleSync(
-          state.id,
-          `status changed: ${previousStatus} → stopped (boot backfill reconcile: no live tmux session)`,
-        );
+        logAgentLifecycleSync(state.id, `status changed: ${previousStatus} → stopped (boot backfill reconcile: no live tmux session)`);
         markedStoppedIds.push({ id: state.id, previousStatus });
         state.status = 'stopped';
         state.stoppedAt = state.stoppedAt ?? new Date().toISOString();

--- a/src/lib/overdeck/agents.ts
+++ b/src/lib/overdeck/agents.ts
@@ -881,14 +881,13 @@ export function backfillAgentsSync(options?: BackfillAgentsSyncOptions): Backfil
 
   let processed = 0;
   let skipped = 0;
-  let markedStopped = 0;
   const markedStoppedIds: Array<{ id: string; previousStatus: string }> = [];
 
   let entries: string[] = [];
   try {
     entries = readdirSync(agentsDir);
   } catch {
-    return { processed, skipped, markedStopped, markedStoppedIds };
+    return { processed, skipped, markedStopped: 0, markedStoppedIds };
   }
 
   const cols = OVERDECK_AGENT_COLUMNS.join(', ');
@@ -930,14 +929,11 @@ export function backfillAgentsSync(options?: BackfillAgentsSyncOptions): Backfil
         continue;
       }
 
-      // Reconcile: mark stopped if no live tmux session
+      let reconciledStop: { id: string; previousStatus: string } | undefined;
       if ((state.status === 'running' || state.status === 'starting') && !liveSessions.has(state.id)) {
-        const previousStatus = state.status;
-        logAgentLifecycleSync(state.id, `status changed: ${previousStatus} → stopped (boot backfill reconcile: no live tmux session)`);
-        markedStoppedIds.push({ id: state.id, previousStatus });
+        reconciledStop = { id: state.id, previousStatus: state.status };
         state.status = 'stopped';
         state.stoppedAt = state.stoppedAt ?? new Date().toISOString();
-        markedStopped++;
       }
 
       // Per-row resilience (PAN-1972): the disposable agents cache is rebuilt
@@ -950,6 +946,7 @@ export function backfillAgentsSync(options?: BackfillAgentsSyncOptions): Backfil
         const row = agentStateToOverdeckRow(state);
         ensureIssue.run(row[issueIdIdx], Date.now());
         upsert.run(...row);
+        if (reconciledStop) markedStoppedIds.push(reconciledStop);
         processed++;
         if (options?.verbose) {
           console.log(`[backfill] ${state.id} -> ${state.status}`);
@@ -962,7 +959,10 @@ export function backfillAgentsSync(options?: BackfillAgentsSyncOptions): Backfil
   });
 
   tx();
-  return { processed, skipped, markedStopped, markedStoppedIds };
+  for (const { id, previousStatus } of markedStoppedIds) {
+    logAgentLifecycleSync(id, `status changed: ${previousStatus} → stopped (boot backfill reconcile: no live tmux session)`);
+  }
+  return { processed, skipped, markedStopped: markedStoppedIds.length, markedStoppedIds };
 }
 
 /**

--- a/src/lib/overdeck/agents.ts
+++ b/src/lib/overdeck/agents.ts
@@ -10,6 +10,7 @@ import { HttpApiEndpoint, HttpApiGroup } from 'effect/unstable/httpapi';
 import { Db, EventBus, Records, Tmux, getOverdeckDatabaseSync } from './infra.js';
 import { IssueId } from './issues.js';
 import { getOverdeckHome } from '../paths.js';
+import { logAgentLifecycleSync } from '../persistent-logger.js';
 import type { AgentState } from '../agents.js';
 export { getIssueStageSync, isTerminalIssueStage } from './issue-stage-sync.js';
 
@@ -829,6 +830,7 @@ export interface BackfillAgentsSyncResult {
   processed: number;
   skipped: number;
   markedStopped: number;
+  markedStoppedIds: Array<{ id: string; previousStatus: string }>;
 }
 
 /**
@@ -886,12 +888,13 @@ export function backfillAgentsSync(options?: BackfillAgentsSyncOptions): Backfil
   let processed = 0;
   let skipped = 0;
   let markedStopped = 0;
+  const markedStoppedIds: Array<{ id: string; previousStatus: string }> = [];
 
   let entries: string[] = [];
   try {
     entries = readdirSync(agentsDir);
   } catch {
-    return { processed, skipped, markedStopped };
+    return { processed, skipped, markedStopped, markedStoppedIds };
   }
 
   const cols = OVERDECK_AGENT_COLUMNS.join(', ');
@@ -935,6 +938,12 @@ export function backfillAgentsSync(options?: BackfillAgentsSyncOptions): Backfil
 
       // Reconcile: mark stopped if no live tmux session
       if ((state.status === 'running' || state.status === 'starting') && !liveSessions.has(state.id)) {
+        const previousStatus = state.status;
+        logAgentLifecycleSync(
+          state.id,
+          `status changed: ${previousStatus} → stopped (boot backfill reconcile: no live tmux session)`,
+        );
+        markedStoppedIds.push({ id: state.id, previousStatus });
         state.status = 'stopped';
         state.stoppedAt = state.stoppedAt ?? new Date().toISOString();
         markedStopped++;
@@ -962,7 +971,7 @@ export function backfillAgentsSync(options?: BackfillAgentsSyncOptions): Backfil
   });
 
   tx();
-  return { processed, skipped, markedStopped };
+  return { processed, skipped, markedStopped, markedStoppedIds };
 }
 
 /**

--- a/src/lib/reconstruct/reconstruct-cache.ts
+++ b/src/lib/reconstruct/reconstruct-cache.ts
@@ -35,6 +35,7 @@ export interface ReconstructOptions {
 export interface ReconstructResult {
   issuesEnumerated: number;
   agentsRebuilt: number;
+  markedStoppedIds: Array<{ id: string; previousStatus: string }>;
   phaseCounts: Record<PipelinePhase, number>;
   agentRuntimeById: Record<string, AgentRuntimeSnapshot>;
   agentsById: Record<string, AgentSnapshot>;
@@ -282,7 +283,10 @@ export async function reconstructCache(
   const verbose = opts?.verbose ?? false;
 
   // 1. Rebuild the agents table from state.json + tmux (sources-only).
-  const { processed: agentsRebuilt } = backfillAgentsSync({
+  const {
+    processed: agentsRebuilt,
+    markedStoppedIds = [],
+  } = backfillAgentsSync({
     verbose,
     listLiveSessions: opts?.listLiveSessions,
   });
@@ -396,6 +400,7 @@ export async function reconstructCache(
   return {
     issuesEnumerated: inFlight.size,
     agentsRebuilt,
+    markedStoppedIds,
     phaseCounts,
     agentRuntimeById,
     agentsById,

--- a/tests/unit/dashboard/server/reconstruct-boot.test.ts
+++ b/tests/unit/dashboard/server/reconstruct-boot.test.ts
@@ -141,6 +141,30 @@ describe('ReadModelService bootstrap (PAN-1938 source-swap)', () => {
     await vi.waitFor(() => expect(reconstructCacheAutoMock).toHaveBeenCalled());
   });
 
+  it('reads authoritative agent rows after reconstruction finishes', async () => {
+    let reconstructFinished = false;
+    reconstructCacheAutoMock.mockImplementation(async () => {
+      reconstructFinished = true;
+      return fakeReconstructResult as any;
+    });
+    const list = vi.fn(() => {
+      expect(reconstructFinished).toBe(true);
+      return Effect.succeed([]);
+    });
+    const resolverLayer = Layer.succeed(AgentsResolver, AgentsResolver.of({
+      list,
+      get: (_id) => Effect.fail(new Error('not found') as never),
+      isAlive: (_id) => Effect.succeed(false),
+      getRuntime: (_id) => Effect.succeed(null),
+      getHealthHistory: (_id) => Effect.succeed([]),
+    }));
+    const layer = ReadModelServiceLive.pipe(Layer.provide(resolverLayer));
+
+    await Effect.runPromise(Effect.provide(Effect.void, layer));
+
+    expect(list).toHaveBeenCalledOnce();
+  });
+
   it('durably emits each source-reconciled stop during bootstrap', async () => {
     reconstructCacheAutoMock.mockResolvedValue({
       ...fakeReconstructResult,

--- a/tests/unit/dashboard/server/reconstruct-boot.test.ts
+++ b/tests/unit/dashboard/server/reconstruct-boot.test.ts
@@ -29,6 +29,8 @@ const fakeReconstructResult = {
 const readFromSpy = vi.fn(() => []);
 const subscribeSpy = vi.fn(() => () => {});
 const appendAsyncSpy = vi.fn(async () => 1);
+const getLatestSequenceSpy = vi.fn(() => 0);
+const queryByTypeSpy = vi.fn(() => []);
 
 vi.mock('../../../../src/lib/reconstruct/reconstruct-cache.js', () => ({
   reconstructCache: vi.fn(),
@@ -37,6 +39,7 @@ vi.mock('../../../../src/lib/reconstruct/reconstruct-cache.js', () => ({
 
 vi.mock('../../../../src/dashboard/server/event-store.js', () => ({
   initEventStore: vi.fn(),
+  getEventStore: vi.fn(),
 }));
 
 vi.mock('../../../../src/lib/agent-runtime-mirror.js', () => ({
@@ -46,7 +49,7 @@ vi.mock('../../../../src/lib/agent-runtime-mirror.js', () => ({
 }));
 
 import { reconstructCache, reconstructCacheAuto } from '../../../../src/lib/reconstruct/reconstruct-cache.js';
-import { initEventStore } from '../../../../src/dashboard/server/event-store.js';
+import { getEventStore, initEventStore } from '../../../../src/dashboard/server/event-store.js';
 import { AgentStateServiceLive } from '../../../../src/dashboard/server/services/agent-state-service.js';
 import { ReadModelServiceLive } from '../../../../src/dashboard/server/read-model.js';
 import { AgentsResolver } from '../../../../src/lib/overdeck/agents.js';
@@ -54,17 +57,25 @@ import { AgentsResolver } from '../../../../src/lib/overdeck/agents.js';
 const reconstructCacheMock = vi.mocked(reconstructCache);
 const reconstructCacheAutoMock = vi.mocked(reconstructCacheAuto);
 const initEventStoreMock = vi.mocked(initEventStore);
+const getEventStoreMock = vi.mocked(getEventStore);
 
 beforeEach(() => {
   vi.resetAllMocks();
+  appendAsyncSpy.mockResolvedValue(1);
+  getLatestSequenceSpy.mockReturnValue(0);
+  queryByTypeSpy.mockReturnValue([]);
   reconstructCacheMock.mockResolvedValue(fakeReconstructResult as any);
   reconstructCacheAutoMock.mockResolvedValue(fakeReconstructResult as any);
-  initEventStoreMock.mockResolvedValue({
+  const eventStore = {
     readFrom: readFromSpy,
     subscribe: subscribeSpy,
     appendAsync: appendAsyncSpy,
     emitOnly: vi.fn(),
-  } as any);
+    getLatestSequence: getLatestSequenceSpy,
+    queryByType: queryByTypeSpy,
+  } as any;
+  initEventStoreMock.mockResolvedValue(eventStore);
+  getEventStoreMock.mockReturnValue(eventStore);
 });
 
 describe('AgentStateService bootstrap (PAN-1920)', () => {
@@ -74,6 +85,39 @@ describe('AgentStateService bootstrap (PAN-1920)', () => {
 
     expect(readFromSpy).not.toHaveBeenCalled();
     expect(subscribeSpy).toHaveBeenCalled();
+  });
+
+  it('durably emits each source-reconciled stop before merging the seed', async () => {
+    reconstructCacheAutoMock.mockResolvedValue({
+      ...fakeReconstructResult,
+      markedStoppedIds: [{ id: 'agent-pan-1920', previousStatus: 'running' }],
+      agentsById: {
+        'agent-pan-1920': {
+          ...fakeReconstructResult.agentsById['agent-pan-1920'],
+          status: 'stopped',
+          hasLiveTmuxSession: false,
+        },
+      },
+      agentRuntimeById: {
+        'agent-pan-1920': {
+          ...fakeReconstructResult.agentRuntimeById['agent-pan-1920'],
+          activity: 'stopped',
+        },
+      },
+    } as any);
+
+    await Effect.runPromise(Effect.provide(Effect.void, AgentStateServiceLive));
+    await vi.waitFor(() => expect(appendAsyncSpy).toHaveBeenCalled());
+
+    expect(appendAsyncSpy).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'agent.status_changed',
+      payload: expect.objectContaining({
+        agentId: 'agent-pan-1920',
+        status: 'stopped',
+        previousStatus: 'running',
+        hasLiveTmuxSession: false,
+      }),
+    }));
   });
 });
 
@@ -95,5 +139,42 @@ describe('ReadModelService bootstrap (PAN-1938 source-swap)', () => {
     const layer = ReadModelServiceLive.pipe(Layer.provide(MockAgentsResolverLive));
     await Effect.runPromise(Effect.provide(Effect.void, layer));
     await vi.waitFor(() => expect(reconstructCacheAutoMock).toHaveBeenCalled());
+  });
+
+  it('durably emits each source-reconciled stop during bootstrap', async () => {
+    reconstructCacheAutoMock.mockResolvedValue({
+      ...fakeReconstructResult,
+      markedStoppedIds: [{ id: 'agent-pan-1920', previousStatus: 'running' }],
+    } as any);
+    const layer = ReadModelServiceLive.pipe(Layer.provide(MockAgentsResolverLive));
+
+    await Effect.runPromise(Effect.provide(Effect.void, layer));
+
+    expect(appendAsyncSpy).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'agent.status_changed',
+      payload: expect.objectContaining({
+        agentId: 'agent-pan-1920',
+        status: 'stopped',
+        previousStatus: 'running',
+        hasLiveTmuxSession: false,
+      }),
+    }));
+  });
+
+  it('logs an append failure and still completes bootstrap', async () => {
+    reconstructCacheAutoMock.mockResolvedValue({
+      ...fakeReconstructResult,
+      markedStoppedIds: [{ id: 'agent-pan-1920', previousStatus: 'running' }],
+    } as any);
+    appendAsyncSpy.mockRejectedValueOnce(new Error('event store unavailable'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const layer = ReadModelServiceLive.pipe(Layer.provide(MockAgentsResolverLive));
+
+    await expect(Effect.runPromise(Effect.provide(Effect.void, layer))).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[ReadModel] Failed to emit boot-reconciled stop events:',
+      expect.any(Error),
+    );
+    errorSpy.mockRestore();
   });
 });

--- a/tests/unit/dashboard/server/reconstruct-boot.test.ts
+++ b/tests/unit/dashboard/server/reconstruct-boot.test.ts
@@ -190,7 +190,7 @@ describe('ReadModelService bootstrap (PAN-1938 source-swap)', () => {
       ...fakeReconstructResult,
       markedStoppedIds: [{ id: 'agent-pan-1920', previousStatus: 'running' }],
     } as any);
-    appendAsyncSpy.mockRejectedValueOnce(new Error('event store unavailable'));
+    appendAsyncSpy.mockResolvedValueOnce(0);
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const layer = ReadModelServiceLive.pipe(Layer.provide(MockAgentsResolverLive));
 

--- a/tests/unit/dashboard/server/reconstruct-boot.test.ts
+++ b/tests/unit/dashboard/server/reconstruct-boot.test.ts
@@ -4,6 +4,7 @@ import { Effect, Layer } from 'effect';
 const fakeReconstructResult = {
   issuesEnumerated: 1,
   agentsRebuilt: 2,
+  markedStoppedIds: [],
   phaseCounts: { work: 1, review: 0, merge: 0, done: 0 },
   agentsById: {
     'agent-pan-1920': {

--- a/tests/unit/dashboard/server/services/agent-state-service.test.ts
+++ b/tests/unit/dashboard/server/services/agent-state-service.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentRuntimeSnapshot, AgentSnapshot } from '@overdeck/contracts';
+import { mergeRuntimeBySequence } from '../../../../../src/dashboard/server/services/agent-state-service.js';
+
+function runtime(activity: AgentRuntimeSnapshot['activity'], sequence: number): AgentRuntimeSnapshot {
+  return {
+    id: 'agent-pan-3183',
+    activity,
+    lastActivity: '2026-07-27T02:52:14.000Z',
+    updatedAtSequence: sequence,
+  } as AgentRuntimeSnapshot;
+}
+
+function sourceAgent(hasLiveTmuxSession: boolean, status: AgentSnapshot['status'] = 'stopped'): AgentSnapshot {
+  return {
+    id: 'agent-pan-3183',
+    issueId: 'PAN-3183',
+    status,
+    hasLiveTmuxSession,
+  } as AgentSnapshot;
+}
+
+describe('mergeRuntimeBySequence', () => {
+  it('keeps a source-reconstructed stop when no live tmux session exists', () => {
+    const merged = mergeRuntimeBySequence(
+      { 'agent-pan-3183': runtime('working', 726958) },
+      { 'agent-pan-3183': runtime('stopped', 0) },
+      { 'agent-pan-3183': sourceAgent(false) },
+    );
+
+    expect(merged['agent-pan-3183']?.activity).toBe('stopped');
+  });
+
+  it('keeps the event-folded running state when a live tmux session exists', () => {
+    const merged = mergeRuntimeBySequence(
+      { 'agent-pan-3183': runtime('working', 726958) },
+      { 'agent-pan-3183': runtime('stopped', 0) },
+      { 'agent-pan-3183': sourceAgent(true) },
+    );
+
+    expect(merged['agent-pan-3183']?.activity).toBe('working');
+  });
+
+  it('preserves sequence precedence when both snapshots are running', () => {
+    const source = { 'agent-pan-3183': sourceAgent(true, 'running') };
+
+    expect(mergeRuntimeBySequence(
+      { 'agent-pan-3183': runtime('working', 1) },
+      { 'agent-pan-3183': runtime('working', 2) },
+      source,
+    )['agent-pan-3183']?.updatedAtSequence).toBe(2);
+
+    expect(mergeRuntimeBySequence(
+      { 'agent-pan-3183': runtime('working', 3) },
+      { 'agent-pan-3183': runtime('working', 2) },
+      source,
+    )['agent-pan-3183']?.updatedAtSequence).toBe(3);
+  });
+});

--- a/tests/unit/dashboard/server/services/boot-reconciled-stop-events.test.ts
+++ b/tests/unit/dashboard/server/services/boot-reconciled-stop-events.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { openDatabase, type SqliteDatabase } from '../../../../../src/lib/database/driver.js';
+import { createEventStore, type DbAdapter } from '../../../../../src/dashboard/server/event-store.js';
+import { emitBootReconciledStopEvents } from '../../../../../src/dashboard/server/services/boot-reconciled-stop-events.js';
+
+const stop = [{ id: 'agent-pan-3183', previousStatus: 'running' }];
+const present = { 'agent-pan-3183': {} };
+
+function createEventsDb(): SqliteDatabase {
+  const db = openDatabase(':memory:');
+  db.exec(`
+    CREATE TABLE events (
+      sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+      type TEXT NOT NULL,
+      timestamp INTEGER NOT NULL,
+      payload TEXT NOT NULL DEFAULT '{}'
+    )
+  `);
+  return db;
+}
+
+describe('emitBootReconciledStopEvents', () => {
+  let db: SqliteDatabase;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    db = createEventsDb();
+  });
+
+  afterEach(() => {
+    db.close();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('logs sequence zero from the real async event-store failure contract', async () => {
+    const failingDb: DbAdapter = {
+      prepare: db.prepare.bind(db) as DbAdapter['prepare'],
+      exec: (sql) => {
+        if (sql === 'BEGIN IMMEDIATE') throw new Error('forced write failure');
+        db.exec(sql);
+      },
+    };
+    const store = createEventStore(failingDb);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const emitted = emitBootReconciledStopEvents(store, stop, present, 'boot append failed');
+    await vi.runAllTimersAsync();
+    await emitted;
+
+    expect(store.getLatestSequence()).toBe(0);
+    expect(errorSpy).toHaveBeenCalledWith(
+      'boot append failed',
+      expect.objectContaining({ message: 'Event append returned invalid sequence 0' }),
+    );
+  });
+
+  it('deduplicates concurrent callers after one durable append succeeds', async () => {
+    const store = createEventStore(db as unknown as DbAdapter);
+
+    const first = emitBootReconciledStopEvents(store, stop, present, 'boot append failed');
+    const second = emitBootReconciledStopEvents(store, stop, present, 'boot append failed');
+    await vi.runAllTimersAsync();
+    await Promise.all([first, second]);
+
+    expect(store.readFrom(0)).toHaveLength(1);
+  });
+});

--- a/tests/unit/lib/database/agent-backfill.test.ts
+++ b/tests/unit/lib/database/agent-backfill.test.ts
@@ -132,6 +132,30 @@ describe('backfillAgentsFromStateJsonSync', () => {
     expect(row?.stoppedAt).toBeDefined();
   });
 
+  it('does not log a stop when the transaction rolls back', () => {
+    const validState = {
+      id: 'agent-pan-1907',
+      issueId: 'PAN-1907',
+      role: 'work',
+      status: 'running',
+      workspace: '/workspaces/feature-pan-1907',
+      startedAt: '2026-06-15T00:00:00.000Z',
+    };
+    writeAgentState('agent-pan-1907', validState);
+    backfillAgentsFromStateJsonSync(testDb, {
+      listLiveSessions: () => new Set(['agent-pan-1907']),
+    });
+    vi.clearAllMocks();
+    const { issueId: _issueId, ...invalidState } = validState;
+    writeAgentState('agent-pan-1907', invalidState);
+
+    expect(() => backfillAgentsFromStateJsonSync(testDb, {
+      listLiveSessions: () => new Set(),
+    })).toThrow();
+    expect(logAgentLifecycleSync).not.toHaveBeenCalled();
+    expect(getAgent('agent-pan-1907')?.status).toBe('running');
+  });
+
   it('keeps running agents running when a live tmux session matches', () => {
     writeAgentState('agent-pan-1908', {
       id: 'agent-pan-1908',

--- a/tests/unit/lib/database/agent-backfill.test.ts
+++ b/tests/unit/lib/database/agent-backfill.test.ts
@@ -20,6 +20,10 @@ vi.mock('../../../../src/lib/database/index.js', () => ({
   getDatabase: () => testDb,
 }));
 
+vi.mock('../../../../src/lib/persistent-logger.js', () => ({
+  logAgentLifecycleSync: vi.fn(),
+}));
+
 beforeEach(() => {
   testDb = openDatabase(':memory:');
   testDb.pragma('foreign_keys = ON');
@@ -29,6 +33,7 @@ beforeEach(() => {
   originalHome = process.env.OVERDECK_HOME;
   process.env.OVERDECK_HOME = tmpHome;
   delete process.env.OVERDECK_TMUX_SOCKET_NAME;
+  vi.clearAllMocks();
 });
 
 afterEach(() => {
@@ -46,6 +51,7 @@ import {
   type BackfillAgentsResult,
 } from '../../../../src/lib/database/agent-backfill.js';
 import { getAgent } from '../../../../src/lib/database/agents-db.js';
+import { logAgentLifecycleSync } from '../../../../src/lib/persistent-logger.js';
 
 function writeAgentState(agentId: string, state: Record<string, unknown>): void {
   const dir = join(tmpHome, 'agents', agentId);
@@ -114,6 +120,13 @@ describe('backfillAgentsFromStateJsonSync', () => {
     });
 
     expect(result.markedStopped).toBe(1);
+    expect(result.markedStoppedIds).toEqual([
+      { id: 'agent-pan-1908', previousStatus: 'running' },
+    ]);
+    expect(logAgentLifecycleSync).toHaveBeenCalledWith(
+      'agent-pan-1908',
+      expect.stringContaining('boot backfill reconcile'),
+    );
     const row = getAgent('agent-pan-1908');
     expect(row?.status).toBe('stopped');
     expect(row?.stoppedAt).toBeDefined();

--- a/tests/unit/lib/overdeck/backfill-agents-fk.test.ts
+++ b/tests/unit/lib/overdeck/backfill-agents-fk.test.ts
@@ -5,9 +5,13 @@
  * crash-looped on `FOREIGN KEY constraint failed`. The smoke tests missed this
  * because they ran against a throwaway home with NO state.json files.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+
+vi.mock('../../../../src/lib/persistent-logger.js', () => ({
+  logAgentLifecycleSync: vi.fn(),
+}));
 
 import {
   setupOverdeckTestDb,
@@ -15,10 +19,14 @@ import {
   type OverdeckTestDb,
 } from '../../../helpers/overdeck-test-db.js';
 import { backfillAgentsSync } from '../../../../src/lib/overdeck/agents.js';
+import { logAgentLifecycleSync } from '../../../../src/lib/persistent-logger.js';
 
 describe('backfillAgentsSync FK-safety on a fresh overdeck.db (PAN-1938)', () => {
   let odb: OverdeckTestDb;
-  beforeEach(() => { odb = setupOverdeckTestDb(); });
+  beforeEach(() => {
+    vi.clearAllMocks();
+    odb = setupOverdeckTestDb();
+  });
   afterEach(() => { teardownOverdeckTestDb(odb); });
 
   it('creates the parent issue row so the agents.issue_id FK is satisfied (no FOREIGN KEY error)', () => {
@@ -46,5 +54,35 @@ describe('backfillAgentsSync FK-safety on a fresh overdeck.db (PAN-1938)', () =>
     // The parent issue row was created (FK satisfied) and the agent is present.
     expect(odb.raw().prepare('SELECT id FROM issues WHERE id = ?').get('PAN-9999')).toBeTruthy();
     expect(odb.raw().prepare('SELECT issue_id FROM agents WHERE id = ?').get('agent-pan-9999')).toBeTruthy();
+  });
+
+  it('reports and logs agents reconciled from running to stopped', () => {
+    const agentDir = join(odb.home, 'agents', 'agent-pan-9998');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(
+      join(agentDir, 'state.json'),
+      JSON.stringify({
+        id: 'agent-pan-9998',
+        issueId: 'PAN-9998',
+        role: 'work',
+        status: 'running',
+        workspace: '/tmp/ws',
+        model: 'x',
+        harness: 'claude-code',
+        startedAt: new Date().toISOString(),
+      }),
+    );
+
+    const result = backfillAgentsSync({ listLiveSessions: () => new Set() });
+
+    expect(result.markedStoppedIds).toEqual([
+      { id: 'agent-pan-9998', previousStatus: 'running' },
+    ]);
+    expect(logAgentLifecycleSync).toHaveBeenCalledWith(
+      'agent-pan-9998',
+      expect.stringContaining('boot backfill reconcile'),
+    );
+    expect(odb.raw().prepare('SELECT status FROM agents WHERE id = ?').get('agent-pan-9998'))
+      .toEqual(expect.objectContaining({ status: 'stopped' }));
   });
 });

--- a/tests/unit/lib/overdeck/backfill-agents-fk.test.ts
+++ b/tests/unit/lib/overdeck/backfill-agents-fk.test.ts
@@ -85,4 +85,37 @@ describe('backfillAgentsSync FK-safety on a fresh overdeck.db (PAN-1938)', () =>
     expect(odb.raw().prepare('SELECT status FROM agents WHERE id = ?').get('agent-pan-9998'))
       .toEqual(expect.objectContaining({ status: 'stopped' }));
   });
+
+  it('does not report or log a stop when the row upsert fails', () => {
+    const agentDir = join(odb.home, 'agents', 'agent-pan-9997');
+    mkdirSync(agentDir, { recursive: true });
+    const statePath = join(agentDir, 'state.json');
+    const validState = {
+      id: 'agent-pan-9997',
+      issueId: 'PAN-9997',
+      role: 'work',
+      status: 'running',
+      workspace: '/tmp/ws',
+      model: 'x',
+      harness: 'claude-code',
+      startedAt: new Date().toISOString(),
+    };
+    writeFileSync(statePath, JSON.stringify(validState));
+    backfillAgentsSync({ listLiveSessions: () => new Set(['agent-pan-9997']) });
+    vi.clearAllMocks();
+    const { issueId: _issueId, ...invalidState } = validState;
+    writeFileSync(statePath, JSON.stringify(invalidState));
+
+    const result = backfillAgentsSync({ listLiveSessions: () => new Set() });
+
+    expect(result).toEqual(expect.objectContaining({
+      processed: 0,
+      skipped: 1,
+      markedStopped: 0,
+      markedStoppedIds: [],
+    }));
+    expect(logAgentLifecycleSync).not.toHaveBeenCalled();
+    expect(odb.raw().prepare('SELECT status FROM agents WHERE id = ?').get('agent-pan-9997'))
+      .toEqual(expect.objectContaining({ status: 'running' }));
+  });
 });

--- a/tests/unit/lib/reconstruct/no-loss-superset.test.ts
+++ b/tests/unit/lib/reconstruct/no-loss-superset.test.ts
@@ -76,7 +76,12 @@ function fakeDb(): any {
 
 beforeEach(() => {
   vi.resetAllMocks();
-  backfillMock.mockReturnValue({ processed: 0, skipped: 0, markedStopped: 0 });
+  backfillMock.mockReturnValue({
+    processed: 0,
+    skipped: 0,
+    markedStopped: 0,
+    markedStoppedIds: [],
+  });
   listRunningAgentsMock.mockReturnValue(Effect.succeed([]) as any);
   listAllAgentsMock.mockReturnValue([]);
   listProjectsMock.mockReturnValue([]);

--- a/tests/unit/lib/reconstruct/reconstruct-cache.test.ts
+++ b/tests/unit/lib/reconstruct/reconstruct-cache.test.ts
@@ -72,7 +72,7 @@ function fakeDb(): any {
 
 beforeEach(() => {
   vi.resetAllMocks();
-  backfillMock.mockReturnValue({ processed: 0, skipped: 0, markedStopped: 0 });
+  backfillMock.mockReturnValue({ processed: 0, skipped: 0, markedStopped: 0, markedStoppedIds: [] });
   listRunningAgentsMock.mockReturnValue(Effect.succeed([]) as any);
   listAllAgentsMock.mockReturnValue([]);
   listProjectsMock.mockReturnValue([]);
@@ -86,25 +86,34 @@ describe('reconstructCache', () => {
     const result = await reconstructCache(fakeDb());
     expect(result.issuesEnumerated).toBe(0);
     expect(result.agentsRebuilt).toBe(0);
+    expect(result.markedStoppedIds).toEqual([]);
     expect(result.phaseCounts).toEqual({ work: 0, review: 0, merge: 0, done: 0 });
     expect(Object.keys(result.agentsById)).toEqual([]);
     expect(Object.keys(result.agentRuntimeById)).toEqual([]);
   });
 
-  it('reports agents rebuilt from backfill', async () => {
-    backfillMock.mockReturnValue({ processed: 3, skipped: 0, markedStopped: 0 });
+  it('reports agents rebuilt and marked stopped from backfill', async () => {
+    backfillMock.mockReturnValue({
+      processed: 3,
+      skipped: 0,
+      markedStopped: 1,
+      markedStoppedIds: [{ id: 'agent-pan-old', previousStatus: 'running' }],
+    });
     listRunningAgentsMock.mockReturnValue(Effect.succeed([
       agentState({ id: 'agent-pan-1920', issueId: 'PAN-1920' }),
     ]) as any);
 
     const result = await reconstructCache(fakeDb());
     expect(result.agentsRebuilt).toBe(3);
+    expect(result.markedStoppedIds).toEqual([
+      { id: 'agent-pan-old', previousStatus: 'running' },
+    ]);
     expect(result.agentsById['agent-pan-1920']?.issueId).toBe('PAN-1920');
     expect(result.agentRuntimeById['agent-pan-1920']?.activity).toBe('working');
   });
 
   it('falls back to agents table when listRunningAgents fails', async () => {
-    backfillMock.mockReturnValue({ processed: 1, skipped: 0, markedStopped: 0 });
+    backfillMock.mockReturnValue({ processed: 1, skipped: 0, markedStopped: 0, markedStoppedIds: [] });
     listRunningAgentsMock.mockReturnValue(Effect.fail(new Error('tmux unavailable')) as any);
     listAllAgentsMock.mockReturnValue([{
       id: 'agent-pan-1919',


### PR DESCRIPTION
**Issue:** #3183

## Acceptance Criteria

- [ ] Confirm the 02:52:14Z writer from live evidence and audit all direct agents-table status writers
- [ ] backfillAgentsSync reports marked-stopped ids and writes lifecycle log lines per flipped agent
- [ ] Legacy backfillAgentsFromStateJsonSync gets the same marked-stopped reporting and lifecycle logging
- [ ] Dashboard boot callers emit agent.status_changed for each backfill-marked stop
- [ ] mergeRuntimeBySequence gives source-reconstructed stopped-without-tmux precedence over event-folded running
- [ ] Lint guard fails direct agents-table status mutations outside the allowlisted doors
- [ ] docs/AGENT-STATE-PLANES.md documents the boot-path event-door invariant and the lint guard