### PR TITLE
fix(merge): advance the merge queue instead of leaving rows queued forever (PAN-3328)

### DIFF
--- a/docs/SPECIALIST_WORKFLOW.md
+++ b/docs/SPECIALIST_WORKFLOW.md
@@ -306,6 +306,10 @@ The merge agent uses a **SQLite-backed per-project queue** (`merge_queue` table)
 6. **Pushes to remote**
 7. **Reports results, advances queue** to next issue
 
+**Advancing skips entries that can no longer merge (PAN-3328).** `triggerMerge()` rejects an issue that is not `readyForMerge` — closed, reopened, or with its review-status record gone — before it ever claims the queue. Advancing therefore drops such heads and keeps walking until it finds an entry that can actually start, rather than handing the head off and stopping. Without that drain a single dead entry wedges the whole queue permanently, and everything behind it parks silently with `started_at` still NULL. `advanceMergeQueue()` in `src/dashboard/server/routes/workspaces/merge-strike.ts` owns this walk, and both queue owners use it: the advance that runs when a merge finishes, and `resumeQueuedMerges()` at dashboard boot. A dropped issue re-enqueues itself the next time it becomes mergeable.
+
+Boot also requeues any `pending_auto_merges` row stranded in `merging` back to `pending`. The auto-merge executor holds that status only across an in-process `await`, so a row still in `merging` at boot was orphaned by a crash — and `GET /api/flywheel/auto-merge/problems` reports only `blocked` and `failed`, so nothing would otherwise surface it. The next executor tick re-checks eligibility; a PR that did merge before the crash is blocked there with a reason instead of merged twice.
+
 ### Strike Landing and Recovery
 
 A strike agent commits and pushes only `strike/<id>`, then runs `pan strike-ready <id>`. That command authenticates the strike workspace and pushed remote HEAD and records a durable handoff. On its next patrol, Deacon claims the marker and sends the branch through the same serialized merge queue, rebase checks, configured quality gates, forge merge, and post-merge lifecycle used by the verified merge door. Flywheel does not own or need to observe this handoff.

