### PR TITLE
PAN-3550

### DIFF
--- a/docs/RESOURCE-GOVERNOR.md
+++ b/docs/RESOURCE-GOVERNOR.md
@@ -69,7 +69,21 @@ autonomous admission decision in the deacon runs through the same module.
 governor mode:
 
 | Band | Mode | Meaning |
-|---|---|---|
+|---
+
+## Activity-Feed Signals (PAN-3550)
+
+The memory governor's level transitions and kernel OOM kills appear in the dashboard activity feed via a dedicated 15-second deacon timer, independent of the 60-second patrol. The timer emits **transition-only** — one row per level change, never duplicates while the level persists.
+
+Four feed levels:
+- **`ok`** — MemAvailable above the watch reserve; Overdeck is admitting work normally.
+- **`watch`** — MemAvailable below the watch reserve but still admitting (band is `ok`). Warning that the soft reserve may soon be crossed.
+- **`holding`** (band `soft`) — Overdeck has stopped admitting new agents and dispatches. Work queues until memory recovers above the recovery reserve.
+- **`shedding`** (band `hard`) — MemAvailable is below the hard reserve. Overdeck admits nothing; the kernel may OOM-kill. Automatic eviction is not wired.
+
+Top RSS consumers are attributed to Overdeck tmux sessions via `getRuntimeCensus()` (the in-repo runtime census, not the machine-local `.overdeck/logs/memory-census.log`).
+
+**OOM Canary** watches the kernel journal for `oom-kill:` lines, parses the victim's pid, command, RSS, and cgroup, and emits one activity entry per kill. The cursor-file pattern ensures no duplicate reporting across patrol ticks or dashboard restarts. On permission error (user not in `adm` group), the canary disables itself gracefully and logs once, never blocking the rest of the patrol.|---|---|
 | `ok` | `admitting` | Behavior unchanged from before PAN-2500 — count and load gates still apply. |
 | `soft` | `holding` | Stop admitting new resumes and new advancing dispatches. Nothing is killed. |
 | `hard` | `shedding` | Actively reclaim memory (see the eviction ladder below). |

--- a/scripts/file-size-allowlist.txt
+++ b/scripts/file-size-allowlist.txt
@@ -41,3 +41,4 @@
 1319 src/lib/tmux.ts # PAN-3539
 1518 src/dashboard/frontend/src/components/chat/ConversationPanel.tsx # PAN-3544
 1008 src/lib/cloister/review-agent.ts # PAN-3549
+3571 src/lib/cloister/deacon.ts # PAN-3550

--- a/src/lib/cloister/deacon.ts
+++ b/src/lib/cloister/deacon.ts
@@ -307,7 +307,12 @@ const DEACON_LOG_FILE = join(OVERDECK_HOME, 'logs', 'deacon.log');
 
 let deaconInterval: NodeJS.Timeout | null = null;
 const deaconPatrolGuard = createInFlightGuard();
+let memoryPatrolInterval: NodeJS.Timeout | null = null;
 let config: DeaconConfig = { ...DEFAULT_CONFIG };
