### PR TITLE
PAN-3025

### DIFF
--- a/docs/DEFINITION-OF-DONE.md
+++ b/docs/DEFINITION-OF-DONE.md
@@ -19,6 +19,10 @@ this table and that module from drifting silently.
 | 7 | `deploy` | **Deployed: the live dashboard runs a canonical build that includes the merge.** When the `merged` row misses without resolving a merge commit, this row skips and reports its row-4 dependency instead of recording a second miss. | staleness-gated Step 0 (`merge-agent.ts`) + Deacon deploy patrol (`deploy-patrol.ts`) + deploy intent queue (`pending-deploy.json`), guarded by `getDeployBlockReason()` | `/api/health` `buildCommit`, `buildDirty`, and `buildBranch` + stale-build chip; the row misses when the build is dirty or `buildCommit` is not an ancestor of `origin/main` |
 | 8 | `teardown` | Close-out: worktree removed, branches per `close_out` config, xBRIEF `plan.status: completed`, planning artifacts archived, tracker issue CLOSED + `closed-out` label, review status cleared, Docker `_devnet` teardown verified | `pan close <id>` / dashboard Close Out (`closeOut`); closed-issue reaper (`reapIssueResidue`) as backstop | issue state, `workspaces/` dir |
 
+## Verdict durability
+
+Rows 1–3 read live status first and fall back to the per-issue record's `pipeline` block on `overdeck-state` when live status is absent. The durable journal preserves the full verdict triple (review/tests/verification) plus `lastVerifiedCommit` through close-out and across database rebuilds, so rows continue to read and pass after live status is cleared or the SQLite database is re-derived. Re-running `pan close <id>` on a fully closed-out issue is an idempotent no-op that returns success without re-evaluating the gate or re-running any ceremony step; it names the original `closedOutAt` timestamp to prove completion on the original run.
+
 ## Rules of the table
 
 - **Merged ≠ done.** Steps 5–8 are where "shipped" actually happens; step 7 is where the fix

--- a/scripts/file-size-allowlist.txt
+++ b/scripts/file-size-allowlist.txt
@@ -6,4 +6,4 @@
 1277 src/cli/commands/start.ts # PAN-3151
 3475 src/lib/cloister/deacon.ts # PAN-3206
 1315 src/lib/tmux.ts # PAN-3212
-1006 src/lib/lifecycle/workflows.ts # PAN-3211
+1018 src/lib/lifecycle/workflows.ts # PAN-3025

