### PR TITLE
PAN-3451

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -134,8 +134,8 @@ Pi also writes local compatibility files under `~/.overdeck/agents/<agent-id>/` 
 
 Pi work agents use `turn_end` to approximate Claude Code's `Stop` hook completion flow:
 
-1. Check evidence first: issue beads must all be closed and the workspace xBRIEF/continue state must be satisfied when present.
-2. Scan the turn output/transcript for explicit completion markers such as `OVERDECK_WORK_COMPLETE`, `Implementation complete`, `all beads closed`, or `ready for review`.
+1. Check evidence first: POST `/api/agents/:id/plan-checklist` and treat the work as complete only when the server reports every xBRIEF checklist item complete through the canonical `checkIncompletePlanItemsPromise` gate (the same door `runVerificationForIssue()` uses).
+2. Scan the turn output/transcript for explicit completion markers such as `OVERDECK_WORK_COMPLETE`, `Implementation complete`, `all tasks closed`, or `ready for review`.
 3. Ask the dashboard classifier endpoint for a final verdict when the transcript is ambiguous.
 4. Emit `agent.resolution_changed` with `done`, `needs_input`, or `stuck` as appropriate.
 

--- a/packages/ohmypi-extension/src/__tests__/index.test.ts
+++ b/packages/ohmypi-extension/src/__tests__/index.test.ts
@@ -37,12 +37,15 @@ const fixedTime = '2026-05-07T05:00:00.000Z'
 const now = () => fixedTime
 
 // Track fetch calls and control responses per test.
+type FetchResponse = { status: number; body?: Record<string, unknown>; reject?: boolean }
 let fetchCalls: { url: string; body: unknown; headers: Record<string, string> }[] = []
-let fetchResponse: { status: number; body?: Record<string, unknown> } = { status: 200 }
+let fetchResponse: FetchResponse = { status: 200 }
+let fetchResponses = new Map<string, FetchResponse>()
 
 beforeEach(() => {
   fetchCalls = []
   fetchResponse = { status: 200 }
+  fetchResponses = new Map()
   // Neutralize any ambient OVERDECK_DASHBOARD_URL (set on developer machines
   // running a live `pan dev`) so the default-host tests assert against the
   // production fallback (http://localhost:3011), not the host's value. Tests
@@ -54,10 +57,12 @@ beforeEach(() => {
       const url = _url
       const body = init?.body ? JSON.parse(init.body as string) : undefined
       fetchCalls.push({ url, body, headers: init?.headers as Record<string, string> })
+      const response = fetchResponses.get(url) ?? fetchResponse
+      if (response.reject) throw new Error('dashboard unavailable')
       return {
-        status: fetchResponse.status,
-        ok: fetchResponse.status >= 200 && fetchResponse.status < 300,
-        json: async () => fetchResponse.body ?? {},
+        status: response.status,
+        ok: response.status >= 200 && response.status < 300,
+        json: async () => response.body ?? {},
       } as Response
     }),
   )
@@ -506,41 +511,61 @@ describe('handleTurnEnd', () => {
   })
 
   it('posts work-complete when the dashboard plan checklist is complete', async () => {
-    fetchResponse.body = { success: true, complete: true, incomplete: [] }
+    const checklistUrl = 'http://localhost:3011/api/agents/agent-pan-636/plan-checklist'
+    fetchResponses.set(checklistUrl, { status: 200, body: { success: true, complete: true, incomplete: [] } })
 
     await handleTurnEnd(
-      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, role: 'work', issueId: 'PAN-636' },
+      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, role: 'work', issueId: 'PAN-636', workspace: '/workspace' },
       {},
     )
 
-    expect(fetchCalls.map(call => call.url)).toContain('http://localhost:3011/api/agents/agent-pan-636/plan-checklist')
+    expect(fetchCalls.find(call => call.url === checklistUrl)?.body).toEqual({ issueId: 'PAN-636' })
     expect(fetchCalls.map(call => call.url)).toContain('http://localhost:3011/api/agents/agent-pan-636/work-complete')
     expect(fetchCalls.some(call => (call.body as any).resolution === 'done')).toBe(true)
   })
 
   it('does not post evidence-clean completion when the dashboard plan checklist is incomplete', async () => {
-    fetchResponse.body = {
-      success: true,
-      complete: false,
-      incomplete: ['    - item-one First item (pending)'],
-    }
+    const checklistUrl = 'http://localhost:3011/api/agents/agent-pan-636/plan-checklist'
+    fetchResponses.set(checklistUrl, {
+      status: 200,
+      body: { success: true, complete: false, incomplete: ['    - item-one First item (pending)'] },
+    })
 
     await handleTurnEnd(
-      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, role: 'work', issueId: 'PAN-636' },
+      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, role: 'work', issueId: 'PAN-636', workspace: '/workspace' },
       {},
     )
 
-    expect(fetchCalls.map(call => call.url)).toContain('http://localhost:3011/api/agents/agent-pan-636/plan-checklist')
+    expect(fetchCalls.map(call => call.url)).toContain(checklistUrl)
     expect(fetchCalls.map(call => call.url)).not.toContain('http://localhost:3011/api/agents/agent-pan-636/work-complete')
     expect(fetchCalls.some(call => (call.body as any).resolution === 'done')).toBe(false)
   })
 