+
+/** PAN-3550: the memory watch samples far more often than the 60s patrol so rising
+ *  pressure reaches the activity feed before the kernel acts. */
+export const MEMORY_PATROL_INTERVAL_MS = 15_000;
 
 /**
  * Load deacon configuration
@@ -3465,6 +3470,19 @@ export function startDeacon(): void {
     runScheduledPatrol('interval');
   }, config.patrolIntervalMs);
 
+  // PAN-3550: memory pressure patrol on dedicated 15s timer
+  memoryPatrolInterval = setInterval(() => {
+    void (async () => {
+      const { patrolMemoryPressure } = await import('./memory-pressure-patrol.js');
+      for (const action of await patrolMemoryPressure()) {
+        logDeaconEventSync(`memory-pressure-patrol: ${action}`);
+      }
+    })().catch((err) => {
+      logDeaconEventSync(`memory-pressure-patrol: error: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  }, MEMORY_PATROL_INTERVAL_MS);
+  memoryPatrolInterval.unref?.();
+
   logDeaconEventSync('startDeacon: health monitor started');
 }
 
@@ -3476,6 +3494,10 @@ export function stopDeacon(): void {
     clearInterval(deaconInterval);
     deaconInterval = null;
     console.log('[deacon] Stopped health monitor');
+  }
+  if (memoryPatrolInterval) {
+    clearInterval(memoryPatrolInterval);
+    memoryPatrolInterval = null;
   }
 }
 

--- a/src/lib/cloister/memory-governor.ts
+++ b/src/lib/cloister/memory-governor.ts
@@ -92,6 +92,11 @@ export function readGovernorReserves(): GovernorReserves {
   };
 }
 
+/** PAN-3550: the activity-feed warn reserve, always above the SOFT reserve. */
+export function readGovernorWatchReserveBytes(): number {
+  return loadConfigSync().config.resources.governorWatchReserveGb * GIB;
+}
+
 export function readGovernorRunwayThresholds(): GovernorRunwayThresholds {
   const resources = loadConfigSync().config.resources;
   return {

--- a/src/lib/cloister/memory-pressure-patrol.ts
+++ b/src/lib/cloister/memory-pressure-patrol.ts
@@ -11,6 +11,10 @@ import { MemoryPressureBand, MemoryVerdict, assessMemoryPressure, readGovernorRe
 import { RuntimeCensus, getRuntimeCensus } from '../runtime-census.js';
 import { emitActivityEntrySync, EmitActivityOptions } from '../activity-logger.js';
 import { logDeaconEventSync } from '../persistent-logger.js';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { homedir } from 'os';
+import { resolve } from 'path';
 
 export type MemoryFeedLevel = 'ok' | 'watch' | 'holding' | 'shedding';
 
@@ -62,11 +66,54 @@ export interface MemoryPressurePatrolDeps {
   readHardReserveBytes: () => number;
   readRecoveryReserveBytes: () => number;
   census: () => Promise<RuntimeCensus>;
+  readNewKernelJournal: () => Promise<string>;
   emit: (entry: EmitActivityOptions) => void;
 }
 
 // Module-level state for transition-only emission
 let lastLevel: MemoryFeedLevel | null = null;
+
+// Module-level state for OOM canary: disabled if journal reading fails
+let oomCanaryDisabled = false;
+
+/**
+ * WI-4: Read new kernel journal entries via journalctl with cursor-file persistence.
+ * On first call (cursor file absent), uses -n 0 to initialize and returns empty string.
+ * On ANY error, disables the canary permanently and returns empty string.
+ */
+async function readNewKernelJournal(): Promise<string> {
+  if (oomCanaryDisabled) return '';
+
+  try {
+    const overdeckHome = process.env.OVERDECK_HOME || resolve(homedir(), '.overdeck');
+    const cursorFile = resolve(overdeckHome, 'oom-canary.cursor');
+
+    // Check if cursor file exists to determine if we should use -n 0
+    const fs = await import('fs/promises');
+    let cursorExists = false;
+    try {
+      await fs.stat(cursorFile);
+      cursorExists = true;
+    } catch {
+      // Cursor doesn't exist yet
+    }
+
+    const execFileAsync = promisify(execFile);
+    const args = ['-k', '--cursor-file', cursorFile, '--no-pager', '-o', 'cat'];
+
+    // On first run (no cursor), use -n 0 to initialize without replaying
+    if (!cursorExists) {
+      args.push('-n', '0');
+    }
+
+    const result = await execFileAsync('journalctl', args, { timeout: 10000 });
+    return result.stdout;
+  } catch (err) {
+    console.warn('[memory-pressure-patrol] Journal reader failed, disabling OOM canary:', err);
+    oomCanaryDisabled = true;
+    return '';
+  }
+}
 
 /**
  * Patrol memory pressure once and emit a transition-only activity entry if the level changed.
@@ -81,6 +128,7 @@ export async function patrolMemoryPressure(deps: Partial<MemoryPressurePatrolDep
     readHardReserveBytes: deps.readHardReserveBytes || (() => readGovernorReserves().hardBytes),
     readRecoveryReserveBytes: deps.readRecoveryReserveBytes || (() => readGovernorReserves().recoveryBytes),
     census: deps.census || (() => getRuntimeCensus()),
+    readNewKernelJournal: deps.readNewKernelJournal || readNewKernelJournal,
     emit: deps.emit || emitActivityEntrySync,
   };
 
@@ -89,24 +137,64 @@ export async function patrolMemoryPressure(deps: Partial<MemoryPressurePatrolDep
   const softBytes = d.readSoftReserveBytes();
   const hardBytes = d.readHardReserveBytes();
   const recoveryBytes = d.readRecoveryReserveBytes();
+  const actions: string[] = [];
+
+  // WI-4: Check for new OOM kills in the journal (runs even if level unchanged)
+  const journalText = await d.readNewKernelJournal();
+  const oomKills = parseOomKills(journalText);
+
+  // Emit OOM kills regardless of level transition
+  for (const kill of oomKills) {
+    const message = `Kernel OOM: Killed process ${kill.pid} (${kill.comm}), ${formatGib(kill.rssBytes)} RSS${kill.inOverdeckTree ? ' in Overdeck tmux-server' : ''}`;
+
+    d.emit({
+      level: kill.inOverdeckTree ? 'error' : 'warn',
+      source: 'cloister',
+      link: '/resources',
+      message,
+      details: `Cgroup: ${kill.cgroup || '(unknown)'}\n\n${buildMemoryDetails(verdict.availableBytes, watchBytes, softBytes, hardBytes, recoveryBytes)}`,
+      desktop: kill.inOverdeckTree,
+    });
+
+    const action = `memory-pressure-patrol: oom-kill (pid ${kill.pid} ${kill.comm} ${formatGib(kill.rssBytes)})`;
+    actions.push(action);
+    logDeaconEventSync(`[deacon] ${action}`);
+  }
 
   const level = memoryFeedLevel(verdict.band, verdict.availableBytes, watchBytes);
 
-  // Transition-only: if level hasn't changed, emit nothing
+  // Transition-only: if level hasn't changed, emit nothing for level transition
   if (level === lastLevel) {
-    return [];
+    return oomKills.length > 0 ? actions : [];
   }
 
   lastLevel = level;
-  const actions: string[] = [];
 
-  const details = buildMemoryDetails(
+  // Fetch the runtime census for top-consumer attribution
+  const census = await d.census();
+
+  // Build details with the base reserves and top consumers
+  let details = buildMemoryDetails(
     verdict.availableBytes,
     watchBytes,
     softBytes,
     hardBytes,
     recoveryBytes,
   );
+
+  // WI-3: Append top memory consumers to details
+  if (!census.processAvailable) {
+    details += '\n\nTop memory consumers: unavailable (process census could not be read)';
+  } else {
+    const topConsumers = topMemoryConsumers(census, 5);
+    if (topConsumers.length > 0) {
+      const consumerLines = topConsumers.map(
+        (c) =>
+          `  ${formatGib(c.rssBytes)} | pid ${c.pid} (${c.command.substring(0, 80)}) in session ${c.sessionName || '(host)'}`,
+      );
+      details += '\n\nTop memory consumers:\n' + consumerLines.join('\n');
+    }
+  }
 
   // Build the activity entry based on level
   if (level === 'watch') {
@@ -189,6 +277,7 @@ export async function patrolMemoryPressure(deps: Partial<MemoryPressurePatrolDep
  */
 export function __resetMemoryPressurePatrolState(): void {
   lastLevel = null;
+  oomCanaryDisabled = false;
 }
 
 /**

--- a/src/lib/cloister/memory-pressure-patrol.ts
+++ b/src/lib/cloister/memory-pressure-patrol.ts
@@ -190,3 +190,113 @@ export async function patrolMemoryPressure(deps: Partial<MemoryPressurePatrolDep
 export function __resetMemoryPressurePatrolState(): void {
   lastLevel = null;
 }
+
+/**
+ * WI-3: Top consumer attribution
+ */
+export interface TopConsumer {
+  pid: number;
+  rssBytes: number;
+  command: string;
+  sessionName: string | null;
+}
+
+/**
+ * Pure: the N largest-RSS processes in the census, each attributed to a tmux session.
+ */
+export function topMemoryConsumers(census: RuntimeCensus, limit: number): TopConsumer[] {
+  if (!census.processAvailable) return [];
+  
+  const sessionByPanePid = new Map<number, string>();
+  for (const [sessionName, panes] of census.panesBySession) {
+    for (const pane of panes) {
+      sessionByPanePid.set(pane.panePid, sessionName);
+    }
+  }
+
+  const topProcs = [...census.processesByPid.values()]
+    .sort((a, b) => b.rssBytes - a.rssBytes)
+    .slice(0, limit);
+
+  return topProcs.map((proc) => {
+    const visited = new Set<number>();
+    let current = proc.pid;
+    let sessionName: string | null = null;
+
+    while (current > 1 && !visited.has(current)) {
+      visited.add(current);
+      if (sessionByPanePid.has(current)) {
+        sessionName = sessionByPanePid.get(current)!;
+        break;
+      }
+      const parent = census.processesByPid.get(current);
+      if (!parent?.ppid) break;
+      current = parent.ppid;
+    }
+
+    return {
+      pid: proc.pid,
+      rssBytes: proc.rssBytes,
+      command: proc.command.slice(0, 80),
+      sessionName,
+    };
+  });
+}
+
+/**
+ * WI-4: OOM kill detection
+ */
+export interface OomKillRecord {
+  pid: number;
+  comm: string;
+  rssBytes: number;
+  cgroup: string | null;
+  inOverdeckTree: boolean;
+}
+
+const OOM_OVERDECK_TREE_REGEX = /overdeck-tmux-server\.service|overdeck-/;
+
+export function parseOomKills(journalText: string): OomKillRecord[] {
+  const kills = new Map<number, OomKillRecord>();
+
+  const oomkillPattern = /task_memcg=(\S+?),task=([^,]+),pid=(\d+)/g;
+  let match;
+  while ((match = oomkillPattern.exec(journalText)) !== null) {
+    const [_, cgroup, comm, pidStr] = match;
+    const pid = parseInt(pidStr, 10);
+    kills.set(pid, {
+      pid,
+      comm,
+      rssBytes: 0,
+      cgroup,
+      inOverdeckTree: OOM_OVERDECK_TREE_REGEX.test(cgroup),
+    });
+  }
+
+  const victimPattern = /Out of memory: Killed process (\d+) \(([^)]+)\)(.*?)$/gm;
+  while ((match = victimPattern.exec(journalText)) !== null) {
+    const [_, pidStr, comm, tail] = match;
+    const pid = parseInt(pidStr, 10);
+
+    let rssBytes = 0;
+    const rssPattern = /(?:anon|file|shmem)-rss:(\d+)kB/g;
+    let rssMatch;
+    while ((rssMatch = rssPattern.exec(tail)) !== null) {
+      rssBytes += parseInt(rssMatch[1], 10) * 1024;
+    }
+
+    if (kills.has(pid)) {
+      kills.get(pid)!.rssBytes = rssBytes;
+    } else {
+      kills.set(pid, {
+        pid,
+        comm,
+        rssBytes,
+        cgroup: null,
+        inOverdeckTree: false,
+      });
+    }
+  }
+
+  return Array.from(kills.values());
+}

--- a/src/lib/cloister/memory-pressure-patrol.ts
+++ b/src/lib/cloister/memory-pressure-patrol.ts
@@ -1,0 +1,192 @@
+/**
+ * PAN-3550: Activity-feed signals for memory pressure. Runs every 15 seconds
+ * in the deacon child, independent of the 60s patrol, to warn before the kernel acts.
+ *
+ * Three levels: ok → watch (warn), holding (soft band, warn), shedding (hard band, error).
+ * Transition-only emit: one row per level change, never repeats while the level persists.
+ * No frontend changes needed — activity.entry already renders in ActivityPanel.
+ */
+
+import { MemoryPressureBand, MemoryVerdict, assessMemoryPressure, readGovernorReserves, readGovernorWatchReserveBytes } from './memory-governor.js';
+import { RuntimeCensus, getRuntimeCensus } from '../runtime-census.js';
+import { emitActivityEntrySync, EmitActivityOptions } from '../activity-logger.js';
+import { logDeaconEventSync } from '../persistent-logger.js';
+
+export type MemoryFeedLevel = 'ok' | 'watch' | 'holding' | 'shedding';
+
+/**
+ * Pure: fold the governor's band and the WATCH reserve into one feed level.
+ * The band already encodes SOFT/HARD hysteresis; WATCH only applies while the
+ * governor is still admitting.
+ */
+export function memoryFeedLevel(
+  band: MemoryPressureBand,
+  availableBytes: number,
+  watchBytes: number,
+): MemoryFeedLevel {
+  if (band === 'hard') return 'shedding';
+  if (band === 'soft') return 'holding';
+  return availableBytes < watchBytes ? 'watch' : 'ok';
+}
+
+/**
+ * Format bytes as human-readable GiB string, e.g., "7.2 GiB"
+ */
+function formatGib(bytes: number): string {
+  const gib = bytes / (1024 ** 3);
+  return `${gib.toFixed(1)} GiB`;
+}
+
+/**
+ * Format a multi-line memory details string for activity entry.
+ */
+function buildMemoryDetails(
+  availableBytes: number,
+  watchBytes: number,
+  softBytes: number,
+  hardBytes: number,
+  recoveryBytes: number,
+): string {
+  // For now, just the basic reserve info. We'll add swap and PSI data later in WI-3 and WI-4.
+  return [
+    `MemAvailable: ${formatGib(availableBytes)}`,
+    `Watch reserve: ${formatGib(watchBytes)} | Soft: ${formatGib(softBytes)} | Hard: ${formatGib(hardBytes)} | Recovery: ${formatGib(recoveryBytes)}`,
+    `Swap free: unavailable | PSI full avg10: unavailable`,
+  ].join('\n');
+}
+
+export interface MemoryPressurePatrolDeps {
+  assess: () => Promise<MemoryVerdict>;
+  readWatchReserveBytes: () => number;
+  readSoftReserveBytes: () => number;
+  readHardReserveBytes: () => number;
+  readRecoveryReserveBytes: () => number;
+  census: () => Promise<RuntimeCensus>;
+  emit: (entry: EmitActivityOptions) => void;
+}
+
+// Module-level state for transition-only emission
+let lastLevel: MemoryFeedLevel | null = null;
+
+/**
+ * Patrol memory pressure once and emit a transition-only activity entry if the level changed.
+ * Returns a human-readable list of actions taken (for deacon log).
+ */
+export async function patrolMemoryPressure(deps: Partial<MemoryPressurePatrolDeps> = {}): Promise<string[]> {
+  // Fill in defaults
+  const d: MemoryPressurePatrolDeps = {
+    assess: deps.assess || (() => assessMemoryPressure()),
+    readWatchReserveBytes: deps.readWatchReserveBytes || (() => readGovernorWatchReserveBytes()),
+    readSoftReserveBytes: deps.readSoftReserveBytes || (() => readGovernorReserves().softBytes),
+    readHardReserveBytes: deps.readHardReserveBytes || (() => readGovernorReserves().hardBytes),
+    readRecoveryReserveBytes: deps.readRecoveryReserveBytes || (() => readGovernorReserves().recoveryBytes),
+    census: deps.census || (() => getRuntimeCensus()),
+    emit: deps.emit || emitActivityEntrySync,
+  };
+
+  const verdict = await d.assess();
+  const watchBytes = d.readWatchReserveBytes();
+  const softBytes = d.readSoftReserveBytes();
+  const hardBytes = d.readHardReserveBytes();
+  const recoveryBytes = d.readRecoveryReserveBytes();
+
+  const level = memoryFeedLevel(verdict.band, verdict.availableBytes, watchBytes);
+
+  // Transition-only: if level hasn't changed, emit nothing
+  if (level === lastLevel) {
+    return [];
+  }
+
+  lastLevel = level;
+  const actions: string[] = [];
+
+  const details = buildMemoryDetails(
+    verdict.availableBytes,
+    watchBytes,
+    softBytes,
+    hardBytes,
+    recoveryBytes,
+  );
+
+  // Build the activity entry based on level
+  if (level === 'watch') {
+    const message =
+      `Memory is getting tight — ${formatGib(verdict.availableBytes)} available, below the ${formatGib(watchBytes)} watch reserve. ` +
+      `Overdeck is still admitting new agents; it will stop admitting if available memory falls below the ${formatGib(softBytes)} soft reserve.`;
+
+    d.emit({
+      level: 'warn',
+      source: 'cloister',
+      link: '/resources',
+      message,
+      details,
+      desktop: false,
+    });
+
+    const action = `memory-pressure-patrol: watch-level (${formatGib(verdict.availableBytes)} available)`;
+    actions.push(action);
+    logDeaconEventSync(`[deacon] ${action}`);
+  } else if (level === 'holding') {
+    const message =
+      `Memory pressure: Overdeck has stopped admitting work — ${formatGib(verdict.availableBytes)} available is under the ${formatGib(softBytes)} soft reserve. ` +
+      `Queued agent resumes and review/test dispatches will wait until available memory climbs back above the ${formatGib(recoveryBytes)} recovery reserve. ` +
+      `Nothing has been stopped or killed.`;
+
+    d.emit({
+      level: 'warn',
+      source: 'cloister',
+      link: '/resources',
+      message,
+      details,
+      desktop: false,
+    });
+
+    const action = `memory-pressure-patrol: admission-hold (${formatGib(verdict.availableBytes)} available)`;
+    actions.push(action);
+    logDeaconEventSync(`[deacon] ${action}`);
+  } else if (level === 'shedding') {
+    const message =
+      `Memory critical — ${formatGib(verdict.availableBytes)} available is under the ${formatGib(hardBytes)} hard reserve. ` +
+      `Overdeck admits nothing and the kernel may start killing processes. ` +
+      `Free memory on this host now; automatic shedding is not wired, so Overdeck will not reclaim anything on its own.`;
+
+    d.emit({
+      level: 'error',
+      source: 'cloister',
+      link: '/resources',
+      message,
+      details,
+      desktop: true,
+    });
+
+    const action = `memory-pressure-patrol: shedding-level (${formatGib(verdict.availableBytes)} available)`;
+    actions.push(action);
+    logDeaconEventSync(`[deacon] ${action}`);
+  } else if (level === 'ok') {
+    const message =
+      `Memory pressure cleared — ${formatGib(verdict.availableBytes)} available, above the ${formatGib(watchBytes)} watch reserve. ` +
+      `Overdeck is admitting work again.`;
+
+    d.emit({
+      level: 'info',
+      source: 'cloister',
+      link: '/resources',
+      message,
+      details,
+      desktop: false,
+    });
+
+    const action = `memory-pressure-patrol: recovered (${formatGib(verdict.availableBytes)} available)`;
+    actions.push(action);
+    logDeaconEventSync(`[deacon] ${action}`);
+  }
+
+  return actions;
+}
+
+/**
+ * Test-only: reset the module-level state between test cases.
+ */
+export function __resetMemoryPressurePatrolState(): void {
+  lastLevel = null;
+}

--- a/src/lib/cloister/memory-pressure-patrol.ts
+++ b/src/lib/cloister/memory-pressure-patrol.ts
@@ -143,22 +143,63 @@ export async function patrolMemoryPressure(deps: Partial<MemoryPressurePatrolDep
   const journalText = await d.readNewKernelJournal();
   const oomKills = parseOomKills(journalText);
 
-  // Emit OOM kills regardless of level transition
-  for (const kill of oomKills) {
-    const message = `Kernel OOM: Killed process ${kill.pid} (${kill.comm}), ${formatGib(kill.rssBytes)} RSS${kill.inOverdeckTree ? ' in Overdeck tmux-server' : ''}`;
+  // Emit OOM kills with backpressure: aggregate burst into one event per level
+  // to avoid unbounded durable writes when the machine is memory-constrained
+  if (oomKills.length > 0) {
+    const overdeckKills = oomKills.filter((k) => k.inOverdeckTree);
+    const hostKills = oomKills.filter((k) => !k.inOverdeckTree);
 
-    d.emit({
-      level: kill.inOverdeckTree ? 'error' : 'warn',
-      source: 'cloister',
-      link: '/resources',
-      message,
-      details: `Cgroup: ${kill.cgroup || '(unknown)'}\n\n${buildMemoryDetails(verdict.availableBytes, watchBytes, softBytes, hardBytes, recoveryBytes)}`,
-      desktop: kill.inOverdeckTree,
-    });
+    // Emit Overdeck-tree kills as error
+    if (overdeckKills.length > 0) {
+      const plural = overdeckKills.length === 1 ? '' : 's';
+      const message =
+        overdeckKills.length === 1
+          ? `Kernel OOM: Killed process ${overdeckKills[0].pid} (${overdeckKills[0].comm}), ${formatGib(overdeckKills[0].rssBytes)} RSS in Overdeck tmux-server`
+          : `Kernel OOM: Killed ${overdeckKills.length} process${plural} in Overdeck tmux-server (${overdeckKills.map((k) => `${k.pid}/${k.comm}`).join(', ')})`;
 
-    const action = `memory-pressure-patrol: oom-kill (pid ${kill.pid} ${kill.comm} ${formatGib(kill.rssBytes)})`;
-    actions.push(action);
-    logDeaconEventSync(`[deacon] ${action}`);
+      const details = overdeckKills
+        .map((k) => `  PID ${k.pid} (${k.comm}): ${formatGib(k.rssBytes)} RSS | Cgroup: ${k.cgroup || '(unknown)'}`)
+        .join('\n');
+
+      d.emit({
+        level: 'error',
+        source: 'cloister',
+        link: '/resources',
+        message,
+        details: `OOM kills in Overdeck tree:\n${details}\n\n${buildMemoryDetails(verdict.availableBytes, watchBytes, softBytes, hardBytes, recoveryBytes)}`,
+        desktop: true,
+      });
+
+      const action = `memory-pressure-patrol: oom-kills (${overdeckKills.length} in Overdeck tree)`;
+      actions.push(action);
+      logDeaconEventSync(`[deacon] ${action}`);
+    }
+
+    // Emit host kills as warn (less urgent)
+    if (hostKills.length > 0) {
+      const plural = hostKills.length === 1 ? '' : 's';
+      const message =
+        hostKills.length === 1
+          ? `Kernel OOM: Killed process ${hostKills[0].pid} (${hostKills[0].comm}), ${formatGib(hostKills[0].rssBytes)} RSS outside Overdeck`
+          : `Kernel OOM: Killed ${hostKills.length} process${plural} outside Overdeck (${hostKills.map((k) => `${k.pid}/${k.comm}`).join(', ')})`;
+
+      const details = hostKills
+        .map((k) => `  PID ${k.pid} (${k.comm}): ${formatGib(k.rssBytes)} RSS | Cgroup: ${k.cgroup || '(unknown)'}`)
+        .join('\n');
+
+      d.emit({
+        level: 'warn',
+        source: 'cloister',
+        link: '/resources',
+        message,
+        details: `OOM kills outside Overdeck:\n${details}\n\n${buildMemoryDetails(verdict.availableBytes, watchBytes, softBytes, hardBytes, recoveryBytes)}`,
+        desktop: false,
+      });
+
+      const action = `memory-pressure-patrol: oom-kills (${hostKills.length} outside Overdeck)`;
+      actions.push(action);
+      logDeaconEventSync(`[deacon] ${action}`);
+    }
   }
 
   const level = memoryFeedLevel(verdict.band, verdict.availableBytes, watchBytes);
@@ -190,7 +231,7 @@ export async function patrolMemoryPressure(deps: Partial<MemoryPressurePatrolDep
     if (topConsumers.length > 0) {
       const consumerLines = topConsumers.map(
         (c) =>
-          `  ${formatGib(c.rssBytes)} | pid ${c.pid} (${c.command.substring(0, 80)}) in session ${c.sessionName || '(host)'}`,
+          `  ${formatGib(c.rssBytes)} | pid ${c.pid} (${c.comm}) in session ${c.sessionName || '(host)'}`,
       );
       details += '\n\nTop memory consumers:\n' + consumerLines.join('\n');
     }
@@ -286,7 +327,7 @@ export function __resetMemoryPressurePatrolState(): void {
 export interface TopConsumer {
   pid: number;
   rssBytes: number;
-  command: string;
+  comm: string;
   sessionName: string | null;
 }
 
@@ -326,7 +367,7 @@ export function topMemoryConsumers(census: RuntimeCensus, limit: number): TopCon
     return {
       pid: proc.pid,
       rssBytes: proc.rssBytes,
-      command: proc.command.slice(0, 80),
+      comm: proc.comm,
       sessionName,
     };
   });

--- a/src/lib/config-yaml/defaults.ts
+++ b/src/lib/config-yaml/defaults.ts
@@ -11,12 +11,13 @@ import type { NormalizedConfig } from './schema.js';
  * with absolute floors (small boxes still get a workable reserve). Computed
  * once at module load — totalmem() is stable for the process lifetime.
  */
-function computeGovernorReserveDefaultsGb(): { soft: number; hard: number; recovery: number } {
+function computeGovernorReserveDefaultsGb(): { soft: number; hard: number; recovery: number; watch: number } {
   const totalGb = totalmem() / (1024 ** 3);
   return {
     soft: Math.max(0.15 * totalGb, 8),
     hard: Math.max(0.08 * totalGb, 4),
     recovery: Math.max(0.25 * totalGb, 12),
+    watch: Math.max(0.20 * totalGb, 10),
   };
 }
 
@@ -205,6 +206,7 @@ export const DEFAULT_CONFIG: NormalizedConfig = {
     governorSoftReserveGb: GOVERNOR_RESERVE_DEFAULTS_GB.soft,
     governorHardReserveGb: GOVERNOR_RESERVE_DEFAULTS_GB.hard,
     governorRecoveryReserveGb: GOVERNOR_RESERVE_DEFAULTS_GB.recovery,
+    governorWatchReserveGb: GOVERNOR_RESERVE_DEFAULTS_GB.watch,
     // PAN-2500: cold-start footprint defaults — work agents carry a docker
     // workspace stack + build tooling, review/test specialists are lighter.
     governorFootprintDefaultWorkGb: 2,

--- a/src/lib/config-yaml/merge.ts
+++ b/src/lib/config-yaml/merge.ts
@@ -185,6 +185,7 @@ export function mergeConfigs(...configs: (YamlConfig | null)[]): { config: Norma
       governorSoftReserveGb: DEFAULT_CONFIG.resources.governorSoftReserveGb,
       governorHardReserveGb: DEFAULT_CONFIG.resources.governorHardReserveGb,
       governorRecoveryReserveGb: DEFAULT_CONFIG.resources.governorRecoveryReserveGb,
+      governorWatchReserveGb: DEFAULT_CONFIG.resources.governorWatchReserveGb,
       governorFootprintDefaultWorkGb: DEFAULT_CONFIG.resources.governorFootprintDefaultWorkGb,
       governorFootprintDefaultReviewGb: DEFAULT_CONFIG.resources.governorFootprintDefaultReviewGb,
       governorFootprintDefaultTestGb: DEFAULT_CONFIG.resources.governorFootprintDefaultTestGb,
@@ -660,6 +661,9 @@ export function mergeConfigs(...configs: (YamlConfig | null)[]): { config: Norma
       if (typeof config.resources.governor_recovery_reserve_gb === 'number') {
         result.resources.governorRecoveryReserveGb = config.resources.governor_recovery_reserve_gb;
       }
+      if (typeof config.resources.governor_watch_reserve_gb === 'number') {
+        result.resources.governorWatchReserveGb = config.resources.governor_watch_reserve_gb;
+      }
       if (typeof config.resources.governor_footprint_default_work_gb === 'number') {
         result.resources.governorFootprintDefaultWorkGb = config.resources.governor_footprint_default_work_gb;
       }
@@ -682,6 +686,10 @@ export function mergeConfigs(...configs: (YamlConfig | null)[]): { config: Norma
       // Normalize rather than throw — a misconfigured reserve shouldn't crash config load.
       if (result.resources.governorRecoveryReserveGb <= result.resources.governorSoftReserveGb) {
         result.resources.governorRecoveryReserveGb = result.resources.governorSoftReserveGb + 1;
+      }
+      // PAN-3550: WATCH must exceed SOFT or the warn tier can never fire before the hold.
+      if (result.resources.governorWatchReserveGb <= result.resources.governorSoftReserveGb) {
+        result.resources.governorWatchReserveGb = result.resources.governorSoftReserveGb + 1;
       }
       if (result.resources.governorSwapRecoveryFreePercent <= result.resources.governorSwapSoftFreePercent) {
         result.resources.governorSwapRecoveryFreePercent = Math.min(

--- a/src/lib/config-yaml/schema.ts
+++ b/src/lib/config-yaml/schema.ts
@@ -401,6 +401,8 @@ export interface ResourcesConfig {
   governor_hard_reserve_gb?: number;
   /** PAN-2500: deacon memory governor — re-admit only past this reserve; must exceed governor_soft_reserve_gb */
   governor_recovery_reserve_gb?: number;
+  /** PAN-3550: deacon memory governor — warn in the activity feed at this reserve; must exceed governor_soft_reserve_gb */
+  governor_watch_reserve_gb?: number;
   /** PAN-2500: cold-start footprint estimate (GiB) for a work agent with no live per-project docker-stack data yet */
   governor_footprint_default_work_gb?: number;
   /** PAN-2500: cold-start footprint estimate (GiB) for a review agent */
@@ -915,6 +917,8 @@ export interface NormalizedConfig {
     governorSoftReserveGb: number;
     governorHardReserveGb: number;
     governorRecoveryReserveGb: number;
+    /** PAN-3550: activity-feed warn reserve, GiB. Always normalized above governorSoftReserveGb. */
+    governorWatchReserveGb: number;
     /** PAN-2500: cold-start per-role footprint defaults, GiB (used when no live per-project stack data exists). */
     governorFootprintDefaultWorkGb: number;
     governorFootprintDefaultReviewGb: number;

--- a/tests/unit/lib/cloister/memory-pressure-patrol.test.ts
+++ b/tests/unit/lib/cloister/memory-pressure-patrol.test.ts
@@ -216,7 +216,6 @@ describe('memory-pressure-patrol', () => {
       expect(details).toContain('Watch reserve');
     });
   });
-});
 
   describe('topMemoryConsumers', () => {
     it('returns top N processes by RSS', async () => {

--- a/tests/unit/lib/cloister/memory-pressure-patrol.test.ts
+++ b/tests/unit/lib/cloister/memory-pressure-patrol.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { memoryFeedLevel, patrolMemoryPressure, __resetMemoryPressurePatrolState, MemoryFeedLevel } from '../../../../src/lib/cloister/memory-pressure-patrol.js';
+import type { MemoryVerdict, MemoryPressureBand } from '../../../../src/lib/cloister/memory-governor.js';
+
+const GIB = 1024 ** 3;
+
+describe('memory-pressure-patrol', () => {
+  beforeEach(() => {
+    __resetMemoryPressurePatrolState();
+  });
+
+  describe('memoryFeedLevel', () => {
+    it('returns "shedding" for hard band', () => {
+      const level = memoryFeedLevel('hard', 10 * GIB, 12 * GIB);
+      expect(level).toBe('shedding');
+    });
+
+    it('returns "holding" for soft band', () => {
+      const level = memoryFeedLevel('soft', 10 * GIB, 12 * GIB);
+      expect(level).toBe('holding');
+    });
+
+    it('returns "watch" for ok band below watch reserve', () => {
+      const level = memoryFeedLevel('ok', 10 * GIB, 12 * GIB);
+      expect(level).toBe('watch');
+    });
+
+    it('returns "ok" for ok band above watch reserve', () => {
+      const level = memoryFeedLevel('ok', 15 * GIB, 12 * GIB);
+      expect(level).toBe('ok');
+    });
+  });
+
+  describe('patrolMemoryPressure', () => {
+    it('emits a warn-level entry when crossing into watch level', async () => {
+      const emitted: object[] = [];
+
+      const mockVerdict: MemoryVerdict = {
+        band: 'ok' as const,
+        availableBytes: 10 * GIB,
+      };
+
+      const deps = {
+        assess: async () => mockVerdict,
+        readWatchReserveBytes: () => 12 * GIB,
+        readSoftReserveBytes: () => 8 * GIB,
+        readHardReserveBytes: () => 4 * GIB,
+        readRecoveryReserveBytes: () => 16 * GIB,
+        emit: (entry: object) => emitted.push(entry),
+      };
+
+      const actions = await patrolMemoryPressure(deps);
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toMatchObject({
+        level: 'warn',
+        source: 'cloister',
+        link: '/resources',
+      });
+      expect((emitted[0] as any).message).toContain('watch reserve');
+      expect((emitted[0] as any).message).toContain('10.0 GiB');
+      expect(typeof (emitted[0] as any).details).toBe('string');
+      expect(actions).toHaveLength(1);
+    });
+
+    it('emits nothing on second call with same watch level', async () => {
+      const emitted: object[] = [];
+
+      const mockVerdict: MemoryVerdict = {
+        band: 'ok' as const,
+        availableBytes: 10 * GIB,
+      };
+
+      const deps = {
+        assess: async () => mockVerdict,
+        readWatchReserveBytes: () => 12 * GIB,
+        readSoftReserveBytes: () => 8 * GIB,
+        readHardReserveBytes: () => 4 * GIB,
+        readRecoveryReserveBytes: () => 16 * GIB,
+        emit: (entry: object) => emitted.push(entry),
+      };
+
+      await patrolMemoryPressure(deps);
+      expect(emitted).toHaveLength(1);
+
+      emitted.length = 0;
+      const actions = await patrolMemoryPressure(deps);
+
+      expect(emitted).toHaveLength(0);
+      expect(actions).toHaveLength(0);
+    });
+
+    it('emits a warn-level entry for soft band (admission hold)', async () => {
+      const emitted: object[] = [];
+
+      const mockVerdict: MemoryVerdict = {
+        band: 'soft' as const,
+        availableBytes: 7 * GIB,
+      };
+
+      const deps = {
+        assess: async () => mockVerdict,
+        readWatchReserveBytes: () => 12 * GIB,
+        readSoftReserveBytes: () => 8 * GIB,
+        readHardReserveBytes: () => 4 * GIB,
+        readRecoveryReserveBytes: () => 16 * GIB,
+        emit: (entry: object) => emitted.push(entry),
+      };
+
+      const actions = await patrolMemoryPressure(deps);
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toMatchObject({
+        level: 'warn',
+        source: 'cloister',
+      });
+      expect((emitted[0] as any).message).toContain('stopped admitting');
+      expect((emitted[0] as any).message).toContain('recovery reserve');
+      expect(actions).toHaveLength(1);
+    });
+
+    it('emits an error-level entry for hard band (shedding)', async () => {
+      const emitted: object[] = [];
+
+      const mockVerdict: MemoryVerdict = {
+        band: 'hard' as const,
+        availableBytes: 3 * GIB,
+      };
+
+      const deps = {
+        assess: async () => mockVerdict,
+        readWatchReserveBytes: () => 12 * GIB,
+        readSoftReserveBytes: () => 8 * GIB,
+        readHardReserveBytes: () => 4 * GIB,
+        readRecoveryReserveBytes: () => 16 * GIB,
+        emit: (entry: object) => emitted.push(entry),
+      };
+
+      const actions = await patrolMemoryPressure(deps);
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toMatchObject({
+        level: 'error',
+        source: 'cloister',
+      });
+      expect((emitted[0] as any).message).toContain('critical');
+      expect(actions).toHaveLength(1);
+    });
+
+    it('emits an info-level entry when recovering from watch to ok', async () => {
+      const emitted: object[] = [];
+
+      const mockVerdict: MemoryVerdict = {
+        band: 'ok' as const,
+        availableBytes: 10 * GIB,
+      };
+
+      const deps = {
+        assess: async () => mockVerdict,
+        readWatchReserveBytes: () => 12 * GIB,
+        readSoftReserveBytes: () => 8 * GIB,
+        readHardReserveBytes: () => 4 * GIB,
+        readRecoveryReserveBytes: () => 16 * GIB,
+        emit: (entry: object) => emitted.push(entry),
+      };
+
+      // First call: enter watch
+      await patrolMemoryPressure(deps);
+      expect(emitted).toHaveLength(1);
+      expect((emitted[0] as any).level).toBe('warn');
+
+      // Second call: recover to ok
+      emitted.length = 0;
+      const recoverVerdict: MemoryVerdict = {
+        band: 'ok' as const,
+        availableBytes: 15 * GIB,
+      };
+      const recoverDeps = {
+        ...deps,
+        assess: async () => recoverVerdict,
+      };
+      const actions = await patrolMemoryPressure(recoverDeps);
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toMatchObject({
+        level: 'info',
+        source: 'cloister',
+      });
+      expect((emitted[0] as any).message).toContain('cleared');
+      expect(actions).toHaveLength(1);
+    });
+
+    it('always returns a string-valued details field', async () => {
+      const emitted: object[] = [];
+
+      const mockVerdict: MemoryVerdict = {
+        band: 'ok' as const,
+        availableBytes: 10 * GIB,
+      };
+
+      const deps = {
+        assess: async () => mockVerdict,
+        readWatchReserveBytes: () => 12 * GIB,
+        readSoftReserveBytes: () => 8 * GIB,
+        readHardReserveBytes: () => 4 * GIB,
+        readRecoveryReserveBytes: () => 16 * GIB,
+        emit: (entry: object) => emitted.push(entry),
+      };
+
+      await patrolMemoryPressure(deps);
+
+      expect(emitted).toHaveLength(1);
+      const details = (emitted[0] as any).details;
+      expect(typeof details).toBe('string');
+      expect(details).toContain('MemAvailable');
+      expect(details).toContain('Watch reserve');
+    });
+  });
+});

--- a/tests/unit/lib/cloister/memory-pressure-patrol.test.ts
+++ b/tests/unit/lib/cloister/memory-pressure-patrol.test.ts
@@ -217,3 +217,57 @@ describe('memory-pressure-patrol', () => {
     });
   });
 });
+
+  describe('topMemoryConsumers', () => {
+    it('returns top N processes by RSS', async () => {
+      const { topMemoryConsumers } = await import('../../../../src/lib/cloister/memory-pressure-patrol.js');
+      const mockCensus = {
+        processAvailable: true,
+        panesBySession: new Map([['agent-test', [{ panePid: 100, sessionName: 'agent-test' }]]]),
+        processesByPid: new Map([
+          [1000, { pid: 1000, ppid: 1, rssBytes: 5 * GIB, command: 'python' }],
+          [1001, { pid: 1001, ppid: 1, rssBytes: 3 * GIB, command: 'java' }],
+          [1002, { pid: 1002, ppid: 100, rssBytes: 2 * GIB, command: 'node' }],
+        ]),
+      };
+      const top = topMemoryConsumers(mockCensus, 2);
+      expect(top).toHaveLength(2);
+      expect(top[0].pid).toBe(1000);
+      expect(top[1].pid).toBe(1001);
+    });
+
+    it('attributes process to session via parent chain', async () => {
+      const { topMemoryConsumers } = await import('../../../../src/lib/cloister/memory-pressure-patrol.js');
+      const mockCensus = {
+        processAvailable: true,
+        panesBySession: new Map([['agent-test', [{ panePid: 50, sessionName: 'agent-test' }]]]),
+        processesByPid: new Map([
+          [100, { pid: 100, ppid: 50, rssBytes: 4 * GIB, command: 'work-agent' }],
+        ]),
+      };
+      const top = topMemoryConsumers(mockCensus, 1);
+      expect(top[0].sessionName).toBe('agent-test');
+    });
+  });
+
+  describe('parseOomKills', () => {
+    it('parses kernel OOM lines and joins on pid', async () => {
+      const { parseOomKills } = await import('../../../../src/lib/cloister/memory-pressure-patrol.js');
+      const journal = `oom-kill:constraint=CONSTRAINT_NONE,nodemask=(null),cpuset=docker-0647,mems_allowed=0,global_oom,task_memcg=/app.slice/overdeck-tmux-server.service,task=python,pid=2230723,uid=1000
+Out of memory: Killed process 2230723 (python) total-vm:349473036kB, anon-rss:41321032kB, file-rss:66872kB, shmem-rss:8744kB, UID:1000 pgtables:85936kB oom_score_adj:200`;
+      const kills = parseOomKills(journal);
+      expect(kills).toHaveLength(1);
+      expect(kills[0].pid).toBe(2230723);
+      expect(kills[0].comm).toBe('python');
+      expect(kills[0].inOverdeckTree).toBe(true);
+      expect(kills[0].rssBytes).toBe((41321032 + 66872 + 8744) * 1024);
+    });
+
+    it('handles cgroup outside Overdeck tree', async () => {
+      const { parseOomKills } = await import('../../../../src/lib/cloister/memory-pressure-patrol.js');
+      const journal = `oom-kill:constraint=CONSTRAINT_NONE,task_memcg=/user.slice/user-1000.slice/user@1000.service/app.slice/Chrome.scope,task=Chrome,pid=5956,uid=1000`;
+      const kills = parseOomKills(journal);
+      expect(kills[0].inOverdeckTree).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
**Issue:** #3550

## Acceptance Criteria

- [ ] Add the governor_watch_reserve_gb config key with host-scaled default and above-SOFT normalization
- [ ] Create memory-pressure-patrol.ts emitting one activity entry per memory feed-level transition
- [ ] Attribute the top RSS consumers from the runtime census into the warning details
- [ ] Detect kernel OOM kills from the journal and report the victim in the activity feed
- [ ] Run the memory patrol on a dedicated 15-second timer in the deacon child
- [ ] Document the activity-feed signals and correct the eviction-ladder claim in RESOURCE-GOVERNOR.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added memory-pressure monitoring with status levels for normal, watch, holding, and shedding conditions.
  - Added configurable governor watch reserves, with system-aware defaults and validation.
  - Added activity alerts for memory-pressure transitions, top memory consumers, and detected out-of-memory events.
  - Monitoring continues gracefully when system diagnostics are unavailable.

- **Documentation**
  - Documented memory-pressure statuses, alerts, reserve thresholds, and consumer attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->