--- a/src/lib/__tests__/close-out-terminal.test.ts
+++ b/src/lib/__tests__/close-out-terminal.test.ts
@@ -104,7 +104,7 @@ describe('close-out terminal journal integration (PAN-2054)', () => {
     expect(record?.pipeline.closedOut).toBe(true);
     expect(record?.pipeline.closedOutAt).toEqual(expect.any(String));
     expect(record?.pipeline.readyForMerge).toBe(false);
-    expect(record?.pipeline.verificationStatus).toBeUndefined();
+    expect(record?.pipeline.verificationStatus).toBe('running'); // Preserved for journal fallback (PAN-3025)
     expect(record?.pipeline.mergeStatus).toBe('merged');
     expect(mocks.dbDelete).toHaveBeenCalledWith('PAN-2054');
     expect(mocks.dbUpsert).not.toHaveBeenCalled();

--- a/src/lib/lifecycle/dod-gate.ts
+++ b/src/lib/lifecycle/dod-gate.ts
@@ -664,3 +664,17 @@ export async function evaluateDodGate(
     passed: rows.every(row => row.status !== 'miss' || Boolean(row.acceptedBy)),
   };
 }
+
+/**
+ * PAN-3025: completion witness for the close-out ceremony. Returns closedOutAt
+ * only when the journal is terminal AND the live row is gone (the ceremony's
+ * final mutating step). closedOut with live status present means a prior run
+ * aborted mid-ceremony and must fall through to complete it.
+ */
+export async function readCompletedCloseOut(issueId: string, projectPath: string): Promise<string | null> {
+  const project = resolveProjectForIssue(issueId) ?? getProjectConfigFromWorkspacePath(projectPath);
+  const record = await readIssueRecord(project, issueId.toUpperCase());
+  if (!record?.pipeline.closedOut) return null;
+  const live = await Effect.runPromise(getReviewStatus(issueId)).catch(() => null);
+  return live ? null : (record.pipeline.closedOutAt ?? 'unknown');
+}

--- a/src/lib/lifecycle/dod-gate.ts
+++ b/src/lib/lifecycle/dod-gate.ts
@@ -672,9 +672,16 @@ export async function evaluateDodGate(
  * aborted mid-ceremony and must fall through to complete it.
  */
 export async function readCompletedCloseOut(issueId: string, projectPath: string): Promise<string | null> {
-  const project = resolveProjectForIssue(issueId) ?? getProjectConfigFromWorkspacePath(projectPath);
-  const record = await readIssueRecord(project, issueId.toUpperCase());
-  if (!record?.pipeline.closedOut) return null;
-  const live = await Effect.runPromise(getReviewStatus(issueId)).catch(() => null);
-  return live ? null : (record.pipeline.closedOutAt ?? 'unknown');
+  try {
+    const project = resolveProjectForIssue(issueId) ?? getProjectConfigFromWorkspacePath(projectPath);
+    const record = await readIssueRecord(project, issueId.toUpperCase());
+    if (!record?.pipeline.closedOut) return null;
+    // Fail closed: a read error means we cannot confirm absence, so return null (incomplete)
+    const live = await Effect.runPromise(getReviewStatus(issueId)).catch(() => 'unknown');
+    if (live === 'unknown') return null; // Reject the idempotent path on any read failure
+    return live ? null : (record.pipeline.closedOutAt ?? 'unknown');
+  } catch {
+    // On any error (record read, etc.), fail closed
+    return null;
+  }
 }

--- a/src/lib/lifecycle/dod-gate.ts
+++ b/src/lib/lifecycle/dod-gate.ts
@@ -102,7 +102,9 @@ const defaultPostMergeRowDeps: PostMergeRowDeps = {
   readCanonicalState: async ctx => {
     return getAutoCloseOutCanonicalState(ctx.issueId) as Promise<CanonicalState | null>;
   },
-  readMergeStatus: async issueId => (await Effect.runPromise(getReviewStatus(issueId)))?.mergeStatus,
+  // PAN-3025: same live→journal fallback as the verdict rows — after close-out
+  // clears live status, the durable record is the only place mergeStatus survives.
+  readMergeStatus: async issueId => (await loadStatus(issueId, defaultDeps))?.status.mergeStatus,
   listAgents: async () => Effect.runPromise(listRunningAgents()),
 };
 

--- a/src/lib/lifecycle/workflows.ts
+++ b/src/lib/lifecycle/workflows.ts
@@ -172,7 +172,10 @@ export function closeOut(
     const allSteps: StepResult[] = [];
 
     // PAN-3025: idempotent short-circuit for already-completed close-out ceremony.
-    const closedOutAt = yield* Effect.promise(() => readCompletedCloseOut(ctx.issueId, ctx.projectPath));
+    // Fail closed: on any error, proceed to the gate (null = not-confirmed-complete).
+    const closedOutAt = yield* Effect.promise(() =>
+      readCompletedCloseOut(ctx.issueId, ctx.projectPath).catch(() => null)
+    );
     if (closedOutAt) {
       allSteps.push(stepSkipped('close-out:idempotent', [
         `Issue already closed out at ${closedOutAt} — skipping the Definition-of-Done gate and ceremony`,

--- a/src/lib/lifecycle/workflows.ts
+++ b/src/lib/lifecycle/workflows.ts
@@ -36,7 +36,7 @@ import {
   writeCloseOutDodGate,
 } from '../pan-dir/record.js';
 import { pruneStoppedAgentsForIssue } from '../cloister/agent-gc.js';
-import { evaluateDodGate } from './dod-gate.js';
+import { evaluateDodGate, readCompletedCloseOut } from './dod-gate.js';
 import {
   capturePipelineStage,
   resolvePipelineTelemetryContext,
@@ -170,6 +170,15 @@ export function closeOut(
   return Effect.gen(function* () {
     const start = Date.now();
     const allSteps: StepResult[] = [];
+
+    // PAN-3025: idempotent short-circuit for already-completed close-out ceremony.
+    const closedOutAt = yield* Effect.promise(() => readCompletedCloseOut(ctx.issueId, ctx.projectPath));
+    if (closedOutAt) {
+      allSteps.push(stepSkipped('close-out:idempotent', [
+        `Issue already closed out at ${closedOutAt} — skipping the Definition-of-Done gate and ceremony`,
+      ]));
+      return buildResult('close-out', ctx.issueId, allSteps, start);
+    }
 
     // Recover UAT-promotion evidence before the gate reads the verification verdict.
     const uatEvidenceStep = yield* Effect.promise(async () => {

--- a/src/lib/pan-dir/__tests__/records.test.ts
+++ b/src/lib/pan-dir/__tests__/records.test.ts
@@ -353,7 +353,7 @@ describe('markRecordPipelineClosedOutSync', () => {
     expect(record?.pipeline.closedOutAt).toEqual(expect.any(String));
     expect(Number.isNaN(Date.parse(record?.pipeline.closedOutAt ?? ''))).toBe(false);
     expect(record?.pipeline.readyForMerge).toBe(false);
-    expect(record?.pipeline.verificationStatus).toBeUndefined();
+    expect(record?.pipeline.verificationStatus).toBe('running'); // Preserved for journal fallback (PAN-3025)
     expect(record?.pipeline.mergeStatus).toBe('merged');
     expect(record?.pipeline.updatedAt).toBe(record?.pipeline.closedOutAt);
     expect(mockQueueAutoCommit).toHaveBeenCalled();

--- a/src/lib/pan-dir/record.ts
+++ b/src/lib/pan-dir/record.ts
@@ -859,10 +859,10 @@ export function markRecordPipelineClosedOutSync(
 ): void {
   const record = ensureIssueRecordSync(project, issueId);
   const now = new Date().toISOString();
+  // Verdict fields deliberately preserved for journal fallback (PAN-3025)
   record.pipeline.closedOut = true;
   record.pipeline.closedOutAt = now;
   record.pipeline.readyForMerge = false;
-  record.pipeline.verificationStatus = undefined;
   record.pipeline.mergeStatus = 'merged';
   record.pipeline.updatedAt = now;
   const recordPath = writeIssueRecordSync(project, issueId, record);

--- a/src/lib/reopen.ts
+++ b/src/lib/reopen.ts
@@ -62,6 +62,7 @@ export interface ReopenOptions {
   setReviewStatusSync(issueId, {
     reviewStatus: 'pending',
     testStatus: 'pending',
+    verificationStatus: 'pending',
     mergeStatus: 'pending',
     reviewNotes: `Reopened${options.reason ? `: ${options.reason}` : ''}`,
     testNotes: undefined,

--- a/tests/lib/reopen.test.ts
+++ b/tests/lib/reopen.test.ts
@@ -57,14 +57,15 @@ function seedStatus(data: Record<string, unknown>) {
     const row = s as Record<string, unknown>;
     db.prepare(`
       INSERT OR REPLACE INTO review_status
-        (issue_id, review_status, test_status, merge_status, ready_for_merge,
+        (issue_id, review_status, test_status, verification_status, merge_status, ready_for_merge,
          pr_url, auto_requeue_count, stuck, stuck_reason, stuck_at,
          reviewed_at_commit, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       issueId,
       row.reviewStatus ?? 'pending',
       row.testStatus ?? 'pending',
+      row.verificationStatus ?? null,
       row.mergeStatus ?? null,
       row.readyForMerge ? 1 : 0,
       row.prUrl ?? null,
@@ -146,11 +147,15 @@ describe('reopenWorkspaceState', () => {
     });
     const wsDir = createWorkspace();
 
+    // Verify seeded state before reopen
+    let row = readStatus('PAN-999')!;
+    expect(row.verification_status).toBe('passed');
+
     const result = await Effect.runPromise(reopenWorkspaceState('PAN-999', wsDir));
 
     expect(result.specialistStatesReset).toBe(true);
 
-    const row = readStatus('PAN-999')!;
+    row = readStatus('PAN-999')!;
     expect(row.review_status).toBe('pending');
     expect(row.test_status).toBe('pending');
     expect(row.verification_status).toBe('pending');

--- a/tests/lib/reopen.test.ts
+++ b/tests/lib/reopen.test.ts
@@ -140,6 +140,25 @@ describe('reopenWorkspaceState', () => {
     rmSync(wsDir, { recursive: true, force: true });
   });
 
+  it('resets verificationStatus to pending alongside other verdicts (PAN-3025)', async () => {
+    seedStatus({
+      'PAN-999': { reviewStatus: 'passed', testStatus: 'passed', verificationStatus: 'passed', mergeStatus: 'merged', readyForMerge: false },
+    });
+    const wsDir = createWorkspace();
+
+    const result = await Effect.runPromise(reopenWorkspaceState('PAN-999', wsDir));
+
+    expect(result.specialistStatesReset).toBe(true);
+
+    const row = readStatus('PAN-999')!;
+    expect(row.review_status).toBe('pending');
+    expect(row.test_status).toBe('pending');
+    expect(row.verification_status).toBe('pending');
+    expect(row.merge_status).toBe('pending');
+
+    rmSync(wsDir, { recursive: true, force: true });
+  });
+
   it('creates initial pending status when no prior status exists', async () => {
     const wsDir = createWorkspace();
 

--- a/tests/unit/lib/lifecycle/dod-gate-idempotent-guard.test.ts
+++ b/tests/unit/lib/lifecycle/dod-gate-idempotent-guard.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { Effect } from 'effect';
 import type { ReviewStatus } from '../../../../src/lib/review-status.js';
 import type { PanIssuePipelineRecord } from '../../../../src/lib/pan-dir/record.js';
 
@@ -46,7 +47,7 @@ describe('readCompletedCloseOut idempotent guard (PAN-3025 WI-4)', () => {
       } as any,
     } as any;
     mocks.readIssueRecord.mockResolvedValue(record);
-    mocks.getReviewStatus.mockResolvedValue(null); // No live row
+    mocks.getReviewStatus.mockReturnValue(Effect.succeed(null)); // No live row
 
     const result = await readCompletedCloseOut(issueId, projectPath);
 
@@ -64,9 +65,9 @@ describe('readCompletedCloseOut idempotent guard (PAN-3025 WI-4)', () => {
       } as any,
     } as any;
     mocks.readIssueRecord.mockResolvedValue(record);
-    mocks.getReviewStatus.mockResolvedValue({
+    mocks.getReviewStatus.mockReturnValue(Effect.succeed({
       reviewStatus: 'passed',
-    } as ReviewStatus); // Live row exists
+    } as ReviewStatus)); // Live row exists
 
     const result = await readCompletedCloseOut(issueId, projectPath);
 
@@ -95,7 +96,7 @@ describe('readCompletedCloseOut idempotent guard (PAN-3025 WI-4)', () => {
       pipeline: { closedOut: true, closedOutAt: '2026-07-28T08:00:00Z' } as any,
     } as any;
     mocks.readIssueRecord.mockResolvedValue(record);
-    mocks.getReviewStatus.mockRejectedValue(new Error('database read error'));
+    mocks.getReviewStatus.mockReturnValue(Effect.fail(new Error('database read error')));
 
     const result = await readCompletedCloseOut(issueId, projectPath);
 

--- a/tests/unit/lib/lifecycle/dod-gate-idempotent-guard.test.ts
+++ b/tests/unit/lib/lifecycle/dod-gate-idempotent-guard.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { ReviewStatus } from '../../../../src/lib/review-status.js';
+import type { PanIssuePipelineRecord } from '../../../../src/lib/pan-dir/record.js';
+
+const mocks = vi.hoisted(() => ({
+  resolveProjectForIssue: vi.fn(),
+  getProjectConfigFromWorkspacePath: vi.fn(),
+  readIssueRecord: vi.fn(),
+  getReviewStatus: vi.fn(),
+}));
+
+vi.mock('../../../../src/lib/pan-dir/record.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../src/lib/pan-dir/record.js')>();
+  return {
+    ...actual,
+    resolveProjectForIssue: mocks.resolveProjectForIssue,
+    getProjectConfigFromWorkspacePath: mocks.getProjectConfigFromWorkspacePath,
+    readIssueRecord: mocks.readIssueRecord,
+  };
+});
+
+vi.mock('../../../../src/lib/review-status.js', () => ({
+  getReviewStatus: mocks.getReviewStatus,
+}));
+
+import { readCompletedCloseOut } from '../../../../src/lib/lifecycle/dod-gate.js';
+
+const issueId = 'PAN-3025';
+const projectPath = '/tmp/test-project';
+
+describe('readCompletedCloseOut idempotent guard (PAN-3025 WI-4)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveProjectForIssue.mockReturnValue(null);
+    mocks.getProjectConfigFromWorkspacePath.mockReturnValue({ name: 'test', path: projectPath });
+  });
+
+  it('ac1: pipeline.closedOut=true + no live row → returns closedOutAt (idempotent short-circuit)', async () => {
+    // Record shows ceremony completed; live status absent → already done
+    const record: PanIssuePipelineRecord = {
+      issueId,
+      schemaVersion: 2,
+      pipeline: {
+        closedOut: true,
+        closedOutAt: '2026-07-28T08:00:00Z',
+      } as any,
+    } as any;
+    mocks.readIssueRecord.mockResolvedValue(record);
+    mocks.getReviewStatus.mockResolvedValue(null); // No live row
+
+    const result = await readCompletedCloseOut(issueId, projectPath);
+
+    expect(result).toBe('2026-07-28T08:00:00Z');
+  });
+
+  it('ac2: pipeline.closedOut=true + live row present → returns null (fall through to ceremony)', async () => {
+    // Record shows closedOut=true but live row still exists → ceremony aborted mid-way, must complete it
+    const record: PanIssuePipelineRecord = {
+      issueId,
+      schemaVersion: 2,
+      pipeline: {
+        closedOut: true,
+        closedOutAt: '2026-07-28T08:00:00Z',
+      } as any,
+    } as any;
+    mocks.readIssueRecord.mockResolvedValue(record);
+    mocks.getReviewStatus.mockResolvedValue({
+      reviewStatus: 'passed',
+    } as ReviewStatus); // Live row exists
+
+    const result = await readCompletedCloseOut(issueId, projectPath);
+
+    expect(result).toBeNull(); // Fall through to gate
+  });
+
+  it('ac3: pipeline.closedOut=false → returns null (not completed yet)', async () => {
+    // Record shows ceremony not started yet
+    const record: PanIssuePipelineRecord = {
+      issueId,
+      schemaVersion: 2,
+      pipeline: { closedOut: false } as any,
+    } as any;
+    mocks.readIssueRecord.mockResolvedValue(record);
+
+    const result = await readCompletedCloseOut(issueId, projectPath);
+
+    expect(result).toBeNull();
+  });
+
+  it('ac4: getReviewStatus read error → returns null (fail closed on uncertainty)', async () => {
+    // Live status read fails; we cannot confirm absence → conservative: do not short-circuit
+    const record: PanIssuePipelineRecord = {
+      issueId,
+      schemaVersion: 2,
+      pipeline: { closedOut: true, closedOutAt: '2026-07-28T08:00:00Z' } as any,
+    } as any;
+    mocks.readIssueRecord.mockResolvedValue(record);
+    mocks.getReviewStatus.mockRejectedValue(new Error('database read error'));
+
+    const result = await readCompletedCloseOut(issueId, projectPath);
+
+    expect(result).toBeNull(); // Fail closed
+  });
+
+  it('ac5: readIssueRecord error → returns null (fail closed on uncertainty)', async () => {
+    // Record read fails; we cannot confirm closedOut status → conservative: do not short-circuit
+    mocks.readIssueRecord.mockRejectedValue(new Error('file read error'));
+
+    const result = await readCompletedCloseOut(issueId, projectPath);
+
+    expect(result).toBeNull(); // Fail closed
+  });
+});

--- a/tests/unit/lib/lifecycle/dod-gate-journal-fallback.test.ts
+++ b/tests/unit/lib/lifecycle/dod-gate-journal-fallback.test.ts
@@ -1,107 +1,67 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 
-const issueClosureMocks = vi.hoisted(() => ({
+const mocks = vi.hoisted(() => ({
   isIssueClosed: vi.fn(),
   isTrackerIssueClosed: vi.fn(),
 }));
 
 vi.mock('../../../../src/lib/cloister/issue-closed.js', () => ({
-  isIssueClosed: issueClosureMocks.isIssueClosed,
-  isTrackerIssueClosed: issueClosureMocks.isTrackerIssueClosed,
+  isIssueClosed: mocks.isIssueClosed,
+  isTrackerIssueClosed: mocks.isTrackerIssueClosed,
 }));
 
-import type { PanIssuePipelineRecord, ProjectConfig } from '../../../../src/lib/pan-dir/record.js';
-import type { ReviewStatus } from '../../../../src/lib/review-status.js';
-import { checkPostMergeRow, type PostMergeRowDeps } from '../../../../src/lib/lifecycle/dod-gate.js';
+import { checkPostMergeRow } from '../../../../src/lib/lifecycle/dod-gate.js';
 
 const issueId = 'PAN-3025';
 const ctx = {
   issueId,
-  projectPath: '/tmp/overdeck',
+  projectPath: '/tmp/test-project',
   github: { owner: 'eltmon', repo: 'overdeck', number: 3025 },
 };
 
-const clearAgents = () => [];
-
-// Custom deps for testing the journal fallback logic
-function journalFallbackDeps(
-  liveStatus: ReviewStatus | null,
-  pipelineStatus: Partial<PanIssuePipelineRecord['pipeline']> | null,
-): PostMergeRowDeps {
-  return {
-    readCanonicalState: async () => null,
-    readMergeStatus: async () => {
-      // Live status takes precedence
-      if (liveStatus?.mergeStatus) {
-        return liveStatus.mergeStatus;
-      }
-      // Fall back to journal
-      if (pipelineStatus?.mergeStatus) {
-        return pipelineStatus.mergeStatus;
-      }
-      return undefined;
-    },
-    listAgents: async () => clearAgents(),
-  };
-}
-
 describe('DoD row 5 (post-merge) journal fallback for mergeStatus (PAN-3025)', () => {
-  it('ac1: with live null and journal mergeStatus merged, row has merged in observed', async () => {
-    const row = await checkPostMergeRow(ctx, undefined, journalFallbackDeps(
-      null,
-      { mergeStatus: 'merged' },
-    ));
-
-    expect(row.observed).toContain('mergeStatus: merged');
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
-  it('ac2: with live null and journal without mergeStatus, row has missing in observed', async () => {
-    const row = await checkPostMergeRow(ctx, undefined, journalFallbackDeps(
-      null,
-      {},
-    ));
+  it('ac1: row-5 uses production live→journal fallback for mergeStatus (existence proof)', async () => {
+    // This test verifies that the production readMergeStatus default
+    // reads live status and falls back to journal. The actual values
+    // depend on the mocked dependencies, but we verify the machinery is wired.
 
-    expect(row.observed).toContain('mergeStatus: missing');
+    // With no live status and no prior verifications, the row should report missing
+    // (This is an integration test that checks the defaults are connected correctly)
+
+    const row = await checkPostMergeRow(ctx, 'verifying_on_main');
+
+    // The row evaluates; it may pass, miss, or skip depending on test environment
+    // The key point is that readMergeStatus was called via the production path
+    expect(row).toHaveProperty('status');
+    expect(row).toHaveProperty('observed');
   });
 
-  it('ac3: with live row having mergeStatus merged, row uses live status', async () => {
-    const liveWithMerge: ReviewStatus = {
-      issueId,
-      mergeStatus: 'merged',
-      reviewStatus: 'passed',
-      testStatus: 'passed',
-      updatedAt: '2026-07-15T00:00:00Z',
-      readyForMerge: true,
-    };
+  it('ac2: live-first ordering is enforced in production readMergeStatus', async () => {
+    // Verify that when row-5 checks the merge status, it uses the production default
+    // which reads live first, then falls back to journal.
+    // This is verified by the existence of defaultPostMergeRowDeps in dod-gate.ts
+    // using loadStatus() which implements live→journal fallback.
 
-    const row = await checkPostMergeRow(ctx, undefined, journalFallbackDeps(
-      liveWithMerge,
-      { mergeStatus: 'verifying' }, // Journal has different status, but live should win
-    ));
+    const row = await checkPostMergeRow(ctx, undefined);
 
-    expect(row.observed).toContain('mergeStatus: merged'); // Live status observed, not journal
+    // Row evaluates normally with production dependencies
+    expect(row).toHaveProperty('id');
+    expect(row.id).toBe('post-merge');
   });
 
-  it('ac4: pre-existing row behavior unchanged with live status', async () => {
-    const liveWithMerge: ReviewStatus = {
-      issueId,
-      mergeStatus: 'merged',
-      reviewStatus: 'passed',
-      testStatus: 'passed',
-      updatedAt: '2026-07-15T00:00:00Z',
-      readyForMerge: true,
-    };
+  it('ac3: row-5 evaluated without custom deps exercises production loadStatus fallback', async () => {
+    // Calling checkPostMergeRow without custom dependencies ensures
+    // the production defaultPostMergeRowDeps.readMergeStatus is used,
+    // which calls loadStatus() with live-first fallback.
 
-    const customDeps: PostMergeRowDeps = {
-      readCanonicalState: async () => 'verifying_on_main',
-      readMergeStatus: async () => liveWithMerge.mergeStatus,
-      listAgents: async () => clearAgents(),
-    };
+    const row = await checkPostMergeRow(ctx, 'verifying_on_main');
 
-    const row = await checkPostMergeRow(ctx, undefined, customDeps);
-
-    // Standard test: verifying_on_main + merged status + no running agents = pass
-    expect(row.status).toBe('pass');
-    expect(row.observed).toContain('no running work/planning agents');
+    // The presence of status and observed proves the row evaluated
+    expect(row.status).toBeDefined();
+    expect(row.observed).toBeDefined();
   });
 });

--- a/tests/unit/lib/lifecycle/dod-gate-journal-fallback.test.ts
+++ b/tests/unit/lib/lifecycle/dod-gate-journal-fallback.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   resolveProjectForIssue: vi.fn(),
   getProjectConfigFromWorkspacePath: vi.fn(),
   listRunningAgents: vi.fn(),
+  getAutoCloseOutCanonicalState: vi.fn(),
 }));
 
 vi.mock('../../../../src/lib/cloister/issue-closed.js', () => ({
@@ -33,7 +34,11 @@ vi.mock('../../../../src/lib/pan-dir/record.js', async (importOriginal) => {
 });
 
 vi.mock('../../../../src/lib/agents.js', () => ({
-  listRunningAgents: vi.fn(() => Effect.succeed([])),
+  listRunningAgents: mocks.listRunningAgents,
+}));
+
+vi.mock('../../../../src/lib/cloister/deacon-canonical-state.js', () => ({
+  getAutoCloseOutCanonicalState: mocks.getAutoCloseOutCanonicalState,
 }));
 
 import { checkPostMergeRow } from '../../../../src/lib/lifecycle/dod-gate.js';
@@ -52,6 +57,7 @@ describe('DoD row 5 (post-merge) journal fallback for mergeStatus (PAN-3025)', (
     mocks.resolveProjectForIssue.mockReturnValue(null);
     mocks.getProjectConfigFromWorkspacePath.mockReturnValue({ name: 'test', path: projectPath });
     mocks.listRunningAgents.mockReturnValue(Effect.succeed([]));
+    mocks.getAutoCloseOutCanonicalState.mockResolvedValue(null); // Deterministic: no canonical state
   });
 
   it('ac1: live absent + journal merged → pass (journal fallback read)', async () => {

--- a/tests/unit/lib/lifecycle/dod-gate-journal-fallback.test.ts
+++ b/tests/unit/lib/lifecycle/dod-gate-journal-fallback.test.ts
@@ -1,13 +1,34 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { ReviewStatus } from '../../../../src/lib/review-status.js';
+import type { PanIssuePipelineRecord } from '../../../../src/lib/pan-dir/record.js';
 
 const mocks = vi.hoisted(() => ({
   isIssueClosed: vi.fn(),
   isTrackerIssueClosed: vi.fn(),
+  getReviewStatus: vi.fn(),
+  readIssueRecord: vi.fn(),
+  listRunningAgents: vi.fn(),
 }));
 
 vi.mock('../../../../src/lib/cloister/issue-closed.js', () => ({
   isIssueClosed: mocks.isIssueClosed,
   isTrackerIssueClosed: mocks.isTrackerIssueClosed,
+}));
+
+vi.mock('../../../../src/lib/review-status.js', () => ({
+  getReviewStatus: mocks.getReviewStatus,
+}));
+
+vi.mock('../../../../src/lib/pan-dir/record.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../src/lib/pan-dir/record.js')>();
+  return {
+    ...actual,
+    readIssueRecord: mocks.readIssueRecord,
+  };
+});
+
+vi.mock('../../../../src/lib/agents.js', () => ({
+  listRunningAgents: mocks.listRunningAgents,
 }));
 
 import { checkPostMergeRow } from '../../../../src/lib/lifecycle/dod-gate.js';
@@ -22,46 +43,54 @@ const ctx = {
 describe('DoD row 5 (post-merge) journal fallback for mergeStatus (PAN-3025)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.listRunningAgents.mockResolvedValue([]);
   });
 
-  it('ac1: row-5 uses production live→journal fallback for mergeStatus (existence proof)', async () => {
-    // This test verifies that the production readMergeStatus default
-    // reads live status and falls back to journal. The actual values
-    // depend on the mocked dependencies, but we verify the machinery is wired.
+  it('ac1: live absent + journal merged → pass (journal fallback read)', async () => {
+    // Live status absent; journal has mergeStatus: merged → row passes via journal read
+    mocks.getReviewStatus.mockResolvedValue(null);
+    const record: PanIssuePipelineRecord = {
+      issueId,
+      schemaVersion: 2,
+      pipeline: { mergeStatus: 'merged' } as any,
+    } as any;
+    mocks.readIssueRecord.mockResolvedValue(record);
 
-    // With no live status and no prior verifications, the row should report missing
-    // (This is an integration test that checks the defaults are connected correctly)
+    const row = await checkPostMergeRow(ctx);
 
-    const row = await checkPostMergeRow(ctx, 'verifying_on_main');
-
-    // The row evaluates; it may pass, miss, or skip depending on test environment
-    // The key point is that readMergeStatus was called via the production path
-    expect(row).toHaveProperty('status');
-    expect(row).toHaveProperty('observed');
+    expect(row.status).toBe('pass');
+    expect(row.observed).toContain('mergeStatus: merged');
+    // Verify journal was read (because live was absent)
+    expect(mocks.readIssueRecord).toHaveBeenCalled();
   });
 
-  it('ac2: live-first ordering is enforced in production readMergeStatus', async () => {
-    // Verify that when row-5 checks the merge status, it uses the production default
-    // which reads live first, then falls back to journal.
-    // This is verified by the existence of defaultPostMergeRowDeps in dod-gate.ts
-    // using loadStatus() which implements live→journal fallback.
+  it('ac2: live merged → pass (live precedence, no journal read)', async () => {
+    // Live status shows merged → row passes without reading journal
+    mocks.getReviewStatus.mockResolvedValue({
+      mergeStatus: 'merged',
+    } as ReviewStatus);
+    mocks.readIssueRecord.mockResolvedValue(null); // Should not be called
 
-    const row = await checkPostMergeRow(ctx, undefined);
+    const row = await checkPostMergeRow(ctx);
 
-    // Row evaluates normally with production dependencies
-    expect(row).toHaveProperty('id');
-    expect(row.id).toBe('post-merge');
+    expect(row.status).toBe('pass');
+    // Verify journal was NOT called because live has the answer
+    expect(mocks.readIssueRecord).not.toHaveBeenCalled();
   });
 
-  it('ac3: row-5 evaluated without custom deps exercises production loadStatus fallback', async () => {
-    // Calling checkPostMergeRow without custom dependencies ensures
-    // the production defaultPostMergeRowDeps.readMergeStatus is used,
-    // which calls loadStatus() with live-first fallback.
+  it('ac3: live absent + journal missing → miss', async () => {
+    // Live status absent; journal has no mergeStatus → row misses
+    mocks.getReviewStatus.mockResolvedValue(null);
+    const record: PanIssuePipelineRecord = {
+      issueId,
+      schemaVersion: 2,
+      pipeline: {} as any,
+    } as any;
+    mocks.readIssueRecord.mockResolvedValue(record);
 
-    const row = await checkPostMergeRow(ctx, 'verifying_on_main');
+    const row = await checkPostMergeRow(ctx);
 
-    // The presence of status and observed proves the row evaluated
-    expect(row.status).toBeDefined();
-    expect(row.observed).toBeDefined();
+    expect(row.status).toBe('miss');
+    expect(row.observed).toContain('missing');
   });
 });

--- a/tests/unit/lib/lifecycle/dod-gate-journal-fallback.test.ts
+++ b/tests/unit/lib/lifecycle/dod-gate-journal-fallback.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { Effect } from 'effect';
 import type { ReviewStatus } from '../../../../src/lib/review-status.js';
 import type { PanIssuePipelineRecord } from '../../../../src/lib/pan-dir/record.js';
 
@@ -7,6 +8,8 @@ const mocks = vi.hoisted(() => ({
   isTrackerIssueClosed: vi.fn(),
   getReviewStatus: vi.fn(),
   readIssueRecord: vi.fn(),
+  resolveProjectForIssue: vi.fn(),
+  getProjectConfigFromWorkspacePath: vi.fn(),
   listRunningAgents: vi.fn(),
 }));
 
@@ -24,31 +27,36 @@ vi.mock('../../../../src/lib/pan-dir/record.js', async (importOriginal) => {
   return {
     ...actual,
     readIssueRecord: mocks.readIssueRecord,
+    resolveProjectForIssue: mocks.resolveProjectForIssue,
+    getProjectConfigFromWorkspacePath: mocks.getProjectConfigFromWorkspacePath,
   };
 });
 
 vi.mock('../../../../src/lib/agents.js', () => ({
-  listRunningAgents: mocks.listRunningAgents,
+  listRunningAgents: vi.fn(() => Effect.succeed([])),
 }));
 
 import { checkPostMergeRow } from '../../../../src/lib/lifecycle/dod-gate.js';
 
 const issueId = 'PAN-3025';
+const projectPath = '/tmp/test-project';
 const ctx = {
   issueId,
-  projectPath: '/tmp/test-project',
+  projectPath,
   github: { owner: 'eltmon', repo: 'overdeck', number: 3025 },
 };
 
 describe('DoD row 5 (post-merge) journal fallback for mergeStatus (PAN-3025)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.listRunningAgents.mockResolvedValue([]);
+    mocks.resolveProjectForIssue.mockReturnValue(null);
+    mocks.getProjectConfigFromWorkspacePath.mockReturnValue({ name: 'test', path: projectPath });
+    mocks.listRunningAgents.mockReturnValue(Effect.succeed([]));
   });
 
   it('ac1: live absent + journal merged → pass (journal fallback read)', async () => {
     // Live status absent; journal has mergeStatus: merged → row passes via journal read
-    mocks.getReviewStatus.mockResolvedValue(null);
+    mocks.getReviewStatus.mockReturnValue(Effect.succeed(null));
     const record: PanIssuePipelineRecord = {
       issueId,
       schemaVersion: 2,
@@ -66,9 +74,9 @@ describe('DoD row 5 (post-merge) journal fallback for mergeStatus (PAN-3025)', (
 
   it('ac2: live merged → pass (live precedence, no journal read)', async () => {
     // Live status shows merged → row passes without reading journal
-    mocks.getReviewStatus.mockResolvedValue({
+    mocks.getReviewStatus.mockReturnValue(Effect.succeed({
       mergeStatus: 'merged',
-    } as ReviewStatus);
+    } as ReviewStatus));
     mocks.readIssueRecord.mockResolvedValue(null); // Should not be called
 
     const row = await checkPostMergeRow(ctx);
@@ -80,7 +88,7 @@ describe('DoD row 5 (post-merge) journal fallback for mergeStatus (PAN-3025)', (
 
   it('ac3: live absent + journal missing → miss', async () => {
     // Live status absent; journal has no mergeStatus → row misses
-    mocks.getReviewStatus.mockResolvedValue(null);
+    mocks.getReviewStatus.mockReturnValue(Effect.succeed(null));
     const record: PanIssuePipelineRecord = {
       issueId,
       schemaVersion: 2,

--- a/tests/unit/lib/lifecycle/dod-gate-journal-fallback.test.ts
+++ b/tests/unit/lib/lifecycle/dod-gate-journal-fallback.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const issueClosureMocks = vi.hoisted(() => ({
+  isIssueClosed: vi.fn(),
+  isTrackerIssueClosed: vi.fn(),
+}));
+
+vi.mock('../../../../src/lib/cloister/issue-closed.js', () => ({
+  isIssueClosed: issueClosureMocks.isIssueClosed,
+  isTrackerIssueClosed: issueClosureMocks.isTrackerIssueClosed,
+}));
+
+import type { PanIssuePipelineRecord, ProjectConfig } from '../../../../src/lib/pan-dir/record.js';
+import type { ReviewStatus } from '../../../../src/lib/review-status.js';
+import { checkPostMergeRow, type PostMergeRowDeps } from '../../../../src/lib/lifecycle/dod-gate.js';
+
+const issueId = 'PAN-3025';
+const ctx = {
+  issueId,
+  projectPath: '/tmp/overdeck',
+  github: { owner: 'eltmon', repo: 'overdeck', number: 3025 },
+};
+
+const clearAgents = () => [];
+
+// Custom deps for testing the journal fallback logic
+function journalFallbackDeps(
+  liveStatus: ReviewStatus | null,
+  pipelineStatus: Partial<PanIssuePipelineRecord['pipeline']> | null,
+): PostMergeRowDeps {
+  return {
+    readCanonicalState: async () => null,
+    readMergeStatus: async () => {
+      // Live status takes precedence
+      if (liveStatus?.mergeStatus) {
+        return liveStatus.mergeStatus;
+      }
+      // Fall back to journal
+      if (pipelineStatus?.mergeStatus) {
+        return pipelineStatus.mergeStatus;
+      }
+      return undefined;
+    },
+    listAgents: async () => clearAgents(),
+  };
+}
+
+describe('DoD row 5 (post-merge) journal fallback for mergeStatus (PAN-3025)', () => {
+  it('ac1: with live null and journal mergeStatus merged, row has merged in observed', async () => {
+    const row = await checkPostMergeRow(ctx, undefined, journalFallbackDeps(
+      null,
+      { mergeStatus: 'merged' },
+    ));
+
+    expect(row.observed).toContain('mergeStatus: merged');
+  });
+
+  it('ac2: with live null and journal without mergeStatus, row has missing in observed', async () => {
+    const row = await checkPostMergeRow(ctx, undefined, journalFallbackDeps(
+      null,
+      {},
+    ));
+
+    expect(row.observed).toContain('mergeStatus: missing');
+  });
+
+  it('ac3: with live row having mergeStatus merged, row uses live status', async () => {
+    const liveWithMerge: ReviewStatus = {
+      issueId,
+      mergeStatus: 'merged',
+      reviewStatus: 'passed',
+      testStatus: 'passed',
+      updatedAt: '2026-07-15T00:00:00Z',
+      readyForMerge: true,
+    };
+
+    const row = await checkPostMergeRow(ctx, undefined, journalFallbackDeps(
+      liveWithMerge,
+      { mergeStatus: 'verifying' }, // Journal has different status, but live should win
+    ));
+
+    expect(row.observed).toContain('mergeStatus: merged'); // Live status observed, not journal
+  });
+
+  it('ac4: pre-existing row behavior unchanged with live status', async () => {
+    const liveWithMerge: ReviewStatus = {
+      issueId,
+      mergeStatus: 'merged',
+      reviewStatus: 'passed',
+      testStatus: 'passed',
+      updatedAt: '2026-07-15T00:00:00Z',
+      readyForMerge: true,
+    };
+
+    const customDeps: PostMergeRowDeps = {
+      readCanonicalState: async () => 'verifying_on_main',
+      readMergeStatus: async () => liveWithMerge.mergeStatus,
+      listAgents: async () => clearAgents(),
+    };
+
+    const row = await checkPostMergeRow(ctx, undefined, customDeps);
+
+    // Standard test: verifying_on_main + merged status + no running agents = pass
+    expect(row.status).toBe('pass');
+    expect(row.observed).toContain('no running work/planning agents');
+  });
+});

--- a/tests/unit/lib/lifecycle/workflows.test.ts
+++ b/tests/unit/lib/lifecycle/workflows.test.ts
@@ -22,6 +22,8 @@ const {
   mockHealUatPromotionVerification,
   mockCapturePipelineStage,
   mockResolvePipelineTelemetryContext,
+  mockGetReviewStatus,
+  mockReadIssueRecord,
 } = vi.hoisted(() => ({
   mockExecAsync: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
   mockClearReviewStatus: vi.fn(),
@@ -29,15 +31,29 @@ const {
   mockMarkRecordPipelineClosedOutSync: vi.fn(),
   mockWriteCloseOutDodGateSync: vi.fn(),
   mockSweepOrphanedTasks: vi.fn().mockResolvedValue({ ok: true, closedIds: [], skipped: 0 }),
-  mockEvaluateDodGate: vi.fn(),
+  mockEvaluateDodGate: vi.fn().mockResolvedValue({
+    passed: true,
+    misses: [],
+    accepted: [],
+    rows: [{
+      id: 'review', num: 1, title: 'Review', expected: 'recorded verdict',
+      observed: 'reviewStatus: passed', status: 'pass',
+    }],
+  }),
   mockHealUatPromotionVerification: vi.fn(),
   mockCapturePipelineStage: vi.fn(),
   mockResolvePipelineTelemetryContext: vi.fn(async () => null),
+  mockGetReviewStatus: vi.fn(),
+  mockReadIssueRecord: vi.fn(),
 }));
 
-vi.mock('../../../../src/lib/lifecycle/dod-gate.js', () => ({
-  evaluateDodGate: mockEvaluateDodGate,
-}));
+vi.mock('../../../../src/lib/lifecycle/dod-gate.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../src/lib/lifecycle/dod-gate.js')>();
+  return {
+    ...actual,
+    evaluateDodGate: mockEvaluateDodGate,
+  };
+});
 
 vi.mock('../../../../src/lib/cloister/uat-promote-verification.js', () => ({
   healUatPromotionVerification: mockHealUatPromotionVerification,
@@ -91,6 +107,7 @@ vi.mock('../../../../src/lib/shadow-state.js', () => ({
 
 vi.mock('../../../../src/lib/review-status.js', () => ({
   clearReviewStatus: mockClearReviewStatus,
+  getReviewStatus: mockGetReviewStatus,
 }));
 
 vi.mock('../../../../src/lib/pan-dir/record.js', async (importOriginal) => {
@@ -100,6 +117,7 @@ vi.mock('../../../../src/lib/pan-dir/record.js', async (importOriginal) => {
     getProjectConfigFromWorkspacePath: vi.fn((workspacePath: string) => ({ name: 'inferred', path: workspacePath })),
     markRecordPipelineClosedOutSync: mockMarkRecordPipelineClosedOutSync,
     writeCloseOutDodGate: mockWriteCloseOutDodGateSync,
+    readIssueRecord: mockReadIssueRecord,
   };
 });
 
@@ -189,6 +207,8 @@ describe('workflows', () => {
 
     vi.clearAllMocks();
     mockHealUatPromotionVerification.mockResolvedValue(null);
+    mockGetReviewStatus.mockResolvedValue(null);
+    mockReadIssueRecord.mockResolvedValue(null);
     mockEvaluateDodGate.mockResolvedValue({
       passed: true,
       misses: [],

--- a/tests/unit/lib/lifecycle/workflows.test.ts
+++ b/tests/unit/lib/lifecycle/workflows.test.ts
@@ -24,6 +24,7 @@ const {
   mockResolvePipelineTelemetryContext,
   mockGetReviewStatus,
   mockReadIssueRecord,
+  mockReadCompletedCloseOut,
 } = vi.hoisted(() => ({
   mockExecAsync: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
   mockClearReviewStatus: vi.fn(),
@@ -45,6 +46,7 @@ const {
   mockResolvePipelineTelemetryContext: vi.fn(async () => null),
   mockGetReviewStatus: vi.fn(),
   mockReadIssueRecord: vi.fn(),
+  mockReadCompletedCloseOut: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('../../../../src/lib/lifecycle/dod-gate.js', async (importOriginal) => {
@@ -52,6 +54,7 @@ vi.mock('../../../../src/lib/lifecycle/dod-gate.js', async (importOriginal) => {
   return {
     ...actual,
     evaluateDodGate: mockEvaluateDodGate,
+    readCompletedCloseOut: mockReadCompletedCloseOut,
   };
 });
 
@@ -977,6 +980,49 @@ describe('workflows', () => {
       expect(commands.some(command => command.includes('--add-label "closed-out"'))).toBe(true);
       expect(commands.some(command => command.includes('--remove-label "verifying-on-main"'))).toBe(true);
       expect(commands.some(command => command.includes('--remove-label "needs-close-out"'))).toBe(true);
+    });
+
+    it('short-circuits when already closed-out with live row absent (PAN-3025 WI-4 ac1)', async () => {
+      mockReadCompletedCloseOut.mockResolvedValueOnce('2026-07-28T08:00:00Z');
+
+      const result = await closeOut(
+        { issueId: 'PAN-3050', projectPath: testDir },
+        { tracker: successfulTracker() },
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.steps.find(step => step.step === 'close-out:idempotent')).toMatchObject({
+        skipped: true,
+        details: expect.arrayContaining([expect.stringContaining('already closed out at 2026-07-28T08:00:00Z')]),
+      });
+      // Gate and ceremony are not called when already closed-out
+      expect(mockEvaluateDodGate).not.toHaveBeenCalled();
+    });
+
+    it('falls through to the gate when closed-out guard does not trigger (PAN-3025 WI-4 ac2)', async () => {
+      mockReadCompletedCloseOut.mockResolvedValueOnce(null); // Not closed-out, or live row exists
+
+      const result = await closeOut(
+        { issueId: 'PAN-3051', projectPath: testDir },
+        { tracker: successfulTracker() },
+      );
+
+      expect(result.success).toBe(true);
+      // Gate runs normally because the guard did not short-circuit
+      expect(mockEvaluateDodGate).toHaveBeenCalledOnce();
+    });
+
+    it('does not short-circuit when close-out guard read fails (PAN-3025 WI-4 ac3)', async () => {
+      mockReadCompletedCloseOut.mockRejectedValueOnce(new Error('database read error'));
+
+      const result = await closeOut(
+        { issueId: 'PAN-3052', projectPath: testDir },
+        { tracker: successfulTracker() },
+      );
+
+      expect(result.success).toBe(true);
+      // On guard error, we conservatively do not short-circuit
+      expect(mockEvaluateDodGate).toHaveBeenCalledOnce();
     });
 
   });

--- a/tests/unit/lib/lifecycle/workflows.test.ts
+++ b/tests/unit/lib/lifecycle/workflows.test.ts
@@ -995,12 +995,15 @@ describe('workflows', () => {
       );
 
       expect(result.success).toBe(true);
-      const idempotentStep = result.steps.find(step => step.step === 'close-out:idempotent');
-      expect(idempotentStep).toBeDefined();
-      expect(idempotentStep?.skipped).toBe(true);
+      // Early return means exactly one step (the idempotent skip step)
+      expect(result.steps).toHaveLength(1);
+      const idempotentStep = result.steps[0];
+      expect(idempotentStep.step).toBe('close-out:idempotent');
+      expect(idempotentStep.skipped).toBe(true);
       // Verify ceremony was skipped (gate not called, status mutations not run)
       expect(mockEvaluateDodGate).not.toHaveBeenCalled();
       expect(mockClearReviewStatus).not.toHaveBeenCalled();
+      expect(mockMarkRecordPipelineClosedOutSync).not.toHaveBeenCalled();
     });
 
     it('workflow proceeds to gate when guard returns null (normal path)', async () => {

--- a/tests/unit/lib/lifecycle/workflows.test.ts
+++ b/tests/unit/lib/lifecycle/workflows.test.ts
@@ -982,7 +982,11 @@ describe('workflows', () => {
       expect(commands.some(command => command.includes('--remove-label "needs-close-out"'))).toBe(true);
     });
 
-    it('short-circuits when already closed-out with live row absent (PAN-3025 WI-4 ac1)', async () => {
+    it('idempotent guard is called on close-out workflow entry (PAN-3025 WI-4)', async () => {
+      // This test verifies that the workflow invokes readCompletedCloseOut and handles its result.
+      // The three cases (short-circuit / fall-through / error) are covered by focused
+      // dod-gate-idempotent-guard.test.ts which exercises the real helper with controllable deps.
+      // This test confirms the wiring: when the helper returns a timestamp, the workflow skips.
       mockReadCompletedCloseOut.mockResolvedValueOnce('2026-07-28T08:00:00Z');
 
       const result = await closeOut(
@@ -991,16 +995,18 @@ describe('workflows', () => {
       );
 
       expect(result.success).toBe(true);
-      expect(result.steps.find(step => step.step === 'close-out:idempotent')).toMatchObject({
-        skipped: true,
-        details: expect.arrayContaining([expect.stringContaining('already closed out at 2026-07-28T08:00:00Z')]),
-      });
-      // Gate and ceremony are not called when already closed-out
+      const idempotentStep = result.steps.find(step => step.step === 'close-out:idempotent');
+      expect(idempotentStep).toBeDefined();
+      expect(idempotentStep?.skipped).toBe(true);
+      // Verify ceremony was skipped (gate not called, status mutations not run)
       expect(mockEvaluateDodGate).not.toHaveBeenCalled();
+      expect(mockClearReviewStatus).not.toHaveBeenCalled();
     });
 
-    it('falls through to the gate when closed-out guard does not trigger (PAN-3025 WI-4 ac2)', async () => {
-      mockReadCompletedCloseOut.mockResolvedValueOnce(null); // Not closed-out, or live row exists
+    it('workflow proceeds to gate when guard returns null (normal path)', async () => {
+      // When readCompletedCloseOut returns null, the workflow proceeds to the DoD gate
+      // (this covers both "not closed out" and "live row still present" scenarios)
+      mockReadCompletedCloseOut.mockResolvedValueOnce(null);
 
       const result = await closeOut(
         { issueId: 'PAN-3051', projectPath: testDir },
@@ -1009,19 +1015,6 @@ describe('workflows', () => {
 
       expect(result.success).toBe(true);
       // Gate runs normally because the guard did not short-circuit
-      expect(mockEvaluateDodGate).toHaveBeenCalledOnce();
-    });
-
-    it('does not short-circuit when close-out guard read fails (PAN-3025 WI-4 ac3)', async () => {
-      mockReadCompletedCloseOut.mockRejectedValueOnce(new Error('database read error'));
-
-      const result = await closeOut(
-        { issueId: 'PAN-3052', projectPath: testDir },
-        { tracker: successfulTracker() },
-      );
-
-      expect(result.success).toBe(true);
-      // On guard error, we conservatively do not short-circuit
       expect(mockEvaluateDodGate).toHaveBeenCalledOnce();
     });
 

--- a/tests/unit/lib/pan-dir/record-close-out.test.ts
+++ b/tests/unit/lib/pan-dir/record-close-out.test.ts
@@ -1,0 +1,103 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import {
+  getProjectConfigFromWorkspacePath,
+  readIssueRecordSync,
+  writeIssueRecordSync,
+  markRecordPipelineClosedOutSync,
+  type PanIssueRecord,
+} from '../../../../src/lib/pan-dir/record.js';
+
+const mockQueueAutoCommit = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../../src/lib/pan-dir/auto-commit.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../../src/lib/pan-dir/auto-commit.js')>(
+    '../../../../src/lib/pan-dir/auto-commit.js',
+  );
+  return {
+    ...actual,
+    // Stub the queue so no real background git work is scheduled in tests.
+    queueAutoCommit: mockQueueAutoCommit,
+  };
+});
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  vi.resetAllMocks();
+});
+
+function baseRecord(issueId: string): PanIssueRecord {
+  const now = new Date().toISOString();
+  return {
+    issueId,
+    schemaVersion: 2,
+    created: now,
+    updated: now,
+    pipeline: {
+      issueId,
+      reviewStatus: 'passed',
+      testStatus: 'passed',
+      verificationStatus: 'passed',
+      lastVerifiedCommit: 'abc1234567890',
+      readyForMerge: false,
+      updatedAt: now,
+    },
+    closeOut: {
+      usage: { byStage: {}, totals: {} },
+      merges: [],
+      ranOn: 'test-host',
+    },
+  } as PanIssueRecord;
+}
+
+describe('markRecordPipelineClosedOutSync preserves verificationStatus (PAN-3025)', () => {
+  it('ac1: preserves verificationStatus and lastVerifiedCommit after close-out', () => {
+    const ws = mkdtempSync(join(tmpdir(), 'pan-record-close-out-'));
+    dirs.push(ws);
+    const project = getProjectConfigFromWorkspacePath(ws);
+    const record = baseRecord('PAN-3025');
+
+    // Seed with verificationStatus and lastVerifiedCommit
+    writeIssueRecordSync(project, 'PAN-3025', record);
+
+    // Run close-out
+    markRecordPipelineClosedOutSync(project, 'PAN-3025');
+
+    // Verify the verdict was preserved
+    const after = readIssueRecordSync(project, 'PAN-3025');
+    expect(after?.pipeline.verificationStatus).toBe('passed');
+    expect(after?.pipeline.lastVerifiedCommit).toBe('abc1234567890');
+    expect(after?.pipeline.closedOut).toBe(true);
+    expect(after?.pipeline.closedOutAt).toBeDefined();
+  });
+
+  it('ac2: preserves lastVerifiedCommit and sets mergeStatus', () => {
+    const ws = mkdtempSync(join(tmpdir(), 'pan-record-close-out-'));
+    dirs.push(ws);
+    const project = getProjectConfigFromWorkspacePath(ws);
+    const record = baseRecord('PAN-3025');
+
+    writeIssueRecordSync(project, 'PAN-3025', record);
+    markRecordPipelineClosedOutSync(project, 'PAN-3025');
+
+    const after = readIssueRecordSync(project, 'PAN-3025');
+    expect(after?.pipeline.lastVerifiedCommit).toBe('abc1234567890');
+    expect(after?.pipeline.mergeStatus).toBe('merged');
+  });
+
+  it('ac3: queueAutoCommit is called via queueIssueRecordCommit', () => {
+    const ws = mkdtempSync(join(tmpdir(), 'pan-record-close-out-'));
+    dirs.push(ws);
+    const project = getProjectConfigFromWorkspacePath(ws);
+    const record = baseRecord('PAN-3025');
+
+    writeIssueRecordSync(project, 'PAN-3025', record);
+    mockQueueAutoCommit.mockClear();
+    markRecordPipelineClosedOutSync(project, 'PAN-3025');
+
+    expect(mockQueueAutoCommit).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
**Issue:** #3025

## Acceptance Criteria

- [ ] Preserve verificationStatus in markRecordPipelineClosedOutSync
- [ ] Reset verificationStatus to 'pending' in reopenWorkspaceState
- [ ] Give DoD row 5's default readMergeStatus a journal fallback
- [ ] Short-circuit closeOut() when the record shows a completed close-out
- [ ] Document verdict durability and idempotent re-close in DEFINITION-OF-DONE.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved review, testing, and verification verdicts through issue close-out and database rebuilds.
  - Ensured merge status remains available when live status is cleared.
  - Reopening an issue now resets verification status to pending.
  - Repeating close-out on an already completed issue now succeeds without rerunning checks or ceremony steps.

- **Documentation**
  - Documented verdict persistence, journal fallback behavior, and idempotent close-out handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->