### PR TITLE
fix(dashboard): restore commitment diagnostic to SystemHealthPill (PAN-3473, red main)

### DIFF
--- a/src/dashboard/frontend/src/components/SystemHealthPill.test.tsx
+++ b/src/dashboard/frontend/src/components/SystemHealthPill.test.tsx
@@ -234,6 +234,15 @@ describe('SystemHealthPill', () => {
     }
   });
 
+  it('keeps virtual commitment visible as a historical diagnostic', () => {
+    setSnapshot('healthy');
+    renderPill();
+
+    fireEvent.click(screen.getByTestId('system-health-pill'));
+
+    expect(screen.getByText('Overcommit 33.3%')).toBeInTheDocument();
+  });
+
   it('selects the primary label by structured reason code, not message text', () => {
     const snapshot = createSnapshot('critical');
     snapshot.host.reasons = [{

--- a/src/dashboard/frontend/src/components/SystemHealthPill.tsx
+++ b/src/dashboard/frontend/src/components/SystemHealthPill.tsx
@@ -408,6 +408,9 @@ export function SystemHealthPill({ compact = false }: { compact?: boolean }) {
                   />
                 </div>
               )}
+              <div className="mt-1 text-muted-foreground">
+                Overcommit {data.host.metrics.virtualCommitmentPercent == null ? 'Unavailable' : `${data.host.metrics.virtualCommitmentPercent.toFixed(1)}%`}
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
P0 red-main strike. The PAN-3423 popover redesign dropped `metrics.virtualCommitmentPercent` from `SystemHealthPill.tsx`, tripping the system-health no-loss audit on every commit. The data existed upstream the whole time — this restores it to the surface the audit inspects. Guard untouched.

Unblocks four PRs that were failing on inherited red, not their own changes: #3470 and #3471 (both operator-expedited PAN-3447 unblockers), #3461 (PAN-3450), and #3472 (PAN-3462).

Closes PAN-3473.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhNVZuskT1Xw9qmw65g5dq