### PR TITLE
PAN-3523

### DIFF
--- a/src/dashboard/server/main.ts
+++ b/src/dashboard/server/main.ts
@@ -56,7 +56,7 @@ import { resumeQueuedMerges } from './services/merge-queue-service.js';
 import { mkdir } from 'node:fs/promises';
 import { getOverdeckHome } from '../../lib/paths.js';
 import { ensureManagedTmuxContextOnce } from '../../lib/tmux.js';
-import { startCliproxyWatchdog } from './routes/cliproxy.js';
+import { startCliproxyWatchdogForDashboard } from './routes/cliproxy.js';
 import { startResourcesSnapshotService } from './routes/resources/snapshot.js';
 import { cleanupOrphanedConversationAttachments } from './services/conversation-attachments.js';
 import { closeMemoryFtsDatabases } from '../../lib/memory/fts-db.js';
@@ -620,8 +620,11 @@ void (async () => {
 })().catch(err => console.warn('[memory-poller] lifecycle subscription failed:', err?.message ?? err));
 
 // Start CLIProxy watchdog — auto-restarts the sidecar if it crashes
-startCliproxyWatchdog();
-console.log('[overdeck] CLIProxy watchdog started (30s interval)');
+if (startCliproxyWatchdogForDashboard(isPeerDashboard)) {
+  console.log('[overdeck] CLIProxy watchdog started (30s interval)');
+} else {
+  console.log('[overdeck] CLIProxy watchdog skipped — peer dashboard (OVERDECK_DISABLE_DEACON=1)');
+}
 
 if (isPeerDashboard) {
   console.log('[overdeck] smee-client webhook relay skipped — peer dashboard (OVERDECK_DISABLE_DEACON=1)');

--- a/src/dashboard/server/routes/cliproxy.ts
+++ b/src/dashboard/server/routes/cliproxy.ts
@@ -75,6 +75,16 @@ export function startCliproxyWatchdog(): void {
   setInterval(() => void tick(), intervalMs);
 }
 
+/** Host dashboards supervise CLIProxy; read-only peer dashboards do not. */
+export function startCliproxyWatchdogForDashboard(
+  isPeerDashboard: boolean,
+  startWatchdog: () => void = startCliproxyWatchdog,
+): boolean {
+  if (isPeerDashboard) return false;
+  startWatchdog();
+  return true;
+}
+
 // ─── Routes ───────────────────────────────────────────────────────────────────
 
 const getCliproxyStatusRoute = HttpRouter.add(

--- a/src/lib/cliproxy.ts
+++ b/src/lib/cliproxy.ts
@@ -25,7 +25,7 @@ import {
 import { mkdir, readFile, writeFile } from 'fs/promises';
 import { homedir } from 'os';
 import { join } from 'path';
-import { spawn, execSync, exec } from 'child_process';
+import { spawn, execSync, exec, type ChildProcess } from 'child_process';
 import { promisify } from 'util';
 import net from 'net';
 import { Effect, Data } from 'effect';
@@ -678,6 +678,33 @@ export function getCliproxyClientEnv(): Record<string, string> {
 
 // ─── Async lifecycle (safe for dashboard server — no execSync) ─────────────────
 
+export async function waitForCliproxySpawn(
+  child: Pick<ChildProcess, 'once' | 'removeListener' | 'pid' | 'unref'>,
+): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const cleanup = () => {
+      child.removeListener('spawn', onSpawn);
+      child.removeListener('error', onError);
+    };
+    const onSpawn = () => {
+      cleanup();
+      if (!child.pid) {
+        reject(new Error('Failed to spawn cliproxy'));
+        return;
+      }
+      child.unref();
+      resolve(child.pid);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+
+    child.once('spawn', onSpawn);
+    child.once('error', onError);
+  });
+}
+
 /** Check whether the cliproxy TCP port is accepting connections. */
 async function checkCliproxyPortTask(): Promise<boolean> {
   return new Promise((resolve) => {
@@ -740,21 +767,20 @@ async function startCliproxyTask(): Promise<void> {
   const config = getCliproxyConfigPath();
   const logPath = getCliproxyLogPath();
 
-  const { openSync } = await import('fs');
+  const { closeSync, openSync } = await import('fs');
   const logFd = openSync(logPath, 'a');
 
-  const child = spawn(bin, ['-config', config], {
-    detached: true,
-    stdio: ['ignore', logFd, logFd],
-    cwd: getCliproxyDir(),
-  });
-
-  if (!child.pid) {
-    throw new Error('Failed to spawn cliproxy');
+  try {
+    const child = spawn(bin, ['-config', config], {
+      detached: true,
+      stdio: ['ignore', logFd, logFd],
+      cwd: getCliproxyDir(),
+    });
+    const pid = await waitForCliproxySpawn(child);
+    writeFileSync(getCliproxyPidPath(), String(pid));
+  } finally {
+    closeSync(logFd);
   }
-
-  writeFileSync(getCliproxyPidPath(), String(child.pid));
-  child.unref();
 }
 
 /** Restart cliproxy asynchronously. Safe for the event loop. */

--- a/tests/lib/cliproxy-spawn.test.ts
+++ b/tests/lib/cliproxy-spawn.test.ts
@@ -1,0 +1,34 @@
+import { EventEmitter } from 'node:events';
+import type { ChildProcess } from 'node:child_process';
+import { describe, expect, it, vi } from 'vitest';
+import { waitForCliproxySpawn } from '../../src/lib/cliproxy.js';
+
+function fakeChild(pid?: number): ChildProcess {
+  return Object.assign(new EventEmitter(), {
+    pid,
+    unref: vi.fn(),
+  }) as unknown as ChildProcess;
+}
+
+describe('waitForCliproxySpawn', () => {
+  it('turns a spawn ENOENT into a rejected promise instead of an unhandled process error', async () => {
+    const child = fakeChild();
+    const spawnPromise = waitForCliproxySpawn(child);
+    const error = new Error('spawn /missing/cliproxy ENOENT');
+
+    child.emit('error', error);
+
+    await expect(spawnPromise).rejects.toBe(error);
+    expect(child.listenerCount('error')).toBe(0);
+  });
+
+  it('resolves with the spawned pid and detaches the child', async () => {
+    const child = fakeChild(3523);
+    const spawnPromise = waitForCliproxySpawn(child);
+
+    child.emit('spawn');
+
+    await expect(spawnPromise).resolves.toBe(3523);
+    expect(child.unref).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/dashboard/server/routes/cliproxy-watchdog.test.ts
+++ b/tests/unit/dashboard/server/routes/cliproxy-watchdog.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest';
+import { startCliproxyWatchdogForDashboard } from '../../../../../src/dashboard/server/routes/cliproxy.js';
+
+describe('startCliproxyWatchdogForDashboard', () => {
+  it('does not start the host-only watchdog in a peer dashboard', () => {
+    const startWatchdog = vi.fn();
+
+    expect(startCliproxyWatchdogForDashboard(true, startWatchdog)).toBe(false);
+    expect(startWatchdog).not.toHaveBeenCalled();
+  });
+
+  it('starts the watchdog once in the host dashboard', () => {
+    const startWatchdog = vi.fn();
+
+    expect(startCliproxyWatchdogForDashboard(false, startWatchdog)).toBe(true);
+    expect(startWatchdog).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
**Issue:** #3523


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CLI proxy startup reliability by waiting for successful process spawning before recording its process ID.
  - Ensured startup errors are handled cleanly and log resources are released properly.
  - Prevented peer dashboards from starting duplicate CLI proxy watchdogs.

- **Tests**
  - Added coverage for successful and failed process startup scenarios.
  - Added tests confirming watchdog behavior for host and peer dashboards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->