### PR TITLE
fix(delivery): composer text submits reliably — tighten blocking-menu detection (PAN-3422)

### DIFF
--- a/src/lib/channels/__tests__/injection-budget.test.ts
+++ b/src/lib/channels/__tests__/injection-budget.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   INPUT_ECHO_CONFIRM_ATTEMPTS,
   INPUT_PURGE_MAX_CHARS,
+  INPUT_SUBMIT_CONFIRM_ATTEMPTS,
+  INPUT_SUBMIT_CONFIRM_INTERVAL_MS,
   SUPERVISOR_CLIENT_MARGIN_MS,
   echoConfirmTimeoutMs,
   inputSettleMs,
@@ -19,7 +21,9 @@ describe('injection budget', () => {
 
   it('preserves the documented floors', () => {
     expect(echoConfirmTimeoutMs(1_024)).toBe(2_600);
-    expect(supervisorInjectionBudgetMs(0)).toBe(2 * 2_500 + 2 * 150 + 300 + 3_000);
+    expect(supervisorInjectionBudgetMs(0)).toBe(
+      2 * 2_500 + 2 * 150 + 300 + 2 * 500 + 150 + 3_000,
+    );
   });
 
   it('caps each payload-scaled wait for a 10 MB payload', () => {
@@ -28,7 +32,7 @@ describe('injection budget', () => {
     expect(echoConfirmTimeoutMs(tenMb)).toBe(15_000);
     expect(inputSettleMs(tenMb)).toBe(2_000);
     expect(purgeSettleMs(tenMb)).toBe(1_000);
-    expect(supervisorInjectionBudgetMs(tenMb)).toBe(37_000);
+    expect(supervisorInjectionBudgetMs(tenMb)).toBe(39_000);
   });
 
   it.each([0, 8 * 1_024, 30 * 1_024, 1_024 * 1_024])(
@@ -38,7 +42,9 @@ describe('injection budget', () => {
       const internalWaitSum =
         INPUT_ECHO_CONFIRM_ATTEMPTS * echoConfirmTimeoutMs(length) +
         INPUT_ECHO_CONFIRM_ATTEMPTS * purgeSettleMs(erased) +
-        inputSettleMs(length);
+        inputSettleMs(length) +
+        INPUT_SUBMIT_CONFIRM_ATTEMPTS * INPUT_SUBMIT_CONFIRM_INTERVAL_MS +
+        purgeSettleMs(erased);
       const clientTimeout = supervisorInjectionBudgetMs(length) + SUPERVISOR_CLIENT_MARGIN_MS;
 
       expect(clientTimeout).toBeGreaterThan(internalWaitSum);

--- a/src/lib/channels/__tests__/pty-supervisor.test.ts
+++ b/src/lib/channels/__tests__/pty-supervisor.test.ts
@@ -7,7 +7,12 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PTY_TOKEN_HEADER, writePtyToken } from '../../pty-token.js';
 import { createPtySupervisorServer, createSocketWriteLogQueue, injectPtyMessage } from '../pty-supervisor.js';
-import { INPUT_PURGE_MAX_CHARS, echoConfirmTimeoutMs, purgeSettleMs } from '../injection-budget.js';
+import {
+  INPUT_PURGE_MAX_CHARS,
+  INPUT_SUBMIT_CONFIRM_INTERVAL_MS,
+  echoConfirmTimeoutMs,
+  purgeSettleMs,
+} from '../injection-budget.js';
 
 const REPO_ROOT = process.cwd();
 const SUPERVISOR_ENTRY = join(REPO_ROOT, 'dist/pty-supervisor.js');
@@ -205,6 +210,53 @@ describe.skipIf(isBun)('injectPtyMessage', () => {
 
     await expect(delivered).resolves.toBeUndefined();
     expect(fake.writes).toEqual(['hello   world', '\r']);
+  });
+
+  it('retries Enter when the payload remains in the active composer', async () => {
+    vi.useFakeTimers();
+    const fake = createFakePty();
+    const readPayloadPresence = vi.fn()
+      .mockResolvedValueOnce('present')
+      .mockResolvedValueOnce('absent');
+
+    const delivered = injectPtyMessage(
+      fake.child,
+      'agent-unit-submit-retry',
+      { content: 'retry dropped Enter', echo: false },
+      { readPayloadPresence },
+    );
+    fake.emit('retry dropped Enter');
+    await vi.advanceTimersByTimeAsync(400);
+    expect(fake.writes).toEqual(['retry dropped Enter', '\r']);
+
+    await vi.advanceTimersByTimeAsync(INPUT_SUBMIT_CONFIRM_INTERVAL_MS);
+    expect(fake.writes).toEqual(['retry dropped Enter', '\r', '\r']);
+    await vi.advanceTimersByTimeAsync(INPUT_SUBMIT_CONFIRM_INTERVAL_MS);
+
+    await expect(delivered).resolves.toBeUndefined();
+    expect(readPayloadPresence).toHaveBeenCalledTimes(2);
+  });
+
+  it('purges a payload that survives every Enter before allowing fallback', async () => {
+    vi.useFakeTimers();
+    const fake = createFakePty();
+    const content = 'persistently stranded payload';
+    const purge = '\x7f'.repeat(content.length + 8);
+
+    const delivered = injectPtyMessage(
+      fake.child,
+      'agent-unit-submit-failed',
+      { content, echo: false },
+      { readPayloadPresence: () => Promise.resolve('present') },
+    );
+    const rejected = expect(delivered).rejects.toThrow(/submit confirmation failed/);
+    fake.emit(content);
+    await vi.advanceTimersByTimeAsync(
+      400 + (2 * INPUT_SUBMIT_CONFIRM_INTERVAL_MS) + purgeSettleMs(content.length + 8),
+    );
+
+    await rejected;
+    expect(fake.writes).toEqual([content, '\r', '\r', purge]);
   });
 
   it('purges between retries and before rejecting so unconfirmed writes never stack', async () => {

--- a/src/lib/channels/injection-budget.ts
+++ b/src/lib/channels/injection-budget.ts
@@ -12,6 +12,8 @@
 export const INPUT_ECHO_CONFIRM_INTERVAL_MS = 50;
 export const INPUT_ECHO_CONFIRM_ATTEMPTS = 2;
 export const INPUT_ECHO_CONFIRM_PREFIX_CHARS = 40;
+export const INPUT_SUBMIT_CONFIRM_ATTEMPTS = 2;
+export const INPUT_SUBMIT_CONFIRM_INTERVAL_MS = 500;
 export const INPUT_PURGE_MAX_CHARS = 262_144;
 export const SUPERVISOR_CLIENT_MARGIN_MS = 2_000;
 const INJECTION_OVERHEAD_MS = 3_000; // PTY writes, log appends, scheduler slack
@@ -38,6 +40,8 @@ export function supervisorInjectionBudgetMs(contentLength: number): number {
     INPUT_ECHO_CONFIRM_ATTEMPTS * echoConfirmTimeoutMs(contentLength) +
     INPUT_ECHO_CONFIRM_ATTEMPTS * purgeSettleMs(clamped) +
     inputSettleMs(contentLength) +
+    INPUT_SUBMIT_CONFIRM_ATTEMPTS * INPUT_SUBMIT_CONFIRM_INTERVAL_MS +
+    purgeSettleMs(clamped) +
     INJECTION_OVERHEAD_MS
   );
 }

--- a/src/lib/channels/pty-supervisor.ts
+++ b/src/lib/channels/pty-supervisor.ts
@@ -13,26 +13,37 @@
  * passed through unchanged. The supervisor proxies stdin/stdout/resize between
  * tmux and Claude, and listens on `${OVERDECK_HOME}/sockets/pty-<agentId>.sock`
  * for authenticated HTTP-on-unix POSTs. Socket-injected messages echo to stdout
- * by default so the tmux transcript shows what Cloister sent. Accepted payloads
- * never exceed the shared purge cap, preserving the invariant that an
- * unconfirmed write is fully erased before retry. Permission relay
+ * by default so the tmux transcript shows what Cloister sent. After Enter, the
+ * supervisor checks the cursor-anchored composer and retries once when the
+ * payload is still present. Accepted payloads never exceed the shared purge cap,
+ * preserving the invariant that an unconfirmed write is fully erased before
+ * retry or fallback. Permission relay
  * is intentionally out of scope; existing Channels MCP remains the bidirectional
  * permission path for agents that opt into it.
  */
 
 import * as pty from '@lydell/node-pty';
+import { execFile } from 'node:child_process';
 import { timingSafeEqual } from 'node:crypto';
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { existsSync } from 'node:fs';
 import { appendFile, chmod, mkdir, unlink } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 import { join } from 'node:path';
+import { promisify } from 'node:util';
 import { getOverdeckHome } from '../paths.js';
+import {
+  activeComposerPayloadPresence,
+  type ComposerPayloadPresence,
+  type PaneViewport,
+} from '../pane-composer.js';
 import { PTY_TOKEN_HEADER, readPtyToken } from '../pty-token.js';
 import {
   INPUT_ECHO_CONFIRM_INTERVAL_MS,
   INPUT_ECHO_CONFIRM_ATTEMPTS,
   INPUT_ECHO_CONFIRM_PREFIX_CHARS,
+  INPUT_SUBMIT_CONFIRM_ATTEMPTS,
+  INPUT_SUBMIT_CONFIRM_INTERVAL_MS,
   echoConfirmTimeoutMs,
   inputSettleMs,
   INPUT_PURGE_MAX_CHARS,
@@ -43,6 +54,7 @@ const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
 const SHUTDOWN_GRACE_MS = 2_000;
 const MAX_REQUEST_BYTES = 1024 * 1024;
+const execFileAsync = promisify(execFile);
 
 export interface PtySupervisorPayload {
   content: string;
@@ -325,10 +337,36 @@ async function purgePtyInput(child: pty.IPty, charCount: number): Promise<void> 
   await sleep(purgeSettleMs(count));
 }
 
+async function captureHostPaneViewport(): Promise<PaneViewport> {
+  const hostTmux = process.env.OVERDECK_HOST_TMUX;
+  const hostPane = process.env.OVERDECK_HOST_TMUX_PANE;
+  if (!hostTmux || !hostPane) throw new Error('host tmux pane is unavailable');
+  const options = {
+    encoding: 'utf8' as const,
+    env: { ...process.env, TMUX: hostTmux },
+  };
+  const [pane, cursor] = await Promise.all([
+    execFileAsync('tmux', ['capture-pane', '-p', '-t', hostPane], options),
+    execFileAsync('tmux', ['display-message', '-p', '-t', hostPane, '#{cursor_y}'], options),
+  ]);
+  const cursorY = Number.parseInt(cursor.stdout.trim(), 10);
+  if (!Number.isInteger(cursorY)) throw new Error('host tmux cursor row is unreadable');
+  return { text: pane.stdout, cursorY };
+}
+
+async function readHostComposerPayloadPresence(content: string): Promise<ComposerPayloadPresence> {
+  return activeComposerPayloadPresence(await captureHostPaneViewport(), content);
+}
+
+export interface InjectPtyMessageDeps {
+  readPayloadPresence?: (content: string) => Promise<ComposerPayloadPresence>;
+}
+
 export async function injectPtyMessage(
   child: pty.IPty,
   agentId: string,
   payload: PtySupervisorPayload,
+  deps: InjectPtyMessageDeps = {},
 ): Promise<void> {
   // Claude Code's TUI distinguishes "pasted text" from "Submit keystroke" by
   // whether bytes arrive in the same PTY read. Writing content + `\r`
@@ -377,6 +415,29 @@ export async function injectPtyMessage(
 
     await sleep(inputSettleMs(trimmed.length));
     child.write('\r');
+
+    if (deps.readPayloadPresence) {
+      for (let attempt = 1; attempt <= INPUT_SUBMIT_CONFIRM_ATTEMPTS; attempt++) {
+        await sleep(INPUT_SUBMIT_CONFIRM_INTERVAL_MS);
+        const presence = await deps.readPayloadPresence(trimmed).catch(() => 'unproven' as const);
+        if (presence !== 'present') break;
+        if (attempt < INPUT_SUBMIT_CONFIRM_ATTEMPTS) {
+          console.warn(
+            `[pty-supervisor] Submitted text is still in ${agentId}'s active composer; ` +
+            `sending standalone Enter again (${attempt}/${INPUT_SUBMIT_CONFIRM_ATTEMPTS - 1}).`,
+          );
+          child.write('\r');
+          continue;
+        }
+
+        // The payload is positively still in the cursor-anchored composer after
+        // every Enter attempt. Erase it before returning 502 so auto delivery may
+        // safely fall back to tmux without stacking a duplicate copy.
+        await purgePtyInput(child, trimmed.length);
+        throw new Error(`submit confirmation failed after ${INPUT_SUBMIT_CONFIRM_ATTEMPTS} Enter attempts`);
+      }
+    }
+
     if (payload.echo !== false) {
       process.stdout.write(trimmed.endsWith('\n') ? trimmed : `${trimmed}\n`);
     }
@@ -389,7 +450,11 @@ export async function injectPtyMessage(
   }
 }
 
-export function createPtySupervisorServer(agentId: string, child: pty.IPty): Server {
+export function createPtySupervisorServer(
+  agentId: string,
+  child: pty.IPty,
+  deps: InjectPtyMessageDeps = {},
+): Server {
   // Per-server dedup memory. A supervisor exit kills the agent with it (H1),
   // so this never needs to survive the supervisor itself — only the
   // dashboard, whose crash between the supervisor's injection and the
@@ -462,7 +527,7 @@ export function createPtySupervisorServer(agentId: string, child: pty.IPty): Ser
       inFlightDedupKeys.set(key, { promise, settle });
 
       try {
-        await injectPtyMessage(child, agentId, payload);
+        await injectPtyMessage(child, agentId, payload, deps);
         // Completed only after a confirmed injection, inside the
         // supervisor's own crash boundary — the dashboard cannot interrupt
         // this ordering.
@@ -481,7 +546,7 @@ export function createPtySupervisorServer(agentId: string, child: pty.IPty): Ser
     }
 
     try {
-      await injectPtyMessage(child, agentId, payload);
+      await injectPtyMessage(child, agentId, payload, deps);
       writeJson(res, 200, 'ok');
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -585,7 +650,9 @@ async function main(): Promise<void> {
   proxyResizeToPty(child);
 
   const socketPath = getPtySupervisorSocketPath(agentId);
-  const server = createPtySupervisorServer(agentId, child);
+  const server = createPtySupervisorServer(agentId, child, {
+    readPayloadPresence: readHostComposerPayloadPresence,
+  });
   let shuttingDown = false;
 
   const childExited = new Promise<{ exitCode: number; signal?: number }>((resolve) => {

--- a/src/lib/pane-composer.ts
+++ b/src/lib/pane-composer.ts
@@ -1,0 +1,48 @@
+const PANE_ANSI_PATTERN = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
+const COMPOSER_TOP_BOUNDARY = /^\s*[─━═]{6,}/;
+
+export interface PaneViewport {
+  text: string;
+  cursorY: number;
+}
+
+export type ComposerPayloadPresence = 'present' | 'absent' | 'unproven';
+
+export function deliveryVerifyLine(content: string): string {
+  const lines = content.split('\n');
+  return ([...lines].reverse().find(line => line.trim().length >= 3) ?? lines[lines.length - 1])?.trim() ?? '';
+}
+
+function activeComposerRegion(viewport: PaneViewport): string | null {
+  const lines = viewport.text
+    .replace(PANE_ANSI_PATTERN, '')
+    .split('\n')
+    .map(line => line.replace(/\s+$/g, ''));
+  if (lines.every(line => line.trim() === '')) return null;
+  if (viewport.cursorY < 0 || viewport.cursorY >= lines.length) return null;
+
+  let start = viewport.cursorY;
+  for (let index = viewport.cursorY; index >= 0; index -= 1) {
+    if (COMPOSER_TOP_BOUNDARY.test(lines[index]!)) {
+      start = index + 1;
+      break;
+    }
+  }
+  return lines.slice(start, viewport.cursorY + 1).join('\n');
+}
+
+/**
+ * Prove whether a delivered payload is still in the cursor-anchored active
+ * composer. Matching only that region avoids mistaking old transcript output
+ * for pending input after the message has already submitted.
+ */
+export function activeComposerPayloadPresence(
+  viewport: PaneViewport,
+  content: string,
+): ComposerPayloadPresence {
+  const verify = deliveryVerifyLine(content);
+  if (verify.length < 3) return 'unproven';
+  const composer = activeComposerRegion(viewport);
+  if (composer === null) return 'unproven';
+  return composer.includes(verify.slice(0, 40)) ? 'present' : 'absent';
+}

--- a/src/lib/tmux-dedup.ts
+++ b/src/lib/tmux-dedup.ts
@@ -41,9 +41,14 @@ import { randomUUID } from 'node:crypto';
 import { unlink, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { capturePaneText, deliveryVerifyLine, tmuxExecAsync, validateSessionName } from './tmux.js';
+import { capturePaneText, tmuxExecAsync, validateSessionName } from './tmux.js';
 import { MessageDeliveryFailed } from './errors.js';
 import { paneHasBlockingChoiceMenu } from './pane-choice-menu.js';
+import {
+  activeComposerPayloadPresence,
+  type ComposerPayloadPresence,
+  type PaneViewport,
+} from './pane-composer.js';
 
 export const DEDUP_KEY_RE = /^[A-Za-z0-9:_-]+$/;
 
@@ -216,13 +221,6 @@ async function readPendingPayloadState(
   throw new KeyedMarkerVerificationError(sessionName, `${context} payload-state is ${detail} (key "${dedupKey}")`);
 }
 
-type PayloadPresence = 'present' | 'absent' | 'unproven';
-
-interface PaneViewport {
-  text: string;
-  cursorY: number;
-}
-
 async function captureVisiblePane(sessionName: string): Promise<PaneViewport> {
   const [pane, cursor] = await Promise.all([
     tmuxExecAsync(['capture-pane', '-t', sessionName, '-p'], { encoding: 'utf-8' }),
@@ -233,44 +231,16 @@ async function captureVisiblePane(sessionName: string): Promise<PaneViewport> {
   return { text: String(pane.stdout), cursorY };
 }
 
-const PANE_ANSI_PATTERN = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
-const COMPOSER_TOP_BOUNDARY = /^\s*[─━═]{6,}/;
-
-function activeComposerRegion(viewport: PaneViewport): string | null {
-  const lines = viewport.text
-    .replace(PANE_ANSI_PATTERN, '')
-    .split('\n')
-    .map(line => line.replace(/\s+$/g, ''));
-  if (lines.every(line => line.trim() === '')) return null;
-  if (viewport.cursorY < 0 || viewport.cursorY >= lines.length) return null;
-
-  let start = viewport.cursorY;
-  for (let index = viewport.cursorY; index >= 0; index -= 1) {
-    if (COMPOSER_TOP_BOUNDARY.test(lines[index]!)) {
-      start = index + 1;
-      break;
-    }
-  }
-  return lines.slice(start, viewport.cursorY + 1).join('\n');
-}
-
 async function pendingPayloadPresence(
   sessionName: string,
   keys: string,
   readViewport: (sessionName: string) => Promise<PaneViewport>,
-): Promise<PayloadPresence> {
-  const verifyLine = deliveryVerifyLine(keys);
-  if (verifyLine.length < 3) return 'unproven';
-
-  let viewport: PaneViewport;
+): Promise<ComposerPayloadPresence> {
   try {
-    viewport = await readViewport(sessionName);
+    return activeComposerPayloadPresence(await readViewport(sessionName), keys);
   } catch {
     return 'unproven';
   }
-  const composer = activeComposerRegion(viewport);
-  if (composer === null) return 'unproven';
-  return composer.includes(verifyLine.slice(0, 40)) ? 'present' : 'absent';
 }
 
 /**

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -15,8 +15,10 @@ export { MessageDeliveryFailed } from './errors.js';
 import { getUiTheme, TERMINAL_BG } from './ui-theme.js';
 import { paneTreeHasHarnessProcess } from './tmux-process-tree.js';
 import { paneHasBlockingChoiceMenu } from './pane-choice-menu.js';
+import { deliveryVerifyLine } from './pane-composer.js';
 
 export { paneTreeHasHarnessProcess } from './tmux-process-tree.js';
+export { deliveryVerifyLine } from './pane-composer.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -1145,7 +1147,6 @@ export async function sendEscapeKeyAsync(sessionName: string, times = 1): Promis
   }
 }
 
-export function deliveryVerifyLine(content: string): string { const lines = content.split('\n'); return ([...lines].reverse().find(line => line.trim().length >= 3) ?? lines[lines.length - 1])?.trim() ?? ''; }
 export const sendKeys = (
   sessionName: string,
   keys: string,

--- a/tests/lib/pane-composer.test.ts
+++ b/tests/lib/pane-composer.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { activeComposerPayloadPresence } from '../../src/lib/pane-composer.js';
+
+describe('activeComposerPayloadPresence', () => {
+  it('finds a delivered payload at the cursor-anchored composer', () => {
+    const viewport = {
+      text: [
+        'older terminal output',
+        '───────────────────────────── agent-pan-3422 ──',
+        '❯ verification feedback is waiting here',
+        'usage 21% · cost $25.00',
+      ].join('\n'),
+      cursorY: 2,
+    };
+
+    expect(activeComposerPayloadPresence(viewport, 'verification feedback is waiting here'))
+      .toBe('present');
+  });
+
+  it('does not mistake submitted transcript output above an empty composer for pending input', () => {
+    const viewport = {
+      text: [
+        'verification feedback is waiting here',
+        'older terminal output',
+        '───────────────────────────── agent-pan-3422 ──',
+        '❯ ',
+        'usage 21% · cost $25.00',
+      ].join('\n'),
+      cursorY: 3,
+    };
+
+    expect(activeComposerPayloadPresence(viewport, 'verification feedback is waiting here'))
+      .toBe('absent');
+  });
+});


### PR DESCRIPTION
Strike for PAN-3422: nudge/feedback text landed in agent composers but was never submitted — 4 MYN agents wedged idle 20m-2.5h with visible unsubmitted text.

Root cause per the strike's investigation: the PTY supervisor delivery path did not verify Enter submission — text could land in the composer with the submit keystroke unconfirmed. Fix verifies supervisor Enter submission with a confirmation budget (tests included).

Landing note: fix committed; the agent was governor-paused mid-gates during the 17:00Z memory emergency (PSI 41.9) — landing via CI per standing decision rather than re-running the local suite.

Closes PAN-3422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhNVZuskT1Xw9qmw65g5dq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message submission reliability by confirming whether content remains in the active input area.
  * Automatically retries submission when needed and safely clears persistent content after repeated failures.
  * Improved detection of submitted content across terminal views, including handling of formatting sequences and ambiguous states.

* **Tests**
  * Added coverage for submission retries, persistent-content cleanup, payload detection, and updated timing budgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->