### PR TITLE
PAN-3293

### DIFF
--- a/docs/OVERDECK_DEV_SOP.md
+++ b/docs/OVERDECK_DEV_SOP.md
@@ -75,6 +75,10 @@ The latest restart outcome is written to `${OVERDECK_HOME}/restart-status.json`.
 
 `pan up`, `pan reload`, and dashboard-starting `pan restart` scopes refuse to run from a non-primary checkout, including workspace and handoff worktrees. They exit with code 2 and name the primary checkout to use. Their post-boot health gates also require `/api/health` to report the expected `repoRoot` and `mode`; a 200 response from a different server fails as `port held by non-primary server (cwd=…, mode=…)`. This prevents the workspace-peer port-squatting incident class tracked by [PAN-2252](https://github.com/eltmon/overdeck/issues/2252).
 
+Dashboard health also reports the serving process PID. A restart reports verified success only when that PID equals the process it just spawned, so an old listener returning HTTP 200 cannot impersonate the replacement. A mismatch fails as `port answered by pid X — not the freshly spawned server (pid Y)` and leaves the processes available for inspection; if the spawn PID cannot be resolved, the success line explicitly says `ownership unverified` instead of claiming verified replacement. Teardown separately checks that every targeted PID is dead after signal escalation — a later HTTP 200 is never evidence that the old process stopped.
+
+During the post-spawn health window, restart reads only bytes newly appended to `~/.overdeck/logs/dashboard.log`. A fresh `EADDRINUSE` fails immediately instead of waiting for the full health deadline, and the error names the current port owner and command when resolvable. The failed child has already exited in this case, so restart leaves the existing owner running for inspection rather than killing an unidentified process.
+
 ## Automatic deployment after merges
 
 Production builds embed their Git commit and build time. Deacon compares that commit with

--- a/src/cli/commands/__tests__/reload.test.ts
+++ b/src/cli/commands/__tests__/reload.test.ts
@@ -197,7 +197,7 @@ describe('reloadCommand', () => {
       traefikDomain: 'overdeck.localhost',
       traefikDir: '/tmp/traefik',
     });
-    mocks.restartDashboard.mockReturnValue(Effect.succeed(undefined));
+    mocks.restartDashboard.mockReturnValue(Effect.succeed({ ownershipVerified: true, spawnedPid: 1234 }));
     mocks.writeRestartStatus.mockReturnValue(Effect.succeed(undefined));
     mocks.refuseNonPrimaryDashboardCwd.mockReturnValue(false);
     mocks.resolveBundledServerPath.mockReturnValue('/tmp/server.js');
@@ -372,6 +372,16 @@ describe('reloadCommand', () => {
     expect(installOrder).toBeLessThan(buildOrder);
     expect(mocks.restartDashboard).toHaveBeenCalledTimes(1);
     expect(process.exitCode).toBeUndefined();
+  });
+
+  it('qualifies reload success when spawned dashboard ownership was not verified', async () => {
+    mocks.restartDashboard.mockReturnValue(Effect.succeed({ ownershipVerified: false, spawnedPid: null }));
+
+    await reloadCommand({ skipBuild: true });
+
+    const messages = vi.mocked(console.log).mock.calls.map(([message]) => String(message));
+    expect(messages.some(message => message.includes('ownership unverified'))).toBe(true);
+    expect(messages).not.toContain('✓ Dashboard reloaded and healthy');
   });
 
   // PAN-3172: the HTTP health check stays green when a generation's

--- a/src/cli/commands/reload.ts
+++ b/src/cli/commands/reload.ts
@@ -26,6 +26,7 @@ import {
   readPlatformConfigSync,
   restartDashboard,
   StageError,
+  type DashboardRestartResult,
 } from '../../lib/platform-lifecycle.js';
 import { writeRestartStatus } from '../../lib/restart-status.js';
 import { agentRestartBlockReason } from '../../lib/deploy/agent-restart-gate.js';
@@ -212,8 +213,9 @@ export async function reloadCommand(options: ReloadOptions): Promise<void> {
       }
     }
 
