### PR TITLE
fix(supervisor): survive stale deployment cwd — stop serial dashboard evictions after reboot (PAN-3436)

### DIFF
--- a/src/lib/supervisor.ts
+++ b/src/lib/supervisor.ts
@@ -19,6 +19,7 @@ import { Effect } from 'effect';
 import { LOGS_DIR, OVERDECK_HOME, packageRoot } from './paths.js';
 import { readPlatformConfigSync } from './platform-lifecycle.js';
 import { ProcessSpawnError } from './errors.js';
+import { readActiveDashboardBundleSync } from './deploy/active-dashboard-bundle.js';
 
 const SUPERVISOR_PID_PATH = join(OVERDECK_HOME, 'supervisor.pid');
 const SUPERVISOR_LOG_PATH = join(LOGS_DIR, 'supervisor.log');
@@ -66,6 +67,10 @@ export function isSupervisorRunningSync(): boolean {
   return pid !== null && isProcessAlive(pid);
 }
 
+export function resolveSupervisorPrimaryRepoRoot(): string {
+  return readActiveDashboardBundleSync()?.repoRoot ?? packageRoot;
+}
+
 export function resolveSupervisorBundle(): string {
   // Always the built bundle (dist/supervisor/server.js) so import resolution
   // works under Node 22. Resolve from packageRoot — robust across every
@@ -110,6 +115,7 @@ export function startSupervisorProcessSync(): void {
 
   const port = getSupervisorPortSync();
   const child = spawn(process.execPath, [bundle], {
+    cwd: resolveSupervisorPrimaryRepoRoot(),
     detached: true,
     stdio: ['ignore', logFd, logFd],
     env: {

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -3,8 +3,8 @@ import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { access, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { promisify } from 'node:util';
-import { OVERDECK_HOME, packageRoot } from './paths.js';
-import { getSupervisorPortSync, resolveSupervisorBundle } from './supervisor.js';
+import { OVERDECK_HOME } from './paths.js';
+import { getSupervisorPortSync, resolveSupervisorBundle, resolveSupervisorPrimaryRepoRoot } from './supervisor.js';
 
 const execAsync = promisify(exec);
 
@@ -64,7 +64,7 @@ export function renderSupervisorUnit(options: RenderSupervisorUnitOptions = {}):
   const nodePath = options.nodePath ?? process.execPath;
   const supervisorBundle = options.supervisorBundle ?? resolveSupervisorBundle();
   const supervisorPort = options.supervisorPort ?? getSupervisorPortSync();
-  const workingDirectory = options.workingDirectory ?? packageRoot;
+  const workingDirectory = options.workingDirectory ?? resolveSupervisorPrimaryRepoRoot();
   const overdeckHome = options.overdeckHome ?? OVERDECK_HOME;
   const restartSec = options.restartSec ?? DEFAULT_RESTART_SEC;
   const startLimitIntervalSec = options.startLimitIntervalSec ?? DEFAULT_START_LIMIT_INTERVAL_SEC;

--- a/src/supervisor/__tests__/restart-spawn.test.ts
+++ b/src/supervisor/__tests__/restart-spawn.test.ts
@@ -34,6 +34,7 @@ describe('supervisor restart spawner', () => {
     const spawnFn = vi.fn(() => child as never);
     const spawnRestart = createSupervisorRestartSpawner({
       panBinary: 'pan',
+      cwd: '/primary/overdeck',
       log: vi.fn(),
       spawnFn: spawnFn as never,
     });
@@ -42,6 +43,7 @@ describe('supervisor restart spawner', () => {
 
     expect(result).toMatchObject({ pid: 4242, error: null });
     expect(spawnFn).toHaveBeenCalledWith('pan', buildSupervisorRestartArgs(), expect.objectContaining({
+      cwd: '/primary/overdeck',
       detached: true,
       stdio: ['ignore', 'pipe', 'pipe'],
       env: expect.objectContaining({

--- a/src/supervisor/__tests__/watchdog.test.ts
+++ b/src/supervisor/__tests__/watchdog.test.ts
@@ -31,9 +31,16 @@ function makeWatchdog(overrides: Partial<{
   logs: string[];
   fetchOk: boolean;
   fetchTimeout: boolean;
+  fetchFn: (input: string, init: { signal: AbortSignal }) => Promise<{
+    ok: boolean;
+    status: number;
+    statusText: string;
+    json?: () => Promise<unknown>;
+  }>;
   healthBody: unknown;
   deaconStatus: unknown;
   spawnOptions: Array<Parameters<SpawnRestart>[0]>;
+  spawnRestart: SpawnRestart;
   config: SupervisorWatchdogConfig;
   evictPortHoldersFn: (port: number) => Promise<{ pids: number[]; error: string | null }>;
 }> = {}): SupervisorWatchdog {
@@ -51,13 +58,13 @@ function makeWatchdog(overrides: Partial<{
     config: overrides.config ?? config,
     now: overrides.now ?? (() => Date.parse('2026-05-17T15:30:00.000Z')),
     log: (msg) => logs.push(msg),
-    spawnRestart: (options) => {
+    spawnRestart: overrides.spawnRestart ?? ((options) => {
       overrides.spawnOptions?.push(options);
       spawns.count += 1;
       return { pid: 1000 + spawns.count, error: null };
-    },
+    }),
     evictPortHoldersFn: overrides.evictPortHoldersFn,
-    fetchFn: async (input) => {
+    fetchFn: overrides.fetchFn ?? (async (input) => {
       if (input.endsWith('/api/deacon/status')) {
         return {
           ok: true,
@@ -75,7 +82,7 @@ function makeWatchdog(overrides: Partial<{
             ...(healthBody === undefined ? {} : { json: async () => healthBody }),
           }
         : { ok: false, status: 503, statusText: 'Service Unavailable' };
-    },
+    }),
   });
 }
 
@@ -601,6 +608,92 @@ describe('SupervisorWatchdog', () => {
     expect(logs.some((msg) => msg.includes('WATCHDOG GIVING UP'))).toBe(true);
   });
 
+  it('does not re-arm boot grace when the restart command fails', async () => {
+    let now = Date.parse('2026-05-17T15:30:00.000Z');
+    let health: 'healthy' | 'foreign' | 'down' = 'healthy';
+    let spawnCount = 0;
+    const watchdog = makeWatchdog({
+      now: () => now,
+      config: {
+        ...config,
+        failThreshold: 1,
+        bootGraceMs: 300_000,
+        expectedIdentity: { repoRoot: '/repo', mode: 'primary' },
+      },
+      fetchFn: async (input) => {
+        if (input.endsWith('/api/deacon/status')) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            json: async () => ({
+              isRunning: true,
+              config: { patrolIntervalMs: 60_000 },
+              state: { lastPatrol: new Date(now).toISOString() },
+            }),
+          };
+        }
+        if (health === 'down') return { ok: false, status: 503, statusText: 'Service Unavailable' };
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => ({
+            status: 'ok',
+            repoRoot: health === 'foreign' ? '/other-repo' : '/repo',
+            mode: 'primary',
+          }),
+        };
+      },
+      evictPortHoldersFn: async () => ({ pids: [4242], error: null }),
+      spawnRestart: () => {
+        spawnCount += 1;
+        return { pid: null, error: 'pan restart --dashboard exited 2' };
+      },
+    });
+
+    await watchdog.checkOnce();
+    health = 'foreign';
+    now += 1_000;
+    await watchdog.checkOnce();
+    expect(spawnCount).toBe(1);
+
+    health = 'down';
+    now += 1_000;
+    await watchdog.checkOnce();
+
+    expect(spawnCount).toBe(2);
+    expect(watchdog.status().restartBlockedUntil).toBeNull();
+  });
+
+  it('stops evicting dashboards after the watchdog gives up', async () => {
+    mkdirSync(testHome, { recursive: true });
+    writeFileSync(
+      join(testHome, 'supervisor-watchdog.json'),
+      `${JSON.stringify({ restartAttempts: [], gaveUp: true })}\n`,
+      'utf8',
+    );
+    const spawns = { count: 0 };
+    const evict = vi.fn(async () => ({ pids: [4242], error: null }));
+    const watchdog = makeWatchdog({
+      spawns,
+      fetchOk: true,
+      config: { ...config, expectedIdentity: { repoRoot: '/repo', mode: 'primary' } },
+      healthBody: { status: 'ok', repoRoot: '/other-repo', mode: 'primary' },
+      evictPortHoldersFn: evict,
+    });
+
+    await watchdog.checkOnce();
+
+    expect(evict).not.toHaveBeenCalled();
+    expect(spawns.count).toBe(0);
+    expect(watchdog.status()).toMatchObject({
+      gaveUp: true,
+      restartBlockedReason: 'watchdog previously gave up; manual intervention required',
+      restartBlockedUntil: null,
+    });
+  });
+
   it('skips a locked restart cycle without consuming an attempt', async () => {
     mkdirSync(testHome, { recursive: true });
     writeFileSync(
@@ -644,6 +737,13 @@ describe('SupervisorWatchdog', () => {
   it('parses supervisor boot-grace environment configuration', () => {
     expect(readWatchdogConfig({}, 3011).bootGraceMs).toBe(300_000);
     expect(readWatchdogConfig({ OVERDECK_SUPERVISOR_BOOT_GRACE_MS: '45000' }, 3011).bootGraceMs).toBe(45_000);
+  });
+
+  it('uses the resolved primary checkout for dashboard identity checks', () => {
+    expect(readWatchdogConfig({}, 3011, '/primary/overdeck').expectedIdentity).toEqual({
+      repoRoot: '/primary/overdeck',
+      mode: 'primary',
+    });
   });
 
   it('waits for a restart that completes after a 60s dashboard boot', async () => {

--- a/src/supervisor/restart-spawn.ts
+++ b/src/supervisor/restart-spawn.ts
@@ -13,6 +13,7 @@ type LogFn = (msg: string) => void | Promise<void>;
 interface SupervisorRestartSpawnerOptions {
   panBinary: string;
   panArgsPrefix?: string[];
+  cwd?: string;
   log: LogFn;
   env?: NodeJS.ProcessEnv;
   acquireRestartLockFn?: typeof acquireRestartLock;
@@ -93,6 +94,7 @@ export function createSupervisorRestartSpawner(options: SupervisorRestartSpawner
       let stdout = '';
       let stderr = '';
       const child = spawnImpl(options.panBinary, [...(options.panArgsPrefix ?? []), ...buildSupervisorRestartArgs()], {
+        cwd: options.cwd,
         detached: true,
         stdio: ['ignore', 'pipe', 'pipe'],
         env: {

--- a/src/supervisor/server.ts
+++ b/src/supervisor/server.ts
@@ -21,6 +21,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { appendFile } from 'node:fs/promises';
 import { readPlatformConfigSync } from '../lib/platform-lifecycle.js';
+import { resolveSupervisorPrimaryRepoRoot } from '../lib/supervisor.js';
 import { readWatchdogConfig, SupervisorWatchdog } from './watchdog.js';
 import { createSupervisorRestartSpawner, resolveBundledPanInvocation } from './restart-spawn.js';
 import { readTtsWatchdogConfig, TtsWatchdog } from './tts-watchdog.js';
@@ -31,7 +32,8 @@ const PAN_INVOCATION = process.env.OVERDECK_PAN_BINARY
   : resolveBundledPanInvocation();
 const LOG_FILE = path.join(os.homedir(), '.overdeck', 'logs', 'supervisor.log');
 const platformConfig = readPlatformConfigSync();
-const watchdogConfig = readWatchdogConfig(process.env, platformConfig.dashboardApiPort);
+const primaryRepoRoot = resolveSupervisorPrimaryRepoRoot();
+const watchdogConfig = readWatchdogConfig(process.env, platformConfig.dashboardApiPort, primaryRepoRoot);
 const ttsWatchdogConfig = readTtsWatchdogConfig(process.env);
 
 async function log(msg: string): Promise<void> {
@@ -72,7 +74,7 @@ function sendJson(req: http.IncomingMessage, res: http.ServerResponse, status: n
   res.end(JSON.stringify(body));
 }
 
-const spawnRestart = createSupervisorRestartSpawner({ ...PAN_INVOCATION, log });
+const spawnRestart = createSupervisorRestartSpawner({ ...PAN_INVOCATION, cwd: primaryRepoRoot, log });
 
 const watchdog = new SupervisorWatchdog({
   config: watchdogConfig,

--- a/src/supervisor/watchdog.ts
+++ b/src/supervisor/watchdog.ts
@@ -124,12 +124,16 @@ export function parsePositiveIntEnv(value: string | undefined, fallback: number)
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-export function readWatchdogConfig(env: NodeJS.ProcessEnv, dashboardApiPort: number): SupervisorWatchdogConfig {
+export function readWatchdogConfig(
+  env: NodeJS.ProcessEnv,
+  dashboardApiPort: number,
+  primaryRepoRoot = process.cwd(),
+): SupervisorWatchdogConfig {
   return {
     enabled: env.OVERDECK_SUPERVISOR_WATCHDOG !== '0',
     dashboardApiPort,
     expectedIdentity: {
-      repoRoot: resolve(process.cwd()),
+      repoRoot: resolve(primaryRepoRoot),
       mode: 'primary',
     },
     pollMs: parsePositiveIntEnv(env.OVERDECK_SUPERVISOR_POLL_MS, 10_000),
@@ -334,6 +338,11 @@ export class SupervisorWatchdog {
       restartEligibleForBootGrace = hardDown;
     }
 
+    if (this.state.gaveUp) {
+      this.state.restartBlockedUntil = null;
+      return;
+    }
+
     if (foreignDashboard) {
       const eviction = await this.evictPortHoldersFn(this.config.dashboardApiPort);
       if (eviction.error) {
@@ -465,13 +474,14 @@ export class SupervisorWatchdog {
       await lock.release();
     }
 
-    // PAN-2219: a restart gives the new server a fresh patrol-grace window.
-    // Without this the pre-restart staleness clock carried over, so each new
-    // boot was killed before boot reconciliation + its first patrol could
-    // complete — restart churn until maxRestarts/gaveUp.
-    this.state.patrolUnhealthySince = null;
-    this.state.hasBecomeHealthy = false;
-    this.state.bootGraceStartedAt = this.now();
+    // PAN-2219: a successful restart gives the new server a fresh patrol-grace
+    // window. A failed spawn did not create a successor, so re-arming grace
+    // there only delays the next recovery attempt and restart-cap enforcement.
+    if (!restartError) {
+      this.state.patrolUnhealthySince = null;
+      this.state.hasBecomeHealthy = false;
+      this.state.bootGraceStartedAt = this.now();
+    }
 
     await Effect.runPromise(writeRestartStatus({
       ts: new Date(startedAt).toISOString(),

--- a/tests/unit/lib/supervisor.test.ts
+++ b/tests/unit/lib/supervisor.test.ts
@@ -26,6 +26,7 @@ describe('supervisor lifecycle', () => {
   let startSupervisorProcessSync: typeof supervisor.startSupervisorProcessSync;
   let stopSupervisorProcessSync: typeof supervisor.stopSupervisorProcessSync;
   let isSupervisorRunningSync: typeof supervisor.isSupervisorRunningSync;
+  let resolveSupervisorPrimaryRepoRoot: typeof supervisor.resolveSupervisorPrimaryRepoRoot;
 
   beforeEach(async () => {
     home = mkdtempSync(join(tmpdir(), 'pan-sup-'));
@@ -50,6 +51,7 @@ describe('supervisor lifecycle', () => {
     startSupervisorProcessSync = mod.startSupervisorProcessSync;
     stopSupervisorProcessSync = mod.stopSupervisorProcessSync;
     isSupervisorRunningSync = mod.isSupervisorRunningSync;
+    resolveSupervisorPrimaryRepoRoot = mod.resolveSupervisorPrimaryRepoRoot;
   });
 
   afterEach(() => {
@@ -66,6 +68,20 @@ describe('supervisor lifecycle', () => {
     writeFileSync(join(dir, 'server.js'), '// dummy supervisor bundle\n', 'utf-8');
   }
 
+  it('resolves the primary checkout from the active dashboard bundle', () => {
+    const deployRoot = join(home, 'deployments', 'dashboard', '.pan-reload-generation-a');
+    const serverPath = join(deployRoot, 'dist', 'dashboard', 'server.js');
+    mkdirSync(join(deployRoot, 'dist', 'dashboard'), { recursive: true });
+    writeFileSync(serverPath, '// active dashboard bundle\n', 'utf-8');
+    writeFileSync(join(home, 'active-dashboard-bundle.json'), `${JSON.stringify({
+      repoRoot: '/home/dev/Projects/overdeck',
+      deployRoot,
+      serverPath,
+    })}\n`, 'utf-8');
+
+    expect(resolveSupervisorPrimaryRepoRoot()).toBe('/home/dev/Projects/overdeck');
+  });
+
   describe('startSupervisorProcessSync', () => {
     it('removes the pidfile and logs an error when the child dies immediately', () => {
       makeBundle();
@@ -76,6 +92,9 @@ describe('supervisor lifecycle', () => {
 
       expect(() => startSupervisorProcessSync()).toThrow(/exited immediately/);
 
+      expect(spawn).toHaveBeenCalledWith(process.execPath, [join(home, 'dist', 'supervisor', 'server.js')], expect.objectContaining({
+        cwd: home,
+      }));
       expect(existsSync(join(home, 'supervisor.pid'))).toBe(false);
       expect(isSupervisorRunningSync()).toBe(false);
       expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('exited immediately'));


### PR DESCRIPTION
P0 strike: after a host reboot the supervisor watchdog serially SIGTERMed every dashboard as 'foreign' while its own replacement spawn failed the non-primary-checkout guard — the dashboard could not stay up until the supervisor was stopped.

Fix: the supervisor survives a stale deployment cwd, so it no longer evicts legitimate dashboards it can't replace.

Landing note: the strike could not rebase (agent git guard blocks raw rebase; `pan sync-main` does not handle strike workspaces — filing that gap separately). Branch is pushed as-is and mergeable; CI is the authoritative gate.

Closes PAN-3436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhNVZuskT1Xw9qmw65g5dq