-  it('routes work turn-end completion from launcher session type env', async () => {
-    vi.stubEnv('OVERDECK_SESSION_TYPE', 'work')
-    fetchResponse.body = { success: true, complete: true, incomplete: [] }
+  it('falls back to a structured completion marker when the plan checklist request fails', async () => {
+    const checklistUrl = 'http://localhost:3011/api/agents/agent-pan-636/plan-checklist'
+    fetchResponses.set(checklistUrl, { status: 503, reject: true })
 
     await handleTurnEnd(
-      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, issueId: 'PAN-636' },
+      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, role: 'work', issueId: 'PAN-636', workspace: '/workspace' },
+      { output: 'OVERDECK_WORK_COMPLETE' },
+    )
+
+    expect(fetchCalls.map(call => call.url)).toContain(checklistUrl)
+    expect(fetchCalls).toContainEqual(expect.objectContaining({
+      url: 'http://localhost:3011/api/agents/agent-pan-636/work-complete',
+      body: expect.objectContaining({ reason: 'structured-reply' }),
+    }))
+  })
+
+  it('routes work turn-end completion from launcher session type env', async () => {
+    vi.stubEnv('OVERDECK_SESSION_TYPE', 'work')
+    fetchResponses.set('http://localhost:3011/api/agents/agent-pan-636/plan-checklist', {
+      status: 200,
+      body: { success: true, complete: true, incomplete: [] },
+    })
+
+    await handleTurnEnd(
+      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, issueId: 'PAN-636', workspace: '/workspace' },
       {},
     )
 

--- a/packages/ohmypi-extension/src/__tests__/index.test.ts
+++ b/packages/ohmypi-extension/src/__tests__/index.test.ts
@@ -38,7 +38,7 @@ const now = () => fixedTime
 
 // Track fetch calls and control responses per test.
 let fetchCalls: { url: string; body: unknown; headers: Record<string, string> }[] = []
-let fetchResponse: { status: number } = { status: 200 }
+let fetchResponse: { status: number; body?: Record<string, unknown> } = { status: 200 }
 
 beforeEach(() => {
   fetchCalls = []
@@ -54,7 +54,11 @@ beforeEach(() => {
       const url = _url
       const body = init?.body ? JSON.parse(init.body as string) : undefined
       fetchCalls.push({ url, body, headers: init?.headers as Record<string, string> })
-      return { status: fetchResponse.status } as Response
+      return {
+        status: fetchResponse.status,
+        ok: fetchResponse.status >= 200 && fetchResponse.status < 300,
+        json: async () => fetchResponse.body ?? {},
+      } as Response
     }),
   )
 })
