### PR TITLE
PAN-3216

### DIFF
--- a/src/lib/briefing-assembler.ts
+++ b/src/lib/briefing-assembler.ts
@@ -148,7 +148,7 @@ function renderLocalWorkspaceSection(workspace: WorkspaceContext | null, status:
 function renderDashboardWorkspaceSection(snapshot: DashboardSnapshot): string[] {
   const runningAgents = snapshot.agents.filter((agent) => agent.status === 'running' || agent.hasLiveTmuxSession);
   const pausedAgents = snapshot.agents.filter((agent) => agent.paused);
-  const troubledAgents = snapshot.agents.filter((agent) => agent.troubled || (agent.consecutiveFailures ?? 0) > 0);
+  const troubledAgents = snapshot.agents.filter((agent) => agent.troubled === true);
   const activeIssues = new Set(snapshot.agents.map((agent) => agent.issueId).filter(Boolean));
   const failedReviews = snapshot.reviewStatuses.filter((status) =>
     status.testStatus === 'failed' ||

--- a/tests/unit/lib/briefing-assembler.test.ts
+++ b/tests/unit/lib/briefing-assembler.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { assembleLiveBriefingMarkdown } from '../../../src/lib/briefing-assembler.js';
+import type { DashboardSnapshot } from '@overdeck/contracts';
+
+describe('assembleLiveBriefingMarkdown', () => {
+  it('filters troubled agents on troubled gate alone — counts only troubled=true agents', async () => {
+    const snapshot: DashboardSnapshot = {
+      sequence: 1,
+      agents: [
+        {
+          id: 'agent-1',
+          issueId: 'PAN-1',
+          status: 'stopped',
+          troubled: true,
+        },
+        {
+          id: 'agent-2',
+          issueId: 'PAN-2',
+          status: 'stopped',
+          consecutiveFailures: 1,
+          troubled: undefined,
+        },
+        {
+          id: 'agent-3',
+          issueId: 'PAN-3',
+          status: 'stopped',
+          consecutiveFailures: 2,
+          troubled: undefined,
+        },
+        {
+          id: 'agent-4',
+          issueId: 'PAN-4',
+          status: 'stopped',
+          consecutiveFailures: 3,
+          troubled: undefined,
+        },
+      ],
+      specialists: [],
+      reviewStatuses: [],
+      issues: [],
+      timestamp: new Date().toISOString(),
+    } as DashboardSnapshot;
+
+    const output = await assembleLiveBriefingMarkdown({ snapshot });
+    expect(output).toContain('- Troubled agents: 1');
+  });
+
+  it('shows zero troubled agents when none have troubled=true', async () => {
+    const snapshot: DashboardSnapshot = {
+      sequence: 1,
+      agents: [
+        {
+          id: 'agent-1',
+          issueId: 'PAN-1',
+          status: 'stopped',
+          consecutiveFailures: 1,
+          troubled: undefined,
+        },
+        {
+          id: 'agent-2',
+          issueId: 'PAN-2',
+          status: 'stopped',
+          consecutiveFailures: 2,
+          troubled: undefined,
+        },
+        {
+          id: 'agent-3',
+          issueId: 'PAN-3',
+          status: 'stopped',
+          consecutiveFailures: 3,
+          troubled: undefined,
+        },
+      ],
+      specialists: [],
+      reviewStatuses: [],
+      issues: [],
+      timestamp: new Date().toISOString(),
+    } as DashboardSnapshot;
+
+    const output = await assembleLiveBriefingMarkdown({ snapshot });
+    expect(output).toContain('- Troubled agents: 0');
+  });
+});


### PR DESCRIPTION
**Issue:** #3216

## Acceptance Criteria

- [ ] Filter the briefing 'Troubled agents' line on the troubled gate alone and pin it with a regression test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard briefing accuracy by counting only agents explicitly marked as troubled.

* **Tests**
  * Added coverage to verify troubled-agent counts in live briefing summaries, including cases where no agents are marked troubled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->