### PR TITLE
PAN-3341

### DIFF
--- a/docs/PIPELINE-MEMBERSHIP.md
+++ b/docs/PIPELINE-MEMBERSHIP.md
@@ -29,6 +29,12 @@ Agent state, tmux sessions, workspaces, and `review_status` are L5 liveness anno
 | `planned_backlog` | An open issue has a convention branch (unmerged work, or a fresh zero-ahead branch with no unique commits yet — PAN-2887) or a durable xBRIEF but no open PR. |
 | `clean_terminal` | The issue is closed with no open PR, or it is open but has never started and has no durable plan. It is outside the pipeline. |
 
+### Surface reconciliation (PAN-3341)
+
+Resource discovery and frontend lane assignment defer to the canonical membership verdict when stored tracker or record phases are stale. A `post_merge_limbo` issue renders as **Merged — Needs Close-Out** and enters the Ship lane; this is the only membership bucket that overrides a stored phase. The shared issue-action state also treats this bucket as merged, which enables the existing **Close out** action.
+
+A `clean_terminal` verdict renders **Done** when no tmux session remains and **Closed** when a session remains, but only when `L3_issueOpen === false`. The guard preserves the existing state for open, never-started backlog issues, which also use the `clean_terminal` bucket. When membership is unavailable, resource labels, lane assignment, and actions continue to use their existing tracker and artifact signals.
+
 ### Display filtering (PAN-2822)
 
 The dashboard Issues pane has a display-only toggle for rows whose `planned_backlog` membership comes from the L6 durable-spec lens. The preference is visible by default and persists under the localStorage key `overdeck.ui.showPlannedBacklog`; disabling it hides only rows with the derived `specOnlyPlanned` DTO field set to `true`. Rows classified through the unmerged-branch or ready-label reasons remain visible.

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectOverview.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectOverview.tsx
@@ -64,6 +64,7 @@ function reviewStatusForClassifier(
 function featureState(feature: ProjectFeature): CanonicalState | undefined {
   const raw = `${feature.status} ${feature.stateLabel}`.toLowerCase();
   if (raw.includes('verifying')) return 'verifying_on_main';
+  if (raw.includes('close-out')) return 'done';
   if (raw.includes('review')) return 'in_review';
   if (raw.includes('progress') || hasActiveAgentSignal(feature)) return 'in_progress';
   if (raw.includes('done') || raw.includes('complete')) return 'done';

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.test.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.test.tsx
@@ -759,6 +759,19 @@ describe('FeatureItem', () => {
     expect(screen.getByText('Planning')).toHaveClass('featureState_planning');
   });
 
+  it('uses the review tone for merged work that needs close-out', () => {
+    renderFeature(
+      <FeatureItem
+        feature={makeFeature({ stateLabel: 'Merged — Needs Close-Out' })}
+        isSelected={false}
+        onSelect={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('Merged — Needs Close-Out')).toHaveClass('featureState_review');
+    expect(screen.getByText('Merged — Needs Close-Out')).not.toHaveClass('featureState_planning', 'featureState_todo');
+  });
+
   it('adds contextual tooltip text to the feature state pill', () => {
     renderFeature(
       <FeatureItem

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.tsx
@@ -516,6 +516,7 @@ function getFeatureStateTone(stateLabel: string): 'done' | 'progress' | 'review'
   const normalized = stateLabel.trim().toLowerCase();
   if (normalized === 'done') return 'done';
   if (normalized === 'in progress' || normalized === 'active') return 'progress';
+  if (normalized.includes('close-out')) return 'review';
   if (normalized === 'in review' || normalized === 'review' || normalized === 'verifying' || normalized === 'verifying on main') return 'review';
   if (normalized === 'has context') return 'context';
   if (normalized === 'planning') return 'planning';

--- a/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/ProjectTree/FeatureItem.tsx
@@ -516,8 +516,7 @@ function getFeatureStateTone(stateLabel: string): 'done' | 'progress' | 'review'
   const normalized = stateLabel.trim().toLowerCase();
   if (normalized === 'done') return 'done';
   if (normalized === 'in progress' || normalized === 'active') return 'progress';
-  if (normalized.includes('close-out')) return 'review';
-  if (normalized === 'in review' || normalized === 'review' || normalized === 'verifying' || normalized === 'verifying on main') return 'review';
+  if (normalized.includes('close-out') || normalized === 'in review' || normalized === 'review' || normalized === 'verifying' || normalized === 'verifying on main') return 'review';
   if (normalized === 'has context') return 'context';
   if (normalized === 'planning') return 'planning';
   return 'todo';

--- a/src/dashboard/frontend/src/components/CommandDeck/__tests__/ProjectOverview.test.tsx
+++ b/src/dashboard/frontend/src/components/CommandDeck/__tests__/ProjectOverview.test.tsx
@@ -114,6 +114,10 @@ describe('bucketFeaturePhase', () => {
     expectPhase('verifying', { stateLabel: 'Verifying On Main' }, { mergeStatus: 'merged' });
   });
 
+  it('buckets merged work that needs close-out in the ship lane', () => {
+    expectPhase('ship', { stateLabel: 'Merged — Needs Close-Out' });
+  });
+
   it('buckets testing issues as tests', () => {
     expectPhase('review', {}, { testStatus: 'testing' });
   });

--- a/src/dashboard/frontend/src/components/IssueActionMenu/IssueActionMenu.test.tsx
+++ b/src/dashboard/frontend/src/components/IssueActionMenu/IssueActionMenu.test.tsx
@@ -103,6 +103,28 @@ describe('IssueActionMenu', () => {
     expect(screen.getByTestId('issue-action-startAgent')).toHaveTextContent('Start agent');
   });
 
+  it('enables Close out as the primary action for post-merge limbo membership', async () => {
+    mockStore({
+      currentIssue: issue({
+        status: 'In Progress',
+        state: 'in_progress',
+        pipelineMembership: {
+          available: true,
+          inPipeline: true,
+          bucket: 'post_merge_limbo',
+          labelDrift: null,
+        },
+      }),
+    });
+
+    renderMenu(<IssueActionMenu issueId="PAN-1" mode="primary-strip" />);
+
+    const closeOut = await screen.findByTestId('issue-action-closeOut');
+    expect(closeOut).toBeEnabled();
+    expect(closeOut).toHaveTextContent('Close out');
+    expect(screen.queryByTestId('issue-action-plan')).not.toBeInTheDocument();
+  });
+
   it('renders overflow-only as a single trigger with the action dropdown', () => {
     renderMenu(<IssueActionMenu issueId="PAN-1" mode="overflow-only" />);
 

--- a/src/dashboard/frontend/src/components/IssueActionMenu/useIssueActions.ts
+++ b/src/dashboard/frontend/src/components/IssueActionMenu/useIssueActions.ts
@@ -327,7 +327,7 @@ export function useIssueActions(issueId: string): UseIssueActionsResult {
       hasTranscripts: false,
       hasDiscussions: false,
       issueCanonicalState: issue?.state ?? STATUS_LABELS[issue?.status ?? ''] ?? issue?.status ?? null,
-      isMerged: reviewStatus?.mergeStatus === 'merged' || issue?.mergeStatus === 'merged',
+      isMerged: reviewStatus?.mergeStatus === 'merged' || issue?.mergeStatus === 'merged' || issue?.pipelineMembership?.bucket === 'post_merge_limbo',
       hasPr: Boolean(reviewStatus?.readyForMerge || reviewStatus?.prUrl),
       prUrl: reviewStatus?.prUrl ?? null,
       hasPendingInput: agent?.hasPendingQuestion === true,

--- a/src/dashboard/frontend/src/components/Pipeline/PipelineView.test.tsx
+++ b/src/dashboard/frontend/src/components/Pipeline/PipelineView.test.tsx
@@ -132,21 +132,21 @@ describe('PipelineView', () => {
     expect(container.querySelectorAll('[data-component="phase-header"]')).toHaveLength(6);
   });
 
-  it('keeps phase derivation unchanged when server membership is attached', () => {
+  it('renders available post-merge limbo membership in the ship lane', () => {
     useDashboardStore.setState({
       issuesRaw: [issue({
         identifier: 'PAN-10',
         title: 'Merged but still open',
         state: 'in_review',
-        pipelineMembership: { inPipeline: true, bucket: 'post_merge_limbo', labelDrift: null },
+        pipelineMembership: { available: true, inPipeline: true, bucket: 'post_merge_limbo', labelDrift: null },
       })],
       reviewStatusByIssueId: {},
       agentsById: {},
     } as Parameters<typeof useDashboardStore.setState>[0]);
 
     const { container } = renderPipelineView();
-    const reviewPhase = container.querySelector('[data-component="pipeline-phase"][data-phase="review"]') as HTMLElement;
-    expect(within(reviewPhase).getByText('Merged but still open')).toBeInTheDocument();
+    const shipPhase = container.querySelector('[data-component="pipeline-phase"][data-phase="ship"]') as HTMLElement;
+    expect(within(shipPhase).getByText('Merged but still open')).toBeInTheDocument();
   });
 
   it('excludes open clean-terminal issues before lane derivation and metric counting', () => {

--- a/src/dashboard/frontend/src/lib/pipeline-state.test.ts
+++ b/src/dashboard/frontend/src/lib/pipeline-state.test.ts
@@ -35,21 +35,24 @@ describe('Definition of Ready (PAN-1966)', () => {
     expect(getPipelineIssuePhase(backlogIssue())).toBe('todo');
   });
 
-  it('does not use server membership as a lane-assignment signal', () => {
-    const withoutMembership = backlogIssue();
-    const withMembership = backlogIssue({
-      pipelineMembership: { inPipeline: true, bucket: 'post_merge_limbo', labelDrift: null },
-    });
-    expect(getPipelineIssuePhase(withMembership)).toBe(getPipelineIssuePhase(withoutMembership));
-    expect(getPipelineIssuePhase(withMembership)).toBe('todo');
+  it('uses only available post-merge limbo membership as a lane-assignment override', () => {
+    expect(getPipelineIssuePhase(backlogIssue({
+      pipelineMembership: { available: true, inPipeline: true, bucket: 'post_merge_limbo', labelDrift: null },
+    }))).toBe('ship');
 
     const readyWithoutMembership = backlogIssue({ labels: ['ready'] });
-    const readyWithMembership = backlogIssue({
+    const readyWithCleanMembership = backlogIssue({
       labels: ['ready'],
-      pipelineMembership: { inPipeline: false, bucket: 'clean_terminal', labelDrift: 'stale_present' },
+      pipelineMembership: { available: true, inPipeline: false, bucket: 'clean_terminal', labelDrift: 'stale_present' },
     });
-    expect(getPipelineIssuePhase(readyWithMembership)).toBe(getPipelineIssuePhase(readyWithoutMembership));
-    expect(getPipelineIssuePhase(readyWithMembership)).toBe('ready');
+    expect(getPipelineIssuePhase(readyWithCleanMembership)).toBe(getPipelineIssuePhase(readyWithoutMembership));
+    expect(getPipelineIssuePhase(readyWithCleanMembership)).toBe('ready');
+
+    const unavailableMembership = backlogIssue({
+      pipelineMembership: { available: false, inPipeline: true, bucket: 'post_merge_limbo', labelDrift: null },
+    });
+    expect(getPipelineIssuePhase(unavailableMembership)).toBe(getPipelineIssuePhase(backlogIssue()));
+    expect(getPipelineIssuePhase(unavailableMembership)).toBe('todo');
   });
 
   it('preserves in-flight lane assignment when membership is attached', () => {

--- a/src/dashboard/frontend/src/lib/pipeline-state.ts
+++ b/src/dashboard/frontend/src/lib/pipeline-state.ts
@@ -134,6 +134,11 @@ export function getPipelineIssuePhase(
     return 'ship';
   }
 
+  // PAN-3341: the canonical post-merge verdict outranks a stale stored phase.
+  if (issue.pipelineMembership?.available === true && issue.pipelineMembership.bucket === 'post_merge_limbo') {
+    return 'ship';
+  }
+
   if (state === 'verifying_on_main') {
     return 'verifying';
   }

--- a/src/dashboard/server/services/resource-discovery.ts
+++ b/src/dashboard/server/services/resource-discovery.ts
@@ -202,8 +202,17 @@ function projectPrefixes(project: ProjectRef): string[] {
   return [...prefixes];
 }
 
-function deriveStateLabel(issue: MutableResourceIssue, hasTmux: boolean, hasFreshHeartbeat: boolean): string {
+function deriveStateLabel(
+  issue: MutableResourceIssue,
+  hasTmux: boolean,
+  hasFreshHeartbeat: boolean,
+  membership?: PipelineMembership,
+): string {
   const trackerState = issue.trackerState ?? '';
+  if (membership?.bucket === 'post_merge_limbo') return 'Merged — Needs Close-Out';
+  if (membership?.bucket === 'clean_terminal' && membership.lenses.L3_issueOpen === false) {
+    return hasTmux ? 'Closed' : 'Done';
+  }
   if (issue.readyForMerge) return 'In Review';
   if (trackerState === 'done' || trackerState === 'closed' || trackerState === 'canceled') {
     return hasTmux ? 'Closed' : 'Done';
@@ -746,7 +755,7 @@ async function computeResourceAllocatedIssues(
         const membership = memberships.get(issue.issueId);
         const hasTmux = issue.resourceDetails.tmuxSessions.length > 0;
         const hasRecentHeartbeat = hasRecentActivity(issue.lastActivity);
-        const stateLabel = deriveStateLabel(issue, hasTmux, hasRecentHeartbeat);
+        const stateLabel = deriveStateLabel(issue, hasTmux, hasRecentHeartbeat, membership);
         const isRemoteRunning = issue.resourceDetails.remoteAgent?.status === 'running'
           || issue.resourceDetails.remoteAgent?.status === 'starting';
         const status = (hasTmux && (issue.agentStatus === 'active' || hasRecentHeartbeat)) || isRemoteRunning

--- a/tests/unit/dashboard/server/services/resource-discovery.test.ts
+++ b/tests/unit/dashboard/server/services/resource-discovery.test.ts
@@ -466,6 +466,161 @@ describe('resource-discovery terminal issue filtering', () => {
   });
 });
 
+describe('resource-discovery membership-aware state labels', () => {
+  const project = {
+    name: 'overdeck',
+    path: '/tmp/overdeck',
+    issue_prefix: 'PAN',
+    github_repo: 'eltmon/overdeck',
+  };
+
+  it('labels post-merge limbo with stale PRD residue as needing close-out', async () => {
+    mocks.issueService.getIssues.mockReturnValue([
+      { identifier: 'PAN-3341', title: 'Merged work without cached tracker state' },
+    ]);
+    mocks.findDraftPrd.mockReturnValue(Effect.succeed({
+      path: '/state/drafts/PAN-3341.md',
+      format: 'pan-draft',
+      status: 'draft',
+    }));
+    mocks.getPipelineMembershipForProjects.mockResolvedValue([{
+      issueId: 'PAN-3341',
+      inPipeline: true,
+      bucket: 'post_merge_limbo',
+      reasons: ['merged but never closed out'],
+      labelDrift: null,
+      lenses: { L1_openPr: false, L2_unmergedBranch: false, L3_issueOpen: false, L4_phaseLabel: 'planning' },
+    }]);
+
+    await refreshResourceAllocatedProjects([project]);
+
+    await expect(getCachedResourceAllocatedIssues()).resolves.toEqual([
+      expect.objectContaining({
+        issueId: 'PAN-3341',
+        hasPrd: true,
+        stateLabel: 'Merged — Needs Close-Out',
+      }),
+    ]);
+  });
+
+  it('lets post-merge limbo outrank a stale ready-for-merge flag', async () => {
+    mocks.issueService.getIssues.mockReturnValue([
+      { identifier: 'PAN-3342', title: 'Merged work with stale review state', state: 'in_progress' },
+    ]);
+    mocks.listSessionNames.mockReturnValue(Effect.succeed(['agent-pan-3342']));
+    mocks.loadReadyForMergeFlags.mockReturnValue(new Map([['PAN-3342', true]]));
+    mocks.getPipelineMembershipForProjects.mockResolvedValue([{
+      issueId: 'PAN-3342',
+      inPipeline: true,
+      bucket: 'post_merge_limbo',
+      reasons: ['merged but never closed out'],
+      labelDrift: null,
+      lenses: { L1_openPr: false, L2_unmergedBranch: false, L3_issueOpen: false, L4_phaseLabel: 'in_review' },
+    }]);
+
+    await refreshResourceAllocatedProjects([project]);
+
+    await expect(getCachedResourceAllocatedIssues()).resolves.toEqual([
+      expect.objectContaining({
+        issueId: 'PAN-3342',
+        readyForMerge: true,
+        stateLabel: 'Merged — Needs Close-Out',
+      }),
+    ]);
+  });
+
+  it('labels tracker-closed clean-terminal residue without tmux as done', async () => {
+    mocks.issueService.getIssues.mockReturnValue([
+      { identifier: 'PAN-3343', title: 'Closed work with Docker residue', state: 'closed' },
+    ]);
+    mocks.execFile.mockImplementation((command: string, args: string[], _options: unknown, callback: (error: Error | null, result?: { stdout: string }) => void) => {
+      if (command === 'docker') {
+        callback(null, { stdout: 'overdeck-feature-pan-3343-server-1\n' });
+        return;
+      }
+      if (command === 'gh' && args[0] === 'pr') {
+        callback(null, { stdout: JSON.stringify(mocks.openPullRequests) });
+        return;
+      }
+      callback(null, { stdout: '' });
+    });
+    mocks.getPipelineMembershipForProjects.mockResolvedValue([{
+      issueId: 'PAN-3343',
+      inPipeline: false,
+      bucket: 'clean_terminal',
+      reasons: ['tracker closed and branch merged'],
+      labelDrift: null,
+      lenses: { L1_openPr: false, L2_unmergedBranch: false, L3_issueOpen: false, L4_phaseLabel: null },
+    }]);
+
+    await refreshResourceAllocatedProjects([project]);
+
+    await expect(getCachedResourceAllocatedIssues()).resolves.toEqual([
+      expect.objectContaining({ issueId: 'PAN-3343', stateLabel: 'Done' }),
+    ]);
+  });
+
+  it('labels tracker-closed clean-terminal residue with tmux as closed', async () => {
+    mocks.issueService.getIssues.mockReturnValue([
+      { identifier: 'PAN-3344', title: 'Closed work with a surviving session', state: 'closed' },
+    ]);
+    mocks.listSessionNames.mockReturnValue(Effect.succeed(['agent-pan-3344']));
+    mocks.getPipelineMembershipForProjects.mockResolvedValue([{
+      issueId: 'PAN-3344',
+      inPipeline: false,
+      bucket: 'clean_terminal',
+      reasons: ['tracker closed and branch merged'],
+      labelDrift: null,
+      lenses: { L1_openPr: false, L2_unmergedBranch: false, L3_issueOpen: false, L4_phaseLabel: null },
+    }]);
+
+    await refreshResourceAllocatedProjects([project]);
+
+    await expect(getCachedResourceAllocatedIssues()).resolves.toEqual([
+      expect.objectContaining({ issueId: 'PAN-3344', stateLabel: 'Closed' }),
+    ]);
+  });
+
+  it('does not label an open clean-terminal issue as done', async () => {
+    mocks.issueService.getIssues.mockReturnValue([
+      { identifier: 'PAN-3345', title: 'Open work without pipeline residue', state: 'open' },
+    ]);
+    mocks.listSessionNames.mockReturnValue(Effect.succeed(['agent-pan-3345']));
+    mocks.getPipelineMembershipForProjects.mockResolvedValue([{
+      issueId: 'PAN-3345',
+      inPipeline: false,
+      bucket: 'clean_terminal',
+      reasons: ['open issue never started'],
+      labelDrift: null,
+      lenses: { L1_openPr: false, L2_unmergedBranch: false, L3_issueOpen: true, L4_phaseLabel: null },
+    }]);
+
+    await refreshResourceAllocatedProjects([project]);
+
+    const issue = (await getCachedResourceAllocatedIssues())[0];
+    expect(issue).toMatchObject({ issueId: 'PAN-3345' });
+    expect(issue?.stateLabel).not.toBe('Done');
+  });
+
+  it('preserves artifact heuristics when membership is unavailable', async () => {
+    mocks.issueService.getIssues.mockReturnValue([
+      { identifier: 'PAN-3346', title: 'Planning work without membership' },
+    ]);
+    mocks.listSessionNames.mockReturnValue(Effect.succeed(['agent-pan-3346']));
+    mocks.findDraftPrd.mockReturnValue(Effect.succeed({
+      path: '/state/drafts/PAN-3346.md',
+      format: 'pan-draft',
+      status: 'draft',
+    }));
+
+    await refreshResourceAllocatedProjects([project], { refreshMembership: false });
+
+    await expect(getCachedResourceAllocatedIssues()).resolves.toEqual([
+      expect.objectContaining({ issueId: 'PAN-3346', stateLabel: 'Planning' }),
+    ]);
+  });
+});
+
 describe('resource-discovery planned backlog annotation', () => {
   it('marks only spec-lens planned backlog rows as spec-only planned', async () => {
     mocks.issueService.getIssues.mockReturnValue([


### PR DESCRIPTION
**Issue:** #3341

## Acceptance Criteria

- [ ] Make deriveStateLabel membership-aware: post_merge_limbo → 'Merged — Needs Close-Out', tracker-closed → Done/Closed
- [ ] Render 'Merged — Needs Close-Out' correctly in the Command Deck tree and ProjectOverview pipeline section
- [ ] getPipelineIssuePhase returns 'ship' for available post_merge_limbo membership; rewrite the two tests locking the old contract
- [ ] Enable the existing Close out action on post_merge_limbo rows via useIssueActions.isMerged
- [ ] Document the surface reconciliation contract in docs/PIPELINE-MEMBERSHIP.md