+    let restartResult: DashboardRestartResult;
     try {
-      await Effect.runPromise(restartDashboard(config, () => spawnDashboardDetached(config, {
+      restartResult = await Effect.runPromise(restartDashboard(config, () => spawnDashboardDetached(config, {
         deacon: options.deacon,
         serverPath: deployment?.serverPath,
         repoRoot,
@@ -244,7 +246,9 @@ export async function reloadCommand(options: ReloadOptions): Promise<void> {
       await sweepDashboardDeployments(repoRoot, dashboardDeploymentRoots()).catch(() => undefined);
     }
     await recordReloadStatus(startedAt, true);
-    console.log(chalk.green('✓ Dashboard reloaded and healthy'));
+    console.log(chalk.green(restartResult.ownershipVerified
+      ? '✓ Dashboard reloaded and healthy'
+      : '✓ Dashboard reloaded and healthy — ownership unverified: could not resolve the spawned server pid'));
   } catch (error) {
     const message = error instanceof StageError
       ? `[${error.failure.stage}] ${error.failure.reason}`

--- a/src/cli/commands/restart.ts
+++ b/src/cli/commands/restart.ts
@@ -232,9 +232,12 @@ export function scrubAgentIdentityFromDashboardEnv(env: NodeJS.ProcessEnv): void
   }
 }
 
+export type SystemctlRunner = (args: readonly string[]) => string;
+
 export interface DashboardSpawnOptions extends BootGateOptions {
   readonly serverPath?: string;
   readonly repoRoot?: string;
+  readonly runSystemctl?: SystemctlRunner;
 }
 
 export function spawnDashboardDetached(config: PlatformConfig, opts?: DashboardSpawnOptions): DashboardSpawnHandle {
@@ -272,7 +275,7 @@ export function spawnDashboardDetached(config: PlatformConfig, opts?: DashboardS
   // and a conversation/flywheel-spawned one dies with that tmux pane's scope.
   // Run the server in its own transient systemd unit (same isolation the
   // shared tmux server gets, PAN-1798) so its lifecycle belongs to nobody.
-  const systemdHandle = spawnDashboardSystemdUnit(serverPath, fullEnv, identity.repoRoot);
+  const systemdHandle = spawnDashboardSystemdUnit(serverPath, fullEnv, identity.repoRoot, opts?.runSystemctl);
   if (systemdHandle) return systemdHandle;
 
   const child = spawn(resolveNode22(), [serverPath], {
@@ -295,21 +298,46 @@ export function spawnDashboardDetached(config: PlatformConfig, opts?: DashboardS
         if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
       }
     },
+    pid: async () => child.pid ?? null,
   };
 }
 
 /** Valid systemd --setenv names; skips exported bash functions etc. */
 const ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const SYSTEMD_MAIN_PID_POLL_MS = 100;
+const SYSTEMD_MAIN_PID_TIMEOUT_MS = 5_000;
+
+async function resolveSystemdMainPid(unit: string, runSystemctl: SystemctlRunner): Promise<number | null> {
+  const deadline = Date.now() + SYSTEMD_MAIN_PID_TIMEOUT_MS;
+  while (true) {
+    let output: string;
+    try {
+      output = runSystemctl(['--user', 'show', '-p', 'MainPID', '--value', unit]);
+    } catch {
+      return null;
+    }
+
+    const value = output.trim();
+    if (value === '') return null;
+    const pid = Number(value);
+    if (Number.isInteger(pid) && pid > 0) return pid;
+    if (Date.now() >= deadline) return null;
+    await new Promise(resolve => setTimeout(resolve, SYSTEMD_MAIN_PID_POLL_MS));
+  }
+}
 
 function spawnDashboardSystemdUnit(
   serverPath: string,
   fullEnv: Record<string, string | undefined>,
   repoRoot: string,
+  systemctlRunner?: SystemctlRunner,
 ): DashboardSpawnHandle | null {
   if (process.platform !== 'linux') return null;
   try {
     mkdirSync(dirname(DASHBOARD_LOG_FILE), { recursive: true });
     const unitName = `overdeck-dashboard-${Date.now()}`;
+    const runSystemctl = systemctlRunner ?? ((args: readonly string[]) =>
+      execFileSync('systemctl', [...args], { encoding: 'utf8' }));
     const setenvArgs = Object.entries(fullEnv)
       .filter(([k, v]) => v !== undefined && ENV_NAME_RE.test(k))
       .flatMap(([k, v]) => ['--setenv', `${k}=${v}`]);
@@ -343,6 +371,7 @@ function spawnDashboardSystemdUnit(
           throw stopError;
         }
       },
+      pid: () => resolveSystemdMainPid(`${unitName}.service`, runSystemctl),
     };
   } catch {
     return null;

--- a/src/cli/commands/restart.ts
+++ b/src/cli/commands/restart.ts
@@ -485,12 +485,14 @@ export async function restartCommand(options: RestartOptions): Promise<void> {
           } catch { /* non-fatal */ }
         }
 
-        await Effect.runPromise(restartDashboard(config, () => spawnDashboardDetached(config, options), {
+        const result = await Effect.runPromise(restartDashboard(config, () => spawnDashboardDetached(config, options), {
           healthTimeoutMs,
           expectedIdentity: resolvePrimaryDashboardIdentity(),
         }));
         await recordRestartStatus(startedAt, true);
-        console.log(chalk.green('✓ Dashboard restarted and healthy'));
+        console.log(chalk.green(result.ownershipVerified
+          ? '✓ Dashboard restarted and healthy'
+          : '✓ Dashboard restarted and healthy — ownership unverified: could not resolve the spawned server pid'));
         console.log(chalk.dim('  CLIProxy, Traefik, and TLDR were left running.'));
         break;
       }
@@ -602,10 +604,12 @@ async function runFullRestart(
   }));
 
   const spawnedDashboard = spawnDashboardDetached(config, opts.bootGateOptions);
+  const spawnedPid = await spawnedDashboard.pid?.() ?? null;
   try {
     await Effect.runPromise(waitForDashboardHealth(config.dashboardApiPort, {
       timeoutMs: opts.healthTimeoutMs,
       expectedIdentity: resolvePrimaryDashboardIdentity(),
+      expectedPid: spawnedPid ?? undefined,
     }));
   } catch (error) {
     await spawnedDashboard.stop();
@@ -628,5 +632,7 @@ async function runFullRestart(
     }
   }
 
-  console.log(chalk.green('✓ Full stack restarted and healthy'));
+  console.log(chalk.green(spawnedPid !== null
+    ? '✓ Full stack restarted and healthy'
+    : '✓ Full stack restarted and healthy — dashboard ownership unverified: could not resolve the spawned server pid'));
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -991,12 +991,11 @@ program
           traefikEnabled,
           traefikDomain,
           dashboardPort,
-          dashboardApiPort,
-          expectedIdentity: restartModule.resolvePrimaryDashboardIdentity(),
+          dashboardApiPort, expectedIdentity: restartModule.resolvePrimaryDashboardIdentity(), expectedPid: child.pid,
         });
         readyUrl = resolved.readyUrl;
         apiUrl = resolved.apiUrl;
-        console.log(chalk.green('✓ Dashboard started in background and passed /api/health'));
+        console.log(chalk.green(child.pid === undefined ? '✓ Dashboard started in background and passed /api/health — ownership unverified: child pid unavailable' : '✓ Dashboard started in background and passed /api/health'));
         if (traefikEnabled && !resolved.traefikReady) {
           console.log(
             chalk.yellow(
@@ -1047,7 +1046,7 @@ program
           traefikEnabled,
           traefikDomain,
           dashboardPort,
-          dashboardApiPort, expectedIdentity: restartModule.resolvePrimaryDashboardIdentity(),
+          dashboardApiPort, expectedIdentity: restartModule.resolvePrimaryDashboardIdentity(), expectedPid: child.pid,
         });
         readyUrl = resolved.readyUrl;
         apiUrl = resolved.apiUrl;

--- a/src/cli/up-readiness.ts
+++ b/src/cli/up-readiness.ts
@@ -14,12 +14,14 @@ export async function resolveDashboardReadyUrl(config: {
   healthTimeoutMs?: number;
   traefikTimeoutMs?: number;
   expectedIdentity?: { repoRoot: string; mode: 'primary' | 'peer' };
+  expectedPid?: number;
 }): Promise<{ readyUrl: string; apiUrl: string; traefikReady: boolean }> {
   const { waitForDashboardHealth, waitForTraefikHealth } = await import('../lib/platform-lifecycle.js');
   await Effect.runPromise(
     waitForDashboardHealth(config.dashboardApiPort, {
       timeoutMs: config.healthTimeoutMs ?? 15_000,
       expectedIdentity: config.expectedIdentity,
+      expectedPid: config.expectedPid,
     }),
   );
   if (config.traefikEnabled) {

--- a/src/dashboard/server/identity.ts
+++ b/src/dashboard/server/identity.ts
@@ -12,12 +12,14 @@ export type DashboardMode = 'primary' | 'peer';
 export interface DashboardIdentity extends BuildInfo {
   readonly repoRoot: string;
   readonly mode: DashboardMode;
+  readonly pid: number;
 }
 
 export function getDashboardIdentity(): DashboardIdentity {
   return {
     repoRoot: resolve(cwd()),
     mode: process.env.OVERDECK_DISABLE_DEACON === '1' ? 'peer' : 'primary',
+    pid: process.pid,
     ...getBuildInfo(),
   };
 }

--- a/src/lib/platform-lifecycle.ts
+++ b/src/lib/platform-lifecycle.ts
@@ -227,10 +227,23 @@ function killPidsSync(pids: number[], signal: NodeJS.Signals | number): void {
   }
 }
 
-async function waitForPortFree(port: number, timeoutMs: number): Promise<boolean> {
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
+async function waitForPortFree(
+  port: number,
+  timeoutMs: number,
+  portOwnerProbe: (port: number) => Promise<number[]> = pidsOnPort,
+): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const pids = await pidsOnPort(port);
+    const pids = await portOwnerProbe(port);
     if (pids.length === 0) return true;
     await sleep(100);
   }
@@ -310,10 +323,14 @@ function createEaddrinuseProbe(
 
 async function stopDashboardPromise(
   config: PlatformConfig,
-  opts: { graceTimeoutMs?: number } = {},
+  opts: {
+    graceTimeoutMs?: number;
+    portOwnerProbe?: (port: number) => Promise<number[]>;
+  } = {},
 ): Promise<void> {
   const graceMs = opts.graceTimeoutMs ?? 5000;
   const ports = [config.dashboardPort, config.dashboardApiPort];
+  const portOwnerProbe = opts.portOwnerProbe ?? pidsOnPort;
 
   // 0. If an interactive `pan dev` session owns these ports, route the stop to
   //    the supervisor itself rather than port-killing its children. The dev
@@ -324,7 +341,7 @@ async function stopDashboardPromise(
   const dev = readDevSupervisorMarker();
   if (dev && dev.dashboardPort === config.dashboardPort && dev.apiPort === config.dashboardApiPort) {
     killPidsSync([dev.pid], 'SIGTERM');
-    const freed = await Promise.all(ports.map((p) => waitForPortFree(p, graceMs)));
+    const freed = await Promise.all(ports.map((p) => waitForPortFree(p, graceMs, portOwnerProbe)));
     if (freed.every(Boolean)) return;
     // Supervisor failed to release the ports in time — escalate, then fall
     // through to the normal port-based teardown to mop up orphaned children.
@@ -334,38 +351,41 @@ async function stopDashboardPromise(
   // 1. Collect pids across both ports, then SIGTERM.
   const allPids = new Set<number>();
   for (const p of ports) {
-    for (const pid of await pidsOnPort(p)) allPids.add(pid);
+    for (const pid of await portOwnerProbe(p)) allPids.add(pid);
   }
   if (allPids.size === 0) return;
 
   killPidsSync([...allPids], 'SIGTERM');
 
-  // 2. Wait for ports to free. If any remain, escalate to SIGKILL.
-  const freed = await Promise.all(ports.map((p) => waitForPortFree(p, graceMs)));
-  if (freed.every(Boolean)) return;
-
-  const stubbornPids = new Set<number>();
-  for (const p of ports) {
-    for (const pid of await pidsOnPort(p)) stubbornPids.add(pid);
+  // 2. Wait for ports to free. A process that closes its listener but survives
+  // SIGTERM is still part of this teardown, so include it in the SIGKILL set.
+  const freed = await Promise.all(ports.map((p) => waitForPortFree(p, graceMs, portOwnerProbe)));
+  const stubbornPids = new Set([...allPids].filter(isPidAlive));
+  if (!freed.every(Boolean)) {
+    for (const p of ports) {
+      for (const pid of await portOwnerProbe(p)) stubbornPids.add(pid);
+    }
   }
-  if (stubbornPids.size > 0) {
-    killPidsSync([...stubbornPids], 'SIGKILL');
-    const finalFreed = await Promise.all(ports.map((p) => waitForPortFree(p, 2000)));
-    if (finalFreed.every(Boolean)) return;
+  if (stubbornPids.size > 0) killPidsSync([...stubbornPids], 'SIGKILL');
 
-    const stillHeld: string[] = [];
-    for (const [index, port] of ports.entries()) {
-      if (finalFreed[index]) continue;
-      for (const pid of await pidsOnPort(port)) {
-        stillHeld.push(`port ${port} still held by PID ${pid} (cmd: ${await describePid(pid)})`);
-      }
+  const finalFreed = await Promise.all(ports.map((p) => waitForPortFree(p, 2000, portOwnerProbe)));
+  const failures: string[] = [];
+  for (const pid of allPids) {
+    if (isPidAlive(pid)) {
+      failures.push(`PID ${pid} (cmd: ${await describePid(pid)}) survived SIGKILL`);
     }
-    if (stillHeld.length > 0) {
-      throw new StageError({
-        stage: 'dashboard',
-        reason: stillHeld.join('; '),
-      });
+  }
+  for (const [index, port] of ports.entries()) {
+    if (finalFreed[index]) continue;
+    for (const pid of await portOwnerProbe(port)) {
+      failures.push(`port ${port} still held by PID ${pid} (cmd: ${await describePid(pid)})`);
     }
+  }
+  if (failures.length > 0) {
+    throw new StageError({
+      stage: 'dashboard',
+      reason: failures.join('; '),
+    });
   }
 }async function waitForDashboardHealthPromise(
   apiPort: number,
@@ -629,7 +649,10 @@ const stageErrorOf = (op: string) => (cause: unknown): StageError => {
 /** Effect variant of {@link stopDashboard}. */
 export const stopDashboard = (
   config: PlatformConfig,
-  opts: { graceTimeoutMs?: number } = {},
+  opts: {
+    graceTimeoutMs?: number;
+    portOwnerProbe?: (port: number) => Promise<number[]>;
+  } = {},
 ): Effect.Effect<void, StageError> =>
   Effect.tryPromise({ try: () => stopDashboardPromise(config, opts), catch: stageErrorOf('stopDashboard') });
 

--- a/src/lib/platform-lifecycle.ts
+++ b/src/lib/platform-lifecycle.ts
@@ -306,6 +306,7 @@ async function describePid(pid: number): Promise<string> {
     timeoutMs?: number;
     pollIntervalMs?: number;
     expectedIdentity?: { repoRoot: string; mode: 'primary' | 'peer' };
+    expectedPid?: number;
   } = {},
 ): Promise<void> {
   const timeoutMs = opts.timeoutMs ?? 15_000;
@@ -314,17 +315,37 @@ async function describePid(pid: number): Promise<string> {
   const deadline = Date.now() + timeoutMs;
 
   let lastError = 'never got a response';
+  let lastResponderPid: number | null = null;
   while (Date.now() < deadline) {
     try {
       const res = await fetch(url, { signal: AbortSignal.timeout(2000) });
       if (res.ok) {
-        if (!opts.expectedIdentity) return;
+        if (!opts.expectedIdentity && opts.expectedPid === undefined) return;
         const body = await res.json().catch(() => null) as unknown;
         const payload = body && typeof body === 'object' ? body as Record<string, unknown> : {};
-        const repoRoot = typeof payload.repoRoot === 'string' ? payload.repoRoot : '(missing)';
-        const mode = typeof payload.mode === 'string' ? payload.mode : '(missing)';
-        if (repoRoot === opts.expectedIdentity.repoRoot && mode === opts.expectedIdentity.mode) return;
-        lastError = `port held by non-${opts.expectedIdentity.mode} server (cwd=${repoRoot}, mode=${mode})`;
+        const reportedPid = typeof payload.pid === 'number' && Number.isInteger(payload.pid) && payload.pid > 0
+          ? payload.pid
+          : null;
+        if (reportedPid !== null) lastResponderPid = reportedPid;
+
+        if (opts.expectedIdentity) {
+          const repoRoot = typeof payload.repoRoot === 'string' ? payload.repoRoot : '(missing)';
+          const mode = typeof payload.mode === 'string' ? payload.mode : '(missing)';
+          if (repoRoot !== opts.expectedIdentity.repoRoot || mode !== opts.expectedIdentity.mode) {
+            lastError = `port held by non-${opts.expectedIdentity.mode} server (cwd=${repoRoot}, mode=${mode})`;
+            await sleep(pollIntervalMs);
+            continue;
+          }
+        }
+
+        if (opts.expectedPid !== undefined && reportedPid !== opts.expectedPid) {
+          lastError =
+            `port answered by pid ${reportedPid ?? '(unreported)'} — ` +
+            `not the freshly spawned server (pid ${opts.expectedPid})`;
+          await sleep(pollIntervalMs);
+          continue;
+        }
+        return;
       } else {
         lastError = `HTTP ${res.status}`;
       }
@@ -333,9 +354,14 @@ async function describePid(pid: number): Promise<string> {
     }
     await sleep(pollIntervalMs);
   }
+  const responderDetails = lastResponderPid === null
+    ? ''
+    : `; responder PID ${lastResponderPid} command: ${await describePid(lastResponderPid)}`;
   throw new StageError({
     stage: 'dashboard',
-    reason: `health check at ${url} did not pass within ${formatTimeoutMs(timeoutMs)} (last: ${lastError})`,
+    reason:
+      `health check at ${url} did not pass within ${formatTimeoutMs(timeoutMs)} ` +
+      `(last: ${lastError}${responderDetails})`,
   });
 }async function waitForTraefikHealthPromise(
   traefikDomain: string,
@@ -403,6 +429,11 @@ export interface DashboardSpawnHandle {
   pid?: () => Promise<number | null>;
 }
 
+export interface DashboardRestartResult {
+  ownershipVerified: boolean;
+  spawnedPid: number | null;
+}
+
 async function restartDashboardPromise(
   config: PlatformConfig,
   startDashboardFn: () => Promise<DashboardSpawnHandle | void> | DashboardSpawnHandle | void,
@@ -410,13 +441,15 @@ async function restartDashboardPromise(
     healthTimeoutMs?: number;
     expectedIdentity?: { repoRoot: string; mode: 'primary' | 'peer' };
   } = {},
-): Promise<void> {
+): Promise<DashboardRestartResult> {
   await Effect.runPromise(stopDashboard(config));
-  await startDashboardFn();
+  const handle = await startDashboardFn();
+  const spawnedPid = await handle?.pid?.() ?? null;
   try {
     await Effect.runPromise(waitForDashboardHealth(config.dashboardApiPort, {
       timeoutMs: opts.healthTimeoutMs,
       expectedIdentity: opts.expectedIdentity,
+      expectedPid: spawnedPid ?? undefined,
     }));
   } catch (error) {
     // #3099: NEVER reap the freshly spawned server on a health timeout. The old
@@ -434,6 +467,7 @@ async function restartDashboardPromise(
       recovery: 'dashboard-left-running',
     });
   }
+  return { ownershipVerified: spawnedPid !== null, spawnedPid };
 }async function restartCliproxyPromise(
   cliproxy: {
     stopCliproxy: () => void;
@@ -520,6 +554,7 @@ export const waitForDashboardHealth = (
     timeoutMs?: number;
     pollIntervalMs?: number;
     expectedIdentity?: { repoRoot: string; mode: 'primary' | 'peer' };
+    expectedPid?: number;
   } = {},
 ): Effect.Effect<void, StageError> =>
   Effect.tryPromise({ try: () => waitForDashboardHealthPromise(apiPort, opts), catch: stageErrorOf('waitForDashboardHealth') });
@@ -551,7 +586,7 @@ export const restartDashboard = (
     healthTimeoutMs?: number;
     expectedIdentity?: { repoRoot: string; mode: 'primary' | 'peer' };
   } = {},
-): Effect.Effect<void, StageError> =>
+): Effect.Effect<DashboardRestartResult, StageError> =>
   Effect.tryPromise({
     try: () => restartDashboardPromise(config, startDashboardFn, opts),
     catch: stageErrorOf('restartDashboard'),

--- a/src/lib/platform-lifecycle.ts
+++ b/src/lib/platform-lifecycle.ts
@@ -344,6 +344,7 @@ export interface RestartResult {
 
 export interface DashboardSpawnHandle {
   stop: () => Promise<void> | void;
+  pid?: () => Promise<number | null>;
 }
 
 async function restartDashboardPromise(

--- a/src/lib/platform-lifecycle.ts
+++ b/src/lib/platform-lifecycle.ts
@@ -21,6 +21,7 @@
 import { spawn, exec } from 'child_process';
 import { promisify } from 'util';
 import { existsSync, mkdirSync, openSync, readFileSync } from 'fs';
+import { open as openFile, stat } from 'fs/promises';
 import { join } from 'path';
 import { parse as parseToml } from '@iarna/toml';
 import { Effect } from 'effect';
@@ -117,6 +118,8 @@ export class StageError extends Error {
     this.name = 'StageError';
   }
 }
+
+class EaddrinuseSpawnError extends StageError {}
 
 export function readPlatformConfigSync(): PlatformConfig {
   const defaults: PlatformConfig = {
@@ -241,7 +244,71 @@ async function describePid(pid: number): Promise<string> {
   } catch {
     return 'unknown';
   }
-}async function stopDashboardPromise(
+}
+
+async function fileSizeOrZero(path: string): Promise<number> {
+  try {
+    return (await stat(path)).size;
+  } catch {
+    return 0;
+  }
+}
+
+async function readAppendedLog(path: string, offset: number): Promise<{ text: string; offset: number }> {
+  let size: number;
+  try {
+    size = (await stat(path)).size;
+  } catch {
+    return { text: '', offset: 0 };
+  }
+  const start = size < offset ? 0 : offset;
+  if (size <= start) return { text: '', offset: size };
+
+  let file: Awaited<ReturnType<typeof openFile>>;
+  try {
+    file = await openFile(path, 'r');
+  } catch {
+    return { text: '', offset: 0 };
+  }
+  try {
+    const buffer = Buffer.alloc(size - start);
+    const { bytesRead } = await file.read(buffer, 0, buffer.length, start);
+    return { text: buffer.subarray(0, bytesRead).toString('utf8'), offset: start + bytesRead };
+  } catch {
+    return { text: '', offset: start };
+  } finally {
+    await file.close().catch(() => {});
+  }
+}
+
+function createEaddrinuseProbe(
+  logPath: string,
+  initialOffset: number,
+  port: number,
+  portOwnerProbe: (port: number) => Promise<number[]>,
+  pidDescriptor: (pid: number) => Promise<string>,
+): () => Promise<StageError | null> {
+  let offset = initialOffset;
+  let carry = '';
+  return async () => {
+    const appended = await readAppendedLog(logPath, offset);
+    offset = appended.offset;
+    const text = carry + appended.text;
+    carry = text.slice(-10);
+    if (!/EADDRINUSE/.test(text)) return null;
+
+    const ownerPid = (await portOwnerProbe(port))[0] ?? null;
+    const owner = ownerPid === null
+      ? 'an unresolved PID'
+      : `PID ${ownerPid} (cmd: ${await pidDescriptor(ownerPid)})`;
+    return new EaddrinuseSpawnError({
+      stage: 'dashboard',
+      reason: `port ${port} is owned by ${owner} — the freshly spawned server crashed with EADDRINUSE`,
+    });
+  };
+}
+
+async function stopDashboardPromise(
   config: PlatformConfig,
   opts: { graceTimeoutMs?: number } = {},
 ): Promise<void> {
@@ -307,6 +374,7 @@ async function describePid(pid: number): Promise<string> {
     pollIntervalMs?: number;
     expectedIdentity?: { repoRoot: string; mode: 'primary' | 'peer' };
     expectedPid?: number;
+    pollFailure?: () => Promise<StageError | null>;
   } = {},
 ): Promise<void> {
   const timeoutMs = opts.timeoutMs ?? 15_000;
@@ -317,6 +385,8 @@ async function describePid(pid: number): Promise<string> {
   let lastError = 'never got a response';
   let lastResponderPid: number | null = null;
   while (Date.now() < deadline) {
+    const pollFailure = await opts.pollFailure?.();
+    if (pollFailure) throw pollFailure;
     try {
       const res = await fetch(url, { signal: AbortSignal.timeout(2000) });
       if (res.ok) {
@@ -440,18 +510,34 @@ async function restartDashboardPromise(
   opts: {
     healthTimeoutMs?: number;
     expectedIdentity?: { repoRoot: string; mode: 'primary' | 'peer' };
+    eaddrinuseLogPath?: string;
+    portOwnerProbe?: (port: number) => Promise<number[]>;
+    pidDescriptor?: (pid: number) => Promise<string>;
   } = {},
 ): Promise<DashboardRestartResult> {
   await Effect.runPromise(stopDashboard(config));
+  const logPath = opts.eaddrinuseLogPath ?? DASHBOARD_LOG_FILE;
+  const logOffset = await fileSizeOrZero(logPath);
   const handle = await startDashboardFn();
   const spawnedPid = await handle?.pid?.() ?? null;
+  const pollFailure = handle?.pid
+    ? createEaddrinuseProbe(
+        logPath,
+        logOffset,
+        config.dashboardApiPort,
+        opts.portOwnerProbe ?? pidsOnPort,
+        opts.pidDescriptor ?? describePid,
+      )
+    : undefined;
   try {
-    await Effect.runPromise(waitForDashboardHealth(config.dashboardApiPort, {
+    await waitForDashboardHealthPromise(config.dashboardApiPort, {
       timeoutMs: opts.healthTimeoutMs,
       expectedIdentity: opts.expectedIdentity,
       expectedPid: spawnedPid ?? undefined,
-    }));
+      pollFailure,
+    });
   } catch (error) {
+    if (error instanceof EaddrinuseSpawnError) throw error;
     // #3099: NEVER reap the freshly spawned server on a health timeout. The old
     // policy killed the new server after a false-fast health check and exited
     // with zero listeners — a full dashboard outage caused by a slow-but-healthy
@@ -585,6 +671,9 @@ export const restartDashboard = (
   opts: {
     healthTimeoutMs?: number;
     expectedIdentity?: { repoRoot: string; mode: 'primary' | 'peer' };
+    eaddrinuseLogPath?: string;
+    portOwnerProbe?: (port: number) => Promise<number[]>;
+    pidDescriptor?: (pid: number) => Promise<string>;
   } = {},
 ): Effect.Effect<DashboardRestartResult, StageError> =>
   Effect.tryPromise({

--- a/src/lib/platform-lifecycle.ts
+++ b/src/lib/platform-lifecycle.ts
@@ -14,10 +14,11 @@
  * Health-gating: each stage reports success only after the component's healthcheck
  * passes, or fails with an explicit `{ stage, reason }` on timeout.
  *
- * CLI-side only. Not used from dashboard server code — ok to use sync I/O here.
+ * Shared with the supervisor sidecar. Keep shell/process I/O asynchronous so
+ * lifecycle checks cannot block its request loop.
  */
 
-import { spawn, exec, execSync } from 'child_process';
+import { spawn, exec } from 'child_process';
 import { promisify } from 'util';
 import { existsSync, mkdirSync, openSync, readFileSync } from 'fs';
 import { join } from 'path';
@@ -142,16 +143,71 @@ export function readPlatformConfigSync(): PlatformConfig {
 
 // ─── Port / process helpers ───────────────────────────────────────────────────
 
-async function pidsOnPort(port: number): Promise<number[]> {
-  try {
-    const { stdout } = await execAsync(`fuser ${port}/tcp 2>/dev/null || true`);
-    return stdout
-      .split(/\s+/)
-      .map((s) => parseInt(s.trim(), 10))
-      .filter((n) => Number.isFinite(n) && n > 0);
-  } catch {
-    return [];
+export type PortProbeExec = (command: string) => Promise<{ stdout: string | Buffer }>;
+
+const defaultPortProbeExec: PortProbeExec = async (command) => {
+  const { stdout } = await execAsync(command);
+  return { stdout };
+};
+
+function parsePidList(output: string | Buffer): number[] {
+  return [...new Set(String(output)
+    .split(/\s+/)
+    .map(value => Number(value.trim()))
+    .filter(pid => Number.isInteger(pid) && pid > 0))];
+}
+
+function parseSsListenerPids(output: string | Buffer, port: number): number[] {
+  const pids = new Set<number>();
+  const portPattern = new RegExp(`(?:^|\\s)\\S*:${port}(?:\\s|$)`);
+  for (const line of String(output).split('\n')) {
+    if (!portPattern.test(line)) continue;
+    for (const match of line.matchAll(/pid=(\d+)/g)) {
+      pids.add(Number(match[1]));
+    }
   }
+  return [...pids];
+}
+
+function isEmptyExitOne(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const failure = error as { code?: number | string; stdout?: string | Buffer };
+  return Number(failure.code) === 1 && String(failure.stdout ?? '').trim() === '';
+}
+
+export async function pidsOnPort(port: number, run: PortProbeExec = defaultPortProbeExec): Promise<number[]> {
+  const probes = [
+    {
+      tool: 'lsof',
+      command: `lsof -nP -iTCP:${port} -sTCP:LISTEN -t`,
+      parse: parsePidList,
+      emptyExitOne: true,
+    },
+    {
+      tool: 'fuser',
+      command: `fuser ${port}/tcp`,
+      parse: parsePidList,
+      emptyExitOne: true,
+    },
+    {
+      tool: 'ss',
+      command: 'ss -ltnp',
+      parse: (output: string | Buffer) => parseSsListenerPids(output, port),
+      emptyExitOne: false,
+    },
+  ];
+
+  for (const probe of probes) {
+    try {
+      const { stdout } = await run(probe.command);
+      return probe.parse(stdout);
+    } catch (error) {
+      if (probe.emptyExitOne && isEmptyExitOne(error)) return [];
+    }
+  }
+
+  console.warn(`[dashboard] could not inspect port ${port}; lsof, fuser, and ss all failed to execute`);
+  return [];
 }
 
 async function sleep(ms: number): Promise<void> {

--- a/sync-sources/skills/pan-restart/SKILL.md
+++ b/sync-sources/skills/pan-restart/SKILL.md
@@ -38,9 +38,9 @@ pan restart --force              # explicit operator bypass of the deploy-window
 pan restart --cliproxy --force   # redownload the pinned CLIProxy binary
 ```
 
-Each stage is health-gated: the command waits for `GET /api/health` (dashboard)
-or port binding (CLIProxy) to succeed before reporting `✓`, and exits non-zero
-with a `[stage] reason` message on timeout.
+Each stage is health-gated: the command waits for `GET /api/health` from the
+newly spawned dashboard process, or port binding for CLIProxy, before reporting
+`✓`. It exits non-zero with a `[stage] reason` message on timeout.
 
 ## Identity guard
 
@@ -49,10 +49,29 @@ non-primary checkout: either a workspace worktree or any linked Git worktree,
 including a handoff worktree. It exits with code 2 and names the primary
 checkout where the command must run.
 
-The post-boot health gate verifies both `repoRoot` and `mode` from
-`GET /api/health`. If another server holds the port, the command reports
-`port held by non-primary server (cwd=…, mode=…)`; a 200 response from the wrong
-server is a failure, not a successful restart.
+The post-boot health gate verifies `repoRoot`, `mode`, and the serving process
+PID from `GET /api/health`. A 200 response succeeds only when its PID matches the
+process this restart spawned. A different checkout reports
+`port held by non-primary server (cwd=…, mode=…)`; an old process from the same
+checkout reports `port answered by pid X — not the freshly spawned server (pid
+Y)`. Either response is a failure, not a successful restart.
+
+## Ownership-mismatch recovery
+
+When restart names PID X as the existing port owner, inspect that exact process
+before acting:
+
+```bash
+ps -p X -o pid=,ppid=,etime=,cmd=
+lsof -nP -iTCP:3011 -sTCP:LISTEN
+```
+
+If it is the stale dashboard named by the failure, terminate it with `kill X`,
+verify that the PID and listener are gone, then rerun `pan restart`. Do not use a
+broad `pkill` pattern: it can terminate the supervisor, agents, or unrelated Node
+processes. A fresh `EADDRINUSE` line fails restart immediately and names the same
+owner, while a health timeout leaves the newly spawned process running for
+inspection.
 
 ## Important Notes
 

--- a/tests/unit/cli/restart-spawn-pid.test.ts
+++ b/tests/unit/cli/restart-spawn-pid.test.ts
@@ -1,0 +1,101 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const processMocks = vi.hoisted(() => ({
+  execFileSync: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+vi.mock('child_process', async (importActual) => ({
+  ...(await importActual<typeof import('child_process')>()),
+  execFileSync: processMocks.execFileSync,
+  spawn: processMocks.spawn,
+}));
+
+import { spawnDashboardDetached } from '../../../src/cli/commands/restart.js';
+
+const fixtureRoots: string[] = [];
+const config = {
+  dashboardPort: 3010,
+  dashboardApiPort: 3011,
+  traefikEnabled: false,
+  traefikDomain: 'overdeck.localhost',
+} as Parameters<typeof spawnDashboardDetached>[0];
+
+function createDashboardBundleFixture(): { serverPath: string; repoRoot: string } {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'overdeck-dashboard-spawn-pid-'));
+  fixtureRoots.push(repoRoot);
+  const serverPath = join(repoRoot, 'dist', 'dashboard', 'server.js');
+  mkdirSync(join(repoRoot, 'dist', 'dashboard'), { recursive: true });
+  writeFileSync(serverPath, 'export {};');
+  return { serverPath, repoRoot };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+  vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  for (const root of fixtureRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('dashboard spawn pid handles', () => {
+  it('returns the detached child pid when systemd-run is unavailable', async () => {
+    const bundle = createDashboardBundleFixture();
+    const child = { pid: 4321, unref: vi.fn() };
+    processMocks.execFileSync.mockImplementation(() => { throw new Error('systemd unavailable'); });
+    processMocks.spawn.mockReturnValue(child);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const handle = spawnDashboardDetached(config, bundle);
+
+    expect(handle.pid).toBeTypeOf('function');
+    await expect(handle.pid!()).resolves.toBe(4321);
+  });
+
+  it('returns an immediately available systemd MainPID', async () => {
+    const bundle = createDashboardBundleFixture();
+    processMocks.execFileSync.mockReturnValue(undefined);
+    const runSystemctl = vi.fn(() => '5432\n');
+
+    const handle = spawnDashboardDetached(config, { ...bundle, runSystemctl });
+
+    await expect(handle.pid!()).resolves.toBe(5432);
+    expect(runSystemctl).toHaveBeenCalledWith([
+      '--user', 'show', '-p', 'MainPID', '--value', 'overdeck-dashboard-0.service',
+    ]);
+  });
+
+  it('polls MainPID=0 until systemd reports the server pid', async () => {
+    const bundle = createDashboardBundleFixture();
+    processMocks.execFileSync.mockReturnValue(undefined);
+    const runSystemctl = vi.fn()
+      .mockReturnValueOnce('0\n')
+      .mockReturnValueOnce('6543\n');
+    const handle = spawnDashboardDetached(config, { ...bundle, runSystemctl });
+
+    const pidPromise = handle.pid!();
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(pidPromise).resolves.toBe(6543);
+    expect(runSystemctl).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null when the systemd unit has already vanished', async () => {
+    const bundle = createDashboardBundleFixture();
+    processMocks.execFileSync.mockReturnValue(undefined);
+    const runSystemctl = vi.fn(() => { throw new Error('unit not found'); });
+    const handle = spawnDashboardDetached(config, { ...bundle, runSystemctl });
+
+    await expect(handle.pid!()).resolves.toBeNull();
+  });
+});

--- a/tests/unit/dashboard/health-identity.test.ts
+++ b/tests/unit/dashboard/health-identity.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { getDashboardIdentity } from '../../../src/dashboard/server/identity.js';
+
+describe('dashboard health identity', () => {
+  it('identifies the serving process alongside the repository and mode', () => {
+    const identity = getDashboardIdentity();
+
+    expect(identity).toMatchObject({
+      repoRoot: process.cwd(),
+      mode: expect.stringMatching(/^(primary|peer)$/),
+    });
+    expect(identity.pid).toBe(process.pid);
+  });
+});

--- a/tests/unit/lib/platform-lifecycle-squatter.test.ts
+++ b/tests/unit/lib/platform-lifecycle-squatter.test.ts
@@ -1,0 +1,140 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { Effect } from 'effect';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  restartDashboard,
+  type PlatformConfig,
+  type StageError,
+} from '../../../src/lib/platform-lifecycle.js';
+
+function listen(server: Server, port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+}
+
+async function reserveEphemeralPort(): Promise<number> {
+  const reservation = createServer();
+  await listen(reservation, 0);
+  const address = reservation.address();
+  if (!address || typeof address === 'string') throw new Error('expected TCP address');
+  await close(reservation);
+  return address.port;
+}
+
+describe('dashboard restart with a live port squatter', () => {
+  let server: Server | null = null;
+  let tempDir: string;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout'] });
+    vi.setSystemTime(0);
+    tempDir = mkdtempSync(join(tmpdir(), 'overdeck-squatter-'));
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    if (server?.listening) await close(server);
+    server = null;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('rejects a wrong-pid responder while leaving the squatter reachable', async () => {
+    const port = await reserveEphemeralPort();
+    const expectedPid = process.pid + 100_000;
+    let requests = 0;
+    server = createServer((request, response) => {
+      requests += 1;
+      response.setHeader('content-type', 'application/json');
+      response.end(JSON.stringify({
+        status: 'ok',
+        repoRoot: '/expected/repo',
+        mode: 'primary',
+        pid: process.pid,
+      }));
+    });
+    const stop = vi.fn();
+    const config: PlatformConfig = {
+      dashboardPort: port,
+      dashboardApiPort: port,
+      traefikEnabled: false,
+      traefikDomain: 'overdeck.localhost',
+      traefikDir: tempDir,
+    };
+
+    const restart = Effect.runPromise(restartDashboard(
+      config,
+      async () => {
+        await listen(server!, port);
+        return { stop, pid: async () => expectedPid };
+      },
+      {
+        healthTimeoutMs: 200,
+        expectedIdentity: { repoRoot: '/expected/repo', mode: 'primary' },
+        eaddrinuseLogPath: join(tempDir, 'dashboard.log'),
+      },
+    ));
+    const rejection = expect(restart).rejects.toSatisfy((error: StageError) =>
+      error.failure.reason.includes(`pid ${process.pid}`) &&
+      error.failure.reason.includes(`pid ${expectedPid}`) &&
+      error.failure.recovery === 'dashboard-left-running');
+    while (requests === 0) {
+      await new Promise<void>(resolve => setImmediate(resolve));
+    }
+
+    await vi.advanceTimersByTimeAsync(300);
+    await rejection;
+    expect(stop).not.toHaveBeenCalled();
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/health`);
+    expect(response.ok).toBe(true);
+    await expect(response.json()).resolves.toMatchObject({ pid: process.pid });
+  });
+
+  it('accepts the same real responder when its pid matches the spawn handle', async () => {
+    const port = await reserveEphemeralPort();
+    server = createServer((_request, response) => {
+      response.setHeader('content-type', 'application/json');
+      response.end(JSON.stringify({
+        status: 'ok',
+        repoRoot: '/expected/repo',
+        mode: 'primary',
+        pid: process.pid,
+      }));
+    });
+    const config: PlatformConfig = {
+      dashboardPort: port,
+      dashboardApiPort: port,
+      traefikEnabled: false,
+      traefikDomain: 'overdeck.localhost',
+      traefikDir: tempDir,
+    };
+
+    await expect(Effect.runPromise(restartDashboard(
+      config,
+      async () => {
+        await listen(server!, port);
+        return { stop: vi.fn(), pid: async () => process.pid };
+      },
+      {
+        expectedIdentity: { repoRoot: '/expected/repo', mode: 'primary' },
+        eaddrinuseLogPath: join(tempDir, 'dashboard.log'),
+      },
+    ))).resolves.toEqual({ ownershipVerified: true, spawnedPid: process.pid });
+  });
+});

--- a/tests/unit/lib/platform-lifecycle.test.ts
+++ b/tests/unit/lib/platform-lifecycle.test.ts
@@ -17,6 +17,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   restartCliproxy,
   restartDashboard,
+  stopDashboard,
   waitForDashboardHealth,
   StageError,
   parseHealthTimeoutMs,
@@ -90,6 +91,58 @@ describe('pidsOnPort', () => {
     await expect(pidsOnPort(3011, run)).resolves.toEqual([]);
     expect(warning).toHaveBeenCalledOnce();
     expect(warning).toHaveBeenCalledWith(expect.stringMatching(/lsof.*fuser.*ss/));
+  });
+});
+
+describe('stopDashboard pid death verification', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects when an originally targeted pid survives SIGKILL after releasing its port', async () => {
+    const portOwnerProbe = vi.fn()
+      .mockResolvedValueOnce([9101])
+      .mockResolvedValue([]);
+    const kill = vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+
+    await expect(Effect.runPromise(stopDashboard(baseConfig, {
+      graceTimeoutMs: 100,
+      portOwnerProbe,
+    }))).rejects.toMatchObject({
+      failure: {
+        stage: 'dashboard',
+        reason: expect.stringContaining('PID 9101 (cmd: unknown) survived SIGKILL'),
+      },
+    });
+    expect(kill).toHaveBeenCalledWith(9101, 'SIGKILL');
+    expect(kill).toHaveBeenCalledWith(9101, 0);
+  });
+
+  it('resolves when every targeted pid is ESRCH-dead and the ports are free', async () => {
+    const portOwnerProbe = vi.fn()
+      .mockResolvedValueOnce([9202])
+      .mockResolvedValue([]);
+    const kill = vi.spyOn(process, 'kill').mockImplementation(((pid, signal) => {
+      if (signal === 0) throw Object.assign(new Error(`process ${pid} not found`), { code: 'ESRCH' });
+      return true;
+    }) as typeof process.kill);
+
+    await expect(Effect.runPromise(stopDashboard(baseConfig, {
+      graceTimeoutMs: 100,
+      portOwnerProbe,
+    }))).resolves.toBeUndefined();
+    expect(kill).toHaveBeenCalledWith(9202, 'SIGTERM');
+    expect(kill).not.toHaveBeenCalledWith(9202, 'SIGKILL');
+  });
+
+  it('returns without checking pid death when no listener pids are found', async () => {
+    const portOwnerProbe = vi.fn().mockResolvedValue([]);
+    const kill = vi.spyOn(process, 'kill');
+
+    await expect(Effect.runPromise(stopDashboard(baseConfig, {
+      portOwnerProbe,
+    }))).resolves.toBeUndefined();
+    expect(kill).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/lib/platform-lifecycle.test.ts
+++ b/tests/unit/lib/platform-lifecycle.test.ts
@@ -16,6 +16,7 @@ import {
   waitForDashboardHealth,
   StageError,
   parseHealthTimeoutMs,
+  pidsOnPort,
 } from '../../../src/lib/platform-lifecycle.js';
 
 // Use ephemeral ports so stopDashboard's lsof scan never hits a real
@@ -27,6 +28,66 @@ const baseConfig = {
   traefikDomain: 'overdeck.localhost',
   traefikDir: '/tmp/does-not-exist/traefik',
 };
+
+describe('pidsOnPort', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses lsof first so IPv4 and IPv6 TCP listeners are covered', async () => {
+    const run = vi.fn().mockResolvedValue({ stdout: '4123\n' });
+
+    await expect(pidsOnPort(3011, run)).resolves.toEqual([4123]);
+    expect(run).toHaveBeenCalledOnce();
+    expect(run).toHaveBeenCalledWith('lsof -nP -iTCP:3011 -sTCP:LISTEN -t');
+  });
+
+  it('treats lsof exit code 1 with empty stdout as a free port', async () => {
+    const run = vi.fn().mockRejectedValue({ code: 1, stdout: '' });
+
+    await expect(pidsOnPort(3011, run)).resolves.toEqual([]);
+    expect(run).toHaveBeenCalledOnce();
+  });
+
+  it('falls back from unavailable lsof to fuser and stops on its result', async () => {
+    const run = vi.fn()
+      .mockRejectedValueOnce(Object.assign(new Error('lsof not found'), { code: 127 }))
+      .mockResolvedValueOnce({ stdout: '5234 5235\n' });
+
+    await expect(pidsOnPort(3011, run)).resolves.toEqual([5234, 5235]);
+    expect(run.mock.calls.map(([command]) => command)).toEqual([
+      'lsof -nP -iTCP:3011 -sTCP:LISTEN -t',
+      'fuser 3011/tcp',
+    ]);
+  });
+
+  it('falls back to ss and returns only pids from lines matching the exact port', async () => {
+    const run = vi.fn()
+      .mockRejectedValueOnce(Object.assign(new Error('lsof not found'), { code: 127 }))
+      .mockRejectedValueOnce(Object.assign(new Error('fuser not found'), { code: 127 }))
+      .mockResolvedValueOnce({
+        stdout:
+          'LISTEN 0 511 127.0.0.1:13011 0.0.0.0:* users:(("node",pid=6000,fd=1))\n' +
+          'LISTEN 0 511 [::]:3011 [::]:* users:(("node",pid=6234,fd=2))\n',
+      });
+
+    await expect(pidsOnPort(3011, run)).resolves.toEqual([6234]);
+    expect(run.mock.calls.map(([command]) => command)).toEqual([
+      'lsof -nP -iTCP:3011 -sTCP:LISTEN -t',
+      'fuser 3011/tcp',
+      'ss -ltnp',
+    ]);
+  });
+
+  it('warns once with every attempted tool when no port probe executes', async () => {
+    const run = vi.fn().mockRejectedValue(Object.assign(new Error('not found'), { code: 127 }));
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(pidsOnPort(3011, run)).resolves.toEqual([]);
+    expect(warning).toHaveBeenCalledOnce();
+    expect(warning).toHaveBeenCalledWith(expect.stringMatching(/lsof.*fuser.*ss/));
+  });
+});
 
 describe('restartDashboard — scope contract', () => {
   beforeEach(() => {

--- a/tests/unit/lib/platform-lifecycle.test.ts
+++ b/tests/unit/lib/platform-lifecycle.test.ts
@@ -312,3 +312,111 @@ describe('waitForDashboardHealth', () => {
     }
   });
 });
+
+describe('dashboard health ownership', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout'] });
+    vi.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('rejects a healthy responder whose pid differs from the freshly spawned server', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: 'ok', repoRoot: '/repo', mode: 'primary', pid: 7101 }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const restart = Effect.runPromise(restartDashboard(
+      baseConfig,
+      () => ({ stop: vi.fn(), pid: async () => 7202 }),
+      {
+        healthTimeoutMs: 200,
+        expectedIdentity: { repoRoot: '/repo', mode: 'primary' },
+      },
+    ));
+    const rejection = expect(restart).rejects.toMatchObject({
+      failure: {
+        stage: 'dashboard',
+        reason: expect.stringMatching(/pid 7101.*pid 7202.*LEFT RUNNING/s),
+        recovery: 'dashboard-left-running',
+      },
+    });
+    while (fetchMock.mock.calls.length === 0) {
+      await new Promise<void>(resolve => setImmediate(resolve));
+    }
+
+    await vi.advanceTimersByTimeAsync(300);
+    await rejection;
+  });
+
+  it('accepts a healthy responder whose pid matches the freshly spawned server', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: 'ok', repoRoot: '/repo', mode: 'primary', pid: 7303 }),
+    }));
+
+    await expect(Effect.runPromise(restartDashboard(
+      baseConfig,
+      () => ({ stop: vi.fn(), pid: async () => 7303 }),
+      { expectedIdentity: { repoRoot: '/repo', mode: 'primary' } },
+    ))).resolves.toEqual({ ownershipVerified: true, spawnedPid: 7303 });
+  });
+
+  it('rejects a pre-fix health payload that omits pid when ownership is expected', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: 'ok', repoRoot: '/repo', mode: 'primary' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const restart = Effect.runPromise(restartDashboard(
+      baseConfig,
+      () => ({ stop: vi.fn(), pid: async () => 7404 }),
+      {
+        healthTimeoutMs: 200,
+        expectedIdentity: { repoRoot: '/repo', mode: 'primary' },
+      },
+    ));
+    const rejection = expect(restart).rejects.toMatchObject({
+      failure: {
+        reason: expect.stringMatching(/pid \(unreported\).*pid 7404.*LEFT RUNNING/s),
+      },
+    });
+    while (fetchMock.mock.calls.length === 0) {
+      await new Promise<void>(resolve => setImmediate(resolve));
+    }
+
+    await vi.advanceTimersByTimeAsync(300);
+    await rejection;
+  });
+
+  it('preserves legacy 200 behavior when no expected pid or identity is provided', async () => {
+    const response = { ok: true, status: 200 };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
+
+    await expect(Effect.runPromise(
+      waitForDashboardHealth(43991, { timeoutMs: 200, pollIntervalMs: 50 }),
+    )).resolves.toBeUndefined();
+  });
+
+  it('reports unverified ownership when a spawn handle cannot resolve its pid', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: 'ok', repoRoot: '/repo', mode: 'primary' }),
+    }));
+
+    await expect(Effect.runPromise(restartDashboard(
+      baseConfig,
+      () => ({ stop: vi.fn(), pid: async () => null }),
+      { expectedIdentity: { repoRoot: '/repo', mode: 'primary' } },
+    ))).resolves.toEqual({ ownershipVerified: false, spawnedPid: null });
+  });
+});

--- a/tests/unit/lib/platform-lifecycle.test.ts
+++ b/tests/unit/lib/platform-lifecycle.test.ts
@@ -1,3 +1,7 @@
+import { appendFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { Effect } from 'effect';
 /**
  * Tests for src/lib/platform-lifecycle.ts.
@@ -418,5 +422,86 @@ describe('dashboard health ownership', () => {
       () => ({ stop: vi.fn(), pid: async () => null }),
       { expectedIdentity: { repoRoot: '/repo', mode: 'primary' } },
     ))).resolves.toEqual({ ownershipVerified: false, spawnedPid: null });
+  });
+});
+
+describe('dashboard EADDRINUSE fast failure', () => {
+  const tempDirs: string[] = [];
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout'] });
+    vi.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects before the health deadline when the fresh spawn logs EADDRINUSE', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'overdeck-eaddrinuse-'));
+    tempDirs.push(dir);
+    const logPath = join(dir, 'dashboard.log');
+    appendFileSync(logPath, 'old log content\n');
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: 'ok', repoRoot: '/repo', mode: 'primary', pid: 8101 }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    let caught: StageError | undefined;
+    const restart = Effect.runPromise(restartDashboard(
+      baseConfig,
+      () => ({ stop: vi.fn(), pid: async () => 8202 }),
+      {
+        healthTimeoutMs: 5_000,
+        expectedIdentity: { repoRoot: '/repo', mode: 'primary' },
+        eaddrinuseLogPath: logPath,
+        portOwnerProbe: async () => [8101],
+        pidDescriptor: async () => '8101 node old-dashboard.js',
+      },
+    )).catch((error) => {
+      caught = error as StageError;
+      throw error;
+    });
+    const rejection = expect(restart).rejects.toMatchObject({
+      failure: {
+        stage: 'dashboard',
+        reason: expect.stringMatching(/port 43991.*PID 8101.*node old-dashboard\.js.*EADDRINUSE/s),
+      },
+    });
+    while (fetchMock.mock.calls.length === 0) {
+      await new Promise<void>(resolve => setImmediate(resolve));
+    }
+    appendFileSync(logPath, 'Error: listen EADDRINUSE: address already in use 127.0.0.1:43991\n');
+
+    await vi.advanceTimersByTimeAsync(250);
+    await rejection;
+    expect(caught?.failure.recovery).toBeUndefined();
+    expect(Date.now()).toBeLessThan(5_000);
+  });
+
+  it('treats a missing pre-spawn log as an empty file without blocking startup', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'overdeck-eaddrinuse-missing-'));
+    tempDirs.push(dir);
+    const logPath = join(dir, 'dashboard.log');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: 'ok', repoRoot: '/repo', mode: 'primary', pid: 8303 }),
+    }));
+
+    await expect(Effect.runPromise(restartDashboard(
+      baseConfig,
+      () => ({ stop: vi.fn(), pid: async () => 8303 }),
+      {
+        expectedIdentity: { repoRoot: '/repo', mode: 'primary' },
+        eaddrinuseLogPath: logPath,
+      },
+    ))).resolves.toEqual({ ownershipVerified: true, spawnedPid: 8303 });
   });
 });


### PR DESCRIPTION
**Issue:** #3293

## Acceptance Criteria

- [ ] Add serving pid to /api/health identity payload
- [ ] Expose the spawned server's pid from both dashboard spawn paths
- [ ] Replace fuser-only pidsOnPort with async lsof-first multi-probe (IPv4+IPv6, Linux+macOS)
- [ ] Health gate requires responder pid == spawned pid; timeout names the actual owner
- [ ] Fail restart fast when EADDRINUSE appears in the dashboard log after spawn
- [ ] stopDashboard verifies targeted pids are dead, naming survivors
- [ ] Integration test: a real squatter on the port makes restart fail loudly, naming the pid
- [ ] Document the owner-verified restart contract in DEV SOP and pan-restart skill