### PR TITLE
fix(lifecycle): settle ownerless pending verifications on merged issues (PAN-3339)

### DIFF
--- a/src/lib/cloister/verification-runner.ts
+++ b/src/lib/cloister/verification-runner.ts
@@ -14,6 +14,7 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 import { Effect } from 'effect';
 import { getReviewStatusSync, markWorkspaceStuck, setReviewStatusSync } from '../review-status.js';
+import { MERGED_VERIFICATION_REASON } from '../review-status-reconcile.js';
 import { runQualityGates, DEFAULT_GATES } from './validation.js';
 import { readVerificationArtifact, writeVerificationArtifact } from './verification-artifact.js';
 import { buildFinalFailureInstructions } from './verification-feedback.js';
@@ -45,7 +46,6 @@ const execAsync = promisify(exec);
 
 export const VERIFICATION_MAX_CYCLES = 3;
 const NO_PROGRESS_REPEAT_THRESHOLD = 2;
-const MERGED_VERIFICATION_REASON = 'Merge already landed; verify-on-main owns post-merge validation.';
 
 export type { VerificationRunnerOptions, VerificationRunnerOutcome, WorkspaceInfo } from './verification-types.js';
 
@@ -151,17 +151,36 @@ async function escalateVerificationStuck(
 }
 
 /**
- * Boot reconciliation for interrupted verifications. Live supervised workers
+ * Boot reconciliation for verifications no worker owns. Live supervised workers
  * survive dashboard restarts and retain ownership of their running status.
  * A running status without a live worker is orphaned, so reset it to pending
  * and finalize the artifact rather than leaving the issue wedged forever.
+ *
+ * PAN-3339: `pending` on an already-merged issue is the other ownerless shape.
+ * "Verification re-runs on the next cycle" is true only while the review
+ * pipeline can still dispatch one; after merge there is no next cycle, so the
+ * verdict sits at `pending` and DoD row 3 blocks close-out forever. The write
+ * door settles this at the merge write going forward — this sweep heals rows
+ * that were already stranded before that guard existed.
  */
 export function reconcileInterruptedVerifications(logPrefix = 'boot-reconciliation'): number {
   let reset = 0;
   try {
     const statuses = readReviewStatusMap() ?? {};
     for (const [issueId, status] of Object.entries(statuses)) {
-      if ((status as { verificationStatus?: string }).verificationStatus !== 'running') continue;
+      const verificationStatus = (status as { verificationStatus?: string }).verificationStatus;
+      if (
+        verificationStatus === 'pending' &&
+        (status as { mergeStatus?: string }).mergeStatus === 'merged'
+      ) {
+        setReviewStatusSync(issueId, {
+          verificationStatus: 'skipped',
+          verificationNotes: MERGED_VERIFICATION_REASON,
+        });
+        console.log(`[${logPrefix}] settled ownerless pending verification for merged ${issueId} (PAN-3339)`);
+        continue;
+      }
+      if (verificationStatus !== 'running') continue;
       if (isVerificationWorkerActive(issueId)) {
         console.log(`[${logPrefix}] preserved live supervised verification for ${issueId}`);
         continue;

--- a/src/lib/review-status-reconcile.ts
+++ b/src/lib/review-status-reconcile.ts
@@ -97,6 +97,31 @@ export function verificationSatisfied(
   return status.verificationStatus !== 'failed';
 }
 
+/**
+ * The one reason a merged issue's verification is `skipped`. Every verification
+ * run for a merged issue already returns this (`skipMergedVerification` in
+ * cloister/verification-runner.ts).
+ */
+export const MERGED_VERIFICATION_REASON =
+  'Merge already landed; verify-on-main owns post-merge validation.';
+
+/**
+ * PAN-3339: `pending` verification on a merged issue is a state with no owner.
+ * Verification is dispatched only from inside the review pipeline, and that
+ * pipeline never runs again once the issue merges — so the verdict recorded as
+ * `pending` at finalization can never advance, and DoD row 3 blocks close-out
+ * forever (observed on PAN-3296 with verificationCycleCount 0). The write door
+ * settles it at the write that makes it unownable, using the same policy every
+ * merged-issue verification run already applies. A merge lifecycle reset writes
+ * mergeStatus 'pending' in the same update, so it never trips this.
+ */
+export function settleMergedVerification<
+  T extends Pick<ReviewStatus, 'mergeStatus' | 'verificationStatus' | 'verificationNotes'>,
+>(status: T): T {
+  if (status.mergeStatus !== 'merged' || status.verificationStatus !== 'pending') return status;
+  return { ...status, verificationStatus: 'skipped', verificationNotes: MERGED_VERIFICATION_REASON };
+}
+
 /** PAN-1988: merge-gate predicate shared by direct writes and journal reconciliation. */
 export function reviewGatesPassedSync(
   status: Pick<
@@ -142,7 +167,9 @@ export function reconcileJournalIntoCacheSync(
   merged.updatedAt = journal.updatedAt;
   const hasBlockers = (merged.blockerReasons?.length ?? 0) > 0;
   merged.readyForMerge = hasBlockers ? false : reviewGatesPassedSync(merged);
-  const reconciled = normalizeReviewStatusSync(merged);
+  // PAN-3339: same settlement as the write door, so a journal record still
+  // carrying the ownerless `pending` cannot reinstate it in the cache on read.
+  const reconciled = normalizeReviewStatusSync(settleMergedVerification(merged));
   try {
     dbUpsert(reconciled);
     // PAN-2988 — the reconcile changed the effective status; the read model only

--- a/src/lib/review-status.ts
+++ b/src/lib/review-status.ts
@@ -22,7 +22,7 @@ import { updateIssueRecordForReviewStatusSync, readJournalStatusSync } from './o
 import { carriesNewTerminalVerdict } from './pan-dir/pipeline-verdict-merge.js';
 import {
   reviewGatesPassedSync,
-  verificationSatisfied,
+  verificationSatisfied, settleMergedVerification,
   type BlockerReason, type ReviewStatus, type StatusHistoryEntry,
 } from './review-status-reconcile.js';
 import { isReviewRequestStale, needsReviewDispatch } from './review-dispatch-decision.js';
@@ -32,7 +32,7 @@ import { resolveJournalReconciledReviewStatusSync } from './review-status-read.j
 import { capturePipelineStageForIssue } from './telemetry/pipeline.js';
 import type { ReviewStatusUpdate } from './workspace-anchor-drift.js';
 
-export { reviewGatesPassedSync, verificationSatisfied } from './review-status-reconcile.js';
+export { reviewGatesPassedSync, verificationSatisfied, MERGED_VERIFICATION_REASON } from './review-status-reconcile.js';
 export type { BlockerReason, ReviewStatus, StatusHistoryEntry } from './review-status-reconcile.js';
 export type { ReviewStatusUpdate } from './workspace-anchor-drift.js';
 
@@ -237,7 +237,7 @@ export function setReviewStatusSync(
     delete update.testNotes;
   }
 
-  const merged = { ...status, ...update };
+  const merged = settleMergedVerification({ ...status, ...update });
 
   // PAN-1862 (FR-6): reviewerVerdicts is a per-sub-role MAP — a partial update
   // (synthesis reporting only the reviewers that re-ran this cycle) must merge

--- a/tests/unit/lib/cloister/verification-runner-reconcile.test.ts
+++ b/tests/unit/lib/cloister/verification-runner-reconcile.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockReadReviewStatusMap,
+  mockSetReviewStatus,
+  mockIsVerificationWorkerActive,
+} = vi.hoisted(() => ({
+  mockReadReviewStatusMap: vi.fn(),
+  mockSetReviewStatus: vi.fn(),
+  mockIsVerificationWorkerActive: vi.fn(() => false),
+}));
+
+vi.mock('../../../../src/lib/review-status.js', () => ({
+  getReviewStatusSync: vi.fn(() => null),
+  markWorkspaceStuck: vi.fn(),
+  setReviewStatusSync: mockSetReviewStatus,
+}));
+
+vi.mock('../../../../src/lib/cloister/review-status-source.js', () => ({
+  readReviewStatusMap: mockReadReviewStatusMap,
+}));
+
+vi.mock('../../../../src/lib/cloister/verification-worker-supervisor.js', () => ({
+  isVerificationWorkerActive: mockIsVerificationWorkerActive,
+  markVerificationWorkerAdmissionPhase: vi.fn(),
+  runSupervisedVerification: vi.fn(),
+}));
+
+vi.mock('../../../../src/lib/projects.js', () => ({
+  findProjectByPathSync: vi.fn(() => null),
+  resolveProjectFromIssueSync: vi.fn(() => null),
+}));
+
+import { reconcileInterruptedVerifications } from '../../../../src/lib/cloister/verification-runner.js';
+
+describe('reconcileInterruptedVerifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsVerificationWorkerActive.mockReturnValue(false);
+  });
+
+  // PAN-3339: verification is dispatched only from inside the review pipeline, and
+  // that pipeline never runs again after merge — so a `pending` verdict left behind
+  // by the merge has no owner and DoD row 3 blocks close-out forever.
+  it('settles a pending verification on a merged issue', () => {
+    mockReadReviewStatusMap.mockReturnValue({
+      'PAN-3296': { issueId: 'PAN-3296', mergeStatus: 'merged', verificationStatus: 'pending' },
+    });
+
+    const reset = reconcileInterruptedVerifications('test');
+
+    expect(reset).toBe(0);
+    expect(mockSetReviewStatus).toHaveBeenCalledExactlyOnceWith('PAN-3296', {
+      verificationStatus: 'skipped',
+      verificationNotes: 'Merge already landed; verify-on-main owns post-merge validation.',
+    });
+  });
+
+  it('leaves a pending verification alone while the issue can still be dispatched', () => {
+    mockReadReviewStatusMap.mockReturnValue({
+      'PAN-3296': { issueId: 'PAN-3296', mergeStatus: 'pending', verificationStatus: 'pending' },
+    });
+
+    expect(reconcileInterruptedVerifications('test')).toBe(0);
+    expect(mockSetReviewStatus).not.toHaveBeenCalled();
+  });
+
+  it('still resets an orphaned running verification to pending', () => {
+    mockReadReviewStatusMap.mockReturnValue({
+      'PAN-3296': { issueId: 'PAN-3296', mergeStatus: 'pending', verificationStatus: 'running' },
+    });
+
+    expect(reconcileInterruptedVerifications('test')).toBe(1);
+    expect(mockSetReviewStatus).toHaveBeenCalledExactlyOnceWith('PAN-3296', {
+      verificationStatus: 'pending',
+      verificationNotes: expect.stringContaining('verification re-runs on the next cycle'),
+    });
+  });
+
+  it('preserves a running verification owned by a live supervised worker', () => {
+    mockReadReviewStatusMap.mockReturnValue({
+      'PAN-3296': { issueId: 'PAN-3296', mergeStatus: 'pending', verificationStatus: 'running' },
+    });
+    mockIsVerificationWorkerActive.mockReturnValue(true);
+
+    expect(reconcileInterruptedVerifications('test')).toBe(0);
+    expect(mockSetReviewStatus).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/lib/review-status-reconcile.test.ts
+++ b/tests/unit/lib/review-status-reconcile.test.ts
@@ -86,6 +86,26 @@ describe('review status journal reconciliation', () => {
     expect(result?.updatedAt).toBe('2026-07-22T20:01:00.000Z');
   });
 
+  // PAN-3339: the write door settles merged + pending verification to skipped.
+  // A journal record still carrying the ownerless `pending` must not reinstate it.
+  it('settles a pending verification carried by a merged journal record', () => {
+    mockReadJournalStatusSync.mockReturnValue({
+      updatedAt: '2026-07-22T20:01:00.000Z',
+      durable: {
+        reviewStatus: 'passed',
+        testStatus: 'passed',
+        verificationStatus: 'pending',
+        mergeStatus: 'merged',
+      },
+    });
+
+    expect(getReviewStatusSync(dbStatus.issueId)).toMatchObject({
+      mergeStatus: 'merged',
+      verificationStatus: 'skipped',
+      verificationNotes: 'Merge already landed; verify-on-main owns post-merge validation.',
+    });
+  });
+
   it('does not emit when the DB cache is current with the journal', () => {
     mockReadJournalStatusSync.mockReturnValue({
       updatedAt: dbStatus.updatedAt,

--- a/tests/unit/lib/review-status.test.ts
+++ b/tests/unit/lib/review-status.test.ts
@@ -118,6 +118,53 @@ describe('review status', () => {
     expect(capturePipelineStageForIssueMock).toHaveBeenCalledWith('PAN-2200', 'review_passed');
   });
 
+  // PAN-3339: verification is dispatched only from inside the review pipeline, which
+  // never runs again once the issue merges. A `pending` verdict carried past the merge
+  // has no owner and blocks DoD row 3 forever, so the merge write settles it here with
+  // the same policy every merged-issue verification run already applies.
+  it('settles a pending verification when the merge lands', () => {
+    setReviewStatusSync('PAN-3296', {
+      reviewStatus: 'passed',
+      testStatus: 'passed',
+      verificationStatus: 'pending',
+    });
+
+    const merged = setReviewStatusSync('PAN-3296', { mergeStatus: 'merged', readyForMerge: false });
+
+    // The note is journal-only (PAN-1988), so assert it on the write's own result.
+    expect(merged).toMatchObject({
+      mergeStatus: 'merged',
+      verificationStatus: 'skipped',
+      verificationNotes: 'Merge already landed; verify-on-main owns post-merge validation.',
+      readyForMerge: false,
+    });
+    expect(getReviewStatusSync('PAN-3296')).toMatchObject({
+      mergeStatus: 'merged',
+      verificationStatus: 'skipped',
+    });
+  });
+
+  it('leaves verification pending when a merge lifecycle reset restarts the work', () => {
+    setReviewStatusSync('PAN-3297', {
+      reviewStatus: 'passed',
+      testStatus: 'passed',
+      verificationStatus: 'passed',
+      mergeStatus: 'merged',
+    });
+
+    setReviewStatusSync('PAN-3297', {
+      reviewStatus: 'pending',
+      testStatus: 'pending',
+      mergeStatus: 'pending',
+      verificationStatus: 'pending',
+    });
+
+    expect(getReviewStatusSync('PAN-3297')).toMatchObject({
+      mergeStatus: 'pending',
+      verificationStatus: 'pending',
+    });
+  });
+
   it('consumes a serviced review request when review passes', () => {
     const initial = setReviewStatusSync('PAN-3083', {
       reviewStatus: 'pending',


### PR DESCRIPTION
A merged issue whose verificationStatus is pending was unclosable: nothing dispatches it (only review-pipeline.ts does), boot reconciliation skipped anything not 'running', and there is no pan verify verb — so DoD row 3 blocked close-out forever with --accept-verification the only exit.

Settles pending+merged to skipped with MERGED_VERIFICATION_REASON, and fixes the write door at the merge write so new rows are never stranded; the sweep heals rows stranded before that guard existed.

Reviewed by flywheel-orchestrator RUN-75. Closes PAN-3339