### PR TITLE
fix(dashboard): cockpit Terminal toggle must always render a visible state (PAN-3407)

### DIFF
--- a/src/dashboard/frontend/src/components/Stage/cockpit/IssueMissionControl.test.tsx
+++ b/src/dashboard/frontend/src/components/Stage/cockpit/IssueMissionControl.test.tsx
@@ -5,10 +5,17 @@ import type { PaneType } from '../../../lib/panesStore'
 import { useDashboardStore } from '../../../lib/store'
 
 const actionInvoke = vi.fn()
+const originalScrollIntoView = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollIntoView')
+let scrollIntoView: ReturnType<typeof vi.fn>
 let queryClient: QueryClient | undefined
 let unexpectedRequests: string[] = []
 
 beforeEach(() => {
+  scrollIntoView = vi.fn()
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: scrollIntoView,
+  })
   window.localStorage.clear()
   window.history.replaceState(null, '', '/')
   actionInvoke.mockClear()
@@ -100,6 +107,11 @@ afterEach(async () => {
   queryClient?.clear()
   queryClient = undefined
   const requests = unexpectedRequests
+  if (originalScrollIntoView) {
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', originalScrollIntoView)
+  } else {
+    Reflect.deleteProperty(HTMLElement.prototype, 'scrollIntoView')
+  }
   vi.unstubAllGlobals()
   expect(requests).toEqual([])
 })
@@ -506,7 +518,7 @@ describe('IssueMissionControl', () => {
     expect(screen.getByTestId('issue-detail-page-mock')).toHaveAttribute('data-tab', 'conversation')
   })
 
-  it('switches Conversation and Terminal inside Session without leaving the top-level tab', () => {
+  it('switches Conversation and Terminal inside Session and reveals the terminal body', async () => {
     const { container } = renderMissionControl()
     const sessionViews = screen.getByRole('tablist', { name: 'Session views' })
     const conversation = within(sessionViews).getByRole('tab', { name: 'Conversation' })
@@ -514,6 +526,7 @@ describe('IssueMissionControl', () => {
 
     expect(conversation).toHaveAttribute('aria-selected', 'true')
     expect(screen.getByTestId('issue-detail-page-mock')).toHaveAttribute('data-tab', 'conversation')
+    expect(scrollIntoView).not.toHaveBeenCalled()
 
     fireEvent.click(terminal)
 
@@ -521,6 +534,7 @@ describe('IssueMissionControl', () => {
     expect(container.querySelector('main')).toHaveAttribute('data-active-subview', 'terminal')
     expect(screen.getByTestId('issue-detail-page-mock')).toHaveAttribute('data-tab', 'terminal')
     expect(terminal).toHaveAttribute('aria-selected', 'true')
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalledWith({ block: 'start', inline: 'nearest' }))
   })
 
   it('shows a blue live signal and leaves composer ownership with IssueDetail', () => {

--- a/src/dashboard/frontend/src/components/Stage/cockpit/IssueMissionControl.tsx
+++ b/src/dashboard/frontend/src/components/Stage/cockpit/IssueMissionControl.tsx
@@ -447,6 +447,7 @@ export function IssueMissionControl({ issueId, title, branch, projectName, launc
     routeSelection?.subView ?? DEFAULT_SUB_VIEW[initialTab],
   )
   const tabSelectionLocked = useRef(Boolean(routeSelection) || issueAgents.length > 0)
+  const sessionContentRef = useRef<HTMLDivElement>(null)
   const [treeContext, setTreeContext] = useState<IssueTreeContext | null>(null)
   const [selectedTreeSession, setSelectedTreeSession] = useState<SessionNode | null>(null)
   const [treeSessions, setTreeSessions] = useState<readonly SessionNode[]>([])
@@ -527,6 +528,14 @@ export function IssueMissionControl({ issueId, title, branch, projectName, launc
   const trackerHref = trackerIssueUrl(issueId, issueRecord?.url)
   const createPrHref = pr.data?.pr ? null : githubCompareUrl(trackerHref, branch)
   const issueDetailTab = issueDetailTabFor(activeTab, activeSubView)
+
+  useEffect(() => {
+    if (activeTab !== 'session' || activeSubView !== 'terminal') return
+    // At narrow pane widths the crew lane stacks above Session. The Terminal
+    // panel still mounts and opens its WebSocket, but can land below the
+    // scrollable pane's viewport, making the selected toggle look like a no-op.
+    sessionContentRef.current?.scrollIntoView?.({ block: 'start', inline: 'nearest' })
+  }, [activeSubView, activeTab])
 
   useEffect(() => {
     if (tabSelectionLocked.current || issueAgents.length === 0) return
@@ -799,6 +808,7 @@ export function IssueMissionControl({ issueId, title, branch, projectName, launc
                 preserving the ONE IssueDetail page-density renderer. */}
             {issueDetailTab && (
               <div
+                ref={sessionContentRef}
                 data-section="Session tab"
                 className={`h-[calc(100vh-340px)] min-h-[520px] ${activeTab === 'session' ? 'flex flex-col' : ''}`}
               >

--- a/src/dashboard/frontend/src/components/Stage/cockpit/IssueMissionControl.tsx
+++ b/src/dashboard/frontend/src/components/Stage/cockpit/IssueMissionControl.tsx
@@ -528,15 +528,9 @@ export function IssueMissionControl({ issueId, title, branch, projectName, launc
   const trackerHref = trackerIssueUrl(issueId, issueRecord?.url)
   const createPrHref = pr.data?.pr ? null : githubCompareUrl(trackerHref, branch)
   const issueDetailTab = issueDetailTabFor(activeTab, activeSubView)
-
   useEffect(() => {
-    if (activeTab !== 'session' || activeSubView !== 'terminal') return
-    // At narrow pane widths the crew lane stacks above Session. The Terminal
-    // panel still mounts and opens its WebSocket, but can land below the
-    // scrollable pane's viewport, making the selected toggle look like a no-op.
-    sessionContentRef.current?.scrollIntoView?.({ block: 'start', inline: 'nearest' })
+    if (activeTab === 'session' && activeSubView === 'terminal') sessionContentRef.current?.scrollIntoView?.({ block: 'start', inline: 'nearest' })
   }, [activeSubView, activeTab])
-
   useEffect(() => {
     if (tabSelectionLocked.current || issueAgents.length === 0) return
     tabSelectionLocked.current = true
@@ -807,11 +801,7 @@ export function IssueMissionControl({ issueId, title, branch, projectName, launc
             {/* The six cockpit tabs fold the legacy surfaces into sub-views while
                 preserving the ONE IssueDetail page-density renderer. */}
             {issueDetailTab && (
-              <div
-                ref={sessionContentRef}
-                data-section="Session tab"
-                className={`h-[calc(100vh-340px)] min-h-[520px] ${activeTab === 'session' ? 'flex flex-col' : ''}`}
-              >
+              <div ref={sessionContentRef} data-section="Session tab" className={`h-[calc(100vh-340px)] min-h-[520px] ${activeTab === 'session' ? 'flex flex-col' : ''}`}>
                 {activeTab === 'session' ? (
                   <div
                     role="tablist"


### PR DESCRIPTION
Strike for PAN-3407 (operator-reported): clicking Terminal on an issue cockpit did nothing while the agent's tmux session was verifiably alive.

Landing note: typecheck + lint green; focused regression and every full-suite failure pass in isolation; full-suite failures are the unrelated 5s setup timeouts under host load (PAN-3344, 5th strike affected today). CI is the authoritative gate per standing flywheel decision.

Closes PAN-3407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhNVZuskT1Xw9qmw65g5dq