### PR TITLE
fix(dashboard): retire the waiting-for-answer banner when the agent is demonstrably working (PAN-3408)

### DIFF
--- a/src/lib/__tests__/compute-agent-enrichment.test.ts
+++ b/src/lib/__tests__/compute-agent-enrichment.test.ts
@@ -537,4 +537,21 @@ describe('computeAgentEnrichment blocking-prompt resolution', () => {
     expect(e.pendingInputKinds).toEqual([])
     rmSync(dir, { recursive: true, force: true })
   })
+
+  it('retires a stale needs_input fallback once the agent resumes tool activity', async () => {
+    const agentId = 'agent-pan-3367'
+    const dir = arrange(agentId)
+    getAgentRuntimeStateMock.mockReturnValue(
+      Effect.succeed({ state: 'active', resolution: 'needs_input', resolutionCount: 8 }),
+    )
+    detectAwaitingInputForAgentMock.mockReturnValue(Effect.succeed(null))
+
+    const e = await Effect.runPromise(computeAgentEnrichment(agentId, undefined, false, EMPTY_PENDING_INPUTS_SCAN))
+
+    expect(e.hasPendingQuestion).toBe(false)
+    expect(e.pendingQuestionPrompt).toBeUndefined()
+    expect(e.pendingInputKinds).toEqual([])
+    expect(e.resolution).toBe('needs_input')
+    rmSync(dir, { recursive: true, force: true })
+  })
 })

--- a/src/lib/agent-enrichment.ts
+++ b/src/lib/agent-enrichment.ts
@@ -650,12 +650,16 @@ async function getAgentJsonlMtimePromise(agentId: string): Promise<number | null
     ? await Effect.runPromise(detectAwaitingInputForAgent(agentId, { isPlanning }))
     : null
 
-  const fallbackDetection: AwaitingInputDetection | null = runtimeState?.resolution === 'needs_input'
-    ? {
-        reason: 'other',
-        prompt: normalizeAwaitingInputPrompt('Agent stopped because it needs human input or hit a blocker'),
-      }
-    : null
+  // Resolution is a stop-hook verdict and can outlive the stop that produced it.
+  // Once tool activity resumes, the current activity is stronger evidence: do
+  // not keep projecting the old needs_input verdict as an actionable decision.
+  const fallbackDetection: AwaitingInputDetection | null =
+    runtimeState?.resolution === 'needs_input' && runtimeState.state !== 'active'
+      ? {
+          reason: 'other',
+          prompt: normalizeAwaitingInputPrompt('Agent stopped because it needs human input or hit a blocker'),
+        }
+      : null
 
   // An interactive session does not finish — it yields the turn. The Stop hook
   // reports that as `activity: idle`, which until now carried no operator


### PR DESCRIPTION
Strike for PAN-3408 (operator-reported): the 'agent is waiting for your answer' banner persisted on an actively-working agent with no pending decision.

The banner now derives from current liveness + an actually-unanswered decision instead of a sticky turn-end state.

Landing note: typecheck, lint, and the focused regression pass locally; the full local suite hit 34 unrelated setup timeouts under load ~30 (PAN-3344) — CI is the authoritative gate per standing flywheel decision.

Closes PAN-3408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhNVZuskT1Xw9qmw65g5dq