### PR TITLE
fix(deploy): fire deferred deploys when the gate window clears (PAN-3462)

### DIFF
--- a/src/lib/cloister/deploy-patrol.ts
+++ b/src/lib/cloister/deploy-patrol.ts
@@ -282,6 +282,19 @@ function emitDeferral(reason: string, now: number, emitEntry: EmitEntry): void {
   state.lastDeferralAt = now;
 }
 
+async function refreshQueuedDeployReason(
+  queuedDeploy: PendingDeploy | null,
+  reason: string,
+  context: DeployPatrolContext,
+): Promise<void> {
+  if (!queuedDeploy) return;
+  await (context.recordIntent ?? recordDeployIntent)({
+    requestedBy: DEPLOY_PATROL_INITIATOR,
+    reason,
+    blockedBy: [],
+  });
+}
+
 async function escalateOverdueQueue(
   queuedDeploy: PendingDeploy | null,
   blockReason: string,
@@ -336,6 +349,7 @@ export async function runDeployPatrol(context: DeployPatrolContext): Promise<voi
       });
       state.unknownObserved = true;
     }
+    await refreshQueuedDeployReason(queuedDeploy, reason, context);
     await escalateOverdueQueue(queuedDeploy, reason, context, now, emitEntry, emitTts);
     return;
   }
@@ -367,11 +381,13 @@ export async function runDeployPatrol(context: DeployPatrolContext): Promise<voi
     && now - staleness.originMainLastBuildInputCommitAt < context.config.debounce_minutes * 60 * 1000
   ) {
     const reason = 'Automatic deployment deferred because the merge debounce has not elapsed.';
+    await refreshQueuedDeployReason(queuedDeploy, reason, context);
     await escalateOverdueQueue(queuedDeploy, reason, context, now, emitEntry, emitTts);
     return;
   }
   if (state.lastDeploySpawnAt > 0 && now - state.lastDeploySpawnAt < DEPLOY_SPAWN_COOLDOWN_MS) {
     const reason = 'Automatic deployment deferred because a recent deploy is still inside the spawn cooldown.';
+    await refreshQueuedDeployReason(queuedDeploy, reason, context);
     await escalateOverdueQueue(queuedDeploy, reason, context, now, emitEntry, emitTts);
     return;
   }
@@ -379,6 +395,7 @@ export async function runDeployPatrol(context: DeployPatrolContext): Promise<voi
   if (!staleness.originMainSha) {
     const reason = 'Automatic deployment deferred because the origin/main commit is unknown.';
     emitDeferral(reason, now, emitEntry);
+    await refreshQueuedDeployReason(queuedDeploy, reason, context);
     await escalateOverdueQueue(queuedDeploy, reason, context, now, emitEntry, emitTts);
     return;
   }
@@ -387,6 +404,7 @@ export async function runDeployPatrol(context: DeployPatrolContext): Promise<voi
     const reason = ciState.reason
       ?? `Automatic deployment deferred because CI is ${ciState.status} for origin/main ${shortSha(staleness.originMainSha)}.`;
     emitDeferral(reason, now, emitEntry);
+    await refreshQueuedDeployReason(queuedDeploy, reason, context);
     await escalateOverdueQueue(queuedDeploy, reason, context, now, emitEntry, emitTts);
     return;
   }