@@ -489,7 +493,7 @@ describe('handleTurnEnd', () => {
 
   it('PAN-1134: POSTs activity idle and a turn cost event', async () => {
     await handleTurnEnd(
-      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, issueId: 'PAN-636' },
+      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, issueId: 'PAN-636', role: 'conversation' },
       {},
     )
     expect(fetchCalls.length).toBe(2)
@@ -501,28 +505,42 @@ describe('handleTurnEnd', () => {
     expect(fetchCalls[1]!.body).toMatchObject({ kind: 'cost-event', issueId: 'PAN-636', tool: 'turn_end' })
   })
 
-  it('posts work-complete when all issue beads are closed', async () => {
-    const workspace = join(h.home, 'workspace')
-    mkdirSync(join(workspace, '.beads'), { recursive: true })
-    writeFileSync(join(workspace, '.beads', 'issues.jsonl'), `${JSON.stringify({ id: 'b1', title: 'PAN-636 implementation', status: 'closed', labels: ['pan-636'] })}\n`)
+  it('posts work-complete when the dashboard plan checklist is complete', async () => {
+    fetchResponse.body = { success: true, complete: true, incomplete: [] }
 
     await handleTurnEnd(
-      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, role: 'work', issueId: 'PAN-636', workspace },
+      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, role: 'work', issueId: 'PAN-636' },
       {},
     )
 
+    expect(fetchCalls.map(call => call.url)).toContain('http://localhost:3011/api/agents/agent-pan-636/plan-checklist')
     expect(fetchCalls.map(call => call.url)).toContain('http://localhost:3011/api/agents/agent-pan-636/work-complete')
     expect(fetchCalls.some(call => (call.body as any).resolution === 'done')).toBe(true)
   })
 
-  it('routes work turn-end completion from launcher session type env', async () => {
-    vi.stubEnv('OVERDECK_SESSION_TYPE', 'work')
-    const workspace = join(h.home, 'workspace')
-    mkdirSync(join(workspace, '.beads'), { recursive: true })
-    writeFileSync(join(workspace, '.beads', 'issues.jsonl'), `${JSON.stringify({ id: 'b1', title: 'PAN-636 implementation', status: 'closed', labels: ['pan-636'] })}\n`)
+  it('does not post evidence-clean completion when the dashboard plan checklist is incomplete', async () => {
+    fetchResponse.body = {
+      success: true,
+      complete: false,
+      incomplete: ['    - item-one First item (pending)'],
+    }
 
     await handleTurnEnd(
-      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, issueId: 'PAN-636', workspace },
+      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, role: 'work', issueId: 'PAN-636' },
+      {},
+    )
+
+    expect(fetchCalls.map(call => call.url)).toContain('http://localhost:3011/api/agents/agent-pan-636/plan-checklist')
+    expect(fetchCalls.map(call => call.url)).not.toContain('http://localhost:3011/api/agents/agent-pan-636/work-complete')
+    expect(fetchCalls.some(call => (call.body as any).resolution === 'done')).toBe(false)
+  })
+
+  it('routes work turn-end completion from launcher session type env', async () => {
+    vi.stubEnv('OVERDECK_SESSION_TYPE', 'work')
+    fetchResponse.body = { success: true, complete: true, incomplete: [] }
+
+    await handleTurnEnd(
+      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, issueId: 'PAN-636' },
       {},
     )
 

--- a/packages/ohmypi-extension/src/index.ts
+++ b/packages/ohmypi-extension/src/index.ts
@@ -386,6 +386,13 @@ async function issueIdFor(env: HookEnv): Promise<string | null> {
   return match ? `${match[1]!.toUpperCase()}-${match[2]}` : null
 }
 
+async function workspaceFor(env: HookEnv): Promise<string | null> {
+  if (env.workspace) return env.workspace
+  if (process.env['OVERDECK_WORKSPACE']) return process.env['OVERDECK_WORKSPACE']!
+  const state = await readAgentState(env)
+  return typeof state['workspace'] === 'string' && state['workspace'].trim() ? state['workspace'] : null
+}
+
 async function sessionIdFor(env: HookEnv): Promise<string | null> {
   const { paths } = envFor(env)
   try {
@@ -442,11 +449,10 @@ async function recordCostEvent(env: HookEnv, event: ToolExecutionEndEvent | Turn
 }
 
 async function evidenceClean(env: HookEnv): Promise<boolean> {
-  const result = await postJsonWithTimeout(
-    env,
-    `${getDashboardUrl()}/api/agents/${env.agentId}/plan-checklist`,
-    {},
-  )
+  const issueId = await issueIdFor(env)
+  const workspace = await workspaceFor(env)
+  if (!issueId || !workspace) return false
+  const result = await postJsonWithTimeout(env, `${getDashboardUrl()}/api/agents/${env.agentId}/plan-checklist`, { issueId })
   return result?.['complete'] === true
 }
 
@@ -483,7 +489,7 @@ async function markStuck(env: HookEnv, reason: string): Promise<void> {
 
 const COMPLETION_PHRASES = [
   'Implementation complete',
-  'all beads closed',
+  'all tasks closed',
   'ready for review',
   'work complete',
 ]
@@ -522,7 +528,7 @@ async function updateProgress(env: HookEnv, kind: 'tool' | 'turn', timestamp: st
 export async function handleWorkAgentTurnEnd(env: HookEnv, event: TurnEndEvent): Promise<void> {
   const output = await readTurnOutput(env, event)
   if (await evidenceClean(env)) {
-    await postWorkComplete(env, 'evidence-clean', 'All xBRIEF checklist items are complete')
+    await postWorkComplete(env, 'evidence-clean', 'All xBRIEF plan items are complete')
     return
   }
 

--- a/packages/ohmypi-extension/src/index.ts
+++ b/packages/ohmypi-extension/src/index.ts
@@ -386,13 +386,6 @@ async function issueIdFor(env: HookEnv): Promise<string | null> {
   return match ? `${match[1]!.toUpperCase()}-${match[2]}` : null
 }
 
-async function workspaceFor(env: HookEnv): Promise<string | null> {
-  if (env.workspace) return env.workspace
-  if (process.env['OVERDECK_WORKSPACE']) return process.env['OVERDECK_WORKSPACE']!
-  const state = await readAgentState(env)
-  return typeof state['workspace'] === 'string' && state['workspace'].trim() ? state['workspace'] : null
-}
-
 async function sessionIdFor(env: HookEnv): Promise<string | null> {
   const { paths } = envFor(env)
   try {
@@ -448,66 +441,13 @@ async function recordCostEvent(env: HookEnv, event: ToolExecutionEndEvent | Turn
   await postEvent(env, body)
 }
 
-function isClosedBead(issue: Record<string, unknown>): boolean {
-  const status = String(issue['status'] ?? '').toLowerCase()
-  return status === 'closed' || status === 'done' || status === 'completed'
-}
-
-function beadMatchesIssue(issue: Record<string, unknown>, issueId: string): boolean {
-  const label = issueId.toLowerCase()
-  const labels = Array.isArray(issue['labels']) ? issue['labels'] : []
-  return labels.some((entry) => String(entry).toLowerCase() === label)
-    || String(issue['title'] ?? '').toLowerCase().includes(issueId.toLowerCase())
-    || String(issue['id'] ?? '').toLowerCase().includes(issueId.toLowerCase())
-}
-
-async function allIssueBeadsClosed(workspace: string, issueId: string): Promise<boolean> {
-  let raw = ''
-  try {
-    raw = await readFile(join(workspace, '.beads', 'issues.jsonl'), 'utf8')
-  } catch {
-    return false
-  }
-  const issues = raw.split('\n')
-    .filter((line) => line.trim())
-    .map((line) => {
-      try { return JSON.parse(line) as Record<string, unknown> } catch { return null }
-    })
-    .filter((issue): issue is Record<string, unknown> => !!issue && beadMatchesIssue(issue, issueId))
-
-  return issues.length > 0 && issues.every(isClosedBead)
-}
-
-function statusComplete(value: unknown): boolean {
-  return String(value ?? '').toLowerCase() === 'completed'
-}
-
-function planItemsComplete(plan: Record<string, unknown>): boolean {
-  const root = (plan['plan'] && typeof plan['plan'] === 'object') ? plan['plan'] as Record<string, unknown> : plan
-  const items = Array.isArray(root['items']) ? root['items'] as Record<string, unknown>[] : []
-  if (items.length === 0) return true
-  return items.every((item) => {
-    const subItems = Array.isArray(item['subItems']) ? item['subItems'] as Record<string, unknown>[] : []
-    return statusComplete(item['status']) && subItems.every((subItem) => statusComplete(subItem['status']))
-  })
-}
-
-async function xbriefSatisfied(workspace: string): Promise<boolean> {
-  for (const path of [join(workspace, '.pan', 'spec.vbrief.json'), join(workspace, '.pan', 'continue.json')]) {
-    try {
-      const parsed = JSON.parse(await readFile(path, 'utf8')) as Record<string, unknown>
-      if (!planItemsComplete(parsed)) return false
-      return true
-    } catch {}
-  }
-  return true
-}
-
 async function evidenceClean(env: HookEnv): Promise<boolean> {
-  const issueId = await issueIdFor(env)
-  const workspace = await workspaceFor(env)
-  if (!issueId || !workspace) return false
-  return await allIssueBeadsClosed(workspace, issueId) && await xbriefSatisfied(workspace)
+  const result = await postJsonWithTimeout(
+    env,
+    `${getDashboardUrl()}/api/agents/${env.agentId}/plan-checklist`,
+    {},
+  )
+  return result?.['complete'] === true
 }
 
 async function readTurnOutput(env: HookEnv, event: TurnEndEvent): Promise<string> {
@@ -582,7 +522,7 @@ async function updateProgress(env: HookEnv, kind: 'tool' | 'turn', timestamp: st
 export async function handleWorkAgentTurnEnd(env: HookEnv, event: TurnEndEvent): Promise<void> {
   const output = await readTurnOutput(env, event)
   if (await evidenceClean(env)) {
-    await postWorkComplete(env, 'evidence-clean', 'All issue beads are closed and the plan is satisfied')
+    await postWorkComplete(env, 'evidence-clean', 'All xBRIEF checklist items are complete')
     return
   }
 

--- a/packages/pi-extension/src/__tests__/index.test.ts
+++ b/packages/pi-extension/src/__tests__/index.test.ts
@@ -32,12 +32,15 @@ const fixedTime = '2026-05-07T05:00:00.000Z'
 const now = () => fixedTime
 
 // Track fetch calls and control responses per test.
+type FetchResponse = { status: number; body?: Record<string, unknown>; reject?: boolean }
 let fetchCalls: { url: string; body: unknown; headers: Record<string, string> }[] = []
-let fetchResponse: { status: number; body?: Record<string, unknown> } = { status: 200 }
+let fetchResponse: FetchResponse = { status: 200 }
+let fetchResponses = new Map<string, FetchResponse>()
 
 beforeEach(() => {
   fetchCalls = []
   fetchResponse = { status: 200 }
+  fetchResponses = new Map()
   // Neutralize any ambient OVERDECK_DASHBOARD_URL (set on developer machines
   // running a live `pan dev`) so the default-host tests assert against the
   // production fallback (http://localhost:3011), not the host's value. Tests
@@ -49,10 +52,12 @@ beforeEach(() => {
       const url = _url
       const body = init?.body ? JSON.parse(init.body as string) : undefined
       fetchCalls.push({ url, body, headers: init?.headers as Record<string, string> })
+      const response = fetchResponses.get(url) ?? fetchResponse
+      if (response.reject) throw new Error('dashboard unavailable')
       return {
-        status: fetchResponse.status,
-        ok: fetchResponse.status >= 200 && fetchResponse.status < 300,
-        json: async () => fetchResponse.body ?? {},
+        status: response.status,
+        ok: response.status >= 200 && response.status < 300,
+        json: async () => response.body ?? {},
       } as Response
     }),
   )
@@ -501,41 +506,61 @@ describe('handleTurnEnd', () => {
   })
 
   it('posts work-complete when the dashboard plan checklist is complete', async () => {
-    fetchResponse.body = { success: true, complete: true, incomplete: [] }
+    const checklistUrl = 'http://localhost:3011/api/agents/agent-pan-636/plan-checklist'
+    fetchResponses.set(checklistUrl, { status: 200, body: { success: true, complete: true, incomplete: [] } })
 
     await handleTurnEnd(
-      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, role: 'work', issueId: 'PAN-636' },
+      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, role: 'work', issueId: 'PAN-636', workspace: '/workspace' },
       {},
     )
 
-    expect(fetchCalls.map(call => call.url)).toContain('http://localhost:3011/api/agents/agent-pan-636/plan-checklist')
+    expect(fetchCalls.find(call => call.url === checklistUrl)?.body).toEqual({ issueId: 'PAN-636' })
     expect(fetchCalls.map(call => call.url)).toContain('http://localhost:3011/api/agents/agent-pan-636/work-complete')
     expect(fetchCalls.some(call => (call.body as any).resolution === 'done')).toBe(true)
   })
 
   it('does not post evidence-clean completion when the dashboard plan checklist is incomplete', async () => {
-    fetchResponse.body = {
-      success: true,
-      complete: false,
-      incomplete: ['    - item-one First item (pending)'],
-    }
+    const checklistUrl = 'http://localhost:3011/api/agents/agent-pan-636/plan-checklist'
+    fetchResponses.set(checklistUrl, {
+      status: 200,
+      body: { success: true, complete: false, incomplete: ['    - item-one First item (pending)'] },
+    })
 
     await handleTurnEnd(
-      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, role: 'work', issueId: 'PAN-636' },
+      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, role: 'work', issueId: 'PAN-636', workspace: '/workspace' },
       {},
     )
 
-    expect(fetchCalls.map(call => call.url)).toContain('http://localhost:3011/api/agents/agent-pan-636/plan-checklist')
+    expect(fetchCalls.map(call => call.url)).toContain(checklistUrl)
     expect(fetchCalls.map(call => call.url)).not.toContain('http://localhost:3011/api/agents/agent-pan-636/work-complete')
     expect(fetchCalls.some(call => (call.body as any).resolution === 'done')).toBe(false)
   })
 
-  it('routes work turn-end completion from launcher session type env', async () => {
-    vi.stubEnv('OVERDECK_SESSION_TYPE', 'work')
-    fetchResponse.body = { success: true, complete: true, incomplete: [] }
+  it('falls back to a structured completion marker when the plan checklist request fails', async () => {
+    const checklistUrl = 'http://localhost:3011/api/agents/agent-pan-636/plan-checklist'
+    fetchResponses.set(checklistUrl, { status: 503, reject: true })
 
     await handleTurnEnd(
-      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, issueId: 'PAN-636' },
+      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, role: 'work', issueId: 'PAN-636', workspace: '/workspace' },
+      { output: 'OVERDECK_WORK_COMPLETE' },
+    )
+
+    expect(fetchCalls.map(call => call.url)).toContain(checklistUrl)
+    expect(fetchCalls).toContainEqual(expect.objectContaining({
+      url: 'http://localhost:3011/api/agents/agent-pan-636/work-complete',
+      body: expect.objectContaining({ reason: 'structured-reply' }),
+    }))
+  })
+
+  it('routes work turn-end completion from launcher session type env', async () => {
+    vi.stubEnv('OVERDECK_SESSION_TYPE', 'work')
+    fetchResponses.set('http://localhost:3011/api/agents/agent-pan-636/plan-checklist', {
+      status: 200,
+      body: { success: true, complete: true, incomplete: [] },
+    })
+
+    await handleTurnEnd(
+      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, issueId: 'PAN-636', workspace: '/workspace' },
       {},
     )
 

--- a/packages/pi-extension/src/__tests__/index.test.ts
+++ b/packages/pi-extension/src/__tests__/index.test.ts
@@ -33,7 +33,7 @@ const now = () => fixedTime
 
 // Track fetch calls and control responses per test.
 let fetchCalls: { url: string; body: unknown; headers: Record<string, string> }[] = []
-let fetchResponse: { status: number } = { status: 200 }
+let fetchResponse: { status: number; body?: Record<string, unknown> } = { status: 200 }
 
 beforeEach(() => {
   fetchCalls = []
@@ -49,7 +49,11 @@ beforeEach(() => {
       const url = _url
       const body = init?.body ? JSON.parse(init.body as string) : undefined
       fetchCalls.push({ url, body, headers: init?.headers as Record<string, string> })
-      return { status: fetchResponse.status } as Response
+      return {
+        status: fetchResponse.status,
+        ok: fetchResponse.status >= 200 && fetchResponse.status < 300,
+        json: async () => fetchResponse.body ?? {},
+      } as Response
     }),
   )
 })
@@ -484,7 +488,7 @@ describe('handleTurnEnd', () => {
 
   it('PAN-1134: POSTs activity idle and a turn cost event', async () => {
     await handleTurnEnd(
-      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, issueId: 'PAN-636' },
+      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, issueId: 'PAN-636', role: 'conversation' },
       {},
     )
     expect(fetchCalls.length).toBe(2)
@@ -496,28 +500,42 @@ describe('handleTurnEnd', () => {
     expect(fetchCalls[1]!.body).toMatchObject({ kind: 'cost-event', issueId: 'PAN-636', tool: 'turn_end' })
   })
 
-  it('posts work-complete when all issue beads are closed', async () => {
-    const workspace = join(h.home, 'workspace')
-    mkdirSync(join(workspace, '.beads'), { recursive: true })
-    writeFileSync(join(workspace, '.beads', 'issues.jsonl'), `${JSON.stringify({ id: 'b1', title: 'PAN-636 implementation', status: 'closed', labels: ['pan-636'] })}\n`)
+  it('posts work-complete when the dashboard plan checklist is complete', async () => {
+    fetchResponse.body = { success: true, complete: true, incomplete: [] }
 
     await handleTurnEnd(
-      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, role: 'work', issueId: 'PAN-636', workspace },
+      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, role: 'work', issueId: 'PAN-636' },
       {},
     )
 
+    expect(fetchCalls.map(call => call.url)).toContain('http://localhost:3011/api/agents/agent-pan-636/plan-checklist')
     expect(fetchCalls.map(call => call.url)).toContain('http://localhost:3011/api/agents/agent-pan-636/work-complete')
     expect(fetchCalls.some(call => (call.body as any).resolution === 'done')).toBe(true)
   })
 
-  it('routes work turn-end completion from launcher session type env', async () => {
-    vi.stubEnv('OVERDECK_SESSION_TYPE', 'work')
-    const workspace = join(h.home, 'workspace')
-    mkdirSync(join(workspace, '.beads'), { recursive: true })
-    writeFileSync(join(workspace, '.beads', 'issues.jsonl'), `${JSON.stringify({ id: 'b1', title: 'PAN-636 implementation', status: 'closed', labels: ['pan-636'] })}\n`)
+  it('does not post evidence-clean completion when the dashboard plan checklist is incomplete', async () => {
+    fetchResponse.body = {
+      success: true,
+      complete: false,
+      incomplete: ['    - item-one First item (pending)'],
+    }
 
     await handleTurnEnd(
-      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, issueId: 'PAN-636', workspace },
+      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, role: 'work', issueId: 'PAN-636' },
+      {},
+    )
+
+    expect(fetchCalls.map(call => call.url)).toContain('http://localhost:3011/api/agents/agent-pan-636/plan-checklist')
+    expect(fetchCalls.map(call => call.url)).not.toContain('http://localhost:3011/api/agents/agent-pan-636/work-complete')
+    expect(fetchCalls.some(call => (call.body as any).resolution === 'done')).toBe(false)
+  })
+
+  it('routes work turn-end completion from launcher session type env', async () => {
+    vi.stubEnv('OVERDECK_SESSION_TYPE', 'work')
+    fetchResponse.body = { success: true, complete: true, incomplete: [] }
+
+    await handleTurnEnd(
+      { agentId: 'agent-pan-636', home: h.home, pid: 7, now, issueId: 'PAN-636' },
       {},
     )
 

--- a/packages/pi-extension/src/index.ts
+++ b/packages/pi-extension/src/index.ts
@@ -379,13 +379,6 @@ async function issueIdFor(env: HookEnv): Promise<string | null> {
   return match ? `${match[1]!.toUpperCase()}-${match[2]}` : null
 }
 
-async function workspaceFor(env: HookEnv): Promise<string | null> {
-  if (env.workspace) return env.workspace
-  if (process.env['OVERDECK_WORKSPACE']) return process.env['OVERDECK_WORKSPACE']!
-  const state = await readAgentState(env)
-  return typeof state['workspace'] === 'string' && state['workspace'].trim() ? state['workspace'] : null
-}
-
 async function sessionIdFor(env: HookEnv): Promise<string | null> {
   const { paths } = envFor(env)
   try {
@@ -441,66 +434,13 @@ async function recordCostEvent(env: HookEnv, event: ToolExecutionEndEvent | Turn
   await postEvent(env, body)
 }
 
-function isClosedBead(issue: Record<string, unknown>): boolean {
-  const status = String(issue['status'] ?? '').toLowerCase()
-  return status === 'closed' || status === 'done' || status === 'completed'
-}
-
-function beadMatchesIssue(issue: Record<string, unknown>, issueId: string): boolean {
-  const label = issueId.toLowerCase()
-  const labels = Array.isArray(issue['labels']) ? issue['labels'] : []
-  return labels.some((entry) => String(entry).toLowerCase() === label)
-    || String(issue['title'] ?? '').toLowerCase().includes(issueId.toLowerCase())
-    || String(issue['id'] ?? '').toLowerCase().includes(issueId.toLowerCase())
-}
-
-async function allIssueBeadsClosed(workspace: string, issueId: string): Promise<boolean> {
-  let raw = ''
-  try {
-    raw = await readFile(join(workspace, '.beads', 'issues.jsonl'), 'utf8')
-  } catch {
-    return false
-  }
-  const issues = raw.split('\n')
-    .filter((line) => line.trim())
-    .map((line) => {
-      try { return JSON.parse(line) as Record<string, unknown> } catch { return null }
-    })
-    .filter((issue): issue is Record<string, unknown> => !!issue && beadMatchesIssue(issue, issueId))
-
-  return issues.length > 0 && issues.every(isClosedBead)
-}
-
-function statusComplete(value: unknown): boolean {
-  return String(value ?? '').toLowerCase() === 'completed'
-}
-
-function planItemsComplete(plan: Record<string, unknown>): boolean {
-  const root = (plan['plan'] && typeof plan['plan'] === 'object') ? plan['plan'] as Record<string, unknown> : plan
-  const items = Array.isArray(root['items']) ? root['items'] as Record<string, unknown>[] : []
-  if (items.length === 0) return true
-  return items.every((item) => {
-    const subItems = Array.isArray(item['subItems']) ? item['subItems'] as Record<string, unknown>[] : []
-    return statusComplete(item['status']) && subItems.every((subItem) => statusComplete(subItem['status']))
-  })
-}
-
-async function xbriefSatisfied(workspace: string): Promise<boolean> {
-  for (const path of [join(workspace, '.pan', 'spec.vbrief.json'), join(workspace, '.pan', 'continue.json')]) {
-    try {
-      const parsed = JSON.parse(await readFile(path, 'utf8')) as Record<string, unknown>
-      if (!planItemsComplete(parsed)) return false
-      return true
-    } catch {}
-  }
-  return true
-}
-
 async function evidenceClean(env: HookEnv): Promise<boolean> {
-  const issueId = await issueIdFor(env)
-  const workspace = await workspaceFor(env)
-  if (!issueId || !workspace) return false
-  return await allIssueBeadsClosed(workspace, issueId) && await xbriefSatisfied(workspace)
+  const result = await postJsonWithTimeout(
+    env,
+    `${getDashboardUrl()}/api/agents/${env.agentId}/plan-checklist`,
+    {},
+  )
+  return result?.['complete'] === true
 }
 
 async function readTurnOutput(env: HookEnv, event: TurnEndEvent): Promise<string> {
@@ -575,7 +515,7 @@ async function updateProgress(env: HookEnv, kind: 'tool' | 'turn', timestamp: st
 export async function handleWorkAgentTurnEnd(env: HookEnv, event: TurnEndEvent): Promise<void> {
   const output = await readTurnOutput(env, event)
   if (await evidenceClean(env)) {
-    await postWorkComplete(env, 'evidence-clean', 'All issue beads are closed and the plan is satisfied')
+    await postWorkComplete(env, 'evidence-clean', 'All xBRIEF checklist items are complete')
     return
   }
 

--- a/packages/pi-extension/src/index.ts
+++ b/packages/pi-extension/src/index.ts
@@ -379,6 +379,13 @@ async function issueIdFor(env: HookEnv): Promise<string | null> {
   return match ? `${match[1]!.toUpperCase()}-${match[2]}` : null
 }
 
+async function workspaceFor(env: HookEnv): Promise<string | null> {
+  if (env.workspace) return env.workspace
+  if (process.env['OVERDECK_WORKSPACE']) return process.env['OVERDECK_WORKSPACE']!
+  const state = await readAgentState(env)
+  return typeof state['workspace'] === 'string' && state['workspace'].trim() ? state['workspace'] : null
+}
+
 async function sessionIdFor(env: HookEnv): Promise<string | null> {
   const { paths } = envFor(env)
   try {
@@ -435,11 +442,10 @@ async function recordCostEvent(env: HookEnv, event: ToolExecutionEndEvent | Turn
 }
 
 async function evidenceClean(env: HookEnv): Promise<boolean> {
-  const result = await postJsonWithTimeout(
-    env,
-    `${getDashboardUrl()}/api/agents/${env.agentId}/plan-checklist`,
-    {},
-  )
+  const issueId = await issueIdFor(env)
+  const workspace = await workspaceFor(env)
+  if (!issueId || !workspace) return false
+  const result = await postJsonWithTimeout(env, `${getDashboardUrl()}/api/agents/${env.agentId}/plan-checklist`, { issueId })
   return result?.['complete'] === true
 }
 
@@ -476,7 +482,7 @@ async function markStuck(env: HookEnv, reason: string): Promise<void> {
 
 const COMPLETION_PHRASES = [
   'Implementation complete',
-  'all beads closed',
+  'all tasks closed',
   'ready for review',
   'work complete',
 ]
@@ -515,7 +521,7 @@ async function updateProgress(env: HookEnv, kind: 'tool' | 'turn', timestamp: st
 export async function handleWorkAgentTurnEnd(env: HookEnv, event: TurnEndEvent): Promise<void> {
   const output = await readTurnOutput(env, event)
   if (await evidenceClean(env)) {
-    await postWorkComplete(env, 'evidence-clean', 'All xBRIEF checklist items are complete')
+    await postWorkComplete(env, 'evidence-clean', 'All xBRIEF plan items are complete')
     return
   }
 

--- a/src/dashboard/server/routes/agents.ts
+++ b/src/dashboard/server/routes/agents.ts
@@ -40,6 +40,7 @@ import {
   postAgentWorkCompleteRoute,
   postAgentStuckRoute,
   postAgentClassifyCompletionRoute,
+  postAgentPlanChecklistRoute,
   getAgentRuntimeRoute,
 } from './agents/runtime-events.js';
 import {
@@ -113,6 +114,7 @@ export const agentsRouteLayer = Layer.mergeAll(
   postAgentWorkCompleteRoute,
   postAgentStuckRoute,
   postAgentClassifyCompletionRoute,
+  postAgentPlanChecklistRoute,
   postInternalAgentPermissionRequestRoute,
   postAgentPermissionResponseRoute,
   getAgentRuntimeRoute,

--- a/src/dashboard/server/routes/agents/runtime-events.ts
+++ b/src/dashboard/server/routes/agents/runtime-events.ts
@@ -173,6 +173,32 @@ export const postAgentClassifyCompletionRoute = HttpRouter.add(
   })),
 );
 
+export const postAgentPlanChecklistRoute = HttpRouter.add(
+  'POST',
+  '/api/agents/:id/plan-checklist',
+  httpHandler(Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const auth = yield* Effect.promise(() => validateAgentRuntimeEventAuth(request));
+    if (!auth.ok) return auth.response;
+
+    const params = yield* HttpRouter.params;
+    const id = params['id'] ?? '';
+    const { getAgentState } = yield* Effect.promise(() => import('../../../../lib/agents.js'));
+    const state = yield* getAgentState(id);
+    if (!state?.workspace || !state.issueId) {
+      return jsonResponse({ success: false, error: 'agent has no resolvable workspace or issue id' }, { status: 422 });
+    }
+
+    const { checkIncompletePlanItemsPromise } = yield* Effect.promise(
+      () => import('../../../../lib/work/done-preflight.js'),
+    );
+    const incomplete = yield* Effect.promise(
+      () => checkIncompletePlanItemsPromise(state.workspace, state.issueId),
+    );
+    return jsonResponse({ success: true, complete: incomplete.length === 0, incomplete });
+  })),
+);
+
 // ─── Route: GET /api/agents/:id/runtime (PAN-800) ────────────────────────────
 // Exposes AgentRuntimeSnapshot to out-of-process readers (CLI, tests).
 

--- a/src/lib/work/__tests__/done-preflight-checklist.test.ts
+++ b/src/lib/work/__tests__/done-preflight-checklist.test.ts
@@ -1,0 +1,85 @@
+import { Effect } from 'effect';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { XBriefDocument } from '../../xbrief/types.js';
+
+const planMocks = vi.hoisted(() => ({
+  readWorkspacePlan: vi.fn(),
+  readWorkspacePlanSync: vi.fn(),
+}));
+
+vi.mock('../../xbrief/io.js', () => ({
+  readWorkspacePlan: planMocks.readWorkspacePlan,
+  readWorkspacePlanSync: planMocks.readWorkspacePlanSync,
+}));
+
+import {
+  checkIncompletePlanItemsPromise,
+  checkIncompletePlanItemsSync,
+  evaluateIncompletePlanItems,
+} from '../done-preflight.js';
+
+function planWithStatus(status: 'pending' | 'completed'): XBriefDocument {
+  return {
+    xBRIEFInfo: {
+      version: '0.8',
+      created: '2026-08-01T00:00:00.000Z',
+      author: 'overdeck/test',
+      description: 'Checklist evaluator fixture',
+    },
+    plan: {
+      id: 'pan-3451',
+      title: 'Checklist evaluator fixture',
+      status: 'running',
+      uid: 'f679e06f-89e2-46df-b60e-c670668135bf',
+      author: 'agent:test',
+      sequence: 1,
+      created: '2026-08-01T00:00:00.000Z',
+      updated: '2026-08-01T00:00:00.000Z',
+      items: [{
+        id: 'item-one',
+        title: 'First item',
+        status,
+        created: '2026-08-01T00:00:00.000Z',
+      }],
+      edges: [],
+    },
+  };
+}
+
+beforeEach(() => {
+  planMocks.readWorkspacePlan.mockReset();
+  planMocks.readWorkspacePlanSync.mockReset();
+});
+
+describe('plan checklist evaluation', () => {
+  it('uses the asynchronous workspace-plan door for Promise callers', async () => {
+    planMocks.readWorkspacePlan.mockReturnValue(Effect.succeed(planWithStatus('pending')));
+    planMocks.readWorkspacePlanSync.mockImplementation(() => {
+      throw new Error('synchronous plan reader must not run');
+    });
+
+    const incomplete = await checkIncompletePlanItemsPromise('/project/workspaces/feature-pan-3451', 'PAN-3451');
+
+    expect(incomplete).toEqual([
+      '  Incomplete plan items (1):',
+      '    - item-one First item (pending)',
+    ]);
+    expect(planMocks.readWorkspacePlan).toHaveBeenCalledWith('/project/workspaces/feature-pan-3451');
+    expect(planMocks.readWorkspacePlanSync).not.toHaveBeenCalled();
+  });
+
+  it('keeps the synchronous reader for synchronous callers', () => {
+    planMocks.readWorkspacePlanSync.mockReturnValue(planWithStatus('completed'));
+
+    expect(checkIncompletePlanItemsSync('/project/workspaces/feature-pan-3451')).toEqual([]);
+    expect(planMocks.readWorkspacePlanSync).toHaveBeenCalledWith('/project/workspaces/feature-pan-3451');
+    expect(planMocks.readWorkspacePlan).not.toHaveBeenCalled();
+  });
+
+  it('reports a missing plan consistently through the shared evaluator', () => {
+    expect(evaluateIncompletePlanItems(null)).toEqual([
+      '  The required xBRIEF checklist is missing or unreadable; return the issue to planning before completion.',
+    ]);
+  });
+});

--- a/src/lib/work/done-preflight.ts
+++ b/src/lib/work/done-preflight.ts
@@ -7,15 +7,14 @@ import { Effect } from 'effect';
 
 import { ProcessSpawnError } from '../errors.js';
 import { isOverdeckOwnedOnlyStatus } from '../state-plane.js';
-import { readWorkspacePlanSync } from '../xbrief/io.js';
-import { subItemsOf } from '../xbrief/types.js';
+import { readWorkspacePlan, readWorkspacePlanSync } from '../xbrief/io.js';
+import { subItemsOf, type XBriefDocument } from '../xbrief/types.js';
 import { runTestRequirementCheck } from './test-requirement-gate.js';
 
 const execAsync = promisify(exec);
 const terminal = new Set(['completed', 'cancelled']);
 
-export function checkIncompletePlanItemsSync(workspacePath: string): string[] {
-  const doc = readWorkspacePlanSync(workspacePath);
+export function evaluateIncompletePlanItems(doc: XBriefDocument | null): string[] {
   if (!doc) return ['  The required xBRIEF checklist is missing or unreadable; return the issue to planning before completion.'];
   const incomplete = doc.plan.items.flatMap((item) => {
     const lines: string[] = [];
@@ -28,8 +27,12 @@ export function checkIncompletePlanItemsSync(workspacePath: string): string[] {
   return incomplete.length === 0 ? [] : [`  Incomplete plan items (${incomplete.length}):`, ...incomplete];
 }
 
+export function checkIncompletePlanItemsSync(workspacePath: string): string[] {
+  return evaluateIncompletePlanItems(readWorkspacePlanSync(workspacePath));
+}
+
 export async function checkIncompletePlanItemsPromise(workspacePath: string, _issueId?: string): Promise<string[]> {
-  return checkIncompletePlanItemsSync(workspacePath);
+  return evaluateIncompletePlanItems(await Effect.runPromise(readWorkspacePlan(workspacePath)));
 }
 
 /**

--- a/tests/unit/dashboard/routes/agents-no-loss.test.ts
+++ b/tests/unit/dashboard/routes/agents-no-loss.test.ts
@@ -27,6 +27,7 @@ const EXPECTED_AGENT_ROUTE_LAYERS = [
   'postAgentWorkCompleteRoute',
   'postAgentStuckRoute',
   'postAgentClassifyCompletionRoute',
+  'postAgentPlanChecklistRoute',
   'postInternalAgentPermissionRequestRoute',
   'postAgentPermissionResponseRoute',
   'getAgentRuntimeRoute',
@@ -92,11 +93,11 @@ function enumerateMergeAllLayers(source: string): string[] {
 }
 
 describe('PAN-2147 agents route barrel no-loss audit', () => {
-  it('keeps the same 46 agentsRouteLayer entries in the same order', () => {
+  it('keeps the same 47 agentsRouteLayer entries in the same order', () => {
     const liveLayers = enumerateMergeAllLayers(readAgentsRoute());
 
     expect(liveLayers).toEqual(EXPECTED_AGENT_ROUTE_LAYERS);
-    expect(liveLayers).toHaveLength(46);
+    expect(liveLayers).toHaveLength(47);
   });
 
   it('keeps routes/agents.ts as a thin barrel with no handler bodies', () => {

--- a/tests/unit/dashboard/server/routes/plan-checklist.test.ts
+++ b/tests/unit/dashboard/server/routes/plan-checklist.test.ts
@@ -1,0 +1,139 @@
+import { Effect } from 'effect';
+import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { INTERNAL_TOKEN_HEADER } from '../../../../../src/lib/internal-token.js';
+
+const routeMocks = vi.hoisted(() => ({
+  getAgentState: vi.fn(),
+}));
+
+vi.mock('../../../../../src/lib/agents.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../../src/lib/agents.js')>();
+  return { ...actual, getAgentState: routeMocks.getAgentState };
+});
+
+import { postAgentPlanChecklistRoute } from '../../../../../src/dashboard/server/routes/agents/runtime-events.js';
+
+let projectPath: string;
+let workspace: string;
+
+async function writePlan(status: 'pending' | 'completed'): Promise<void> {
+  const planDir = join(workspace, '.overdeck');
+  await mkdir(planDir, { recursive: true });
+  await writeFile(join(planDir, 'spec.vbrief.json'), JSON.stringify({
+    xBRIEFInfo: {
+      version: '0.8',
+      created: '2026-08-01T00:00:00.000Z',
+      author: 'overdeck/test',
+      description: 'Plan checklist route fixture',
+    },
+    plan: {
+      id: 'pan-3451',
+      title: 'Plan checklist route fixture',
+      status: 'running',
+      uid: '20c18fe7-f0fe-4d1e-a7dd-bfc2234496a7',
+      author: 'agent:test',
+      sequence: 1,
+      created: '2026-08-01T00:00:00.000Z',
+      updated: '2026-08-01T00:00:00.000Z',
+      items: [{
+        id: 'check-extension-evidence',
+        title: 'Check extension completion evidence',
+        status,
+        created: '2026-08-01T00:00:00.000Z',
+      }],
+      edges: [],
+    },
+  }));
+}
+
+async function postPlanChecklist(options: { token?: string; agentId?: string } = {}): Promise<{
+  status: number;
+  body: Record<string, unknown>;
+}> {
+  const headers = options.token === undefined
+    ? {}
+    : { [INTERNAL_TOKEN_HEADER]: options.token };
+  const request = HttpServerRequest.fromWeb(new Request(
+    `http://localhost/api/agents/${options.agentId ?? 'agent-pan-3451'}/plan-checklist`,
+    { method: 'POST', headers },
+  ));
+  const response = await Effect.runPromise(Effect.scoped(
+    Effect.flatMap(HttpRouter.toHttpEffect(postAgentPlanChecklistRoute), (app) =>
+      Effect.provideService(app, HttpServerRequest.HttpServerRequest, request)),
+  ));
+  const responseBody = response.body as { body?: Uint8Array } | null;
+  const text = responseBody?.body ? new TextDecoder().decode(responseBody.body) : '{}';
+  return { status: response.status, body: JSON.parse(text) as Record<string, unknown> };
+}
+
+beforeEach(async () => {
+  projectPath = await mkdtemp(join(tmpdir(), 'pan-3451-plan-checklist-'));
+  workspace = join(projectPath, 'workspaces', 'feature-pan-3451');
+  await mkdir(workspace, { recursive: true });
+  process.env.OVERDECK_INTERNAL_TOKEN = 'test-token';
+  routeMocks.getAgentState.mockReset();
+  routeMocks.getAgentState.mockReturnValue(Effect.succeed({
+    id: 'agent-pan-3451',
+    issueId: 'PAN-3451',
+    workspace,
+    role: 'work',
+    model: 'test-model',
+    status: 'running',
+    startedAt: '2026-08-01T00:00:00.000Z',
+  }));
+});
+
+afterEach(async () => {
+  delete process.env.OVERDECK_INTERNAL_TOKEN;
+  await rm(projectPath, { recursive: true, force: true });
+});
+
+describe('POST /api/agents/:id/plan-checklist', () => {
+  it('returns complete when every plan item is terminal', async () => {
+    await writePlan('completed');
+
+    const result = await postPlanChecklist({ token: 'test-token' });
+
+    expect(result).toEqual({
+      status: 200,
+      body: { success: true, complete: true, incomplete: [] },
+    });
+  });
+
+  it('returns the pending item when the plan is incomplete', async () => {
+    await writePlan('pending');
+
+    const result = await postPlanChecklist({ token: 'test-token' });
+
+    expect(result.status).toBe(200);
+    expect(result.body).toMatchObject({ success: true, complete: false });
+    expect(result.body['incomplete']).toEqual(expect.arrayContaining([
+      expect.stringContaining('check-extension-evidence'),
+    ]));
+  });
+
+  it('rejects a request without the internal token', async () => {
+    await writePlan('completed');
+
+    const result = await postPlanChecklist();
+
+    expect(result).toEqual({
+      status: 403,
+      body: { success: false, error: 'forbidden' },
+    });
+  });
+
+  it('returns 422 when the agent has no resolvable workspace', async () => {
+    routeMocks.getAgentState.mockReturnValue(Effect.succeed(null));
+
+    const result = await postPlanChecklist({ token: 'test-token', agentId: 'missing-agent' });
+
+    expect(result.status).toBe(422);
+    expect(result.body).toMatchObject({ success: false });
+  });
+});


### PR DESCRIPTION
**Issue:** #3451

## Acceptance Criteria

- [ ] Add POST /api/agents/:id/plan-checklist route backed by checkIncompletePlanItemsPromise
- [ ] pi extension: evidenceClean consults plan-checklist endpoint; delete beads helpers
- [ ] ohmypi extension: evidenceClean consults plan-checklist endpoint; delete beads helpers
- [ ] docs/HOOKS.md: Pi Completion Detection documents the plan-checklist endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dashboard endpoint to check whether an agent’s plan checklist is complete.
  * Completion evidence now uses checklist status, including reporting unfinished plan items.

* **Bug Fixes**
  * Improved completion detection when checklist data is unavailable by using recognized completion markers as a fallback.
  * Updated completion wording from “all beads closed” to “all tasks closed.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->