### PR TITLE
fix(plan): prefer the authored workspace spec on finalize (PAN-3467)

### DIFF
--- a/src/cli/commands/plan-finalize.ts
+++ b/src/cli/commands/plan-finalize.ts
@@ -194,7 +194,7 @@ export async function planFinalizeCommand(options: PlanFinalizeOptions = {}): Pr
     return exitCli(1);
   }
 
-  const planPath = findWorkspaceDraftPlanSync(workspacePath) ?? findPlanSync(workspacePath);
+  const planPath = findWorkspaceDraftPlanSync(workspacePath, 'authored-first') ?? findPlanSync(workspacePath);
   if (!planPath) {
     const msg = `xBRIEF plan not readable at ${workspacePath}/.pan/spec.vbrief.json`;
     if (options.json) console.log(JSON.stringify({ success: false, error: msg }));

--- a/src/dashboard/server/routes/__tests__/complete-planning.test.ts
+++ b/src/dashboard/server/routes/__tests__/complete-planning.test.ts
@@ -266,6 +266,32 @@ describe('completePlanningArtifacts', () => {
     expect(promoted.plan.status).toBe('proposed');
   });
 
+  it('promotes the authored .pan spec when a stored .overdeck draft also exists', async () => {
+    const issueId = 'PAN-3467';
+    const { projectPath, workspacePath } = makeProject(issueId);
+    await Promise.all([
+      mkdir(join(workspacePath, '.overdeck'), { recursive: true }),
+      mkdir(join(workspacePath, '.pan'), { recursive: true }),
+    ]);
+    const storedDraft = makeDoc(issueId);
+    storedDraft.plan.title = 'Stored server draft';
+    const authoredDoc = makeDoc(issueId);
+    authoredDoc.plan.title = 'Operator-authored plan';
+    authoredDoc.plan.items[0]!.id = 'operator-authored';
+    writeFileSync(join(workspacePath, '.overdeck', 'spec.vbrief.json'), JSON.stringify(storedDraft, null, 2));
+    writeFileSync(join(workspacePath, '.pan', 'spec.vbrief.json'), JSON.stringify(authoredDoc, null, 2));
+
+    const result = await completePlanningArtifacts({
+      projectPath,
+      workspacePath,
+      issueId,
+    });
+
+    const promoted = JSON.parse(readFileSync(result.proposed.path, 'utf-8')) as XBriefDocument;
+    expect(promoted.plan.title).toBe('Operator-authored plan');
+    expect(promoted.plan.items[0]?.id).toBe('operator-authored');
+  });
+
   it('rejects quality lint failures before writing a proposed spec', async () => {
     const issueId = 'PAN-1149';
     const { projectPath, workspacePath } = makeProject(issueId);

--- a/src/lib/overdeck/planning-promotion.ts
+++ b/src/lib/overdeck/planning-promotion.ts
@@ -162,7 +162,7 @@ export async function completePlanningArtifacts(options: {
   const issueLower = issueId.toLowerCase();
   const upperIssueId = issueId.toUpperCase();
   const workspacePlanPath = await Effect.runPromise(Effect.gen(function* () {
-    return (yield* findWorkspaceDraftPlan(workspacePath)) ?? (yield* findPlan(workspacePath));
+    return (yield* findWorkspaceDraftPlan(workspacePath, 'authored-first')) ?? (yield* findPlan(workspacePath));
   }));
   if (!workspacePlanPath) {
     throw new Error(`No workspace xBRIEF found for ${upperIssueId} at ${workspacePath}/.overdeck/spec.vbrief.json`);
@@ -618,7 +618,7 @@ export async function completePlanningForIssue(options: {
       }
 
       const workspacePlanPath = await (async () =>
-        (await Effect.runPromise(findWorkspaceDraftPlan(workspacePath))) ?? (await Effect.runPromise(findPlan(workspacePath)))
+        (await Effect.runPromise(findWorkspaceDraftPlan(workspacePath, 'authored-first'))) ?? (await Effect.runPromise(findPlan(workspacePath)))
       )();
       if (workspacePlanPath) {
         const workspaceDoc = await Effect.runPromise(readPlan(workspacePlanPath));

--- a/src/lib/xbrief/io.ts
+++ b/src/lib/xbrief/io.ts
@@ -129,11 +129,23 @@ function workspaceDraftPath(workspacePath: string): string {
   return getWorkspacePanPaths(workspacePath).specPath;
 }
 
-function readableWorkspaceDraftPath(workspacePath: string): string | null {
-  const canonicalPath = workspaceDraftPath(workspacePath);
-  if (existsSync(canonicalPath)) return canonicalPath;
-  const legacyPath = getLegacyWorkspacePanPaths(workspacePath).specPath;
-  return existsSync(legacyPath) ? legacyPath : null;
+// Runtime reads prefer `.overdeck/`, but planning finalization must prefer the
+// `.pan/` path that the planning and write-xbrief contracts tell agents to author.
+type WorkspaceDraftOrder = 'runtime-first' | 'authored-first';
+
+function workspaceDraftPaths(workspacePath: string, order: WorkspaceDraftOrder): string[] {
+  const runtimePath = workspaceDraftPath(workspacePath);
+  const authoredPath = getLegacyWorkspacePanPaths(workspacePath).specPath;
+  return order === 'authored-first'
+    ? [authoredPath, runtimePath]
+    : [runtimePath, authoredPath];
+}
+
+function readableWorkspaceDraftPath(
+  workspacePath: string,
+  order: WorkspaceDraftOrder = 'runtime-first',
+): string | null {
+  return workspaceDraftPaths(workspacePath, order).find(existsSync) ?? null;
 }
 
 function workspaceContinuePath(workspacePath: string): string {
@@ -147,8 +159,11 @@ function readableWorkspaceContinuePath(workspacePath: string): string {
   return existsSync(legacyPath) ? legacyPath : canonicalPath;
 }
 
-export function findWorkspaceDraftPlanSync(workspacePath: string): string | null {
-  const path = readableWorkspaceDraftPath(workspacePath);
+export function findWorkspaceDraftPlanSync(
+  workspacePath: string,
+  order: WorkspaceDraftOrder = 'runtime-first',
+): string | null {
+  const path = readableWorkspaceDraftPath(workspacePath, order);
   if (!path) return null;
 
   const issueId = issueIdFromWorkspacePath(workspacePath);
@@ -515,12 +530,10 @@ export const readPlan = (
 
 export const findWorkspaceDraftPlan = (
   workspacePath: string,
+  order: WorkspaceDraftOrder = 'runtime-first',
 ): Effect.Effect<string | null, FsError> =>
   Effect.gen(function* () {
-    const paths = [
-      workspaceDraftPath(workspacePath),
-      getLegacyWorkspacePanPaths(workspacePath).specPath,
-    ];
+    const paths = workspaceDraftPaths(workspacePath, order);
     let path: string | null = null;
     for (const candidate of paths) {
       const exists = yield* Effect.tryPromise({

--- a/tests/unit/cli/plan-finalize-pending-promotion.test.ts
+++ b/tests/unit/cli/plan-finalize-pending-promotion.test.ts
@@ -165,6 +165,39 @@ describe('plan finalize pending-promotion marker', () => {
     });
   });
 
+  it('finalizes the authored .pan spec when a stored .overdeck draft also exists', async () => {
+    const { root, workspacePath, specPath: storedDraftPath } = createWorkspace();
+    process.env.OVERDECK_HOME = root;
+    const authoredDir = join(workspacePath, '.pan');
+    const authoredPath = join(authoredDir, 'spec.vbrief.json');
+    mkdirSync(authoredDir, { recursive: true });
+    const authoredDoc = JSON.parse(readFileSync(storedDraftPath, 'utf-8'));
+    authoredDoc.plan.title = 'Operator-authored plan';
+    authoredDoc.plan.sequence = 7;
+    authoredDoc.plan.items[0].id = 'operator-authored';
+    writeFileSync(authoredPath, JSON.stringify(authoredDoc, null, 2));
+
+    await planFinalizeCommand({
+      workspace: workspacePath,
+      json: true,
+      prd: false,
+      qualityLint: false,
+      promote: false,
+    });
+
+    expect(JSON.parse(readFileSync(authoredPath, 'utf-8'))).toMatchObject({
+      plan: {
+        title: 'Operator-authored plan',
+        status: 'proposed',
+        sequence: 8,
+        items: [{ id: 'operator-authored' }],
+      },
+    });
+    expect(JSON.parse(readFileSync(storedDraftPath, 'utf-8'))).toMatchObject({
+      plan: { status: 'approved', sequence: 0, items: [{ id: 'marker' }] },
+    });
+  });
+
   it('names the deacon recovery owner in human output while preserving exit code 1', async () => {
     const { root, workspacePath } = createWorkspace();
     process.env.OVERDECK_HOME = root;


### PR DESCRIPTION
Operator-expedited. `pan plan finalize` silently discarded the workspace `.pan/spec.vbrief.json` and re-promoted the stored server draft, so an operator's swarm-shaped plan never became canonical — the loss was never surfaced.

Finalize now prefers the authored workspace spec.

Unblocks PAN-3447 (God View Confluence): once deployed, re-running finalize from `workspaces/feature-pan-3447` promotes the operator's intact 16-item spec, then `pan swarm PAN-3447` dispatches the wide wave.

Closes PAN-3467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhNVZuskT1Xw9qmw65g5dq