@@ -394,7 +412,7 @@ export async function runDeployPatrol(context: DeployPatrolContext): Promise<voi
   const assessment = await (context.getWindowAssessment ?? getDeployWindowAssessment)();
   if (assessment.reason) {
     emitDeferral(assessment.reason, now, emitEntry);
-    if (context.config.auto_deploy) {
+    if (context.config.auto_deploy || queuedDeploy) {
       await (context.recordIntent ?? recordDeployIntent)({
         requestedBy: DEPLOY_PATROL_INITIATOR,
         reason: assessment.reason,

--- a/src/lib/deploy/agent-restart-gate.ts
+++ b/src/lib/deploy/agent-restart-gate.ts
@@ -35,5 +35,5 @@ export async function agentRestartBlockReason(
     blockedBy: [],
   });
 
-  return `Restart refused. The active deployment gate says: "${assessment.reason}" This deploy has been queued since ${queued.requestedAt} (${formatQueueAge(queued.requestedAt)} ago); it fires automatically as soon as the window clears — do not retry or use --force, which would interrupt the operation the gate is protecting.`;
+  return `Restart refused. The active deployment gate says: "${assessment.reason}" This deploy has been queued since ${queued.requestedAt} (${formatQueueAge(queued.requestedAt)} ago). The deploy patrol retries automatically after the merge debounce has elapsed, CI is green for the exact origin/main tip, and the safety window clears — do not retry or use --force, which would interrupt the operation the gate is protecting.`;
 }

--- a/tests/unit/lib/cloister/deploy-patrol.test.ts
+++ b/tests/unit/lib/cloister/deploy-patrol.test.ts
@@ -174,6 +174,25 @@ describe('runDeployPatrol', () => {
     expect(ctx.clearQueue).not.toHaveBeenCalled();
   });
 
+  it('reassesses a queued deploy and starts the reload when the gate clears', async () => {
+    const ctx = context();
+    ctx.readQueue.mockResolvedValue(queuedDeploy());
+    ctx.getWindowAssessment
+      .mockResolvedValueOnce({
+        reason: 'Deployment deferred because the post-merge lifecycle is pending.',
+      })
+      .mockResolvedValueOnce({ reason: null });
+
+    await runDeployPatrol(ctx);
+    expect(ctx.spawnReload).not.toHaveBeenCalled();
+
+    await runDeployPatrol(ctx);
+
+    expect(ctx.getWindowAssessment).toHaveBeenCalledTimes(2);
+    expect(ctx.spawnReload).toHaveBeenCalledOnce();
+    expect(ctx.clearQueue).not.toHaveBeenCalled();
+  });
+
   it('escalates one long-queued deploy and persists the escalated flag', async () => {
     const ctx = context();
     let queue = queuedDeploy({ requestedAt: '2026-07-15T11:29:00.000Z' });
@@ -243,6 +262,11 @@ describe('runDeployPatrol', () => {
     expect(ctx.spawnReload).not.toHaveBeenCalled();
     expect(ctx.getWindowAssessment).not.toHaveBeenCalled();
     expect(ctx.clearQueue).not.toHaveBeenCalled();
+    expect(ctx.recordIntent).toHaveBeenCalledWith({
+      requestedBy: 'deploy-patrol',
+      reason: 'Automatic deployment blocked because CI failed.',
+      blockedBy: [],
+    });
   });
 
   it('escalates an overdue queued deploy while CI is blocked', async () => {

--- a/tests/unit/lib/deploy/agent-restart-gate.test.ts
+++ b/tests/unit/lib/deploy/agent-restart-gate.test.ts
@@ -75,7 +75,10 @@ describe('agentRestartBlockReason', () => {
       escalated: false,
     });
     expect(result).toContain('queued since 2026-07-26T12:00:00.000Z (0s ago)');
-    expect(result).toContain('fires automatically as soon as the window clears');
+    expect(result).toContain('deploy patrol retries automatically');
+    expect(result).toContain('merge debounce has elapsed');
+    expect(result).toContain('CI is green for the exact origin/main tip');
+    expect(result).toContain('safety window clears');
     expect(result).toContain('do not retry or use --force');
   });
 


### PR DESCRIPTION
A deploy deferred by the deploy window promised "it fires automatically as soon as the window clears — do not retry", but nothing ever fired it: the queued marker sat in `pending-deploy.json` with an incrementing deferral count while the blocking condition was long gone. Two occurrences today, each needing a manual reload, each blocking close-outs in the meantime.

Landing note: typecheck + lint green, focused deploy tests 34/34, representative DB tests pass in isolation. Full local suite failed three times only on the unrelated 5s `setupOverdeckTestDb` timeouts under host contention (21/39/65 failures against 13k+ passing each run) — PAN-3344, and the 9th strike it has taxed today. CI is the authoritative gate per standing flywheel decision.

Closes PAN-3462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhNVZuskT1Xw9qmw65g5dq