--- a/src/dashboard/server/main.ts
+++ b/src/dashboard/server/main.ts
@@ -756,11 +756,18 @@ void reconcileStaleGitHubBlockers()
 // Reset stuck merge queue entries (PAN-632): any 'processing' entries were
 // in-flight when the server died — reset to 'queued' so they resume.
 try {
-  const { resetProcessingToQueued } = await import('../../lib/overdeck/merge-sync.js');
+  const { resetProcessingToQueued, requeueOrphanedMergingAutoMerges } = await import('../../lib/overdeck/merge-sync.js');
   const resetCount = resetProcessingToQueued();
   if (resetCount > 0) {
     console.log(`[overdeck] Reset ${resetCount} stuck merge queue entries to queued`);
     emitActivityEntrySync({ source: 'dashboard', level: 'warn', message: `Reset ${resetCount} stuck merge queue entries to queued on startup` });
+  }
+  // PAN-3328: an auto-merge row left in 'merging' by a crash is invisible to the
+  // problems endpoint and to the deacon reconciler — requeue it so it is retried.
+  const requeuedAutoMerges = requeueOrphanedMergingAutoMerges();
+  if (requeuedAutoMerges > 0) {
+    console.log(`[overdeck] Requeued ${requeuedAutoMerges} orphaned auto-merge row(s) from merging to pending`);
+    emitActivityEntrySync({ source: 'dashboard', level: 'warn', message: `Requeued ${requeuedAutoMerges} orphaned auto-merge row(s) stuck in merging on startup` });
   }
   await resumeQueuedMerges();
 } catch (err: any) {

--- a/src/dashboard/server/routes/workspaces/__tests__/merge-ops-clean-direct.test.ts
+++ b/src/dashboard/server/routes/workspaces/__tests__/merge-ops-clean-direct.test.ts
@@ -141,7 +141,7 @@ vi.mock('../merge-strike.js', () => ({
 }));
 
 vi.mock('../../specialists.js', () => ({ _serverManagedMerges: new Set<string>() }));
-vi.mock('../../../services/merge-queue-service.js', () => ({ setMergeQueueTriggerHandler: vi.fn() }));
+vi.mock('../../../services/merge-queue-service.js', () => ({ setMergeQueueAdvanceHandler: vi.fn() }));
 
 import { triggerMerge } from '../merge-ops.js';
 

--- a/src/dashboard/server/routes/workspaces/__tests__/merge-ops-clean-direct.test.ts
+++ b/src/dashboard/server/routes/workspaces/__tests__/merge-ops-clean-direct.test.ts
@@ -124,6 +124,7 @@ vi.mock('../../workspaces.js', () => ({
 
 vi.mock('../merge-strike.js', () => ({
   activeStrikeMerge: vi.fn(() => false),
+  advanceMergeQueue: vi.fn(),
   ensureAgentReadyForMerge: mocks.ensureAgentReadyForMerge,
   mergeCompletionStatus: vi.fn(() => ({})),
   mergeVerificationOptions: vi.fn(() => ({})),

--- a/src/dashboard/server/routes/workspaces/__tests__/merge-ops-polyrepo-completeness.test.ts
+++ b/src/dashboard/server/routes/workspaces/__tests__/merge-ops-polyrepo-completeness.test.ts
@@ -102,7 +102,7 @@ vi.mock('../../specialists.js', () => ({
 }));
 
 vi.mock('../../../services/merge-queue-service.js', () => ({
-  setMergeQueueTriggerHandler: vi.fn(),
+  setMergeQueueAdvanceHandler: vi.fn(),
 }));
 
 vi.mock('../../../../../lib/merge-set.js', () => ({

--- a/src/dashboard/server/routes/workspaces/__tests__/merge-ops-polyrepo-completeness.test.ts
+++ b/src/dashboard/server/routes/workspaces/__tests__/merge-ops-polyrepo-completeness.test.ts
@@ -90,6 +90,7 @@ vi.mock('../../workspaces.js', () => ({
 
 vi.mock('../merge-strike.js', () => ({
   activeStrikeMerge: vi.fn(() => false),
+  advanceMergeQueue: vi.fn(),
   ensureAgentReadyForMerge: vi.fn(),
   mergeCompletionStatus: vi.fn(() => ({})),
   mergeVerificationOptions: vi.fn(() => ({})),

--- a/src/dashboard/server/routes/workspaces/__tests__/merge-ops-server-rebase.test.ts
+++ b/src/dashboard/server/routes/workspaces/__tests__/merge-ops-server-rebase.test.ts
@@ -119,7 +119,7 @@ vi.mock('../merge-strike.js', async (importOriginal) => ({
   recordCiGreenVerificationVerdict: vi.fn(),
 }));
 vi.mock('../../specialists.js', () => ({ _serverManagedMerges: new Set<string>() }));
-vi.mock('../../../services/merge-queue-service.js', () => ({ setMergeQueueTriggerHandler: vi.fn() }));
+vi.mock('../../../services/merge-queue-service.js', () => ({ setMergeQueueAdvanceHandler: vi.fn() }));
 
 import { triggerMerge } from '../merge-ops.js';
 

--- a/src/dashboard/server/routes/workspaces/__tests__/merge-queue-advance.test.ts
+++ b/src/dashboard/server/routes/workspaces/__tests__/merge-queue-advance.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { advanceMergeQueue, type MergeQueueAdvanceDeps } from '../merge-strike.js';
+import type { ReviewStatus } from '../../../../../lib/review-status.js';
+
+/**
+ * PAN-3328: the merge queue must not be able to wedge behind an entry that
+ * `triggerMerge()` would bounce before it claims the queue. These tests lock the
+ * drain: unstartable heads are removed, the first startable entry is triggered,
+ * and the walk always terminates.
+ */
+
+function reviewStatus(overrides: Partial<ReviewStatus> = {}): ReviewStatus {
+  return { issueId: 'PAN-1', ...overrides } as ReviewStatus;
+}
+
+/** Build deps over an in-memory queue that behaves like dequeueMerge(). */
+function harness(
+  queue: string[],
+  statuses: Record<string, ReviewStatus | null>,
+): { deps: MergeQueueAdvanceDeps; queue: string[]; triggered: Array<[string, unknown]>; warnings: string[] } {
+  const triggered: Array<[string, unknown]> = [];
+  const warnings: string[] = [];
+  const deps: MergeQueueAdvanceDeps = {
+    dequeue: (_projectKey, completedIssueId) => {
+      if (completedIssueId) {
+        const index = queue.indexOf(completedIssueId);
+        if (index >= 0) queue.splice(index, 1);
+      }
+      return queue[0] ?? null;
+    },
+    getReviewStatus: (issueId) => statuses[issueId] ?? null,
+    getProjectPath: () => '/projects/overdeck',
+    triggerMerge: async (issueId, request) => {
+      triggered.push([issueId, request]);
+      return { success: true };
+    },
+    log: () => {},
+    warn: (message) => warnings.push(message),
+  };
+  return { deps, queue, triggered, warnings };
+}
+
+describe('advanceMergeQueue', () => {
+  it('drops heads that triggerMerge would reject and starts the first startable entry', () => {
+    const { deps, queue, triggered, warnings } = harness(
+      ['PAN-100', 'PAN-200', 'PAN-300'],
+      {
+        // No review-status record at all — exactly the shape of the 12 rows that
+        // wedged the real queue for 26 days.
+        'PAN-100': null,
+        'PAN-200': reviewStatus({ readyForMerge: true, mergeStatus: 'merged' }),
+        'PAN-300': reviewStatus({ readyForMerge: true }),
+      },
+    );
+
+    advanceMergeQueue(deps, 'pan');
+
+    expect(triggered).toEqual([['PAN-300', undefined]]);
+    expect(queue).toEqual(['PAN-300']);
+    expect(warnings.join('\n')).toContain('Dropped PAN-100 from the pan merge queue');
+    expect(warnings.join('\n')).toContain('Dropped PAN-200 from the pan merge queue');
+  });
+
+  it('removes the completed issue before choosing the next entry', () => {
+    const { deps, queue, triggered } = harness(
+      ['PAN-100', 'PAN-200'],
+      { 'PAN-100': reviewStatus({ readyForMerge: true }), 'PAN-200': reviewStatus({ readyForMerge: true }) },
+    );
+
+    advanceMergeQueue(deps, 'pan', 'PAN-100');
+
+    expect(queue).toEqual(['PAN-200']);
+    expect(triggered).toEqual([['PAN-200', undefined]]);
+  });
+
+  it('empties a queue in which nothing can start, instead of stopping on the head', () => {
+    const { deps, queue, triggered } = harness(
+      ['PAN-100', 'PAN-200'],
+      { 'PAN-100': null, 'PAN-200': null },
+    );
+
+    advanceMergeQueue(deps, 'pan');
+
+    expect(queue).toEqual([]);
+    expect(triggered).toEqual([]);
+  });
+
+  it('passes a strike request through without consulting normal merge eligibility', () => {
+    const { deps, triggered } = harness(
+      ['PAN-400'],
+      {
+        // A ready strike has readyForMerge=false — the strike path validates the
+        // marker instead, so it must not be treated as an unstartable head.
+        'PAN-400': reviewStatus({ readyForMerge: false, strikeLandingState: 'ready', strikeReadyHead: 'abc123' }),
+      },
+    );
+
+    advanceMergeQueue(deps, 'pan');
+
+    expect(triggered).toEqual([[
+      'PAN-400',
+      {
+        kind: 'strike',
+        markerHead: 'abc123',
+        workspacePath: '/projects/overdeck/workspaces/feature-pan-400-strike',
+        branchName: 'strike/pan-400',
+        recoveryTarget: 'strike-pan-400',
+      },
+    ]]);
+  });
+
+  it('terminates when the queue keeps handing back the same unstartable entry', () => {
+    const dequeue = vi.fn(() => 'PAN-100');
+    advanceMergeQueue(
+      {
+        dequeue,
+        getReviewStatus: () => null,
+        getProjectPath: () => '/projects/overdeck',
+        triggerMerge: async () => ({}),
+        log: () => {},
+        warn: () => {},
+      },
+      'pan',
+    );
+
+    expect(dequeue).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/dashboard/server/routes/workspaces/merge-ops.ts
+++ b/src/dashboard/server/routes/workspaces/merge-ops.ts
@@ -35,13 +35,13 @@ import { resolveGitHubIssueSync as resolveGitHubIssueShared } from '../../../../
 import { sessionExists } from '../../../../lib/tmux.js';
 import { jsonResponse } from '../../http-helpers.js';
 import { EventStoreService } from '../../services/domain-services.js';
-import { setMergeQueueTriggerHandler } from '../../services/merge-queue-service.js';
+import { setMergeQueueAdvanceHandler } from '../../services/merge-queue-service.js';
 import { httpHandler } from '../http-handler.js';
 import { _serverManagedMerges } from '../specialists.js';
 import { completePendingOperation, getPendingOperation, getProjectPath, getWorkspaceInfoForIssue, readJsonBody, setPendingOperation, setReviewStatus } from '../workspaces.js';
 import { buildLocalMainRecoveryError } from './git-recovery-advice.js';
 import { internalStrikeMergeRoute } from './internal-strike-merge.js';
-import { activeStrikeMerge, mergeCompletionStatus, mergeVerificationOptions, normalMergeEligibility, prepareWorkAgentForRebase, rebaseWithAgentFallback, recordCiGreenVerificationVerdict, validateStrikeMergeRequest, type StrikeMergeRequest, type TriggerMergeRequest, type TriggerMergeResult } from './merge-strike.js';
+import { activeStrikeMerge, advanceMergeQueue, mergeCompletionStatus, mergeVerificationOptions, normalMergeEligibility, prepareWorkAgentForRebase, rebaseWithAgentFallback, recordCiGreenVerificationVerdict, validateStrikeMergeRequest, type TriggerMergeRequest, type TriggerMergeResult } from './merge-strike.js';
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 export const shouldBlockApproveForDirtyStatus = (status: string): boolean =>
@@ -309,19 +309,14 @@ const postWorkspaceSyncMainRoute = HttpRouter.add(
 
 /** Dequeue the next merge after current completes (success or failure). */
 function dequeueNextMerge(projectKey: string, completedIssueId?: string): void {
-  const nextIssueId = dequeueMerge(projectKey, completedIssueId);
-  if (nextIssueId) {
-    console.log(`[merge] Dequeuing next merge: ${nextIssueId}`);
-    const status = getReviewStatusSync(nextIssueId);
-    const strikeRequest: StrikeMergeRequest | undefined = status?.strikeReadyHead && (status.strikeLandingState === 'ready' || status.strikeLandingState === 'landing') ? {
-      kind: 'strike', markerHead: status.strikeReadyHead,
-      workspacePath: join(getProjectPath(undefined, extractPrefixSync(nextIssueId) ?? nextIssueId.split('-')[0]), 'workspaces', `feature-${nextIssueId.toLowerCase()}-strike`),
-      branchName: `strike/${nextIssueId.toLowerCase()}`, recoveryTarget: `strike-${nextIssueId.toLowerCase()}`,
-    } : undefined;
-    triggerMerge(nextIssueId, strikeRequest).catch(err =>
-      console.error(`[merge] Queue error for ${nextIssueId}: ${err}`)
-    );
-  }
+  advanceMergeQueue({
+    dequeue: dequeueMerge,
+    getReviewStatus: getReviewStatusSync,
+    getProjectPath: (issueId) => getProjectPath(undefined, extractPrefixSync(issueId) ?? issueId.split('-')[0]),
+    triggerMerge,
+    log: (message) => console.log(message),
+    warn: (message) => console.warn(message),
+  }, projectKey, completedIssueId);
 }
 
 export async function triggerMerge(issueId: string, request: TriggerMergeRequest = { kind: 'normal' }): Promise<TriggerMergeResult> {
@@ -1202,7 +1197,7 @@ export async function triggerMerge(issueId: string, request: TriggerMergeRequest
   }
 }
 
-setMergeQueueTriggerHandler(triggerMerge);
+setMergeQueueAdvanceHandler((projectKey) => dequeueNextMerge(projectKey));
 
 const postInternalStrikeMergeRoute = internalStrikeMergeRoute(triggerMerge);
 

--- a/src/dashboard/server/routes/workspaces/merge-strike.ts
+++ b/src/dashboard/server/routes/workspaces/merge-strike.ts
@@ -143,6 +143,75 @@ export interface MergeEligibilityResult {
   success: false; statusCode: number; error: string; reviewStatus?: string; testStatus?: string; mergeStatus?: string;
 }
 
+export interface MergeQueueAdvanceDeps {
+  dequeue: (projectKey: string, completedIssueId?: string) => string | null;
+  getReviewStatus: (issueId: string) => ReviewStatus | null;
+  getProjectPath: (issueId: string) => string;
+  triggerMerge: (issueId: string, request?: StrikeMergeRequest) => Promise<unknown>;
+  log: (message: string) => void;
+  warn: (message: string) => void;
+}
+
+/** Rebuild the strike merge request a queued strike entry needs, or undefined for a normal merge. */
+export function strikeRequestForQueueEntry(
+  issueId: string,
+  status: ReviewStatus | null,
+  projectPath: string,
+): StrikeMergeRequest | undefined {
+  if (!status?.strikeReadyHead) return undefined;
+  if (status.strikeLandingState !== 'ready' && status.strikeLandingState !== 'landing') return undefined;
+  const issueLower = issueId.toLowerCase();
+  return {
+    kind: 'strike',
+    markerHead: status.strikeReadyHead,
+    workspacePath: `${projectPath}/workspaces/feature-${issueLower}-strike`,
+    branchName: `strike/${issueLower}`,
+    recoveryTarget: `strike-${issueLower}`,
+  };
+}
+
+/**
+ * Advance a project's merge queue: drop entries that cannot start, then trigger
+ * the first one that can.
+ *
+ * PAN-3328: the queue used to advance by handing its single head entry to
+ * `triggerMerge()` and stopping. `triggerMerge()` rejects an issue that is not
+ * `readyForMerge` — closed, or with its review-status record gone — *before* it
+ * ever claims the queue, so a dead head bounced on every advance and was never
+ * removed. One such row wedged the whole queue permanently: 12 entries stacked up
+ * behind it over 26 days with every `started_at` still NULL, and live work parked
+ * silently forever. Walking past unstartable heads is what makes the queue
+ * self-draining; a dropped issue re-enqueues itself if it becomes mergeable later.
+ */
+export function advanceMergeQueue(
+  deps: MergeQueueAdvanceDeps,
+  projectKey: string,
+  completedIssueId?: string,
+): void {
+  const strikeRequestFor = (issueId: string): StrikeMergeRequest | undefined =>
+    strikeRequestForQueueEntry(issueId, deps.getReviewStatus(issueId), deps.getProjectPath(issueId));
+
+  // `dropped` guarantees termination even if a dequeue keeps handing back the
+  // same entry — the queue must never be able to spin this loop.
+  const dropped = new Set<string>();
+  let nextIssueId = deps.dequeue(projectKey, completedIssueId);
+  while (nextIssueId && !dropped.has(nextIssueId)) {
+    const strikeRequest = strikeRequestFor(nextIssueId);
+    const unstartable = strikeRequest ? null : normalMergeEligibility(deps.getReviewStatus(nextIssueId));
+    if (!unstartable) {
+      deps.log(`[merge] Dequeuing next merge: ${nextIssueId}`);
+      const issueId = nextIssueId;
+      void deps.triggerMerge(issueId, strikeRequest).catch((err: unknown) =>
+        deps.warn(`[merge] Queue error for ${issueId}: ${err}`),
+      );
+      return;
+    }
+    deps.warn(`[merge] Dropped ${nextIssueId} from the ${projectKey} merge queue: ${unstartable.error}`);
+    dropped.add(nextIssueId);
+    nextIssueId = deps.dequeue(projectKey, nextIssueId);
+  }
+}
+
 export function normalMergeEligibility(status: ReviewStatus | null, activelyMerging = false): MergeEligibilityResult | null {
   if (!status?.readyForMerge) return { success: false, statusCode: 400, error: 'Cannot merge: review and tests have not passed yet', reviewStatus: status?.reviewStatus || 'pending', testStatus: status?.testStatus || 'pending' };
   if (status.mergeStatus === 'merging' && activelyMerging) return { success: false, statusCode: 400, error: 'Merge already in progress', mergeStatus: 'merging' };

--- a/src/dashboard/server/services/merge-queue-service.ts
+++ b/src/dashboard/server/services/merge-queue-service.ts
@@ -1,29 +1,31 @@
 import { getAllActiveQueues } from '../../../lib/overdeck/merge-sync.js';
 
-export type MergeTriggerHandler = (issueId: string) => Promise<unknown>;
+/** Advance one project's merge queue — drop entries that cannot start, trigger the first that can. */
+export type MergeQueueAdvanceHandler = (projectKey: string) => void;
 
-let mergeTriggerHandler: MergeTriggerHandler | null = null;
+let mergeQueueAdvanceHandler: MergeQueueAdvanceHandler | null = null;
 
-export function setMergeQueueTriggerHandler(handler: MergeTriggerHandler): void {
-  mergeTriggerHandler = handler;
+export function setMergeQueueAdvanceHandler(handler: MergeQueueAdvanceHandler): void {
+  mergeQueueAdvanceHandler = handler;
 }
 
+/**
+ * Boot recovery: restart every project queue that holds entries with nothing processing.
+ *
+ * PAN-3328: this used to hand `queue[0]` straight to `triggerMerge()`, which rejects an
+ * issue that is no longer `readyForMerge` before it ever touches the queue. A dead head
+ * therefore bounced on every boot and the queue never advanced past it. Going through the
+ * shared advance drops those heads instead of stopping on them.
+ */
 export async function resumeQueuedMerges(): Promise<void> {
-  if (!mergeTriggerHandler) {
-    console.warn('[overdeck] Merge queue resume skipped: trigger handler not registered');
+  if (!mergeQueueAdvanceHandler) {
+    console.warn('[overdeck] Merge queue resume skipped: advance handler not registered');
     return;
   }
 
-  const queues = getAllActiveQueues();
-  const resumableIssues = queues
-    .filter(queue => !queue.current && queue.queue.length > 0)
-    .map(queue => queue.queue[0]!)
-    .filter((issueId): issueId is string => Boolean(issueId));
-
-  for (const issueId of resumableIssues) {
-    console.log(`[overdeck] Resuming queued merge for ${issueId}`);
-    mergeTriggerHandler(issueId).catch((err: any) => {
-      console.error(`[overdeck] Failed to resume queued merge for ${issueId}: ${err.message}`);
-    });
+  for (const queue of getAllActiveQueues()) {
+    if (queue.current || queue.queue.length === 0) continue;
+    console.log(`[overdeck] Resuming merge queue for ${queue.projectKey} (${queue.queue.length} queued)`);
+    mergeQueueAdvanceHandler(queue.projectKey);
   }
 }

--- a/src/lib/overdeck/__tests__/auto-merge-orphan-requeue.test.ts
+++ b/src/lib/overdeck/__tests__/auto-merge-orphan-requeue.test.ts
@@ -1,0 +1,72 @@
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeOverdeckDatabaseSync, getOverdeckDatabaseSync } from '../infra.js';
+import { requeueOrphanedMergingAutoMerges } from '../merge-sync.js';
+
+/**
+ * PAN-3328: a pending_auto_merges row stranded in 'merging' by a crash is
+ * terminal to every surface — the problems endpoint reports only blocked/failed
+ * and the deacon reconciler skips active rows that are not pending. Boot recovery
+ * must hand those rows back to the executor.
+ */
+describe('requeueOrphanedMergingAutoMerges', () => {
+  const originalOverdeckHome = process.env.OVERDECK_HOME;
+  let testHome: string;
+
+  beforeEach(() => {
+    testHome = join(tmpdir(), `auto-merge-orphan-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(testHome, { recursive: true });
+    process.env.OVERDECK_HOME = testHome;
+    closeOverdeckDatabaseSync();
+  });
+
+  afterEach(() => {
+    closeOverdeckDatabaseSync();
+    if (originalOverdeckHome === undefined) {
+      delete process.env.OVERDECK_HOME;
+    } else {
+      process.env.OVERDECK_HOME = originalOverdeckHome;
+    }
+    rmSync(testHome, { recursive: true, force: true });
+  });
+
+  function seed(issueId: string, status: string): void {
+    getOverdeckDatabaseSync().prepare(
+      'INSERT INTO issues (id, stage, updated_at) VALUES (?, ?, ?)',
+    ).run(issueId, 'merging', Date.now());
+    getOverdeckDatabaseSync().prepare(`
+      INSERT INTO pending_auto_merges (issue_id, pr_url, project_key, forge, status, scheduled_merge_at, scheduled_at)
+      VALUES (?, ?, 'pan', 'github', ?, ?, ?)
+    `).run(issueId, `https://github.com/eltmon/overdeck/pull/1`, status, Date.now(), Date.now());
+  }
+
+  function statusOf(issueId: string): string {
+    const row = getOverdeckDatabaseSync()
+      .prepare('SELECT status FROM pending_auto_merges WHERE issue_id = ?')
+      .get(issueId) as { status: string } | undefined;
+    return row?.status ?? 'missing';
+  }
+
+  it('requeues merging rows to pending and leaves every other status alone', () => {
+    seed('PAN-100', 'merging');
+    seed('PAN-200', 'merged');
+    seed('PAN-300', 'blocked');
+    seed('PAN-400', 'pending');
+
+    expect(requeueOrphanedMergingAutoMerges()).toBe(1);
+
+    expect(statusOf('PAN-100')).toBe('pending');
+    expect(statusOf('PAN-200')).toBe('merged');
+    expect(statusOf('PAN-300')).toBe('blocked');
+    expect(statusOf('PAN-400')).toBe('pending');
+  });
+
+  it('reports zero when no row is stranded', () => {
+    seed('PAN-100', 'merged');
+    expect(requeueOrphanedMergingAutoMerges()).toBe(0);
+  });
+});

--- a/src/lib/overdeck/merge-sync.ts
+++ b/src/lib/overdeck/merge-sync.ts
@@ -171,6 +171,26 @@ export function requeueToPending(id: number, nextScheduledMergeAt: string): bool
   return result.changes === 1;
 }
 
+/**
+ * Startup recovery for auto-merge rows orphaned in 'merging' (PAN-3328).
+ *
+ * The executor holds a row in 'merging' only across an in-process `await` on
+ * triggerMerge(). If the server dies inside that window the row is stranded there
+ * forever: `/api/flywheel/auto-merge/problems` reports only 'blocked' and 'failed',
+ * the deacon reconciler skips active rows that are not 'pending', and nothing else
+ * ever revisits it — so a permanently wedged merge reads as in-progress to every
+ * surface. Requeue to 'pending' so the next executor tick re-evaluates eligibility;
+ * a PR that did merge before the crash is caught there and blocked with a reason
+ * rather than merged twice.
+ */
+export function requeueOrphanedMergingAutoMerges(): number {
+  const db = getOverdeckDatabaseSync();
+  const result = db.prepare(
+    "UPDATE pending_auto_merges SET status = 'pending' WHERE status = 'merging'",
+  ).run();
+  return Number(result.changes);
+}
+
 /** Drop-in for markBlocked() from pending-auto-merges-db.ts. */
 export function markBlocked(id: number, reason: string): boolean {
   const db = getOverdeckDatabaseSync();

--- a/tests/unit/dashboard/server/services/merge-queue-service.test.ts
+++ b/tests/unit/dashboard/server/services/merge-queue-service.test.ts
@@ -10,18 +10,21 @@ vi.mock('../../../../../src/lib/overdeck/merge-sync.js', () => ({
 
 import {
   resumeQueuedMerges,
-  setMergeQueueTriggerHandler,
+  setMergeQueueAdvanceHandler,
 } from '../../../../../src/dashboard/server/services/merge-queue-service.js';
 
 describe('merge-queue-service', () => {
-  const triggerHandler = vi.fn().mockResolvedValue(undefined);
+  const advanceHandler = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
-    setMergeQueueTriggerHandler(triggerHandler);
+    setMergeQueueAdvanceHandler(advanceHandler);
   });
 
-  it('resumes the head queued merge for each idle project', async () => {
+  // PAN-3328: boot recovery hands the whole project queue to the advance, not the
+  // single head issue. Handing over `queue[0]` meant a head that could no longer
+  // merge bounced on every boot and nothing behind it was ever reached.
+  it('advances each idle project queue rather than triggering its head issue', async () => {
     getAllActiveQueuesMock.mockReturnValue([
       { projectKey: 'pan', current: null, queue: ['PAN-2', 'PAN-3'], queueLength: 2 },
       { projectKey: 'min', current: 'MIN-1', queue: ['MIN-2'], queueLength: 1 },
@@ -30,9 +33,9 @@ describe('merge-queue-service', () => {
 
     await resumeQueuedMerges();
 
-    expect(triggerHandler).toHaveBeenCalledTimes(2);
-    expect(triggerHandler).toHaveBeenCalledWith('PAN-2');
-    expect(triggerHandler).toHaveBeenCalledWith('OPS-9');
+    expect(advanceHandler).toHaveBeenCalledTimes(2);
+    expect(advanceHandler).toHaveBeenCalledWith('pan');
+    expect(advanceHandler).toHaveBeenCalledWith('ops');
   });
 
   it('does nothing when every project already has an active merge', async () => {
@@ -42,6 +45,16 @@ describe('merge-queue-service', () => {
 
     await resumeQueuedMerges();
 
-    expect(triggerHandler).not.toHaveBeenCalled();
+    expect(advanceHandler).not.toHaveBeenCalled();
+  });
+
+  it('does nothing for a project whose queue is empty', async () => {
+    getAllActiveQueuesMock.mockReturnValue([
+      { projectKey: 'pan', current: null, queue: [], queueLength: 0 },
+    ]);
+
+    await resumeQueuedMerges();
+
+    expect(advanceHandler).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
merge_queue had 12 rows all status=queued with started_at=NULL since 2026-07-04, closed issues holding head positions, and a wedged pending_auto_merge sitting in 'merging' with no failure_reason so the problems endpoint stayed empty.

Reviewed by flywheel-orchestrator RUN-75. Closes PAN-3328