### PR TITLE
PAN-3581

### DIFF
--- a/src/lib/lifecycle/dod-gate.ts
+++ b/src/lib/lifecycle/dod-gate.ts
@@ -403,6 +403,12 @@ export async function checkVerificationRow(
     notes.length > 0 ? ` (${notes.join('; ')})` : ''
   }`;
   if (accepted) return result('verification', 'pass', observed);
+  // An out-of-band merge never enters merge-ops, so the CI-green skip cannot
+  // record its normal verification verdict. Once rows 4 and 6 prove the landed
+  // work and main CI green, that evidence satisfies row 3 without an override.
+  if (value === undefined && settlement?.landedWork && settlement.mainVerifyStatus === 'pass') {
+    return result('verification', 'pass', `${observed}; verification satisfied by green main CI after landing`);
+  }
   return terminalVerdictSettlement('verification', value, observed, settlement) ??
     result('verification', 'miss', observed);
 }

--- a/tests/unit/lib/lifecycle/dod-gate.test.ts
+++ b/tests/unit/lib/lifecycle/dod-gate.test.ts
@@ -103,6 +103,21 @@ describe('Definition-of-Done status rows', () => {
     });
   });
 
+  it('accepts missing verification verdicts when merged work is green on main', async () => {
+    // An out-of-band landing bypasses merge-ops, which normally writes the
+    // verdict for CI-green skip. Merge plus main-CI evidence is still sufficient.
+    const row = await checkVerificationRow(
+      issueId,
+      deps(live({ verificationStatus: undefined, lastVerifiedCommit: undefined })),
+      { trackerClosed: false, landedWork: true, mainVerifyStatus: 'pass' },
+    );
+
+    expect(row).toMatchObject({
+      status: 'pass',
+      observed: 'verificationStatus: missing; verification satisfied by green main CI after landing',
+    });
+  });
+
   it('falls back to durable pipeline journal verdicts after live status is cleared', async () => {
     const source = deps(null, journal());
     for (const row of await Promise.all([checkReviewRow(issueId, source), checkTestsRow(issueId, source), checkVerificationRow(issueId, source)])) {


### PR DESCRIPTION
**Issue:** #3581


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Verification now passes when landed work has a successful main CI result, even if no separate verification verdict is available.
  * Missing verification details remain visible in the recorded status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->