### PR TITLE
PAN-2876

### DIFF
--- a/docs/CONVERSATION-SUBAGENTS.md
+++ b/docs/CONVERSATION-SUBAGENTS.md
@@ -1,0 +1,70 @@
+# Conversation subagents
+
+Claude Code writes each subagent beside its parent conversation transcript. Overdeck reads these files to list subagents and show their full transcripts in the conversation panel. The dashboard never modifies the files.
+
+## On-disk layout
+
+For a parent transcript at:
+
+```text
+~/.claude/projects/<encoded-project>/<session-id>.jsonl
+```
+
+Claude Code writes subagent data under the parent session directory:
+
+```text
+~/.claude/projects/<encoded-project>/<session-id>/subagents/
+├── agent-<agent-id>.jsonl
+└── agent-<agent-id>.meta.json
+```
+
+The JSONL file uses the same message format as the parent transcript, so Overdeck reuses the existing parser and watcher. The metadata file has this verified shape:
+
+```json
+{
+  "agentType": "Explore",
+  "description": "Trace conversation message handling",
+  "toolUseId": "toolu_01ABC...",
+  "spawnDepth": 1
+}
+```
+
+Overdeck derives `agentId` from the metadata filename. `spawnDepth` is display metadata; the dashboard shows nested subagents in one flat rail with a depth marker.
+
+## Parent-row join
+
+The metadata field `toolUseId` equals the `id` of the parent transcript's `tool_use` block. The conversation parser stores that block id as the work-log entry id. This gives the frontend a direct join:
+
+```text
+subagent.meta.toolUseId == workLogEntry.id == tool_use.id
+```
+
+An expanded `Agent` or legacy `Task` row uses this join to show **Open subagent transcript**.
+
+## Transport
+
+`SubagentSummary` is the shared server/frontend shape. It contains the metadata fields, derived `agentId`, and a status of `running` or `done`.
+
+The existing conversation transport carries subagent data:
+
+- A parent `pan.subscribeConversationMessages` stream emits `{ kind: "subagents", subagents }` after its initial message snapshot. A two-second poll emits a replacement list only when the list or a status changes.
+- The subscription payload accepts an optional `agentId`. When present, the same RPC streams the matching subagent JSONL through the existing snapshot and tail pipeline. Subagent transcript streams do not emit nested subagent-list events.
+- `GET /api/conversations/:name/messages` includes `subagents` for the parent response. `?agentId=<id>` returns one subagent transcript for ended conversations and other one-shot reads.
+
+The frontend keeps parent and subagent transcripts in separate React Query cache keys, so opening a subagent cannot replace the parent timeline.
+
+## Status derivation
+
+Metadata files do not contain runtime status. While the parent stream is live, Overdeck marks a subagent `running` when its `toolUseId` remains in the parser's `pendingToolUse` map. It marks all other entries `done`.
+
+A watcher delta triggers an immediate status refresh. The two-second metadata poll catches new subagent files. REST responses for ended conversations mark every discovered subagent `done`.
+
+## Path safety
+
+Subagent transcript lookup accepts only ids that match:
+
+```text
+^[A-Za-z0-9_-]+$
+```
+
+The resolver then builds the candidate with `path.resolve` and verifies that its parent directory is the resolved `subagents` directory. Invalid ids return `null`, and the REST route returns HTTP 400 before any transcript read. Discovery and transcript access use asynchronous filesystem APIs and remain read-only.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -22,6 +22,7 @@
 |----------|-------------|
 | [AGENTS.md](./AGENTS.md) | Agent directory structure, naming patterns, standard contents, and cleanup |
 | [AGENT-STATE-PLANES.md](./AGENT-STATE-PLANES.md) | Three-plane state model: permanent git records, local SQLite runtime registry, and tmux liveness oracle |
+| [CONVERSATION-SUBAGENTS.md](./CONVERSATION-SUBAGENTS.md) | Claude Code subagent transcript layout, parent-row join, transport, status derivation, and path safety |
 | [CODEBASE-HEALTH-ROADMAP.md](./CODEBASE-HEALTH-ROADMAP.md) | Architecture debt-reduction roadmap (four epics A–D): why fix-work dominates feature-work, the deep-module diagnosis, and the handoff-orchestration execution model. PRDs under [codebase-health/](./codebase-health/) |
 | [PAN-1908-POST-MERGE-RUNBOOK.md](./PAN-1908-POST-MERGE-RUNBOOK.md) | Post-merge close-out runbook for superseded/narrowed issues tracked by PAN-1908 |
 | [Architecture Diagram](./diagrams/overdeck-architecture.png) | Visual overview of Overdeck system architecture (UI → Core → Agents → Infrastructure → Pipeline)
@@ -161,6 +162,7 @@
 
 ### Agent System
 - **"agent"** / **"agents"** → AGENTS.md, SPECIALIST_WORKFLOW.md, CLAUDE.md
+- **"conversation subagent"** / **"subagent transcript"** / **"toolUseId"** → CONVERSATION-SUBAGENTS.md
 - **"lifecycle"** → AGENTS.md, PRD-CLOISTER.md
 - **"specialist"** / **"specialists"** → SPECIALIST_WORKFLOW.md
 - **"worker"** → SPECIALIST_WORKFLOW.md

--- a/packages/contracts/src/rpc.test.ts
+++ b/packages/contracts/src/rpc.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+import { Schema } from "effect"
+import {
+  ConversationEvent,
+  ConversationResponse,
+  SubscribeConversationMessagesRpc,
+} from "./rpc"
+
+const subagent = {
+  agentId: "a1b2c3",
+  agentType: "Explore",
+  description: "Trace conversation message handling",
+  toolUseId: "toolu_123",
+  spawnDepth: 1,
+  status: "running",
+} as const
+
+describe("ConversationEvent", () => {
+  it("decodes a subagents event", () => {
+    const event = {
+      kind: "subagents",
+      subagents: [subagent],
+    }
+
+    expect(Schema.decodeUnknownSync(ConversationEvent)(event)).toEqual(event)
+  })
+})
+
+describe("SubscribeConversationMessagesRpc", () => {
+  const decodePayload = Schema.decodeUnknownSync(SubscribeConversationMessagesRpc.payloadSchema)
+
+  it("decodes payloads with and without an agent id", () => {
+    expect(decodePayload({ conversationName: "conv-123" })).toEqual({
+      conversationName: "conv-123",
+    })
+    expect(decodePayload({ conversationName: "conv-123", agentId: "a1b2c3" })).toEqual({
+      conversationName: "conv-123",
+      agentId: "a1b2c3",
+    })
+  })
+})
+
+describe("ConversationResponse", () => {
+  const decodeResponse = Schema.decodeUnknownSync(ConversationResponse)
+  const legacyResponse = {
+    messages: [],
+    workLog: [],
+    streaming: false,
+    totalCost: 0,
+    byteOffset: 0,
+  }
+
+  it("decodes responses with and without subagents", () => {
+    expect(decodeResponse(legacyResponse)).toEqual(legacyResponse)
+    expect(decodeResponse({ ...legacyResponse, subagents: [subagent] })).toEqual({
+      ...legacyResponse,
+      subagents: [subagent],
+    })
+  })
+})

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -171,22 +171,34 @@ export const WorkLogEntry = Schema.Struct({
 })
 export type WorkLogEntry = typeof WorkLogEntry.Type
 
+export const SubagentSummary = Schema.Struct({
+  agentId: Schema.String,
+  agentType: Schema.String,
+  description: Schema.String,
+  toolUseId: Schema.String,
+  spawnDepth: Schema.Number,
+  status: Schema.Literals(['running', 'done']),
+})
+export type SubagentSummary = typeof SubagentSummary.Type
+
 /**
  * Response shape for GET /api/agents/:id/conversation.
  * Shared between the dashboard server route and the frontend TerminalPanel.
  */
-export interface ConversationResponse {
-  messages: ChatMessage[];
-  workLog: WorkLogEntry[];
-  streaming: boolean;
-  totalCost: number;
+export const ConversationResponse = Schema.Struct({
+  messages: Schema.Array(ChatMessage),
+  workLog: Schema.Array(WorkLogEntry),
+  streaming: Schema.Boolean,
+  totalCost: Schema.Number,
   /** Total token throughput (input + output + cache read + cache write). */
-  totalTokens?: number;
-  byteOffset: number;
-  proposedPlan?: ProposedPlan;
-  compactBoundaries?: CompactBoundary[];
-  contextUsage?: ContextUsage | null;
-}
+  totalTokens: Schema.optional(Schema.Number),
+  byteOffset: Schema.Number,
+  proposedPlan: Schema.optional(ProposedPlan),
+  compactBoundaries: Schema.optional(Schema.Array(CompactBoundary)),
+  contextUsage: Schema.optional(Schema.NullOr(ContextUsage)),
+  subagents: Schema.optional(Schema.Array(SubagentSummary)),
+})
+export type ConversationResponse = typeof ConversationResponse.Type
 
 export const ConversationEvent = Schema.Union([
   Schema.Struct({
@@ -201,6 +213,10 @@ export const ConversationEvent = Schema.Union([
   }),
   Schema.Struct({
     kind: Schema.Literal('discovering'),
+  }),
+  Schema.Struct({
+    kind: Schema.Literal('subagents'),
+    subagents: Schema.Array(SubagentSummary),
   }),
 ])
 export type ConversationEvent = typeof ConversationEvent.Type
@@ -387,7 +403,10 @@ export const ResizeTerminalRpc = Rpc.make(WS_METHODS.resizeTerminal, {
 
 /** 16. Subscribe to structured conversation messages from a JSONL session file (stream, PAN-451) */
 export const SubscribeConversationMessagesRpc = Rpc.make(WS_METHODS.subscribeConversationMessages, {
-  payload: Schema.Struct({ conversationName: Schema.String }),
+  payload: Schema.Struct({
+    conversationName: Schema.String,
+    agentId: Schema.optional(Schema.String),
+  }),
   success: ConversationEvent,
   error: PanRpcError,
   stream: true,

--- a/reference/architecture.mdx
+++ b/reference/architecture.mdx
@@ -52,6 +52,12 @@ Because the `projects.yaml` registry (see [Directory Structure](#directory-struc
   alt="God View: aggregate cross-project view of all agent activity across every registered project"
 />
 
+### Conversation subagents
+
+When a Claude Code conversation starts subagents through the `Agent` tool, the conversation panel opens a **Subagents** rail on the right. Each row shows the subagent type, description, live status, and nesting depth. Select a row—or choose **Open subagent transcript** from its expanded tool row—to read the subagent's full transcript without leaving the parent conversation.
+
+The selected subagent is stored in the `?subagent=<id>` URL parameter, so a direct link reopens the same transcript. The rail stays hidden when a conversation has no subagents. Pi and Codex conversations are unchanged because they do not use Claude Code's subagent file layout.
+
 ## Directory Structure
 
 Overdeck stores all runtime state in `~/.overdeck/`:

--- a/src/cli/commands/__tests__/dashboard-cwd-guard.test.ts
+++ b/src/cli/commands/__tests__/dashboard-cwd-guard.test.ts
@@ -29,6 +29,14 @@ function createFixture(prefix: string): string {
   return root;
 }
 
+function createDashboardBundleFixture(): { serverPath: string; repoRoot: string } {
+  const repoRoot = createFixture('pan-dashboard-bundle-');
+  const serverPath = join(repoRoot, 'dist', 'dashboard', 'server.js');
+  mkdirSync(join(repoRoot, 'dist', 'dashboard'), { recursive: true });
+  writeFileSync(serverPath, 'export {};');
+  return { serverPath, repoRoot };
+}
+
 afterEach(() => {
   process.exitCode = undefined;
   vi.clearAllMocks();
@@ -50,6 +58,7 @@ describe('resolvePrimaryDashboardIdentity', () => {
 
   it('starts the dashboard with the identity root as its working directory', () => {
     const child = { unref: vi.fn() };
+    const bundle = createDashboardBundleFixture();
     processMocks.execFileSync.mockImplementation(() => { throw new Error('systemd unavailable'); });
     processMocks.spawn.mockReturnValue(child);
     vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -59,12 +68,12 @@ describe('resolvePrimaryDashboardIdentity', () => {
       dashboardApiPort: 3011,
       traefikEnabled: false,
       traefikDomain: 'overdeck.localhost',
-    } as Parameters<typeof spawnDashboardDetached>[0]);
+    } as Parameters<typeof spawnDashboardDetached>[0], bundle);
 
     expect(processMocks.spawn).toHaveBeenCalledWith(
       expect.any(String),
-      [resolveBundledServerPath()],
-      expect.objectContaining({ cwd: resolvePrimaryDashboardIdentity().repoRoot }),
+      [bundle.serverPath],
+      expect.objectContaining({ cwd: bundle.repoRoot }),
     );
     expect(child.unref).toHaveBeenCalled();
   });
@@ -95,6 +104,7 @@ describe('resolvePrimaryDashboardIdentity', () => {
   });
 
   it('returns a handle that stops the spawned systemd unit', () => {
+    const bundle = createDashboardBundleFixture();
     processMocks.execFileSync.mockReturnValue(undefined);
     vi.spyOn(Date, 'now').mockReturnValue(123456);
 
@@ -103,7 +113,7 @@ describe('resolvePrimaryDashboardIdentity', () => {
       dashboardApiPort: 3011,
       traefikEnabled: false,
       traefikDomain: 'overdeck.localhost',
-    } as Parameters<typeof spawnDashboardDetached>[0]);
+    } as Parameters<typeof spawnDashboardDetached>[0], bundle);
     handle.stop();
 
     expect(processMocks.execFileSync).toHaveBeenLastCalledWith(

--- a/src/dashboard/frontend/src/components/chat/ConversationPanel.tsx
+++ b/src/dashboard/frontend/src/components/chat/ConversationPanel.tsx
@@ -17,7 +17,7 @@ import { fetchWithTimeout } from '../../lib/apiFetch';
 import { useConversationPaneChoice } from '../../lib/useConversationPaneChoice';
 import { ModelPicker, saveStoredHarness, saveStoredModel, type Harness } from './ModelPicker';
 import { getDefaultConversationModel } from './defaultConversationModel';
-import type { ChatMessage, CompactBoundary, ContextUsage, ProposedPlan, TurnDiffSummary, WorkLogEntry } from './chat-types';
+import type { ChatMessage, CompactBoundary, ContextUsage, ProposedPlan, SubagentSummary, TurnDiffSummary, WorkLogEntry } from './chat-types';
 import {
   useComposerStore,
   useConversationOptimistic,
@@ -35,6 +35,7 @@ import { useConversationMutations } from '../CommandDeck/useConversationMutation
 import { ForkModal } from '../CommandDeck/ForkModal';
 import { closeConversationPanes } from '../../lib/panesStore';
 import { conversationMessagesQueryKey, useConversationMessagesStream } from './useConversationMessagesStream';
+import { SubagentRail } from './SubagentRail';
 import { useComposerDeliveryState } from './useComposerDeliveryState';
 import styles from '../CommandDeck/styles/command-deck.module.css';
 
@@ -998,14 +999,11 @@ export function ConversationPanel({
         </div>
       )}
 
-      {/* Body — conversation + optional diff panel */}
       <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
         <div className={styles.conversationTerminalBody}>
-          {/* Terminal: only mounted when actively viewing (xterm.js crashes with visibility:hidden) */}
           {showTerminal && effectiveViewMode === 'terminal' && (
             <XTerminal sessionName={conversation.tmuxSession} />
           )}
-          {/* Conversation view — shown when in conversation mode, diff mode, or session ended */}
           {(effectiveViewMode === 'conversation' || !showTerminal) && (
             <ConversationView
               conversation={conversation}
@@ -1053,7 +1051,6 @@ export function ConversationPanel({
             />
           )}
         </div>
-        {/* Diff side panel — rendered when ?diff=1 is in the URL */}
         {diffOpen && diffData?.summaries && (
           <DiffWorkerPoolProvider>
             <DiffPanel
@@ -1065,6 +1062,7 @@ export function ConversationPanel({
             />
           </DiffWorkerPoolProvider>
         )}
+        <SubagentRail conversation={conversation} subagents={messagesData?.subagents ?? []} resolvedTheme={resolvedTheme} />
       </div>
 
       {convMutations.forkTarget && (
@@ -1166,6 +1164,7 @@ interface MessagesResponse {
   compactBoundaries?: CompactBoundary[];
   compacting?: boolean;
   contextUsage?: ContextUsage | null;
+  subagents?: SubagentSummary[];
   /** Server-side resolution failure to surface in the panel (e.g. the live
    * session could not be resolved from the launcher). Rendered as a banner. */
   error?: string;

--- a/src/dashboard/frontend/src/components/chat/ConversationPanel.tsx
+++ b/src/dashboard/frontend/src/components/chat/ConversationPanel.tsx
@@ -35,7 +35,7 @@ import { useConversationMutations } from '../CommandDeck/useConversationMutation
 import { ForkModal } from '../CommandDeck/ForkModal';
 import { closeConversationPanes } from '../../lib/panesStore';
 import { conversationMessagesQueryKey, useConversationMessagesStream } from './useConversationMessagesStream';
-import { SubagentRail } from './SubagentRail';
+import { SubagentRail, updateSelectedSubagent } from './SubagentRail';
 import { useComposerDeliveryState } from './useComposerDeliveryState';
 import styles from '../CommandDeck/styles/command-deck.module.css';
 
@@ -1231,12 +1231,8 @@ export type { FailedMessage } from './chat-types';
 
 function ConversationView({ conversation, onResume, onArchive, resumePending, resumeLabel, hideComposer = false, onSendFailed: onSendFailedProp, modelPicker, roundMarkers, roundMetadata, turnDiffSummaryByAssistantMessageId, onOpenTurnDiff, resolvedTheme, agentId, hideToolCalls, workingPhase, agentBusy = false, streamMessagesEnabled, messagesData, messagesLoading, onOpenTerminal, targetMessageId, targetMessageIndex, targetMessageNonce, onTargetMessageHandled }: ConversationViewProps) {
   const isCompacting = useDashboardStore((s) => s.conversationsCompactingByName?.[conversation.name] ?? false);
-  // Optimistic sent messages and the failed-send retry outbox live in the
-  // module-level composerStore, keyed by conversation name. ConversationView is
-  // unmounted on every conversation switch (PAN-1591 renders only the active
-  // pane), so component-local state would lose an in-flight optimistic message
-  // and — worse — silently drop the failed-send outbox, costing the user their
-  // retry. The store keeps both with the conversation they belong to.
+  // Keep optimistic messages and failed-send retries in the conversation-keyed
+  // composer store so switching panes cannot discard them (PAN-1591).
   const optimisticMessages = useConversationOptimistic(conversation.name);
   const optimisticBaseCount = useConversationOptimisticBaseCount(conversation.name);
   const addOptimistic = useComposerStore((s) => s.addOptimistic);
@@ -1258,9 +1254,10 @@ function ConversationView({ conversation, onResume, onArchive, resumePending, re
 
   const data = messagesData;
   const isLoading = messagesLoading ?? false;
+  const subagentByToolUseId = useMemo(() => new Map((data?.subagents ?? []).map((subagent) => [subagent.toolUseId, subagent])), [data?.subagents]);
+  const handleOpenSubagent = useCallback((toolUseId: string) => { const subagent = subagentByToolUseId.get(toolUseId); if (subagent) updateSelectedSubagent(subagent.agentId); }, [subagentByToolUseId]);
 
-  // PAN-3113 — this conversation's blocking pane choice menu (session-resume
-  // gate et al.) and the mount-local record of dashboard-answered choices.
+  // PAN-3113 — blocking pane choice plus mount-local dashboard answers.
   const { livePaneChoice, answeredPaneChoices, handlePaneChoiceAnswered } =
     useConversationPaneChoice(conversation.name, agentId);
 
@@ -1497,6 +1494,8 @@ function ConversationView({ conversation, onResume, onArchive, resumePending, re
           conversationName={conversation.name}
           cwd={conversation.cwd}
           issueId={conversation.issueId}
+          subagentByToolUseId={subagentByToolUseId}
+          onOpenSubagent={handleOpenSubagent}
           turnDiffSummaryByAssistantMessageId={turnDiffSummaryByAssistantMessageId}
           onOpenTurnDiff={onOpenTurnDiff}
           resolvedTheme={resolvedTheme}

--- a/src/dashboard/frontend/src/components/chat/SubagentRail.test.tsx
+++ b/src/dashboard/frontend/src/components/chat/SubagentRail.test.tsx
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Conversation } from '../CommandDeck/ConversationList';
+import type { SubagentSummary } from './chat-types';
+
+const hookMocks = vi.hoisted(() => ({ useSubagentTranscript: vi.fn() }));
+
+vi.mock('./useConversationMessagesStream', () => ({
+  useSubagentTranscript: hookMocks.useSubagentTranscript,
+}));
+vi.mock('./MessagesTimeline', () => ({
+  MessagesTimeline: ({ messages }: { messages: Array<{ text: string }> }) => (
+    <div data-testid="subagent-timeline">{messages.map((message) => message.text).join(' ')}</div>
+  ),
+}));
+
+import { SubagentRail } from './SubagentRail';
+
+const conversation: Conversation = {
+  id: 42,
+  name: 'conv-parent',
+  tmuxSession: 'conv-parent',
+  status: 'active',
+  cwd: '/workspace',
+  issueId: 'PAN-2876',
+  createdAt: '2026-07-18T00:00:00Z',
+  endedAt: null,
+  lastAttachedAt: null,
+  sessionAlive: true,
+  harness: 'claude-code',
+};
+
+const subagents: SubagentSummary[] = [
+  {
+    agentId: 'alpha',
+    agentType: 'Explore',
+    description: 'Trace the conversation parser',
+    toolUseId: 'toolu_alpha',
+    spawnDepth: 1,
+    status: 'running',
+  },
+  {
+    agentId: 'deep',
+    agentType: 'general-purpose',
+    description: 'Inspect nested behavior',
+    toolUseId: 'toolu_deep',
+    spawnDepth: 2,
+    status: 'done',
+  },
+];
+
+describe('SubagentRail', () => {
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/conv/42');
+    hookMocks.useSubagentTranscript.mockReset().mockReturnValue({
+      data: {
+        messages: [{ id: 'sub-msg', role: 'assistant', text: 'Subagent transcript', createdAt: '2026-07-18T00:01:00Z' }],
+        workLog: [],
+        streaming: false,
+      },
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  it('renders nothing when no subagents exist', () => {
+    const { container } = render(<SubagentRail conversation={conversation} subagents={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders flat rows with status and nested-depth markers', () => {
+    render(<SubagentRail conversation={conversation} subagents={subagents} />);
+
+    expect(screen.getByText('Explore')).toBeInTheDocument();
+    expect(screen.getByText('Trace the conversation parser')).toBeInTheDocument();
+    expect(screen.getByText('general-purpose')).toBeInTheDocument();
+    expect(screen.getByText('depth 2')).toBeInTheDocument();
+    expect(screen.getByLabelText('running')).toHaveClass('bg-primary');
+    expect(screen.getByLabelText('done')).toHaveClass('bg-muted-foreground/40');
+    expect(screen.getByRole('complementary', { name: 'Conversation subagents' })).toHaveClass('min-w-0');
+  });
+
+  it('selects a subagent in the URL and renders its transcript without a composer', async () => {
+    const user = userEvent.setup();
+    render(<SubagentRail conversation={conversation} subagents={subagents} />);
+
+    await user.click(screen.getByRole('button', { name: /Explore/i }));
+
+    expect(new URLSearchParams(window.location.search).get('subagent')).toBe('alpha');
+    expect(screen.getByText(/Explore/)).toHaveTextContent('Explore · Trace the conversation parser');
+    expect(screen.getByTestId('subagent-timeline')).toHaveTextContent('Subagent transcript');
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(hookMocks.useSubagentTranscript).toHaveBeenLastCalledWith(conversation, 'alpha');
+
+    await user.click(screen.getByRole('button', { name: 'Close subagent transcript' }));
+    expect(new URLSearchParams(window.location.search).has('subagent')).toBe(false);
+    expect(screen.getByText('Subagents')).toBeInTheDocument();
+  });
+
+  it('opens a matching subagent directly from the URL', () => {
+    window.history.replaceState({}, '', '/conv/42?subagent=deep');
+
+    render(<SubagentRail conversation={conversation} subagents={subagents} />);
+
+    expect(screen.getByText(/general-purpose/)).toHaveTextContent('general-purpose · Inspect nested behavior');
+    expect(screen.getByTestId('subagent-timeline')).toBeInTheDocument();
+    expect(hookMocks.useSubagentTranscript).toHaveBeenLastCalledWith(conversation, 'deep');
+  });
+});

--- a/src/dashboard/frontend/src/components/chat/SubagentRail.tsx
+++ b/src/dashboard/frontend/src/components/chat/SubagentRail.tsx
@@ -15,7 +15,7 @@ function readSelectedSubagent(): string | null {
   return new URLSearchParams(window.location.search).get('subagent');
 }
 
-function updateSelectedSubagent(agentId: string | null): void {
+export function updateSelectedSubagent(agentId: string | null): void {
   const searchParams = new URLSearchParams(window.location.search);
   if (agentId) searchParams.set('subagent', agentId);
   else searchParams.delete('subagent');

--- a/src/dashboard/frontend/src/components/chat/SubagentRail.tsx
+++ b/src/dashboard/frontend/src/components/chat/SubagentRail.tsx
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Loader2, X } from 'lucide-react';
+import type { Conversation } from '../CommandDeck/ConversationList';
+import { MessagesTimeline } from './MessagesTimeline';
+import type { SubagentSummary } from './chat-types';
+import { useSubagentTranscript } from './useConversationMessagesStream';
+
+interface SubagentRailProps {
+  conversation: Conversation;
+  subagents: SubagentSummary[];
+  resolvedTheme?: 'light' | 'dark';
+}
+
+function readSelectedSubagent(): string | null {
+  return new URLSearchParams(window.location.search).get('subagent');
+}
+
+function updateSelectedSubagent(agentId: string | null): void {
+  const searchParams = new URLSearchParams(window.location.search);
+  if (agentId) searchParams.set('subagent', agentId);
+  else searchParams.delete('subagent');
+  const query = searchParams.toString();
+  window.history.pushState({}, '', query ? `${window.location.pathname}?${query}` : window.location.pathname);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}
+
+export function SubagentRail({ conversation, subagents, resolvedTheme }: SubagentRailProps) {
+  const [selectedAgentId, setSelectedAgentId] = useState(readSelectedSubagent);
+  const selected = subagents.find((subagent) => subagent.agentId === selectedAgentId) ?? null;
+  const transcript = useSubagentTranscript(conversation, selected?.agentId ?? null);
+
+  useEffect(() => {
+    const onPopState = () => setSelectedAgentId(readSelectedSubagent());
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, []);
+
+  const select = useCallback((agentId: string) => {
+    updateSelectedSubagent(agentId);
+    setSelectedAgentId(agentId);
+  }, []);
+  const close = useCallback(() => {
+    updateSelectedSubagent(null);
+    setSelectedAgentId(null);
+  }, []);
+
+  if (subagents.length === 0) return null;
+
+  return (
+    <aside
+      aria-label="Conversation subagents"
+      className={`flex min-h-0 min-w-0 shrink-0 flex-col border-l border-border bg-card ${selected ? 'w-[min(44rem,45vw)]' : 'w-64'}`}
+    >
+      {selected ? (
+        <>
+          <header className="flex h-11 shrink-0 items-center gap-2 border-b border-border px-3">
+            <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+              {selected.agentType} <span className="text-muted-foreground">· {selected.description}</span>
+            </span>
+            <button
+              type="button"
+              aria-label="Close subagent transcript"
+              className="rounded-sm p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              onClick={close}
+            >
+              <X size={16} />
+            </button>
+          </header>
+          <div className="min-h-0 min-w-0 flex-1">
+            {transcript.isLoading ? (
+              <div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
+                <Loader2 size={14} className="animate-spin text-primary" />
+                Loading transcript…
+              </div>
+            ) : transcript.isError ? (
+              <div className="flex h-full items-center justify-center px-4 text-sm text-destructive-foreground">
+                Couldn&apos;t load this subagent transcript.
+              </div>
+            ) : (
+              <MessagesTimeline
+                messages={transcript.data?.messages ?? []}
+                workLog={transcript.data?.workLog ?? []}
+                streaming={transcript.data?.streaming ?? selected.status === 'running'}
+                conversationName={`${conversation.name}:${selected.agentId}`}
+                cwd={conversation.cwd}
+                issueId={conversation.issueId}
+                resolvedTheme={resolvedTheme}
+              />
+            )}
+          </div>
+        </>
+      ) : (
+        <>
+          <header className="flex h-11 shrink-0 items-center border-b border-border px-3 text-xs font-medium text-muted-foreground">
+            Subagents
+          </header>
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            {subagents.map((subagent) => (
+              <button
+                key={subagent.agentId}
+                type="button"
+                className="flex w-full items-start gap-2 border-b border-border px-3 py-2 text-left transition-colors hover:bg-accent"
+                onClick={() => select(subagent.agentId)}
+              >
+                <span
+                  aria-label={subagent.status}
+                  className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${subagent.status === 'running' ? 'bg-primary' : 'bg-muted-foreground/40'}`}
+                />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-xs font-medium text-foreground">{subagent.agentType}</span>
+                  <span className="block truncate text-xs text-muted-foreground">{subagent.description}</span>
+                </span>
+                {subagent.spawnDepth > 1 && (
+                  <span className="rounded-sm border border-border bg-muted px-1 py-0.5 text-[10px] font-medium text-muted-foreground">
+                    depth {subagent.spawnDepth}
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </aside>
+  );
+}

--- a/src/dashboard/frontend/src/components/chat/chat-types.ts
+++ b/src/dashboard/frontend/src/components/chat/chat-types.ts
@@ -49,6 +49,15 @@ export interface WorkLogEntry {
   sequence?: number;
 }
 
+export interface SubagentSummary {
+  agentId: string;
+  agentType: string;
+  description: string;
+  toolUseId: string;
+  spawnDepth: number;
+  status: 'running' | 'done';
+}
+
 export interface ProposedPlan {
   id: string;
   plan: string;
@@ -87,7 +96,8 @@ export interface ContextUsage {
 
 export type ConversationEvent =
   | { kind: 'messages'; messages: ChatMessage[]; workLog: WorkLogEntry[]; streaming: boolean; snapshot?: boolean; proposedPlan?: ProposedPlan; compactBoundaries?: CompactBoundary[]; contextUsage?: ContextUsage | null }
-  | { kind: 'discovering' };
+  | { kind: 'discovering' }
+  | { kind: 'subagents'; subagents: SubagentSummary[] };
 
 // ─── Turn Diff Types ─────────────────────────────────────────────────────────
 // Mirror T3Code's types from apps/web/src/types.ts

--- a/src/dashboard/frontend/src/components/chat/messagesTimeline/MessagesTimeline.tsx
+++ b/src/dashboard/frontend/src/components/chat/messagesTimeline/MessagesTimeline.tsx
@@ -64,6 +64,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   conversationName,
   cwd,
   issueId,
+  subagentByToolUseId,
+  onOpenSubagent,
   turnDiffSummaryByAssistantMessageId,
   onOpenTurnDiff,
   resolvedTheme,
@@ -478,6 +480,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                     conversationName={conversationName}
                     cwd={cwd}
                     issueId={issueId}
+                    subagentByToolUseId={subagentByToolUseId}
+                    onOpenSubagent={onOpenSubagent}
                     turnDiffSummary={row.kind === 'message' && row.message.role === 'assistant' ? turnDiffSummaryByAssistantMessageId?.get(row.message.id) : undefined}
                     onOpenTurnDiff={onOpenTurnDiff}
                     resolvedTheme={resolvedTheme}
@@ -518,6 +522,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                 conversationName={conversationName}
                 cwd={cwd}
                 issueId={issueId}
+                subagentByToolUseId={subagentByToolUseId}
+                onOpenSubagent={onOpenSubagent}
                 turnDiffSummary={row.kind === 'message' && row.message.role === 'assistant' ? turnDiffSummaryByAssistantMessageId?.get(row.message.id) : undefined}
                 onOpenTurnDiff={onOpenTurnDiff}
                 resolvedTheme={resolvedTheme}

--- a/src/dashboard/frontend/src/components/chat/messagesTimeline/TimelineRowRenderer.tsx
+++ b/src/dashboard/frontend/src/components/chat/messagesTimeline/TimelineRowRenderer.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 import type { WorkingPhase } from '../../../lib/workingPhase';
-import type { TurnDiffSummary } from '../chat-types';
+import type { SubagentSummary, TurnDiffSummary } from '../chat-types';
 import type { MessagesTimelineRow } from '../MessagesTimeline.logic';
 import { PlanCard } from '../PlanCard';
 import { AssistantMessageRow, UserMessageRow } from './messageRows';
@@ -20,6 +20,8 @@ interface RowProps {
   conversationName?: string;
   cwd?: string;
   issueId?: string | null;
+  subagentByToolUseId?: ReadonlyMap<string, SubagentSummary>;
+  onOpenSubagent?: (toolUseId: string) => void;
   turnDiffSummary?: TurnDiffSummary;
   onOpenTurnDiff?: (turnId: string, filePath?: string) => void;
   resolvedTheme?: 'light' | 'dark';
@@ -32,12 +34,12 @@ interface RowProps {
   onPaneChoiceAnswered?: (signature: string, label: string) => void;
 }
 
-export const TimelineRowRenderer = memo(function TimelineRowRenderer({ row, isStreaming, conversationName, cwd, issueId, turnDiffSummary, onOpenTurnDiff, resolvedTheme, hideToolCalls, workingPhase, onConfirmCommand, onOpenTerminal, onPaneChoiceAnswered }: RowProps) {
+export const TimelineRowRenderer = memo(function TimelineRowRenderer({ row, isStreaming, conversationName, cwd, issueId, subagentByToolUseId, onOpenSubagent, turnDiffSummary, onOpenTurnDiff, resolvedTheme, hideToolCalls, workingPhase, onConfirmCommand, onOpenTerminal, onPaneChoiceAnswered }: RowProps) {
   if (row.kind === 'working') {
     return <WorkingIndicator startedAt={row.createdAt} phase={workingPhase} />;
   }
   if (row.kind === 'work') {
-    return <WorkLogGroup entries={row.groupedEntries} hideToolCalls={hideToolCalls} cwd={cwd} issueId={issueId} />;
+    return <WorkLogGroup entries={row.groupedEntries} hideToolCalls={hideToolCalls} cwd={cwd} issueId={issueId} subagentByToolUseId={subagentByToolUseId} onOpenSubagent={onOpenSubagent} />;
   }
   if (row.kind === 'proposed-plan') {
     return <PlanCard plan={row.plan} conversationName={conversationName ?? ''} />;

--- a/src/dashboard/frontend/src/components/chat/messagesTimeline/messageRows.test.tsx
+++ b/src/dashboard/frontend/src/components/chat/messagesTimeline/messageRows.test.tsx
@@ -114,17 +114,21 @@ describe('subagent transcript action', () => {
     status: 'done',
   };
 
-  it('opens the matching subagent from an expanded Task row', () => {
+  it('opens the matching subagent from an expanded Agent row without a raw JSON fallback', () => {
+    const agentEntry = { ...entry, label: 'Agent', toolTitle: 'Agent' };
     const onOpenSubagent = vi.fn();
     render(
       <WorkLogGroup
-        entries={[entry]}
+        entries={[agentEntry]}
         subagentByToolUseId={new Map([[entry.id, subagent]])}
         onOpenSubagent={onOpenSubagent}
       />,
     );
 
-    fireEvent.click(screen.getByText('Task'));
+    fireEvent.click(screen.getByText('Agent'));
+    expect(screen.getByText('Explore')).toBeInTheDocument();
+    expect(screen.getByTestId('md')).toHaveTextContent('Find the relevant message path.');
+    expect(screen.queryByText(/"subagent_type"/)).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Open subagent transcript' }));
     expect(onOpenSubagent).toHaveBeenCalledWith(entry.id);
   });

--- a/src/dashboard/frontend/src/components/chat/messagesTimeline/messageRows.test.tsx
+++ b/src/dashboard/frontend/src/components/chat/messagesTimeline/messageRows.test.tsx
@@ -8,7 +8,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { TurnBody } from './messageRows';
 import { WorkLogGroup } from './workLogRows';
-import type { WorkLogEntry } from '../chat-types';
+import type { SubagentSummary, WorkLogEntry } from '../chat-types';
 
 // ChatMarkdown pulls in the syntax-highlight chain; the gate asserts budget
 // behavior, not markdown fidelity.
@@ -89,5 +89,50 @@ describe('C-VERB gate: command groups collapse (pre-existing)', () => {
     expect(screen.getByText(/payload-10/)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /Collapse/ }));
     expect(screen.queryByText(/payload-10/)).not.toBeInTheDocument();
+  });
+});
+
+describe('subagent transcript action', () => {
+  const entry: WorkLogEntry = {
+    id: 'toolu-subagent',
+    createdAt: '2026-07-20T00:00:00Z',
+    label: 'Task',
+    toolTitle: 'Task',
+    tone: 'tool',
+    toolInput: {
+      subagent_type: 'Explore',
+      description: 'Trace the parser',
+      prompt: 'Find the relevant message path.',
+    },
+  };
+  const subagent: SubagentSummary = {
+    agentId: 'subagent-1',
+    agentType: 'Explore',
+    description: 'Trace the parser',
+    toolUseId: entry.id,
+    spawnDepth: 1,
+    status: 'done',
+  };
+
+  it('opens the matching subagent from an expanded Task row', () => {
+    const onOpenSubagent = vi.fn();
+    render(
+      <WorkLogGroup
+        entries={[entry]}
+        subagentByToolUseId={new Map([[entry.id, subagent]])}
+        onOpenSubagent={onOpenSubagent}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Task'));
+    fireEvent.click(screen.getByRole('button', { name: 'Open subagent transcript' }));
+    expect(onOpenSubagent).toHaveBeenCalledWith(entry.id);
+  });
+
+  it('omits the action when no subagent matches the tool use id', () => {
+    render(<WorkLogGroup entries={[entry]} subagentByToolUseId={new Map()} onOpenSubagent={vi.fn()} />);
+
+    fireEvent.click(screen.getByText('Task'));
+    expect(screen.queryByRole('button', { name: 'Open subagent transcript' })).not.toBeInTheDocument();
   });
 });

--- a/src/dashboard/frontend/src/components/chat/messagesTimeline/types.ts
+++ b/src/dashboard/frontend/src/components/chat/messagesTimeline/types.ts
@@ -1,5 +1,5 @@
 import type { WorkingPhase } from '../../../lib/workingPhase';
-import type { ChatMessage, CompactBoundary, ProposedPlan, TurnDiffSummary, WorkLogEntry } from '../chat-types';
+import type { ChatMessage, CompactBoundary, ProposedPlan, SubagentSummary, TurnDiffSummary, WorkLogEntry } from '../chat-types';
 import type { FailedMessage } from '../ConversationPanel';
 import type { RoundVerdict } from '../../CommandDeck/RoundCard';
 import type { AnsweredPaneChoice, PendingPaneChoice } from '../../../lib/paneChoice';
@@ -44,6 +44,8 @@ export interface MessagesTimelineProps {
   conversationName?: string;
   cwd?: string;
   issueId?: string | null;
+  subagentByToolUseId?: ReadonlyMap<string, SubagentSummary>;
+  onOpenSubagent?: (toolUseId: string) => void;
   turnDiffSummaryByAssistantMessageId?: Map<string, TurnDiffSummary>;
   onOpenTurnDiff?: (turnId: string, filePath?: string) => void;
   resolvedTheme?: 'light' | 'dark';

--- a/src/dashboard/frontend/src/components/chat/messagesTimeline/workLogRows.tsx
+++ b/src/dashboard/frontend/src/components/chat/messagesTimeline/workLogRows.tsx
@@ -1,11 +1,20 @@
 import { useState } from 'react';
 import { ChevronDown, ChevronRight, Circle, Wrench } from 'lucide-react';
-import type { WorkLogEntry } from '../chat-types';
+import type { SubagentSummary, WorkLogEntry } from '../chat-types';
 import { ChatMarkdown } from '../ChatMarkdown';
 import styles from '../../CommandDeck/styles/command-deck.module.css';
 import { MAX_VISIBLE_WORK_LOG_ENTRIES } from './helpers';
 
-export function WorkLogGroup({ entries, hideToolCalls, cwd, issueId }: { entries: WorkLogEntry[]; hideToolCalls?: boolean; cwd?: string; issueId?: string | null }) {
+interface WorkLogGroupProps {
+  entries: WorkLogEntry[];
+  hideToolCalls?: boolean;
+  cwd?: string;
+  issueId?: string | null;
+  subagentByToolUseId?: ReadonlyMap<string, SubagentSummary>;
+  onOpenSubagent?: (toolUseId: string) => void;
+}
+
+export function WorkLogGroup({ entries, hideToolCalls, cwd, issueId, subagentByToolUseId, onOpenSubagent }: WorkLogGroupProps) {
   const [expanded, setExpanded] = useState(false);
 
   const onlyToolEntries = entries.every((entry) => entry.tone === 'tool' || entry.tone === 'error');
@@ -53,7 +62,7 @@ export function WorkLogGroup({ entries, hideToolCalls, cwd, issueId }: { entries
         </button>
       )}
       {visible.map((entry) => (
-        <SimpleWorkEntryRow key={entry.id} entry={entry} cwd={cwd} issueId={issueId} />
+        <SimpleWorkEntryRow key={entry.id} entry={entry} cwd={cwd} issueId={issueId} subagentByToolUseId={subagentByToolUseId} onOpenSubagent={onOpenSubagent} />
       ))}
       {expanded && (
         <button
@@ -96,10 +105,14 @@ function ToolUseExpanded({
   entry,
   cwd,
   issueId,
+  subagentByToolUseId,
+  onOpenSubagent,
 }: {
   entry: WorkLogEntry;
   cwd?: string;
   issueId?: string | null;
+  subagentByToolUseId?: ReadonlyMap<string, SubagentSummary>;
+  onOpenSubagent?: (toolUseId: string) => void;
 }) {
   const tool = entry.toolTitle ?? entry.label;
   const input = entry.toolInput;
@@ -208,6 +221,15 @@ function ToolUseExpanded({
       const prompt = asString(input.prompt);
       return (
         <div className={styles.workLogResult}>
+          {subagentByToolUseId?.has(entry.id) && onOpenSubagent && (
+            <button
+              type="button"
+              className="mb-2 text-xs font-medium text-primary transition-colors hover:text-primary/80"
+              onClick={() => onOpenSubagent(entry.id)}
+            >
+              Open subagent transcript
+            </button>
+          )}
           {(subagent || description) && (
             <div className={styles.workLogToolHeader}>
               {subagent && <code>{subagent}</code>}
@@ -271,7 +293,13 @@ function ToolUseExpanded({
   );
 }
 
-function SimpleWorkEntryRow({ entry, cwd, issueId }: { entry: WorkLogEntry; cwd?: string; issueId?: string | null }) {
+function SimpleWorkEntryRow({ entry, cwd, issueId, subagentByToolUseId, onOpenSubagent }: {
+  entry: WorkLogEntry;
+  cwd?: string;
+  issueId?: string | null;
+  subagentByToolUseId?: ReadonlyMap<string, SubagentSummary>;
+  onOpenSubagent?: (toolUseId: string) => void;
+}) {
   const [showResult, setShowResult] = useState(false);
   const toneColor: Record<WorkLogEntry['tone'], string> = {
     thinking: 'var(--muted-foreground)',
@@ -334,7 +362,7 @@ function SimpleWorkEntryRow({ entry, cwd, issueId }: { entry: WorkLogEntry; cwd?
       </div>
       {showResult && (
         <>
-          {hasToolBody && <ToolUseExpanded entry={entry} cwd={cwd} issueId={issueId} />}
+          {hasToolBody && <ToolUseExpanded entry={entry} cwd={cwd} issueId={issueId} subagentByToolUseId={subagentByToolUseId} onOpenSubagent={onOpenSubagent} />}
           {isThinking && entry.detail && (
             <div className={styles.workLogResult}>
               <ChatMarkdown text={entry.detail} cwd={cwd} issueId={issueId} />

--- a/src/dashboard/frontend/src/components/chat/messagesTimeline/workLogRows.tsx
+++ b/src/dashboard/frontend/src/components/chat/messagesTimeline/workLogRows.tsx
@@ -215,7 +215,8 @@ function ToolUseExpanded({
       );
     }
 
-    case 'Task': {
+    case 'Task':
+    case 'Agent': {
       const subagent = asString(input.subagent_type);
       const description = asString(input.description);
       const prompt = asString(input.prompt);

--- a/src/dashboard/frontend/src/components/chat/useConversationMessagesStream.test.ts
+++ b/src/dashboard/frontend/src/components/chat/useConversationMessagesStream.test.ts
@@ -1,8 +1,60 @@
-import { describe, it, expect } from 'vitest';
-import { shouldStreamConversationMessages } from './useConversationMessagesStream';
+import { createElement, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { Stream } from 'effect';
+import { WS_METHODS } from '@overdeck/contracts';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const transportMocks = vi.hoisted(() => ({
+  rpc: vi.fn(),
+  subscribe: vi.fn(),
+  unsubscribe: vi.fn(),
+}));
+const fetchMocks = vi.hoisted(() => ({ fetchWithTimeout: vi.fn() }));
+
+vi.mock('../../lib/wsTransport', () => ({
+  getTransport: () => ({ subscribe: transportMocks.subscribe }),
+}));
+vi.mock('../../lib/apiFetch', () => ({
+  fetchWithTimeout: fetchMocks.fetchWithTimeout,
+}));
+
+import {
+  applyConversationMessagesEvent,
+  conversationMessagesQueryKey,
+  shouldStreamConversationMessages,
+  subagentTranscriptQueryKey,
+  useSubagentTranscript,
+  type ConversationMessagesCache,
+} from './useConversationMessagesStream';
+import type { ConversationEvent, SubagentSummary } from './chat-types';
 
 type GateArg = Parameters<typeof shouldStreamConversationMessages>[0];
 const base = (over: Partial<GateArg>): GateArg => ({ name: 'conv-x', harness: 'claude-code', sessionAlive: true, id: 1, ...over });
+
+const parentCache: ConversationMessagesCache = {
+  messages: [{ id: 'parent-message', role: 'user', text: 'Parent', createdAt: '2026-01-01T00:00:00Z' }],
+  workLog: [{ id: 'parent-tool', label: 'Read', createdAt: '2026-01-01T00:00:01Z', tone: 'tool' }],
+  streaming: true,
+};
+
+const subagents: SubagentSummary[] = [{
+  agentId: 'sub-1',
+  agentType: 'Explore',
+  description: 'Trace the stream',
+  toolUseId: 'toolu_sub_1',
+  spawnDepth: 1,
+  status: 'running',
+}];
+
+function wrapper(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+function createQueryClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
 
 describe('shouldStreamConversationMessages (PAN-1908 agent streaming)', () => {
   it('streams a real claude-code DB conversation (unchanged)', () => {
@@ -40,5 +92,90 @@ describe('shouldStreamConversationMessages (PAN-1908 agent streaming)', () => {
   it('never streams a dead session', () => {
     expect(shouldStreamConversationMessages(base({ id: -1, name: 'agent-pan-1908', harness: 'ohmypi', sessionAlive: false }))).toBe(false);
     expect(shouldStreamConversationMessages(base({ id: 42, harness: 'claude-code', endedAt: '2026-01-01T00:00:00Z' }))).toBe(false);
+  });
+});
+
+describe('subagent message cache', () => {
+  it('replaces the subagent list without changing parent messages or work log', () => {
+    const next = applyConversationMessagesEvent(parentCache, { kind: 'subagents', subagents });
+
+    expect(next.subagents).toEqual(subagents);
+    expect(next.messages).toBe(parentCache.messages);
+    expect(next.workLog).toBe(parentCache.workLog);
+  });
+
+  it('preserves subagents when applying a messages event', () => {
+    const previous = { ...parentCache, subagents };
+    const event: ConversationEvent = {
+      kind: 'messages',
+      messages: [],
+      workLog: [],
+      streaming: false,
+      snapshot: false,
+    };
+
+    expect(applyConversationMessagesEvent(previous, event).subagents).toEqual(subagents);
+  });
+});
+
+describe('useSubagentTranscript', () => {
+  let listener: ((event: ConversationEvent) => void) | undefined;
+
+  beforeEach(() => {
+    listener = undefined;
+    transportMocks.rpc.mockReset().mockReturnValue(Stream.empty);
+    transportMocks.unsubscribe.mockReset();
+    transportMocks.subscribe.mockReset().mockImplementation((connect, onEvent) => {
+      connect({ [WS_METHODS.subscribeConversationMessages]: transportMocks.rpc });
+      listener = onEvent;
+      return transportMocks.unsubscribe;
+    });
+    fetchMocks.fetchWithTimeout.mockReset();
+  });
+
+  it('uses an isolated query key and unsubscribes when the subagent is deselected', () => {
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(conversationMessagesQueryKey('conv-x'), parentCache);
+    const { rerender } = renderHook(
+      ({ agentId }: { agentId: string | null }) => useSubagentTranscript(base({}), agentId),
+      { initialProps: { agentId: 'sub-1' }, wrapper: wrapper(queryClient) },
+    );
+
+    expect(transportMocks.rpc).toHaveBeenCalledWith({ conversationName: 'conv-x', agentId: 'sub-1' });
+    act(() => listener?.({
+      kind: 'messages',
+      messages: [{ id: 'sub-message', role: 'assistant', text: 'Subagent', createdAt: '2026-01-01T00:00:02Z' }],
+      workLog: [],
+      streaming: true,
+      snapshot: true,
+    }));
+
+    expect(queryClient.getQueryData(subagentTranscriptQueryKey('conv-x', 'sub-1'))).toMatchObject({
+      messages: [{ id: 'sub-message' }],
+    });
+    expect(queryClient.getQueryData(conversationMessagesQueryKey('conv-x'))).toEqual(parentCache);
+
+    rerender({ agentId: null });
+    expect(transportMocks.unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it('fetches an ended subagent transcript once over HTTP', async () => {
+    fetchMocks.fetchWithTimeout.mockResolvedValue(new Response(JSON.stringify({
+      messages: [{ id: 'ended', role: 'assistant', text: 'Done', createdAt: '2026-01-01T00:00:00Z' }],
+      workLog: [],
+      streaming: false,
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+    const queryClient = createQueryClient();
+    const { result } = renderHook(
+      () => useSubagentTranscript(base({ endedAt: '2026-01-01T00:00:00Z' }), 'sub-1'),
+      { wrapper: wrapper(queryClient) },
+    );
+
+    await waitFor(() => expect(result.current.data?.messages[0]?.text).toBe('Done'));
+    expect(fetchMocks.fetchWithTimeout).toHaveBeenCalledWith(
+      '/api/conversations/conv-x/messages?agentId=sub-1',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(transportMocks.subscribe).not.toHaveBeenCalled();
   });
 });

--- a/src/dashboard/frontend/src/components/chat/useConversationMessagesStream.test.ts
+++ b/src/dashboard/frontend/src/components/chat/useConversationMessagesStream.test.ts
@@ -133,7 +133,7 @@ describe('useSubagentTranscript', () => {
     fetchMocks.fetchWithTimeout.mockReset();
   });
 
-  it('uses an isolated query key and unsubscribes when the subagent is deselected', () => {
+  it('uses an isolated query key and clears the live cache when the subagent is deselected', () => {
     const queryClient = createQueryClient();
     queryClient.setQueryData(conversationMessagesQueryKey('conv-x'), parentCache);
     const { rerender } = renderHook(
@@ -157,18 +157,41 @@ describe('useSubagentTranscript', () => {
 
     rerender({ agentId: null });
     expect(transportMocks.unsubscribe).toHaveBeenCalledOnce();
+    expect(queryClient.getQueryData(subagentTranscriptQueryKey('conv-x', 'sub-1'))).toBeUndefined();
   });
 
-  it('fetches an ended subagent transcript once over HTTP', async () => {
+  it('clears the live cache when the transcript hook unmounts', () => {
+    const queryClient = createQueryClient();
+    const { unmount } = renderHook(
+      () => useSubagentTranscript(base({}), 'sub-1'),
+      { wrapper: wrapper(queryClient) },
+    );
+
+    act(() => listener?.({
+      kind: 'messages',
+      messages: [{ id: 'sub-message', role: 'assistant', text: 'Subagent', createdAt: '2026-01-01T00:00:02Z' }],
+      workLog: [],
+      streaming: true,
+      snapshot: true,
+    }));
+    expect(queryClient.getQueryData(subagentTranscriptQueryKey('conv-x', 'sub-1'))).toBeDefined();
+
+    unmount();
+    expect(transportMocks.unsubscribe).toHaveBeenCalledOnce();
+    expect(queryClient.getQueryData(subagentTranscriptQueryKey('conv-x', 'sub-1'))).toBeUndefined();
+  });
+
+  it('fetches an ended subagent transcript once over HTTP and clears it on deselect', async () => {
     fetchMocks.fetchWithTimeout.mockResolvedValue(new Response(JSON.stringify({
       messages: [{ id: 'ended', role: 'assistant', text: 'Done', createdAt: '2026-01-01T00:00:00Z' }],
       workLog: [],
       streaming: false,
     }), { status: 200, headers: { 'content-type': 'application/json' } }));
     const queryClient = createQueryClient();
-    const { result } = renderHook(
-      () => useSubagentTranscript(base({ endedAt: '2026-01-01T00:00:00Z' }), 'sub-1'),
-      { wrapper: wrapper(queryClient) },
+    const { result, rerender } = renderHook(
+      ({ agentId }: { agentId: string | null }) =>
+        useSubagentTranscript(base({ endedAt: '2026-01-01T00:00:00Z' }), agentId),
+      { initialProps: { agentId: 'sub-1' }, wrapper: wrapper(queryClient) },
     );
 
     await waitFor(() => expect(result.current.data?.messages[0]?.text).toBe('Done'));
@@ -177,5 +200,8 @@ describe('useSubagentTranscript', () => {
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(transportMocks.subscribe).not.toHaveBeenCalled();
+
+    rerender({ agentId: null });
+    expect(queryClient.getQueryData(subagentTranscriptQueryKey('conv-x', 'sub-1'))).toBeUndefined();
   });
 });

--- a/src/dashboard/frontend/src/components/chat/useConversationMessagesStream.ts
+++ b/src/dashboard/frontend/src/components/chat/useConversationMessagesStream.ts
@@ -1,12 +1,14 @@
-import { useEffect } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useMemo } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Stream } from 'effect';
 import { getHarnessBehavior, WS_METHODS } from '@overdeck/contracts';
 import { getTransport, type PanRpcProtocolClient } from '../../lib/wsTransport';
+import { fetchWithTimeout } from '../../lib/apiFetch';
 import type { Conversation } from '../CommandDeck/ConversationList';
-import type { ChatMessage, CompactBoundary, ContextUsage, ConversationEvent, ProposedPlan, WorkLogEntry } from './chat-types';
+import type { ChatMessage, CompactBoundary, ContextUsage, ConversationEvent, ProposedPlan, SubagentSummary, WorkLogEntry } from './chat-types';
 
 export const conversationMessagesQueryKey = (name: string) => ['conversation-messages', name] as const;
+export const subagentTranscriptQueryKey = (name: string, agentId: string) => ['conversation-messages', name, 'subagent', agentId] as const;
 
 
 function allSequencesAfter<T extends { sequence?: number }>(sequence: number, items: T[]): boolean {
@@ -47,10 +49,11 @@ function mergeById<T extends { id: string; sequence?: number }>(previous: T[], n
   return Array.from(merged.values());
 }
 
-interface ConversationMessagesCache {
+export interface ConversationMessagesCache {
   messages: ChatMessage[];
   workLog: WorkLogEntry[];
   streaming: boolean;
+  subagents?: SubagentSummary[];
   discovering?: boolean;
   totalCost?: number;
   proposedPlan?: ProposedPlan;
@@ -71,6 +74,15 @@ export function applyConversationMessagesEvent(
       streaming: previous?.streaming ?? true,
       ...previous,
       discovering: true,
+    };
+  }
+  if (event.kind === 'subagents') {
+    return {
+      messages: previous?.messages ?? [],
+      workLog: previous?.workLog ?? [],
+      streaming: previous?.streaming ?? true,
+      ...previous,
+      subagents: event.subagents,
     };
   }
 
@@ -162,4 +174,47 @@ export function useConversationMessagesStream(conversation: Pick<Conversation, '
   }, [conversation.name, enabled, queryClient]);
 
   return enabled;
+}
+
+export function useSubagentTranscript(
+  conversation: Pick<Conversation, 'name' | 'harness' | 'sessionAlive'> & { id?: number; endedAt?: string | null },
+  agentId: string | null,
+) {
+  const queryClient = useQueryClient();
+  const streaming = agentId !== null && shouldStreamConversationMessages(conversation);
+  const queryKey = useMemo(
+    () => subagentTranscriptQueryKey(conversation.name, agentId ?? ''),
+    [agentId, conversation.name],
+  );
+
+  useEffect(() => {
+    if (!agentId || !streaming) return;
+
+    void queryClient.cancelQueries({ queryKey });
+    const unsubscribe = getTransport().subscribe(
+      (client) =>
+        (client as PanRpcProtocolClient)[WS_METHODS.subscribeConversationMessages]({
+          conversationName: conversation.name,
+          agentId,
+        }) as Stream.Stream<ConversationEvent, Error>,
+      (event) => {
+        queryClient.setQueryData<ConversationMessagesCache>(queryKey, (previous) =>
+          applyConversationMessagesEvent(previous, event));
+      },
+    );
+    return () => unsubscribe();
+  }, [agentId, conversation.name, queryClient, queryKey, streaming]);
+
+  return useQuery<ConversationMessagesCache>({
+    queryKey,
+    queryFn: async ({ signal }) => {
+      const response = await fetchWithTimeout(
+        `/api/conversations/${encodeURIComponent(conversation.name)}/messages?agentId=${encodeURIComponent(agentId ?? '')}`,
+        { signal },
+      );
+      if (!response.ok) throw new Error('Failed to fetch subagent messages');
+      return response.json() as Promise<ConversationMessagesCache>;
+    },
+    enabled: agentId !== null && !streaming,
+  });
 }

--- a/src/dashboard/frontend/src/components/chat/useConversationMessagesStream.ts
+++ b/src/dashboard/frontend/src/components/chat/useConversationMessagesStream.ts
@@ -205,6 +205,11 @@ export function useSubagentTranscript(
     return () => unsubscribe();
   }, [agentId, conversation.name, queryClient, queryKey, streaming]);
 
+  useEffect(() => {
+    if (!agentId) return;
+    return () => queryClient.removeQueries({ queryKey, exact: true });
+  }, [agentId, queryClient, queryKey]);
+
   return useQuery<ConversationMessagesCache>({
     queryKey,
     queryFn: async ({ signal }) => {

--- a/src/dashboard/server/routes/conversations.ts
+++ b/src/dashboard/server/routes/conversations.ts
@@ -460,8 +460,8 @@ const getConversationMessagesRoute = HttpRouter.add(
     const params = yield* HttpRouter.params;
     const name = params['name'] ?? '';
     return yield* Effect.promise(async () => {
-      const response = await getConversationMessagesRead(name, conversationReadDependencies);
-      return conversationReadJson(response);
+      const agentId = new URL(request.url, 'http://localhost').searchParams.get('agentId') ?? undefined;
+      return conversationReadJson(await getConversationMessagesRead(name, conversationReadDependencies, agentId));
     });
   }),
 );

--- a/src/dashboard/server/services/__tests__/format-tool-input.test.ts
+++ b/src/dashboard/server/services/__tests__/format-tool-input.test.ts
@@ -83,9 +83,9 @@ describe('summarizeToolInputForWorkLog', () => {
     expect(summarizeToolInputForWorkLog('TodoWrite', { todos: [{}, {}, {}] })).toBe('3 items');
   });
 
-  it('formats Task with subagent and description', () => {
+  it.each(['Task', 'Agent'])('formats %s with subagent and description', (tool) => {
     expect(
-      summarizeToolInputForWorkLog('Task', {
+      summarizeToolInputForWorkLog(tool, {
         subagent_type: 'general-purpose',
         description: 'Investigate the cache bug',
       }),

--- a/src/dashboard/server/services/conversation/subagents.ts
+++ b/src/dashboard/server/services/conversation/subagents.ts
@@ -1,3 +1,7 @@
+/**
+ * Read-only discovery and streaming support for Claude Code conversation subagents.
+ * See docs/CONVERSATION-SUBAGENTS.md for the file layout and transport contract.
+ */
 import { readdir, readFile } from 'node:fs/promises';
 import { dirname, join, resolve, sep } from 'node:path';
 import type { ConversationEvent, SubagentSummary } from '@overdeck/contracts';

--- a/src/dashboard/server/services/conversation/subagents.ts
+++ b/src/dashboard/server/services/conversation/subagents.ts
@@ -1,6 +1,6 @@
 import { readdir, readFile } from 'node:fs/promises';
 import { dirname, join, resolve, sep } from 'node:path';
-import type { SubagentSummary } from '@overdeck/contracts';
+import type { ConversationEvent, SubagentSummary } from '@overdeck/contracts';
 
 export type SubagentMeta = Omit<SubagentSummary, 'status'>;
 
@@ -85,4 +85,47 @@ export function subagentTranscriptPath(sessionFile: string, agentId: string): st
     return null;
   }
   return transcriptPath;
+}
+
+export interface SubagentListPoller {
+  refresh: () => Promise<void>;
+  stop: () => void;
+}
+
+export async function startSubagentListPolling(
+  sessionFile: string,
+  pendingToolUseIds: () => ReadonlySet<string>,
+  emit: (event: ConversationEvent) => void,
+): Promise<SubagentListPoller> {
+  let stopped = false;
+  let lastSerialized: string | null = null;
+  let refreshChain = Promise.resolve();
+
+  const refresh = (): Promise<void> => {
+    refreshChain = refreshChain.then(async () => {
+      if (stopped) return;
+      const pending = pendingToolUseIds();
+      const subagents: SubagentSummary[] = (await listSubagentMetas(sessionFile)).map((meta) => ({
+        ...meta,
+        status: pending.has(meta.toolUseId) ? 'running' : 'done',
+      }));
+      const serialized = JSON.stringify(subagents);
+      if (serialized === lastSerialized) return;
+      lastSerialized = serialized;
+      emit({ kind: 'subagents', subagents });
+    }).catch((error) => {
+      console.warn(`[conversation-subagents] Failed to refresh ${sessionFile}:`, error);
+    });
+    return refreshChain;
+  };
+
+  await refresh();
+  const interval = setInterval(() => void refresh(), 2_000);
+  return {
+    refresh,
+    stop: () => {
+      stopped = true;
+      clearInterval(interval);
+    },
+  };
 }

--- a/src/dashboard/server/services/conversation/subagents.ts
+++ b/src/dashboard/server/services/conversation/subagents.ts
@@ -1,0 +1,88 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { dirname, join, resolve, sep } from 'node:path';
+import type { SubagentSummary } from '@overdeck/contracts';
+
+export type SubagentMeta = Omit<SubagentSummary, 'status'>;
+
+const metaCache = new Map<string, SubagentMeta | null>();
+const SAFE_AGENT_ID = /^[A-Za-z0-9_-]+$/;
+
+export function subagentsDirFor(sessionFile: string): string {
+  const sessionDir = sessionFile.endsWith('.jsonl')
+    ? sessionFile.slice(0, -'.jsonl'.length)
+    : sessionFile;
+  return join(sessionDir, 'subagents');
+}
+
+function parseMeta(agentId: string, value: unknown): SubagentMeta {
+  if (
+    typeof value !== 'object'
+    || value === null
+    || !('agentType' in value)
+    || typeof value.agentType !== 'string'
+    || !('description' in value)
+    || typeof value.description !== 'string'
+    || !('toolUseId' in value)
+    || typeof value.toolUseId !== 'string'
+    || !('spawnDepth' in value)
+    || typeof value.spawnDepth !== 'number'
+  ) {
+    throw new Error('invalid subagent metadata');
+  }
+
+  return {
+    agentId,
+    agentType: value.agentType,
+    description: value.description,
+    toolUseId: value.toolUseId,
+    spawnDepth: value.spawnDepth,
+  };
+}
+
+async function readMeta(metaPath: string, agentId: string): Promise<SubagentMeta | null> {
+  const cached = metaCache.get(metaPath);
+  if (cached !== undefined || metaCache.has(metaPath)) return cached ?? null;
+
+  try {
+    const parsed = parseMeta(agentId, JSON.parse(await readFile(metaPath, 'utf8')));
+    metaCache.set(metaPath, parsed);
+    return parsed;
+  } catch (error) {
+    console.warn(`[conversation-subagents] Failed to parse ${metaPath}:`, error);
+    metaCache.set(metaPath, null);
+    return null;
+  }
+}
+
+export async function listSubagentMetas(sessionFile: string): Promise<SubagentMeta[]> {
+  const subagentsDir = subagentsDirFor(sessionFile);
+  let entries: string[];
+
+  try {
+    entries = await readdir(subagentsDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
+
+  const metas: SubagentMeta[] = [];
+  for (const entry of entries.sort()) {
+    const match = /^agent-(.+)\.meta\.json$/.exec(entry);
+    if (!match?.[1]) continue;
+
+    const meta = await readMeta(join(subagentsDir, entry), match[1]);
+    if (meta) metas.push(meta);
+  }
+  return metas;
+}
+
+export function subagentTranscriptPath(sessionFile: string, agentId: string): string | null {
+  if (!SAFE_AGENT_ID.test(agentId)) return null;
+
+  const subagentsDir = resolve(subagentsDirFor(sessionFile));
+  const transcriptPath = resolve(subagentsDir, `agent-${agentId}.jsonl`);
+  if (dirname(transcriptPath) !== subagentsDir || !transcriptPath.startsWith(`${subagentsDir}${sep}`)) {
+    return null;
+  }
+  return transcriptPath;
+}

--- a/src/dashboard/server/services/conversation/subagents.ts
+++ b/src/dashboard/server/services/conversation/subagents.ts
@@ -8,7 +8,7 @@ import type { ConversationEvent, SubagentSummary } from '@overdeck/contracts';
 
 export type SubagentMeta = Omit<SubagentSummary, 'status'>;
 
-const metaCache = new Map<string, SubagentMeta | null>();
+const metaCache = new Map<string, SubagentMeta>();
 const SAFE_AGENT_ID = /^[A-Za-z0-9_-]+$/;
 
 export function subagentsDirFor(sessionFile: string): string {
@@ -45,7 +45,7 @@ function parseMeta(agentId: string, value: unknown): SubagentMeta {
 
 async function readMeta(metaPath: string, agentId: string): Promise<SubagentMeta | null> {
   const cached = metaCache.get(metaPath);
-  if (cached !== undefined || metaCache.has(metaPath)) return cached ?? null;
+  if (cached !== undefined) return cached;
 
   try {
     const parsed = parseMeta(agentId, JSON.parse(await readFile(metaPath, 'utf8')));
@@ -53,7 +53,6 @@ async function readMeta(metaPath: string, agentId: string): Promise<SubagentMeta
     return parsed;
   } catch (error) {
     console.warn(`[conversation-subagents] Failed to parse ${metaPath}:`, error);
-    metaCache.set(metaPath, null);
     return null;
   }
 }

--- a/src/dashboard/server/services/format-tool-input.ts
+++ b/src/dashboard/server/services/format-tool-input.ts
@@ -86,7 +86,8 @@ export function summarizeToolInputForWorkLog(
       return todos ? `${todos.length} item${todos.length === 1 ? '' : 's'}` : undefined;
     }
 
-    case 'Task': {
+    case 'Task':
+    case 'Agent': {
       const description = asString(input.description);
       const subagentType = asString(input.subagent_type);
       if (description && subagentType) return truncate(`${subagentType}: ${description}`);

--- a/src/dashboard/server/ws-rpc.ts
+++ b/src/dashboard/server/ws-rpc.ts
@@ -43,7 +43,7 @@ import { readWorkspaceFileEffect } from './services/read-workspace-file.js';
 import { resolveFilePathExistsEffect } from './services/resolve-file-path-exists.js';
 import { getHarnessBehavior } from '../../lib/runtimes/behavior.js';
 import { normalizeSessionsFeedFilter, toDiscoveredSessionSnapshot, toSessionsFeedRowSnapshot } from './services/sessions-feed-rpc.js';
-import { subagentTranscriptPath } from './services/conversation/subagents.js';
+import { startSubagentListPolling, subagentTranscriptPath } from './services/conversation/subagents.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -888,16 +888,8 @@ const PanRpcLayer = PanRpcGroup.toLayer(
               return conversationDiscoveringStream();
             }
 
-            // Resolve the live session id from the launcher's pinned --session-id
-            // FIRST (ground truth — the exact session the running pane uses), then
-            // fall back to the conversations-table claudeSessionId. This mirrors
-            // resolveSessionFile() on the REST /messages path. Without it the live
-            // stream resolved ONLY via claudeSessionId, which the read door derives
-            // as the OLDEST conversation_files locator (`ORDER BY created_at ASC`).
-            // For a re-run singleton (e.g. the Backlog Sequencer) that oldest
-            // locator is a stale/never-written session, so the stream tailed a
-            // missing file and the panel showed the empty "How can I help you?"
-            // state even though the terminal showed the live run (PAN-1866).
+            // Prefer the launcher's pinned live session; the oldest stored locator
+            // can point at a stale file when singleton conversations re-run (PAN-1866).
             const launcherTmuxSession = conv.tmuxSession;
             const pinnedSessionId = launcherTmuxSession
               ? yield* Effect.promise(() => readLauncherPinnedSessionId(launcherTmuxSession))
@@ -977,6 +969,8 @@ const PanRpcLayer = PanRpcGroup.toLayer(
                     compactBoundaries: initial.compactBoundaries && initial.compactBoundaries.length > 0 ? initial.compactBoundaries : undefined,
                     contextUsage: currentContextUsage,
                   });
+                  let pendingSubagentToolUseIds = new Set(initial.pendingToolUse.keys());
+                  const subagentPoller = input.agentId ? null : await startSubagentListPolling(sessionFile, () => pendingSubagentToolUseIds, offer);
 
                   // Watch only bytes written after the initial full parse. Subsequent
                   // events are deltas; the client merges them into its cache.
@@ -993,6 +987,8 @@ const PanRpcLayer = PanRpcGroup.toLayer(
                     highWaterCount = gate.highWaterCount;
                     currentByteOffset = result.byteOffset;
                     currentContextUsage = contextUsageFromParseResult(result, model);
+                    pendingSubagentToolUseIds = new Set(result.pendingToolUse.keys());
+                    void subagentPoller?.refresh();
                     if (gate.suppressedShrink) {
                       console.warn(
                         `[conv-stream] suppressed shrinking reset for ${input.conversationName}: ` +
@@ -1012,7 +1008,7 @@ const PanRpcLayer = PanRpcGroup.toLayer(
                     });
                   }, { byteOffset: initial.byteOffset, priorState });
 
-                  return handle;
+                  return { stop() { handle.stop(); subagentPoller?.stop(); } };
                 }),
                 (handle) =>
                   Effect.sync(() => {

--- a/src/dashboard/server/ws-rpc.ts
+++ b/src/dashboard/server/ws-rpc.ts
@@ -43,6 +43,7 @@ import { readWorkspaceFileEffect } from './services/read-workspace-file.js';
 import { resolveFilePathExistsEffect } from './services/resolve-file-path-exists.js';
 import { getHarnessBehavior } from '../../lib/runtimes/behavior.js';
 import { normalizeSessionsFeedFilter, toDiscoveredSessionSnapshot, toSessionsFeedRowSnapshot } from './services/sessions-feed-rpc.js';
+import { subagentTranscriptPath } from './services/conversation/subagents.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -902,7 +903,7 @@ const PanRpcLayer = PanRpcGroup.toLayer(
               ? yield* Effect.promise(() => readLauncherPinnedSessionId(launcherTmuxSession))
               : null;
             const resolvedSessionId = pinnedSessionId ?? conv.claudeSessionId;
-            const sessionFile = resolvedSessionId
+            let sessionFile = resolvedSessionId
               ? sessionFilePath(conv.cwd, resolvedSessionId)
               : null;
             const model = conv.model ?? null;
@@ -911,6 +912,11 @@ const PanRpcLayer = PanRpcGroup.toLayer(
               // Session file not yet discovered — keep the subscription alive
               // without causing the client to reconnect in a tight loop.
               return conversationDiscoveringStream();
+            }
+
+            if (input.agentId) {
+              sessionFile = subagentTranscriptPath(sessionFile, input.agentId);
+              if (!sessionFile) return conversationDiscoveringStream();
             }
 
             if (isPiSessionFile(sessionFile)) {

--- a/src/dashboard/server/ws-rpc.ts
+++ b/src/dashboard/server/ws-rpc.ts
@@ -903,20 +903,14 @@ const PanRpcLayer = PanRpcGroup.toLayer(
               ? yield* Effect.promise(() => readLauncherPinnedSessionId(launcherTmuxSession))
               : null;
             const resolvedSessionId = pinnedSessionId ?? conv.claudeSessionId;
-            let sessionFile = resolvedSessionId
-              ? sessionFilePath(conv.cwd, resolvedSessionId)
-              : null;
+            const parentSessionFile = resolvedSessionId ? sessionFilePath(conv.cwd, resolvedSessionId) : null;
+            const sessionFile = parentSessionFile && input.agentId ? subagentTranscriptPath(parentSessionFile, input.agentId) : parentSessionFile;
             const model = conv.model ?? null;
 
             if (!sessionFile) {
               // Session file not yet discovered — keep the subscription alive
               // without causing the client to reconnect in a tight loop.
               return conversationDiscoveringStream();
-            }
-
-            if (input.agentId) {
-              sessionFile = subagentTranscriptPath(sessionFile, input.agentId);
-              if (!sessionFile) return conversationDiscoveringStream();
             }
 
             if (isPiSessionFile(sessionFile)) {

--- a/src/lib/conversations/__tests__/summary-fork-handoff.test.ts
+++ b/src/lib/conversations/__tests__/summary-fork-handoff.test.ts
@@ -170,7 +170,7 @@ afterEach(() => {
   }
 });
 
-describe('summary fork transcript resolution', () => {
+describe('summary fork transcript resolution', { timeout: 20_000 }, () => {
   it('summarizes an ACP conversation without a Claude session ID', async () => {
     const home = join(tmpdir(), `pan-summary-fork-acp-${Date.now()}`);
     const source = await createSourceConversation(home, {
@@ -264,7 +264,7 @@ describe('validateHandoffDoc', () => {
   });
 });
 
-describe('handoff fork handshake', () => {
+describe('handoff fork handshake', { timeout: 20_000 }, () => {
   it('delivers the rendered handoff prompt and returns the validated document', async () => {
     const home = join(tmpdir(), `pan-handoff-request-${Date.now()}`);
     process.env.OVERDECK_HOME = home;

--- a/src/lib/overdeck/conversation-reads.ts
+++ b/src/lib/overdeck/conversation-reads.ts
@@ -44,6 +44,7 @@ import { isPiSessionFile, parsePiConversationMessages } from '../../dashboard/se
 import { isOhmypiSessionFile, parseOhmypiConversationMessages } from '../../dashboard/server/services/ohmypi-conversation-parser.js';
 import { parseCodexConversationMessages } from '../../dashboard/server/services/codex-conversation-parser.js';
 import { isCompacting } from '../../dashboard/server/services/conversation-compaction.js';
+import { listSubagentMetas, subagentTranscriptPath } from '../../dashboard/server/services/conversation/subagents.js';
 import {
   readLauncherPinnedSessionId,
   resolveAgentHarness,
@@ -594,6 +595,7 @@ async function resolveSpecialistSessionFile(name: string): Promise<string | null
 export async function getConversationMessagesRead(
   name: string,
   deps: Pick<ConversationReadDependencies, 'resolveSessionFile' | 'shouldReportUnresolvedLiveSession'>,
+  agentId?: string,
 ): Promise<ConversationReadResult> {
   try {
     const conv = getConversationByName(name);
@@ -618,9 +620,15 @@ export async function getConversationMessagesRead(
       return result({ messages: [], workLog: [], streaming: false });
     }
 
+    const parentSessionFile = sessionFile;
+    if (agentId !== undefined) {
+      sessionFile = subagentTranscriptPath(parentSessionFile, agentId);
+      if (!sessionFile) return result({ error: 'Invalid subagent id' }, 400);
+    }
+
     try {
       const parsed = await getCachedMessages(sessionFile, false);
-      if (conv && (parsed.totalCost > 0 || parsed.totalTokens > 0)) {
+      if (agentId === undefined && conv && (parsed.totalCost > 0 || parsed.totalTokens > 0)) {
         updateConversationCost(name, parsed.totalCost, parsed.totalTokens);
       }
 
@@ -632,6 +640,9 @@ export async function getConversationMessagesRead(
           contextUsage = null;
         }
       }
+      const subagents = agentId === undefined
+        ? (await listSubagentMetas(parentSessionFile)).map((meta) => ({ ...meta, status: 'done' as const }))
+        : undefined;
 
       return result({
         messages: parsed.messages,
@@ -643,6 +654,7 @@ export async function getConversationMessagesRead(
         compactBoundaries: (parsed.compactBoundaries?.length ?? 0) > 0 ? parsed.compactBoundaries : undefined,
         compacting: isCompacting(sessionFile) || undefined,
         contextUsage,
+        subagents,
       });
     } catch (parseErr: unknown) {
       const code = (parseErr as { code?: string })?.code;

--- a/tests/unit/dashboard/server/routes/conversation-subagent-messages.test.ts
+++ b/tests/unit/dashboard/server/routes/conversation-subagent-messages.test.ts
@@ -1,7 +1,9 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import type { ConversationEvent } from '@overdeck/contracts';
+import { createConversation } from '../../../../../src/lib/overdeck/conversations.js';
+import { getConversationMessagesRead } from '../../../../../src/lib/overdeck/conversation-reads.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   startSubagentListPolling,
@@ -22,6 +24,19 @@ async function writeMeta(agentId: string, toolUseId: string): Promise<void> {
     toolUseId,
     spawnDepth: 1,
   }));
+}
+
+function createConversationRecord(): string {
+  const name = `subagent-rest-${basename(tempDir)}`;
+  createConversation({ name, tmuxSession: `conv-${name}`, cwd: tempDir });
+  return name;
+}
+
+function readMessages(name: string, agentId?: string) {
+  return getConversationMessagesRead(name, {
+    resolveSessionFile: async () => sessionFile,
+    shouldReportUnresolvedLiveSession: () => false,
+  }, agentId);
 }
 
 describe('conversation subagent list emission', () => {
@@ -110,5 +125,42 @@ describe('conversation subagent list emission', () => {
     await vi.advanceTimersByTimeAsync(4_000);
     await poller.refresh();
     expect(events).toHaveLength(2);
+  });
+
+  it('returns a subagent transcript and includes done subagents in the parent response', async () => {
+    const name = createConversationRecord();
+    await writeFile(sessionFile, `${JSON.stringify({
+      type: 'user',
+      uuid: 'parent-user',
+      timestamp: '2026-07-18T00:00:00.000Z',
+      message: { content: [{ type: 'text', text: 'Parent transcript' }] },
+    })}\n`);
+    await writeMeta('reader', 'toolu_reader');
+    await writeFile(join(subagentsDirFor(sessionFile), 'agent-reader.jsonl'), `${JSON.stringify({
+      type: 'user',
+      uuid: 'subagent-user',
+      timestamp: '2026-07-18T00:01:00.000Z',
+      message: { content: [{ type: 'text', text: 'Subagent transcript' }] },
+    })}\n`);
+
+    const parent = (await readMessages(name)).body as Record<string, unknown>;
+    expect(parent.subagents).toEqual([expect.objectContaining({ agentId: 'reader', status: 'done' })]);
+
+    const subagent = (await readMessages(name, 'reader')).body as {
+      messages: Array<{ text: string }>;
+      subagents?: unknown;
+    };
+    expect(subagent.messages.map((message) => message.text)).toEqual(['Subagent transcript']);
+    expect(subagent.subagents).toBeUndefined();
+  });
+
+  it('rejects traversal-unsafe subagent ids before parsing a transcript', async () => {
+    const name = createConversationRecord();
+    await writeFile(sessionFile, '');
+
+    const response = await readMessages(name, '../evil');
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: 'Invalid subagent id' });
   });
 });

--- a/tests/unit/dashboard/server/routes/conversation-subagent-messages.test.ts
+++ b/tests/unit/dashboard/server/routes/conversation-subagent-messages.test.ts
@@ -1,0 +1,114 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ConversationEvent } from '@overdeck/contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  startSubagentListPolling,
+  subagentsDirFor,
+  type SubagentListPoller,
+} from '../../../../../src/dashboard/server/services/conversation/subagents.js';
+
+let tempDir: string;
+let sessionFile: string;
+let poller: SubagentListPoller | null;
+
+async function writeMeta(agentId: string, toolUseId: string): Promise<void> {
+  const subagentsDir = subagentsDirFor(sessionFile);
+  await mkdir(subagentsDir, { recursive: true });
+  await writeFile(join(subagentsDir, `agent-${agentId}.meta.json`), JSON.stringify({
+    agentType: 'Explore',
+    description: `Subagent ${agentId}`,
+    toolUseId,
+    spawnDepth: 1,
+  }));
+}
+
+describe('conversation subagent list emission', () => {
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    tempDir = await mkdtemp(join(tmpdir(), 'overdeck-subagent-messages-'));
+    sessionFile = join(tempDir, 'session.jsonl');
+    poller = null;
+  });
+
+  afterEach(async () => {
+    poller?.stop();
+    vi.useRealTimers();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('emits the initial full list with statuses derived from pending tool uses', async () => {
+    await writeMeta('running', 'toolu_running');
+    await writeMeta('done', 'toolu_done');
+    const events: ConversationEvent[] = [];
+
+    poller = await startSubagentListPolling(
+      sessionFile,
+      () => new Set(['toolu_running']),
+      (event) => events.push(event),
+    );
+
+    expect(events).toEqual([{
+      kind: 'subagents',
+      subagents: [
+        {
+          agentId: 'done',
+          agentType: 'Explore',
+          description: 'Subagent done',
+          toolUseId: 'toolu_done',
+          spawnDepth: 1,
+          status: 'done',
+        },
+        {
+          agentId: 'running',
+          agentType: 'Explore',
+          description: 'Subagent running',
+          toolUseId: 'toolu_running',
+          spawnDepth: 1,
+          status: 'running',
+        },
+      ],
+    }]);
+  });
+
+  it('emits changed lists after 2000 ms and suppresses unchanged polls', async () => {
+    const events: ConversationEvent[] = [];
+    poller = await startSubagentListPolling(sessionFile, () => new Set(), (event) => events.push(event));
+    expect(events).toEqual([{ kind: 'subagents', subagents: [] }]);
+
+    await writeMeta('new', 'toolu_new');
+    await vi.advanceTimersByTimeAsync(2_000);
+    await poller.refresh();
+    expect(events).toHaveLength(2);
+    expect(events[1]).toMatchObject({
+      kind: 'subagents',
+      subagents: [{ agentId: 'new', status: 'done' }],
+    });
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    await poller.refresh();
+    expect(events).toHaveLength(2);
+  });
+
+  it('re-stamps statuses on demand and stops polling on release', async () => {
+    await writeMeta('status', 'toolu_status');
+    let pending = new Set(['toolu_status']);
+    const events: ConversationEvent[] = [];
+    poller = await startSubagentListPolling(sessionFile, () => pending, (event) => events.push(event));
+
+    pending = new Set();
+    await poller.refresh();
+    expect(events).toHaveLength(2);
+    expect(events[1]).toMatchObject({
+      kind: 'subagents',
+      subagents: [{ agentId: 'status', status: 'done' }],
+    });
+
+    poller.stop();
+    await writeMeta('after-stop', 'toolu_after_stop');
+    await vi.advanceTimersByTimeAsync(4_000);
+    await poller.refresh();
+    expect(events).toHaveLength(2);
+  });
+});

--- a/tests/unit/dashboard/server/services/conversation/subagents.test.ts
+++ b/tests/unit/dashboard/server/services/conversation/subagents.test.ts
@@ -67,7 +67,7 @@ describe('conversation subagent discovery', () => {
     await expect(listSubagentMetas(sessionFile)).resolves.toEqual([]);
   });
 
-  it('warns and skips corrupt metadata while preserving valid entries', async () => {
+  it('warns and retries corrupt metadata while preserving valid entries', async () => {
     await writeMeta('valid', {
       agentType: 'Explore',
       description: 'Inspect valid metadata',
@@ -88,6 +88,29 @@ describe('conversation subagent discovery', () => {
       },
     ]);
     expect(warn).toHaveBeenCalledOnce();
+
+    await writeMeta('corrupt', {
+      agentType: 'general-purpose',
+      description: 'Recover after a partial write',
+      toolUseId: 'toolu_recovered',
+      spawnDepth: 2,
+    });
+    await expect(listSubagentMetas(sessionFile)).resolves.toEqual([
+      {
+        agentId: 'corrupt',
+        agentType: 'general-purpose',
+        description: 'Recover after a partial write',
+        toolUseId: 'toolu_recovered',
+        spawnDepth: 2,
+      },
+      {
+        agentId: 'valid',
+        agentType: 'Explore',
+        description: 'Inspect valid metadata',
+        toolUseId: 'toolu_valid',
+        spawnDepth: 1,
+      },
+    ]);
   });
 
   it('resolves valid transcript ids inside the subagents directory and rejects unsafe ids', () => {

--- a/tests/unit/dashboard/server/services/conversation/subagents.test.ts
+++ b/tests/unit/dashboard/server/services/conversation/subagents.test.ts
@@ -1,0 +1,101 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  listSubagentMetas,
+  subagentTranscriptPath,
+  subagentsDirFor,
+} from '../../../../../../src/dashboard/server/services/conversation/subagents.js';
+
+let tempDir: string;
+let sessionFile: string;
+
+async function writeMeta(agentId: string, meta: unknown): Promise<void> {
+  const subagentsDir = subagentsDirFor(sessionFile);
+  await mkdir(subagentsDir, { recursive: true });
+  await writeFile(join(subagentsDir, `agent-${agentId}.meta.json`), JSON.stringify(meta));
+}
+
+describe('conversation subagent discovery', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'overdeck-subagents-'));
+    sessionFile = join(tempDir, 'session.jsonl');
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('discovers subagent metadata with ids derived from filenames', async () => {
+    await writeMeta('alpha', {
+      agentType: 'Explore',
+      description: 'Find the conversation parser',
+      toolUseId: 'toolu_alpha',
+      spawnDepth: 1,
+    });
+    await writeMeta('beta-2', {
+      agentType: 'general-purpose',
+      description: 'Trace the message stream',
+      toolUseId: 'toolu_beta',
+      spawnDepth: 2,
+    });
+
+    await expect(listSubagentMetas(sessionFile)).resolves.toEqual([
+      {
+        agentId: 'alpha',
+        agentType: 'Explore',
+        description: 'Find the conversation parser',
+        toolUseId: 'toolu_alpha',
+        spawnDepth: 1,
+      },
+      {
+        agentId: 'beta-2',
+        agentType: 'general-purpose',
+        description: 'Trace the message stream',
+        toolUseId: 'toolu_beta',
+        spawnDepth: 2,
+      },
+    ]);
+  });
+
+  it('returns an empty list for absent and empty subagent directories', async () => {
+    await expect(listSubagentMetas(sessionFile)).resolves.toEqual([]);
+
+    await mkdir(subagentsDirFor(sessionFile), { recursive: true });
+    await expect(listSubagentMetas(sessionFile)).resolves.toEqual([]);
+  });
+
+  it('warns and skips corrupt metadata while preserving valid entries', async () => {
+    await writeMeta('valid', {
+      agentType: 'Explore',
+      description: 'Inspect valid metadata',
+      toolUseId: 'toolu_valid',
+      spawnDepth: 1,
+    });
+    await mkdir(subagentsDirFor(sessionFile), { recursive: true });
+    await writeFile(join(subagentsDirFor(sessionFile), 'agent-corrupt.meta.json'), '{not json');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(listSubagentMetas(sessionFile)).resolves.toEqual([
+      {
+        agentId: 'valid',
+        agentType: 'Explore',
+        description: 'Inspect valid metadata',
+        toolUseId: 'toolu_valid',
+        spawnDepth: 1,
+      },
+    ]);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it('resolves valid transcript ids inside the subagents directory and rejects unsafe ids', () => {
+    expect(subagentTranscriptPath(sessionFile, 'alpha_2')).toBe(
+      join(subagentsDirFor(sessionFile), 'agent-alpha_2.jsonl'),
+    );
+    expect(subagentTranscriptPath(sessionFile, '../evil')).toBeNull();
+    expect(subagentTranscriptPath(sessionFile, 'a/b')).toBeNull();
+    expect(subagentTranscriptPath(sessionFile, 'agent.id')).toBeNull();
+  });
+});


### PR DESCRIPTION
**Issue:** #2876

## Acceptance Criteria

- [ ] Contracts: SubagentSummary schema, subagents event variant, optional agentId payload, ConversationResponse.subagents
- [ ] Server: subagent discovery module (list metas, resolve transcript path safely)
- [ ] Server WS: agentId payload streams the subagent transcript through the existing snapshot+tail flow
- [ ] Server WS: emit {kind:'subagents'} list on snapshot and via 2 s change-detecting poll
- [ ] Server REST: ?agentId= transcript fetch and subagents[] in the parent messages response
- [ ] Frontend: subagents in the messages cache and a useSubagentTranscript hook
- [ ] Frontend: SubagentRail component in the conversation body with ?subagent= URL state
- [ ] Frontend: 'Open subagent transcript' action in the expanded Agent/Task row
- [ ] Agent tool-name parity with Task in ToolUseExpanded and summarizeToolInputForWorkLog
- [ ] Docs: developer doc for the subagent data layout/transport and a user-facing Subagents note

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Subagents rail to conversation views, showing agent type, description, nesting, and running/completed status.
  * Added “Open subagent transcript” actions directly from relevant conversation entries.
  * Enabled transcript viewing with URL-based selection and deep-linking.
  * Added live updates for active subagents and loading of completed transcripts.
  * Added support for both Task and Agent activity summaries.

* **Documentation**
  * Added architecture and usage documentation for conversation subagents.

* **Tests**
  * Added coverage for subagent discovery, streaming, transcript access, UI interactions, and path validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->